### PR TITLE
feat(routes): filter waypoints that resolve far off the route

### DIFF
--- a/src/weatherbrief/airports.py
+++ b/src/weatherbrief/airports.py
@@ -46,7 +46,9 @@ def is_known_waypoint(code: str, db_path: str) -> bool:
     return resolver.resolve_point(code.upper()) is not None
 
 
-def resolve_waypoints(codes: list[str], db_path: str) -> list[Waypoint]:
+def resolve_waypoints(
+    codes: list[str], db_path: str
+) -> tuple[list[Waypoint], list[str]]:
     """Resolve waypoint codes to Waypoints using euro_aip RouteResolver.
 
     Accepts ICAO airport codes (4 letters), navaid codes (2-3 letters),
@@ -54,25 +56,36 @@ def resolve_waypoints(codes: list[str], db_path: str) -> list[Waypoint]:
     destination midpoint, then progressive proximity) to disambiguate
     navaids that exist in multiple regions (e.g. "ABB" in Europe vs US).
 
+    Middle waypoints whose resolved coordinates fall too far from the
+    route (per RouteResolver's detour filter) are dropped and returned
+    in the rejected list instead of raising.
+
     Args:
         codes: Ordered list of waypoint codes (min 2).
         db_path: Path to the euro_aip SQLite database.
 
     Returns:
-        List of Waypoint objects with coordinates from the database.
+        Tuple of (waypoints, rejected):
+          - waypoints: resolved Waypoint objects in order, always includes
+            departure and destination.
+          - rejected: token names that resolved but were filtered out for
+            being too far off route (empty list when nothing was filtered).
 
     Raises:
-        KeyError: If any code is not found in the database.
+        KeyError: If departure, destination, or any middle code is not
+            found in the database at all.
     """
     from euro_aip.models.route_resolver import RouteResolver
 
     model = _load_airport_model(db_path)
     resolver = RouteResolver(model)
 
-    # Use the full route resolver which disambiguates by proximity:
-    # dep/dest midpoint for context, then progressive last-resolved point.
+    # Use the full route resolver which disambiguates by proximity and
+    # filters points whose detour from the route is too large.
     route_string = " ".join(codes)
     route = resolver.resolve(route_string)
+
+    rejected_names = [str(r["name"]) for r in route.rejected_waypoints]
 
     # Collect all resolved points in order: departure, waypoints, destination
     all_points = []
@@ -89,9 +102,13 @@ def resolve_waypoints(codes: list[str], db_path: str) -> list[Waypoint]:
     else:
         raise KeyError(f"We did not find in our database: {codes[-1]}")
 
-    # Check for unresolved middle waypoints
+    # Middle tokens that were neither resolved nor rejected = genuinely unknown.
     resolved_middle = set(route.waypoints)
-    missing = [c for c in codes[1:-1] if c.upper() not in resolved_middle]
+    rejected_set = {n.upper() for n in rejected_names}
+    missing = [
+        c for c in codes[1:-1]
+        if c.upper() not in resolved_middle and c.upper() not in rejected_set
+    ]
     if missing:
         raise KeyError(f"We did not find in our database: {', '.join(missing)}")
 
@@ -107,7 +124,7 @@ def resolve_waypoints(codes: list[str], db_path: str) -> list[Waypoint]:
             Waypoint(icao=name.upper(), name=name.upper(), lat=lat, lon=lon)
         )
 
-    return waypoints
+    return waypoints, rejected_names
 
 
 def get_runway_ends(icao_codes: list[str], db_path: str) -> dict[str, list[RunwayEnd]]:

