### PR TITLE
Add flight parameter profiles (issue #8)

### DIFF
--- a/alembic/versions/004_flight_profiles.py
+++ b/alembic/versions/004_flight_profiles.py
@@ -1,0 +1,44 @@
+"""Add flight_profiles table and profile_id to flights.
+
+Revision ID: 004
+Revises: 003
+Create Date: 2026-02-19
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "004"
+down_revision: Union[str, None] = "003"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "flight_profiles",
+        sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),
+        sa.Column("user_id", sa.String(64), sa.ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True),
+        sa.Column("name", sa.String(100), nullable=False, server_default="Default"),
+        sa.Column("is_default", sa.Boolean, nullable=False, server_default=sa.text("0")),
+        sa.Column("settings_json", sa.Text, nullable=False, server_default="{}"),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.add_column(
+        "flights",
+        sa.Column(
+            "profile_id",
+            sa.Integer,
+            sa.ForeignKey("flight_profiles.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("flights", "profile_id")
+    op.drop_table("flight_profiles")

--- a/src/weatherbrief/api/app.py
+++ b/src/weatherbrief/api/app.py
@@ -18,6 +18,7 @@ from weatherbrief.api.auth_config import get_jwt_secret, is_dev_mode
 from weatherbrief.api.flights import router as flights_router
 from weatherbrief.api.packs import router as packs_router
 from weatherbrief.api.preferences import router as preferences_router
+from weatherbrief.api.profiles import router as profiles_router
 from weatherbrief.api.admin import router as admin_router
 from weatherbrief.api.models import router as models_router
 from weatherbrief.api.usage import router as usage_router
@@ -80,6 +81,7 @@ def create_app() -> FastAPI:
     app.include_router(flights_router, prefix="/api")
     app.include_router(packs_router, prefix="/api")
     app.include_router(preferences_router, prefix="/api")
+    app.include_router(profiles_router, prefix="/api")
     app.include_router(usage_router, prefix="/api")
     app.include_router(admin_router, prefix="/api")
     app.include_router(models_router, prefix="/api")

--- a/src/weatherbrief/api/flights.py
+++ b/src/weatherbrief/api/flights.py
@@ -39,6 +39,7 @@ class CreateFlightRequest(BaseModel):
     cruise_altitude_ft: int | None = None
     flight_ceiling_ft: int | None = None
     flight_duration_hours: float | None = None
+    profile_id: int | None = None  # flight profile to associate
 
     @field_validator("target_date")
     @classmethod
@@ -72,6 +73,7 @@ class FlightResponse(BaseModel):
 
     id: str
     user_id: str
+    profile_id: int | None = None
     route_name: str
     waypoints: list[str] = []
     target_date: str
@@ -86,6 +88,7 @@ def _flight_to_response(flight: Flight) -> FlightResponse:
     return FlightResponse(
         id=flight.id,
         user_id=flight.user_id,
+        profile_id=flight.profile_id,
         route_name=flight.route_name,
         waypoints=flight.waypoints,
         target_date=flight.target_date,
@@ -116,10 +119,10 @@ def create_flight(
 ):
     """Create a new flight.
 
-    Request fields that are None are filled from the user's saved preferences,
-    then from system defaults.
+    Request fields that are None are filled from the associated profile's
+    settings (or user's default profile), then from system defaults.
     """
-    from weatherbrief.api.preferences import load_user_defaults
+    from weatherbrief.api.profiles import load_profile_settings
 
     if not req.waypoints and not req.route_name:
         raise HTTPException(
@@ -141,18 +144,18 @@ def create_flight(
             except KeyError as exc:
                 raise HTTPException(status_code=422, detail=exc.args[0])
 
-    # Apply user defaults for any field left as None
-    defaults = load_user_defaults(db, user_id)
+    # Load defaults from the selected profile (or the user's default profile)
+    profile_settings = load_profile_settings(db, req.profile_id, user_id)
     target_time_utc = req.target_time_utc if req.target_time_utc is not None else 9
     cruise_altitude_ft = (
         req.cruise_altitude_ft
         if req.cruise_altitude_ft is not None
-        else (defaults.cruise_altitude_ft or 8000)
+        else (profile_settings.get("cruise_altitude_ft") or 8000)
     )
     flight_ceiling_ft = (
         req.flight_ceiling_ft
         if req.flight_ceiling_ft is not None
-        else (defaults.flight_ceiling_ft or 18000)
+        else (profile_settings.get("flight_ceiling_ft") or 18000)
     )
     flight_duration_hours = req.flight_duration_hours if req.flight_duration_hours is not None else 0.0
 
@@ -184,6 +187,7 @@ def create_flight(
     flight = Flight(
         id=flight_id,
         user_id=user_id,
+        profile_id=req.profile_id,
         route_name=route_name,
         waypoints=waypoints,
         target_date=req.target_date,

--- a/src/weatherbrief/api/packs.py
+++ b/src/weatherbrief/api/packs.py
@@ -213,31 +213,29 @@ def _prepare_refresh(flight, db_path, user_id, flight_id, db=None, *, is_privile
     pack_path = pack_dir_for(user_id, flight_id, fetch_ts)
     pack_path.mkdir(parents=True, exist_ok=True)
 
-    # Load user preferences for models and autorouter credentials
+    # Load settings from the flight's profile (falls back to user default profile)
     autorouter_creds = None
     models = None
     advisory_models = None
     do_gramet = True
     do_llm_digest = True
     if db is not None:
-        from weatherbrief.api.preferences import (
-            load_autorouter_credentials,
-            load_service_toggles,
-            load_user_defaults,
-        )
+        from weatherbrief.api.preferences import load_autorouter_credentials
+        from weatherbrief.api.profiles import load_profile_settings
 
         autorouter_creds = load_autorouter_credentials(db, user_id)
-        defaults = load_user_defaults(db, user_id)
-        if defaults.models:
+        profile_settings = load_profile_settings(db, flight.profile_id, user_id)
+
+        profile_models = profile_settings.get("models")
+        if profile_models:
             valid = {m.value for m in ModelSource}
-            models = [ModelSource(m) for m in defaults.models if m in valid]
+            models = [ModelSource(m) for m in profile_models if m in valid]
 
-        advisory_models = defaults.advisory_models  # may be None
+        advisory_models = profile_settings.get("advisory_models")  # may be None
 
-        # User-level service toggles
-        toggles = load_service_toggles(db, user_id)
-        do_gramet = toggles["gramet_enabled"]
-        do_llm_digest = toggles["llm_digest_enabled"]
+        # Service toggles from profile
+        do_gramet = profile_settings.get("gramet_enabled", True)
+        do_llm_digest = profile_settings.get("llm_digest_enabled", True)
 
     # Check rate limits before running the pipeline
     if db is not None:
@@ -834,19 +832,21 @@ def recalculate_advisories(
         for cs_item in cs_data.get("cross_sections", []):
             cross_sections.append(RouteCrossSection.model_validate(cs_item))
 
-    # Load user advisory preferences
-    from weatherbrief.api.preferences import load_advisory_prefs, load_user_defaults
+    # Load advisory preferences from the flight's profile
+    from weatherbrief.api.profiles import load_profile_settings
 
-    adv_prefs = load_advisory_prefs(db, user_id)
+    profile_settings = load_profile_settings(db, flight.profile_id, user_id)
+    adv_config = profile_settings.get("advisories", {})
+    enabled_map = adv_config.get("enabled")
     enabled_ids = None
-    if adv_prefs.enabled:
-        enabled_ids = {k for k, v in adv_prefs.enabled.items() if v}
-    user_params = adv_prefs.params or {}
+    if enabled_map:
+        enabled_ids = {k for k, v in enabled_map.items() if v}
+    user_params = adv_config.get("params") or {}
 
-    # Compute advisory model list (may be a subset of all fetched models)
-    defaults = load_user_defaults(db, user_id)
-    if defaults.advisory_models:
-        advisory_model_names = [m for m in defaults.advisory_models if m in manifest.models]
+    # Compute advisory model list from profile (may be a subset of all fetched models)
+    profile_adv_models = profile_settings.get("advisory_models")
+    if profile_adv_models:
+        advisory_model_names = [m for m in profile_adv_models if m in manifest.models]
     else:
         advisory_model_names = [m for m in manifest.models if m != "best_match"]
     if not advisory_model_names:

--- a/src/weatherbrief/api/profiles.py
+++ b/src/weatherbrief/api/profiles.py
@@ -1,0 +1,282 @@
+"""API endpoints for flight profile management."""
+
+from __future__ import annotations
+
+import json
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from weatherbrief.db.deps import current_user_id, get_db
+from weatherbrief.db.models import FlightProfileRow
+from weatherbrief.storage.flights import (
+    delete_profile,
+    ensure_default_profile,
+    list_profiles,
+    load_profile,
+    save_profile,
+    update_profile,
+)
+from weatherbrief.models import FlightProfile
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/user/profiles", tags=["profiles"])
+
+
+class ProfileSettings(BaseModel):
+    """Settings stored inside a profile."""
+
+    cruise_altitude_ft: int | None = None
+    flight_ceiling_ft: int | None = None
+    models: list[str] | None = None
+    advisory_models: list[str] | None = None
+    gramet_enabled: bool | None = None
+    llm_digest_enabled: bool | None = None
+    advisories: dict | None = None  # {enabled: {}, params: {}}
+
+
+class ProfileResponse(BaseModel):
+    """Profile data returned to the client."""
+
+    id: int
+    name: str
+    is_default: bool
+    settings: ProfileSettings
+    created_at: str
+    updated_at: str
+
+
+class CreateProfileRequest(BaseModel):
+    """Request to create a new profile."""
+
+    name: str
+    settings: ProfileSettings | None = None
+
+
+class UpdateProfileRequest(BaseModel):
+    """Request to update an existing profile."""
+
+    name: str | None = None
+    settings: ProfileSettings | None = None
+    is_default: bool | None = None
+
+
+class DuplicateProfileRequest(BaseModel):
+    """Request to duplicate a profile with a new name."""
+
+    name: str
+
+
+def _profile_to_response(profile: FlightProfile) -> ProfileResponse:
+    return ProfileResponse(
+        id=profile.id,
+        name=profile.name,
+        is_default=profile.is_default,
+        settings=ProfileSettings(**profile.settings),
+        created_at=profile.created_at.isoformat(),
+        updated_at=profile.updated_at.isoformat(),
+    )
+
+
+@router.get("", response_model=list[ProfileResponse])
+def list_user_profiles(
+    user_id: str = Depends(current_user_id),
+    db: Session = Depends(get_db),
+):
+    """List all profiles for the current user. Creates a default if none exist."""
+    ensure_default_profile(db, user_id)
+    profiles = list_profiles(db, user_id)
+    return [_profile_to_response(p) for p in profiles]
+
+
+@router.post("", response_model=ProfileResponse, status_code=201)
+def create_profile(
+    req: CreateProfileRequest,
+    user_id: str = Depends(current_user_id),
+    db: Session = Depends(get_db),
+):
+    """Create a new profile."""
+    if not req.name or not req.name.strip():
+        raise HTTPException(status_code=422, detail="Profile name is required")
+
+    # Check for duplicate names
+    existing = list_profiles(db, user_id)
+    if any(p.name.lower() == req.name.strip().lower() for p in existing):
+        raise HTTPException(status_code=409, detail=f"Profile '{req.name.strip()}' already exists")
+
+    settings = req.settings.model_dump(exclude_none=True) if req.settings else {}
+    from datetime import datetime, timezone
+
+    profile = FlightProfile(
+        id=0,  # will be assigned by DB
+        user_id=user_id,
+        name=req.name.strip(),
+        is_default=False,
+        settings=settings,
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+    )
+    saved = save_profile(db, profile, user_id)
+    return _profile_to_response(saved)
+
+
+@router.get("/{profile_id}", response_model=ProfileResponse)
+def get_profile(
+    profile_id: int,
+    user_id: str = Depends(current_user_id),
+    db: Session = Depends(get_db),
+):
+    """Get a specific profile."""
+    profile = _load_owned_profile(db, profile_id, user_id)
+    return _profile_to_response(profile)
+
+
+@router.put("/{profile_id}", response_model=ProfileResponse)
+def update_user_profile(
+    profile_id: int,
+    req: UpdateProfileRequest,
+    user_id: str = Depends(current_user_id),
+    db: Session = Depends(get_db),
+):
+    """Update an existing profile."""
+    profile = _load_owned_profile(db, profile_id, user_id)
+
+    kwargs: dict = {}
+    if req.name is not None:
+        name = req.name.strip()
+        if not name:
+            raise HTTPException(status_code=422, detail="Profile name cannot be empty")
+        # Check for duplicate names (excluding this profile)
+        existing = list_profiles(db, user_id)
+        if any(p.name.lower() == name.lower() and p.id != profile_id for p in existing):
+            raise HTTPException(status_code=409, detail=f"Profile '{name}' already exists")
+        kwargs["name"] = name
+
+    if req.settings is not None:
+        # Merge new settings with existing
+        current_settings = profile.settings.copy()
+        new_settings = req.settings.model_dump(exclude_none=True)
+        current_settings.update(new_settings)
+        kwargs["settings"] = current_settings
+
+    if req.is_default is True:
+        # Clear default flag from all other profiles
+        from sqlalchemy import select, update as sql_update
+
+        db.execute(
+            sql_update(FlightProfileRow)
+            .where(FlightProfileRow.user_id == user_id)
+            .values(is_default=False)
+        )
+        kwargs["is_default"] = True
+
+    if kwargs:
+        updated = update_profile(db, profile_id, **kwargs)
+        return _profile_to_response(updated)
+    return _profile_to_response(profile)
+
+
+@router.delete("/{profile_id}", status_code=204)
+def delete_user_profile(
+    profile_id: int,
+    user_id: str = Depends(current_user_id),
+    db: Session = Depends(get_db),
+):
+    """Delete a profile. Cannot delete the default profile."""
+    profile = _load_owned_profile(db, profile_id, user_id)
+    if profile.is_default:
+        raise HTTPException(status_code=400, detail="Cannot delete the default profile")
+    try:
+        delete_profile(db, profile_id)
+    except KeyError:
+        raise HTTPException(status_code=404, detail="Profile not found")
+
+
+@router.post("/{profile_id}/duplicate", response_model=ProfileResponse, status_code=201)
+def duplicate_profile(
+    profile_id: int,
+    req: DuplicateProfileRequest,
+    user_id: str = Depends(current_user_id),
+    db: Session = Depends(get_db),
+):
+    """Duplicate an existing profile with a new name."""
+    source = _load_owned_profile(db, profile_id, user_id)
+
+    name = req.name.strip()
+    if not name:
+        raise HTTPException(status_code=422, detail="Profile name is required")
+
+    # Check for duplicate names
+    existing = list_profiles(db, user_id)
+    if any(p.name.lower() == name.lower() for p in existing):
+        raise HTTPException(status_code=409, detail=f"Profile '{name}' already exists")
+
+    from datetime import datetime, timezone
+
+    new_profile = FlightProfile(
+        id=0,
+        user_id=user_id,
+        name=name,
+        is_default=False,
+        settings=source.settings.copy(),
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+    )
+    saved = save_profile(db, new_profile, user_id)
+    return _profile_to_response(saved)
+
+
+def _load_owned_profile(db: Session, profile_id: int, user_id: str) -> FlightProfile:
+    """Load a profile, verifying ownership."""
+    try:
+        profile = load_profile(db, profile_id)
+    except KeyError:
+        raise HTTPException(status_code=404, detail="Profile not found")
+    if profile.user_id != user_id:
+        raise HTTPException(status_code=404, detail="Profile not found")
+    return profile
+
+
+def load_profile_settings(db: Session, profile_id: int | None, user_id: str) -> dict:
+    """Load profile settings for use by the pipeline.
+
+    Falls back to empty dict if profile_id is None or not found.
+    """
+    if profile_id is None:
+        # Try the user's default profile
+        profile = _get_default_profile(db, user_id)
+        if profile:
+            return profile.settings
+        return {}
+    try:
+        profile = load_profile(db, profile_id)
+        if profile.user_id == user_id:
+            return profile.settings
+    except KeyError:
+        pass
+    return {}
+
+
+def _get_default_profile(db: Session, user_id: str) -> FlightProfile | None:
+    """Get the user's default profile, or None."""
+    from sqlalchemy import select
+
+    stmt = (
+        select(FlightProfileRow)
+        .where(FlightProfileRow.user_id == user_id, FlightProfileRow.is_default.is_(True))
+    )
+    row = db.execute(stmt).scalar_one_or_none()
+    if row:
+        return FlightProfile(
+            id=row.id,
+            user_id=row.user_id,
+            name=row.name,
+            is_default=row.is_default,
+            settings=json.loads(row.settings_json) if row.settings_json else {},
+            created_at=row.created_at,
+            updated_at=row.updated_at,
+        )
+    return None

--- a/src/weatherbrief/db/models.py
+++ b/src/weatherbrief/db/models.py
@@ -31,6 +31,9 @@ class UserRow(Base):
     preferences: Mapped[UserPreferencesRow | None] = relationship(
         back_populates="user", uselist=False, cascade="all, delete-orphan"
     )
+    profiles: Mapped[list[FlightProfileRow]] = relationship(
+        back_populates="user", cascade="all, delete-orphan"
+    )
     flights: Mapped[list[FlightRow]] = relationship(
         back_populates="user", cascade="all, delete-orphan"
     )
@@ -52,12 +55,38 @@ class UserPreferencesRow(Base):
     user: Mapped[UserRow] = relationship(back_populates="preferences")
 
 
+class FlightProfileRow(Base):
+    __tablename__ = "flight_profiles"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    user_id: Mapped[str] = mapped_column(
+        String(64), ForeignKey("users.id", ondelete="CASCADE"), index=True
+    )
+    name: Mapped[str] = mapped_column(String(100), default="Default")
+    is_default: Mapped[bool] = mapped_column(Boolean, default=False)
+    settings_json: Mapped[str] = mapped_column(Text, default="{}")
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+    )
+
+    user: Mapped[UserRow] = relationship(back_populates="profiles")
+    flights: Mapped[list[FlightRow]] = relationship(back_populates="profile")
+
+
 class FlightRow(Base):
     __tablename__ = "flights"
 
     id: Mapped[str] = mapped_column(String(256), primary_key=True)
     user_id: Mapped[str] = mapped_column(
         String(64), ForeignKey("users.id", ondelete="CASCADE"), index=True
+    )
+    profile_id: Mapped[int | None] = mapped_column(
+        Integer, ForeignKey("flight_profiles.id", ondelete="SET NULL"), nullable=True
     )
     route_name: Mapped[str] = mapped_column(String(256), default="")
     waypoints_json: Mapped[str] = mapped_column(Text, default="[]")
@@ -71,6 +100,7 @@ class FlightRow(Base):
     )
 
     user: Mapped[UserRow] = relationship(back_populates="flights")
