### PR TITLE
Adapt ECMWF ingestion for IFS Cycle 50r1 (12 May 2026)

### DIFF
--- a/designs/analysis-metrics.md
+++ b/designs/analysis-metrics.md
@@ -72,7 +72,7 @@ Pressure levels vary by model (range 1000–150 hPa, ~SFC to ~FL450):
 |-------|--------|-------|------|
 | GFS / Best-Match | 1000, 975, 950, ..., 300, 250, 200, 150 | 28 | 25 hPa spacing below 500, extends to FL450 |
 | ECMWF (Open-Meteo) | 1000, 925, 850, 700, 600, 500, 400, 300, 250, 200, 150, 100, 50 | 13 | Fallback when outside direct-GRIB coverage or beyond 7-day range |
-| ECMWF (direct GRIB) | 1000, 950, 925, 900, 850, 800, 700, 600, 500, 400, 300, 250, 200, 150, 100, 70, 50, 30, 20, 10, 7, 5, 3, 2, 1 | 25 | ECPDS push, Europe + US, 0–192h (oper) / 0–144h (scda). Replaces the 13-level Open-Meteo sounding for covered points. |
+| ECMWF (direct GRIB) | 1000, 950, 925, 900, 850, 800, 700, 600, 500, 400, 300, 250, 200, 150, 100, 70, 50, 30, 20, 10, 7, 5, 3, 2, 1 | 25 | ECPDS push, Europe + US, 0–168h at 00/12z, 0–144h at 06/18z. Replaces the 13-level Open-Meteo sounding for covered points. Horizon is derived from files on disk, not stream name (robust to the 50r1 `scda`→`oper` merge). |
 | ICON | 1000, 975, 950, 925, 900, 850, 800, 700, 600, 500, 400, 300, 250, 200, 150, 100, 70, 50, 30 | 19 | Open-Meteo (verified Mar 2026). Still no intermediate levels between 800–300 hPa. GRIB enrichment adds CLW/ICMR/cloud diagnostics via DWD ICON-EU model-level data (Europe only). |
 | Météo-France | 1000, 950, 925, ..., 300, 250, 200, 150 | 19 | |
 | UKMO | 1000, 975, 950, ..., 300, 250, 200, 150 | 20 | Supports vertical_velocity |
@@ -182,7 +182,7 @@ Surface (a1) single-level scalar fields. Stored in `NWPCloudDiagnostics` model.
 
 **Surface fields delivered but not yet processed:** `10fg` (wind gusts), `10u`/`10v` (10m wind), `2t`/`2d` (screen T/Td), `blh` (boundary layer height), `capes` (CAPE-shear), `cp` (convective precipitation), `degm10l` (-10°C level), `fzra` (freezing rain accum), `kx` (K-index), `totalx` (Total Totals), `lsp` (large-scale precip), `msl`/`sp` (pressure), `ptype` (precip type code), `sf` (snowfall), `tp` (total precip), `vis` (visibility). `kx`, `totalx`, and `cp` are the highest-value follow-ups — they directly indicate model-observed thunderstorm activity (the fields Windy uses to drive ECMWF thunder icons).
 
-**ECMWF specifics:** ECPDS push delivery to `ECMWF_GRIB_DIR` (no HTTP, no cache). Coverage is the `ifs-ens-cf` subscription grid: Europe + US at 0.25°. Cycles: oper (00z/12z) deliver 0–192h, scda (06z/18z) deliver 0–144h. Publication delay ~6–8h after init. Forecast steps every 3h — intermediate hours within the flight window get forward-filled from the preceding native step (`fetch/grib/fill.py::_forward_fill_pressure_levels`); linear time interpolation is a future improvement. Files may contain multiple geographic sub-grids; cfgrib splits them into separate Datasets and the decoder uses first-wins per point.
+**ECMWF specifics:** ECPDS push delivery to `ECMWF_GRIB_DIR` (no HTTP, no cache). Coverage is the `ifs-ens-cf` subscription grid: Europe + US at 0.25°. Cycles: 00/12z deliver 0–168h, 06/18z deliver 0–144h (horizon is read from files on disk, not from stream name — robust to the 50r1 `scda`→`oper` merge on 12-May-2026). Publication delay ~6–8h after init. Post-amendment cadence is hourly 0–90h then 3h tail on pressure-level data; surface fields are 3h throughout. Intermediate hours within the flight window get forward-filled from the preceding native step (`fetch/grib/fill.py::_forward_fill_pressure_levels`); linear time interpolation is a future improvement. Files may contain multiple geographic sub-grids; cfgrib splits them into separate Datasets and the decoder uses first-wins per point.
 
 ---
 
@@ -415,7 +415,7 @@ The `_no_vv` suffix indicates omega (vertical velocity) is unavailable for the m
 
 \* ICON uses full variant only when route is within ICON-EU domain (Europe). Falls back to proxy for routes outside the domain.
 
-† ECMWF uses full variant only when route and flight window fall within the ECPDS GRIB coverage (Europe + US, 0–192h for 00z/12z oper, 0–144h for 06z/18z scda). Outside coverage, no direct GRIB is applied and SFIP falls back to `proxy` (ω from Open-Meteo API still available).
+† ECMWF uses full variant only when route and flight window fall within the ECPDS GRIB coverage (Europe + US, 0–168h for 00/12z, 0–144h for 06/18z). Outside coverage, no direct GRIB is applied and SFIP falls back to `proxy` (ω from Open-Meteo API still available).
 
 ### 3.3 Convective Assessment
 
@@ -550,7 +550,7 @@ Shows data source for each key quantity per model. **Bold** = derived when API f
 
 † ICON GRIB2 enrichment only available when route is within ICON-EU domain (Europe: 29.5–70.5°N, 23.5°W–62.5°E).
 
-‡ ECMWF GRIB2 enrichment (ECPDS commercial feed) only available when route falls within the ifs-ens-cf coverage grid (Europe + US) and the flight window is within the run's forecast range (0–192h oper / 0–144h scda). Outside coverage, ECMWF falls back to Open-Meteo's 13-level sounding and SFIP uses the proxy variant.
+‡ ECMWF GRIB2 enrichment (ECPDS commercial feed) only available when route falls within the ifs-ens-cf coverage grid (Europe + US) and the flight window is within the run's forecast range (0–168h at 00/12z, 0–144h at 06/18z). Outside coverage, ECMWF falls back to Open-Meteo's 13-level sounding and SFIP uses the proxy variant.
 
 ### 4.2 Key Derivation Methods
 

--- a/designs/future/ifs-cycle-50r1-migration.md
+++ b/designs/future/ifs-cycle-50r1-migration.md
@@ -2,8 +2,20 @@
 
 > Adapt our ECMWF GRIB ingestion pipeline for IFS Cycle 50r1 changes.
 
-**Status:** Pending — cycle goes live May 12, 2026.  
-**Reference:** https://confluence.ecmwf.int/display/FCST/Implementation+of+IFS+Cycle+50r1  
+**Status:** Implemented in PR #89 (2026-04-24). Cycle goes live 12-May-2026.
+This document is retained as the historical plan; current authoritative
+reference is `weather-engine-specs.md` and `analysis-metrics.md`.
+
+Notable deltas from the plan below, discovered during implementation:
+- Horizon is now derived from the max step observed on disk per run,
+  not from parsed init-hour or stream name (see `find_best_ecmwf_run`).
+- 00/12z horizon is 168h post-2026-04-22 amendment, not 192h.
+- `delivery_config.json` was re-keyed by init hour (0/6/12/18) instead
+  of stream name — cleaner and future-proof for similar rename events.
+- TPREd test feed was mis-provisioned by ECMWF on first delivery; they
+  are re-sending with the correct spec.
+
+**Reference:** https://confluence.ecmwf.int/display/FCST/Implementation+of+IFS+Cycle+50r1
 **Test data:** expver `0080`, available at https://data.ecmwf.int/forecasts/testdata/
 
 ## What's Changing