--- a/src/weatherbrief/airports.py
+++ b/src/weatherbrief/airports.py
@@ -85,7 +85,10 @@ def resolve_waypoints(
     route_string = " ".join(codes)
     route = resolver.resolve(route_string)
 
-    rejected_names = [str(r["name"]) for r in route.rejected_waypoints]
+    # Older euro_aip releases lack the detour filter — treat as "nothing rejected".
+    rejected_names = [
+        str(r["name"]) for r in getattr(route, "rejected_waypoints", [])
+    ]
 
     # Collect all resolved points in order: departure, waypoints, destination
     all_points = []

--- a/src/weatherbrief/airports.py
+++ b/src/weatherbrief/airports.py
@@ -85,7 +85,9 @@ def resolve_waypoints(
     route_string = " ".join(codes)
     route = resolver.resolve(route_string)
 
-    # Older euro_aip releases lack the detour filter — treat as "nothing rejected".
+    # euro_aip emits rejected entries as dicts: {"name", "reason", "detour_nm",
+    # "leg_nm", "threshold_nm"}. Older releases lack the field entirely — the
+    # getattr fallback treats that as "nothing rejected".
     rejected_names = [
         str(r["name"]) for r in getattr(route, "rejected_waypoints", [])
     ]

--- a/src/weatherbrief/api/flights.py
+++ b/src/weatherbrief/api/flights.py
@@ -266,9 +266,17 @@ def create_flight(
             from weatherbrief.airports import resolve_waypoints
 
             try:
-                resolve_waypoints(waypoints, db_path)
+                _, _rejected = resolve_waypoints(waypoints, db_path)
             except KeyError as exc:
                 raise HTTPException(status_code=422, detail=exc.args[0])
+            if _rejected:
+                raise HTTPException(
+                    status_code=422,
+                    detail=(
+                        "Waypoint(s) resolved too far from route: "
+                        f"{', '.join(_rejected)}"
+                    ),
+                )
 
     # Parse departure_time
     departure_time = datetime.fromisoformat(req.departure_time)
@@ -396,7 +404,7 @@ def compute_route_distance(
         raise HTTPException(status_code=500, detail="Airport database not configured")
 
     try:
-        resolved = resolve_waypoints(req.waypoints, db_path)
+        resolved, _ = resolve_waypoints(req.waypoints, db_path)
     except KeyError as exc:
         raise HTTPException(status_code=422, detail=exc.args[0])
 
@@ -480,16 +488,27 @@ def interpret_route(
                 skipped.append(token)
         else:
             try:
-                resolve_waypoints(test_list, db_path)
-                interpreted.append(token)
+                _, progressive_rejected = resolve_waypoints(test_list, db_path)
             except KeyError:
                 skipped.append(token)
+                continue
+            # Token resolves but lands too far off the running route → skip.
+            if token.upper() in {r.upper() for r in progressive_rejected}:
+                skipped.append(token)
+            else:
+                interpreted.append(token)
 
-    # Resolve the interpreted waypoints to get full info
+    # Final resolve — authoritative list of survivors + rejected.
     waypoint_infos: list[WaypointInfo] = []
     if len(interpreted) >= 2:
         try:
-            resolved = resolve_waypoints(interpreted, db_path)
+            resolved, final_rejected = resolve_waypoints(interpreted, db_path)
+            if final_rejected:
+                rej_set = {r.upper() for r in final_rejected}
+                # Move late-rejected tokens to skipped and rebuild interpreted
+                # from the resolver's surviving list so the two stay in sync.
+                skipped.extend(r for r in interpreted if r.upper() in rej_set)
+                interpreted = [wp.icao for wp in resolved]
             waypoint_infos = [
                 WaypointInfo(
                     icao=wp.icao,
@@ -731,9 +750,17 @@ def update_flight(
             from weatherbrief.airports import resolve_waypoints
 
             try:
-                resolve_waypoints(new_waypoints, db_path)
+                _, _rejected = resolve_waypoints(new_waypoints, db_path)
             except KeyError as exc:
                 raise HTTPException(status_code=422, detail=exc.args[0])
+            if _rejected:
+                raise HTTPException(
+                    status_code=422,
+                    detail=(
+                        "Waypoint(s) resolved too far from route: "
+                        f"{', '.join(_rejected)}"
+                    ),
+                )
         # Enforce same origin and destination
         old_origin = original_flight.waypoints[0] if original_flight.waypoints else None
         old_dest = original_flight.waypoints[-1] if original_flight.waypoints else None

--- a/src/weatherbrief/api/flights.py
+++ b/src/weatherbrief/api/flights.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 import re
 from datetime import datetime, timezone
 
@@ -25,6 +26,8 @@ from weatherbrief.storage.flights import (
 )
 
 router = APIRouter(prefix="/flights", tags=["flights"])
+
+logger = logging.getLogger(__name__)
 
 from weatherbrief.api.validation import WAYPOINT_RE
 
@@ -404,9 +407,15 @@ def compute_route_distance(
         raise HTTPException(status_code=500, detail="Airport database not configured")
 
     try:
-        resolved, _ = resolve_waypoints(req.waypoints, db_path)
+        resolved, rejected = resolve_waypoints(req.waypoints, db_path)
     except KeyError as exc:
         raise HTTPException(status_code=422, detail=exc.args[0])
+
+    if rejected:
+        logger.warning(
+            "compute_route_distance: dropped %d off-route waypoint(s) from %s: %s",
+            len(rejected), req.waypoints, rejected,
+        )
 
     total_nm = 0.0
     for wp_a, wp_b in zip(resolved, resolved[1:]):
@@ -470,8 +479,9 @@ def interpret_route(
     # Filter to valid waypoint patterns (2-5 alphanumeric chars)
     candidate_tokens = [t for t in tokens if WAYPOINT_RE.match(t)]
 
-    # Validate each candidate: use single-point lookup until we have 2+
-    # points, then switch to full route resolution for proper disambiguation
+    # Validate each candidate against the DB; detour filtering happens in the
+    # final resolve below, which rejects middle waypoints that sit too far
+    # off the departure→destination route.
     interpreted: list[str] = []
     skipped: list[str] = []
 
@@ -479,24 +489,10 @@ def interpret_route(
         # Skip consecutive duplicates (e.g. "ABDIL ABDIL" after filtering)
         if interpreted and interpreted[-1] == token:
             continue
-        test_list = interpreted + [token]
-        if len(test_list) < 2:
-            # Not enough points for route resolver, validate individually
-            if is_known_waypoint(token, db_path):
-                interpreted.append(token)
-            else:
-                skipped.append(token)
+        if is_known_waypoint(token, db_path):
+            interpreted.append(token)
         else:
-            try:
-                _, progressive_rejected = resolve_waypoints(test_list, db_path)
-            except KeyError:
-                skipped.append(token)
-                continue
-            # Token resolves but lands too far off the running route → skip.
-            if token.upper() in {r.upper() for r in progressive_rejected}:
-                skipped.append(token)
-            else:
-                interpreted.append(token)
+            skipped.append(token)
 
     # Final resolve — authoritative list of survivors + rejected.
     waypoint_infos: list[WaypointInfo] = []

--- a/src/weatherbrief/api/packs.py
+++ b/src/weatherbrief/api/packs.py
@@ -377,7 +377,12 @@ def _build_route_config(flight, db_path):
 
     if not flight.waypoints:
         raise ValueError("Flight has no waypoints defined")
-    waypoint_objs, _ = resolve_waypoints(flight.waypoints, db_path)
+    waypoint_objs, rejected = resolve_waypoints(flight.waypoints, db_path)
+    if rejected:
+        logger.warning(
+            "Flight %s: briefing route dropped %d off-route waypoint(s) from %s: %s",
+            getattr(flight, "id", "?"), len(rejected), flight.waypoints, rejected,
+        )
     return RouteConfig(
         name=flight.route_name or " \u2192 ".join(flight.waypoints),
         waypoints=waypoint_objs,

--- a/src/weatherbrief/api/packs.py
+++ b/src/weatherbrief/api/packs.py
@@ -377,7 +377,7 @@ def _build_route_config(flight, db_path):
 
     if not flight.waypoints:
         raise ValueError("Flight has no waypoints defined")
-    waypoint_objs = resolve_waypoints(flight.waypoints, db_path)
+    waypoint_objs, _ = resolve_waypoints(flight.waypoints, db_path)
     return RouteConfig(
         name=flight.route_name or " \u2192 ".join(flight.waypoints),
         waypoints=waypoint_objs,

--- a/src/weatherbrief/api/pireps.py
+++ b/src/weatherbrief/api/pireps.py
@@ -265,7 +265,7 @@ def _resolve_airport(icao: str, request: Request) -> tuple[float, float]:
         raise HTTPException(status_code=503, detail="Airport database not configured")
     try:
         from weatherbrief.airports import resolve_waypoints
-        waypoints = resolve_waypoints([icao.upper()], db_path)
+        waypoints, _ = resolve_waypoints([icao.upper()], db_path)
         return (waypoints[0].lat, waypoints[0].lon)
     except (KeyError, IndexError):
         raise HTTPException(status_code=400, detail=f"Unknown airport: {icao}")

--- a/tests/test_airports.py
+++ b/tests/test_airports.py
@@ -20,8 +20,9 @@ def test_resolve_waypoints(mock_load):
     }
     mock_load.return_value = mock_model(airports)
 
-    result = resolve_waypoints(["EGTK", "LSGS"], "/fake/db.sqlite")
+    result, rejected = resolve_waypoints(["EGTK", "LSGS"], "/fake/db.sqlite")
 
+    assert rejected == []
     assert len(result) == 2
     assert result[0].icao == "EGTK"
     assert result[0].lat == 51.8361

--- a/tests/test_airports.py
+++ b/tests/test_airports.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -28,6 +28,43 @@ def test_resolve_waypoints(mock_load):
     assert result[0].lat == 51.8361
     assert result[1].icao == "LSGS"
     assert result[1].lon == 7.3267
+
+
+@patch("weatherbrief.airports._load_airport_model")
+def test_resolve_waypoints_rejects_off_route_middle(mock_load):
+    """Detour-rejected middles are dropped from the result and surfaced in
+    `rejected`, not reported as missing (no spurious KeyError)."""
+    airports = {
+        "EGTK": mock_airport("EGTK", "Oxford Kidlington", 51.8361, -1.32),
+        "LSGS": mock_airport("LSGS", "Sion", 46.2192, 7.3267),
+    }
+    mock_load.return_value = mock_model(airports)
+
+    fake_route = MagicMock()
+    fake_route.departure_coords = (51.8361, -1.32)
+    fake_route.destination_coords = (46.2192, 7.3267)
+    fake_route.waypoints = []  # ABB rejected — not in resolved middles
+    fake_route.waypoint_coords = []
+    fake_route.rejected_waypoints = [
+        {
+            "name": "ABB",
+            "reason": "detour_exceeds_threshold",
+            "detour_nm": 400.0,
+            "leg_nm": 500.0,
+            "threshold_nm": 250.0,
+        }
+    ]
+
+    with patch(
+        "euro_aip.models.route_resolver.RouteResolver.resolve",
+        return_value=fake_route,
+    ):
+        result, rejected = resolve_waypoints(
+            ["EGTK", "ABB", "LSGS"], "/fake/db.sqlite"
+        )
+
+    assert rejected == ["ABB"]
+    assert [wp.icao for wp in result] == ["EGTK", "LSGS"]
 
 
 @patch("weatherbrief.airports._load_airport_model")


### PR DESCRIPTION
## Summary
- Add a detour-based filter that drops middle waypoints whose resolved coordinates sit too far off the departure→destination route. Fixes ambiguous navaid lookups like `ABB` (Europe vs US) picking a wildly wrong candidate.
- `resolve_waypoints` now returns `(waypoints, rejected)` — all call sites updated.
- `create_flight` / `update_flight` return 422 naming the off-route waypoint(s).
- `interpret_route` surfaces rejects via the existing `skipped` list, which the frontend popup already shows for user confirmation — the normal UX path.
- `compute_route_distance` and `_build_route_config` log a warning when a rejection happens, since in the gated flow they shouldn't see any.

## UX per call site
| Site | On rejection |
| --- | --- |
| `create_flight` / `update_flight` | 422 with waypoint names — hard failure (backstop for non-UI callers) |
| `interpret_route` | goes to `skipped` → existing frontend popup asks user to confirm |
| `compute_route_distance` | dropped silently, warning logged |
| `_build_route_config` (packs) | dropped silently, warning logged with flight id |
| `_resolve_airport` (pireps), `is_known_waypoint` | unaffected (no route context) |

## Notes
- The detour gate lives in `euro_aip.RouteResolver`; this branch reads `route.rejected_waypoints` via `getattr` with an empty-list fallback, so it ships independently of a `euro_aip` release. Once a `euro_aip` version with the filter is pinned, rejections will start flowing through.
- The initial commit included a progressive per-token check inside `interpret_route` that couldn't fire (the new token was always the destination of the test route, and the gate only runs on middle waypoints). Second commit removes it — O(n) instead of O(n²), same observable behavior.

## Test plan
- [x] `tests/test_airports.py` — updated for new return shape, `rejected == []` on old euro_aip
- [x] `tests/test_packs.py`, `tests/test_flights_storage.py`, `tests/test_route_points.py` — all pass
- [ ] Manual: paste a route with a ambiguous-navaid-in-wrong-region and confirm the popup flow
- [ ] Manual: create via MCP with a deliberately off-route waypoint and confirm 422 message
- [ ] Watch for the new warnings in production logs after deploy — indicates grandfathered flights or threshold drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)