+    profile: Mapped[FlightProfileRow | None] = relationship(back_populates="flights")
     packs: Mapped[list[BriefingPackRow]] = relationship(
         back_populates="flight", cascade="all, delete-orphan"
     )

--- a/src/weatherbrief/models/__init__.py
+++ b/src/weatherbrief/models/__init__.py
@@ -67,4 +67,5 @@ from weatherbrief.models.airport_conditions import (  # noqa: F401
 from weatherbrief.models.storage import (  # noqa: F401
     BriefingPackMeta,
     Flight,
+    FlightProfile,
 )

--- a/src/weatherbrief/models/storage.py
+++ b/src/weatherbrief/models/storage.py
@@ -1,4 +1,4 @@
-"""Pydantic v2 models for flights and briefing packs (API/storage layer)."""
+"""Pydantic v2 models for flights, briefing packs, and flight profiles (API/storage layer)."""
 
 from __future__ import annotations
 
@@ -8,11 +8,24 @@ from typing import Optional
 from pydantic import BaseModel, Field
 
 
+class FlightProfile(BaseModel):
+    """A named set of flight parameters and advisory settings."""
+
+    id: int
+    user_id: str = ""
+    name: str = "Default"
+    is_default: bool = False
+    settings: dict = Field(default_factory=dict)
+    created_at: datetime
+    updated_at: datetime
+
+
 class Flight(BaseModel):
     """A saved briefing target — route + date/time specifics."""
 
     id: str  # slug: "{route_name}-{target_date}"
     user_id: str = ""  # owner; empty in single-user / dev mode
+    profile_id: int | None = None  # associated flight profile
     route_name: str  # user-assigned name or derived from waypoints
     waypoints: list[str] = Field(default_factory=list)  # ICAO codes
     target_date: str  # YYYY-MM-DD

--- a/src/weatherbrief/storage/flights.py
+++ b/src/weatherbrief/storage/flights.py
@@ -10,8 +10,8 @@ from pathlib import Path
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from weatherbrief.db.models import BriefingPackRow, FlightRow
-from weatherbrief.models import BriefingPackMeta, Flight
+from weatherbrief.db.models import BriefingPackRow, FlightProfileRow, FlightRow
+from weatherbrief.models import BriefingPackMeta, Flight, FlightProfile
 
 
 def _data_dir() -> Path:
@@ -25,6 +25,7 @@ def _flight_to_row(flight: Flight, user_id: str) -> FlightRow:
     return FlightRow(
         id=flight.id,
         user_id=user_id,
+        profile_id=flight.profile_id,
         route_name=flight.route_name,
         waypoints_json=json.dumps(flight.waypoints),
         target_date=flight.target_date,
@@ -40,6 +41,7 @@ def _row_to_flight(row: FlightRow) -> Flight:
     return Flight(
         id=row.id,
         user_id=row.user_id,
+        profile_id=row.profile_id,
         route_name=row.route_name,
         waypoints=json.loads(row.waypoints_json),
         target_date=row.target_date,
@@ -48,6 +50,27 @@ def _row_to_flight(row: FlightRow) -> Flight:
         flight_ceiling_ft=row.flight_ceiling_ft,
         flight_duration_hours=row.flight_duration_hours,
         created_at=row.created_at,
+    )
+
+
+def _profile_to_row(profile: FlightProfile, user_id: str) -> FlightProfileRow:
+    return FlightProfileRow(
+        user_id=user_id,
+        name=profile.name,
+        is_default=profile.is_default,
+        settings_json=json.dumps(profile.settings),
+    )
+
+
+def _row_to_profile(row: FlightProfileRow) -> FlightProfile:
+    return FlightProfile(
+        id=row.id,
+        user_id=row.user_id,
+        name=row.name,
+        is_default=row.is_default,
+        settings=json.loads(row.settings_json) if row.settings_json else {},
+        created_at=row.created_at,
+        updated_at=row.updated_at,
     )
 
 
@@ -90,6 +113,7 @@ def save_flight(session: Session, flight: Flight, user_id: str) -> None:
     existing = session.get(FlightRow, flight.id)
     if existing:
         existing.route_name = flight.route_name
+        existing.profile_id = flight.profile_id
         existing.waypoints_json = json.dumps(flight.waypoints)
         existing.target_date = flight.target_date
         existing.target_time_utc = flight.target_time_utc
@@ -167,6 +191,110 @@ def list_packs(session: Session, flight_id: str) -> list[BriefingPackMeta]:
     )
     rows = session.execute(stmt).scalars().all()
     return [_row_to_meta(r) for r in rows]
+
+
+# --- FlightProfile CRUD ---
+
+
+def list_profiles(session: Session, user_id: str) -> list[FlightProfile]:
+    """List all profiles for a user, default first then by name."""
+    stmt = (
+        select(FlightProfileRow)
+        .where(FlightProfileRow.user_id == user_id)
+        .order_by(FlightProfileRow.is_default.desc(), FlightProfileRow.name)
+    )
+    rows = session.execute(stmt).scalars().all()
+    return [_row_to_profile(r) for r in rows]
+
+
+def load_profile(session: Session, profile_id: int) -> FlightProfile:
+    """Load a profile by ID. Raises KeyError if not found."""
+    row = session.get(FlightProfileRow, profile_id)
+    if row is None:
+        raise KeyError(f"Profile not found: {profile_id}")
+    return _row_to_profile(row)
+
+
+def save_profile(session: Session, profile: FlightProfile, user_id: str) -> FlightProfile:
+    """Insert a new profile. Returns the profile with its generated ID."""
+    row = FlightProfileRow(
+        user_id=user_id,
+        name=profile.name,
+        is_default=profile.is_default,
+        settings_json=json.dumps(profile.settings),
+    )
+    session.add(row)
+    session.flush()
+    return _row_to_profile(row)
+
+
+def update_profile(session: Session, profile_id: int, **kwargs) -> FlightProfile:
+    """Update profile fields. Raises KeyError if not found."""
+    row = session.get(FlightProfileRow, profile_id)
+    if row is None:
+        raise KeyError(f"Profile not found: {profile_id}")
+    if "name" in kwargs:
+        row.name = kwargs["name"]
+    if "is_default" in kwargs:
+        row.is_default = kwargs["is_default"]
+    if "settings" in kwargs:
+        row.settings_json = json.dumps(kwargs["settings"])
+    session.flush()
+    return _row_to_profile(row)
+
+
+def delete_profile(session: Session, profile_id: int) -> None:
+    """Delete a profile. Raises KeyError if not found."""
+    row = session.get(FlightProfileRow, profile_id)
+    if row is None:
+        raise KeyError(f"Profile not found: {profile_id}")
+    session.delete(row)
+    session.flush()
+
+
+def ensure_default_profile(session: Session, user_id: str) -> FlightProfile:
+    """Ensure a default profile exists for a user, creating one if needed.
+
+    If the user has existing preferences in defaults_json, migrates them
+    to the default profile's settings.
+    """
+    from weatherbrief.db.models import UserPreferencesRow
+
+    stmt = (
+        select(FlightProfileRow)
+        .where(FlightProfileRow.user_id == user_id, FlightProfileRow.is_default.is_(True))
+    )
+    row = session.execute(stmt).scalar_one_or_none()
+    if row is not None:
+        return _row_to_profile(row)
+
+    # Migrate existing preferences if available
+    settings: dict = {}
+    prefs_row = session.get(UserPreferencesRow, user_id)
+    if prefs_row and prefs_row.defaults_json:
+        try:
+            data = json.loads(prefs_row.defaults_json)
+            # Extract profile-relevant fields
+            for key in (
+                "cruise_altitude_ft", "flight_ceiling_ft",
+                "models", "advisory_models",
+                "gramet_enabled", "llm_digest_enabled",
+                "advisories",
+            ):
+                if key in data:
+                    settings[key] = data[key]
+        except json.JSONDecodeError:
+            pass
+
+    new_row = FlightProfileRow(
+        user_id=user_id,
+        name="Default",
+        is_default=True,
+        settings_json=json.dumps(settings),
+    )
+    session.add(new_row)
+    session.flush()
+    return _row_to_profile(new_row)
 
 
 def safe_path_component(value: str) -> str:

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -1047,6 +1047,44 @@ label {
   display: block;
 }
 
+/* --- Profile section --- */
+
+.profile-section {
+  padding-bottom: 0.5rem;
+}
+
+.profile-controls {
+  align-items: flex-end;
+}
+
+.profile-actions {
+  flex-shrink: 0;
+}
+
+.profile-actions .btn-group {
+  display: flex;
+  gap: 0.35rem;
+}
+
+.input-select {
+  padding: 0.35rem 0.5rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  font-size: 0.9rem;
+  background: var(--surface);
+  color: var(--text);
+}
+
+#profile-select {
+  padding: 0.35rem 0.5rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  font-size: 0.9rem;
+  background: var(--surface);
+  color: var(--text);
+  min-width: 180px;
+}
+
 /* --- Advisory settings --- */
 
 .advisory-category {

--- a/web/index.html
+++ b/web/index.html
@@ -31,6 +31,10 @@
         </div>
         <div class="form-row">
           <div class="form-group">
+            <label for="input-profile">Profile</label>
+            <select id="input-profile" style="width:140px"></select>
+          </div>
+          <div class="form-group">
             <label for="input-date">Date</label>
             <input type="date" id="input-date" required>
           </div>

--- a/web/settings.html
+++ b/web/settings.html
@@ -26,30 +26,11 @@
 
       <!-- Tab navigation -->
       <div class="settings-tabs">
-        <button type="button" class="tab-btn active" data-tab="services">Services</button>
-        <button type="button" class="tab-btn" data-tab="flight">Flight Parameters</button>
+        <button type="button" class="tab-btn" data-tab="flight">Flight Profiles</button>
+        <button type="button" class="tab-btn active" data-tab="services">Account</button>
       </div>
       <!-- Services tab -->
       <div id="tab-services" class="tab-panel active">
-        <div class="section">
-          <h3>Forecast Models</h3>
-          <p class="muted section-hint">Select which NWP models to use for briefings.</p>
-          <div id="model-checkboxes" class="form-row model-checkboxes"></div>
-        </div>
-
-        <div class="section">
-          <h3>Optional Services</h3>
-          <p class="muted section-hint">Toggle optional services on or off. Disabled services are skipped during refresh.</p>
-          <div class="form-row model-checkboxes">
-            <label class="checkbox-label">
-              <input type="checkbox" id="toggle-gramet" checked> GRAMET cross-section
-            </label>
-            <label class="checkbox-label">
-              <input type="checkbox" id="toggle-llm-digest" checked> AI weather synopsis
-            </label>
-          </div>
-        </div>
-
         <div class="section">
           <h3>Autorouter (GRAMET) Credentials</h3>
           <p class="muted section-hint">
@@ -88,9 +69,30 @@
 
       <!-- Flight Parameters tab -->
       <div id="tab-flight" class="tab-panel">
+        <!-- Profile selector -->
+        <div class="section profile-section">
+          <h3>Flight Profiles</h3>
+          <p class="muted section-hint">Create profiles for different aircraft or flight types (e.g., VFR, IFR). Each profile has its own parameters and advisory settings.</p>
+          <div class="form-row profile-controls">
+            <div class="form-group grow">
+              <label for="profile-select">Active Profile</label>
+              <select id="profile-select" class="input-select"></select>
+            </div>
+            <div class="form-group profile-actions">
+              <label>&nbsp;</label>
+              <div class="btn-group">
+                <button type="button" id="btn-new-profile" class="btn btn-secondary btn-sm">New</button>
+                <button type="button" id="btn-duplicate-profile" class="btn btn-secondary btn-sm">Duplicate</button>
+                <button type="button" id="btn-rename-profile" class="btn btn-secondary btn-sm">Rename</button>
+                <button type="button" id="btn-delete-profile" class="btn btn-danger btn-sm">Delete</button>
+              </div>
+            </div>
+          </div>
+        </div>
+
         <div class="section">
           <h3>Flight Defaults</h3>
-          <p class="muted section-hint">Default values when creating new flights.</p>
+          <p class="muted section-hint">Default values when creating new flights with this profile.</p>
           <div class="form-row">
             <div class="form-group">
               <label for="input-altitude">Cruise Altitude (ft)</label>
@@ -99,6 +101,23 @@
             <div class="form-group">
               <label for="input-ceiling">Flight Ceiling (ft)</label>
               <input type="number" id="input-ceiling" value="18000" min="1000" max="45000" step="500" class="input-narrow">
+            </div>
+          </div>
+        </div>
+
+        <div class="section">
+          <h3>Forecast Models</h3>
+          <p class="muted section-hint">Select which NWP models to use for briefings with this profile.</p>
+          <div id="model-checkboxes" class="form-row model-checkboxes"></div>
+          <div class="subsection">
+            <h4 class="subsection-heading">Optional Services</h4>
+            <div class="form-row model-checkboxes">
+              <label class="checkbox-label">
+                <input type="checkbox" id="toggle-gramet" checked> GRAMET cross-section
+              </label>
+              <label class="checkbox-label">
+                <input type="checkbox" id="toggle-llm-digest" checked> AI weather synopsis
+              </label>
             </div>
           </div>
         </div>

--- a/web/ts/adapters/profiles-adapter.ts
+++ b/web/ts/adapters/profiles-adapter.ts
@@ -1,0 +1,55 @@
+/** Profiles adapter — CRUD for flight profiles. */
+
+import { apiFetch } from '../utils';
+import type { AdvisoryPreferences } from './preferences-adapter';
+
+export interface ProfileSettings {
+  cruise_altitude_ft: number | null;
+  flight_ceiling_ft: number | null;
+  models: string[] | null;
+  advisory_models: string[] | null;
+  gramet_enabled: boolean | null;
+  llm_digest_enabled: boolean | null;
+  advisories: AdvisoryPreferences | null;
+}
+
+export interface ProfileResponse {
+  id: number;
+  name: string;
+  is_default: boolean;
+  settings: ProfileSettings;
+  created_at: string;
+  updated_at: string;
+}
+
+export async function fetchProfiles(): Promise<ProfileResponse[]> {
+  return apiFetch<ProfileResponse[]>('/user/profiles');
+}
+
+export async function createProfile(name: string, settings?: Partial<ProfileSettings>): Promise<ProfileResponse> {
+  return apiFetch<ProfileResponse>('/user/profiles', {
+    method: 'POST',
+    body: JSON.stringify({ name, settings }),
+  });
+}
+
+export async function updateProfile(
+  id: number,
+  update: { name?: string; settings?: Partial<ProfileSettings>; is_default?: boolean },
+): Promise<ProfileResponse> {
+  return apiFetch<ProfileResponse>(`/user/profiles/${id}`, {
+    method: 'PUT',
+    body: JSON.stringify(update),
+  });
+}
+
+export async function deleteProfile(id: number): Promise<void> {
+  return apiFetch<void>(`/user/profiles/${id}`, { method: 'DELETE' });
+}
+
+export async function duplicateProfile(id: number, name: string): Promise<ProfileResponse> {
+  return apiFetch<ProfileResponse>(`/user/profiles/${id}/duplicate`, {
+    method: 'POST',
+    body: JSON.stringify({ name }),
+  });
+}

--- a/web/ts/flights-main.ts
+++ b/web/ts/flights-main.ts
@@ -1,9 +1,12 @@
 /** Flights page entry point — wires store, UI manager, and event handlers. */
 
 import { fetchCurrentUser } from './adapters/auth-adapter';
+import { fetchProfiles, type ProfileResponse } from './adapters/profiles-adapter';
 import { flightsStore } from './store/flights-store';
 import * as ui from './managers/flights-ui';
 import { renderUserInfo } from './utils';
+
+let loadedProfiles: ProfileResponse[] = [];
 
 async function init(): Promise<void> {
   // Auth check — redirect to login if not authenticated
@@ -34,6 +37,14 @@ async function init(): Promise<void> {
     }
   });
 
