### PR TITLE
feat: compact mode shows essential info only, rename toggle to Compact | Full Details

### DIFF
--- a/web/briefing.html
+++ b/web/briefing.html
@@ -25,7 +25,7 @@
       <button id="feedback-btn" class="btn btn-secondary">Feedback</button>
       <div class="display-mode-toggle" id="display-mode-toggle">
         <button class="btn-toggle" data-mode="compact">Compact</button>
-        <button class="btn-toggle active" data-mode="annotated">Annotated</button>
+        <button class="btn-toggle active" data-mode="full">Full Details</button>
       </div>
       <div class="toolbar-end-group">
         <select id="history-select">

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -1389,8 +1389,12 @@ label {
   border-color: var(--primary);
 }
 
-/* CSS-driven compact mode: hide annotations */
+/* CSS-driven compact mode: hide annotations and detail sections */
 .display-compact .metric-annotation-row {
+  display: none;
+}
+.display-compact [data-section="sounding"],
+.display-compact [data-section="comparison"] {
   display: none;
 }
 

--- a/web/ts/briefing-main.ts
+++ b/web/ts/briefing-main.ts
@@ -5,6 +5,7 @@ import { briefingStore, type BriefingState } from './store/briefing-store';
 import * as api from './adapters/api-adapter';
 import * as ui from './managers/briefing-ui';
 import { renderAdvisories } from './managers/advisories-ui';
+import type { DisplayMode } from './types/metrics';
 import { renderUserInfo, initModelCatalog, isFlightPast } from './utils';
 import { initInfoPopup, showMetricInfo } from './components/info-popup';
 import { CrossSectionRenderer } from './visualization/cross-section/renderer';
