### PR TITLE
feat: add alternative departure time with lite advisory re-analysis

### DIFF
--- a/alembic/versions/018_alt_departure_time.py
+++ b/alembic/versions/018_alt_departure_time.py
@@ -1,0 +1,43 @@
+"""Add alt_departure_time to flights and alt assessment fields to briefing_packs.
+
+Revision ID: 018
+Revises: 017
+Create Date: 2026-03-03
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "018"
+down_revision: Union[str, None] = "017"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "flights",
+        sa.Column("alt_departure_time", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.add_column(
+        "briefing_packs",
+        sa.Column("alt_assessment", sa.String(16), nullable=True),
+    )
+    op.add_column(
+        "briefing_packs",
+        sa.Column("alt_assessment_reason", sa.Text, nullable=True),
+    )
+    op.add_column(
+        "briefing_packs",
+        sa.Column("has_alt_advisories", sa.Boolean, nullable=False, server_default="0"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("briefing_packs", "has_alt_advisories")
+    op.drop_column("briefing_packs", "alt_assessment_reason")
+    op.drop_column("briefing_packs", "alt_assessment")
+    op.drop_column("flights", "alt_departure_time")

--- a/src/weatherbrief/api/flights.py
+++ b/src/weatherbrief/api/flights.py
@@ -487,11 +487,9 @@ def update_flight(
             row.alt_departure_time = None
         else:
             alt_dt = datetime.fromisoformat(req.alt_departure_time)
-            if alt_dt.tzinfo is None:
-                alt_dt = alt_dt.replace(tzinfo=timezone.utc)
             # Validate same-day constraint
             effective_departure = row.departure_time
-            if alt_dt.strftime("%Y-%m-%d") != effective_departure.strftime("%Y-%m-%d"):
+            if alt_dt.date() != effective_departure.date():
                 raise HTTPException(
                     status_code=422,
                     detail="Alt departure time must be on the same day as the primary departure.",

--- a/src/weatherbrief/api/flights.py
+++ b/src/weatherbrief/api/flights.py
@@ -72,6 +72,7 @@ class FlightResponse(BaseModel):
     route_name: str
     waypoints: list[str] = []
     departure_time: str
+    alt_departure_time: str | None = None
     target_date: str  # backward compat (computed from departure_time)
     target_time_utc: int  # backward compat (computed from departure_time)
     cruise_altitude_ft: int
@@ -103,6 +104,7 @@ def _flight_to_response(flight: Flight) -> FlightResponse:
         route_name=flight.route_name,
         waypoints=flight.waypoints,
         departure_time=flight.departure_time.isoformat(),
+        alt_departure_time=flight.alt_departure_time.isoformat() if flight.alt_departure_time else None,
         target_date=flight.target_date,
         target_time_utc=flight.target_time_utc,
         cruise_altitude_ft=flight.cruise_altitude_ft,
@@ -379,6 +381,7 @@ class UpdateFlightRequest(BaseModel):
 
     profile_id: int | None = None  # switch aircraft profile (applies its altitude/ceiling)
     departure_time: str | None = None  # ISO 8601 (time-of-day change only; date must match)
+    alt_departure_time: str | None = None  # ISO 8601 or "" to clear
     cruise_altitude_ft: int | None = None
     flight_ceiling_ft: int | None = None
     flight_duration_hours: float | None = None
@@ -394,6 +397,19 @@ class UpdateFlightRequest(BaseModel):
             raise ValueError("departure_time must be a valid ISO 8601 datetime")
         if dt.tzinfo is None:
             raise ValueError("departure_time must include a timezone")
+        return v
+
+    @field_validator("alt_departure_time")
+    @classmethod
+    def validate_alt_departure_time(cls, v: str | None) -> str | None:
+        if v is None or v == "":
+            return v
+        try:
+            dt = datetime.fromisoformat(v)
+        except ValueError:
+            raise ValueError("alt_departure_time must be a valid ISO 8601 datetime or empty string")
+        if dt.tzinfo is None:
+            raise ValueError("alt_departure_time must include a timezone")
         return v
 
 
@@ -464,6 +480,29 @@ def update_flight(
     if req.flight_duration_hours is not None and req.flight_duration_hours != original_flight.flight_duration_hours:
         row.flight_duration_hours = req.flight_duration_hours
         time_changed = True
+
+    # Alt departure time: "" clears, ISO string sets, None = no change
+    if req.alt_departure_time is not None:
+        if req.alt_departure_time == "":
+            row.alt_departure_time = None
+        else:
+            alt_dt = datetime.fromisoformat(req.alt_departure_time)
+            if alt_dt.tzinfo is None:
+                alt_dt = alt_dt.replace(tzinfo=timezone.utc)
+            # Validate same-day constraint
+            effective_departure = row.departure_time
+            if alt_dt.strftime("%Y-%m-%d") != effective_departure.strftime("%Y-%m-%d"):
+                raise HTTPException(
+                    status_code=422,
+                    detail="Alt departure time must be on the same day as the primary departure.",
+                )
+            # Validate alt ≠ primary
+            if alt_dt == effective_departure:
+                raise HTTPException(
+                    status_code=422,
+                    detail="Alt departure time must differ from the primary departure time.",
+                )
+            row.alt_departure_time = alt_dt
 
     db.flush()
     updated = load_flight(db, flight_id)

--- a/src/weatherbrief/api/packs.py
+++ b/src/weatherbrief/api/packs.py
@@ -195,8 +195,11 @@ class PackMetaResponse(BaseModel):
     has_skewt: bool
     has_digest: bool
     has_advisories: bool = False
+    has_alt_advisories: bool = False
     assessment: str | None
     assessment_reason: str | None
+    alt_assessment: str | None = None
+    alt_assessment_reason: str | None = None
     model_init_times: dict[str, int] = Field(default_factory=dict)
     grib_init_times: dict[str, int] = Field(default_factory=dict)
     models_skipped_region: list[str] = Field(default_factory=list)
@@ -223,8 +226,11 @@ def _meta_to_response(
         has_skewt=meta.has_skewt,
         has_digest=meta.has_digest,
         has_advisories=has_advisories,
+        has_alt_advisories=meta.has_alt_advisories,
         assessment=meta.assessment,
         assessment_reason=meta.assessment_reason,
+        alt_assessment=meta.alt_assessment,
+        alt_assessment_reason=meta.alt_assessment_reason,
         model_init_times=meta.model_init_times,
         grib_init_times=meta.grib_init_times,
         models_skipped_region=meta.models_skipped_region,
@@ -313,6 +319,7 @@ _STAGE_LABELS: dict[str, str] = {
     "waypoint_analysis": "Analyzing waypoints",
     "route_analysis": "Analyzing route points",
     "route_advisories": "Evaluating route advisories",
+    "alt_advisories": "Evaluating alt-time advisories",
     "route_weather": "Fetching METAR/TAF observations",
     "save_snapshot": "Saving snapshot",
     "fetch_gramet": "Fetching GRAMET",
@@ -328,6 +335,7 @@ _STAGE_PROGRESS: dict[str, float] = {
     "waypoint_analysis": 0.50,
     "route_analysis": 0.58,
     "route_advisories": 0.62,
+    "alt_advisories": 0.63,
     "route_weather": 0.64,
     "save_snapshot": 0.65,
     "fetch_gramet": 0.75,
@@ -432,6 +440,8 @@ def _prepare_refresh(flight, db_path, user_id, flight_id, db=None, *, is_privile
     )
     if as_of_time:
         options.as_of_time = as_of_time
+    if flight.alt_departure_time:
+        options.alt_departure_time = flight.alt_departure_time
     if icing_method:
         options.icing_method = icing_method
     if cloud_method:
@@ -513,6 +523,17 @@ def _finalize_refresh(flight_id, flight, fetch_ts, pack_path, result, db,
     if model_metadata:
         init_times = {m: meta.last_init_time for m, meta in model_metadata.items()}
 
+    # Derive alt assessment from alt advisory result if available
+    alt_assessment = None
+    alt_assessment_reason = None
+    has_alt_advisories = False
+    if result.alt_advisory_result and result.alt_advisory_result.manifest:
+        has_alt_advisories = True
+        from weatherbrief.tasks.advise import derive_assessment_from_advisories
+        alt_assessment, alt_assessment_reason = derive_assessment_from_advisories(
+            result.alt_advisory_result.manifest,
+        )
+
     meta = BriefingPackMeta(
         flight_id=flight_id,
         fetch_timestamp=fetch_ts,
@@ -527,6 +548,9 @@ def _finalize_refresh(flight_id, flight, fetch_ts, pack_path, result, db,
         grib_init_times=result.grib_init_times,
         models_skipped_region=result.models_skipped_region,
         diagnostics=result.diagnostics,
+        alt_assessment=alt_assessment,
+        alt_assessment_reason=alt_assessment_reason,
+        has_alt_advisories=has_alt_advisories,
     )
 
     save_pack_meta(db, meta)
@@ -1209,6 +1233,101 @@ def get_advisories(
     if not adv_path.exists():
         raise HTTPException(status_code=404, detail="Route advisories not available")
     return FileResponse(adv_path, media_type="application/json")
+
+
+@router.get("/{timestamp}/advisories/alt")
+def get_alt_advisories(
+    flight_id: str,
+    timestamp: str,
+    user_id: str = Depends(current_user_id),
+    db: Session = Depends(get_db),
+):
+    """Get the alt-departure route advisories JSON for a pack."""
+    pack_dir = _get_pack_dir(db, flight_id, timestamp, viewer_id=user_id)
+    adv_path = pack_dir / "route_advisories_alt.json"
+    if not adv_path.exists():
+        raise HTTPException(status_code=404, detail="Alt advisories not available")
+    return FileResponse(adv_path, media_type="application/json")
+
+
+@router.post("/{timestamp}/advisories/alt/compute")
+def compute_alt_advisories(
+    flight_id: str,
+    timestamp: str,
+    request: Request,
+    user_id: str = Depends(current_user_id),
+    db: Session = Depends(get_db),
+):
+    """Compute alt-departure advisories on-demand from existing pack data.
+
+    Uses the flight's ``alt_departure_time`` to re-run analysis and
+    advisories against the already-fetched forecast data.  Updates
+    the pack meta with the alt assessment.
+    """
+    from weatherbrief.tasks.advise import derive_assessment_from_advisories, run_alt_from_pack
+
+    flight = _load_flight_or_404(db, flight_id, viewer_id=user_id)
+    if not flight.alt_departure_time:
+        raise HTTPException(status_code=422, detail="Flight has no alt departure time set")
+
+    pack_dir = _get_pack_dir(db, flight_id, timestamp, viewer_id=user_id)
+    ra_path = pack_dir / "route_analyses.json"
+    if not ra_path.exists():
+        raise HTTPException(status_code=404, detail="Route analyses not available for alt computation")
+
+    # Resolve route for advisory evaluation
+    db_path = getattr(request.app.state, "db_path", "")
+    from weatherbrief.airports import resolve_waypoints
+    from weatherbrief.models import RouteConfig
+
+    waypoint_objs = resolve_waypoints(flight.waypoints, db_path)
+    route = RouteConfig(
+        name=flight.route_name or " → ".join(flight.waypoints),
+        waypoints=waypoint_objs,
+        cruise_altitude_ft=flight.cruise_altitude_ft,
+        flight_ceiling_ft=flight.flight_ceiling_ft,
+        flight_duration_hours=flight.flight_duration_hours,
+    )
+
+    # Load advisory profile
+    enabled_ids, user_params, aggregation, adv_models, icing_method, cloud_method, convective_method, recompute_conds = \
+        _load_advisory_profile(db, flight, user_id, request, pack_dir)
+
+    advisory_result = run_alt_from_pack(
+        pack_dir=pack_dir,
+        alt_departure_time=flight.alt_departure_time,
+        route=route,
+        advisory_models=adv_models,
+        enabled_ids=enabled_ids,
+        user_params=user_params,
+        aggregation=aggregation,
+        airport_conditions_recompute=recompute_conds,
+        icing_method=icing_method,
+        cloud_method=cloud_method,
+        convective_method=convective_method,
+    )
+
+    if advisory_result.manifest is None:
+        raise HTTPException(status_code=500, detail=advisory_result.error or "Alt advisory evaluation failed")
+
+    # Update pack meta with alt assessment
+    alt_assessment, alt_assessment_reason = derive_assessment_from_advisories(advisory_result.manifest)
+    from weatherbrief.db.models import BriefingPackRow
+    from sqlalchemy import select
+
+    naive_ts = datetime.fromisoformat(timestamp).replace(tzinfo=None)
+    stmt = select(BriefingPackRow).where(
+        BriefingPackRow.flight_id == flight_id,
+        BriefingPackRow.fetch_timestamp == naive_ts,
+    )
+    pack_row = db.execute(stmt).scalar_one_or_none()
+    if pack_row:
+        pack_row.alt_assessment = alt_assessment
+        pack_row.alt_assessment_reason = alt_assessment_reason
+        pack_row.has_alt_advisories = True
+        db.flush()
+
+    return advisory_result.manifest.model_dump()
 
 
 def _recompute_airport_conditions(

--- a/src/weatherbrief/api/packs.py
+++ b/src/weatherbrief/api/packs.py
@@ -344,26 +344,33 @@ _STAGE_PROGRESS: dict[str, float] = {
 }
 
 
-def _prepare_refresh(flight, db_path, user_id, flight_id, db=None, *, is_privileged=False, as_of_time=None):
-    """Shared setup for both sync and streaming refresh endpoints.
-
-    If a DB session is provided, loads user preferences (models, autorouter
-    credentials) and applies them to the BriefingOptions.
-    """
+def _build_route_config(flight, db_path):
+    """Build a RouteConfig from a flight, resolving waypoints."""
     from weatherbrief.airports import resolve_waypoints
-    from weatherbrief.models import ModelSource, RouteConfig
-    from weatherbrief.pipeline import BriefingOptions
+    from weatherbrief.models import RouteConfig
 
     if not flight.waypoints:
         raise ValueError("Flight has no waypoints defined")
     waypoint_objs = resolve_waypoints(flight.waypoints, db_path)
-    route = RouteConfig(
+    return RouteConfig(
         name=flight.route_name or " \u2192 ".join(flight.waypoints),
         waypoints=waypoint_objs,
         cruise_altitude_ft=flight.cruise_altitude_ft,
         flight_ceiling_ft=flight.flight_ceiling_ft,
         flight_duration_hours=flight.flight_duration_hours,
     )
+
+
+def _prepare_refresh(flight, db_path, user_id, flight_id, db=None, *, is_privileged=False, as_of_time=None):
+    """Shared setup for both sync and streaming refresh endpoints.
+
+    If a DB session is provided, loads user preferences (models, autorouter
+    credentials) and applies them to the BriefingOptions.
+    """
+    from weatherbrief.models import ModelSource
+    from weatherbrief.pipeline import BriefingOptions
+
+    route = _build_route_config(flight, db_path)
 
     fetch_ts = datetime.now(tz=timezone.utc)
     pack_path = pack_dir_for(user_id, flight_id, fetch_ts)
@@ -1266,7 +1273,7 @@ def compute_alt_advisories(
     """
     from weatherbrief.tasks.advise import derive_assessment_from_advisories, run_alt_from_pack
 
