### PR TITLE
feat: add Compare layout mode for cross-section

### DIFF
--- a/web/css/style.css
+++ b/web/css/style.css
@@ -2639,6 +2639,47 @@ label {
   flex: 1;
 }
 
+/* Compare layout: same as cross-section — show cross-section pane, hide map */
+.viz-layout-wrapper.layout-compare .viz-pane-map {
+  display: none;
+}
+
+/* Model chip toggles */
+.viz-compare-model-chips {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  flex-wrap: wrap;
+}
+
+.btn-chip {
+  padding: 2px 8px;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--text-muted);
+  font-size: 0.75rem;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.btn-chip.active {
+  background: var(--primary);
+  color: white;
+  border-color: var(--primary);
+}
+
+.btn-chip:hover:not(.active) {
+  background: var(--bg);
+}
+
+/* Compare layer selector inline with toolbar */
+.viz-compare-layer-selector {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+}
+
 .map-container {
   width: 100%;
   height: 450px;

--- a/web/ts/briefing-main.ts
+++ b/web/ts/briefing-main.ts
@@ -11,8 +11,11 @@ import { initInfoPopup, showMetricInfo, showPopupContent } from './components/in
 import { CrossSectionRenderer } from './visualization/cross-section/renderer';
 import { extractVizData } from './visualization/data-extract';
 import { getAllLayers, getCompactLayerOverrides } from './visualization/cross-section/layer-registry';
-import { renderVizControls, renderRouteGraphControls, renderMapControls } from './visualization/controls/panel';
+import { renderVizControls, renderRouteGraphControls, renderMapControls, renderCompareControls } from './visualization/controls/panel';
 import { attachInteraction, type InteractionHandle } from './visualization/cross-section/interaction';
+import { CompareSectionRenderer, type CompareModelData } from './visualization/cross-section/compare-renderer';
+import { attachCompareInteraction, type CompareInteractionHandle } from './visualization/cross-section/compare-interaction';
+import { getComparableLayer } from './visualization/cross-section/compare-layers';
 import { RouteGraphRenderer } from './visualization/route-graph/renderer';
 import { getMetricById, METRIC_NONE } from './visualization/route-graph/metrics';
 import { attachRouteGraphInteraction, type RouteGraphInteractionHandle } from './visualization/route-graph/interaction';
@@ -129,12 +132,14 @@ async function init(): Promise<void> {
   let routeGraphInteraction: RouteGraphInteractionHandle | null = null;
   let mapRenderer: RouteMapRenderer | null = null;
   let mapInteraction: MapInteractionHandle | null = null;
+  let compareRenderer: CompareSectionRenderer | null = null;
+  let compareInteraction: CompareInteractionHandle | null = null;
 
   /** Apply the CSS layout class to the layout wrapper. */
   function applyLayoutClass(layout: string): void {
     const wrapper = document.getElementById('viz-layout-wrapper');
     if (wrapper) {
-      wrapper.classList.remove('layout-cross-section', 'layout-map', 'layout-split');
+      wrapper.classList.remove('layout-cross-section', 'layout-map', 'layout-split', 'layout-compare');
       wrapper.classList.add(`layout-${layout}`);
     }
   }
@@ -162,8 +167,76 @@ async function init(): Promise<void> {
 
     const data = extractVizData(state.routeAnalyses, state.selectedModel, state.flight?.flight_ceiling_ft, state.elevationProfile);
     const allLayers = getAllLayers();
-    const showCrossSection = layout !== 'map';
-    const showMap = layout !== 'cross-section';
+    const showCrossSection = layout === 'cross-section' || layout === 'split';
+    const showCompare = layout === 'compare';
+    const showMap = layout === 'map' || layout === 'split';
+    const availableModels = state.routeAnalyses?.models ?? [];
+
+    // --- Compare mode ---
+    if (showCompare) {
+      // Destroy cross-section renderer if exists
+      if (vizInteraction) { vizInteraction.destroy(); vizInteraction = null; }
+      if (vizRenderer) { vizRenderer.destroy(); vizRenderer = null; }
+      if (routeGraphInteraction) { routeGraphInteraction.destroy(); routeGraphInteraction = null; }
+      if (routeGraphRenderer) { routeGraphRenderer.destroy(); routeGraphRenderer = null; }
+
+      // Init compare models if empty
+      store.getState().initCompareModels(availableModels);
+      const compareModels = store.getState().vizSettings.compareModels;
+
+      // Extract VizRouteData for each active model
+      const datasets: CompareModelData[] = [];
+      for (const m of availableModels) {
+        if (compareModels[m] !== false) {
+          datasets.push({
+            model: m,
+            data: extractVizData(state.routeAnalyses!, m, state.flight?.flight_ceiling_ft, state.elevationProfile),
+          });
+        }
+      }
+
+      if (datasets.length > 0) {
+        // Create/reuse compare renderer
+        if (!compareRenderer) {
+          compareRenderer = new CompareSectionRenderer(canvasContainer);
+        }
+
+        const layer = getComparableLayer(state.vizSettings.compareLayer) ?? null;
+        compareRenderer.setModelData(datasets);
+        compareRenderer.setCompareLayer(layer);
+        compareRenderer.setSelectedPointIndex(state.selectedPointIndex);
+        compareRenderer.render();
+
+        // Attach or update compare interaction
+        if (compareInteraction) {
+          compareInteraction.update(datasets, layer);
+        } else {
+          compareInteraction = attachCompareInteraction(
+            compareRenderer, datasets, layer, {
+              onSelectPoint: (idx) => store.getState().setSelectedPoint(idx),
+            },
+          );
+        }
+      }
+
+      // Hide route graph in compare mode
+      if (routeGraphContainer) routeGraphContainer.style.display = 'none';
+
+      // Render compare controls
+      renderCompareControls(controlsContainer, state.vizSettings, {
+        onLayoutChange: (l) => store.getState().setLayout(l),
+        onCompareLayerChange: (layerId) => store.getState().setCompareLayer(layerId),
+        onCompareModelToggle: (model, enabled) => store.getState().setCompareModel(model, enabled),
+      }, availableModels);
+
+      // Hide route graph controls in compare mode
+      if (routeGraphControlsContainer) routeGraphControlsContainer.innerHTML = '';
+
+    } else {
+      // Not compare — destroy compare renderer if exists
+      if (compareInteraction) { compareInteraction.destroy(); compareInteraction = null; }
+      if (compareRenderer) { compareRenderer.destroy(); compareRenderer = null; }
+    }
 
     // --- Cross-section ---
     if (showCrossSection) {
@@ -351,26 +424,30 @@ async function init(): Promise<void> {
       if (mapRenderer) { mapRenderer.destroy(); mapRenderer = null; }
     }
 
-    // Render cross-section controls (above canvas)
-    const availableModels = state.routeAnalyses?.models ?? undefined;
-    renderVizControls(controlsContainer, state.vizSettings, {
-      onLayerToggle: (layerId) => store.getState().toggleVizLayer(layerId),
-      onLayoutChange: (layout) => store.getState().setLayout(layout),
-      onModelChange: (model) => store.getState().setSelectedModel(model),
-    }, state.selectedModel, availableModels, state.displayMode, preferredMethods);
+    // Render cross-section controls (above canvas) — skip in compare mode (rendered above)
+    if (!showCompare) {
+      renderVizControls(controlsContainer, state.vizSettings, {
+        onLayerToggle: (layerId) => store.getState().toggleVizLayer(layerId),
+        onLayoutChange: (l) => store.getState().setLayout(l),
+        onModelChange: (model) => store.getState().setSelectedModel(model),
+      }, state.selectedModel, availableModels.length > 0 ? availableModels : undefined, state.displayMode, preferredMethods);
 
-    // Render route graph controls (below graph)
-    if (routeGraphControlsContainer && showCrossSection) {
-      renderRouteGraphControls(routeGraphControlsContainer, state.vizSettings, {
-        onRouteGraphToggle: (visible) => store.getState().setRouteGraphVisible(visible),
-        onRouteGraphMetricChange: (axis, metricId) => store.getState().setRouteGraphMetric(axis, metricId),
-      });
+      // Render route graph controls (below graph)
+      if (routeGraphControlsContainer && showCrossSection) {
+        renderRouteGraphControls(routeGraphControlsContainer, state.vizSettings, {
+          onRouteGraphToggle: (visible) => store.getState().setRouteGraphVisible(visible),
+          onRouteGraphMetricChange: (axis, metricId) => store.getState().setRouteGraphMetric(axis, metricId),
+        });
+      }
     }
   }
 
   function updateVizOverlay(state: BriefingState): void {
     if (vizRenderer && state.routeAnalyses) {
       vizRenderer.setSelectedPointIndex(state.selectedPointIndex);
+    }
+    if (compareRenderer && state.routeAnalyses) {
+      compareRenderer.setSelectedPointIndex(state.selectedPointIndex);
     }
     if (routeGraphRenderer && state.routeAnalyses && state.vizSettings.routeGraphVisible) {
       routeGraphRenderer.setSelectedPointIndex(state.selectedPointIndex);
@@ -718,6 +795,7 @@ async function init(): Promise<void> {
     // Re-render viz canvases if cross-section was just expanded (canvas needs size)
     if (key === 'cross-section' && !section.classList.contains('collapsed')) {
       if (vizRenderer) vizRenderer.render();
+      if (compareRenderer) compareRenderer.render();
       if (routeGraphRenderer && store.getState().vizSettings.routeGraphVisible) routeGraphRenderer.render();
       if (mapRenderer) {
         mapRenderer.invalidateSize();

--- a/web/ts/store/briefing-store.ts
+++ b/web/ts/store/briefing-store.ts
@@ -39,6 +39,8 @@ function loadVizSettings(): VizSettings {
     routeGraphVisible: true,
     routeGraphLeftMetric: 'headwind',
     routeGraphRightMetric: 'temperature',
+    compareLayer: 'icing-bands',
+    compareModels: {},
   };
   try {
     const v = localStorage.getItem('wb_vizSettings');
@@ -48,6 +50,7 @@ function loadVizSettings(): VizSettings {
         ...defaults,
         ...saved,
         enabledLayers: { ...defaults.enabledLayers, ...saved.enabledLayers },
+        compareModels: { ...defaults.compareModels, ...saved.compareModels },
       };
     }
   } catch { /* ignore */ }
@@ -117,6 +120,9 @@ export interface BriefingState {
   setMapAltitude: (altitudeFt: number | null) => void;
   setRouteGraphVisible: (visible: boolean) => void;
   setRouteGraphMetric: (axis: 'left' | 'right', metricId: string) => void;
+  setCompareLayer: (layerId: string) => void;
+  setCompareModel: (model: string, enabled: boolean) => void;
+  initCompareModels: (models: string[]) => void;
 }
 
 export const briefingStore = createStore<BriefingState>((set, get) => ({
@@ -477,6 +483,30 @@ export const briefingStore = createStore<BriefingState>((set, get) => ({
   setRouteGraphMetric: (axis: 'left' | 'right', metricId: string) => {
     const key = axis === 'left' ? 'routeGraphLeftMetric' : 'routeGraphRightMetric';
     const updated = { ...get().vizSettings, [key]: metricId };
+    set({ vizSettings: updated });
+    saveVizSettings(updated);
+  },
+
+  setCompareLayer: (layerId: string) => {
+    const updated = { ...get().vizSettings, compareLayer: layerId };
+    set({ vizSettings: updated });
+    saveVizSettings(updated);
+  },
+
+  setCompareModel: (model: string, enabled: boolean) => {
+    const current = get().vizSettings;
+    const compareModels = { ...current.compareModels, [model]: enabled };
+    const updated = { ...current, compareModels };
+    set({ vizSettings: updated });
+    saveVizSettings(updated);
+  },
+
+  initCompareModels: (models: string[]) => {
+    const current = get().vizSettings;
+    if (Object.keys(current.compareModels).length > 0) return;
+    const compareModels: Record<string, boolean> = {};
+    for (const m of models) compareModels[m] = true;
+    const updated = { ...current, compareModels };
     set({ vizSettings: updated });
     saveVizSettings(updated);
   },

--- a/web/ts/visualization/controls/panel.ts
+++ b/web/ts/visualization/controls/panel.ts
@@ -3,6 +3,7 @@
 import type { VizLayout, VizSettings } from '../types';
 import type { DisplayMode } from '../../types/metrics';
 import { getLayerGroups, getPreferredLayerForGroup } from '../cross-section/layer-registry';
+import { getComparableLayerGroups } from '../cross-section/compare-layers';
 import { showLayerInfo, showPopupContent } from '../../components/info-popup';
 import { modelLabel } from '../../utils';
 import { getMetricOptions } from '../route-graph/metrics';
@@ -85,6 +86,7 @@ export function renderVizControls(
   // Layout toggle
   html += '<div class="viz-layout-toggle">';
   html += `<button class="btn-toggle${settings.layout === 'cross-section' ? ' active' : ''}" data-layout="cross-section" title="Cross-section only">X-Section</button>`;
+  html += `<button class="btn-toggle${settings.layout === 'compare' ? ' active' : ''}" data-layout="compare" title="Compare one layer across all models">Compare</button>`;
   html += `<button class="btn-toggle${settings.layout === 'split' ? ' active' : ''}" data-layout="split" title="Side-by-side">Split</button>`;
   html += `<button class="btn-toggle${settings.layout === 'map' ? ' active' : ''}" data-layout="map" title="Map only">Map</button>`;
   html += '</div>';
@@ -313,4 +315,93 @@ export function renderMapControls(
       callbacks.onWidthMetricChange(widthSelect.value);
     });
   }
+}
+
+// --- Compare mode controls ---
+
+export interface CompareControlCallbacks {
+  onLayoutChange: (layout: VizLayout) => void;
+  onCompareLayerChange: (layerId: string) => void;
+  onCompareModelToggle: (model: string, enabled: boolean) => void;
+}
+
+/** Render compare-mode controls: layout toggle, layer dropdown, model chips. */
+export function renderCompareControls(
+  container: HTMLElement,
+  settings: VizSettings,
+  callbacks: CompareControlCallbacks,
+  availableModels: string[],
+): void {
+  const layerGroups = getComparableLayerGroups();
+
+  let html = '<div class="viz-toolbar">';
+
+  // Top row: Layout toggle
+  html += '<div class="viz-toolbar-top">';
+
+  // Layout toggle (same 4 buttons, Compare active)
+  html += '<div class="viz-layout-toggle">';
+  html += `<button class="btn-toggle" data-layout="cross-section" title="Cross-section only">X-Section</button>`;
+  html += `<button class="btn-toggle active" data-layout="compare" title="Compare one layer across all models">Compare</button>`;
+  html += `<button class="btn-toggle" data-layout="split" title="Side-by-side">Split</button>`;
+  html += `<button class="btn-toggle" data-layout="map" title="Map only">Map</button>`;
+  html += '</div>';
+
+  // Layer selector
+  html += '<div class="viz-compare-layer-selector">';
+  html += '<span class="viz-toggle-label">Layer:</span>';
+  html += '<select id="compare-layer-select" class="viz-model-select">';
+  for (const group of layerGroups) {
+    html += `<optgroup label="${group.group}">`;
+    for (const layer of group.layers) {
+      const selected = layer.id === settings.compareLayer ? ' selected' : '';
+      html += `<option value="${layer.id}"${selected}>${layer.name}</option>`;
+    }
+    html += '</optgroup>';
+  }
+  html += '</select>';
+  html += '</div>';
+
+  html += '</div>'; // .viz-toolbar-top
+
+  // Model chips
+  if (availableModels.length > 0) {
+    html += '<div class="viz-compare-model-chips">';
+    html += '<span class="viz-toggle-label">Models:</span>';
+    for (const m of availableModels) {
+      const enabled = settings.compareModels[m] !== false;
+      const activeClass = enabled ? ' active' : '';
+      html += `<button class="btn-chip${activeClass}" data-compare-model="${m}">${modelLabel(m)}</button>`;
+    }
+    html += '</div>';
+  }
+
+  html += '</div>'; // .viz-toolbar
+
+  container.innerHTML = html;
+
+  // Wire layout toggle
+  container.querySelectorAll('[data-layout]').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      callbacks.onLayoutChange((btn as HTMLElement).dataset.layout as VizLayout);
+    });
+  });
+
+  // Wire layer selector
+  const layerSelect = container.querySelector('#compare-layer-select') as HTMLSelectElement | null;
+  if (layerSelect) {
+    layerSelect.addEventListener('change', () => {
+      callbacks.onCompareLayerChange(layerSelect.value);
+    });
+  }
+
+  // Wire model chips
+  container.querySelectorAll('[data-compare-model]').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      const el = btn as HTMLElement;
+      const model = el.dataset.compareModel!;
+      const currentlyActive = el.classList.contains('active');
+      callbacks.onCompareModelToggle(model, !currentlyActive);
+    });
+  });
 }

--- a/web/ts/visualization/cross-section/compare-interaction.ts
+++ b/web/ts/visualization/cross-section/compare-interaction.ts
@@ -1,0 +1,270 @@
+/** Compare cross-section interaction: hover crosshair, click-to-select, per-model tooltip. */
+
+import type { VizPoint } from '../types';
+import type { CompareSectionRenderer, CompareModelData } from './compare-renderer';
+import type { ComparableLayer } from './compare-layers';
+import {
+  getCanvasX, getCanvasY, findNearestPointIndex, ensureTooltip as ensureTooltipEl,
+  positionTooltip, hideTooltip as hideTooltipEl, findNearbyWaypoint,
+} from '../interaction-utils';
+import { modelLabel } from '../../utils';
+
+export interface CompareInteractionCallbacks {
+  onSelectPoint: (index: number) => void;
+  onHover?: (x: number | undefined) => void;
+}
+
+export interface CompareInteractionHandle {
+  update(datasets: CompareModelData[], layer: ComparableLayer | null): void;
+  destroy(): void;
+}
+
+export function attachCompareInteraction(
+  renderer: CompareSectionRenderer,
+  datasets: CompareModelData[],
+  layer: ComparableLayer | null,
+  callbacks: CompareInteractionCallbacks,
+): CompareInteractionHandle {
+  const canvas = renderer.getCanvas();
+  canvas.style.pointerEvents = 'auto';
+  canvas.style.cursor = 'crosshair';
+
+  let currentDatasets = datasets;
+  let currentLayer = layer;
+  let tooltip: HTMLElement | null = null;
+
+  function handleMouseMove(e: MouseEvent): void {
+    const transform = renderer.createTransform();
+    if (!transform || currentDatasets.length === 0) return;
+
+    const x = getCanvasX(e, canvas);
+    const y = getCanvasY(e, canvas);
+    const { plotArea } = transform;
+
+    if (x < plotArea.left || x > plotArea.left + plotArea.width) {
+      renderer.renderOverlay();
+      hideTooltipEl(tooltip);
+      callbacks.onHover?.(undefined);
+      return;
+    }
+
+    renderer.renderOverlay(x, y);
+    callbacks.onHover?.(x);
+
+    const distanceNm = transform.xToDistance(x);
+    const hoverAltFt = transform.yToAltitude(y);
+    const refData = currentDatasets[0].data;
+    const idx = findNearestPointIndex(refData.points, distanceNm);
+    showTooltip(e, idx, distanceNm, hoverAltFt);
+  }
+
+  function handleClick(e: MouseEvent): void {
+    const transform = renderer.createTransform();
+    if (!transform || currentDatasets.length === 0) return;
+
+    const x = getCanvasX(e, canvas);
+    const { plotArea } = transform;
+
+    if (x < plotArea.left || x > plotArea.left + plotArea.width) return;
+
+    const distanceNm = transform.xToDistance(x);
+    const refData = currentDatasets[0].data;
+    const idx = findNearestPointIndex(refData.points, distanceNm);
+    callbacks.onSelectPoint(idx);
+  }
+
+  function handleMouseLeave(): void {
+    renderer.renderOverlay();
+    hideTooltipEl(tooltip);
+    callbacks.onHover?.(undefined);
+  }
+
+  function showTooltip(
+    e: MouseEvent, idx: number, distanceNm: number, hoverAltFt: number,
+  ): void {
+    tooltip = ensureTooltipEl(canvas.parentElement!, tooltip);
+    const sections: string[] = [];
+    const refData = currentDatasets[0].data;
+    const refPoint = refData.points[idx];
+
+    // Header
+    const headerLines: string[] = [];
+    const wp = findNearbyWaypoint(refData, refPoint);
+    headerLines.push(wp ? `<strong>${wp.icao}</strong>` : `<strong>Point ${idx}</strong>`);
+    headerLines.push(`${refPoint.distanceNm.toFixed(0)} nm`);
+    try {
+      const d = new Date(refPoint.time);
+      headerLines.push(d.toISOString().slice(11, 16) + 'Z');
+    } catch { /* skip */ }
+    headerLines.push(`${fmtFL(hoverAltFt)}`);
+    sections.push(headerLines.join('<br>'));
+
+    if (!currentLayer) {
+      tooltip.innerHTML = sections.map((s) => `<div class="tt-section">${s}</div>`).join('');
+      tooltip.style.display = 'block';
+      positionTooltip(tooltip, e, canvas, canvas.parentElement!.clientWidth);
+      return;
+    }
+
+    // Layer name
+    sections.push(`<strong>${currentLayer.name}</strong>`);
+
+    // Per-model details
+    const modelLines: string[] = [];
+    let hitCount = 0;
+
+    for (const dataset of currentDatasets) {
+      const point = dataset.data.points[idx];
+      if (!point) continue;
+
+      const label = modelLabel(dataset.model);
+      const hit = currentLayer.type === 'band'
+        ? bandHitTest(point, currentLayer.id, hoverAltFt)
+        : lineHitTest(point, currentLayer, hoverAltFt);
+
+      if (hit) {
+        hitCount++;
+        modelLines.push(`${label} \u2713 ${hit}`);
+      } else {
+        modelLines.push(`<span style="opacity:0.5">${label} \u2717</span>`);
+      }
+    }
+
+    sections.push(modelLines.join('<br>'));
+
+    if (currentDatasets.length > 1) {
+      sections.push(`Agreement: ${hitCount}/${currentDatasets.length} models`);
+    }
+
+    tooltip.innerHTML = sections.map((s) => `<div class="tt-section">${s}</div>`).join('');
+    tooltip.style.display = 'block';
+    positionTooltip(tooltip, e, canvas, canvas.parentElement!.clientWidth);
+  }
+
+  canvas.addEventListener('mousemove', handleMouseMove);
+  canvas.addEventListener('click', handleClick);
+  canvas.addEventListener('mouseleave', handleMouseLeave);
+
+  return {
+    update(newDatasets, newLayer) {
+      currentDatasets = newDatasets;
+      currentLayer = newLayer;
+    },
+    destroy() {
+      canvas.removeEventListener('mousemove', handleMouseMove);
+      canvas.removeEventListener('click', handleClick);
+      canvas.removeEventListener('mouseleave', handleMouseLeave);
+      if (tooltip) { tooltip.remove(); tooltip = null; }
+      canvas.style.pointerEvents = '';
+      canvas.style.cursor = '';
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function fmtFL(ft: number): string {
+  if (ft >= 5000) return `FL${Math.round(ft / 100).toString().padStart(3, '0')}`;
+  return `${Math.round(ft).toLocaleString()} ft`;
+}
+
+function altInBand(hoverAlt: number, baseFt: number, topFt: number): boolean {
+  return hoverAlt >= baseFt && hoverAlt <= topFt;
+}
+
+/** Hit-test for band layers: check if hover altitude falls within any zone. */
+function bandHitTest(point: VizPoint, layerId: string, hoverAltFt: number): string | null {
+  switch (layerId) {
+    case 'icing-bands':
+      for (const z of point.icingZones) {
+        if (z.risk !== 'none' && altInBand(hoverAltFt, z.baseFt, z.topFt)) {
+          return `${z.risk} ${fmtFL(z.baseFt)}\u2013${fmtFL(z.topFt)}`;
+        }
+      }
+      return null;
+
+    case 'icing-ogimet-nwp-bands':
+      for (const z of point.icingOgimetNwpZones) {
+        if (z.risk !== 'none' && altInBand(hoverAltFt, z.baseFt, z.topFt)) {
+          return `${z.risk} ${fmtFL(z.baseFt)}\u2013${fmtFL(z.topFt)}`;
+        }
+      }
+      return null;
+
+    case 'sfip-bands':
+      for (const z of point.sfipZones) {
+        if (z.risk !== 'none' && altInBand(hoverAltFt, z.baseFt, z.topFt)) {
+          return `${z.risk} ${fmtFL(z.baseFt)}\u2013${fmtFL(z.topFt)}`;
+        }
+      }
+      return null;
+
+    case 'cloud-bands':
+      for (const cl of point.cloudLayers) {
+        if (altInBand(hoverAltFt, cl.baseFt, cl.topFt)) {
+          return `${cl.coverage} ${fmtFL(cl.baseFt)}\u2013${fmtFL(cl.topFt)}`;
+        }
+      }
+      return null;
+
+    case 'nwp-cloud-bands':
+      if (point.nwpCloudDiag) {
+        for (const [label, layer] of [['Low', point.nwpCloudDiag.low], ['Mid', point.nwpCloudDiag.mid], ['High', point.nwpCloudDiag.high]] as const) {
+          if (layer.coverPct !== null && layer.coverPct > 0 &&
+              layer.baseFt !== null && layer.topFt !== null &&
+              altInBand(hoverAltFt, layer.baseFt, layer.topFt)) {
+            return `${label} ${Math.round(layer.coverPct)}%`;
+          }
+        }
+      }
+      return null;
+
+    case 'cat-bands':
+      for (const z of point.catLayers) {
+        if (z.risk !== 'none' && altInBand(hoverAltFt, z.baseFt, z.topFt)) {
+          return `${z.risk} ${fmtFL(z.baseFt)}\u2013${fmtFL(z.topFt)}`;
+        }
+      }
+      return null;
+
+    case 'inversion-bands':
+      for (const inv of point.inversions) {
+        if (altInBand(hoverAltFt, inv.baseFt, inv.topFt)) {
+          return `+${inv.strengthC.toFixed(1)}\u00B0C`;
+        }
+      }
+      return null;
+
+    case 'thermo-convective-bg':
+      if (point.convectiveRisk !== 'none' &&
+          point.convectiveBaseFt !== null && point.convectiveTopFt !== null &&
+          altInBand(hoverAltFt, point.convectiveBaseFt, point.convectiveTopFt)) {
+        return point.convectiveRisk;
+      }
+      return null;
+
+    case 'nwp-convective-bg':
+      if (point.nwpConvectiveRisk !== 'none' &&
+          point.nwpConvectiveBaseFt !== null && point.nwpConvectiveTopFt !== null &&
+          altInBand(hoverAltFt, point.nwpConvectiveBaseFt, point.nwpConvectiveTopFt)) {
+        return point.nwpConvectiveRisk;
+      }
+      return null;
+
+    default:
+      return null;
+  }
+}
+
+/** Hit-test for line layers: check proximity to the altitude value. */
+function lineHitTest(point: VizPoint, layer: ComparableLayer, hoverAltFt: number): string | null {
+  if (!layer.lineAccessor) return null;
+  const val = layer.lineAccessor(point);
+  if (val === null) return null;
+  if (Math.abs(hoverAltFt - val) <= 1500) {
+    return `${Math.round(val).toLocaleString()} ft`;
+  }
+  return null;
+}

--- a/web/ts/visualization/cross-section/compare-layers.ts
+++ b/web/ts/visualization/cross-section/compare-layers.ts
@@ -1,0 +1,106 @@
+/** Registry of layers available in compare mode and their rendering type. */
+
+import type { VizPoint, AltitudeLines } from '../types';
+
+export type CompareLayerType = 'band' | 'line';
+
+export interface ComparableLayer {
+  id: string;
+  name: string;
+  group: string;
+  type: CompareLayerType;
+  /** For line layers: extract the altitude value from a VizPoint. */
+  lineAccessor?: (p: VizPoint) => number | null;
+  lineStyle?: { color: string; width: number; dash?: number[] };
+  envelopeFill?: string;
+}
+
+const COMPARABLE_LAYERS: ComparableLayer[] = [
+  // --- Band layers (reuse existing CrossSectionLayer.render via offscreen compositing) ---
+
+  // Clouds
+  { id: 'cloud-bands', name: 'DD Clouds', group: 'Clouds', type: 'band' },
+  { id: 'nwp-cloud-bands', name: 'NWP Clouds', group: 'Clouds', type: 'band' },
+
+  // Icing
+  { id: 'icing-bands', name: 'Ogimet-DD Icing', group: 'Icing', type: 'band' },
+  { id: 'icing-ogimet-nwp-bands', name: 'Ogimet-NWP Icing', group: 'Icing', type: 'band' },
+  { id: 'sfip-bands', name: 'SFIP Icing', group: 'Icing', type: 'band' },
+
+  // Turbulence
+  { id: 'cat-bands', name: 'CAT', group: 'Turbulence', type: 'band' },
+  { id: 'inversion-bands', name: 'Inversions', group: 'Turbulence', type: 'band' },
+
+  // Convection
+  { id: 'thermo-convective-bg', name: 'Thermo Convective', group: 'Convection', type: 'band' },
+  { id: 'nwp-convective-bg', name: 'NWP Convective', group: 'Convection', type: 'band' },
+
+  // --- Line layers (envelope rendering: min/max band + mean line) ---
+
+  // Temperature
+  {
+    id: 'freezing-level', name: '0°C (Freezing)', group: 'Temperature', type: 'line',
+    lineAccessor: (p) => p.altitudeLines.freezingLevelFt,
+    lineStyle: { color: '#2563eb', width: 2 },
+    envelopeFill: 'rgba(37, 99, 235, 0.15)',
+  },
+  {
+    id: 'minus-10c-level', name: '-10°C', group: 'Temperature', type: 'line',
+    lineAccessor: (p) => p.altitudeLines.minus10cLevelFt,
+    lineStyle: { color: '#7c3aed', width: 1.5, dash: [6, 3] },
+    envelopeFill: 'rgba(124, 58, 237, 0.12)',
+  },
+  {
+    id: 'minus-20c-level', name: '-20°C', group: 'Temperature', type: 'line',
+    lineAccessor: (p) => p.altitudeLines.minus20cLevelFt,
+    lineStyle: { color: '#9333ea', width: 1.5, dash: [6, 3] },
+    envelopeFill: 'rgba(147, 51, 234, 0.12)',
+  },
+
+  // Stability
+  {
+    id: 'lcl-line', name: 'LCL', group: 'Stability', type: 'line',
+    lineAccessor: (p) => p.altitudeLines.lclAltitudeFt,
+    lineStyle: { color: '#059669', width: 1.5, dash: [4, 4] },
+    envelopeFill: 'rgba(5, 150, 105, 0.12)',
+  },
+  {
+    id: 'lfc-line', name: 'LFC', group: 'Stability', type: 'line',
+    lineAccessor: (p) => p.altitudeLines.lfcAltitudeFt,
+    lineStyle: { color: '#d97706', width: 1.5, dash: [4, 4] },
+    envelopeFill: 'rgba(217, 119, 6, 0.12)',
+  },
+  {
+    id: 'el-line', name: 'EL', group: 'Stability', type: 'line',
+    lineAccessor: (p) => p.altitudeLines.elAltitudeFt,
+    lineStyle: { color: '#dc2626', width: 1.5, dash: [4, 4] },
+    envelopeFill: 'rgba(220, 38, 38, 0.12)',
+  },
+];
+
+const LAYER_MAP = new Map(COMPARABLE_LAYERS.map((l) => [l.id, l]));
+
+export function getComparableLayer(id: string): ComparableLayer | undefined {
+  return LAYER_MAP.get(id);
+}
+
+export interface ComparableLayerGroup {
+  group: string;
+  layers: ComparableLayer[];
+}
+
+export function getComparableLayerGroups(): ComparableLayerGroup[] {
+  const groupMap = new Map<string, ComparableLayer[]>();
+  for (const l of COMPARABLE_LAYERS) {
+    let arr = groupMap.get(l.group);
+    if (!arr) { arr = []; groupMap.set(l.group, arr); }
+    arr.push(l);
+  }
+  const result: ComparableLayerGroup[] = [];
+  for (const [group, layers] of groupMap) {
+    result.push({ group, layers });
+  }
+  return result;
+}
+
+export { COMPARABLE_LAYERS };

--- a/web/ts/visualization/cross-section/compare-renderer.ts
+++ b/web/ts/visualization/cross-section/compare-renderer.ts
@@ -1,0 +1,318 @@
+/** Compare cross-section renderer: one layer across N models. */
+
+import type { CoordTransform, PlotArea, VizRouteData, CrossSectionLayer } from '../types';
+import type { ComparableLayer } from './compare-layers';
+import { drawAxes } from './axes';
+import { terrainFillLayer } from './layers/terrain-fill';
+import { cruiseAltitudeLayer } from './layers/reference-lines';
+import { getAllLayers } from './layer-registry';
+import { drawSmoothBand, drawSmoothLine, type BandPointData, type PointData } from './layers/base';
+
+const MARGIN = { left: 60, right: 50, top: 20, bottom: 50 };
+
+export interface CompareModelData {
+  model: string;
+  data: VizRouteData;
+}
+
+export class CompareSectionRenderer {
+  private container: HTMLElement;
+  private mainCanvas: HTMLCanvasElement;
+  private overlayCanvas: HTMLCanvasElement;
+  private offscreenCanvas: HTMLCanvasElement;
+  private resizeObserver: ResizeObserver;
+  private datasets: CompareModelData[] = [];
+  private compareLayer: ComparableLayer | null = null;
+  private selectedPointIndex = -1;
+
+  constructor(container: HTMLElement) {
+    this.container = container;
+
+    this.mainCanvas = document.createElement('canvas');
+    this.mainCanvas.style.cssText = 'position:absolute;inset:0;width:100%;height:100%';
+    container.appendChild(this.mainCanvas);
+
+    this.overlayCanvas = document.createElement('canvas');
+    this.overlayCanvas.style.cssText = 'position:absolute;inset:0;width:100%;height:100%;pointer-events:none';
+    container.appendChild(this.overlayCanvas);
+
+    // Offscreen canvas for band layer compositing
+    this.offscreenCanvas = document.createElement('canvas');
+
+    this.resizeObserver = new ResizeObserver(() => this.render());
+    this.resizeObserver.observe(container);
+
+    window.addEventListener('theme-changed', () => this.render());
+  }
+
+  setModelData(datasets: CompareModelData[]): void {
+    this.datasets = datasets;
+  }
+
+  setCompareLayer(layer: ComparableLayer | null): void {
+    this.compareLayer = layer;
+  }
+
+  setSelectedPointIndex(index: number): void {
+    this.selectedPointIndex = index;
+    this.renderOverlay();
+  }
+
+  getCanvas(): HTMLCanvasElement {
+    return this.overlayCanvas;
+  }
+
+  /** Create a coordinate transform using the first dataset's dimensions. */
+  createTransform(): CoordTransform | null {
+    if (this.datasets.length === 0) return null;
+    const data = this.datasets[0].data;
+    const cssW = this.container.clientWidth;
+    const cssH = this.container.clientHeight;
+    if (cssW === 0 || cssH === 0) return null;
+
+    const plotArea: PlotArea = {
+      left: MARGIN.left,
+      top: MARGIN.top,
+      width: cssW - MARGIN.left - MARGIN.right,
+      height: cssH - MARGIN.top - MARGIN.bottom,
+    };
+
+    const maxDist = data.totalDistanceNm;
+    const maxAlt = data.flightCeilingFt;
+
+    return {
+      distanceToX: (d: number) => plotArea.left + (d / maxDist) * plotArea.width,
+      altitudeToY: (a: number) => plotArea.top + (1 - a / maxAlt) * plotArea.height,
+      xToDistance: (x: number) => ((x - plotArea.left) / plotArea.width) * maxDist,
+      yToAltitude: (y: number) => (1 - (y - plotArea.top) / plotArea.height) * maxAlt,
+      plotArea,
+    };
+  }
+
+  render(): void {
+    if (this.datasets.length === 0) return;
+    const cssW = this.container.clientWidth;
+    const cssH = this.container.clientHeight;
+    if (cssW === 0 || cssH === 0) return;
+
+    const dpr = window.devicePixelRatio || 1;
+    this.setupCanvas(this.mainCanvas, cssW, cssH, dpr);
+    this.setupCanvas(this.overlayCanvas, cssW, cssH, dpr);
+    this.setupCanvas(this.offscreenCanvas, cssW, cssH, dpr);
+
+    const ctx = this.mainCanvas.getContext('2d')!;
+    ctx.save();
+    ctx.scale(dpr, dpr);
+    ctx.clearRect(0, 0, cssW, cssH);
+
+    const transform = this.createTransform();
+    if (!transform) { ctx.restore(); return; }
+
+    // Sky-blue background
+    const { plotArea } = transform;
+    ctx.fillStyle = '#87CEEB';
+    ctx.fillRect(plotArea.left, plotArea.top, plotArea.width, plotArea.height);
+
+    // Axes (using first dataset for waypoints/distance)
+    drawAxes(ctx, transform, this.datasets[0].data);
+
+    // Clip to plot area for layer rendering
+    ctx.save();
+    ctx.beginPath();
+    ctx.rect(plotArea.left, plotArea.top, plotArea.width, plotArea.height);
+    ctx.clip();
+
+    // Render the selected compare layer
+    if (this.compareLayer) {
+      if (this.compareLayer.type === 'band') {
+        this.renderBandLayer(ctx, transform, cssW, cssH, dpr);
+      } else {
+        this.renderLineEnvelope(ctx, transform);
+      }
+    }
+
+    // Terrain and reference lines (from first dataset)
+    terrainFillLayer.render(ctx, transform, this.datasets[0].data);
+    ctx.restore(); // unclip
+
+    // Cruise altitude on top (unclipped so labels can extend)
+    ctx.save();
+    ctx.beginPath();
+    ctx.rect(plotArea.left, plotArea.top, plotArea.width, plotArea.height);
+    ctx.clip();
+    cruiseAltitudeLayer.render(ctx, transform, this.datasets[0].data);
+    ctx.restore();
+
+    ctx.restore();
+    this.renderOverlay();
+  }
+
+  renderOverlay(hoverX?: number, hoverY?: number): void {
+    const cssW = this.container.clientWidth;
+    const cssH = this.container.clientHeight;
+    if (cssW === 0 || cssH === 0) return;
+
+    const dpr = window.devicePixelRatio || 1;
+    const ctx = this.overlayCanvas.getContext('2d')!;
+    ctx.save();
+    ctx.scale(dpr, dpr);
+    ctx.clearRect(0, 0, cssW, cssH);
+
+    const transform = this.createTransform();
+    if (!transform || this.datasets.length === 0) { ctx.restore(); return; }
+
+    const { plotArea } = transform;
+    const data = this.datasets[0].data;
+
+    // Selected point indicator
+    if (this.selectedPointIndex >= 0 && this.selectedPointIndex < data.points.length) {
+      const pt = data.points[this.selectedPointIndex];
+      const x = transform.distanceToX(pt.distanceNm);
+      ctx.strokeStyle = 'rgba(37, 99, 235, 0.6)';
+      ctx.lineWidth = 2;
+      ctx.setLineDash([]);
+      ctx.beginPath();
+      ctx.moveTo(x, plotArea.top);
+      ctx.lineTo(x, plotArea.top + plotArea.height);
+      ctx.stroke();
+    }
+
+    // Hover crosshair (vertical)
+    if (hoverX !== undefined && hoverX >= plotArea.left && hoverX <= plotArea.left + plotArea.width) {
+      ctx.strokeStyle = 'rgba(0, 0, 0, 0.3)';
+      ctx.lineWidth = 1;
+      ctx.setLineDash([4, 4]);
+      ctx.beginPath();
+      ctx.moveTo(hoverX, plotArea.top);
+      ctx.lineTo(hoverX, plotArea.top + plotArea.height);
+      ctx.stroke();
+      ctx.setLineDash([]);
+    }
+
+    // Hover crosshair (horizontal)
+    if (hoverY !== undefined && hoverY >= plotArea.top && hoverY <= plotArea.top + plotArea.height) {
+      ctx.strokeStyle = 'rgba(0, 0, 0, 0.2)';
+      ctx.lineWidth = 1;
+      ctx.setLineDash([4, 4]);
+      ctx.beginPath();
+      ctx.moveTo(plotArea.left, hoverY);
+      ctx.lineTo(plotArea.left + plotArea.width, hoverY);
+      ctx.stroke();
+      ctx.setLineDash([]);
+    }
+
+    ctx.restore();
+  }
+
+  destroy(): void {
+    this.resizeObserver.disconnect();
+    this.mainCanvas.remove();
+    this.overlayCanvas.remove();
+  }
+
+  private renderBandLayer(
+    ctx: CanvasRenderingContext2D,
+    transform: CoordTransform,
+    cssW: number,
+    cssH: number,
+    dpr: number,
+  ): void {
+    if (!this.compareLayer) return;
+
+    // Find the CrossSectionLayer with matching id
+    const crossSectionLayer = getAllLayers().find((l) => l.id === this.compareLayer!.id);
+    if (!crossSectionLayer) return;
+
+    const numModels = this.datasets.length;
+    const alpha = Math.min(0.85, Math.max(0.15, 1.5 / numModels));
+
+    const offCtx = this.offscreenCanvas.getContext('2d')!;
+
+    const { plotArea } = transform;
+
+    for (const dataset of this.datasets) {
+      // Clear offscreen and fill plot area with white so semi-transparent
+      // layer fills (e.g. cloud grays) resolve against an opaque background
+      // rather than compositing transparency-on-transparency.
+      offCtx.save();
+      offCtx.scale(dpr, dpr);
+      offCtx.clearRect(0, 0, cssW, cssH);
+      offCtx.fillStyle = '#ffffff';
+      offCtx.fillRect(plotArea.left, plotArea.top, plotArea.width, plotArea.height);
+
+      // Clip offscreen to plot area
+      offCtx.beginPath();
+      offCtx.rect(plotArea.left, plotArea.top, plotArea.width, plotArea.height);
+      offCtx.clip();
+
+      // Render the layer at full opacity on offscreen
+      crossSectionLayer.render(offCtx, transform, dataset.data);
+      offCtx.restore();
+
+      // Composite offscreen onto main canvas with multiply blend so the
+      // white background becomes transparent while the colored layer content
+      // darkens the sky-blue underneath.
+      ctx.save();
+      ctx.globalCompositeOperation = 'multiply';
+      ctx.globalAlpha = alpha;
+      ctx.drawImage(this.offscreenCanvas, 0, 0, cssW * dpr, cssH * dpr, 0, 0, cssW, cssH);
+      ctx.restore();
+    }
+  }
+
+  private renderLineEnvelope(
+    ctx: CanvasRenderingContext2D,
+    transform: CoordTransform,
+  ): void {
+    if (!this.compareLayer || !this.compareLayer.lineAccessor) return;
+
+    const accessor = this.compareLayer.lineAccessor;
+    const style = this.compareLayer.lineStyle ?? { color: '#2563eb', width: 2 };
+    const fillColor = this.compareLayer.envelopeFill ?? 'rgba(37, 99, 235, 0.15)';
+
+    // Use first dataset's points as the distance reference
+    const refPoints = this.datasets[0].data.points;
+
+    // For each route point, compute min/max/mean across all models
+    const bandPoints: BandPointData[] = [];
+    const meanPoints: PointData[] = [];
+
+    for (let i = 0; i < refPoints.length; i++) {
+      const distance = refPoints[i].distanceNm;
+      let min = Infinity;
+      let max = -Infinity;
+      let sum = 0;
+      let count = 0;
+
+      for (const dataset of this.datasets) {
+        if (i >= dataset.data.points.length) continue;
+        const val = accessor(dataset.data.points[i]);
+        if (val !== null) {
+          min = Math.min(min, val);
+          max = Math.max(max, val);
+          sum += val;
+          count++;
+        }
+      }
+
+      if (count > 0) {
+        bandPoints.push({ distance, base: min, top: max });
+        meanPoints.push({ distance, value: sum / count });
+      } else {
+        bandPoints.push({ distance, base: null, top: null });
+        meanPoints.push({ distance, value: null });
+      }
+    }
+
+    // Draw filled envelope (min→max)
+    drawSmoothBand(ctx, bandPoints, transform, fillColor);
+
+    // Draw mean line
+    drawSmoothLine(ctx, meanPoints, transform, style);
+  }
+
+  private setupCanvas(canvas: HTMLCanvasElement, cssW: number, cssH: number, dpr: number): void {
+    canvas.width = cssW * dpr;
+    canvas.height = cssH * dpr;
+  }
+}

--- a/web/ts/visualization/types.ts
+++ b/web/ts/visualization/types.ts
@@ -2,7 +2,7 @@
 
 // --- Settings ---
 
-export type VizLayout = 'cross-section' | 'map' | 'split';
+export type VizLayout = 'cross-section' | 'map' | 'split' | 'compare';
 
 export interface VizSettings {
   layout: VizLayout;
@@ -13,6 +13,8 @@ export interface VizSettings {
   routeGraphVisible: boolean;
   routeGraphLeftMetric: string;
   routeGraphRightMetric: string;  // 'none' to disable right axis
+  compareLayer: string;
+  compareModels: Record<string, boolean>;
 }
 
 // --- Coordinate Transform ---


### PR DESCRIPTION
## Summary

Closes #37

- Adds a **Compare** layout mode to the cross-section visualization that overlays one selected weather layer across all NWP models simultaneously
- **Band layers** (clouds, icing, CAT, convection, inversions) rendered via offscreen compositing with `multiply` blend — areas of model agreement appear darker
- **Line layers** (freezing level, -10°C, -20°C, LCL, LFC, EL) rendered as min/max envelope band with mean line through center
- Model chip toggles to include/exclude specific models from the comparison
- Layer dropdown with grouped options (Clouds, Icing, Turbulence, Convection, Temperature, Stability)
- Per-model tooltip showing hit/miss status and agreement count at hover altitude
- Layout, selected layer, and model toggles persisted to localStorage

### Files created
- `compare-layers.ts` — registry of 15 comparable layers (9 band + 6 line)
- `compare-renderer.ts` — `CompareSectionRenderer` with offscreen compositing and envelope rendering
- `compare-interaction.ts` — compare-specific interaction with per-model tooltip

### Files modified
- `types.ts` — `'compare'` added to `VizLayout`, new `compareLayer`/`compareModels` settings
- `briefing-store.ts` — new actions and defaults
- `panel.ts` — Compare button in layout toggle, `renderCompareControls()` function
- `briefing-main.ts` — compare renderer lifecycle, controls wiring
- `style.css` — `.layout-compare`, `.btn-chip`, `.viz-compare-*` styles

## Test plan

- [ ] Switch between X-Section and Compare — axes, terrain, canvas size should be identical
- [ ] Select icing-bands with all models → areas of agreement appear darker
- [ ] Select freezing-level → filled band showing min/max spread, mean line
- [ ] Toggle models off/on → canvas re-renders with fewer/more overlays
- [ ] Change layer dropdown → canvas re-renders with different layer
- [ ] Hover in compare mode → tooltip lists each model with ✓/✗
- [ ] Refresh page → compare layout, selected layer, model toggles restored
- [ ] Verify dark theme renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)