### PR TITLE
feat(flights): use ICAO Field-15 parser for route interpretation

### DIFF
--- a/src/weatherbrief/airports.py
+++ b/src/weatherbrief/airports.py
@@ -3,12 +3,30 @@
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 from functools import lru_cache
+from typing import Literal
 
 from euro_aip.storage.database_storage import DatabaseStorage
 from timezonefinder import TimezoneFinder
 
 from weatherbrief.models import RunwayEnd, Waypoint
+
+
+RejectReason = Literal["detour", "unknown"]
+
+
+@dataclass(frozen=True)
+class RejectedWaypoint:
+    """A middle waypoint that didn't make the resolved route.
+
+    - ``detour``: resolved to a real point but too far off the direct route
+      (RouteResolver's detour filter).
+    - ``unknown``: not found in the DB under the current route context.
+    """
+
+    name: str
+    reason: RejectReason
 
 logger = logging.getLogger(__name__)
 
@@ -48,7 +66,7 @@ def is_known_waypoint(code: str, db_path: str) -> bool:
 
 def resolve_waypoints(
     codes: list[str], db_path: str
-) -> tuple[list[Waypoint], list[str]]:
+) -> tuple[list[Waypoint], list[RejectedWaypoint]]:
     """Resolve waypoint codes to Waypoints using euro_aip RouteResolver.
 
     Accepts ICAO airport codes (4 letters), navaid codes (2-3 letters),
@@ -56,9 +74,12 @@ def resolve_waypoints(
     destination midpoint, then progressive proximity) to disambiguate
     navaids that exist in multiple regions (e.g. "ABB" in Europe vs US).
 
-    Middle waypoints whose resolved coordinates fall too far from the
-    route (per RouteResolver's detour filter) are dropped and returned
-    in the rejected list instead of raising.
+    Middle waypoints that don't survive resolution are returned in the
+    ``rejected`` list with a reason — either ``detour`` (resolved but too
+    far off the direct route) or ``unknown`` (no DB match under the route
+    context). Callers decide how to react: strict endpoints (create, move,
+    update) surface these as 422; lenient endpoints (briefing, distance)
+    log and continue with the survivors.
 
     Args:
         codes: Ordered list of waypoint codes (min 2).
@@ -68,12 +89,13 @@ def resolve_waypoints(
         Tuple of (waypoints, rejected):
           - waypoints: resolved Waypoint objects in order, always includes
             departure and destination.
-          - rejected: token names that resolved but were filtered out for
-            being too far off route (empty list when nothing was filtered).
+          - rejected: middle tokens that didn't resolve, each tagged with
+            a reason. Empty when the full list was accepted.
 
     Raises:
-        KeyError: If departure, destination, or any middle code is not
-            found in the database at all.
+        KeyError: If the departure or destination code can't be placed
+            on the map — those are mandatory. Missing middles go into
+            ``rejected`` instead.
     """
     from euro_aip.models.route_resolver import RouteResolver
 