@@ -59,7 +60,7 @@ async function init(): Promise<void> {
   function applyDisplayModeClass(mode: string): void {
     const container = document.querySelector('.container');
     if (container) {
-      container.classList.remove('display-compact', 'display-annotated');
+      container.classList.remove('display-compact', 'display-full');
       container.classList.add(`display-${mode}`);
     }
   }
@@ -370,9 +371,9 @@ async function init(): Promise<void> {
       state.elevationProfile !== prev.elevationProfile
     ) {
       ui.renderAssessment(state.currentPack);
-      renderAdvisories(state.routeAdvisories, () => store.getState().recalculateAdvisories());
+      renderAdvisories(state.routeAdvisories, () => store.getState().recalculateAdvisories(), state.displayMode);
       ui.renderRouteObservations(state.snapshot, () => store.getState().refreshObservations());
-      ui.renderSynopsis(state.flight, state.currentPack, state.digest);
+      ui.renderSynopsis(state.flight, state.currentPack, state.digest, state.displayMode);
       ui.renderGramet(state.flight, state.currentPack);
       renderSliderSections(state);
       renderVisualization(state);
@@ -405,6 +406,10 @@ async function init(): Promise<void> {
       applyDisplayModeClass(state.displayMode);
       updateToggleButtons(state.displayMode);
       renderSliderSections(state);
+      if (state.displayMode !== prev.displayMode) {
+        renderAdvisories(state.routeAdvisories, () => store.getState().recalculateAdvisories(), state.displayMode);
+        ui.renderSynopsis(state.flight, state.currentPack, state.digest, state.displayMode);
+      }
     }
     if (state.selectedModel !== prev.selectedModel) {
       ui.renderSkewTs(state.flight, state.currentPack, state.snapshot, state.selectedModel, state.routeAnalyses, state.selectedPointIndex);
@@ -572,7 +577,7 @@ async function init(): Promise<void> {
     toggleContainer.addEventListener('click', (e) => {
       const btn = (e.target as HTMLElement).closest('.btn-toggle') as HTMLElement | null;
       if (btn && btn.dataset.mode) {
-        store.getState().setDisplayMode(btn.dataset.mode as 'compact' | 'annotated');
+        store.getState().setDisplayMode(btn.dataset.mode as DisplayMode);
       }
     });
   }
@@ -655,9 +660,9 @@ async function init(): Promise<void> {
     ui.renderHeader(s.flight, s.snapshot);
     ui.renderHistoryDropdown(s.packs, s.currentPack?.fetch_timestamp || null, (ts) => store.getState().selectPack(ts));
     ui.renderAssessment(s.currentPack);
-    renderAdvisories(s.routeAdvisories, () => store.getState().recalculateAdvisories());
+    renderAdvisories(s.routeAdvisories, () => store.getState().recalculateAdvisories(), s.displayMode);
     ui.renderRouteObservations(s.snapshot, () => store.getState().refreshObservations());
-    ui.renderSynopsis(s.flight, s.currentPack, s.digest);
+    ui.renderSynopsis(s.flight, s.currentPack, s.digest, s.displayMode);
     ui.renderGramet(s.flight, s.currentPack);
     renderSliderSections(s);
     renderVisualization(s);

--- a/web/ts/managers/advisories-ui.ts
+++ b/web/ts/managers/advisories-ui.ts
@@ -1,8 +1,12 @@
 /** Advisory dashboard renderer — compact grid of advisory cards with per-model badges. */
 
 import type { RouteAdvisoriesManifest, RouteAdvisoryResult, AdvisoryStatus, ModelAdvisoryResult, AdvisoryCatalogEntry, AdvisoryParameterDef, AirportConditions, AirportConditionsSummary, AirportModelCondition, FlightCategory, RunwayWind } from '../types/advisories';
+import type { DisplayMode } from '../types/metrics';
 import { showPopupContent } from '../components/info-popup';
 import { $, escapeHtml, modelLabel } from '../utils';
+
+/** Advisory categories hidden in compact mode (informational, not actionable). */
+const COMPACT_HIDDEN_CATEGORIES = new Set(['model']);
 
 const STATUS_ORDER: AdvisoryStatus[] = ['red', 'amber', 'green', 'unavailable'];
 
@@ -178,6 +182,7 @@ function renderAdvisoryCard(adv: RouteAdvisoryResult, catalog: Map<string, Advis
 export function renderAdvisories(
   manifest: RouteAdvisoriesManifest | null,
   onRecalculate?: () => void,
+  displayMode: DisplayMode = 'full',
 ): void {
   const el = $('advisories-section');
   const section = $('advisories-wrapper');
@@ -197,8 +202,16 @@ export function renderAdvisories(
     catalog.set(entry.id, entry);
   }
 
+  // In compact mode, filter out secondary advisories (e.g. model confidence)
+  const advisories = displayMode === 'compact'
+    ? manifest.advisories.filter(adv => {
+        const entry = catalog.get(adv.advisory_id);
+        return !entry || !COMPACT_HIDDEN_CATEGORIES.has(entry.category);
+      })
+    : manifest.advisories;
+
   // Sort: RED first, then AMBER, then GREEN, then UNAVAILABLE
-  const sorted = [...manifest.advisories].sort((a, b) => {
+  const sorted = [...advisories].sort((a, b) => {
     return STATUS_ORDER.indexOf(a.aggregate_status) - STATUS_ORDER.indexOf(b.aggregate_status);
   });
 

--- a/web/ts/managers/briefing-ui.ts
+++ b/web/ts/managers/briefing-ui.ts
@@ -534,10 +534,30 @@ const DIGEST_SECTIONS: Array<{ key: keyof WeatherDigest; label: string; icon: st
   { key: 'watch_items', label: 'Watch Items', icon: '\uD83D\uDC41\uFE0F' },
 ];
 
+/** Digest section keys shown in compact mode (synoptic overview + trend only). */
+const COMPACT_DIGEST_KEYS: Set<keyof WeatherDigest> = new Set(['synoptic', 'trend']);
+
+function renderDigestHtml(digest: WeatherDigest, displayMode: DisplayMode): string {
+  const sections = displayMode === 'compact'
+    ? DIGEST_SECTIONS.filter(s => COMPACT_DIGEST_KEYS.has(s.key))
+    : DIGEST_SECTIONS;
+  return sections.map(({ key, label, icon }) => {
+    const text = digest[key];
+    if (!text) return '';
+    return `
+      <div class="digest-section">
+        <h4>${icon} ${label}</h4>
+        <p>${escapeHtml(text as string)}</p>
+      </div>
+    `;
+  }).join('');
+}
+
 export function renderSynopsis(
   flight: FlightResponse | null,
   pack: PackMeta | null,
   digest: WeatherDigest | null,
+  displayMode: DisplayMode = 'full',
 ): void {
   const el = $('synopsis-section');
   if (!el) return;
@@ -548,22 +568,13 @@ export function renderSynopsis(
   }
 
   if (digest) {
-    el.innerHTML = DIGEST_SECTIONS.map(({ key, label, icon }) => {
-      const text = digest[key];
-      if (!text) return '';
-      return `
-        <div class="digest-section">
-          <h4>${icon} ${label}</h4>
-          <p>${escapeHtml(text as string)}</p>
-        </div>
-      `;
-    }).join('');
+    el.innerHTML = renderDigestHtml(digest, displayMode);
     return;
   }
 
   if (pack.has_digest) {
     el.innerHTML = '<p class="muted">Loading digest...</p>';
-    fetchAndRenderDigestJson(flight.id, pack.fetch_timestamp, el);
+    fetchAndRenderDigestJson(flight.id, pack.fetch_timestamp, el, displayMode);
     return;
   }
 
@@ -571,24 +582,14 @@ export function renderSynopsis(
 }
 
 async function fetchAndRenderDigestJson(
-  flightId: string, timestamp: string, el: HTMLElement,
+  flightId: string, timestamp: string, el: HTMLElement, displayMode: DisplayMode,
 ): Promise<void> {
   try {
     const url = api.digestJsonUrl(flightId, timestamp);
     const resp = await fetch(url);
     if (!resp.ok) throw new Error(`${resp.status}`);
     const digest: WeatherDigest = await resp.json();
-
-    el.innerHTML = DIGEST_SECTIONS.map(({ key, label, icon }) => {
-      const text = digest[key];
-      if (!text) return '';
-      return `
-        <div class="digest-section">
-          <h4>${icon} ${label}</h4>
-          <p>${escapeHtml(text as string)}</p>
-        </div>
-      `;
-    }).join('');
+    el.innerHTML = renderDigestHtml(digest, displayMode);
   } catch {
     el.innerHTML = '<p class="muted">Failed to load digest.</p>';
   }
@@ -640,7 +641,7 @@ export function renderModelComparison(
   snapshot: ForecastSnapshot | null,
   routeAnalyses?: RouteAnalysesManifest | null,
   selectedPointIndex?: number,
-  displayMode: DisplayMode = 'annotated',
+  displayMode: DisplayMode = 'full',
   tierVisibility: Record<Tier, boolean> = { key: true, useful: true, advanced: false },
 ): void {
   const el = $('comparison-section');
@@ -681,7 +682,7 @@ export function renderModelComparison(
 function renderComparisonTable(
   label: string,
   divergences: Array<{ variable: string; model_values: Record<string, number>; mean: number; spread: number; agreement: string }>,
-  displayMode: DisplayMode = 'annotated',
+  displayMode: DisplayMode = 'full',
   tierVisibility: Record<Tier, boolean> = { key: true, useful: true, advanced: false },
 ): string {
   const models = Object.keys(divergences[0]?.model_values || {});
@@ -705,7 +706,7 @@ function renderComparisonTable(
       : d.agreement === 'moderate' ? '&#9888;' : '&#10007;';
     const agreeClass = `agree-${d.agreement}`;
 
-    const infoBtn = metricId && displayMode === 'annotated'
+    const infoBtn = metricId && displayMode === 'full'
       ? ` ${renderInfoButton(metricId, d.mean)}`
       : '';
 
@@ -793,7 +794,7 @@ export function renderSoundingAnalysis(
   snapshot: ForecastSnapshot | null,
   routeAnalyses?: RouteAnalysesManifest | null,
   selectedPointIndex?: number,
-  displayMode: DisplayMode = 'annotated',
+  displayMode: DisplayMode = 'full',
   tierVisibility: Record<Tier, boolean> = { key: true, useful: true, advanced: false },
   enabledLayers?: Record<string, boolean>,
 ): void {
@@ -841,7 +842,7 @@ export function renderSoundingAnalysis(
 
 function renderConvectiveBanner(
   soundings: Record<string, SoundingAnalysis>,
-  displayMode: DisplayMode = 'annotated',
+  displayMode: DisplayMode = 'full',
   tierVisibility: Record<Tier, boolean> = { key: true, useful: true, advanced: false },
 ): string {
   const models = Object.keys(soundings);
@@ -969,7 +970,7 @@ function formatClassification(cls: string): string {
   return cls;
 }
 
-function renderVerticalMotion(soundings: Record<string, SoundingAnalysis>, displayMode: DisplayMode = 'annotated'): string {
+function renderVerticalMotion(soundings: Record<string, SoundingAnalysis>, displayMode: DisplayMode = 'full'): string {
   const models = Object.keys(soundings);
   const hasVerticalMotion = models.some(
     (m) => soundings[m].vertical_motion && soundings[m].vertical_motion!.classification !== 'unavailable',
@@ -1028,7 +1029,7 @@ function renderVerticalMotion(soundings: Record<string, SoundingAnalysis>, displ
     const row = `<tr><td class="var-name">${label}${infoBtn}</td>${cells}</tr>`;
 
     // Add annotation for classification row in annotated mode
-    if (metricId && displayMode === 'annotated') {
+    if (metricId && displayMode === 'full') {
       const metric = getMetric(metricId);
       if (metric && metric.thresholds.length > 0) {
         // For enum-style metrics (like vertical_motion_class), match formatted label to threshold
@@ -1107,7 +1108,7 @@ function renderVerticalMotion(soundings: Record<string, SoundingAnalysis>, displ
 
 function renderAltitudeMarkers(
   soundings: Record<string, SoundingAnalysis>,
-  displayMode: DisplayMode = 'annotated',
+  displayMode: DisplayMode = 'full',
   tierVisibility: Record<Tier, boolean> = { key: true, useful: true, advanced: false },
 ): string {
   const models = Object.keys(soundings);
@@ -1459,7 +1460,7 @@ export function renderRouteSlider(
 
 function renderSinglePointSounding(
   point: RoutePointAnalysis,
-  displayMode: DisplayMode = 'annotated',
+  displayMode: DisplayMode = 'full',
   tierVisibility: Record<Tier, boolean> = { key: true, useful: true, advanced: false },
   enabledLayers?: Record<string, boolean>,
 ): string {

--- a/web/ts/store/briefing-store.ts
+++ b/web/ts/store/briefing-store.ts
@@ -15,9 +15,10 @@ import * as api from '../adapters/api-adapter';
 function loadDisplayMode(): DisplayMode {
   try {
     const v = localStorage.getItem('wb_displayMode');
-    if (v === 'compact' || v === 'annotated') return v;
+    if (v === 'compact') return v;
+    if (v === 'full' || v === 'annotated') return 'full';
   } catch { /* ignore */ }
-  return 'annotated';
+  return 'full';
 }
 
 function loadTierVisibility(): Record<Tier, boolean> {

--- a/web/ts/types/metrics.ts
+++ b/web/ts/types/metrics.ts
@@ -2,7 +2,7 @@
 
 export type RiskLevel = 'none' | 'low' | 'moderate' | 'high' | 'severe';
 export type Tier = 'key' | 'useful' | 'advanced';
-export type DisplayMode = 'compact' | 'annotated';
+export type DisplayMode = 'compact' | 'full';
 
 export interface MetricThreshold {
   min: number | null;


### PR DESCRIPTION
Compact mode now hides sounding analysis, model comparison sections,
filters out secondary advisories (model confidence), and shows only
synoptic + trend in the synopsis. Full Details shows everything.

Renames internal DisplayMode from 'annotated' to 'full' with backward
compat for existing localStorage values. Extracts shared digest
rendering helper to eliminate duplication.

Closes #19

https://claude.ai/code/session_01HHhY4jyH29iRSoKMEapRqx