### PR TITLE
feat: compact mode collapses cloud/icing toggles to preferred method

### DIFF
--- a/web/ts/briefing-main.ts
+++ b/web/ts/briefing-main.ts
@@ -10,7 +10,7 @@ import { renderUserInfo, initModelCatalog, isFlightPast } from './utils';
 import { initInfoPopup, showMetricInfo } from './components/info-popup';
 import { CrossSectionRenderer } from './visualization/cross-section/renderer';
 import { extractVizData } from './visualization/data-extract';
-import { getAllLayers } from './visualization/cross-section/layer-registry';
+import { getAllLayers, getCompactLayerOverrides } from './visualization/cross-section/layer-registry';
 import { renderVizControls, renderRouteGraphControls, renderMapControls } from './visualization/controls/panel';
 import { attachInteraction, type InteractionHandle } from './visualization/cross-section/interaction';
 import { RouteGraphRenderer } from './visualization/route-graph/renderer';
@@ -33,10 +33,16 @@ async function init(): Promise<void> {
   initTheme();
   renderUserInfo(user, 'briefing');
 
-  // Load model catalog (non-blocking — modelLabel() has uppercase fallback)
-  import('./adapters/preferences-adapter').then(({ fetchModelCatalog }) =>
-    fetchModelCatalog().then(initModelCatalog).catch(() => {}),
-  );
+  // Load model catalog + preferred methods (non-blocking)
+  let preferredMethods: Record<string, string> = {};
+  import('./adapters/preferences-adapter').then(({ fetchModelCatalog, fetchPreferences }) => {
+    fetchModelCatalog().then(initModelCatalog).catch(() => {});
+    fetchPreferences().then((prefs) => {
+      preferredMethods = { clouds: prefs.cloud_method, icing: prefs.icing_method };
+      // Re-render controls so compact mode picks up the preferred methods
+      renderVisualization(store.getState());
+    }).catch(() => {});
+  });
 
   // Initialize metric info popup
   initInfoPopup();
@@ -342,7 +348,7 @@ async function init(): Promise<void> {
       onLayerToggle: (layerId) => store.getState().toggleVizLayer(layerId),
       onLayoutChange: (layout) => store.getState().setLayout(layout),
       onModelChange: (model) => store.getState().setSelectedModel(model),
-    }, state.selectedModel, availableModels);
+    }, state.selectedModel, availableModels, state.displayMode, preferredMethods);
 
     // Render route graph controls (below graph)
     if (routeGraphControlsContainer && showCrossSection) {
@@ -428,6 +434,13 @@ async function init(): Promise<void> {
       if (state.displayMode !== prev.displayMode) {
         renderAdvisories(state.routeAdvisories, () => store.getState().recalculateAdvisories(), state.displayMode, getAltitudeOverrideConfig(state));
         ui.renderSynopsis(state.flight, state.currentPack, state.digest, state.displayMode);
+        // Entering compact: enforce preferred-only layers for clouds/icing
+        // (triggers vizSettings change → renderVisualization runs via that subscriber)
+        if (state.displayMode === 'compact' && Object.keys(preferredMethods).length > 0) {
+          store.getState().setLayersBatch(getCompactLayerOverrides(preferredMethods));
+        } else {
+          renderVisualization(state);
+        }
       }
     }
     if (state.selectedModel !== prev.selectedModel) {

--- a/web/ts/store/briefing-store.ts
+++ b/web/ts/store/briefing-store.ts
@@ -101,6 +101,7 @@ export interface BriefingState {
   setDisplayMode: (mode: DisplayMode) => void;
   toggleTier: (tier: Tier) => void;
   toggleVizLayer: (layerId: string) => void;
+  setLayersBatch: (overrides: Record<string, boolean>) => void;
   setAdvisoryAltitudeOverride: (alt: number | null) => void;
   recalculateAdvisories: () => Promise<void>;
   refreshObservations: () => Promise<void>;
@@ -356,6 +357,14 @@ export const briefingStore = createStore<BriefingState>((set, get) => ({
   toggleVizLayer: (layerId: string) => {
     const current = get().vizSettings;
     const enabled = { ...current.enabledLayers, [layerId]: !(current.enabledLayers[layerId] !== false) };
+    const updated = { ...current, enabledLayers: enabled };
+    set({ vizSettings: updated });
+    saveVizSettings(updated);
+  },
+
+  setLayersBatch: (overrides: Record<string, boolean>) => {
+    const current = get().vizSettings;
+    const enabled = { ...current.enabledLayers, ...overrides };
     const updated = { ...current, enabledLayers: enabled };
     set({ vizSettings: updated });
     saveVizSettings(updated);

--- a/web/ts/visualization/controls/panel.ts
+++ b/web/ts/visualization/controls/panel.ts
@@ -1,11 +1,15 @@
 /** Visualization control panel: layout toggle, model selector, layer checkboxes, map controls. */
 
 import type { VizLayout, VizSettings } from '../types';
-import { getLayerGroups } from '../cross-section/layer-registry';
+import type { DisplayMode } from '../../types/metrics';
+import { getLayerGroups, getPreferredLayerForGroup } from '../cross-section/layer-registry';
 import { showLayerInfo, showPopupContent } from '../../components/info-popup';
 import { modelLabel } from '../../utils';
 import { getMetricOptions } from '../route-graph/metrics';
 import { getMapMetricOptions, MAP_METRIC_NONE } from '../route-map/metrics';
+
+/** Groups that collapse to a single preferred-method toggle in compact mode. */
+const COMPACT_GROUPS = new Set(['clouds', 'icing']);
 
 /** Explanatory text for layer group info buttons. */
 const GROUP_INFO: Record<string, string> = {
@@ -60,6 +64,8 @@ export function renderVizControls(
   callbacks: VizControlCallbacks,
   selectedModel?: string,
   availableModels?: string[],
+  displayMode?: DisplayMode,
+  preferredMethods?: Record<string, string>,
 ): void {
   const groups = getLayerGroups();
 
@@ -104,16 +110,21 @@ export function renderVizControls(
   if (settings.layout !== 'map') {
     html += '<div class="viz-layer-toggles">';
     for (const group of groups) {
+      const isCompactCollapse = displayMode === 'compact' && COMPACT_GROUPS.has(group.group);
+      const layersToRender = isCompactCollapse
+        ? [getPreferredLayerForGroup(group.group, group.layers, preferredMethods?.[group.group])]
+        : group.layers;
+
       html += `<div class="viz-layer-group">`;
       html += `<span class="viz-group-label">${group.label}:</span>`;
       if (GROUP_INFO[group.group]) {
         html += `<button class="viz-layer-info-btn viz-group-info-btn" data-group-info="${group.group}" title="About ${group.label}" aria-label="About ${group.label}">\u24d8</button>`;
       }
-      for (const layer of group.layers) {
+      for (const layer of layersToRender) {
         const checked = settings.enabledLayers[layer.id] !== false ? 'checked' : '';
         html += `<label class="viz-layer-checkbox">`;
         html += `<input type="checkbox" data-layer-id="${layer.id}" ${checked}>`;
-        html += `<span>${layer.name}</span>`;
+        html += `<span>${isCompactCollapse ? group.label : layer.name}</span>`;
         html += `</label>`;
         if (layer.metricId) {
           html += `<button class="viz-layer-info-btn" data-layer-info="${layer.id}" data-metric-id="${layer.metricId}" title="More info" aria-label="More info">\u24d8</button>`;

--- a/web/ts/visualization/cross-section/layer-registry.ts
+++ b/web/ts/visualization/cross-section/layer-registry.ts
@@ -52,6 +52,44 @@ export interface LayerGroupInfo {
   layers: CrossSectionLayer[];
 }
 
+/** Maps preference values to layer IDs for groups that collapse in compact mode. */
+const PREFERRED_METHOD_LAYER: Record<string, Record<string, string>> = {
+  clouds: { dd: 'cloud-bands', nwp: 'nwp-cloud-bands' },
+  icing: { ogimet_dd: 'icing-bands', ogimet_nwp: 'icing-ogimet-nwp-bands', sfip_nwp: 'sfip-bands' },
+};
+
+/** Return the preferred layer for a group based on the user's preference method. */
+export function getPreferredLayerForGroup(
+  group: LayerGroup,
+  layers: CrossSectionLayer[],
+  preferredMethod: string | undefined,
+): CrossSectionLayer {
+  const map = PREFERRED_METHOD_LAYER[group];
+  if (map && preferredMethod) {
+    const layerId = map[preferredMethod];
+    const found = layers.find(l => l.id === layerId);
+    if (found) return found;
+  }
+  return layers.find(l => l.defaultEnabled) ?? layers[0];
+}
+
+/**
+ * Return layer overrides for entering compact mode: enable only the preferred
+ * layer in each compact group, disable the rest.
+ */
+export function getCompactLayerOverrides(
+  preferredMethods: Record<string, string>,
+): Record<string, boolean> {
+  const overrides: Record<string, boolean> = {};
+  for (const [group, methodMap] of Object.entries(PREFERRED_METHOD_LAYER)) {
+    const preferredId = methodMap[preferredMethods[group]];
+    for (const layerId of Object.values(methodMap)) {
+      overrides[layerId] = layerId === preferredId;
+    }
+  }
+  return overrides;
+}
+
 export function getLayerGroups(): LayerGroupInfo[] {
   const groupMap = new Map<LayerGroup, CrossSectionLayer[]>();
   for (const layer of ALL_LAYERS) {


### PR DESCRIPTION
## Summary
- In compact mode, clouds and icing groups show a single toggle for the user's preferred method (from profile preferences) instead of all individual method checkboxes
- Switching to compact enforces preferred-only layers (disables non-preferred, enables preferred); switching back to full reveals all toggles as-is
- Preferred methods are fetched from `/user/preferences` (`cloud_method`, `icing_method`) at init

## Test plan
- [ ] Open briefing, switch to compact mode → clouds and icing show single toggle each matching preferred method
- [ ] Toggle clouds/icing off and on — correct layer toggles
- [ ] Click (i) — shows preferred method's description
- [ ] In full mode, enable a non-preferred layer (e.g. NWP clouds), switch to compact → only preferred layer shown and enabled
- [ ] Switch back to full → all individual toggles visible with updated states
- [ ] Change preferred icing method in settings → compact mode reflects new method

🤖 Generated with [Claude Code](https://claude.com/claude-code)