### PR TITLE
feat: auto-skip weather models by route region

### DIFF
--- a/alembic/versions/016_models_skipped_region.py
+++ b/alembic/versions/016_models_skipped_region.py
@@ -1,0 +1,32 @@
+"""Add models_skipped_region_json column to briefing_packs.
+
+Revision ID: 016
+Revises: 015
+Create Date: 2026-02-28
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "016"
+down_revision: Union[str, None] = "015"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "briefing_packs",
+        sa.Column(
+            "models_skipped_region_json",
+            sa.Text,
+            nullable=True,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("briefing_packs", "models_skipped_region_json")

--- a/src/weatherbrief/api/packs.py
+++ b/src/weatherbrief/api/packs.py
@@ -198,6 +198,7 @@ class PackMetaResponse(BaseModel):
     assessment_reason: str | None
     model_init_times: dict[str, int] = Field(default_factory=dict)
     grib_init_times: dict[str, int] = Field(default_factory=dict)
+    models_skipped_region: list[str] = Field(default_factory=list)
     data_status: DataStatus | None = None
 
 
@@ -223,6 +224,7 @@ def _meta_to_response(
         assessment_reason=meta.assessment_reason,
         model_init_times=meta.model_init_times,
         grib_init_times=meta.grib_init_times,
+        models_skipped_region=meta.models_skipped_region,
         data_status=data_status,
     )
 
@@ -503,6 +505,7 @@ def _finalize_refresh(flight_id, flight, fetch_ts, pack_path, result, db,
         artifact_path=str(pack_path),
         model_init_times=init_times,
         grib_init_times=result.grib_init_times,
+        models_skipped_region=result.models_skipped_region,
     )
 
     save_pack_meta(db, meta)

--- a/src/weatherbrief/db/models.py
+++ b/src/weatherbrief/db/models.py
@@ -136,6 +136,7 @@ class BriefingPackRow(Base):
     artifact_path: Mapped[str] = mapped_column(Text, default="")
     model_init_times_json: Mapped[str] = mapped_column(Text, default="{}")
     grib_init_times_json: Mapped[str] = mapped_column(Text, default="{}")
+    models_skipped_region_json: Mapped[str] = mapped_column(Text, default="[]")
 
     flight: Mapped[FlightRow] = relationship(back_populates="packs")
 

--- a/src/weatherbrief/fetch/variables.py
+++ b/src/weatherbrief/fetch/variables.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from enum import Enum
 
 BASE_PRESSURE_LEVELS = [1000, 925, 850, 700, 600, 500, 400, 300]
 
@@ -94,6 +95,14 @@ PRESSURE_LEVEL_VARIABLES = [
 ]
 
 
+class ModelRegion(Enum):
+    """Geographic coverage region for a weather model."""
+
+    GLOBAL = "global"
+    NORTH_AMERICA = "north_america"
+    EUROPE = "europe"
+
+
 @dataclass
 class ModelEndpoint:
     """Open-Meteo model endpoint configuration."""
@@ -108,6 +117,8 @@ class ModelEndpoint:
     pressure_levels: list[int] = field(default_factory=lambda: list(BASE_PRESSURE_LEVELS))
     # Whether this model is included in the default selection for new users
     default: bool = False
+    # Geographic coverage region — used to skip irrelevant models for a route
+    region: ModelRegion = ModelRegion.GLOBAL
 
 
 MODEL_ENDPOINTS: dict[str, ModelEndpoint] = {
@@ -143,6 +154,7 @@ MODEL_ENDPOINTS: dict[str, ModelEndpoint] = {
         unavailable_pressure=["vertical_velocity"],
         pressure_levels=list(ICON_PRESSURE_LEVELS),
         default=True,
+        region=ModelRegion.EUROPE,
     ),
     "ukmo": ModelEndpoint(
         name="UK Met Office",
@@ -152,6 +164,7 @@ MODEL_ENDPOINTS: dict[str, ModelEndpoint] = {
         unavailable_surface=["precipitation_probability",
                              "convective_inhibition", "lifted_index"],
         pressure_levels=list(UKMO_PRESSURE_LEVELS),
+        region=ModelRegion.EUROPE,
     ),
     "meteofrance": ModelEndpoint(
         name="Météo-France",
@@ -162,6 +175,7 @@ MODEL_ENDPOINTS: dict[str, ModelEndpoint] = {
                              "convective_inhibition", "lifted_index"],
         unavailable_pressure=["vertical_velocity"],
         pressure_levels=list(METEOFRANCE_PRESSURE_LEVELS),
+        region=ModelRegion.EUROPE,
     ),
     "gem": ModelEndpoint(
         name="GEM",
@@ -171,6 +185,7 @@ MODEL_ENDPOINTS: dict[str, ModelEndpoint] = {
                              "convective_inhibition", "lifted_index"],
         unavailable_pressure=["vertical_velocity"],
         pressure_levels=list(GEM_PRESSURE_LEVELS),
+        region=ModelRegion.NORTH_AMERICA,
     ),
 }
 
@@ -189,3 +204,34 @@ def build_hourly_params(endpoint: ModelEndpoint) -> str:
             pressure.append(f"{var}_{level}hPa")
 
     return ",".join(surface + pressure)
+
+
+# ICAO prefixes that indicate North American airspace
+_NORTH_AMERICA_PREFIXES = ("K", "C", "P")
+
+
+def detect_model_region(route) -> ModelRegion:
+    """Classify a route's region for model coverage filtering.
+
+    Checks ALL waypoint ICAO prefixes:
+    - K, C, P prefixes → NORTH_AMERICA
+    - Everything else → EUROPE
+
+    If mixed, defaults to GLOBAL (no filtering — safe fallback).
+
+    Takes a RouteConfig but declared untyped to avoid circular imports.
+    """
+    if not route or not route.waypoints:
+        return ModelRegion.GLOBAL
+
+    regions: set[ModelRegion] = set()
+    for wp in route.waypoints:
+        icao = wp.icao.upper()
+        if any(icao.startswith(p) for p in _NORTH_AMERICA_PREFIXES):
+            regions.add(ModelRegion.NORTH_AMERICA)
+        else:
+            regions.add(ModelRegion.EUROPE)
+
+    if len(regions) == 1:
+        return regions.pop()
+    return ModelRegion.GLOBAL

--- a/src/weatherbrief/models/storage.py
+++ b/src/weatherbrief/models/storage.py
@@ -66,3 +66,4 @@ class BriefingPackMeta(BaseModel):
     artifact_path: str = ""  # path to pack directory
     model_init_times: dict[str, int] = Field(default_factory=dict)
     grib_init_times: dict[str, int] = Field(default_factory=dict)
+    models_skipped_region: list[str] = Field(default_factory=list)

--- a/src/weatherbrief/pipeline.py
+++ b/src/weatherbrief/pipeline.py
@@ -98,6 +98,7 @@ class BriefingResult:
     digest: object | None = None  # WeatherDigest (lazy import avoids hard dep)
     text_digest: str | None = None
     grib_init_times: dict[str, int] = field(default_factory=dict)
+    models_skipped_region: list[str] = field(default_factory=list)
     errors: list[str] = field(default_factory=list)
     usage: BriefingUsage = field(default_factory=BriefingUsage)
 
@@ -322,6 +323,7 @@ def execute_briefing(
 
     result = BriefingResult(snapshot=snapshot, snapshot_path=snapshot_path)
     result.grib_init_times = fetch_result.grib_init_times
+    result.models_skipped_region = fetch_result.models_skipped_region
     result.usage.open_meteo_calls = len(fetch_result.cross_sections)
     result.usage.grib_enrichment = fetch_result.grib_enriched
     result.usage.grib_enrichment_failed = fetch_result.grib_enrichment_failed

--- a/src/weatherbrief/storage/flights.py
+++ b/src/weatherbrief/storage/flights.py
@@ -101,6 +101,7 @@ def _meta_to_row(meta: BriefingPackMeta) -> BriefingPackRow:
         artifact_path=meta.artifact_path,
         model_init_times_json=json.dumps(meta.model_init_times),
         grib_init_times_json=json.dumps(meta.grib_init_times),
+        models_skipped_region_json=json.dumps(meta.models_skipped_region),
     )
 
 
@@ -144,6 +145,7 @@ def _row_to_meta(row: BriefingPackRow) -> BriefingPackMeta:
         artifact_path=_resolve_artifact_path(row.artifact_path),
         model_init_times=json.loads(row.model_init_times_json) if row.model_init_times_json else {},
         grib_init_times=json.loads(row.grib_init_times_json) if row.grib_init_times_json else {},
+        models_skipped_region=json.loads(row.models_skipped_region_json) if row.models_skipped_region_json else [],
     )
 
 

--- a/src/weatherbrief/tasks/fetch.py
+++ b/src/weatherbrief/tasks/fetch.py
@@ -14,7 +14,7 @@ from typing import Callable
 
 from weatherbrief.fetch.open_meteo import OpenMeteoClient
 from weatherbrief.fetch.route_points import interpolate_route
-from weatherbrief.fetch.variables import MODEL_ENDPOINTS
+from weatherbrief.fetch.variables import MODEL_ENDPOINTS, ModelRegion, detect_model_region
 from weatherbrief.models import (
     ElevationProfile,
     ModelSource,
@@ -27,6 +27,13 @@ from weatherbrief.models import (
 logger = logging.getLogger(__name__)
 
 
+def _should_skip_for_region(endpoint, route_region: ModelRegion) -> bool:
+    """Return True if a model's coverage region doesn't match the route."""
+    if endpoint.region == ModelRegion.GLOBAL or route_region == ModelRegion.GLOBAL:
+        return False
+    return endpoint.region != route_region
+
+
 @dataclass
 class FetchResult:
     """Output of the fetch stage."""
@@ -36,6 +43,7 @@ class FetchResult:
     cross_sections: list[RouteCrossSection]
     elevation_profile: ElevationProfile | None
     models_fetched: list[str]
+    models_skipped_region: list[str] = field(default_factory=list)
     grib_enriched: bool = False
     grib_enrichment_failed: bool = False
     grib_init_times: dict[str, int] = field(default_factory=dict)
@@ -89,7 +97,10 @@ def run_fetch(
     all_forecasts: list[WaypointForecast] = []
     cross_sections: list[RouteCrossSection] = []
     models_fetched_names: list[str] = []
+    models_skipped_region: list[str] = []
     models_fetched_count = 0
+
+    route_region = detect_model_region(route)
 
     for model in models:
         endpoint = MODEL_ENDPOINTS[model.value]
@@ -98,6 +109,13 @@ def run_fetch(
                 "Skipping %s: %d days out exceeds %d-day range",
                 model.value, days_out, endpoint.max_days,
             )
+            continue
+        if _should_skip_for_region(endpoint, route_region):
+            logger.info(
+                "Skipping %s: %s model not relevant for %s route",
+                model.value, endpoint.region.value, route_region.value,
+            )
+            models_skipped_region.append(model.value)
             continue
         # Delay between model fetches to avoid Open-Meteo rate limiting
         if models_fetched_count > 0:
@@ -164,6 +182,7 @@ def run_fetch(
         cross_sections=cross_sections,
         elevation_profile=elevation_profile,
         models_fetched=models_fetched_names,
+        models_skipped_region=models_skipped_region,
         grib_enriched=grib_enriched,
         grib_enrichment_failed=grib_enrichment_failed,
         grib_init_times=grib_init_times,

--- a/tests/test_model_region.py
+++ b/tests/test_model_region.py
@@ -1,0 +1,112 @@
+"""Tests for model region detection and skip logic."""
+
+from __future__ import annotations
+
+import pytest
+
+from weatherbrief.fetch.variables import (
+    MODEL_ENDPOINTS,
+    ModelEndpoint,
+    ModelRegion,
+    detect_model_region,
+)
+from weatherbrief.models import RouteConfig, Waypoint
+from weatherbrief.tasks.fetch import _should_skip_for_region
+
+
+# --- Fixtures ---
+
+def _route(*icaos: str) -> RouteConfig:
+    """Build a minimal RouteConfig from ICAO codes."""
+    return RouteConfig(
+        name="Test",
+        waypoints=[Waypoint(icao=icao, name=icao, lat=0, lon=0) for icao in icaos],
+    )
+
+
+# --- detect_model_region ---
+
+class TestDetectModelRegion:
+    def test_us_route(self):
+        route = _route("KJFK", "KORD")
+        assert detect_model_region(route) == ModelRegion.NORTH_AMERICA
+
+    def test_canadian_route(self):
+        route = _route("CYUL", "CYYZ")
+        assert detect_model_region(route) == ModelRegion.NORTH_AMERICA
+
+    def test_alaska_route(self):
+        route = _route("PANC", "PAFA")
+        assert detect_model_region(route) == ModelRegion.NORTH_AMERICA
+
+    def test_us_canada_mixed(self):
+        """US + Canada = still NORTH_AMERICA."""
+        route = _route("KJFK", "CYUL")
+        assert detect_model_region(route) == ModelRegion.NORTH_AMERICA
+
+    def test_european_route(self):
+        route = _route("EGTK", "LFPB", "LSGS")
+        assert detect_model_region(route) == ModelRegion.EUROPE
+
+    def test_mixed_us_europe(self):
+        """Mixed continents → GLOBAL (safe fallback, no filtering)."""
+        route = _route("KJFK", "EGLL")
+        assert detect_model_region(route) == ModelRegion.GLOBAL
+
+    def test_empty_route(self):
+        """No waypoints → GLOBAL."""
+        assert detect_model_region(None) == ModelRegion.GLOBAL
+
+    def test_lowercase_icao(self):
+        """ICAO case-insensitive."""
+        route = _route("kjfk", "kord")
+        assert detect_model_region(route) == ModelRegion.NORTH_AMERICA
+
+
+# --- _should_skip_for_region ---
+
+class TestShouldSkipForRegion:
+    def _ep(self, region: ModelRegion) -> ModelEndpoint:
+        return ModelEndpoint(name="test", base_url="", max_days=7, region=region)
+
+    def test_global_model_never_skipped(self):
+        ep = self._ep(ModelRegion.GLOBAL)
+        assert not _should_skip_for_region(ep, ModelRegion.NORTH_AMERICA)
+        assert not _should_skip_for_region(ep, ModelRegion.EUROPE)
+        assert not _should_skip_for_region(ep, ModelRegion.GLOBAL)
+
+    def test_europe_model_skipped_for_na(self):
+        ep = self._ep(ModelRegion.EUROPE)
+        assert _should_skip_for_region(ep, ModelRegion.NORTH_AMERICA)
+
+    def test_europe_model_kept_for_europe(self):
+        ep = self._ep(ModelRegion.EUROPE)
+        assert not _should_skip_for_region(ep, ModelRegion.EUROPE)
+
+    def test_na_model_skipped_for_europe(self):
+        ep = self._ep(ModelRegion.NORTH_AMERICA)
+        assert _should_skip_for_region(ep, ModelRegion.EUROPE)
+
+    def test_na_model_kept_for_na(self):
+        ep = self._ep(ModelRegion.NORTH_AMERICA)
+        assert not _should_skip_for_region(ep, ModelRegion.NORTH_AMERICA)
+
+    def test_regional_model_not_skipped_for_global_route(self):
+        """If route is GLOBAL (mixed), don't skip anything."""
+        ep = self._ep(ModelRegion.EUROPE)
+        assert not _should_skip_for_region(ep, ModelRegion.GLOBAL)
+
+
+# --- MODEL_ENDPOINTS region assignments ---
+
+class TestModelEndpointRegions:
+    def test_global_models(self):
+        for key in ("best_match", "gfs", "ecmwf"):
+            assert MODEL_ENDPOINTS[key].region == ModelRegion.GLOBAL, f"{key} should be GLOBAL"
+
+    def test_european_models(self):
+        for key in ("icon", "ukmo", "meteofrance"):
+            assert MODEL_ENDPOINTS[key].region == ModelRegion.EUROPE, f"{key} should be EUROPE"
+
+    def test_north_america_models(self):
+        assert MODEL_ENDPOINTS["gem"].region == ModelRegion.NORTH_AMERICA

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -368,6 +368,11 @@ label {
   font-size: 0.8rem;
 }
 