+  // --- Load profiles for the selector ---
+  try {
+    loadedProfiles = await fetchProfiles();
+    populateProfileSelector(loadedProfiles);
+  } catch {
+    // Profile selector stays empty; flights still work without it
+  }
+
   // --- Wire create flight form ---
   const form = document.getElementById('create-flight-form') as HTMLFormElement;
   if (form) {
@@ -46,6 +57,8 @@ async function init(): Promise<void> {
       const altitude = parseInt((document.getElementById('input-altitude') as HTMLInputElement).value || '8000', 10);
       const ceiling = parseInt((document.getElementById('input-ceiling') as HTMLInputElement).value || '18000', 10);
       const duration = parseFloat((document.getElementById('input-duration') as HTMLInputElement).value || '0');
+      const profileSelect = document.getElementById('input-profile') as HTMLSelectElement;
+      const profileId = profileSelect?.value ? parseInt(profileSelect.value, 10) : undefined;
 
       const waypoints = wpRaw.split(/[\s,]+/).filter(Boolean).map((w) => w.toUpperCase());
       if (!targetDate) {
@@ -70,6 +83,7 @@ async function init(): Promise<void> {
           cruiseAltitudeFt: altitude,
           flightCeilingFt: ceiling,
           flightDurationHours: duration,
+          profileId: !isNaN(profileId!) ? profileId : undefined,
         });
         // Navigate to briefing page for the new flight
         navigateToBriefing(flight.id);
@@ -79,8 +93,49 @@ async function init(): Promise<void> {
     });
   }
 