-    flight = _load_flight_or_404(db, flight_id, viewer_id=user_id)
+    flight = _load_owned_flight(db, flight_id, user_id)
     if not flight.alt_departure_time:
         raise HTTPException(status_code=422, detail="Flight has no alt departure time set")
 
@@ -1275,19 +1282,8 @@ def compute_alt_advisories(
     if not ra_path.exists():
         raise HTTPException(status_code=404, detail="Route analyses not available for alt computation")
 
-    # Resolve route for advisory evaluation
     db_path = getattr(request.app.state, "db_path", "")
-    from weatherbrief.airports import resolve_waypoints
-    from weatherbrief.models import RouteConfig
-
-    waypoint_objs = resolve_waypoints(flight.waypoints, db_path)
-    route = RouteConfig(
-        name=flight.route_name or " → ".join(flight.waypoints),
-        waypoints=waypoint_objs,
-        cruise_altitude_ft=flight.cruise_altitude_ft,
-        flight_ceiling_ft=flight.flight_ceiling_ft,
-        flight_duration_hours=flight.flight_duration_hours,
-    )
+    route = _build_route_config(flight, db_path)
 
     # Load advisory profile
     enabled_ids, user_params, aggregation, adv_models, icing_method, cloud_method, convective_method, recompute_conds = \

--- a/src/weatherbrief/db/models.py
+++ b/src/weatherbrief/db/models.py
@@ -105,6 +105,9 @@ class FlightRow(Base):
     private: Mapped[bool] = mapped_column(Boolean, default=False)
     auto_refresh: Mapped[bool] = mapped_column(Boolean, default=False)
     auto_refresh_hour: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    alt_departure_time: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True, default=None
+    )
     last_auto_refresh_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True), nullable=True
     )