+.model-skipped {
+  font-style: italic;
+  opacity: 0.6;
+}
+
 .freshness-link {
   font-size: 0.8rem;
   margin-left: 0.5rem;

--- a/web/ts/managers/briefing-ui.ts
+++ b/web/ts/managers/briefing-ui.ts
@@ -182,15 +182,17 @@ export function renderFreshnessBar(
   // Model basis line from the pack's init times, with GRIB annotation when different
   const packTimes = pack?.model_init_times || {};
   const gribTimes = pack?.grib_init_times || {};
-  const basisParts = Object.entries(packTimes)
+  const fetchedParts = Object.entries(packTimes)
     .map(([m, t]) => {
       const gribTs = gribTimes[m];
       if (gribTs && gribTs !== t) {
         return `${modelLabel(m)} ${formatModelRunTime(t)} (GRIB ${formatModelRunTime(gribTs)})`;
       }
       return `${modelLabel(m)} ${formatModelRunTime(t)}`;
-    })
-    .join(', ');
+    });
+  const skippedParts = (pack?.models_skipped_region || [])
+    .map(m => `${modelLabel(m)} <span class="model-skipped">skipped</span>`);
+  const basisParts = [...fetchedParts, ...skippedParts].join(', ');
   const basisLine = basisParts ? `<span class="freshness-basis">Based on ${basisParts}</span>` : '';
 
   const forceLink = isAdmin