--- a/designs/weather-engine-specs.md
+++ b/designs/weather-engine-specs.md
@@ -126,10 +126,10 @@ See [fetch.md](./fetch.md) for implementation details.
 - **Delivery:** ECPDS push to local directory (`ECMWF_GRIB_DIR`, default `/data/ecmwf`). Read-only Docker volume mount.
 - **Model:** ifs-ens-cf (IFS Ensemble Control Forecast), 0.25° over Europe + US
 - **Files:** Two parts per forecast step — a1 (surface, 30 vars) and a2 (pressure levels, 10 vars × 25 levels)
-- **Cycles:** 00z/12z (oper stream, 0–192h), 06z/18z (scda stream, 0–144h)
+- **Cycles:** 00z/06z/12z/18z. Horizon per cycle is derived from the max step observed on disk, not from the stream name (see `find_best_ecmwf_run` in `fetch/grib/ecmwf_fetch.py`). Subscription shape post-2026-04-22 amendment: 00/12z → 168h, 06/18z → 144h. From IFS Cycle 50r1 (12-May-2026), all four cycles arrive with `stream=oper` — the `scda` label is gone. Init hour, not stream, determines the expected manifest (`delivery_config.json` is keyed by cycle hour).
 - **Publication delay:** ~6–8h after init time
-- **Naming convention:** `dest_feed_model_class_stream_type_baseTime_validTime_step[_expver]` — no `.grib2` extension by default
-- **Pressure-level (a2):** t, r, u, v, z, w, d, cc, clwc, ciwc — **full sounding replacement** (replaces Open-Meteo pressure levels entirely). `z` is currently delivered only at 1 hPa; GH on the other 24 levels is filled by hypsometric integration from T+P until the order amendment lands.
+- **Naming convention:** `dest_feed_model_class_stream_type_baseTime_validTime_step[_expver]` — no `.grib2` extension by default. `expver` is absent on prod operational files, and `X0080` on TPREd Release Candidate files (ECMWF_ACCEPT_RCP_EXPVER=1 opt-in for staging).
+- **Pressure-level (a2):** t, r, u, v, z, w, gh, cc, clwc, ciwc — **full sounding replacement** (replaces Open-Meteo pressure levels entirely). Post-amendment (2026-04-22): `d` (divergence) was dropped, `gh` (geopotential height) added at all 25 levels, removing the hypsometric fallback from the decode path. `z` is still delivered only at 1 hPa (catalogue limitation).
 - **Surface (a1) — processed:** ceil, cbh, lcc, mcc, hcc, tcc, hcct, deg0l → `NWPCloudDiagnostics`
 - **Surface (a1) — delivered but not yet processed:** 10fg, 10u, 10v, 2d, 2t, blh, capes, cp, degm10l, fzra, kx, lsp, mlcape100, mlcin100, msl, mucape, ptype, sf, sp, totalx, tp, vis
 - **Multi-grid:** Files may contain multiple geographic sub-grids; cfgrib splits into separate Datasets, decoder uses first-wins per point

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,10 @@ dependencies = [
     "SRTM.py>=0.3.7",
     "PyMuPDF>=1.24",
     "cfgrib>=0.9.12",
+    # eccodes 2.45+ is needed to decode GRIB2 tablesVersion=35, used by
+    # IFS Cycle 50r1 (12-May-2026). Older versions fail with opaque
+    # "unknown parameter" errors on pressure-level messages.
+    "eccodes>=2.45",
     "xarray>=2024.1",
     "timezonefinder>=6.2",
 ]