@@ -138,6 +141,9 @@ class BriefingPackRow(Base):
     grib_init_times_json: Mapped[str] = mapped_column(Text, default="{}")
     models_skipped_region_json: Mapped[str] = mapped_column(Text, default="[]")
     diagnostics_json: Mapped[str] = mapped_column(Text, default="[]")
+    alt_assessment: Mapped[str | None] = mapped_column(String(16), nullable=True)
+    alt_assessment_reason: Mapped[str | None] = mapped_column(Text, nullable=True)
+    has_alt_advisories: Mapped[bool] = mapped_column(Boolean, default=False, server_default="0")
 
     flight: Mapped[FlightRow] = relationship(back_populates="packs")
 

--- a/src/weatherbrief/models/storage.py
+++ b/src/weatherbrief/models/storage.py
@@ -33,6 +33,7 @@ class Flight(BaseModel):
     flight_ceiling_ft: int = 18000
     flight_duration_hours: float = 0.0
     private: bool = False
+    alt_departure_time: datetime | None = None  # optional same-day alt departure
     auto_refresh: bool = False
     auto_refresh_hour: int | None = None
     last_auto_refresh_at: datetime | None = None
@@ -68,6 +69,9 @@ class BriefingPackMeta(BaseModel):
     grib_init_times: dict[str, int] = Field(default_factory=dict)
     models_skipped_region: list[str] = Field(default_factory=list)
     diagnostics: list[dict] = Field(default_factory=list)
+    alt_assessment: Optional[str] = None  # GREEN/AMBER/RED for alt departure
+    alt_assessment_reason: Optional[str] = None
+    has_alt_advisories: bool = False
 
     @computed_field  # type: ignore[prop-decorator]
     @property

--- a/src/weatherbrief/pipeline.py
+++ b/src/weatherbrief/pipeline.py
@@ -28,7 +28,7 @@ from weatherbrief.tasks.analyze import (  # noqa: F401  — backward compat re-e
 )
 from weatherbrief.tasks.fetch import run_fetch
 from weatherbrief.tasks.analyze import run_analysis
-from weatherbrief.tasks.advise import run_advisories
+from weatherbrief.tasks.advise import AdvisoryResult, run_advisories
 from weatherbrief.tasks.outputs import run_gramet, run_skewt, run_llm_digest
 
 logger = logging.getLogger(__name__)
@@ -64,6 +64,7 @@ class BriefingOptions:
     advisory_params: dict[str, dict[str, float]] | None = None  # {advisory_id: {param: value}}
     historical_mode: bool = False  # Use archived NWP data for past departure times
     as_of_time: datetime | None = None  # For historical: the date "as of" which to fetch data
+    alt_departure_time: datetime | None = None  # optional same-day alt departure for lite advisory re-run
 
 
 @dataclass
@@ -103,6 +104,7 @@ class BriefingResult:
     grib_init_times: dict[str, int] = field(default_factory=dict)
     models_skipped_region: list[str] = field(default_factory=list)
     diagnostics: list[dict] = field(default_factory=list)
+    alt_advisory_result: AdvisoryResult | None = None
     errors: list[str] = field(default_factory=list)
     usage: BriefingUsage = field(default_factory=BriefingUsage)
 
@@ -229,18 +231,19 @@ def execute_briefing(
     )
 
     # === 3. Advisories ===
+    # Build advisory preference args from options (shared by primary + alt)
+    adv_aggregation = None
+    if options.advisory_aggregation:
+        from weatherbrief.models import AdvisoryAggregation
+        adv_aggregation = AdvisoryAggregation(options.advisory_aggregation)
+
+    adv_enabled_ids = None
+    if options.advisory_enabled is not None:
+        adv_enabled_ids = {k for k, v in options.advisory_enabled.items() if v}
+
     route_advisories_manifest = None
     if analysis_result.route_analyses_manifest and analysis_result.route_analyses:
         total_distance = fetch_result.route_points[-1].distance_from_origin_nm