--- a/web/ts/store/types.ts
+++ b/web/ts/store/types.ts
@@ -48,6 +48,7 @@ export interface PackMeta {
   assessment_reason: string | null;
   model_init_times?: Record<string, number>;
   grib_init_times?: Record<string, number>;
+  models_skipped_region?: string[];
   data_status?: DataStatus | null;
 }
 


### PR DESCRIPTION
## Summary
- Adds `ModelRegion` enum (GLOBAL, NORTH_AMERICA, EUROPE) and `region` field to `ModelEndpoint`
- `detect_model_region()` classifies routes by ICAO prefixes (K/C/P → NA, else → Europe, mixed → GLOBAL no-filter fallback)
- Fetch loop skips regional models that don't match the route (e.g., ICON/UKMO/Météo-France skipped for US routes, GEM skipped for European routes)
- Skipped models tracked in `FetchResult` → `BriefingPackMeta` → API → freshness bar UI ("skipped" label)
- Includes Alembic migration 016 for new DB column

## Test plan
- [x] 17 unit tests covering detect_model_region, _should_skip_for_region, and MODEL_ENDPOINTS region assignments
- [x] Full test suite passes (809 tests)
- [ ] Integration: refresh a US route → verify ICON/UKMO/Météo-France skipped in logs
- [ ] Integration: refresh a European route → verify GEM skipped
- [ ] UI: verify freshness bar shows "skipped" for filtered models

🤖 Generated with [Claude Code](https://claude.com/claude-code)