### PR TITLE
Add vertical motion and turbulence analysis

### DIFF
--- a/src/weatherbrief/analysis/comparison.py
+++ b/src/weatherbrief/analysis/comparison.py
@@ -23,6 +23,7 @@ DIVERGENCE_THRESHOLDS: dict[str, tuple[float, float]] = {
     "precipitable_water_mm": (5.0, 15.0),
     "lifted_index": (2.0, 5.0),
     "bulk_shear_0_6km_kt": (5.0, 15.0),
+    "max_omega_pa_s": (1.0, 5.0),
 }
 
 # Variables that wrap around 360 degrees

--- a/src/weatherbrief/analysis/sounding/__init__.py
+++ b/src/weatherbrief/analysis/sounding/__init__.py
@@ -31,6 +31,10 @@ def analyze_sounding(
         compute_derived_levels,
         compute_indices,
     )
+    from weatherbrief.analysis.sounding.vertical_motion import (
+        assess_vertical_motion,
+        compute_stability_indicators,
+    )
 
     profile = prepare_profile(levels, hourly)
     if profile is None:
@@ -56,12 +60,17 @@ def analyze_sounding(
     # Convective assessment
     convective = assess_convective(indices)
 
+    # Vertical motion and turbulence assessment
+    compute_stability_indicators(profile, derived_levels)
+    vertical_motion = assess_vertical_motion(derived_levels)
+
     return SoundingAnalysis(
         indices=indices,
         derived_levels=derived_levels,
         cloud_layers=cloud_layers,
         icing_zones=icing_zones,
         convective=convective,
+        vertical_motion=vertical_motion,
         cloud_cover_low_pct=hourly.cloud_cover_low_pct if hourly else None,
         cloud_cover_mid_pct=hourly.cloud_cover_mid_pct if hourly else None,
         cloud_cover_high_pct=hourly.cloud_cover_high_pct if hourly else None,

--- a/src/weatherbrief/analysis/sounding/vertical_motion.py
+++ b/src/weatherbrief/analysis/sounding/vertical_motion.py
@@ -1,0 +1,265 @@
+"""Vertical motion analysis and turbulence indicators.
+
+Computes Richardson Number, Brunt-Vaisala frequency, classifies vertical
+motion profiles, and assesses clear-air turbulence (CAT) risk from
+NWP omega/w and derived stability indicators.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import metpy.calc as mpcalc
+import numpy as np
+from metpy.units import units
+
+from weatherbrief.analysis.sounding.prepare import PreparedProfile
+from weatherbrief.analysis.sounding.thermodynamics import M_TO_FT, _pressure_to_altitude_ft
+from weatherbrief.models import (
+    CATRiskLayer,
+    CATRiskLevel,
+    DerivedLevel,
+    VerticalMotionAssessment,
+    VerticalMotionClass,
+)
+
+logger = logging.getLogger(__name__)
+
+# Richardson number thresholds for CAT risk
+_RI_SEVERE = 0.25
+_RI_MODERATE = 0.5
+_RI_LIGHT = 1.0
+
+# Omega thresholds (Pa/s) for classification
+_OMEGA_QUIESCENT = 1.0  # |omega| < 1 Pa/s → quiescent
+_OMEGA_CONVECTIVE = 10.0  # |omega| > 10 Pa/s → convective
+_OMEGA_SIGNIFICANT = 0.5  # minimum for sign-change counting
+
+# Convective contamination: mid-level (700-400 hPa) omega threshold
+_CONTAMINATION_PRESSURE_MIN = 400  # hPa (top)
+_CONTAMINATION_PRESSURE_MAX = 700  # hPa (bottom)
+_CONTAMINATION_OMEGA = 5.0  # |omega| > 5 Pa/s
+
+# Strong vertical motion threshold
+_STRONG_W_FPM = 200.0
+
+# Gravity constant
+_G = 9.80665  # m/s²
+
+# Minimum shear squared to avoid division by zero
+_MIN_SHEAR_SQ = 1e-10
+
+
+def compute_stability_indicators(
+    profile: PreparedProfile,
+    derived_levels: list[DerivedLevel],
+) -> None:
+    """Compute N² and Richardson number for adjacent layer pairs.
+
+    Enriches derived_levels in-place with richardson_number and
+    bv_freq_squared_per_s2 for each level (representing the layer below).
+    """
+    pressures = profile.pressure.to("hPa").magnitude
+    temps = profile.temperature.to("degC").magnitude
+
+    if profile.height is not None:
+        heights_m = profile.height.to("meter").magnitude
+    else:
+        heights_m = np.array([
+            _pressure_to_altitude_ft(p) / M_TO_FT for p in pressures
+        ])
+
+    # Compute potential temperature at each level
+    theta = np.empty(len(pressures))
+    for i in range(len(pressures)):
+        try:
+            pt = mpcalc.potential_temperature(
+                pressures[i] * units.hPa, temps[i] * units.degC,
+            )
+            theta[i] = float(pt.to("kelvin").magnitude)
+        except Exception:
+            theta[i] = np.nan
+
+    # Compute wind components for shear calculation
+    u_vals = np.full(len(pressures), np.nan)
+    v_vals = np.full(len(pressures), np.nan)
+    if profile.wind_speed is not None and profile.wind_direction is not None:
+        try:
+            u, v = mpcalc.wind_components(profile.wind_speed, profile.wind_direction)
+            u_vals = u.to("m/s").magnitude
+            v_vals = v.to("m/s").magnitude
+        except Exception:
+            logger.debug("Failed to compute wind components", exc_info=True)
+
+    # Per adjacent layer pair (i is lower, i+1 is upper)
+    for i in range(len(pressures) - 1):
+        if i + 1 >= len(derived_levels):
+            break
+
+        dz = heights_m[i + 1] - heights_m[i]
+        if dz <= 0 or np.isnan(theta[i]) or np.isnan(theta[i + 1]):
+            continue
+
+        theta_mean = (theta[i] + theta[i + 1]) / 2.0
+        d_theta = theta[i + 1] - theta[i]
+
+        # Brunt-Vaisala frequency squared: N² = (g/θ) × (dθ/dz)
+        n_sq = (_G / theta_mean) * (d_theta / dz)
+        derived_levels[i + 1].bv_freq_squared_per_s2 = round(float(n_sq), 8)
+
+        # Wind shear squared: S² = (du/dz)² + (dv/dz)²
+        if not np.isnan(u_vals[i]) and not np.isnan(u_vals[i + 1]):
+            du_dz = (u_vals[i + 1] - u_vals[i]) / dz
+            dv_dz = (v_vals[i + 1] - v_vals[i]) / dz
+            shear_sq = du_dz**2 + dv_dz**2
+
+            if shear_sq > _MIN_SHEAR_SQ:
+                ri = n_sq / shear_sq
+                derived_levels[i + 1].richardson_number = round(float(ri), 2)
+
+
+def classify_vertical_motion(
+    derived_levels: list[DerivedLevel],
+) -> VerticalMotionClass:
+    """Classify the vertical motion profile from omega data."""
+    omega_values = [
+        lv.omega_pa_s for lv in derived_levels if lv.omega_pa_s is not None
+    ]
+    if not omega_values:
+        return VerticalMotionClass.UNAVAILABLE
+
+    abs_omegas = [abs(o) for o in omega_values]
+    max_abs = max(abs_omegas)
+
+    # Check for convective
+    if max_abs > _OMEGA_CONVECTIVE:
+        return VerticalMotionClass.CONVECTIVE
+
+    # Check for quiescent
+    if max_abs < _OMEGA_QUIESCENT:
+        return VerticalMotionClass.QUIESCENT
+
+    # Count significant sign changes
+    significant = [o for o in omega_values if abs(o) > _OMEGA_SIGNIFICANT]
+    sign_changes = 0
+    for i in range(len(significant) - 1):
+        if significant[i] * significant[i + 1] < 0:
+            sign_changes += 1
+
+    if sign_changes >= 2:
+        return VerticalMotionClass.OSCILLATING
+
+    # Coherent direction: negative omega = ascent, positive = subsidence
+    mean_omega = sum(omega_values) / len(omega_values)
+    if mean_omega < 0:
+        return VerticalMotionClass.SYNOPTIC_ASCENT
+    return VerticalMotionClass.SYNOPTIC_SUBSIDENCE
+
+
+def _classify_cat_risk(ri: float) -> CATRiskLevel:
+    """Classify CAT risk from Richardson number."""
+    if ri < _RI_SEVERE:
+        return CATRiskLevel.SEVERE
+    if ri < _RI_MODERATE:
+        return CATRiskLevel.MODERATE
+    if ri < _RI_LIGHT:
+        return CATRiskLevel.LIGHT
+    return CATRiskLevel.NONE
+
+
+def _build_cat_layers(derived_levels: list[DerivedLevel]) -> list[CATRiskLayer]:
+    """Group adjacent low-Ri levels into CAT risk layers.
+
+    Follows the same grouping pattern as icing.py: adjacent levels with
+    Ri < 1.0 are merged into bands.
+    """
+    cat_levels: list[tuple[DerivedLevel, CATRiskLevel, float]] = []
+    for lv in derived_levels:
+        if lv.richardson_number is None or lv.altitude_ft is None:
+            continue
+        risk = _classify_cat_risk(lv.richardson_number)
+        if risk == CATRiskLevel.NONE:
+            continue
+        cat_levels.append((lv, risk, lv.richardson_number))
+
+    if not cat_levels:
+        return []
+
+    # Group adjacent levels (pressure gap <= 200 hPa)
+    layers: list[CATRiskLayer] = []
+    current: list[tuple[DerivedLevel, CATRiskLevel, float]] = [cat_levels[0]]
+
+    for item in cat_levels[1:]:
+        prev_lv = current[-1][0]
+        this_lv = item[0]
+        if abs(prev_lv.pressure_hpa - this_lv.pressure_hpa) <= 200:
+            current.append(item)
+        else:
+            layers.append(_build_single_cat_layer(current))
+            current = [item]
+
+    layers.append(_build_single_cat_layer(current))
+    return layers
+
+
+def _build_single_cat_layer(
+    items: list[tuple[DerivedLevel, CATRiskLevel, float]],
+) -> CATRiskLayer:
+    """Build a CATRiskLayer from a group of adjacent low-Ri levels."""
+    risk_order = [CATRiskLevel.NONE, CATRiskLevel.LIGHT, CATRiskLevel.MODERATE, CATRiskLevel.SEVERE]
+    worst_risk = max((r for _, r, _ in items), key=lambda r: risk_order.index(r))
+    min_ri = min(ri for _, _, ri in items)
+
+    base = items[0][0]
+    top = items[-1][0]
+
+    return CATRiskLayer(
+        base_ft=round(base.altitude_ft),
+        top_ft=round(top.altitude_ft),
+        base_pressure_hpa=base.pressure_hpa,
+        top_pressure_hpa=top.pressure_hpa,
+        richardson_number=round(min_ri, 2),
+        risk=worst_risk,
+    )
+
+
+def assess_vertical_motion(
+    derived_levels: list[DerivedLevel],
+) -> VerticalMotionAssessment:
+    """Build complete vertical motion assessment from enriched derived levels."""
+    classification = classify_vertical_motion(derived_levels)
+
+    # Find max omega/w
+    max_omega: float | None = None
+    max_w: float | None = None
+    max_w_level: float | None = None
+
+    for lv in derived_levels:
+        if lv.omega_pa_s is not None:
+            if max_omega is None or abs(lv.omega_pa_s) > abs(max_omega):
+                max_omega = lv.omega_pa_s
+        if lv.w_fpm is not None:
+            if max_w is None or abs(lv.w_fpm) > abs(max_w):
+                max_w = lv.w_fpm
+                max_w_level = lv.altitude_ft
+
+    # Build CAT risk layers from Ri
+    cat_layers = _build_cat_layers(derived_levels)
+
+    # Detect convective contamination: mid-level |omega| > threshold
+    convective_contamination = False
+    for lv in derived_levels:
+        if lv.omega_pa_s is not None and lv.pressure_hpa is not None:
+            if (_CONTAMINATION_PRESSURE_MIN <= lv.pressure_hpa <= _CONTAMINATION_PRESSURE_MAX
+                    and abs(lv.omega_pa_s) > _CONTAMINATION_OMEGA):
+                convective_contamination = True
+                break
+
+    return VerticalMotionAssessment(
+        classification=classification,
+        max_omega_pa_s=round(max_omega, 4) if max_omega is not None else None,
+        max_w_fpm=round(max_w, 1) if max_w is not None else None,
+        max_w_level_ft=round(max_w_level) if max_w_level is not None else None,
+        cat_risk_layers=cat_layers,
+        convective_contamination=convective_contamination,
+    )

--- a/src/weatherbrief/digest/text.py
+++ b/src/weatherbrief/digest/text.py
@@ -11,6 +11,7 @@ from weatherbrief.models import (
     ForecastSnapshot,
     IcingRisk,
     SoundingAnalysis,
+    VerticalMotionClass,
     WaypointAnalysis,
     WaypointForecast,
 )
@@ -226,6 +227,23 @@ def _format_sounding_analysis(soundings: dict[str, SoundingAnalysis]) -> list[st
                     f"{zone.base_ft:.0f}-{zone.top_ft:.0f}ft "
                     f"(Tw={zone.mean_wet_bulb_c:.0f}C){sld_str}"
                 )
+
+        # Vertical motion
+        vm = sa.vertical_motion
+        if vm is not None and vm.classification != VerticalMotionClass.UNAVAILABLE:
+            vm_parts = [vm.classification.value.replace("_", " ").title()]
+            if vm.max_w_fpm is not None:
+                vm_parts.append(f"max {vm.max_w_fpm:+.0f} ft/min at {vm.max_w_level_ft:.0f}ft")
+            lines.append(f"  Vertical motion [{model}]: {', '.join(vm_parts)}")
+            if vm.cat_risk_layers:
+                for layer in vm.cat_risk_layers:
+                    lines.append(
+                        f"    CAT {layer.risk.value.upper()} "
+                        f"{layer.base_ft:.0f}-{layer.top_ft:.0f}ft "
+                        f"(Ri={layer.richardson_number:.2f})"
+                    )
+            if vm.convective_contamination:
+                lines.append(f"    ** Mid-level convective contamination **")
 
         # Cloud layers
         if sa.cloud_layers:

--- a/src/weatherbrief/fetch/open_meteo.py
+++ b/src/weatherbrief/fetch/open_meteo.py
@@ -240,6 +240,7 @@ class OpenMeteoClient:
                     wind_speed_kt=get(f"wind_speed_{level}hPa"),
                     wind_direction_deg=get(f"wind_direction_{level}hPa"),
                     geopotential_height_m=get(f"geopotential_height_{level}hPa"),
+                    vertical_velocity_pa_s=get(f"vertical_velocity_{level}hPa"),
                 )
             )
 

--- a/src/weatherbrief/fetch/variables.py
+++ b/src/weatherbrief/fetch/variables.py
@@ -33,6 +33,7 @@ PRESSURE_LEVEL_VARIABLES = [
     "wind_speed",
     "wind_direction",
     "geopotential_height",
+    "vertical_velocity",
 ]
 
 
@@ -75,6 +76,7 @@ MODEL_ENDPOINTS: dict[str, ModelEndpoint] = {
         base_url="https://api.open-meteo.com/v1/dwd-icon",
         max_days=7,
         unavailable_surface=["precipitation_probability"],
+        unavailable_pressure=["vertical_velocity"],
     ),
     "ukmo": ModelEndpoint(
         name="UK Met Office",
@@ -83,7 +85,7 @@ MODEL_ENDPOINTS: dict[str, ModelEndpoint] = {
         model_param="ukmo_seamless",
         unavailable_surface=["dewpoint_2m", "precipitation_probability",
                              "freezing_level_height", "cape", "visibility"],
-        unavailable_pressure=["dewpoint"],
+        unavailable_pressure=["dewpoint", "vertical_velocity"],
     ),
     "meteofrance": ModelEndpoint(
         name="Météo-France",
@@ -91,7 +93,7 @@ MODEL_ENDPOINTS: dict[str, ModelEndpoint] = {
         max_days=6,
         unavailable_surface=["precipitation_probability",
                              "freezing_level_height", "cape", "visibility"],
-        unavailable_pressure=["dewpoint"],
+        unavailable_pressure=["dewpoint", "vertical_velocity"],
     ),
 }
 

--- a/src/weatherbrief/pipeline.py
+++ b/src/weatherbrief/pipeline.py
@@ -239,6 +239,7 @@ def analyze_waypoint(
     model_pw: dict[str, float] = {}
     model_li: dict[str, float] = {}
     model_shear: dict[str, float] = {}
+    model_max_omega: dict[str, float] = {}
 
     for wf in forecasts:
         hourly = wf.at_time(target_time)
@@ -289,6 +290,11 @@ def analyze_waypoint(
                 if idx.bulk_shear_0_6km_kt is not None:
                     model_shear[model_key] = idx.bulk_shear_0_6km_kt
 
+            # Vertical motion comparison value
+            vm = sounding.vertical_motion
+            if vm is not None and vm.max_omega_pa_s is not None:
+                model_max_omega[model_key] = abs(vm.max_omega_pa_s)
+
         # Collect comparison values
         if hourly.temperature_2m_c is not None:
             model_temps[model_key] = hourly.temperature_2m_c
@@ -322,6 +328,7 @@ def analyze_waypoint(
         "precipitable_water_mm": model_pw,
         "lifted_index": model_li,
         "bulk_shear_0_6km_kt": model_shear,
+        "max_omega_pa_s": model_max_omega,
     }
 
     for var_name, values in comparisons.items():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -64,3 +64,34 @@ def sample_pressure_levels():
                           dewpoint_c=-65, wind_speed_kt=60, wind_direction_deg=270,
                           geopotential_height_m=9100),
     ]
+
+
+@pytest.fixture
+def sample_pressure_levels_with_omega():
+    """Pressure levels with vertical velocity data (GFS/ECMWF-like)."""
+    return [
+        PressureLevelData(pressure_hpa=1000, temperature_c=10, relative_humidity_pct=75,
+                          dewpoint_c=5.5, wind_speed_kt=8, wind_direction_deg=270,
+                          geopotential_height_m=110, vertical_velocity_pa_s=-0.2),
+        PressureLevelData(pressure_hpa=925, temperature_c=5, relative_humidity_pct=85,
+                          dewpoint_c=2.7, wind_speed_kt=15, wind_direction_deg=280,
+                          geopotential_height_m=770, vertical_velocity_pa_s=-0.5),
+        PressureLevelData(pressure_hpa=850, temperature_c=0, relative_humidity_pct=90,
+                          dewpoint_c=-1.5, wind_speed_kt=25, wind_direction_deg=290,
+                          geopotential_height_m=1450, vertical_velocity_pa_s=-1.0),
+        PressureLevelData(pressure_hpa=700, temperature_c=-8, relative_humidity_pct=60,
+                          dewpoint_c=-15, wind_speed_kt=35, wind_direction_deg=300,
+                          geopotential_height_m=3010, vertical_velocity_pa_s=-2.0),
+        PressureLevelData(pressure_hpa=600, temperature_c=-18, relative_humidity_pct=40,
+                          dewpoint_c=-29, wind_speed_kt=40, wind_direction_deg=290,
+                          geopotential_height_m=4200, vertical_velocity_pa_s=-1.5),
+        PressureLevelData(pressure_hpa=500, temperature_c=-28, relative_humidity_pct=30,
+                          dewpoint_c=-40, wind_speed_kt=50, wind_direction_deg=280,
+                          geopotential_height_m=5550, vertical_velocity_pa_s=-1.0),
+        PressureLevelData(pressure_hpa=400, temperature_c=-40, relative_humidity_pct=25,
+                          dewpoint_c=-52, wind_speed_kt=55, wind_direction_deg=275,
+                          geopotential_height_m=7150, vertical_velocity_pa_s=-0.3),
+        PressureLevelData(pressure_hpa=300, temperature_c=-52, relative_humidity_pct=20,
+                          dewpoint_c=-65, wind_speed_kt=60, wind_direction_deg=270,
+                          geopotential_height_m=9100, vertical_velocity_pa_s=-0.1),
+    ]

--- a/tests/test_vertical_motion.py
+++ b/tests/test_vertical_motion.py
@@ -1,0 +1,268 @@
+"""Tests for vertical motion analysis and turbulence indicators."""
+
+from __future__ import annotations
+
+from weatherbrief.analysis.sounding import analyze_sounding
+from weatherbrief.analysis.sounding.prepare import prepare_profile
+from weatherbrief.analysis.sounding.thermodynamics import compute_derived_levels
+from weatherbrief.analysis.sounding.vertical_motion import (
+    assess_vertical_motion,
+    classify_vertical_motion,
+    compute_stability_indicators,
+)
+from weatherbrief.models import (
+    CATRiskLevel,
+    DerivedLevel,
+    PressureLevelData,
+    VerticalMotionClass,
+)
+
+
+# --- Classification tests ---
+
+
+def test_classify_unavailable_no_omega():
+    """UNAVAILABLE when no omega data present."""
+    levels = [
+        DerivedLevel(pressure_hpa=850, altitude_ft=5000),
+        DerivedLevel(pressure_hpa=700, altitude_ft=10000),
+    ]
+    assert classify_vertical_motion(levels) == VerticalMotionClass.UNAVAILABLE
+
+
+def test_classify_quiescent():
+    """QUIESCENT when all |omega| < 1 Pa/s."""
+    levels = [
+        DerivedLevel(pressure_hpa=850, altitude_ft=5000, omega_pa_s=0.2),
+        DerivedLevel(pressure_hpa=700, altitude_ft=10000, omega_pa_s=-0.3),
+        DerivedLevel(pressure_hpa=500, altitude_ft=18000, omega_pa_s=0.1),
+    ]
+    assert classify_vertical_motion(levels) == VerticalMotionClass.QUIESCENT
+
+
+def test_classify_synoptic_ascent():
+    """SYNOPTIC_ASCENT when coherent negative omega."""
+    levels = [
+        DerivedLevel(pressure_hpa=850, altitude_ft=5000, omega_pa_s=-2.0),
+        DerivedLevel(pressure_hpa=700, altitude_ft=10000, omega_pa_s=-3.0),
+        DerivedLevel(pressure_hpa=500, altitude_ft=18000, omega_pa_s=-1.5),
+    ]
+    assert classify_vertical_motion(levels) == VerticalMotionClass.SYNOPTIC_ASCENT
+
+
+def test_classify_synoptic_subsidence():
+    """SYNOPTIC_SUBSIDENCE when coherent positive omega."""
+    levels = [
+        DerivedLevel(pressure_hpa=850, altitude_ft=5000, omega_pa_s=2.0),
+        DerivedLevel(pressure_hpa=700, altitude_ft=10000, omega_pa_s=3.0),
+        DerivedLevel(pressure_hpa=500, altitude_ft=18000, omega_pa_s=1.5),
+    ]
+    assert classify_vertical_motion(levels) == VerticalMotionClass.SYNOPTIC_SUBSIDENCE
+
+
+def test_classify_convective():
+    """CONVECTIVE when |omega| > 10 Pa/s."""
+    levels = [
+        DerivedLevel(pressure_hpa=850, altitude_ft=5000, omega_pa_s=-2.0),
+        DerivedLevel(pressure_hpa=700, altitude_ft=10000, omega_pa_s=-15.0),
+        DerivedLevel(pressure_hpa=500, altitude_ft=18000, omega_pa_s=-3.0),
+    ]
+    assert classify_vertical_motion(levels) == VerticalMotionClass.CONVECTIVE
+
+
+def test_classify_oscillating():
+    """OSCILLATING when >=2 significant sign changes."""
+    levels = [
+        DerivedLevel(pressure_hpa=1000, altitude_ft=300, omega_pa_s=-2.0),
+        DerivedLevel(pressure_hpa=850, altitude_ft=5000, omega_pa_s=3.0),
+        DerivedLevel(pressure_hpa=700, altitude_ft=10000, omega_pa_s=-2.5),
+        DerivedLevel(pressure_hpa=500, altitude_ft=18000, omega_pa_s=1.5),
+    ]
+    assert classify_vertical_motion(levels) == VerticalMotionClass.OSCILLATING
+
+
+# --- Stability indicators tests ---
+
+
+def test_stability_indicators_computed(sample_pressure_levels_with_omega):
+    """N² and Ri are computed for levels with wind and omega data."""
+    profile = prepare_profile(sample_pressure_levels_with_omega)
+    assert profile is not None
+
+    derived = compute_derived_levels(profile)
+    compute_stability_indicators(profile, derived)
+
+    # Upper levels should have N² and Ri values (layer below)
+    levels_with_n2 = [lv for lv in derived if lv.bv_freq_squared_per_s2 is not None]
+    levels_with_ri = [lv for lv in derived if lv.richardson_number is not None]
+
+    # Should have at least some computed values (not all levels will have them)
+    assert len(levels_with_n2) > 0
+    assert len(levels_with_ri) > 0
+
+
+def test_stability_indicators_positive_n2(sample_pressure_levels_with_omega):
+    """N² should generally be positive in a stably-stratified atmosphere."""
+    profile = prepare_profile(sample_pressure_levels_with_omega)
+    derived = compute_derived_levels(profile)
+    compute_stability_indicators(profile, derived)
+
+    n2_vals = [lv.bv_freq_squared_per_s2 for lv in derived if lv.bv_freq_squared_per_s2 is not None]
+    # Standard atmosphere is stably stratified, N² should be positive
+    assert all(n2 > 0 for n2 in n2_vals)
+
+
+# --- CAT risk layer tests ---
+
+
+def test_cat_risk_from_low_ri():
+    """Low Ri values produce CAT risk layers."""
+    levels = [
+        DerivedLevel(pressure_hpa=850, altitude_ft=5000, omega_pa_s=-1.0),
+        DerivedLevel(pressure_hpa=700, altitude_ft=10000, omega_pa_s=-1.5,
+                     richardson_number=0.3),
+        DerivedLevel(pressure_hpa=500, altitude_ft=18000, omega_pa_s=-1.0,
+                     richardson_number=0.8),
+    ]
+    assessment = assess_vertical_motion(levels)
+    assert len(assessment.cat_risk_layers) > 0
+
+    # Ri=0.3 → MODERATE, Ri=0.8 → LIGHT
+    risks = {l.risk for l in assessment.cat_risk_layers}
+    assert CATRiskLevel.MODERATE in risks or CATRiskLevel.LIGHT in risks
+
+
+def test_no_cat_risk_high_ri():
+    """No CAT layers when Ri > 1.0 everywhere."""
+    levels = [
+        DerivedLevel(pressure_hpa=850, altitude_ft=5000, omega_pa_s=-1.0),
+        DerivedLevel(pressure_hpa=700, altitude_ft=10000, omega_pa_s=-1.5,
+                     richardson_number=5.0),
+        DerivedLevel(pressure_hpa=500, altitude_ft=18000, omega_pa_s=-1.0,
+                     richardson_number=10.0),
+    ]
+    assessment = assess_vertical_motion(levels)
+    assert len(assessment.cat_risk_layers) == 0
+
+
+def test_cat_layer_grouping():
+    """Adjacent low-Ri levels are grouped into a single CAT layer."""
+    levels = [
+        DerivedLevel(pressure_hpa=850, altitude_ft=5000, omega_pa_s=-1.0),
+        DerivedLevel(pressure_hpa=700, altitude_ft=10000, omega_pa_s=-1.5,
+                     richardson_number=0.4),
+        DerivedLevel(pressure_hpa=600, altitude_ft=14000, omega_pa_s=-1.2,
+                     richardson_number=0.6),
+        DerivedLevel(pressure_hpa=500, altitude_ft=18000, omega_pa_s=-1.0,
+                     richardson_number=5.0),
+    ]
+    assessment = assess_vertical_motion(levels)
+    # The two adjacent low-Ri levels should form one layer
+    assert len(assessment.cat_risk_layers) == 1
+    layer = assessment.cat_risk_layers[0]
+    assert layer.base_ft == 10000
+    assert layer.top_ft == 14000
+
+
+# --- Convective contamination tests ---
+
+
+def test_convective_contamination_detected():
+    """Mid-level |omega| > 5 Pa/s triggers convective contamination."""
+    levels = [
+        DerivedLevel(pressure_hpa=850, altitude_ft=5000, omega_pa_s=-1.0),
+        DerivedLevel(pressure_hpa=700, altitude_ft=10000, omega_pa_s=-1.5),
+        DerivedLevel(pressure_hpa=600, altitude_ft=14000, omega_pa_s=-8.0),
+        DerivedLevel(pressure_hpa=500, altitude_ft=18000, omega_pa_s=-6.0),
+        DerivedLevel(pressure_hpa=400, altitude_ft=24000, omega_pa_s=-2.0),
+    ]
+    assessment = assess_vertical_motion(levels)
+    assert assessment.convective_contamination is True
+
+
+def test_no_convective_contamination():
+    """No contamination when mid-level omega is moderate."""
+    levels = [
+        DerivedLevel(pressure_hpa=850, altitude_ft=5000, omega_pa_s=-1.0),
+        DerivedLevel(pressure_hpa=700, altitude_ft=10000, omega_pa_s=-1.5),
+        DerivedLevel(pressure_hpa=500, altitude_ft=18000, omega_pa_s=-3.0),
+        DerivedLevel(pressure_hpa=400, altitude_ft=24000, omega_pa_s=-2.0),
+    ]
+    assessment = assess_vertical_motion(levels)
+    assert assessment.convective_contamination is False
+
+
+# --- Omega → w conversion test ---
+
+
+def test_omega_to_w_conversion(sample_pressure_levels_with_omega):
+    """Omega values are converted to w (ft/min) in derived levels."""
+    profile = prepare_profile(sample_pressure_levels_with_omega)
+    assert profile is not None
+    assert profile.omega is not None
+
+    derived = compute_derived_levels(profile)
+
+    # All levels with omega should have w_fpm computed
+    levels_with_omega = [lv for lv in derived if lv.omega_pa_s is not None]
+    levels_with_w = [lv for lv in derived if lv.w_fpm is not None]
+    assert len(levels_with_omega) > 0
+    assert len(levels_with_w) == len(levels_with_omega)
+
+    # Negative omega (ascent) → positive w (upward)
+    # At 500 hPa, -1.0 Pa/s, T=-28C → w should be roughly positive ~30 fpm
+    lv_500 = next(lv for lv in derived if lv.pressure_hpa == 500)
+    assert lv_500.omega_pa_s < 0  # ascending
+    assert lv_500.w_fpm > 0  # upward in ft/min
+
+
+# --- Integration tests ---
+
+
+def test_analyze_sounding_with_omega(sample_pressure_levels_with_omega):
+    """Full sounding analysis produces vertical motion assessment with omega data."""
+    result = analyze_sounding(sample_pressure_levels_with_omega)
+    assert result is not None
+    assert result.vertical_motion is not None
+    assert result.vertical_motion.classification != VerticalMotionClass.UNAVAILABLE
+    assert result.vertical_motion.max_omega_pa_s is not None
+    assert result.vertical_motion.max_w_fpm is not None
+
+
+def test_analyze_sounding_without_omega(sample_pressure_levels):
+    """Full sounding analysis without omega produces UNAVAILABLE classification."""
+    result = analyze_sounding(sample_pressure_levels)
+    assert result is not None
+    assert result.vertical_motion is not None
+    assert result.vertical_motion.classification == VerticalMotionClass.UNAVAILABLE
+    assert result.vertical_motion.max_omega_pa_s is None
+
+
+# --- Backward compatibility ---
+
+
+def test_backward_compat_no_vertical_motion():
+    """SoundingAnalysis deserializes correctly without vertical_motion field."""
+    from weatherbrief.models import SoundingAnalysis
+
+    # Simulate old JSON without vertical_motion
+    old_json = '{"indices": null, "derived_levels": [], "cloud_layers": [], "icing_zones": [], "convective": null}'
+    sa = SoundingAnalysis.model_validate_json(old_json)
+    assert sa.vertical_motion is None
+
+
+def test_backward_compat_no_omega_in_pressure_level():
+    """PressureLevelData deserializes correctly without vertical_velocity_pa_s."""
+    old_json = '{"pressure_hpa": 500, "temperature_c": -28}'
+    pl = PressureLevelData.model_validate_json(old_json)
+    assert pl.vertical_velocity_pa_s is None
+
+
+def test_backward_compat_no_cat_risk_in_regime():
+    """VerticalRegime deserializes correctly without cat_risk field."""
+    from weatherbrief.models import VerticalRegime
+
+    old_json = '{"floor_ft": 0, "ceiling_ft": 18000, "in_cloud": false, "label": "Clear"}'
+    vr = VerticalRegime.model_validate_json(old_json)
+    assert vr.cat_risk is None
+    assert vr.strong_vertical_motion is False

--- a/web/ts/store/types.ts
+++ b/web/ts/store/types.ts
@@ -54,6 +54,8 @@ export type IcingRisk = 'none' | 'light' | 'moderate' | 'severe';
 export type IcingType = 'none' | 'rime' | 'mixed' | 'clear';
 export type CloudCoverage = 'sct' | 'bkn' | 'ovc';
 export type ConvectiveRisk = 'none' | 'low' | 'moderate' | 'high' | 'extreme';
+export type VerticalMotionClass = 'quiescent' | 'synoptic_ascent' | 'synoptic_subsidence' | 'convective' | 'oscillating' | 'unavailable';
+export type CATRiskLevel = 'none' | 'light' | 'moderate' | 'severe';
 
 export interface ThermodynamicIndices {
   lcl_altitude_ft: number | null;
@@ -105,11 +107,30 @@ export interface ConvectiveAssessment {
   severe_modifiers: string[];
 }
 
+export interface CATRiskLayer {
+  base_ft: number;
+  top_ft: number;
+  base_pressure_hpa: number | null;
+  top_pressure_hpa: number | null;
+  richardson_number: number | null;
+  risk: CATRiskLevel;
+}
+
+export interface VerticalMotionAssessment {
+  classification: VerticalMotionClass;
+  max_omega_pa_s: number | null;
+  max_w_fpm: number | null;
+  max_w_level_ft: number | null;
+  cat_risk_layers: CATRiskLayer[];
+  convective_contamination: boolean;
+}
+
 export interface SoundingAnalysis {
   indices: ThermodynamicIndices | null;
   cloud_layers: EnhancedCloudLayer[];
   icing_zones: IcingZone[];
   convective: ConvectiveAssessment | null;
+  vertical_motion: VerticalMotionAssessment | null;
   cloud_cover_low_pct: number | null;
   cloud_cover_mid_pct: number | null;
   cloud_cover_high_pct: number | null;
@@ -122,6 +143,8 @@ export interface VerticalRegime {
   icing_risk: IcingRisk;
   icing_type: IcingType;
   cloud_cover_pct: number | null;
+  cat_risk: string | null;
+  strong_vertical_motion: boolean;
   label: string;
 }
 


### PR DESCRIPTION
## Summary

- Fetch NWP omega (`vertical_velocity`) from Open-Meteo for GFS/ECMWF models, marked unavailable for ICON/UKMO/Meteofrance
- Convert omega to vertical velocity (ft/min) via MetPy in the per-level thermodynamics pipeline
- Compute Richardson Number and Brunt-Vaisala frequency (N²) from potential temperature and wind shear for CAT turbulence detection
- Classify vertical motion profiles into 6 categories: quiescent, synoptic ascent/subsidence, convective, oscillating, unavailable
- Group adjacent low-Ri levels into CAT risk layers (light/moderate/severe) following the icing zone grouping pattern
- Detect mid-level convective contamination (700-400 hPa, |omega| > 5 Pa/s)
- Integrate into altitude advisories (CAT turbulence + strong motion advisories), model divergence comparison, and text digest output
- Add TypeScript types for web UI
- All new fields use `Optional[...] = None` for backward compatibility with existing snapshots

## Test plan

- [x] 19 new unit tests in `test_vertical_motion.py` covering:
  - Classification (6 cases: unavailable, quiescent, ascent, subsidence, convective, oscillating)
  - Stability indicators (N², Ri computation and sign validation)
  - CAT layer grouping and risk levels
  - Convective contamination detection
  - Omega-to-w conversion with sign validation
  - Integration tests with and without omega data
  - Backward compatibility (old JSON deserialization)
- [x] All 180 existing tests still pass (2 pre-existing failures unrelated to this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)