-        # Build advisory preference args from options
-        adv_aggregation = None
-        if options.advisory_aggregation:
-            from weatherbrief.models import AdvisoryAggregation
-            adv_aggregation = AdvisoryAggregation(options.advisory_aggregation)
-
-        adv_enabled_ids = None
-        if options.advisory_enabled is not None:
-            adv_enabled_ids = {k for k, v in options.advisory_enabled.items() if v}
 
         advisory_result = run_advisories(
             rp_analyses=analysis_result.route_analyses,
@@ -261,6 +264,33 @@ def execute_briefing(
             convective_method=options.convective_method,
         )
         route_advisories_manifest = advisory_result.manifest
+
+    # === 3.1 Alt departure advisories (lite re-run) ===
+    alt_advisory_result: AdvisoryResult | None = None
+    if (
+        options.alt_departure_time is not None
+        and analysis_result.route_analyses_manifest
+        and pack_dir
+    ):
+        _notify("alt_advisories")
+        try:
+            from weatherbrief.tasks.advise import run_alt_from_pack
+
+            alt_advisory_result = run_alt_from_pack(
+                pack_dir=pack_dir,
+                alt_departure_time=options.alt_departure_time,
+                route=route,
+                advisory_models=options.advisory_models,
+                enabled_ids=adv_enabled_ids,
+                user_params=options.advisory_params,
+                aggregation=adv_aggregation,
+                airports_db_path=options.airports_db_path,
+                icing_method=options.icing_method,
+                cloud_method=options.cloud_method,
+                convective_method=options.convective_method,
+            )
+        except Exception:
+            logger.warning("Alt advisory evaluation failed (non-fatal)", exc_info=True)
 
     # === 3.5 Route weather observations (D-0 only) ===
     route_observations = None
@@ -343,6 +373,8 @@ def execute_briefing(
         result.elevation_profile_path = pack_dir / "elevation_profile.json"
     if route_advisories_manifest and pack_dir:
         result.route_advisories_path = pack_dir / "route_advisories.json"
+    if alt_advisory_result is not None:
+        result.alt_advisory_result = alt_advisory_result
 
     # === 5. Optional: GRAMET ===
     if options.fetch_gramet:

--- a/src/weatherbrief/storage/flights.py
+++ b/src/weatherbrief/storage/flights.py
@@ -40,6 +40,7 @@ def _flight_to_row(flight: Flight, user_id: str) -> FlightRow:
         cruise_altitude_ft=flight.cruise_altitude_ft,
         flight_ceiling_ft=flight.flight_ceiling_ft,
         flight_duration_hours=flight.flight_duration_hours,
+        alt_departure_time=flight.alt_departure_time,
         private=flight.private,
         auto_refresh=flight.auto_refresh,
         auto_refresh_hour=flight.auto_refresh_hour,
@@ -59,6 +60,7 @@ def _row_to_flight(row: FlightRow) -> Flight:
         cruise_altitude_ft=row.cruise_altitude_ft,
         flight_ceiling_ft=row.flight_ceiling_ft,
         flight_duration_hours=row.flight_duration_hours,
+        alt_departure_time=_ensure_utc(row.alt_departure_time) if row.alt_departure_time else None,
         private=row.private,
         auto_refresh=row.auto_refresh,
         auto_refresh_hour=row.auto_refresh_hour,
@@ -103,6 +105,9 @@ def _meta_to_row(meta: BriefingPackMeta) -> BriefingPackRow:
         grib_init_times_json=json.dumps(meta.grib_init_times),
         models_skipped_region_json=json.dumps(meta.models_skipped_region),
         diagnostics_json=json.dumps(meta.diagnostics),
+        alt_assessment=meta.alt_assessment,
+        alt_assessment_reason=meta.alt_assessment_reason,
+        has_alt_advisories=meta.has_alt_advisories,
     )
 
 
@@ -148,6 +153,9 @@ def _row_to_meta(row: BriefingPackRow) -> BriefingPackMeta:
         grib_init_times=json.loads(row.grib_init_times_json) if row.grib_init_times_json else {},
         models_skipped_region=json.loads(row.models_skipped_region_json) if row.models_skipped_region_json else [],
         diagnostics=json.loads(row.diagnostics_json) if row.diagnostics_json else [],
+        alt_assessment=row.alt_assessment,
+        alt_assessment_reason=row.alt_assessment_reason,
+        has_alt_advisories=row.has_alt_advisories,
     )
 
 
@@ -165,6 +173,7 @@ def save_flight(session: Session, flight: Flight, user_id: str) -> None:
         existing.cruise_altitude_ft = flight.cruise_altitude_ft
         existing.flight_ceiling_ft = flight.flight_ceiling_ft
         existing.flight_duration_hours = flight.flight_duration_hours
+        existing.alt_departure_time = flight.alt_departure_time
         existing.private = flight.private
         existing.auto_refresh = flight.auto_refresh
         existing.auto_refresh_hour = flight.auto_refresh_hour

