### PR TITLE
Smart route interpretation and route editing for flights (#53)

### DIFF
--- a/src/weatherbrief/api/flights.py
+++ b/src/weatherbrief/api/flights.py
@@ -314,6 +314,94 @@ def compute_route_distance(
     )
 
 
+class InterpretRouteRequest(BaseModel):
+    """Request body for interpreting a route string with smart waypoint filtering."""
+
+    raw_route: str = Field(..., min_length=1, max_length=2000)
+
+
+class InterpretRouteResponse(BaseModel):
+    """Result of smart route interpretation."""
+
+    original_tokens: list[str] = []  # all tokens extracted from the input
+    interpreted: list[str] = []  # waypoints that resolved successfully
+    skipped: list[str] = []  # tokens that didn't resolve
+    waypoints: list[WaypointInfo] = []  # resolved waypoint details
+
+
+@router.post("/interpret-route", response_model=InterpretRouteResponse)
+def interpret_route(
+    req: InterpretRouteRequest,
+    request: Request,
+    user_id: str = Depends(current_user_id),
+):
+    """Interpret a raw route string, resolving known waypoints and skipping unknown tokens.
+
+    Accepts free-form route text (e.g. from a flight plan paste). Extracts tokens
+    matching waypoint patterns, resolves each against the airport/navaid database,
+    and returns the list of recognized waypoints plus any skipped tokens.
+    """
+    from weatherbrief.airports import get_timezone, resolve_waypoints
+
+    db_path = getattr(request.app.state, "db_path", "")
+    if not db_path:
+        raise HTTPException(status_code=500, detail="Airport database not configured")
+
+    # Extract tokens that look like waypoint codes
+    tokens = [t.upper() for t in re.split(r"[\s,\-/]+", req.raw_route.strip()) if t]
+    # Filter to valid waypoint patterns (2-5 alphanumeric chars)
+    candidate_tokens = [t for t in tokens if WAYPOINT_RE.match(t)]
+
+    # Resolve each candidate individually to separate known from unknown
+    from euro_aip.models.route_resolver import RouteResolver
+
+    model = None
+    try:
+        from weatherbrief.airports import _load_airport_model
+        model = _load_airport_model(db_path)
+    except Exception:
+        raise HTTPException(status_code=500, detail="Could not load airport database")
+
+    resolver = RouteResolver(model)
+    interpreted: list[str] = []
+    skipped: list[str] = []
+
+    for token in candidate_tokens:
+        point = resolver.resolve_point(token)
+        if point is not None:
+            # Skip consecutive duplicates (e.g. "ABDIL ABDIL" after filtering)
+            if not interpreted or interpreted[-1] != token:
+                interpreted.append(token)
+        else:
+            skipped.append(token)
+
+    # Resolve the interpreted waypoints to get full info
+    waypoint_infos: list[WaypointInfo] = []
+    if len(interpreted) >= 2:
+        try:
+            resolved = resolve_waypoints(interpreted, db_path)
+            waypoint_infos = [
+                WaypointInfo(
+                    icao=wp.icao,
+                    name=wp.name,
+                    lat=wp.lat,
+                    lon=wp.lon,
+                    timezone=get_timezone(wp.lat, wp.lon),
+                )
+                for wp in resolved
+            ]
+        except KeyError:
+            # Should not happen since we pre-filtered, but handle gracefully
+            pass
+
+    return InterpretRouteResponse(
+        original_tokens=candidate_tokens,
+        interpreted=interpreted,
+        skipped=skipped,
+        waypoints=waypoint_infos,
+    )
+
+
 class ParseFplRequest(BaseModel):
     """Request body for parsing an ICAO flight plan string."""
 
@@ -453,6 +541,7 @@ class UpdateFlightRequest(BaseModel):
     cruise_altitude_ft: int | None = None
     flight_ceiling_ft: int | None = None
     flight_duration_hours: float | None = None
+    waypoints: list[str] | None = None  # updated route (origin+destination must match)
 
     @field_validator("departure_time")
     @classmethod
@@ -491,12 +580,13 @@ class UpdateFlightResponse(FlightResponse):
 def update_flight(
     flight_id: str,
     req: UpdateFlightRequest,
+    request: Request,
     user_id: str = Depends(current_user_id),
     db: Session = Depends(get_db),
 ):
-    """Update editable flight parameters (time, altitude, ceiling, duration).
+    """Update editable flight parameters (time, altitude, ceiling, duration, route).
 
-    The date portion of the flight cannot change — only time-of-day.
+    The date portion and origin/destination of the flight cannot change.
     Returns an invalidation hint so the frontend knows whether existing
     briefings need a refetch or just an advisory recalculation.
     """
@@ -506,6 +596,53 @@ def update_flight(
     time_changed = False
     altitude_changed = False
     profile_changed = False
+    route_changed = False
+
+    # Route (waypoints) change — origin and destination must remain the same
+    if req.waypoints is not None:
+        new_waypoints = [w.upper().strip() for w in req.waypoints]
+        if len(new_waypoints) < 2:
+            raise HTTPException(
+                status_code=422,
+                detail="At least 2 waypoints are required",
+            )
+        # Validate waypoint format
+        for wp in new_waypoints:
+            if not WAYPOINT_RE.match(wp):
+                raise HTTPException(
+                    status_code=422,
+                    detail=f"Invalid waypoint '{wp}': must be 2-5 alphanumeric characters",
+                )
+        # Validate waypoints exist in the database
+        db_path = getattr(request.app.state, "db_path", "")
+        if db_path:
+            from weatherbrief.airports import resolve_waypoints
+
+            try:
+                resolve_waypoints(new_waypoints, db_path)
+            except KeyError as exc:
+                raise HTTPException(status_code=422, detail=exc.args[0])
+        # Enforce same origin and destination
+        old_origin = original_flight.waypoints[0] if original_flight.waypoints else None
+        old_dest = original_flight.waypoints[-1] if original_flight.waypoints else None
+        new_origin = new_waypoints[0]
+        new_dest = new_waypoints[-1]
+        if old_origin and new_origin != old_origin:
+            raise HTTPException(
+                status_code=422,
+                detail=f"Origin cannot change (was {old_origin}, got {new_origin}). Create a new flight instead.",
+            )
+        if old_dest and new_dest != old_dest:
+            raise HTTPException(
+                status_code=422,
+                detail=f"Destination cannot change (was {old_dest}, got {new_dest}). Create a new flight instead.",
+            )
+        if new_waypoints != original_flight.waypoints:
+            import json as _json
+            row.waypoints_json = _json.dumps(new_waypoints)
+            # Update route_name to reflect new waypoints
+            row.route_name = "_".join(w.lower() for w in new_waypoints)
+            route_changed = True
 
     # Profile change — apply the new profile's altitude/ceiling to the flight
     if req.profile_id is not None and req.profile_id != original_flight.profile_id:
@@ -573,7 +710,7 @@ def update_flight(
     db.flush()
     updated = load_flight(db, flight_id)
 
-    if time_changed:
+    if time_changed or route_changed:
         invalidation = "refetch_needed"
     elif altitude_changed or profile_changed:
         invalidation = "advisories_only"

--- a/src/weatherbrief/api/flights.py
+++ b/src/weatherbrief/api/flights.py
@@ -352,27 +352,17 @@ def interpret_route(
     # Filter to valid waypoint patterns (2-5 alphanumeric chars)
     candidate_tokens = [t for t in tokens if WAYPOINT_RE.match(t)]
 
-    # Resolve each candidate individually to separate known from unknown
-    from euro_aip.models.route_resolver import RouteResolver
-
-    model = None
-    try:
-        from weatherbrief.airports import _load_airport_model
-        model = _load_airport_model(db_path)
-    except Exception:
-        raise HTTPException(status_code=500, detail="Could not load airport database")
-
-    resolver = RouteResolver(model)
+    # Resolve all candidates via resolve_waypoints; use the KeyError to find unknowns
     interpreted: list[str] = []
     skipped: list[str] = []
 
     for token in candidate_tokens:
-        point = resolver.resolve_point(token)
-        if point is not None:
+        try:
+            resolve_waypoints([token], db_path)
             # Skip consecutive duplicates (e.g. "ABDIL ABDIL" after filtering)
             if not interpreted or interpreted[-1] != token:
                 interpreted.append(token)
-        else:
+        except KeyError:
             skipped.append(token)
 
     # Resolve the interpreted waypoints to get full info
@@ -638,8 +628,7 @@ def update_flight(
                 detail=f"Destination cannot change (was {old_dest}, got {new_dest}). Create a new flight instead.",
             )
         if new_waypoints != original_flight.waypoints:
-            import json as _json
-            row.waypoints_json = _json.dumps(new_waypoints)
+            row.waypoints_json = json.dumps(new_waypoints)
             # Update route_name to reflect new waypoints
             row.route_name = "_".join(w.lower() for w in new_waypoints)
             route_changed = True

--- a/web/ts/adapters/api-adapter.ts
+++ b/web/ts/adapters/api-adapter.ts
@@ -51,6 +51,7 @@ export interface UpdateFlightRequest {
   cruise_altitude_ft?: number;
   flight_ceiling_ft?: number;
   flight_duration_hours?: number;
+  waypoints?: string[];
 }
 
 export interface UpdateFlightResponse extends FlightResponse {
@@ -134,6 +135,22 @@ export async function parseFpl(fplText: string): Promise<ParseFplResponse> {
   return apiFetch<ParseFplResponse>('/flights/parse-fpl', {
     method: 'POST',
     body: JSON.stringify({ fpl_text: fplText }),
+  });
+}
+
+// --- Route interpretation ---
+
+export interface InterpretRouteResponse {
+  original_tokens: string[];
+  interpreted: string[];
+  skipped: string[];
+  waypoints: WaypointInfo[];
+}
+
+export async function interpretRoute(rawRoute: string): Promise<InterpretRouteResponse> {
+  return apiFetch<InterpretRouteResponse>('/flights/interpret-route', {
+    method: 'POST',
+    body: JSON.stringify({ raw_route: rawRoute }),
   });
 }
 

--- a/web/ts/components/route-interpret.ts
+++ b/web/ts/components/route-interpret.ts
@@ -1,0 +1,137 @@
+/**
+ * Route interpretation component — smart waypoint parsing with confirmation popup.
+ *
+ * Accepts raw route text, calls the interpret-route API to resolve known waypoints,
+ * and shows a confirmation popup if any tokens were skipped.
+ */
+
+import { interpretRoute, type InterpretRouteResponse } from '../adapters/api-adapter';
+import { escapeHtml } from '../utils';
+import { t } from '../i18n/i18n';
+
+export interface RouteInterpretResult {
+  /** The final waypoint codes to use. */
+  waypoints: string[];
+  /** Whether the user confirmed (true) or cancelled (false). */
+  confirmed: boolean;
+}
+
+/**
+ * Interpret a raw route string and, if tokens were skipped, show a confirmation popup.
+ * Returns the interpreted waypoints if confirmed, or null if cancelled/failed.
+ *
+ * If no tokens were skipped, returns immediately without showing a popup.
+ */
+export async function interpretAndConfirmRoute(
+  rawRoute: string,
+  onError: (msg: string) => void,
+): Promise<RouteInterpretResult | null> {
+  let resp: InterpretRouteResponse;
+  try {
+    resp = await interpretRoute(rawRoute);
+  } catch (err) {
+    onError(err instanceof Error ? err.message.replace(/^API \d+:\s*/, '') : String(err));
+    return null;
+  }
+
+  if (resp.interpreted.length < 2) {
+    onError(t('flights.form.errorWaypoints'));
+    return null;
+  }
+
+  // No tokens skipped — proceed directly
+  if (resp.skipped.length === 0) {
+    return { waypoints: resp.interpreted, confirmed: true };
+  }
+
+  // Tokens were skipped — show confirmation popup
+  return showRouteConfirmPopup(rawRoute, resp);
+}
+
+/**
+ * Validate that new waypoints preserve the origin and destination of an existing flight.
+ * Returns an error message if validation fails, or null if OK.
+ */
+export function validateOriginDestination(
+  oldWaypoints: string[],
+  newWaypoints: string[],
+): string | null {
+  if (oldWaypoints.length < 2 || newWaypoints.length < 2) return null;
+  const oldOrigin = oldWaypoints[0].toUpperCase();
+  const oldDest = oldWaypoints[oldWaypoints.length - 1].toUpperCase();
+  const newOrigin = newWaypoints[0].toUpperCase();
+  const newDest = newWaypoints[newWaypoints.length - 1].toUpperCase();
+
+  if (newOrigin !== oldOrigin) {
+    return `Origin cannot change (was ${oldOrigin}, got ${newOrigin}). Create a new flight instead.`;
+  }
+  if (newDest !== oldDest) {
+    return `Destination cannot change (was ${oldDest}, got ${newDest}). Create a new flight instead.`;
+  }
+  return null;
+}
+
+function showRouteConfirmPopup(
+  rawRoute: string,
+  resp: InterpretRouteResponse,
+): Promise<RouteInterpretResult> {
+  return new Promise((resolve) => {
+    const backdrop = document.createElement('div');
+    backdrop.className = 'metric-popup-backdrop active';
+
+    const modal = document.createElement('div');
+    modal.className = 'metric-popup';
+
+    const skippedHtml = resp.skipped.map(s => `<code>${escapeHtml(s)}</code>`).join(', ');
+    const interpretedHtml = resp.interpreted.map(s => `<strong>${escapeHtml(s)}</strong>`).join(' \u2192 ');
+
+    modal.innerHTML = `
+      <button class="metric-popup-close" aria-label="${t('popup.close')}">\u00d7</button>
+      <h3>Route Interpreted</h3>
+      <div style="margin:0.75rem 0;">
+        <div style="margin-bottom:0.5rem;">
+          <span class="info-label">Route entered:</span>
+          <span style="font-family:monospace;">${escapeHtml(rawRoute)}</span>
+        </div>
+        <div style="margin-bottom:0.5rem;">
+          <span class="info-label">Route interpreted:</span>
+          <span>${interpretedHtml}</span>
+        </div>
+        <div style="margin-bottom:0.5rem;color:var(--amber,#b45309);">
+          <span class="info-label">Skipped (not recognized):</span>
+          <span>${skippedHtml}</span>
+        </div>
+      </div>
+      <div style="display:flex;gap:0.5rem;justify-content:flex-end;margin-top:1rem;">
+        <button type="button" id="route-confirm-cancel" class="btn btn-outline btn-sm">Cancel</button>
+        <button type="button" id="route-confirm-accept" class="btn btn-primary btn-sm">Accept</button>
+      </div>
+    `;
+
+    backdrop.appendChild(modal);
+    document.body.appendChild(backdrop);
+
+    // Stop clicks inside modal from closing
+    modal.addEventListener('click', (e) => e.stopPropagation());
+
+    const close = (confirmed: boolean) => {
+      document.removeEventListener('keydown', onEsc);
+      backdrop.remove();
+      resolve({
+        waypoints: resp.interpreted,
+        confirmed,
+      });
+    };
+
+    const onEsc = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') close(false);
+    };
+
+    backdrop.addEventListener('click', () => close(false));
+    modal.querySelector('.metric-popup-close')?.addEventListener('click', () => close(false));
+    modal.querySelector('#route-confirm-cancel')?.addEventListener('click', () => close(false));
+    modal.querySelector('#route-confirm-accept')?.addEventListener('click', () => close(true));
+
+    document.addEventListener('keydown', onEsc);
+  });
+}

--- a/web/ts/flight-main.ts
+++ b/web/ts/flight-main.ts
@@ -9,6 +9,7 @@ import { renderUserInfo } from './utils';
 import { initTheme } from './theme';
 import { initI18n } from './i18n/i18n';
 import { localToUtc, utcToLocal } from './utils/timezone';
+import { interpretAndConfirmRoute, validateOriginDestination } from './components/route-interpret';
 
 async function init(): Promise<void> {
   await initI18n();
@@ -150,6 +151,7 @@ async function init(): Promise<void> {
       const ceilEl = document.getElementById('edit-ceiling') as HTMLInputElement;
       const durEl = document.getElementById('edit-duration') as HTMLInputElement;
       const altEnabledEl = document.getElementById('edit-alt-enabled') as HTMLInputElement;
+      const waypointsEl = document.getElementById('edit-waypoints') as HTMLInputElement;
 
       // Sync final UTC values from displayed local time
       syncUtcFromLocal();
@@ -168,6 +170,28 @@ async function init(): Promise<void> {
         ? `${flight.target_date}T${editAltUtcHour.toString().padStart(2, '0')}:${editAltUtcMinute.toString().padStart(2, '0')}:00Z`
         : '';
 
+      // Handle route editing with smart interpretation
+      let newWaypoints: string[] | undefined;
+      const wpRaw = waypointsEl?.value?.trim();
+      if (wpRaw) {
+        const currentRoute = flight.waypoints.join(' ');
+        // Only interpret if route text has changed
+        if (wpRaw.toUpperCase() !== currentRoute.toUpperCase()) {
+          const result = await interpretAndConfirmRoute(wpRaw, (msg) => {
+            ui.renderError(msg);
+          });
+          if (!result || !result.confirmed) return;
+
+          // Validate origin/destination haven't changed
+          const validationError = validateOriginDestination(flight.waypoints, result.waypoints);
+          if (validationError) {
+            ui.renderError(validationError);
+            return;
+          }
+          newWaypoints = result.waypoints;
+        }
+      }
+
       await store.getState().saveFlight({
         profile_id: profileId,
         departure_time: departureTime,
@@ -175,7 +199,13 @@ async function init(): Promise<void> {
         cruise_altitude_ft: altitude,
         flight_ceiling_ft: ceiling,
         flight_duration_hours: duration,
+        ...(newWaypoints ? { waypoints: newWaypoints } : {}),
       });
+
+      // If route changed, reload waypoints for the map
+      if (newWaypoints) {
+        store.getState().loadWaypoints();
+      }
     });
 
     cancelBtn?.addEventListener('click', () => {

--- a/web/ts/flights-main.ts
+++ b/web/ts/flights-main.ts
@@ -2,6 +2,7 @@
 
 import { fetchCurrentUser } from './adapters/auth-adapter';
 import { fetchRouteDistance, parseFpl, type WaypointInfo } from './adapters/api-adapter';
+import { interpretAndConfirmRoute } from './components/route-interpret';
 import { fetchModelCatalog } from './adapters/preferences-adapter';
 import { fetchProfiles, type ProfileResponse } from './adapters/profiles-adapter';
 import { flightsStore } from './store/flights-store';
@@ -390,22 +391,23 @@ async function init(): Promise<void> {
       const profileSelect = document.getElementById('input-profile') as HTMLSelectElement;
       const profileId = profileSelect?.value ? parseInt(profileSelect.value, 10) : undefined;
 
-      const waypoints = wpRaw.split(/[\s,]+/).filter(Boolean).map((w) => w.toUpperCase());
       if (!targetDate) {
         ui.renderError(t('flights.form.errorDate'));
         return;
       }
-      if (waypoints.length < 2) {
+      if (!wpRaw) {
         ui.renderError(t('flights.form.errorWaypoints'));
         return;
       }
-      const invalidCodes = waypoints.filter((w) => !/^[A-Z0-9]{2,5}$/.test(w));
-      if (invalidCodes.length > 0) {
-        ui.renderError(
-          t('flights.form.errorInvalidCodes', { codes: invalidCodes.join(', ') }),
-        );
-        return;
-      }
+
+      // Smart route interpretation — resolve known waypoints, skip unknown tokens
+      const result = await interpretAndConfirmRoute(wpRaw, (msg) => ui.renderError(msg));
+      if (!result || !result.confirmed) return;
+      const waypoints = result.waypoints;
+
+      // Update the waypoints input to show the interpreted route
+      const wpInput = document.getElementById('input-waypoints') as HTMLInputElement;
+      if (wpInput) wpInput.value = waypoints.join(' ');
 
       try {
         const flight = await store.getState().createFlight(waypoints, targetDate, {

--- a/web/ts/managers/flight-detail-ui.ts
+++ b/web/ts/managers/flight-detail-ui.ts
@@ -215,9 +215,7 @@ export function renderFlightInfo(
         </div>`;
     }
 
-    const routeDisplay = flight.waypoints.length > 2
-      ? flight.waypoints.join(' \u2192 ')
-      : flight.waypoints.join(' \u2192 ');
+    const routeDisplay = flight.waypoints.join(' \u2192 ');
 
     container.innerHTML = `
       <div class="flight-info-grid">

--- a/web/ts/managers/flight-detail-ui.ts
+++ b/web/ts/managers/flight-detail-ui.ts
@@ -105,6 +105,13 @@ export function renderFlightInfo(
     container.innerHTML = `
       <div class="flight-info-grid editing">
         <div class="info-row">
+          <span class="info-label">Route</span>
+          <span class="info-value">
+            <input type="text" id="edit-waypoints" class="edit-input" value="${escapeHtml(flight.waypoints.join(' '))}" placeholder="e.g. EGTK LFPB LSGS" style="width:100%;font-family:monospace;">
+            <div class="muted" style="font-size:0.75rem;margin-top:2px;">Origin (${escapeHtml(flight.waypoints[0] || '')}) and destination (${escapeHtml(flight.waypoints[flight.waypoints.length - 1] || '')}) cannot change</div>
+          </span>
+        </div>
+        <div class="info-row">
           <span class="info-label">Profile</span>
           <span class="info-value">
             <select id="edit-profile" class="edit-input">${profileOptions}</select>
@@ -208,8 +215,16 @@ export function renderFlightInfo(
         </div>`;
     }
 
+    const routeDisplay = flight.waypoints.length > 2
+      ? flight.waypoints.join(' \u2192 ')
+      : flight.waypoints.join(' \u2192 ');
+
     container.innerHTML = `
       <div class="flight-info-grid">
+        <div class="info-row">
+          <span class="info-label">Route</span>
+          <span class="info-value" style="font-family:monospace;">${escapeHtml(routeDisplay)}</span>
+        </div>
         <div class="info-row">
           <span class="info-label">Profile</span>
           <span class="info-value">${escapeHtml(profileName)}</span>


### PR DESCRIPTION
- Add interpret-route API endpoint that resolves known waypoints from raw
  route text and returns interpreted/skipped tokens
- Flight creation uses smart parsing: unknown tokens are skipped with a
  confirmation popup showing what was interpreted vs skipped
- Add route editing to flight detail page (PATCH endpoint accepts waypoints)
- Origin and destination are enforced immutable on route edits
- Saved briefing packs are not affected (they store their own route copy)

https://claude.ai/code/session_01X4YZ7gEteevnff8Abawxim