+  // Update altitude/ceiling defaults when profile changes
+  const profileSelect = document.getElementById('input-profile') as HTMLSelectElement;
+  profileSelect?.addEventListener('change', () => {
+    const id = parseInt(profileSelect.value, 10);
+    const profile = loadedProfiles.find(p => p.id === id);
+    if (profile?.settings) {
+      const altInput = document.getElementById('input-altitude') as HTMLInputElement;
+      const ceilInput = document.getElementById('input-ceiling') as HTMLInputElement;
+      if (altInput && profile.settings.cruise_altitude_ft != null) {
+        altInput.value = String(profile.settings.cruise_altitude_ft);
+      }
+      if (ceilInput && profile.settings.flight_ceiling_ft != null) {
+        ceilInput.value = String(profile.settings.flight_ceiling_ft);
+      }
+    }
+  });
+
   // --- Initial load ---
   store.getState().loadFlights();
+}
+
+function populateProfileSelector(profiles: ProfileResponse[]): void {
+  const select = document.getElementById('input-profile') as HTMLSelectElement;
+  if (!select) return;
+
+  select.innerHTML = profiles.map(p => {
+    const defaultTag = p.is_default ? ' (default)' : '';
+    const selected = p.is_default ? ' selected' : '';
+    return `<option value="${p.id}"${selected}>${p.name}${defaultTag}</option>`;
+  }).join('');
+
+  // Apply default profile's altitude/ceiling values
+  const defaultProfile = profiles.find(p => p.is_default) || profiles[0];
+  if (defaultProfile?.settings) {
+    const altInput = document.getElementById('input-altitude') as HTMLInputElement;
+    const ceilInput = document.getElementById('input-ceiling') as HTMLInputElement;
+    if (altInput && defaultProfile.settings.cruise_altitude_ft != null) {
+      altInput.value = String(defaultProfile.settings.cruise_altitude_ft);
+    }
+    if (ceilInput && defaultProfile.settings.flight_ceiling_ft != null) {
+      ceilInput.value = String(defaultProfile.settings.flight_ceiling_ft);
+    }
+  }
 }
 
 function navigateToBriefing(flightId: string): void {

--- a/web/ts/settings-main.ts
+++ b/web/ts/settings-main.ts
@@ -1,4 +1,4 @@
-/** Settings page entry point — tabbed preferences with advisory configuration. */
+/** Settings page entry point — tabbed preferences with profile-based advisory configuration. */
 
 import { fetchCurrentUser } from './adapters/auth-adapter';
 import { renderUserInfo, STATUS_DISMISS_MS, initModelCatalog, allModelKeys, defaultModelKeys, modelLabel } from './utils';
@@ -15,6 +15,15 @@ import {
   type AdvisoryParameterDef,
   type UsageSummary,
 } from './adapters/preferences-adapter';
+import {
+  fetchProfiles,
+  createProfile,
+  updateProfile,
+  deleteProfile,
+  duplicateProfile,
+  type ProfileResponse,
+  type ProfileSettings,
+} from './adapters/profiles-adapter';
 
 /** Category display order and labels.
  *  Any categories not listed here will appear at the end under their raw key. */
@@ -28,6 +37,8 @@ const CATEGORY_ORDER: [string, string][] = [
 ];
 
 let catalog: AdvisoryCatalogEntry[] = [];
+let profiles: ProfileResponse[] = [];
+let activeProfileId: number | null = null;
 
 /** Default advisory models: all default briefing models except best_match. */
 function defaultAdvisoryModelKeys(): string[] {
@@ -45,10 +56,10 @@ function getSelectedBriefingModels(): string[] {
 }
 
 /** Generate model checkboxes from the model catalog. */
-function renderModelCheckboxes(): void {
+function renderModelCheckboxes(selectedModels?: string[]): void {
   const container = document.getElementById('model-checkboxes');
   if (!container) return;
-  const defaults = defaultModelKeys();
+  const defaults = selectedModels || defaultModelKeys();
   container.innerHTML = allModelKeys().map(m => {
     const label = modelLabel(m);
     const checked = defaults.includes(m) ? ' checked' : '';
@@ -92,6 +103,138 @@ function renderAdvisoryModelCheckboxes(
   }).join('');
 }
 
+// --- Profile management ---
+
+function renderProfileSelector(): void {
+  const select = document.getElementById('profile-select') as HTMLSelectElement;
+  if (!select) return;
+
+  select.innerHTML = profiles.map(p => {
+    const defaultTag = p.is_default ? ' (default)' : '';
+    return `<option value="${p.id}"${p.id === activeProfileId ? ' selected' : ''}>${p.name}${defaultTag}</option>`;
+  }).join('');
+
+  // Update delete button state
+  const deleteBtn = document.getElementById('btn-delete-profile') as HTMLButtonElement;
+  if (deleteBtn) {
+    const activeProfile = profiles.find(p => p.id === activeProfileId);
+    deleteBtn.disabled = !!activeProfile?.is_default;
+  }
+}
+
+function populateProfileForm(profile: ProfileResponse): void {
+  const s = profile.settings;
+
+  // Flight defaults
+  const altInput = document.getElementById('input-altitude') as HTMLInputElement;
+  const ceilInput = document.getElementById('input-ceiling') as HTMLInputElement;
+  if (altInput) altInput.value = String(s.cruise_altitude_ft ?? 8000);
+  if (ceilInput) ceilInput.value = String(s.flight_ceiling_ft ?? 18000);
+
+  // Models
+  const selectedModels = s.models || defaultModelKeys();
+  renderModelCheckboxes(selectedModels);
+
+  // Advisory model checkboxes
+  renderAdvisoryModelCheckboxes(selectedModels, s.advisory_models ?? undefined);
+
+  // Service toggles
+  const grametToggle = document.getElementById('toggle-gramet') as HTMLInputElement;
+  const llmToggle = document.getElementById('toggle-llm-digest') as HTMLInputElement;
+  if (grametToggle) grametToggle.checked = s.gramet_enabled ?? true;
+  if (llmToggle) llmToggle.checked = s.llm_digest_enabled ?? true;
+
+  // Advisories
+  const advPrefs: AdvisoryPreferences = s.advisories ?? { enabled: null, params: null };
+  renderAdvisorySettings(catalog, advPrefs);
+}
+
+function switchProfile(profileId: number): void {
+  activeProfileId = profileId;
+  renderProfileSelector();
+  const profile = profiles.find(p => p.id === profileId);
+  if (profile) {
+    populateProfileForm(profile);
+  }
+}
+
+async function handleNewProfile(): Promise<void> {
+  const name = prompt('Enter profile name:');
+  if (!name?.trim()) return;
+
+  try {
+    const newProfile = await createProfile(name.trim());
+    profiles.push(newProfile);
+    activeProfileId = newProfile.id;
+    renderProfileSelector();
+    populateProfileForm(newProfile);
+    showStatus(`Profile "${name.trim()}" created.`);
+  } catch (err) {
+    showStatus(`Failed to create profile: ${err}`, true);
+  }
+}
+
+async function handleDuplicateProfile(): Promise<void> {
+  if (!activeProfileId) return;
+  const source = profiles.find(p => p.id === activeProfileId);
+  const defaultName = source ? `${source.name} (copy)` : 'Copy';
+  const name = prompt('Enter name for the duplicate:', defaultName);
+  if (!name?.trim()) return;
+
+  try {
+    const dup = await duplicateProfile(activeProfileId, name.trim());
+    profiles.push(dup);
+    activeProfileId = dup.id;
+    renderProfileSelector();
+    populateProfileForm(dup);
+    showStatus(`Profile duplicated as "${name.trim()}".`);
+  } catch (err) {
+    showStatus(`Failed to duplicate profile: ${err}`, true);
+  }
+}
+
+async function handleRenameProfile(): Promise<void> {
+  if (!activeProfileId) return;
+  const current = profiles.find(p => p.id === activeProfileId);
+  const name = prompt('Enter new name:', current?.name);
+  if (!name?.trim() || name.trim() === current?.name) return;
+
+  try {
+    const updated = await updateProfile(activeProfileId, { name: name.trim() });
+    const idx = profiles.findIndex(p => p.id === activeProfileId);
+    if (idx >= 0) profiles[idx] = updated;
+    renderProfileSelector();
+    showStatus(`Profile renamed to "${name.trim()}".`);
+  } catch (err) {
+    showStatus(`Failed to rename profile: ${err}`, true);
+  }
+}
+
+async function handleDeleteProfile(): Promise<void> {
+  if (!activeProfileId) return;
+  const current = profiles.find(p => p.id === activeProfileId);
+  if (current?.is_default) {
+    showStatus('Cannot delete the default profile.', true);
+    return;
+  }
+  if (!confirm(`Delete profile "${current?.name}"?`)) return;
+
+  try {
+    await deleteProfile(activeProfileId);
+    profiles = profiles.filter(p => p.id !== activeProfileId);
+    // Switch to the default profile
+    const defaultProfile = profiles.find(p => p.is_default) || profiles[0];
+    if (defaultProfile) {
+      switchProfile(defaultProfile.id);
+    }
+    showStatus('Profile deleted.');
+  } catch (err) {
+    showStatus(`Failed to delete profile: ${err}`, true);
+  }
+}
+
+// --- Init ---
+
 async function init(): Promise<void> {
   const user = await fetchCurrentUser();
   if (!user) {
@@ -105,8 +248,12 @@ async function init(): Promise<void> {
     btn.addEventListener('click', () => switchTab(btn.dataset.tab!));
   }
 
-  // Load preferences, advisory catalog, and model catalog in parallel
-  const [prefs, catalogResult, modelCatalog] = await Promise.all([
+  // Load profiles, preferences, advisory catalog, and model catalog in parallel
+  const [profilesResult, prefs, catalogResult, modelCatalog] = await Promise.all([
+    fetchProfiles().catch(err => {
+      showStatus(`Failed to load profiles: ${err}`, true);
+      return [] as ProfileResponse[];
+    }),
     fetchPreferences().catch(err => {
       showStatus(`Failed to load preferences: ${err}`, true);
       return null;
@@ -122,18 +269,40 @@ async function init(): Promise<void> {
   ]);
 
   catalog = catalogResult;
+  profiles = profilesResult;
   initModelCatalog(modelCatalog);
-  renderModelCheckboxes();
 
-  if (prefs) {
-    populateForm(prefs);
+  // Set active profile to default
+  const defaultProfile = profiles.find(p => p.is_default) || profiles[0];
+  if (defaultProfile) {
+    activeProfileId = defaultProfile.id;
+    renderProfileSelector();
+    populateProfileForm(defaultProfile);
+  } else {
+    renderModelCheckboxes();
+    renderAdvisorySettings(catalog, { enabled: null, params: null });
   }
-  renderAdvisorySettings(catalog, prefs?.advisories ?? { enabled: null, params: null });
+
+  // Populate account-level settings
+  if (prefs) {
+    populateAccountForm(prefs);
+  }
 
   // Load usage (non-blocking)
   fetchUsageSummary()
     .then(renderUsage)
     .catch(() => { /* usage section stays hidden */ });
+
+  // Profile controls
+  const profileSelect = document.getElementById('profile-select') as HTMLSelectElement;
+  profileSelect?.addEventListener('change', () => {
+    const id = parseInt(profileSelect.value, 10);
+    if (!isNaN(id)) switchProfile(id);
+  });
+  document.getElementById('btn-new-profile')?.addEventListener('click', handleNewProfile);
+  document.getElementById('btn-duplicate-profile')?.addEventListener('click', handleDuplicateProfile);
+  document.getElementById('btn-rename-profile')?.addEventListener('click', handleRenameProfile);
+  document.getElementById('btn-delete-profile')?.addEventListener('click', handleDeleteProfile);
 
   // Save button
   const form = document.getElementById('settings-form') as HTMLFormElement;
@@ -166,32 +335,8 @@ function switchTab(tabId: string): void {
   }
 }
 
-function populateForm(prefs: PreferencesResponse): void {
-  const d = prefs.defaults;
-  if (d.cruise_altitude_ft != null) {
-    (document.getElementById('input-altitude') as HTMLInputElement).value = String(d.cruise_altitude_ft);
-  }
-  if (d.flight_ceiling_ft != null) {
-    (document.getElementById('input-ceiling') as HTMLInputElement).value = String(d.flight_ceiling_ft);
-  }
-
-  // Models checkboxes
-  const selectedModels = d.models || defaultModelKeys();
-  for (const m of allModelKeys()) {
-    const cb = document.getElementById(`model-${m}`) as HTMLInputElement;
-    if (cb) cb.checked = selectedModels.includes(m);
-  }
-
-  // Advisory model checkboxes (subset of selected briefing models)
-  renderAdvisoryModelCheckboxes(selectedModels, d.advisory_models ?? undefined);
-
+function populateAccountForm(prefs: PreferencesResponse): void {
   updateAutorouterStatus(prefs.has_autorouter_creds);
-
-  // Service toggles
-  const grametToggle = document.getElementById('toggle-gramet') as HTMLInputElement;
-  const llmToggle = document.getElementById('toggle-llm-digest') as HTMLInputElement;
-  if (grametToggle) grametToggle.checked = prefs.gramet_enabled;
-  if (llmToggle) llmToggle.checked = prefs.llm_digest_enabled;
 }
 
 // --- Advisory settings rendering ---
@@ -325,6 +470,7 @@ function collectAdvisoryPrefs(): AdvisoryPreferences {
 // --- Save ---
 
 async function handleSave(): Promise<void> {
+  // Collect profile settings from the form
   const altitude = parseInt((document.getElementById('input-altitude') as HTMLInputElement).value, 10);
   const ceiling = parseInt((document.getElementById('input-ceiling') as HTMLInputElement).value, 10);
 
@@ -338,7 +484,7 @@ async function handleSave(): Promise<void> {
     return;
   }
 
-  // Collect advisory models from checkboxes
+  // Collect advisory models
   const advisoryModels: string[] = [];
   const advContainer = document.getElementById('advisory-model-checkboxes');
   if (advContainer) {
@@ -347,34 +493,46 @@ async function handleSave(): Promise<void> {
     }
   }
 
+  const grametEnabled = (document.getElementById('toggle-gramet') as HTMLInputElement)?.checked ?? true;
+  const llmDigestEnabled = (document.getElementById('toggle-llm-digest') as HTMLInputElement)?.checked ?? true;
+  const advisories = collectAdvisoryPrefs();
+
+  // Build profile settings
+  const profileSettings: Partial<ProfileSettings> = {
+    cruise_altitude_ft: isNaN(altitude) ? null : altitude,
+    flight_ceiling_ft: isNaN(ceiling) ? null : ceiling,
+    models,
+    advisory_models: advisoryModels.length > 0 ? advisoryModels : null,
+    gramet_enabled: grametEnabled,
+    llm_digest_enabled: llmDigestEnabled,
+    advisories,
+  };
+
+  // Save autorouter creds (account-level)
   const arUsername = (document.getElementById('input-ar-username') as HTMLInputElement).value.trim();
   const arPassword = (document.getElementById('input-ar-password') as HTMLInputElement).value.trim();
 
-  const advisories = collectAdvisoryPrefs();
-
-  const grametEnabled = (document.getElementById('toggle-gramet') as HTMLInputElement)?.checked ?? true;
-  const llmDigestEnabled = (document.getElementById('toggle-llm-digest') as HTMLInputElement)?.checked ?? true;
-
   try {
-    const result = await savePreferences({
-      defaults: {
-        cruise_altitude_ft: isNaN(altitude) ? null : altitude,
-        flight_ceiling_ft: isNaN(ceiling) ? null : ceiling,
-        models,
-        advisory_models: advisoryModels.length > 0 ? advisoryModels : null,
-      },
-      advisories,
-      autorouter_username: arUsername || undefined,
-      autorouter_password: arPassword || undefined,
-      gramet_enabled: grametEnabled,
-      llm_digest_enabled: llmDigestEnabled,
-    });
-    updateAutorouterStatus(result.has_autorouter_creds);
-    // Clear password field after successful save
-    if (arPassword) {
-      (document.getElementById('input-ar-password') as HTMLInputElement).value = '';
+    // Save profile settings
+    if (activeProfileId) {
+      const updated = await updateProfile(activeProfileId, { settings: profileSettings });
+      const idx = profiles.findIndex(p => p.id === activeProfileId);
+      if (idx >= 0) profiles[idx] = updated;
     }
-    showStatus('Preferences saved.');
+
+    // Save account-level preferences (autorouter creds only)
+    if (arUsername || arPassword) {
+      const result = await savePreferences({
+        autorouter_username: arUsername || undefined,
+        autorouter_password: arPassword || undefined,
+      });
+      updateAutorouterStatus(result.has_autorouter_creds);
+      if (arPassword) {
+        (document.getElementById('input-ar-password') as HTMLInputElement).value = '';
+      }
+    }
+
+    showStatus('Settings saved.');
   } catch (err) {
     showStatus(`Failed to save: ${err}`, true);
   }

--- a/web/ts/store/flights-store.ts
+++ b/web/ts/store/flights-store.ts
@@ -21,6 +21,7 @@ export interface FlightsState {
     cruiseAltitudeFt?: number;
     flightCeilingFt?: number;
     flightDurationHours?: number;
+    profileId?: number;
   }) => Promise<FlightResponse>;
   deleteFlight: (id: string) => Promise<void>;
 }
@@ -65,6 +66,7 @@ export const flightsStore = createStore<FlightsState>((set, get) => ({
         cruise_altitude_ft: opts?.cruiseAltitudeFt,
         flight_ceiling_ft: opts?.flightCeilingFt,
         flight_duration_hours: opts?.flightDurationHours,
+        profile_id: opts?.profileId,
       });
       // Refresh the list
       await get().loadFlights();

--- a/web/ts/store/types.ts
+++ b/web/ts/store/types.ts
@@ -3,6 +3,7 @@
 export interface FlightResponse {
   id: string;
   user_id: string;
+  profile_id: number | null;
   route_name: string;
   waypoints: string[];
   target_date: string;
@@ -21,6 +22,7 @@ export interface CreateFlightRequest {
   cruise_altitude_ft?: number;
   flight_ceiling_ft?: number;
   flight_duration_hours?: number;
+  profile_id?: number;
 }
 
 export interface DataStatus {


### PR DESCRIPTION
Implement named flight profiles allowing users to maintain distinct sets
of flight parameters and advisory settings for different aircraft or
flight types (e.g., VFR, IFR).

Backend:
- New FlightProfileRow table with settings_json, is_default flag
- Add profile_id FK to flights table (nullable, SET NULL on delete)
- Profile CRUD API (list, create, update, delete, duplicate)
- Automatic default profile creation with migration from existing prefs
- Flights and packs APIs now load settings from the associated profile
- Advisory recalculation uses profile-specific advisory settings

Frontend:
- Profile selector and management (new/duplicate/rename/delete) on
  settings page under "Flight Profiles" tab
- Models, service toggles, and advisory settings moved into profiles
- Account tab retains autorouter credentials and usage
- Flight creation form includes profile selector dropdown
- Selecting a profile updates altitude/ceiling defaults in the form

Migration: Alembic 004 adds flight_profiles table and profile_id column.

https://claude.ai/code/session_01U6xkQF9jfpQtiofqFUEUha