--- a/src/weatherbrief/tasks/advise.py
+++ b/src/weatherbrief/tasks/advise.py
@@ -9,11 +9,13 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
+from datetime import datetime
 from pathlib import Path
 from typing import Callable
 
 from weatherbrief.models import (
     AdvisoryAggregation,
+    AdvisoryStatus,
     AirportConditions,
     AltitudeTableResult,
     ElevationProfile,
@@ -413,3 +415,141 @@ def run_altitude_table_from_pack(
         user_params=user_params,
         aggregation=effective_aggregation,
     )
+
+
+# ---------------------------------------------------------------------------
+# Alt departure time helpers
+# ---------------------------------------------------------------------------
+
+
+def derive_assessment_from_advisories(
+    manifest: RouteAdvisoriesManifest,
+) -> tuple[str, str]:
+    """Derive an overall assessment (GREEN/AMBER/RED) from an advisories manifest.
+
+    Returns ``(assessment, reason)`` where assessment is the worst aggregate
+    status across all advisories and reason summarises the RED/AMBER ones.
+    """
+    statuses = [
+        AdvisoryStatus(adv.aggregate_status)
+        for adv in manifest.advisories
+        if adv.aggregate_status != "unavailable"
+    ]
+    if not statuses:
+        return ("GREEN", "No advisory data available")
+
+    worst = AdvisoryStatus.worst(statuses)
+    assessment = worst.value.upper()
+
+    # Build reason from the non-green advisories
+    concern_parts: list[str] = []
+    for adv in manifest.advisories:
+        if adv.aggregate_status in ("red", "amber"):
+            concern_parts.append(f"{adv.advisory_id}={adv.aggregate_status.upper()}")
+    reason = ", ".join(concern_parts) if concern_parts else "All clear"
+    return (assessment, reason)
+
+
+def run_alt_from_pack(
+    pack_dir: Path,
+    alt_departure_time: datetime,
+    route: RouteConfig,
+    *,
+    advisory_models: list[str] | None = None,
+    enabled_ids: set[str] | None = None,
+    user_params: dict | None = None,
+    aggregation: AdvisoryAggregation | None = None,
+    airports_db_path: str | None = None,
+    airport_conditions_recompute: Callable | None = None,
+    icing_method: str | None = None,
+    cloud_method: str | None = None,
+    convective_method: str | None = None,
+) -> AdvisoryResult:
+    """Re-run analysis + advisories at an alt departure time using existing pack data.
+
+    Loads cross-sections and route points from disk, calls
+    ``analyze_all_route_points`` with the alt departure time (which picks
+    different hourly forecasts via ``at_time()``), then evaluates advisories.
+    Saves the result as ``route_advisories_alt.json``.
+    """
+    from weatherbrief.tasks.analyze import analyze_all_route_points
+    from weatherbrief.tasks.artifacts import (
+        load_cross_sections,
+        load_elevation_profile,
+        load_route_points,
+        save_alt_advisory_artifacts,
+    )
+
+    cross_sections = load_cross_sections(pack_dir)
+    route_points = load_route_points(pack_dir)
+    elevation = load_elevation_profile(pack_dir)
+
+    if not cross_sections or route_points is None:
+        return AdvisoryResult(manifest=None, error="Missing cross-section or route-point data")
+
+    # Re-run analysis at the alt departure time
+    rp_analyses = analyze_all_route_points(
+        cross_sections=cross_sections,
+        route_points=route_points,
+        departure_time=alt_departure_time,
+        duration_hours=route.flight_duration_hours,
+        cruise_altitude_ft=route.cruise_altitude_ft,
+        flight_ceiling_ft=route.flight_ceiling_ft,
+    )
+
+    if not rp_analyses:
+        return AdvisoryResult(manifest=None, error="Alt analysis produced no results")
+
+    rp_analyses = _resolve_analyses(rp_analyses, icing_method, cloud_method, convective_method)
+
+    total_distance = route_points[-1].distance_from_origin_nm
+    model_names = list(rp_analyses[0].sounding.keys()) if rp_analyses else []
+    advisory_model_names = _compute_advisory_model_names(model_names, advisory_models)
+
+    # Airport conditions
+    airport_conds: AirportConditions | None = None
+    if airport_conditions_recompute is not None:
+        airport_conds = airport_conditions_recompute(
+            rp_analyses, cross_sections, advisory_model_names,
+        )
+    elif airports_db_path:
+        airport_conds = _compute_airport_conditions(
+            rp_analyses, cross_sections, advisory_model_names,
+            route, airports_db_path,
+        )
+
+    # Evaluate advisories
+    try:
+        from weatherbrief.analysis.advisories import RouteContext, evaluate_all, get_catalog
+
+        ctx = RouteContext(
+            analyses=rp_analyses,
+            cross_sections=cross_sections,
+            elevation=elevation,
+            models=advisory_model_names,
+            cruise_altitude_ft=route.cruise_altitude_ft,
+            flight_ceiling_ft=route.flight_ceiling_ft,
+            total_distance_nm=total_distance,
+            airport_conditions=airport_conds,
+        )
+        effective_aggregation = aggregation or AdvisoryAggregation.MAJORITY
+        advisory_results = evaluate_all(ctx, enabled_ids, user_params, aggregation=effective_aggregation)
+        manifest = RouteAdvisoriesManifest(
+            advisories=advisory_results,
+            catalog=get_catalog(),
+            route_name=route.name,
+            cruise_altitude_ft=route.cruise_altitude_ft,
+            flight_ceiling_ft=route.flight_ceiling_ft,
+            total_distance_nm=total_distance,
+            models=advisory_model_names,
+            aggregation=effective_aggregation.value,
+            airport_conditions=airport_conds,
+        )
+
+        save_alt_advisory_artifacts(pack_dir, manifest)
+        logger.info("Alt advisory evaluation complete: %d advisories", len(advisory_results))
+
+        return AdvisoryResult(manifest=manifest, airport_conditions=airport_conds)
+    except Exception as exc:
+        logger.warning("Alt advisory evaluation failed", exc_info=True)
+        return AdvisoryResult(manifest=None, error=str(exc))

--- a/src/weatherbrief/tasks/artifacts.py
+++ b/src/weatherbrief/tasks/artifacts.py
@@ -183,3 +183,25 @@ def load_briefing(pack_dir: Path) -> dict | None:
 def load_forecasts(pack_dir: Path) -> dict | None:
     """Load forecasts.json (route + metadata + raw forecasts), fallback to snapshot.json."""
     return _load_json_with_fallback(pack_dir, "forecasts.json")
+
+
+# ---------------------------------------------------------------------------
+# Alt advisory artifacts
+# ---------------------------------------------------------------------------
+
+def save_alt_advisory_artifacts(
+    pack_dir: Path,
+    manifest: RouteAdvisoriesManifest,
+) -> None:
+    """Persist alt-departure advisory artifacts to *pack_dir*."""
+    pack_dir.mkdir(parents=True, exist_ok=True)
+    adv_path = pack_dir / "route_advisories_alt.json"
+    adv_path.write_text(manifest.model_dump_json(indent=2))
+
+
+def load_alt_advisory_artifacts(pack_dir: Path) -> RouteAdvisoriesManifest | None:
+    """Load alt-departure advisories, returning *None* if missing."""
+    adv_path = pack_dir / "route_advisories_alt.json"
+    if not adv_path.exists():
+        return None
+    return RouteAdvisoriesManifest.model_validate_json(adv_path.read_text())

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -465,6 +465,58 @@ label {
 .assessment-red { background: var(--red-bg); color: var(--red); border: 1px solid var(--red); }
 .assessment-none { background: var(--bg); color: var(--text-muted); border: 1px solid var(--border); }
 
+.assessment-dual {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.assessment-separator {
+  color: var(--text-muted);
+  opacity: 0.5;
+}
+
+.assessment-green-text { color: var(--green); }
+.assessment-amber-text { color: var(--amber); }
+.assessment-red-text { color: var(--red); }
+
+/* --- Advisory time toggle --- */
+
+.advisory-time-toggle {
+  display: flex;
+  gap: 0;
+  margin-bottom: 0.75rem;
+}
+
+.advisory-time-toggle .btn-toggle {
+  border: 1px solid var(--border);
+  background: var(--surface);
+  padding: 0.3rem 0.75rem;
+  font-size: 0.8rem;
+  cursor: pointer;
+  color: var(--text-muted);
+}
+
+.advisory-time-toggle .btn-toggle:first-child {
+  border-radius: var(--radius) 0 0 var(--radius);
+}
+
+.advisory-time-toggle .btn-toggle:last-child {
+  border-radius: 0 var(--radius) var(--radius) 0;
+  border-left: none;
+}
+
+.advisory-time-toggle .btn-toggle.active {
+  background: var(--accent);
+  color: #fff;
+  border-color: var(--accent);
+}
+
+.advisory-time-toggle .btn-toggle:hover:not(.active) {
+  background: var(--bg);
+}
+
 /* --- Briefing header --- */
 
 .briefing-toolbar {

--- a/web/ts/adapters/api-adapter.ts
+++ b/web/ts/adapters/api-adapter.ts
@@ -47,6 +47,7 @@ export async function deleteFlight(id: string): Promise<void> {
 export interface UpdateFlightRequest {
   profile_id?: number;
   departure_time?: string;
+  alt_departure_time?: string | null;
   cruise_altitude_ft?: number;
   flight_ceiling_ft?: number;
   flight_duration_hours?: number;
@@ -268,6 +269,25 @@ export async function fetchRouteAdvisories(
 ): Promise<RouteAdvisoriesManifest> {
   return apiFetch<RouteAdvisoriesManifest>(
     `/flights/${encodeURIComponent(flightId)}/packs/${encodeURIComponent(timestamp)}/advisories`
+  );
+}
+
+export async function fetchAltAdvisories(
+  flightId: string,
+  timestamp: string,
+): Promise<RouteAdvisoriesManifest> {
+  return apiFetch<RouteAdvisoriesManifest>(
+    `/flights/${encodeURIComponent(flightId)}/packs/${encodeURIComponent(timestamp)}/advisories/alt`
+  );
+}
+
+export async function computeAltAdvisories(
+  flightId: string,
+  timestamp: string,
+): Promise<RouteAdvisoriesManifest> {
+  return apiFetch<RouteAdvisoriesManifest>(
+    `/flights/${encodeURIComponent(flightId)}/packs/${encodeURIComponent(timestamp)}/advisories/alt/compute`,
+    { method: 'POST' },
   );
 }
 

--- a/web/ts/briefing-main.ts
+++ b/web/ts/briefing-main.ts
@@ -4,9 +4,9 @@ import { fetchCurrentUser } from './adapters/auth-adapter';
 import { briefingStore, type BriefingState } from './store/briefing-store';
 import * as api from './adapters/api-adapter';
 import * as ui from './managers/briefing-ui';
-import { renderAdvisories, renderAltitudeTablePopup, type AltitudeOverrideConfig } from './managers/advisories-ui';
+import { renderAdvisories, renderAltitudeTablePopup, type AltitudeOverrideConfig, type AltTimeToggleConfig } from './managers/advisories-ui';
 import type { DisplayMode } from './types/metrics';
-import { renderUserInfo, initModelCatalog, isFlightPast } from './utils';
+import { renderUserInfo, initModelCatalog, isFlightPast, formatDepartureTime } from './utils';
 import { initInfoPopup, showMetricInfo, showPopupContent } from './components/info-popup';
 import { CrossSectionRenderer } from './visualization/cross-section/renderer';
 import { extractVizData } from './visualization/data-extract';
@@ -130,6 +130,24 @@ async function init(): Promise<void> {
     if (result) {
       showPopupContent(renderAltitudeTablePopup(result));
     }
+  }
+
+  /** Build alt time toggle config if alt advisories are available. */
+  function getAltTimeToggleConfig(state: BriefingState): AltTimeToggleConfig | undefined {
+    if (!state.flight?.alt_departure_time || !state.altAdvisories) return undefined;
+    const primaryTime = formatDepartureTime(state.flight.departure_time);
+    const altTime = formatDepartureTime(state.flight.alt_departure_time);
+    return {
+      primaryLabel: primaryTime,
+      altLabel: altTime,
+      showingAlt: state.showingAlt,
+      onToggle: () => store.getState().toggleAltView(),
+    };
+  }
+
+  /** Get the effective advisory manifest based on primary/alt toggle state. */
+  function getEffectiveAdvisories(state: BriefingState): import('./types/advisories').RouteAdvisoriesManifest | null {
+    return state.showingAlt && state.altAdvisories ? state.altAdvisories : state.routeAdvisories;
   }
 
   // Apply initial display mode
@@ -486,11 +504,13 @@ async function init(): Promise<void> {
       state.digest !== prev.digest ||
       state.routeAnalyses !== prev.routeAnalyses ||
       state.routeAdvisories !== prev.routeAdvisories ||
+      state.altAdvisories !== prev.altAdvisories ||
+      state.showingAlt !== prev.showingAlt ||
       state.elevationProfile !== prev.elevationProfile ||
       state.advisoryAltitudeOverride !== prev.advisoryAltitudeOverride
     ) {
-      ui.renderAssessment(state.currentPack);
-      renderAdvisories(state.routeAdvisories, () => store.getState().recalculateAdvisories(), state.displayMode, getAltitudeOverrideConfig(state), handleAltitudeTable);
+      ui.renderAssessment(state.currentPack, state.flight);
+      renderAdvisories(getEffectiveAdvisories(state), () => store.getState().recalculateAdvisories(), state.displayMode, getAltitudeOverrideConfig(state), handleAltitudeTable, getAltTimeToggleConfig(state));
       ui.renderRouteObservations(state.snapshot, () => store.getState().refreshObservations());
       ui.renderSynopsis(state.flight, state.currentPack, state.digest, state.displayMode);
       ui.renderGramet(state.flight, state.currentPack);
@@ -529,7 +549,7 @@ async function init(): Promise<void> {
       updateToggleButtons(state.displayMode);
       renderSliderSections(state);
       if (state.displayMode !== prev.displayMode) {
-        renderAdvisories(state.routeAdvisories, () => store.getState().recalculateAdvisories(), state.displayMode, getAltitudeOverrideConfig(state), handleAltitudeTable);
+        renderAdvisories(getEffectiveAdvisories(state), () => store.getState().recalculateAdvisories(), state.displayMode, getAltitudeOverrideConfig(state), handleAltitudeTable, getAltTimeToggleConfig(state));
         ui.renderSynopsis(state.flight, state.currentPack, state.digest, state.displayMode);
         // Entering compact: enforce preferred-only layers for clouds/icing
         // (triggers vizSettings change → renderVisualization runs via that subscriber)
@@ -846,8 +866,8 @@ async function init(): Promise<void> {
     const s = store.getState();
     ui.renderHeader(s.flight, s.snapshot);
     ui.renderHistoryDropdown(s.packs, s.currentPack?.fetch_timestamp || null, (ts) => store.getState().selectPack(ts));
-    ui.renderAssessment(s.currentPack);
-    renderAdvisories(s.routeAdvisories, () => store.getState().recalculateAdvisories(), s.displayMode, getAltitudeOverrideConfig(s), handleAltitudeTable);
+    ui.renderAssessment(s.currentPack, s.flight);
+    renderAdvisories(getEffectiveAdvisories(s), () => store.getState().recalculateAdvisories(), s.displayMode, getAltitudeOverrideConfig(s), handleAltitudeTable, getAltTimeToggleConfig(s));
     ui.renderRouteObservations(s.snapshot, () => store.getState().refreshObservations());
     ui.renderSynopsis(s.flight, s.currentPack, s.digest, s.displayMode);
     ui.renderGramet(s.flight, s.currentPack);

--- a/web/ts/flight-main.ts
+++ b/web/ts/flight-main.ts
@@ -62,6 +62,8 @@ async function init(): Promise<void> {
       const profileEl = document.getElementById('edit-profile') as HTMLSelectElement;
       const hourEl = document.getElementById('edit-hour') as HTMLSelectElement;
       const minuteEl = document.getElementById('edit-minute') as HTMLSelectElement;
+      const altHourEl = document.getElementById('edit-alt-hour') as HTMLSelectElement;
+      const altMinuteEl = document.getElementById('edit-alt-minute') as HTMLSelectElement;
       const altEl = document.getElementById('edit-altitude') as HTMLInputElement;
       const ceilEl = document.getElementById('edit-ceiling') as HTMLInputElement;
       const durEl = document.getElementById('edit-duration') as HTMLInputElement;
@@ -76,9 +78,17 @@ async function init(): Promise<void> {
       // Build ISO datetime using the same date
       const departureTime = `${flight.target_date}T${hour.toString().padStart(2, '0')}:${minute.toString().padStart(2, '0')}:00Z`;
 
+      // Build alt departure time (or empty string to clear)
+      const altHour = altHourEl ? parseInt(altHourEl.value, 10) : -1;
+      const altMinute = altMinuteEl ? parseInt(altMinuteEl.value, 10) : 0;
+      const altDepartureTime = altHour >= 0
+        ? `${flight.target_date}T${altHour.toString().padStart(2, '0')}:${altMinute.toString().padStart(2, '0')}:00Z`
+        : '';
+
       await store.getState().saveFlight({
         profile_id: profileId,
         departure_time: departureTime,
+        alt_departure_time: altDepartureTime,
         cruise_altitude_ft: altitude,
         flight_ceiling_ft: ceiling,
         flight_duration_hours: duration,

--- a/web/ts/managers/advisories-ui.ts
+++ b/web/ts/managers/advisories-ui.ts
@@ -343,6 +343,13 @@ export interface AltitudeOverrideConfig {
   onChange: (alt: number) => void;
 }
 
+export interface AltTimeToggleConfig {
+  primaryLabel: string;   // e.g. "09:00Z"
+  altLabel: string;       // e.g. "15:00Z"
+  showingAlt: boolean;
+  onToggle: () => void;
+}
+
 /**
  * Render the advisory dashboard into the #advisories-section element.
  * onRecalculate callback wires up the recalculate button.
@@ -353,6 +360,7 @@ export function renderAdvisories(
   displayMode: DisplayMode = 'full',
   altitudeOverride?: AltitudeOverrideConfig,
   onAltitudeTable?: () => Promise<void>,
+  altTimeToggle?: AltTimeToggleConfig,
 ): void {
   const el = $('advisories-section');
   const section = $('advisories-wrapper');
@@ -431,9 +439,22 @@ export function renderAdvisories(
     ? renderAirportConditions(manifest.airport_conditions, aggregation)
     : '';
 
+  // Alt time toggle
+  let toggleHtml = '';
+  if (altTimeToggle) {
+    const primaryActive = !altTimeToggle.showingAlt ? ' active' : '';
+    const altActive = altTimeToggle.showingAlt ? ' active' : '';
+    toggleHtml = `
+      <div class="advisory-time-toggle">
+        <button class="btn btn-sm btn-toggle${primaryActive}" data-alt-toggle="primary">${escapeHtml(altTimeToggle.primaryLabel)}</button>
+        <button class="btn btn-sm btn-toggle${altActive}" data-alt-toggle="alt">Alt ${escapeHtml(altTimeToggle.altLabel)}</button>
+      </div>`;
+  }
+
   const cards = sorted.map(adv => renderAdvisoryCard(adv, catalog)).join('');
 
   el.innerHTML = `
+    ${toggleHtml}
     <div class="advisory-toolbar">
       ${summary}
       ${sliderHtml}
@@ -493,6 +514,13 @@ export function renderAdvisories(
         altitudeOverride.onChange(altitudeOverride.defaultAlt);
       });
     }
+  }
+
+  // Wire alt time toggle
+  if (altTimeToggle) {
+    el.querySelectorAll('[data-alt-toggle]').forEach((btn) => {
+      btn.addEventListener('click', () => altTimeToggle.onToggle());
+    });
   }
 
   // Wire advisory info buttons (event delegation)

--- a/web/ts/managers/briefing-ui.ts
+++ b/web/ts/managers/briefing-ui.ts
@@ -98,7 +98,7 @@ export function renderHistoryDropdown(
 
 // --- Assessment banner ---
 
-export function renderAssessment(pack: PackMeta | null): void {
+export function renderAssessment(pack: PackMeta | null, flight?: FlightResponse | null): void {
   const el = $('assessment-banner');
   if (!el) return;
 
@@ -109,10 +109,33 @@ export function renderAssessment(pack: PackMeta | null): void {
   }
 
   const level = pack.assessment.toUpperCase();
-  el.className = `assessment-banner assessment-${level.toLowerCase()}`;
-  el.innerHTML = `
-    <strong>${level}</strong>${pack.assessment_reason ? ` \u2014 ${escapeHtml(pack.assessment_reason)}` : ''}
-  `;
+
+  // Show alt assessment alongside primary if available
+  if (pack.alt_assessment && flight?.alt_departure_time) {
+    const altLevel = pack.alt_assessment.toUpperCase();
+    const primaryTime = formatDepartureTime(flight.departure_time);
+    const altTime = formatDepartureTime(flight.alt_departure_time);
+    const altReason = pack.alt_assessment_reason ? ` \u2014 ${escapeHtml(pack.alt_assessment_reason)}` : '';
+    const primaryReason = pack.assessment_reason ? ` \u2014 ${escapeHtml(pack.assessment_reason)}` : '';
+
+    el.className = `assessment-banner assessment-${level.toLowerCase()}`;
+    el.innerHTML = `
+      <span class="assessment-dual">
+        <span class="assessment-primary">
+          <strong>${primaryTime}: ${level}</strong>${primaryReason}
+        </span>
+        <span class="assessment-separator">\u2502</span>
+        <span class="assessment-alt assessment-${altLevel.toLowerCase()}-text">
+          <strong>Alt ${altTime}: ${altLevel}</strong>${altReason}
+        </span>
+      </span>
+    `;
+  } else {
+    el.className = `assessment-banner assessment-${level.toLowerCase()}`;
+    el.innerHTML = `
+      <strong>${level}</strong>${pack.assessment_reason ? ` \u2014 ${escapeHtml(pack.assessment_reason)}` : ''}
+    `;
+  }
 }
 
 // --- Freshness bar ---

--- a/web/ts/managers/flight-detail-ui.ts
+++ b/web/ts/managers/flight-detail-ui.ts
@@ -46,6 +46,11 @@ export function renderFlightInfo(
   const currentProfile = profiles.find(p => p.id === flight.profile_id);
   const profileName = currentProfile ? currentProfile.name : '\u2014';
 
+  // Alt departure time parsing
+  const altDt = flight.alt_departure_time ? new Date(flight.alt_departure_time) : null;
+  const altUtcHour = altDt ? altDt.getUTCHours() : -1;
+  const altUtcMinute = altDt ? altDt.getUTCMinutes() : 0;
+
   if (editing) {
     // Build hour options
     let hourOptions = '';
@@ -56,6 +61,17 @@ export function renderFlightInfo(
     // Build minute options
     const minuteOptions = [0, 15, 30, 45].map(m => {
       const sel = m === nearestMinute(utcMinute) ? ' selected' : '';
+      return `<option value="${m}"${sel}>${m.toString().padStart(2, '0')}</option>`;
+    }).join('');
+    // Build alt hour options (with "None" option)
+    let altHourOptions = `<option value="-1"${altUtcHour === -1 ? ' selected' : ''}>None</option>`;
+    for (let h = 0; h < 24; h++) {
+      const sel = h === altUtcHour ? ' selected' : '';
+      altHourOptions += `<option value="${h}"${sel}>${h.toString().padStart(2, '0')}</option>`;
+    }
+    // Build alt minute options
+    const altMinuteOptions = [0, 15, 30, 45].map(m => {
+      const sel = m === nearestMinute(altUtcMinute) ? ' selected' : '';
       return `<option value="${m}"${sel}>${m.toString().padStart(2, '0')}</option>`;
     }).join('');
     // Build profile options
@@ -85,6 +101,14 @@ export function renderFlightInfo(
           </span>
         </div>
         <div class="info-row">
+          <span class="info-label">Alt Time (UTC)</span>
+          <span class="info-value">
+            <select id="edit-alt-hour" class="edit-input">${altHourOptions}</select>
+            <span class="time-separator" id="alt-time-sep">:</span>
+            <select id="edit-alt-minute" class="edit-input">${altMinuteOptions}</select>
+          </span>
+        </div>
+        <div class="info-row">
           <span class="info-label">Altitude</span>
           <span class="info-value">
             <input type="number" id="edit-altitude" class="edit-input" value="${flight.cruise_altitude_ft}" min="1000" max="45000" step="500" style="width:80px"> ft
@@ -109,6 +133,18 @@ export function renderFlightInfo(
       </div>
     `;
 
+    // Toggle alt minute visibility based on alt hour selection
+    const altHourSelect = document.getElementById('edit-alt-hour') as HTMLSelectElement;
+    const altMinuteSelect = document.getElementById('edit-alt-minute') as HTMLSelectElement;
+    const altTimeSep = document.getElementById('alt-time-sep');
+    function updateAltMinuteVisibility(): void {
+      const hidden = altHourSelect?.value === '-1';
+      if (altMinuteSelect) altMinuteSelect.style.display = hidden ? 'none' : '';
+      if (altTimeSep) altTimeSep.style.display = hidden ? 'none' : '';
+    }
+    updateAltMinuteVisibility();
+    altHourSelect?.addEventListener('change', updateAltMinuteVisibility);
+
     // When profile changes, update altitude/ceiling to match the selected profile
     const profileSelect = document.getElementById('edit-profile') as HTMLSelectElement;
     profileSelect?.addEventListener('change', () => {
@@ -126,6 +162,20 @@ export function renderFlightInfo(
       }
     });
   } else {
+    // Alt time display with delta
+    let altTimeHtml = '';
+    if (altDt) {
+      const deltaMs = altDt.getTime() - dt.getTime();
+      const deltaH = deltaMs / 3600_000;
+      const sign = deltaH >= 0 ? '+' : '';
+      const deltaStr = Number.isInteger(deltaH) ? `${sign}${deltaH}h` : `${sign}${deltaH.toFixed(1)}h`;
+      altTimeHtml = `
+        <div class="info-row">
+          <span class="info-label">Alt Time</span>
+          <span class="info-value">${formatDepartureTime(flight.alt_departure_time!)} <span class="muted">(${deltaStr})</span></span>
+        </div>`;
+    }
+
     container.innerHTML = `
       <div class="flight-info-grid">
         <div class="info-row">
@@ -140,6 +190,7 @@ export function renderFlightInfo(
           <span class="info-label">Time</span>
           <span class="info-value">${formatDepartureTime(flight.departure_time)}</span>
         </div>
+        ${altTimeHtml}
         <div class="info-row">
           <span class="info-label">Altitude</span>
           <span class="info-value">${formatAlt(flight.cruise_altitude_ft)}</span>

--- a/web/ts/store/briefing-store.ts
+++ b/web/ts/store/briefing-store.ts
@@ -70,6 +70,8 @@ export interface BriefingState {
   digest: WeatherDigest | null;
   routeAnalyses: RouteAnalysesManifest | null;
   routeAdvisories: RouteAdvisoriesManifest | null;
+  altAdvisories: RouteAdvisoriesManifest | null;
+  showingAlt: boolean;
   elevationProfile: ElevationProfile | null;
   freshness: DataStatus | null;
   freshnessLoading: boolean;
@@ -112,6 +114,9 @@ export interface BriefingState {
   fetchAltitudeTable: () => Promise<void>;
   refreshObservations: () => Promise<void>;
   sendEmail: () => Promise<void>;
+  loadAltAdvisories: () => Promise<void>;
+  computeAltAdvisories: () => Promise<void>;
+  toggleAltView: () => void;
   updateFlightAutoRefresh: (autoRefresh: boolean, hour: number | null) => void;
   updateFlightPrivacy: (isPrivate: boolean) => void;
   setLayout: (layout: VizLayout) => void;
@@ -133,6 +138,8 @@ export const briefingStore = createStore<BriefingState>((set, get) => ({
   digest: null,
   routeAnalyses: null,
   routeAdvisories: null,
+  altAdvisories: null,
+  showingAlt: false,
   elevationProfile: null,
   freshness: null,
   freshnessLoading: false,
@@ -210,7 +217,11 @@ export const briefingStore = createStore<BriefingState>((set, get) => ({
       if (raResult.status === 'fulfilled') routeAnalyses = raResult.value;
       if (epResult.status === 'fulfilled') elevationProfile = epResult.value;
       if (advResult.status === 'fulfilled') routeAdvisories = advResult.value;
-      set({ currentPack: pack, snapshot, digest, routeAnalyses, routeAdvisories, elevationProfile, selectedPointIndex: 0, loading: false });
+      set({ currentPack: pack, snapshot, digest, routeAnalyses, routeAdvisories, elevationProfile, altAdvisories: null, showingAlt: false, selectedPointIndex: 0, loading: false });
+      // Auto-load alt advisories if available
+      if (pack.has_alt_advisories) {
+        get().loadAltAdvisories();
+      }
     } catch (err) {
       set({ loading: false, error: `Failed to load pack: ${err}` });
     }
@@ -436,6 +447,34 @@ export const briefingStore = createStore<BriefingState>((set, get) => ({
     } catch (err) {
       set({ emailing: false, error: `Email failed: ${err}` });
     }
+  },
+
+  loadAltAdvisories: async () => {
+    const { flight, currentPack } = get();
+    if (!flight || !currentPack) return;
+    try {
+      const altAdv = await api.fetchAltAdvisories(flight.id, currentPack.fetch_timestamp);
+      set({ altAdvisories: altAdv });
+    } catch {
+      // Non-critical — alt advisories may not exist
+    }
+  },
+
+  computeAltAdvisories: async () => {
+    const { flight, currentPack } = get();
+    if (!flight || !currentPack) return;
+    try {
+      const altAdv = await api.computeAltAdvisories(flight.id, currentPack.fetch_timestamp);
+      // Re-fetch pack meta to get updated alt_assessment fields
+      const updatedPack = await api.fetchPack(flight.id, currentPack.fetch_timestamp);
+      set({ altAdvisories: altAdv, currentPack: updatedPack });
+    } catch (err) {
+      set({ error: `Alt advisories computation failed: ${err}` });
+    }
+  },
+
+  toggleAltView: () => {
+    set({ showingAlt: !get().showingAlt });
   },
 
   updateFlightAutoRefresh: (autoRefresh: boolean, hour: number | null) => {

--- a/web/ts/store/types.ts
+++ b/web/ts/store/types.ts
@@ -7,6 +7,7 @@ export interface FlightResponse {
   route_name: string;
   waypoints: string[];
   departure_time: string;
+  alt_departure_time: string | null;
   target_date: string;        // backward compat (computed from departure_time)
   target_time_utc: number;    // backward compat (computed from departure_time)
   cruise_altitude_ft: number;
@@ -44,8 +45,11 @@ export interface PackMeta {
   has_skewt: boolean;
   has_digest: boolean;
   has_advisories?: boolean;
+  has_alt_advisories?: boolean;
   assessment: string | null;
   assessment_reason: string | null;
+  alt_assessment?: string | null;
+  alt_assessment_reason?: string | null;
   model_init_times?: Record<string, number>;
   grib_init_times?: Record<string, number>;
   models_skipped_region?: string[];


### PR DESCRIPTION
## Summary

- Adds an optional **alternative departure time** (same day) to flights, allowing pilots to compare morning vs afternoon conditions without creating separate flights
- A "lite" pipeline re-runs route analysis and advisories using already-fetched Open-Meteo 24h forecast data at the alt time — no extra GRIB or GRAMET fetches
- Full-stack implementation across 18 files: data model + migration, core analysis logic, API endpoints, and frontend UI

## Changes

**Backend:**
- `Flight.alt_departure_time` field + DB migration (018)
- `run_alt_from_pack()` — re-analyzes route points at alt time using existing cross-section data
- `derive_assessment_from_advisories()` — derives GREEN/AMBER/RED from advisory manifest
- Pipeline step 3.1 — runs alt analysis after primary advisories (graceful degradation on failure)
- `PATCH /flights/{id}` accepts `alt_departure_time` with same-day + not-equal validation
- `GET /flights/{id}/packs/{ts}/advisories/alt` — fetch pre-computed alt advisories
- `POST /flights/{id}/packs/{ts}/advisories/alt/compute` — on-demand computation for existing packs
- Pack meta includes `alt_assessment`, `alt_assessment_reason`, `has_alt_advisories`

**Frontend:**
- Flight detail: alt time hour/minute selects in edit mode, display with time delta in view mode
- Briefing page: dual assessment banner (`09:00Z: AMBER | Alt 15:00Z: GREEN`)
- Advisory section: primary/alt toggle button group to swap between advisory manifests
- Briefing store: `altAdvisories`, `showingAlt` state with auto-load on pack select

## Test plan

- [ ] Run `alembic upgrade head` — verify 4 new columns exist
- [ ] PATCH a flight with `alt_departure_time` — verify response, same-day validation, alt≠primary rejection
- [ ] Refresh a flight with alt time set — verify pack meta includes `alt_assessment`
- [ ] On briefing page: verify dual assessment banner, toggle switches advisory content
- [ ] Clear alt time (send `""`) — verify alt toggle disappears, fields reset
- [ ] POST `/advisories/alt/compute` on existing pack — verify on-demand alt computation works

🤖 Generated with [Claude Code](https://claude.com/claude-code)