@@ -85,37 +107,34 @@ def resolve_waypoints(
     route_string = " ".join(codes)
     route = resolver.resolve(route_string)
 
-    # euro_aip emits rejected entries as dicts: {"name", "reason", "detour_nm",
-    # "leg_nm", "threshold_nm"}. Older releases lack the field entirely — the
-    # getattr fallback treats that as "nothing rejected".
-    rejected_names = [
-        str(r["name"]) for r in getattr(route, "rejected_waypoints", [])
+    # euro_aip emits detour-rejected entries as dicts: {"name", "reason",
+    # "detour_nm", "leg_nm", "threshold_nm"}. Older releases lack the field
+    # entirely — the getattr fallback treats that as "nothing rejected".
+    rejected: list[RejectedWaypoint] = [
+        RejectedWaypoint(name=str(r["name"]), reason="detour")
+        for r in getattr(route, "rejected_waypoints", [])
     ]
 
-    # Collect all resolved points in order: departure, waypoints, destination
-    all_points = []
-    if route.departure_coords:
-        all_points.append((codes[0], route.departure_coords))
-    else:
+    if not route.departure_coords:
         raise KeyError(f"We did not find in our database: {codes[0]}")
-
-    for name, coord in zip(route.waypoints, route.waypoint_coords):
-        all_points.append((name, coord))
-
-    if route.destination_coords:
-        all_points.append((codes[-1], route.destination_coords))
-    else:
+    if not route.destination_coords:
         raise KeyError(f"We did not find in our database: {codes[-1]}")
 
-    # Middle tokens that were neither resolved nor rejected = genuinely unknown.
-    resolved_middle = set(route.waypoints)
-    rejected_set = {n.upper() for n in rejected_names}
-    missing = [
-        c for c in codes[1:-1]
-        if c.upper() not in resolved_middle and c.upper() not in rejected_set
-    ]
-    if missing:
-        raise KeyError(f"We did not find in our database: {', '.join(missing)}")
+    # Middle tokens that the resolver neither placed nor rejected: the
+    # resolver silently dropped them because no DB entry matched under
+    # route context. Surface them as ``unknown`` so callers see a single
+    # categorized rejection list.
+    resolved_middle_upper = {n.upper() for n in route.waypoints}
+    detour_rejected_upper = {r.name.upper() for r in rejected}
+    for c in codes[1:-1]:
+        cu = c.upper()
+        if cu not in resolved_middle_upper and cu not in detour_rejected_upper:
+            rejected.append(RejectedWaypoint(name=c, reason="unknown"))
+
+    all_points: list[tuple[str, object]] = [(codes[0], route.departure_coords)]
+    for name, coord in zip(route.waypoints, route.waypoint_coords):
+        all_points.append((name, coord))
+    all_points.append((codes[-1], route.destination_coords))
 
     waypoints: list[Waypoint] = []
     for name, coord in all_points:
@@ -129,7 +148,7 @@ def resolve_waypoints(
             Waypoint(icao=name.upper(), name=name.upper(), lat=lat, lon=lon)
         )
 
-    return waypoints, rejected_names
+    return waypoints, rejected
 
 
 def get_runway_ends(icao_codes: list[str], db_path: str) -> dict[str, list[RunwayEnd]]:

--- a/src/weatherbrief/api/flights.py
+++ b/src/weatherbrief/api/flights.py
@@ -17,6 +17,7 @@ from sqlalchemy.orm import Session
 from flyfun_common.auth import is_dev_mode
 from flyfun_common.db import current_user_id, get_db
 from flyfun_common.db.models import UserRow
+from weatherbrief.airports import RejectedWaypoint
 from weatherbrief.db.models import BriefingPackRow
 from weatherbrief.models import Flight
 from weatherbrief.storage.flights import (
@@ -126,7 +127,7 @@ class FlightResponse(BaseModel):
     is_subscribed: bool = False  # True when the viewer has subscribed to this flight
 
 
-def _rejected_waypoints_message(rejected) -> str:
+def _rejected_waypoints_message(rejected: list[RejectedWaypoint]) -> str:
     """Human-readable 422 detail for resolve_waypoints rejections.
 
     Separates ``unknown`` (typo / not-in-DB) from ``detour`` (off-route)
@@ -586,7 +587,6 @@ def interpret_route(
         raise HTTPException(status_code=500, detail="Airport database not configured")
 
     tokens = parse_field15(req.raw_route)
-    original_tokens = [t.value for t in tokens]
 
     candidate_waypoints: list[str] = []
     skipped: list[str] = []
@@ -596,13 +596,18 @@ def interpret_route(
             if candidate_waypoints and candidate_waypoints[-1] == t.value:
                 continue
             candidate_waypoints.append(t.value)
-        elif t.kind in (TokenKind.SPEED_LEVEL,):
+        elif t.kind is TokenKind.SPEED_LEVEL:
             # Metadata, not a waypoint — drop silently (not surfaced as skipped).
             continue
         else:
             # AIRWAY / FLIGHT_RULE / DIRECT / UNKNOWN — show the pilot what
             # we set aside so they can sanity-check the parse.
             skipped.append(t.value)
+
+    # ``original_tokens`` has always meant "candidate waypoints before
+    # filtering" (back when the regex grabbed only 2-5 alphanumerics). Keep
+    # that semantic so clients consuming the field see the same shape.
+    original_tokens = list(candidate_waypoints)
 
     interpreted = list(candidate_waypoints)
     waypoint_infos: list[WaypointInfo] = []

--- a/src/weatherbrief/api/flights.py
+++ b/src/weatherbrief/api/flights.py
@@ -587,6 +587,12 @@ def interpret_route(
         raise HTTPException(status_code=500, detail="Airport database not configured")
 
     tokens = parse_field15(req.raw_route)
+    # Everything parse_field15 extracted — matches the
+    # InterpretRouteResponse docstring ("all tokens extracted from the
+    # input") and gives consumers (e.g. an iOS prefill-correction UI)
+    # the full picture of what was parsed, including airway / flight-rule
+    # / direct / speed-level syntax.
+    original_tokens = [t.value for t in tokens]
 
     candidate_waypoints: list[str] = []
     skipped: list[str] = []
@@ -604,12 +610,9 @@ def interpret_route(
             # we set aside so they can sanity-check the parse.
             skipped.append(t.value)
 
-    # ``original_tokens`` has always meant "candidate waypoints before
-    # filtering" (back when the regex grabbed only 2-5 alphanumerics). Keep
-    # that semantic so clients consuming the field see the same shape.
-    original_tokens = list(candidate_waypoints)
-
-    interpreted = list(candidate_waypoints)
+    # Pass-through when we have 0-1 candidates — resolver needs >=2 for a
+    # route. The loop below overwrites this from the resolver on the >=2 path.
+    interpreted: list[str] = list(candidate_waypoints)
     waypoint_infos: list[WaypointInfo] = []
     if len(candidate_waypoints) >= 2:
         try:
@@ -628,11 +631,13 @@ def interpret_route(
             if rejected:
                 rej_set = {r.name.upper() for r in rejected}
                 # Move late-rejected tokens (detour or unknown-under-context)
-                # to skipped and rebuild interpreted from survivors.
+                # to skipped.
                 skipped.extend(
                     c for c in candidate_waypoints if c.upper() in rej_set
                 )
-                interpreted = [wp.icao for wp in resolved]
+            # Always rebuild from the resolver so ``interpreted`` stays in
+            # lock-step with ``waypoint_infos`` (same order, same casing).
+            interpreted = [wp.icao for wp in resolved]
             waypoint_infos = [
                 WaypointInfo(
                     icao=wp.icao,

--- a/src/weatherbrief/api/flights.py
+++ b/src/weatherbrief/api/flights.py
@@ -602,12 +602,12 @@ def interpret_route(
             if candidate_waypoints and candidate_waypoints[-1] == t.value:
                 continue
             candidate_waypoints.append(t.value)
-        elif t.kind is TokenKind.SPEED_LEVEL:
-            # Metadata, not a waypoint — drop silently (not surfaced as skipped).
-            continue
         else:
-            # AIRWAY / FLIGHT_RULE / DIRECT / UNKNOWN — show the pilot what
-            # we set aside so they can sanity-check the parse.
+            # Everything non-waypoint (AIRWAY / FLIGHT_RULE / DIRECT /
+            # SPEED_LEVEL / UNKNOWN) is surfaced in ``skipped`` so the pilot
+            # can see every token that didn't make it into the route — and
+            # so the client can rely on ``interpreted ∪ skipped`` covering
+            # every element of ``original_tokens``.
             skipped.append(t.value)
 
     # Pass-through when we have 0-1 candidates — resolver needs >=2 for a

--- a/src/weatherbrief/api/flights.py
+++ b/src/weatherbrief/api/flights.py
@@ -126,6 +126,23 @@ class FlightResponse(BaseModel):
     is_subscribed: bool = False  # True when the viewer has subscribed to this flight
 
 
+def _rejected_waypoints_message(rejected) -> str:
+    """Human-readable 422 detail for resolve_waypoints rejections.
+
+    Separates ``unknown`` (typo / not-in-DB) from ``detour`` (off-route)
+    so the pilot knows how to fix the input. Accepts a list of
+    ``airports.RejectedWaypoint``.
+    """
+    unknown = [r.name for r in rejected if r.reason == "unknown"]
+    detour = [r.name for r in rejected if r.reason == "detour"]
+    parts: list[str] = []
+    if unknown:
+        parts.append(f"We did not find in our database: {', '.join(unknown)}")
+    if detour:
+        parts.append(f"Waypoint(s) resolved too far from route: {', '.join(detour)}")
+    return "; ".join(parts) if parts else "Route could not be resolved"
+
+
 def _compute_flight_id(
     *,
     route_name: str,
@@ -364,10 +381,7 @@ def create_flight(
             if _rejected:
                 raise HTTPException(
                     status_code=422,
-                    detail=(
-                        "Waypoint(s) resolved too far from route: "
-                        f"{', '.join(_rejected)}"
-                    ),
+                    detail=_rejected_waypoints_message(_rejected),
                 )
 
     # Parse departure_time
@@ -495,8 +509,9 @@ def compute_route_distance(
 
     if rejected:
         logger.warning(
-            "compute_route_distance: dropped %d off-route waypoint(s) from %s: %s",
-            len(rejected), req.waypoints, rejected,
+            "compute_route_distance: dropped %d waypoint(s) from %s: %s",
+            len(rejected), req.waypoints,
+            [(r.name, r.reason) for r in rejected],
         )
 
     total_nm = 0.0
@@ -544,48 +559,74 @@ def interpret_route(
     request: Request,
     user_id: str = Depends(current_user_id),
 ):
-    """Interpret a raw route string, resolving known waypoints and skipping unknown tokens.
+    """Interpret a raw ICAO Field-15 route string into a resolved waypoint list.
 
-    Accepts free-form route text (e.g. from a flight plan paste). Extracts tokens
-    matching waypoint patterns, resolves each against the airport/navaid database,
-    and returns the list of recognized waypoints plus any skipped tokens.
+    Pipeline:
+      1. ``parse_field15`` classifies each token (WAYPOINT / AIRWAY /
+         SPEED_LEVEL / FLIGHT_RULE / DIRECT / UNKNOWN).
+      2. Keep only WAYPOINT tokens — IFR, DCT, airway labels, speed/level
+         suffixes are syntactic and never hit the DB.
+      3. ``resolve_waypoints`` does the authoritative pass with route
+         context, returning a survivors list plus reason-tagged rejects.
+
+    All non-waypoint syntax and all rejected tokens are surfaced in
+    ``skipped`` so the preview popup can show the pilot exactly what
+    survived.
     """
-    from weatherbrief.airports import get_timezone, is_known_waypoint, resolve_waypoints
+    from euro_aip.models.field15 import parse_field15, TokenKind
+
+    from weatherbrief.airports import (
+        get_timezone,
+        is_known_waypoint,
+        resolve_waypoints,
+    )
 
     db_path = getattr(request.app.state, "db_path", "")
     if not db_path:
         raise HTTPException(status_code=500, detail="Airport database not configured")
 
-    # Extract tokens that look like waypoint codes
-    tokens = [t.upper() for t in re.split(r"[\s,\-/]+", req.raw_route.strip()) if t]
-    # Filter to valid waypoint patterns (2-5 alphanumeric chars)
-    candidate_tokens = [t for t in tokens if WAYPOINT_RE.match(t)]
+    tokens = parse_field15(req.raw_route)
+    original_tokens = [t.value for t in tokens]
 
-    # Validate each candidate against the DB; detour filtering happens in the
-    # final resolve below, which rejects middle waypoints that sit too far
-    # off the departure→destination route.
-    interpreted: list[str] = []
+    candidate_waypoints: list[str] = []
     skipped: list[str] = []
-
-    for token in candidate_tokens:
-        # Skip consecutive duplicates (e.g. "ABDIL ABDIL" after filtering)
-        if interpreted and interpreted[-1] == token:
+    for t in tokens:
+        if t.kind is TokenKind.WAYPOINT:
+            # Skip consecutive duplicates (e.g. pasted ``ABDIL ABDIL``)
+            if candidate_waypoints and candidate_waypoints[-1] == t.value:
+                continue
+            candidate_waypoints.append(t.value)
+        elif t.kind in (TokenKind.SPEED_LEVEL,):
+            # Metadata, not a waypoint — drop silently (not surfaced as skipped).
             continue
-        if is_known_waypoint(token, db_path):
-            interpreted.append(token)
         else:
-            skipped.append(token)
+            # AIRWAY / FLIGHT_RULE / DIRECT / UNKNOWN — show the pilot what
+            # we set aside so they can sanity-check the parse.
+            skipped.append(t.value)
 
-    # Final resolve — authoritative list of survivors + rejected.
+    interpreted = list(candidate_waypoints)
     waypoint_infos: list[WaypointInfo] = []
-    if len(interpreted) >= 2:
+    if len(candidate_waypoints) >= 2:
         try:
-            resolved, final_rejected = resolve_waypoints(interpreted, db_path)
-            if final_rejected:
-                rej_set = {r.upper() for r in final_rejected}
-                # Move late-rejected tokens to skipped and rebuild interpreted
-                # from the resolver's surviving list so the two stay in sync.
-                skipped.extend(r for r in interpreted if r.upper() in rej_set)
+            resolved, rejected = resolve_waypoints(candidate_waypoints, db_path)
+        except KeyError:
+            # Departure or destination not placed — the route is a non-starter.
+            # Fall back to a per-token DB check so the popup shows the pilot
+            # which codes are unknown (typo) vs. known-but-not-enough.
+            interpreted = [
+                c for c in candidate_waypoints if is_known_waypoint(c, db_path)
+            ]
+            skipped.extend(
+                c for c in candidate_waypoints if c not in interpreted
+            )
+        else:
+            if rejected:
+                rej_set = {r.name.upper() for r in rejected}
+                # Move late-rejected tokens (detour or unknown-under-context)
+                # to skipped and rebuild interpreted from survivors.
+                skipped.extend(
+                    c for c in candidate_waypoints if c.upper() in rej_set
+                )
                 interpreted = [wp.icao for wp in resolved]
             waypoint_infos = [
                 WaypointInfo(
@@ -597,12 +638,9 @@ def interpret_route(
                 )
                 for wp in resolved
             ]
-        except KeyError:
-            # Should not happen since we pre-filtered, but handle gracefully
-            pass
 
     return InterpretRouteResponse(
-        original_tokens=candidate_tokens,
+        original_tokens=original_tokens,
         interpreted=interpreted,
         skipped=skipped,
         waypoints=waypoint_infos,
@@ -801,9 +839,14 @@ def move_flight(
             from weatherbrief.airports import resolve_waypoints
 
             try:
-                resolve_waypoints(new_waypoints, db_path)
+                _, _rejected = resolve_waypoints(new_waypoints, db_path)
             except KeyError as exc:
                 raise HTTPException(status_code=422, detail=exc.args[0])
+            if _rejected:
+                raise HTTPException(
+                    status_code=422,
+                    detail=_rejected_waypoints_message(_rejected),
+                )
 
     # Past-departure rule mirrors create_flight: only admins can move into the past.
     if new_departure_time < datetime.now(timezone.utc):
@@ -1078,10 +1121,7 @@ def update_flight(
             if _rejected:
                 raise HTTPException(
                     status_code=422,
-                    detail=(
-                        "Waypoint(s) resolved too far from route: "
-                        f"{', '.join(_rejected)}"
-                    ),
+                    detail=_rejected_waypoints_message(_rejected),
                 )
         # Enforce same origin and destination
         old_origin = original_flight.waypoints[0] if original_flight.waypoints else None

--- a/src/weatherbrief/api/packs.py
+++ b/src/weatherbrief/api/packs.py
@@ -380,8 +380,9 @@ def _build_route_config(flight, db_path):
     waypoint_objs, rejected = resolve_waypoints(flight.waypoints, db_path)
     if rejected:
         logger.warning(
-            "Flight %s: briefing route dropped %d off-route waypoint(s) from %s: %s",
-            getattr(flight, "id", "?"), len(rejected), flight.waypoints, rejected,
+            "Flight %s: briefing route dropped %d waypoint(s) from %s: %s",
+            getattr(flight, "id", "?"), len(rejected), flight.waypoints,
+            [(r.name, r.reason) for r in rejected],
         )
     return RouteConfig(
         name=flight.route_name or " \u2192 ".join(flight.waypoints),

--- a/tests/test_airports.py
+++ b/tests/test_airports.py
@@ -7,7 +7,11 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from airport_mocks import mock_airport, mock_model
-from weatherbrief.airports import is_known_waypoint, resolve_waypoints
+from weatherbrief.airports import (
+    RejectedWaypoint,
+    is_known_waypoint,
+    resolve_waypoints,
+)
 from weatherbrief.models import Waypoint
 
 
@@ -63,13 +67,57 @@ def test_resolve_waypoints_rejects_off_route_middle(mock_load):
             ["EGTK", "ABB", "LSGS"], "/fake/db.sqlite"
         )
 
-    assert rejected == ["ABB"]
+    assert rejected == [RejectedWaypoint(name="ABB", reason="detour")]
     assert [wp.icao for wp in result] == ["EGTK", "LSGS"]
 
 
 @patch("weatherbrief.airports._load_airport_model")
-def test_resolve_waypoints_missing(mock_load):
-    """Raises KeyError for unknown ICAO codes."""
+def test_resolve_waypoints_unknown_middle_goes_to_rejected(mock_load):
+    """Middle tokens the resolver silently drops (no DB match under route
+    context) now land in ``rejected`` with reason='unknown' instead of
+    raising KeyError. This is the IFR-style collision case: is_known_waypoint
+    might accept a global navaid match, but ``resolver.resolve`` in route
+    context can't place it."""
+    airports = {
+        "EGTK": mock_airport("EGTK", "Oxford Kidlington", 51.8361, -1.32),
+        "LSGS": mock_airport("LSGS", "Sion", 46.2192, 7.3267),
+    }
+    mock_load.return_value = mock_model(airports)
+
+    fake_route = MagicMock()
+    fake_route.departure_coords = (51.8361, -1.32)
+    fake_route.destination_coords = (46.2192, 7.3267)
+    fake_route.waypoints = []  # IFR neither placed nor rejected
+    fake_route.waypoint_coords = []
+    fake_route.rejected_waypoints = []
+
+    with patch(
+        "euro_aip.models.route_resolver.RouteResolver.resolve",
+        return_value=fake_route,
+    ):
+        result, rejected = resolve_waypoints(
+            ["EGTK", "IFR", "LSGS"], "/fake/db.sqlite"
+        )
+
+    assert rejected == [RejectedWaypoint(name="IFR", reason="unknown")]
+    assert [wp.icao for wp in result] == ["EGTK", "LSGS"]
+
+
+@patch("weatherbrief.airports._load_airport_model")
+def test_resolve_waypoints_missing_departure_raises(mock_load):
+    """Missing departure still raises KeyError — departure is mandatory."""
+    airports = {
+        "EGTK": mock_airport("EGTK", "Oxford Kidlington", 51.8361, -1.32),
+    }
+    mock_load.return_value = mock_model(airports)
+
+    with pytest.raises(KeyError, match="ZZZZ"):
+        resolve_waypoints(["ZZZZ", "EGTK"], "/fake/db.sqlite")
+
+
+@patch("weatherbrief.airports._load_airport_model")
+def test_resolve_waypoints_missing_destination_raises(mock_load):
+    """Missing destination still raises KeyError — destination is mandatory."""
     airports = {
         "EGTK": mock_airport("EGTK", "Oxford Kidlington", 51.8361, -1.32),
     }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -859,3 +859,25 @@ class TestInterpretRoute:
         data = resp.json()
         assert data["interpreted"] == []
         assert set(data["skipped"]) == {"ZZZZ", "YYYY"}
+
+    @patch("weatherbrief.airports._load_airport_model")
+    def test_field15_keywords_skipped(self, mock_load, client):
+        """ICAO Field-15 syntax tokens (IFR/DCT/airways/speed-level) are
+        classified as non-waypoints by the parser and surfaced in `skipped`
+        without hitting the DB. Regression test for the IFR-vs-navaid-collision
+        bug where `IFR` coincidentally matched a global navaid code."""
+        mock_load.return_value = mock_model(TEST_AIRPORTS)
+        client.app.state.db_path = "/fake/db"
+
+        resp = self._post(
+            client,
+            "EGBJ N0152F100 IFR DCT M150 LFOV",
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        # Endpoints survive, syntax tokens are set aside
+        assert data["interpreted"] == ["EGBJ", "LFOV"]
+        # N0152F100 (speed/level) is metadata, not surfaced.
+        # IFR (flight-rule), DCT (direct), M150 (airway) are shown so pilot
+        # sees what was parsed.
+        assert set(data["skipped"]) == {"IFR", "DCT", "M150"}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -877,7 +877,7 @@ class TestInterpretRoute:
         data = resp.json()
         # Endpoints survive, syntax tokens are set aside
         assert data["interpreted"] == ["EGBJ", "LFOV"]
-        # N0152F100 (speed/level) is metadata, not surfaced.
-        # IFR (flight-rule), DCT (direct), M150 (airway) are shown so pilot
-        # sees what was parsed.
-        assert set(data["skipped"]) == {"IFR", "DCT", "M150"}
+        # All non-waypoint tokens surface in skipped so the pilot sees
+        # every parsed token and ``interpreted ∪ skipped`` covers
+        # ``original_tokens``.
+        assert set(data["skipped"]) == {"N0152F100", "IFR", "DCT", "M150"}


### PR DESCRIPTION
## Summary

Fixes the IFR-leak in the route-preview popup: tokens that coincidentally collide with a global navaid code (e.g. `IFR`) used to pass the per-token pre-filter but then get silently dropped by the route-context resolver, so the preview showed a route with `IFR` but `POST /api/flights` 422'd on the same list.

Replaces the regex + `is_known_waypoint` pre-filter with `euro_aip.models.field15.parse_field15`, which classifies each token syntactically:

| Kind | Examples | Handling |
|---|---|---|
| WAYPOINT | EGKA, RUBUT, DIK | DB lookup via `resolve_waypoints` |
| AIRWAY | M150, T122, UL612 | In `skipped` |
| FLIGHT_RULE | IFR, VFR | In `skipped` |
| DIRECT | DCT, → | In `skipped` |
| SPEED_LEVEL | N0152F100 | In `skipped` |
| UNKNOWN | garbage | In `skipped` |

`IFR`, `DCT`, airway labels, speed/level codes never reach the DB — they're known-by-syntax to not be waypoints.

## Rejection contract, unified

`resolve_waypoints` now returns `tuple[list[Waypoint], list[RejectedWaypoint]]` where `RejectedWaypoint` has `(name, reason)` and `reason ∈ {detour, unknown}`. Missing dep/dest still raises `KeyError` — those are required. Missing middles (the IFR case) are categorized as `reason="unknown"` and returned in rejected, letting callers decide 422 vs. log-and-continue.

**Write endpoints** (create / update / move) uniformly 422 on any rejection with a message that distinguishes "not in DB" from "off-route". This also fixes a pre-existing gap where `move` silently ignored detour rejections.

**Read/utility endpoints** (compute-route-distance, briefing) log and continue — they get pre-validated data from the write path.

## API surface — `InterpretRouteResponse`

Wire shape unchanged (`original_tokens`, `interpreted`, `skipped`, `waypoints` — same field names and types). Behaviour refinements worth knowing for downstream:

- `original_tokens` now returns *every* `parse_field15` token (waypoints + airway/flight-rule/direct/speed-level/unknown), matching its "all tokens extracted from the input" docstring. Previously it was filtered to 2–5 alphanumeric via the regex, so speed/level codes like `N0152F100` (9 chars) never appeared. iOS does not read this field (grep'd Swift sources); web `api-adapter.ts` declares but doesn't consume it.
- `skipped` now surfaces every non-waypoint token, preserving the invariant that `interpreted ∪ skipped ⊇ original_tokens` (up to consecutive-waypoint dedup). Pilots see everything that didn't make the route.

## Scope

- `src/weatherbrief/airports.py` — `RejectedWaypoint` dataclass, resolve_waypoints contract
- `src/weatherbrief/api/flights.py` — `parse_field15`-based interpret-route; `_rejected_waypoints_message` helper; move now strict on detour
- `src/weatherbrief/api/packs.py` — updated briefing log
- `tests/test_airports.py` — unknown-middle test, split departure/destination KeyError tests
- `tests/test_api.py` — new IFR/DCT/airway/speed-level skip test

No model / schema change.

## Test plan

- [x] `pytest tests/test_airports.py -v` → 9/9
- [x] `pytest tests/test_api.py::TestInterpretRoute -v` → 8/8
- [x] Full suite → 1318/1318
- [ ] Post-deploy: paste the EGKA…IFR…EDNY route that triggered the original bug; confirm preview shows IFR + speed/level + airway tokens in "Skipped" and Accept succeeds.

Addresses the post-deploy IFR bug. Issue #82 tracks persisting the raw route for re-interpretation as parsing/data improves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)