--- a/src/weatherbrief/fetch/grib/__init__.py
+++ b/src/weatherbrief/fetch/grib/__init__.py
@@ -256,9 +256,9 @@ def _enrich_ecmwf(
             logger.info("No ECMWF GRIB runs before as_of_time=%s", as_of_time)
             return None
 
-    # Pick the best run — prefers latest, but falls back to an older
-    # main run (00z/12z, 192h) when a short-cutoff run (06z/18z, 144h)
-    # can't cover the full flight window.
+    # Pick the best run — prefers latest, but falls back to an earlier
+    # run with a longer observed horizon when the latest can't cover the
+    # full flight window (e.g. a 06/18z short-cutoff run vs an earlier 00/12z).
     flight_end = departure_time + timedelta(hours=max(flight_duration_hours, 1))
     run_files = find_best_ecmwf_run(
         all_files, cover_until=flight_end, data_dir=grib_dir,

--- a/src/weatherbrief/fetch/grib/ecmwf_fetch.py
+++ b/src/weatherbrief/fetch/grib/ecmwf_fetch.py
@@ -19,12 +19,15 @@ File naming convention (from ECMWF):
     cc:     Feed name / part (a1 = surface, a2 = pressure levels)
     nnn:    Model identifier (e.g. ifs-ens-cf, aifs-ens)
     cl:     Data class (od = operational)
-    ssss:   Stream name (oper = main runs 00/12z, scda = short cutoff 06/18z)
+    ssss:   Stream name (oper = main runs 00/12z, scda = short cutoff 06/18z;
+            from IFS Cycle 50r1 / 12-May-2026, scda merges into oper for all
+            cycles, so 06/18z forecasts also arrive with stream=oper)
     t:      Data type (e.g. fc = forecast)
     1st timestamp:  Base date/time (forecast init), ISO 8601
     2nd timestamp:  Valid date/time, ISO 8601
     h:      Forecast step (hours)
-    expver: Experiment version (omitted for operational)
+    expver: Experiment version (omitted for prod operational;
+            "X0080" for TPREd / 50r1 Release Candidate phase)
 
 Files may have no extension (ECPDS default) or .grib2/.grib.
 """
@@ -100,7 +103,7 @@ _FILENAME_RE = re.compile(
     r"_(?P<base_time>\d{8}T\d{6}Z)"
     r"_(?P<valid_time>\d{8}T\d{6}Z)"
     r"_(?P<step>[^_]+)"
-    r"(?:_(?P<expver>\d+))?"
+    r"(?:_(?P<expver>[A-Z]?\d+))?"
     r"$"
 )
 
@@ -157,8 +160,16 @@ class ECMWFFileInfo:
 
         ECMWF delivers operational files with expver "0001" (4-digit) but
         the filename may truncate to "1".  Confirmed from sample data.
+
+        TPREd Release Candidate feeds (IFS Cycle 50r1, 12-May-2026) use
+        expver "X0080". Treated as experimental by default so prod stays
+        strict; set ECMWF_ACCEPT_RCP_EXPVER=1 in staging to consume them.
         """
-        return self.experiment in (None, "1", "0001")
+        if self.experiment in (None, "1", "0001"):
+            return True
+        if self.experiment == "X0080" and os.environ.get("ECMWF_ACCEPT_RCP_EXPVER") == "1":
+            return True
+        return False
 
 
 def _parse_timestamp(ts: str) -> datetime:

--- a/src/weatherbrief/fetch/grib/ecmwf_fetch.py
+++ b/src/weatherbrief/fetch/grib/ecmwf_fetch.py
@@ -56,15 +56,16 @@ ECMWF_MICROPHYSICS_VARS = {
     "cc",     # Cloud cover fraction per level (0-1, convert to 0-100%)
 }
 
-# Full sounding variables available on pressure levels.
+# Full sounding variables available on pressure levels (post-2026-04-22
+# amendment: d dropped, gh added at all 25 levels).
 ECMWF_SOUNDING_VARS = {
     "t",      # Temperature (K)
     "r",      # Relative humidity (%)
     "u",      # U wind component (m/s)
     "v",      # V wind component (m/s)
-    "z",      # Geopotential (m²/s²)
+    "z",      # Geopotential (m²/s²), delivered at 1 hPa only (catalogue limit)
+    "gh",     # Geopotential height (gpm), at all 25 pressure levels
     "w",      # Vertical velocity / omega (Pa/s)
-    "d",      # Divergence (1/s)
     "cc",     # Cloud cover fraction (0-1)
     "clwc",   # Cloud liquid water content (kg/kg)
     "ciwc",   # Cloud ice water content (kg/kg)

--- a/src/weatherbrief/fetch/grib/ecmwf_fetch.py
+++ b/src/weatherbrief/fetch/grib/ecmwf_fetch.py
@@ -73,16 +73,12 @@ ECMWF_SOUNDING_VARS = {
 # Publication delay: ifs-ens-cf typically available ~6-8h after init.
 ECMWF_PUBLISH_DELAY_HOURS = 8
 
-# IFS ensemble control forecast cycles.
-# oper stream at 00z/12z (0-192h), scda stream at 06z/18z (0-144h).
+# IFS ensemble control forecast cycles. Per-cycle horizon depends on the
+# subscription and is NOT inferred from the stream name: we compute it from
+# the max step observed on disk per run (see find_best_ecmwf_run). This
+# avoids drift every time ECMWF changes cycle naming (e.g. scda/fc -> oper/fc
+# at 06/18z from IFS Cycle 50r1, 12-May-2026) or we amend our order.
 ECMWF_CYCLES = [0, 6, 12, 18]
-
-# Maximum forecast step (hours) per stream type.
-ECMWF_MAX_STEP_HOURS = {
-    "oper": 192,   # Main runs (00z, 12z)
-    "scda": 144,   # Short cutoff (06z, 18z)
-}
-ECMWF_MAX_STEP_DEFAULT = 144  # Conservative fallback
 
 # Known file extensions to strip before parsing the ECMWF filename.
 _KNOWN_SUFFIXES = (".grib2", ".grib", ".idx", ".bz2")
@@ -347,12 +343,14 @@ def find_best_ecmwf_run(
     """Select the best ECMWF run whose horizon covers the flight window.
 
     Tries runs in reverse chronological order.  Prefers the latest run
-    whose forecast horizon (base_time + max step for its stream) reaches
-    ``cover_until``.  Falls back to the latest run if none fully covers.
+    whose observed horizon (base_time + max step_hours present on disk)
+    reaches ``cover_until``.  Falls back to the latest run if none fully
+    covers — the uncovered tail simply misses GRIB enrichment.
 
-    This mirrors the ICON-EU ``find_latest_icon_eu_run`` strategy: a 06z
-    scda run (max 144h) is skipped in favour of the previous 00z oper run
-    (max 192h) when the flight extends beyond 144h.
+    The horizon is read from the files themselves rather than a stream-name
+    lookup.  This keeps selection correct across subscription changes (e.g.
+    2026-04-22 amendment trimming 00/12z from 192h to 168h) and cycle-name
+    changes (IFS Cycle 50r1, 12-May-2026, merges 06/18z scda into oper).
 
     Args:
         all_files: Pre-scanned file list (all runs, already filtered for
@@ -379,29 +377,35 @@ def find_best_ecmwf_run(
     # Try runs newest-first
     for base_time in sorted(runs, reverse=True):
         run_files = runs[base_time]
-        # Determine stream from any file in the run
-        stream = run_files[0].stream
-        max_step = ECMWF_MAX_STEP_HOURS.get(stream, ECMWF_MAX_STEP_DEFAULT)
+        max_step = max(f.step_hours for f in run_files)
         horizon = base_time + timedelta(hours=max_step)
         if horizon >= cover_until:
             logger.info(
-                "ECMWF run selection: %s %s (horizon %dh covers flight end)",
-                base_time.isoformat(), stream, max_step,
+                "ECMWF run selection: %s %s (observed horizon %dh covers flight end)",
+                base_time.isoformat(), run_files[0].stream, max_step,
             )
             return run_files
         logger.debug(
-            "ECMWF run %s %s: horizon %dh doesn't reach flight end, skipping",
-            base_time.isoformat(), stream, max_step,
+            "ECMWF run %s %s: observed horizon %dh doesn't reach flight end, skipping",
+            base_time.isoformat(), run_files[0].stream, max_step,
         )
 
-    # No run fully covers — fall back to latest (partial coverage is better
-    # than none; the uncovered tail just won't get GRIB enrichment).
-    latest_bt = max(runs)
+    # No run fully covers — fall back to the run whose horizon reaches
+    # *furthest into the future* (minimizing the uncovered tail), with ties
+    # broken by recency of the init time.  A 12z run with 168h horizon can
+    # reach later in time than an 18z run with 144h, so "latest base_time"
+    # is not the right fallback.
+    def _horizon(bt: datetime) -> datetime:
+        return bt + timedelta(hours=max(f.step_hours for f in runs[bt]))
+
+    best_bt = max(runs, key=lambda bt: (_horizon(bt), bt))
+    best_max_step = max(f.step_hours for f in runs[best_bt])
     logger.info(
-        "ECMWF: no run covers flight end %s, falling back to latest %s",
-        cover_until.isoformat(), latest_bt.isoformat(),
+        "ECMWF: no run covers flight end %s, falling back to %s (observed horizon %dh, reaches %s)",
+        cover_until.isoformat(), best_bt.isoformat(), best_max_step,
+        _horizon(best_bt).isoformat(),
     )
-    return runs[latest_bt]
+    return runs[best_bt]
 
 
 def find_files_for_run(

--- a/src/weatherbrief/fetch/grib/ecmwf_watcher.py
+++ b/src/weatherbrief/fetch/grib/ecmwf_watcher.py
@@ -37,10 +37,9 @@ _PURGE_SKIP_SUFFIXES = frozenset({".json", ".log", ".md", ".txt"})
 
 
 @dataclass
-class StreamConfig:
-    """Expected delivery manifest for one ECMWF stream."""
+class CycleConfig:
+    """Expected delivery manifest for one ECMWF init-hour cycle."""
 
-    cycles: list[int]
     steps: list[int]
     parts: list[str]
 
@@ -51,9 +50,16 @@ class StreamConfig:
 
 @dataclass
 class DeliveryConfig:
-    """Full ECMWF delivery configuration loaded from delivery_config.json."""
+    """Full ECMWF delivery configuration loaded from delivery_config.json.
 
-    streams: dict[str, StreamConfig]
+    Keyed by init hour (0, 6, 12, 18) rather than stream name because the
+    IFS Cycle 50r1 rollout (12-May-2026) merges scda/fc into oper/fc — all
+    four cycles then arrive with the same stream label, so stream-name
+    keying would flag 06/18z as perpetually partial against the 168h
+    oper expectation.
+    """
+
+    cycles: dict[int, CycleConfig]
     publish_delay_hours: float
     completeness_timeout_hours: float
 
@@ -61,7 +67,13 @@ class DeliveryConfig:
     def load(cls, data_dir: Path | None = None) -> DeliveryConfig | None:
         """Load delivery config from the ECMWF data directory.
 
-        Returns None if the config file doesn't exist (graceful degradation).
+        Accepts two schema shapes for deploy-ordering safety:
+          - New: top-level "cycles" keyed by init hour (preferred).
+          - Legacy: top-level "streams" keyed by stream name with an inner
+            "cycles" list — expanded into one CycleConfig per init hour.
+
+        Returns None if the config file doesn't exist or can't be parsed
+        (graceful degradation — completeness checking just disables).
         """
         config_path = (data_dir or ecmwf_grib_dir()) / _CONFIG_FILENAME
         if not config_path.exists():
@@ -74,25 +86,39 @@ class DeliveryConfig:
 
         try:
             raw = json.loads(config_path.read_text())
-            streams = {}
-            for name, spec in raw["streams"].items():
-                streams[name] = StreamConfig(
-                    cycles=spec["cycles"],
-                    steps=spec["steps"],
-                    parts=spec["parts"],
-                )
+            cycles = cls._parse_cycles(raw)
             return cls(
-                streams=streams,
+                cycles=cycles,
                 publish_delay_hours=raw.get("publish_delay_hours", 8),
                 completeness_timeout_hours=raw.get("completeness_timeout_hours", 2),
             )
-        except (json.JSONDecodeError, KeyError):
+        except (json.JSONDecodeError, KeyError, ValueError):
             logger.error(
                 "Failed to parse ECMWF delivery config: %s",
                 config_path,
                 exc_info=True,
             )
             return None
+
+    @staticmethod
+    def _parse_cycles(raw: dict) -> dict[int, CycleConfig]:
+        if "cycles" in raw:
+            return {
+                int(hour): CycleConfig(steps=spec["steps"], parts=spec["parts"])
+                for hour, spec in raw["cycles"].items()
+            }
+        if "streams" in raw:
+            logger.info(
+                "delivery_config.json: legacy 'streams' schema — update to "
+                "'cycles' keyed by init hour before IFS 50r1 (12-May-2026).",
+            )
+            out: dict[int, CycleConfig] = {}
+            for spec in raw["streams"].values():
+                cfg = CycleConfig(steps=spec["steps"], parts=spec["parts"])
+                for hour in spec["cycles"]:
+                    out[int(hour)] = cfg
+            return out
+        raise KeyError("delivery_config.json must define either 'cycles' or 'streams'")
 
 
 def _sentinel_name(base_time: datetime) -> str:
@@ -153,29 +179,31 @@ def check_ecmwf_completeness(
     if not files:
         return []
 
-    # Group files by (base_time, stream)
-    runs: dict[tuple[datetime, str], list[ECMWFFileInfo]] = {}
+    # Group files by base_time (init hour determines the expected manifest
+    # post-50r1; stream is informational only).
+    runs: dict[datetime, list[ECMWFFileInfo]] = {}
     for f in files:
-        key = (f.base_time, f.stream)
-        runs.setdefault(key, []).append(f)
+        runs.setdefault(f.base_time, []).append(f)
 
     now = datetime.now(timezone.utc)
     newly_ready: list[datetime] = []
 
-    for (base_time, stream), run_files in runs.items():
+    for base_time, run_files in runs.items():
         # Skip if already has a sentinel
         if is_run_ready(d, base_time=base_time):
             continue
 
-        stream_config = config.streams.get(stream)
-        if stream_config is None:
+        cycle_config = config.cycles.get(base_time.hour)
+        if cycle_config is None:
             logger.debug(
-                "ECMWF stream %r not in delivery config, skipping", stream,
+                "ECMWF init hour %d not in delivery config, skipping",
+                base_time.hour,
             )
             continue
 
-        expected = stream_config.expected_file_count
+        expected = cycle_config.expected_file_count
         actual = len(run_files)
+        stream = run_files[0].stream  # informational; may mix post-50r1
 
         if actual >= expected:
             # Complete — write sentinel

--- a/tests/test_ecmwf_sample.py
+++ b/tests/test_ecmwf_sample.py
@@ -42,6 +42,11 @@ _SAMPLE_DIR_LOCAL = Path(__file__).parent / "data" / "ecmwf_samples"
 
 SAMPLE_DIR = Path(_SAMPLE_DIR_ENV) if _SAMPLE_DIR_ENV else _SAMPLE_DIR_LOCAL
 
+# Optional dirs for field-presence regression tests — let developers point
+# at real prod and TPREd rsync mirrors without polluting SAMPLE_DIR logic.
+ECMWF_PROD_DIR = Path(os.environ["ECMWF_PROD_GRIB_DIR"]) if "ECMWF_PROD_GRIB_DIR" in os.environ else None
+ECMWF_TEST_DIR = Path(os.environ["ECMWF_TEST_GRIB_DIR"]) if "ECMWF_TEST_GRIB_DIR" in os.environ else None
+
 
 def _grib_files() -> list[Path]:
     """Collect all ECMWF GRIB files from the sample directory.
@@ -1135,3 +1140,197 @@ class TestECMWFWatcher:
         self._make_run(tmp_path, "oper", 0, [0, 3])
         newly_ready = check_ecmwf_completeness(tmp_path)
         assert newly_ready == []
+
+
+# ---------------------------------------------------------------------------
+# Field-presence regression tests
+#
+# These run against real prod + TPREd mirrors on the developer's machine.
+# They exist to catch subscription drift (a field going missing) and 50r1
+# regressions (a shortName changing meaning or disappearing).
+#
+# Set either or both env vars to point at local rsync'd data:
+#   ECMWF_PROD_GRIB_DIR=~/tmp/ecmwf/data
+#   ECMWF_TEST_GRIB_DIR=~/tmp/ecmwf/test_data
+# Tests skip gracefully when the respective var is unset.
+# ---------------------------------------------------------------------------
+
+
+# Expected a1 surface fields per our ECMWF order (unchanged between
+# original order, post-amendment, and 50r1 TPREd — the amendment only
+# changed a2 and cadence, not the a1 field list).
+EXPECTED_A1_SHORTNAMES = frozenset({
+    "10fg", "10u", "10v", "2d", "2t",
+    "blh", "capes", "cbh", "ceil", "cp", "deg0l", "degm10l",
+    "fzra", "hcc", "hcct", "kx", "lcc", "lsp", "mcc",
+    "mlcape100", "mlcin100", "msl", "mucape", "ptype",
+    "sf", "sp", "tcc", "totalx", "tp", "vis",
+})
+
+# a2 pressure-level fields the pipeline depends on — present in every
+# regime (pre-amend 49r1, post-amend 49r1, 50r1 TPREd).
+EXPECTED_A2_CORE_SHORTNAMES = frozenset({
+    "cc", "ciwc", "clwc", "r", "t", "u", "v", "w",
+})
+
+# tablesVersion codes we know how to decode. Expand cautiously — each
+# new version is a GRIB2 dictionary bump and warrants a manual verify.
+KNOWN_TABLES_VERSIONS = frozenset({32, 33, 34, 35})
+
+
+def _scan_shortnames(path: Path) -> tuple[set[str], set[int]]:
+    """Return (shortNames, tablesVersions) across all messages in file."""
+    import eccodes
+    names: set[str] = set()
+    tvs: set[int] = set()
+    with open(path, "rb") as f:
+        while True:
+            gid = eccodes.codes_grib_new_from_file(f)
+            if gid is None:
+                break
+            try:
+                try:
+                    names.add(eccodes.codes_get(gid, "shortName"))
+                except Exception:
+                    pass
+                try:
+                    tvs.add(int(eccodes.codes_get(gid, "tablesVersion")))
+                except Exception:
+                    pass
+            finally:
+                eccodes.codes_release(gid)
+    return names, tvs
+
+
+def _first_file_by_feed(data_dir: Path, feed: str) -> Path | None:
+    """Most-recent file matching feed (a1/a2), skipping .idx sidecars.
+
+    Picks by the parsed base_time so a mirror containing multiple
+    dates returns the latest regime (e.g. post-amendment if both
+    pre- and post-amendment data are present)."""
+    if data_dir is None or not data_dir.exists():
+        return None
+    best: tuple[datetime, Path] | None = None
+    for p in data_dir.rglob("*"):
+        if not p.is_file() or p.name.endswith(".idx") or p.name.startswith("."):
+            continue
+        info = parse_ecmwf_filename(p)
+        if info is None or info.feed != feed:
+            continue
+        if best is None or info.base_time > best[0]:
+            best = (info.base_time, p)
+    return best[1] if best else None
+
+
+class TestFieldPresenceRegression:
+    """Field-level assertions on real prod + TPREd data.
+
+    Run locally with::
+
+        ECMWF_PROD_GRIB_DIR=~/tmp/ecmwf/data \\
+        ECMWF_TEST_GRIB_DIR=~/tmp/ecmwf/test_data \\
+        pytest tests/test_ecmwf_sample.py::TestFieldPresenceRegression -v
+
+    Without the env vars, every test in this class is skipped — so CI
+    stays green without the samples.
+    """
+
+    def test_prod_a1_has_all_expected_fields(self):
+        """Post-amendment 49r1 prod a1 contains all 30 expected shortNames."""
+        if ECMWF_PROD_DIR is None:
+            pytest.skip("ECMWF_PROD_GRIB_DIR not set")
+        a1 = _first_file_by_feed(ECMWF_PROD_DIR, "a1")
+        if a1 is None:
+            pytest.skip(f"No a1 file found in {ECMWF_PROD_DIR}")
+        names, _ = _scan_shortnames(a1)
+        missing = EXPECTED_A1_SHORTNAMES - names
+        assert not missing, f"a1 missing expected fields: {missing}"
+
+    def test_prod_a2_has_gh_not_d(self):
+        """Post-amendment 49r1 a2 has `gh` (added) and no `d` (dropped)."""
+        if ECMWF_PROD_DIR is None:
+            pytest.skip("ECMWF_PROD_GRIB_DIR not set")
+        a2 = _first_file_by_feed(ECMWF_PROD_DIR, "a2")
+        if a2 is None:
+            pytest.skip(f"No a2 file found in {ECMWF_PROD_DIR}")
+        names, _ = _scan_shortnames(a2)
+        missing_core = EXPECTED_A2_CORE_SHORTNAMES - names
+        assert not missing_core, f"a2 missing core sounding vars: {missing_core}"
+        assert "gh" in names, "prod a2 should contain gh post-amendment"
+        assert "d" not in names, "prod a2 should NOT contain d post-amendment"
+
+    def test_tpred_a1_has_all_expected_fields(self):
+        """TPREd a1 contains all 30 expected shortNames (50r1 didn't change a1)."""
+        if ECMWF_TEST_DIR is None:
+            pytest.skip("ECMWF_TEST_GRIB_DIR not set")
+        a1 = _first_file_by_feed(ECMWF_TEST_DIR, "a1")
+        if a1 is None:
+            pytest.skip(f"No a1 file found in {ECMWF_TEST_DIR}")
+        names, _ = _scan_shortnames(a1)
+        missing = EXPECTED_A1_SHORTNAMES - names
+        assert not missing, f"TPREd a1 missing expected fields: {missing}"
+
+    def test_tpred_a2_pre_amendment_shape(self):
+        """TPREd a2 reflects the *pre-amendment* order: has `d`, no `gh`.
+
+        When/if ECMWF updates TPREd to match the amended PREd subscription,
+        this test will flip — change the asserts. That flip is a signal
+        the subscription sync completed and we can mark ready-to-migrate.
+        """
+        if ECMWF_TEST_DIR is None:
+            pytest.skip("ECMWF_TEST_GRIB_DIR not set")
+        a2 = _first_file_by_feed(ECMWF_TEST_DIR, "a2")
+        if a2 is None:
+            pytest.skip(f"No a2 file found in {ECMWF_TEST_DIR}")
+        names, _ = _scan_shortnames(a2)
+        missing_core = EXPECTED_A2_CORE_SHORTNAMES - names
+        assert not missing_core, f"TPREd a2 missing core sounding vars: {missing_core}"
+        assert "d" in names, "TPREd a2 still reflects pre-amendment order (has d)"
+        assert "gh" not in names, (
+            "TPREd a2 is pre-amendment (no gh). If this fails, TPREd has "
+            "been updated to the amended subscription — flip the asserts."
+        )
+
+    def test_tables_version_known(self):
+        """tablesVersion on every sampled file must be one we've verified
+        decodes cleanly. Catches ECMWF bumping the table without us
+        updating eccodes/cfgrib pins."""
+        results = []
+        for label, d in (("prod", ECMWF_PROD_DIR), ("test", ECMWF_TEST_DIR)):
+            if d is None:
+                continue
+            for feed in ("a1", "a2"):
+                p = _first_file_by_feed(d, feed)
+                if p is None:
+                    continue
+                _, tvs = _scan_shortnames(p)
+                results.append((label, feed, tvs))
+                unknown = tvs - KNOWN_TABLES_VERSIONS
+                assert not unknown, (
+                    f"{label}/{feed} uses unknown tablesVersion {unknown}; "
+                    f"update KNOWN_TABLES_VERSIONS and verify eccodes decodes it"
+                )
+        if not results:
+            pytest.skip("Neither ECMWF_PROD_GRIB_DIR nor ECMWF_TEST_GRIB_DIR set")
+
+    def test_cfgrib_decodes_tpred(self):
+        """cfgrib.open_datasets must succeed on a tablesVersion=35 TPREd file."""
+        import cfgrib
+        if ECMWF_TEST_DIR is None:
+            pytest.skip("ECMWF_TEST_GRIB_DIR not set")
+        a2 = _first_file_by_feed(ECMWF_TEST_DIR, "a2")
+        if a2 is None:
+            pytest.skip(f"No a2 file found in {ECMWF_TEST_DIR}")
+        datasets = cfgrib.open_datasets(str(a2))
+        assert len(datasets) > 0, "cfgrib returned no datasets"
+        # Confirm we can read a data variable from at least one dataset
+        core_found = False
+        for ds in datasets:
+            for name in ds.data_vars:
+                if str(name) in EXPECTED_A2_CORE_SHORTNAMES:
+                    _ = ds[name].values  # forces decode
+                    core_found = True
+                    break
+            if core_found:
+                break
+        assert core_found, "No core sounding var decoded from TPREd a2"

--- a/tests/test_ecmwf_sample.py
+++ b/tests/test_ecmwf_sample.py
@@ -1415,15 +1415,23 @@ class TestFieldPresenceRegression:
         if not results:
             pytest.skip("Neither ECMWF_PROD_GRIB_DIR nor ECMWF_TEST_GRIB_DIR set")
 
-    def test_cfgrib_decodes_tpred(self):
-        """cfgrib.open_datasets must succeed on a tablesVersion=35 TPREd file."""
+    def test_cfgrib_decodes_tpred(self, tmp_path):
+        """cfgrib.open_datasets must succeed on a tablesVersion=35 TPREd file.
+
+        Redirects cfgrib's .idx sidecar files into tmp_path so we don't
+        pollute the user's rsync'd TPREd mirror (cfgrib otherwise writes
+        .idx next to the source GRIB whenever the mount is writable).
+        """
         import cfgrib
         if ECMWF_TEST_DIR is None:
             pytest.skip("ECMWF_TEST_GRIB_DIR not set")
         a2 = _first_file_by_feed(ECMWF_TEST_DIR, "a2")
         if a2 is None:
             pytest.skip(f"No a2 file found in {ECMWF_TEST_DIR}")
-        datasets = cfgrib.open_datasets(str(a2))
+        datasets = cfgrib.open_datasets(
+            str(a2),
+            backend_kwargs={"indexpath": str(tmp_path / "{short_hash}.idx")},
+        )
         assert len(datasets) > 0, "cfgrib returned no datasets"
         # Confirm we can read a data variable from at least one dataset
         core_found = False

--- a/tests/test_ecmwf_sample.py
+++ b/tests/test_ecmwf_sample.py
@@ -19,7 +19,7 @@ is safe to run even before the data arrives.
 from __future__ import annotations
 
 import os
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import numpy as np
@@ -348,6 +348,142 @@ class TestDirectoryScanner:
         files = find_files_for_run(bt, tmp_path)
         assert len(files) == 2
         assert all(f.base_time == bt for f in files)
+
+
+# ---------------------------------------------------------------------------
+# Run selection tests (find_best_ecmwf_run) — observed-max-step logic
+# ---------------------------------------------------------------------------
+
+
+class TestRunSelection:
+    """find_best_ecmwf_run must compute horizon from files on disk, not
+    from stream names.  Covers three real-world regimes: pre-amendment 49r1
+    (192h at 00/12z, scda at 06/18z), post-amendment 49r1 (168h at 00/12z),
+    and 50r1 (scda merged into oper at all inits)."""
+
+    @staticmethod
+    def _make_run(tmp_path, base_hour, steps, stream="oper", date="20260422"):
+        """Create empty files for a run with the given steps."""
+        bt_str = f"{date}T{base_hour:02d}0000Z"
+        for step in steps:
+            # valid_time is synthetic — parser doesn't care beyond parseability
+            total = base_hour + step
+            d = int(date[-2:]) + total // 24
+            h = total % 24
+            vt = f"{date[:-2]}{d:02d}T{h:02d}0000Z"
+            name = f"brg_a1_ifs-ens-cf_od_{stream}_fc_{bt_str}_{vt}_{step}h"
+            (tmp_path / name).write_bytes(b"")
+
+    def test_latest_run_covers_selected(self, tmp_path):
+        """Latest run fully covering cover_until is selected."""
+        from weatherbrief.fetch.grib.ecmwf_fetch import find_best_ecmwf_run
+        self._make_run(tmp_path, 12, list(range(0, 169, 3)), stream="oper")
+        all_files = scan_ecmwf_files(tmp_path)
+        bt12 = datetime(2026, 4, 22, 12, 0, tzinfo=timezone.utc)
+        # Flight ending 160h after 12z → within 168h horizon → pick 12z
+        picked = find_best_ecmwf_run(
+            all_files, cover_until=bt12 + timedelta(hours=160), require_ready=False,
+        )
+        assert picked and picked[0].base_time == bt12
+
+    def test_post_amendment_picks_earlier_when_latest_short(self, tmp_path):
+        """Post-amendment regime: 00/12z go to 168h, 06/18z to 144h.
+
+        Flight ending 160h after latest 06z → 06z observed horizon is
+        144h → skip 06z → pick earlier 00z (observed 168h)."""
+        from weatherbrief.fetch.grib.ecmwf_fetch import find_best_ecmwf_run
+        self._make_run(tmp_path, 0,  list(range(0, 169, 3)), stream="oper")
+        self._make_run(tmp_path, 6,  list(range(0, 145, 3)), stream="scda")
+        all_files = scan_ecmwf_files(tmp_path)
+        bt00 = datetime(2026, 4, 22,  0, 0, tzinfo=timezone.utc)
+        bt06 = datetime(2026, 4, 22,  6, 0, tzinfo=timezone.utc)
+        # Cover until 06z+160h = 00z+166h; 06z has only 144h, 00z has 168h
+        picked = find_best_ecmwf_run(
+            all_files, cover_until=bt06 + timedelta(hours=160), require_ready=False,
+        )
+        assert picked, "Expected fallback to 00z run"
+        assert picked[0].base_time == bt00
+
+    def test_fifty_r1_scda_as_oper_no_mishorizon(self, tmp_path):
+        """50r1: 06/18z arrive with stream=oper but only reach 144h.
+
+        Old code (stream-based lookup) would think any oper run reached
+        192h and select 06z; observed-max-step correctly sees 144h and
+        falls back to an earlier 00z with a longer horizon."""
+        from weatherbrief.fetch.grib.ecmwf_fetch import find_best_ecmwf_run
+        self._make_run(tmp_path, 0,  list(range(0, 169, 3)), stream="oper")
+        # 06z in 50r1 world: stream=oper, but horizon is 144h
+        self._make_run(tmp_path, 6,  list(range(0, 145, 3)), stream="oper")
+        all_files = scan_ecmwf_files(tmp_path)
+        bt00 = datetime(2026, 4, 22,  0, 0, tzinfo=timezone.utc)
+        bt06 = datetime(2026, 4, 22,  6, 0, tzinfo=timezone.utc)
+        picked = find_best_ecmwf_run(
+            all_files, cover_until=bt06 + timedelta(hours=160), require_ready=False,
+        )
+        assert picked, "Expected fallback to 00z"
+        assert picked[0].base_time == bt00, (
+            "06z oper with observed 144h should not be mistaken for 192h"
+        )
+
+    def test_pre_amendment_192h_still_works(self, tmp_path):
+        """Pre-amendment 49r1: 00/12z go to 192h. A flight at 180h after
+        00z should pick 00z (not fall back further)."""
+        from weatherbrief.fetch.grib.ecmwf_fetch import find_best_ecmwf_run
+        self._make_run(tmp_path, 0,  list(range(0, 193, 3)), stream="oper")
+        self._make_run(tmp_path, 6,  list(range(0, 145, 3)), stream="scda")
+        all_files = scan_ecmwf_files(tmp_path)
+        bt00 = datetime(2026, 4, 22,  0, 0, tzinfo=timezone.utc)
+        picked = find_best_ecmwf_run(
+            all_files, cover_until=bt00 + timedelta(hours=180), require_ready=False,
+        )
+        assert picked and picked[0].base_time == bt00
+
+    def test_no_run_covers_falls_back_to_longest_horizon(self, tmp_path):
+        """When no run reaches cover_until, return the run whose horizon
+        reaches furthest into the future — NOT simply the latest base_time.
+
+        Real case from Apr 22 post-amendment prod: at a flight ending
+        >192h out, 18z (scda, 144h → reaches 18z+144h = next-day 18z) is
+        the most recent init, but 12z (oper, 168h → reaches 12z+168h =
+        next-day 12z + 6h) actually covers later, so pick 12z."""
+        from weatherbrief.fetch.grib.ecmwf_fetch import find_best_ecmwf_run
+        self._make_run(tmp_path,  0, list(range(0, 169, 3)), stream="oper")
+        self._make_run(tmp_path,  6, list(range(0, 145, 3)), stream="scda")
+        self._make_run(tmp_path, 12, list(range(0, 169, 3)), stream="oper")
+        self._make_run(tmp_path, 18, list(range(0, 145, 3)), stream="scda")
+        all_files = scan_ecmwf_files(tmp_path)
+        bt12 = datetime(2026, 4, 22, 12, 0, tzinfo=timezone.utc)
+        # Flight extending way past any single-run horizon.
+        picked = find_best_ecmwf_run(
+            all_files,
+            cover_until=bt12 + timedelta(hours=500),
+            require_ready=False,
+        )
+        assert picked, "Expected fallback to a run"
+        # 12z (oper, 168h) reaches 12z+168h; 18z (scda, 144h) reaches
+        # only 18z+144h = 12z + 150h. 12z's horizon is later by 18h.
+        assert picked[0].base_time == bt12, (
+            "Fallback should pick longest-horizon run, not latest base_time"
+        )
+
+    def test_tie_break_on_horizon_prefers_recent(self, tmp_path):
+        """Two runs with identical horizons → prefer the more recent init."""
+        from weatherbrief.fetch.grib.ecmwf_fetch import find_best_ecmwf_run
+        # Both 00z and 12z at 168h → horizons are 168h apart, so they
+        # aren't actually tied in time. Force a tie by making 12z go to
+        # 156h so that 00z + 168h == 12z + 156h.
+        self._make_run(tmp_path,  0, list(range(0, 169, 3)), stream="oper")
+        self._make_run(tmp_path, 12, list(range(0, 157, 3)), stream="oper")
+        all_files = scan_ecmwf_files(tmp_path)
+        bt12 = datetime(2026, 4, 22, 12, 0, tzinfo=timezone.utc)
+        picked = find_best_ecmwf_run(
+            all_files,
+            cover_until=bt12 + timedelta(hours=500),
+            require_ready=False,
+        )
+        assert picked and picked[0].base_time == bt12, (
+            "On horizon tie, the more recent init wins"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_ecmwf_sample.py
+++ b/tests/test_ecmwf_sample.py
@@ -127,6 +127,45 @@ class TestFilenameParser:
         assert info.experiment == "0001"
         assert info.is_operational
 
+    def test_parse_tpred_rcp_expver_x0080(self, monkeypatch):
+        """50r1 TPREd test feed: expver X0080 (Release Candidate phase).
+
+        Real filename from the 2026-04-24 TPREd drop. Parser must capture
+        'X0080' in .experiment; is_operational rejects it by default but
+        accepts it when ECMWF_ACCEPT_RCP_EXPVER=1 (staging opt-in).
+        """
+        path = Path(
+            "brg_a1_ifs-ens-cf_od_oper_fc_20260422T000000Z_20260422T060000Z_6h_X0080"
+        )
+        info = parse_ecmwf_filename(path)
+        assert info is not None
+        assert info.experiment == "X0080"
+        assert info.stream == "oper"
+        assert info.step_hours == 6
+
+        # Default (env flag unset) — treated as experimental, prod stays strict.
+        monkeypatch.delenv("ECMWF_ACCEPT_RCP_EXPVER", raising=False)
+        assert not info.is_operational
+
+        # Staging opt-in — env flag lifts X0080 to operational.
+        monkeypatch.setenv("ECMWF_ACCEPT_RCP_EXPVER", "1")
+        assert info.is_operational
+
+        # Any other value of the flag does NOT lift — only the literal "1".
+        monkeypatch.setenv("ECMWF_ACCEPT_RCP_EXPVER", "true")
+        assert not info.is_operational
+
+    def test_other_experimental_expver_never_operational(self, monkeypatch):
+        """ECMWF_ACCEPT_RCP_EXPVER must not whitelist arbitrary experiments."""
+        path = Path(
+            "ABC_XY_ifs_od_oper_fc_20260407T000000Z_20260407T060000Z_6_0042"
+        )
+        info = parse_ecmwf_filename(path)
+        assert info is not None
+        assert info.experiment == "0042"
+        monkeypatch.setenv("ECMWF_ACCEPT_RCP_EXPVER", "1")
+        assert not info.is_operational
+
     def test_parse_aifs_ens(self):
         """Parse AIFS ensemble model filename."""
         path = Path(

--- a/tests/test_ecmwf_sample.py
+++ b/tests/test_ecmwf_sample.py
@@ -1141,6 +1141,108 @@ class TestECMWFWatcher:
         newly_ready = check_ecmwf_completeness(tmp_path)
         assert newly_ready == []
 
+    # ---- New-format 'cycles' schema (post-50r1 ready) ----
+
+    @staticmethod
+    def _write_cycles_config(tmp_path, by_hour):
+        """Write a delivery_config.json using the new 'cycles' schema.
+
+        by_hour: dict[int, list[int]] — init hour → steps list.
+        """
+        import json
+
+        config = {
+            "cycles": {
+                str(hour): {"steps": steps, "parts": ["a1", "a2"]}
+                for hour, steps in by_hour.items()
+            },
+            "publish_delay_hours": 0,
+            "completeness_timeout_hours": 0,
+        }
+        (tmp_path / "delivery_config.json").write_text(json.dumps(config))
+
+    def test_cycles_schema_marks_complete(self, tmp_path):
+        """New 'cycles' schema: a 00z run matching its per-cycle steps is complete."""
+        from weatherbrief.fetch.grib.ecmwf_watcher import (
+            check_ecmwf_completeness, is_run_ready,
+        )
+        self._write_cycles_config(tmp_path, {0: [0, 3, 6], 6: [0, 3]})
+        self._make_run(tmp_path, "oper", 0, [0, 3, 6])
+
+        newly_ready = check_ecmwf_completeness(tmp_path)
+        assert len(newly_ready) == 1
+        bt = datetime(2026, 4, 10, 0, 0, tzinfo=timezone.utc)
+        assert is_run_ready(tmp_path, base_time=bt)
+
+    def test_cycles_schema_per_hour_expectations(self, tmp_path):
+        """Each cycle hour has its own expected step list."""
+        from weatherbrief.fetch.grib.ecmwf_watcher import (
+            check_ecmwf_completeness, is_run_ready,
+        )
+        # 00z expects 3 steps, 06z expects 2 steps.
+        self._write_cycles_config(tmp_path, {0: [0, 3, 6], 6: [0, 3]})
+        self._make_run(tmp_path, "oper", 0, [0, 3, 6])  # 00z complete
+        self._make_run(tmp_path, "scda", 6, [0, 3])     # 06z complete (2 != 3)
+
+        newly_ready = check_ecmwf_completeness(tmp_path)
+        assert len(newly_ready) == 2
+        bt00 = datetime(2026, 4, 10, 0, 0, tzinfo=timezone.utc)
+        bt06 = datetime(2026, 4, 10, 6, 0, tzinfo=timezone.utc)
+        assert is_run_ready(tmp_path, base_time=bt00)
+        assert is_run_ready(tmp_path, base_time=bt06)
+
+    def test_cycles_schema_fifty_r1_all_oper(self, tmp_path):
+        """Post-50r1 regression: 06z arrives with stream=oper but only
+        delivers its short-horizon step list. Without per-cycle config,
+        the watcher would compare 06z's 2 files against 00z's 3-file
+        expected and mark the 06z run as perpetually partial."""
+        from weatherbrief.fetch.grib.ecmwf_watcher import (
+            check_ecmwf_completeness, is_run_ready, is_run_partial,
+        )
+        self._write_cycles_config(tmp_path, {0: [0, 3, 6], 6: [0, 3]})
+        # Both runs arrive as stream=oper (the 50r1 world).
+        self._make_run(tmp_path, "oper", 0, [0, 3, 6])
+        self._make_run(tmp_path, "oper", 6, [0, 3])
+
+        newly_ready = check_ecmwf_completeness(tmp_path)
+        assert len(newly_ready) == 2
+        bt06 = datetime(2026, 4, 10, 6, 0, tzinfo=timezone.utc)
+        assert is_run_ready(tmp_path, base_time=bt06)
+        assert not is_run_partial(tmp_path, base_time=bt06), (
+            "06z complete under new schema — should NOT be marked partial"
+        )
+
+    def test_missing_cycle_hour_in_config_skips(self, tmp_path):
+        """Runs whose init hour isn't configured are skipped gracefully."""
+        from weatherbrief.fetch.grib.ecmwf_watcher import (
+            check_ecmwf_completeness, is_run_ready,
+        )
+        # Only 00z and 12z are configured, but a 09z run arrives.
+        self._write_cycles_config(tmp_path, {0: [0, 3], 12: [0, 3]})
+        self._make_run(tmp_path, "oper", 9, [0, 3])
+
+        newly_ready = check_ecmwf_completeness(tmp_path)
+        assert newly_ready == []
+        bt = datetime(2026, 4, 10, 9, 0, tzinfo=timezone.utc)
+        assert not is_run_ready(tmp_path, base_time=bt)
+
+    def test_legacy_streams_config_still_loads(self, tmp_path):
+        """Legacy 'streams' config expands into per-cycle entries.
+
+        Deploy-ordering safety: a new watcher binary running against an
+        old config must not break the pipeline. Exercises the legacy
+        expansion in DeliveryConfig._parse_cycles."""
+        from weatherbrief.fetch.grib.ecmwf_watcher import DeliveryConfig
+        self._write_config(tmp_path, [0, 3, 6], scda_steps=[0, 3])
+
+        cfg = DeliveryConfig.load(tmp_path)
+        assert cfg is not None
+        assert set(cfg.cycles) == {0, 6, 12, 18}
+        assert cfg.cycles[0].steps == [0, 3, 6]
+        assert cfg.cycles[12].steps == [0, 3, 6]
+        assert cfg.cycles[6].steps == [0, 3]
+        assert cfg.cycles[18].steps == [0, 3]
+
 
 # ---------------------------------------------------------------------------
 # Field-presence regression tests


### PR DESCRIPTION
Closes #87

## Summary

IFS Cycle 50r1 (12-May-2026) brings two changes that touch our ingestion:

- **`scda/fc` → `oper/fc` merger.** 06/18z forecasts, previously delivered with `stream=scda`, now arrive with `stream=oper`. Confirmed empirically via the TPREd test feed.
- **GRIB2 `tablesVersion` 33 → 35.** Dictionary bump; same semantics for every field we use, but older eccodes can't decode it.

Plus a couple of TPREd-specific artifacts (`expver=X0080` filename suffix during the Release Candidate phase).

All changes below are simultaneously forward- and backward-compatible: 49r1 prod stays green today, 50r1 prod works on 12 May with zero redeploy. Merge whenever; nothing is flag-day.

## Commits

| Commit | What | Why |
|---|---|---|
| `cb29f2d6` | Loosen `_FILENAME_RE` to accept `X`-prefixed expver; gate `X0080` acceptance in `is_operational` behind `ECMWF_ACCEPT_RCP_EXPVER=1` | TPREd files would silently fail to parse. Prod stays strict; staging opts in. |
| `f1652dbb` | Replace `ECMWF_MAX_STEP_HOURS = {"oper": 192, "scda": 144}` with max step observed on disk per run; fallback picks longest-horizon run (not latest init) | The stream→horizon table breaks on 12 May when 06/18z arrive as `oper` but only reach 144h. **Also fixes a latent bug from the Apr 22 amendment**: code thought 00/12z still went to 192h but delivery dropped to 168h, causing silent 0–5h tail gaps on week-out flights. |
| `184b76bc` | Field-presence regression suite vs real prod + TPREd mirrors | Catches subscription drift and 50r1 shortName changes. Skips cleanly when `ECMWF_PROD_GRIB_DIR` / `ECMWF_TEST_GRIB_DIR` aren't set, so CI stays green without the rsync data. |
| `90a7c74b` | Pin `eccodes>=2.45` in `pyproject.toml` | First version we've verified decodes `tablesVersion=35`. Older versions fail with opaque "unknown parameter" errors. |
| `aae5aca7` | Re-key `delivery_config.json` by init hour instead of stream name; watcher compares `actual vs expected` per-cycle | Without this, on 12 May 06/18z runs would arrive as `stream=oper` and get compared against the 168h oper expectation — perpetually flagged as partial twice a day. Legacy `streams` schema still loads via a compat path so deploy ordering is safe. |

## Notable findings along the way

1. **Latent 168h coverage bug** (pre-existing, not introduced by this PR, silently degrading tail coverage for week-out flights since the Apr 22 amendment). Fixed by `f1652dbb`.
2. **TPREd feed was mis-provisioned by ECMWF** — had pre-amendment subscription shape (3h cadence, `d` instead of `gh`, 192h at 00/12z). Confirmed as an ECMWF-side error; they're re-sending the test feed with the correct spec. One of the field-presence tests (`test_tpred_a2_pre_amendment_shape`) deliberately asserts the mis-provisioned state and will flip when the new drop arrives — that flip is the signal for marking TPREd "ready to migrate."
3. **Watcher completeness check is lenient** (`actual >= expected`), so stale `delivery_config.json` on the server hasn't been causing functional issues — just cosmetic drift. Captured as a reference memory (private droplet-config repo is the canonical home for this file; deliberately not in the public repo).

## Acceptance criteria

- ✅ Code changes merged for deploy
- ⏳ TPREd end-to-end briefing on staging — blocked on ECMWF re-sending the corrected test feed; then: `ECMWF_GRIB_DIR=/mnt/flyfun_data/ecmwf/test_data ECMWF_ACCEPT_RCP_EXPVER=1`
- ✅ Stream-ambiguity resolved (TPREd 06/18z arrives as `oper`)
- ⏳ Mark "ready to migrate" — blocked on ECMWF re-delivery + field-presence tests going green against the corrected feed
- ⏳ 12 May first post-implementation delivery produces a valid briefing — to verify on the day

## Operational follow-up (post-merge, not blocking)

Update `/mnt/flyfun_data/ecmwf/data/delivery_config.json` on the droplet to the new `cycles`-keyed shape (source in the private DigitalOcean config repo). The legacy `streams` schema still works via the compat path — this is just cleanup to silence the one-line "legacy schema" nudge log.

## Test plan

- [x] Full non-data test suite green: `pytest tests/test_ecmwf_sample.py -k "not Inventory and not Decode and not Fallback and not Pipeline"` → 42 passed
- [x] Field-presence tests green against local prod + TPREd mirrors
- [x] Watcher tests cover new schema, legacy schema compat, 50r1 regression
- [x] Run selection verified against real Apr 22 prod data — preserves prior selections with honest logs
- [ ] Staging end-to-end briefing once ECMWF re-sends the TPREd feed

🤖 Generated with [Claude Code](https://claude.com/claude-code)