### PR TITLE
feat(frontal): Phase A — route sampling + retrospective scripts

### DIFF
--- a/designs/future/hewson-fields-aviation-advisories.md
+++ b/designs/future/hewson-fields-aviation-advisories.md
@@ -361,9 +361,15 @@ What was pivotal about this session — we made the pipeline source-agnostic bef
 - **Source-agnostic CLI**: `new-case --source {open_meteo,era5}`; `plot-hewson`, `score`, `diagnose`, `redraw-zones` all accept any model present in the case including `era5`
 - **ERA5 download pipeline**: `scripts/smoke_era5_hewson.py` (CDS request validated), `scripts/download_era5_hewson.py` (not yet written — see Phase A pickup)
 
-### Phase A — Route sampling on single-level data (next — unblocked)
+### Phase A — Route sampling on single-level data ✅ DONE (2026-04-24)
 
-**Goal**: validate spatial + temporal interpolation with zero API cost, on the data we already have.
+**Shipped**:
+- `src/weatherbrief/frontal/route_sampling.py` — `sample_hewson_at_route(case, model, waypoints, hours)` returning per-waypoint dict of `{lat, lon, hour, theta_e, gradient, tfp, neg_laplacian, advection, tendency}`. Bilinear spatial interp + linear temporal interp between bounding available hours. Fractional hours supported. Out-of-grid or out-of-range returns NaN per field (not an exception).
+- `route-hewson` CLI subcommand — resolves ICAO codes via `weatherbrief.airports.resolve_waypoints` (uses `data/nav.db`); prints per-waypoint table with thresholds color-coded per §3.
+- `tests/test_frontal_route_sampling.py` — 12 tests covering bilinear math (linear-field exactness, cell-center averaging, out-of-grid NaN) and full sampling glue (integer hours, fractional interp, per-waypoint hours, unknown model, range guards).
+- Smoke-tested against Storm Ciarán ERA5 case: cold advection at LFPG behind front, warm advection + rising tendency at LOWW ahead of it.
+
+**Goal (original)**: validate spatial + temporal interpolation with zero API cost, on the data we already have.
 
 **What already exists:**
 - `Case.fields(model, hour)` returns `(n_lat, n_lon)` arrays per hour — clean input for sampling
@@ -457,8 +463,8 @@ What was pivotal about this session — we made the pipeline source-agnostic bef
 | Storage decision | ✅ NPZ (Zarr deferred) |
 | Retention decision | ✅ 48 h cache |
 | ERA5 smoke test | ✅ Storm Ciarán 2023-11-02 validated |
-| ERA5 bulk fetch | ⏳ In flight on server — 2025-02 → 2026-02 (1 year, ~700 MB, covers summer convective + winter cyclonic) |
-| **Phase A** (route sampling) | Next up — unblocked |
+| ERA5 bulk fetch | ✅ Done (1 year, 2025-02 → 2026-02, on `/mnt/data/downloads/era5_download/data/hewson/` — pending rsync to `data/era5/hewson/`) |
+| **Phase A** (route sampling) | ✅ Done (2026-04-24) — `route_sampling.py`, `route-hewson` CLI, unit tests all green |
 | Phase B (multi-level + precompute) | Requires Phase A |
 | Phase C (advisory evaluators) | Requires Phase B |
 | Phase D (map layer) | Requires Phase B; can ship before C |

--- a/scripts/analyze_cancellations.py
+++ b/scripts/analyze_cancellations.py
@@ -1,0 +1,247 @@
+"""Ground-truth test: did pilot-cancelled days actually show bad weather?
+
+Parses a freeform `cancel.md` where each line is a cancellation entry:
+
+    DD-MMM-YYYY: DEP ARR [morning] canceled [, instead went DD-MMM-YYYY [DEP ARR]]
+
+For each entry:
+  1. Analyze the cancelled date (Hewson pipeline, same as analyze_flight_log).
+  2. If a replacement date is given, analyze it too and compute Δscore.
+  3. Emit a markdown table — pilot judgement vs system judgement.
+
+Rationale: the main flight-log retrospective is biased — every logged
+flight was a "flyable" day by definition, so we only see "some weather"
+samples. Cancellations are the pilot's explicit "no-go" signal and the
+closest thing we have to bad-weather ground truth.
+
+Known limitations (surface in the report):
+  - Times not in `cancel.md`; default 09Z for "morning", else 12Z.
+  - Round-trip cancellations: if a trip had dep→arr + return 2-3d later,
+    cancellation may have been driven by *either* leg's weather. We
+    analyze the stated date only; pilot adjusts manually.
+  - ERA5 window 2025-02-01 → 2026-02-28; earlier entries skipped.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import re
+import sys
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+
+import numpy as np
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from analyze_flight_log import (  # noqa: E402
+    AIRPORTS_DB_DEFAULT,
+    GRIB_DIR_DEFAULT,
+    Flight,
+    _prime_terrain_mask,
+    analyze_one_flight,
+)
+
+logger = logging.getLogger("analyze_cancellations")
+
+_MONTHS = {
+    "jan": 1, "feb": 2, "mar": 3, "apr": 4, "may": 5, "jun": 6,
+    "jul": 7, "aug": 8, "sep": 9, "oct": 10, "nov": 11, "dec": 12,
+}
+
+# Example line forms (all lowercased before matching):
+#   7-jun-2025: egtf eick canceled, instead went 8-jun-2025 egtf egjb
+#   19-jul-2025: egtf lfat canceled
+#   24-oct-2025: egtf lsgs morning canceled
+#   27-apr-2025: lfmd egtf morning canceled, instead went 28-apr-2025
+_ENTRY_RE = re.compile(
+    r"^\s*(?P<d1>\d{1,2})-(?P<m1>[a-z]{3})-(?P<y1>\d{4})\s*:\s*"
+    r"(?P<dep>[a-z]{4})\s+(?P<arr>[a-z]{4})\s+"
+    r"(?P<morning>morning\s+)?"
+    r"cancel(?:l)?ed"
+    r"(?:\s*,\s*instead\s+went\s+"
+    r"(?P<d2>\d{1,2})-(?P<m2>[a-z]{3})-(?P<y2>\d{4})"
+    r"(?:\s+(?P<dep2>[a-z]{4})\s+(?P<arr2>[a-z]{4}))?"
+    r")?"
+    r"\s*$"
+)
+
+
+def _parse_date(d: str, m: str, y: str) -> date:
+    return date(int(y), _MONTHS[m], int(d))
+
+
+def _make_flight(d: date, dep: str, arr: str, morning: bool) -> Flight:
+    hour = 9 if morning else 12
+    etd = datetime(d.year, d.month, d.day, hour, 0, tzinfo=timezone.utc)
+    return Flight(d, etd, None, dep.upper(), arr.upper())
+
+
+def parse_cancel_md(path: Path) -> list[dict]:
+    """Return list of {cancel: Flight, replacement: Flight | None, morning: bool}."""
+    entries: list[dict] = []
+    for raw in path.read_text().splitlines():
+        line = raw.strip().lower()
+        if not line:
+            continue
+        m = _ENTRY_RE.match(line)
+        if not m:
+            logger.warning("Unparsed line: %r", raw)
+            continue
+
+        cancel_date = _parse_date(m["d1"], m["m1"], m["y1"])
+        morning = bool(m["morning"])
+        cancel_flight = _make_flight(cancel_date, m["dep"], m["arr"], morning)
+
+        replacement_flight: Flight | None = None
+        if m["d2"]:
+            replacement_date = _parse_date(m["d2"], m["m2"], m["y2"])
+            dep2 = (m["dep2"] or m["dep"]).upper()
+            arr2 = (m["arr2"] or m["arr"]).upper()
+            replacement_flight = _make_flight(
+                replacement_date, dep2, arr2, morning,
+            )
+
+        entries.append({
+            "cancel": cancel_flight,
+            "replacement": replacement_flight,
+            "morning": morning,
+        })
+    return entries
+
+
+def _fmt_result(r: dict | None) -> str:
+    if r is None:
+        return "_(no data)_"
+    agg = r["agg"]
+    t = r["tendency"]
+    t_str = f"{t:+.2f}" if not np.isnan(t) else "NaN"
+    adv = ", ".join(r["advisories"]) or "(none)"
+    return (
+        f"score {r['score']:.2f} · "
+        f"Δθe {agg['theta_e_delta']:.1f} K · "
+        f"|∇θe|max {agg['grad_max']:.2f} · "
+        f"adv {agg['adv_max_signed']:+.2f} · "
+        f"tend {t_str} · "
+        f"TFP⇄ {agg['tfp_zero_crossings']}  \n  "
+        f"**Advisories**: {adv}  \n  "
+        f"**Physical read**: {r['physical_read']}"
+    )
+
+
+def main() -> None:
+    p = argparse.ArgumentParser()
+    p.add_argument("--cancel-md", required=True)
+    p.add_argument("--output", default="flight_cancel_retrospective.md")
+    p.add_argument("--era5-dir", default=str(GRIB_DIR_DEFAULT))
+    p.add_argument("--airports-db", default=str(AIRPORTS_DB_DEFAULT))
+    args = p.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(message)s")
+
+    era5_dir = Path(args.era5_dir)
+    airports_db = Path(args.airports_db)
+    entries = parse_cancel_md(Path(args.cancel_md))
+    logger.info("Parsed %d cancellation entries", len(entries))
+
+    # Prime the terrain mask from any entry's GRIB
+    flights_for_priming = [e["cancel"] for e in entries] + [
+        e["replacement"] for e in entries if e["replacement"]
+    ]
+    terrain_mask = _prime_terrain_mask(flights_for_priming, era5_dir)
+
+    results: list[dict] = []
+    for e in entries:
+        cancel_r = analyze_one_flight(e["cancel"], era5_dir, airports_db, terrain_mask)
+        replacement_r = None
+        if e["replacement"]:
+            replacement_r = analyze_one_flight(e["replacement"], era5_dir, airports_db, terrain_mask)
+        results.append({
+            "cancel_flight": e["cancel"],
+            "cancel_result": cancel_r,
+            "replacement_flight": e["replacement"],
+            "replacement_result": replacement_r,
+            "morning": e["morning"],
+        })
+
+    _write_report(Path(args.output), results)
+    print(f"Wrote {args.output}")
+
+
+def _write_report(out: Path, results: list[dict]) -> None:
+    n = len(results)
+    n_with_replacement = sum(1 for r in results if r["replacement_flight"])
+
+    with out.open("w") as fh:
+        fh.write("# Cancelled-Flight Retrospective\n\n")
+        fh.write(
+            f"{n} cancellation entries parsed; {n_with_replacement} have a replacement day.\n\n"
+        )
+        fh.write(
+            "Default times: 09Z for 'morning canceled', 12Z otherwise. "
+            "Thresholds as in the main retrospective.\n\n"
+        )
+        fh.write("---\n\n## Pairwise comparison (cancel vs replacement)\n\n")
+
+        pairs = [r for r in results if r["replacement_flight"]]
+        if not pairs:
+            fh.write("_(no pairs with replacement day in this data)_\n\n")
+        else:
+            fh.write(
+                "For each pair, if `score(cancel) > score(replacement)` the system "
+                "agrees with your decision. Sign of Δ = cancel − replacement.\n\n"
+            )
+            n_agree = 0
+            for r in pairs:
+                cf: Flight = r["cancel_flight"]
+                rf: Flight = r["replacement_flight"]
+                cr = r["cancel_result"]
+                rr = r["replacement_result"]
+                if cr and rr:
+                    delta = cr["score"] - rr["score"]
+                    agree = "✅ agrees" if delta > 0 else "❌ disagrees"
+                    if delta > 0:
+                        n_agree += 1
+                else:
+                    delta = float("nan")
+                    agree = "_(missing data)_"
+                fh.write(
+                    f"### {cf.date} {cf.dep_icao}→{cf.arr_icao} "
+                    f"(cancelled, {'morning' if r['morning'] else 'midday'}) "
+                    f"vs {rf.date} (flown)\n\n"
+                )
+                fh.write(f"- **Δscore (cancel − replacement): {delta:+.2f}** {agree}\n")
+                fh.write(f"- CANCEL  ({cf.date}): {_fmt_result(cr)}\n")
+                fh.write(f"- FLEW    ({rf.date}): {_fmt_result(rr)}\n\n")
+            fh.write(
+                f"**Pairwise agreement: {n_agree}/{len(pairs)}** "
+                f"(system's score ranks cancel-day higher than replacement-day).\n\n"
+            )
+
+        fh.write("---\n\n## All cancellations (absolute view)\n\n")
+        fh.write(
+            "Sorted by cancel-day score descending. Loud scores here are the positive "
+            "signal we want — 'pilot said no, and the system says it was indeed bad'.\n\n"
+        )
+        results_sorted = sorted(
+            results,
+            key=lambda r: -(r["cancel_result"]["score"] if r["cancel_result"] else -1),
+        )
+        for r in results_sorted:
+            cf: Flight = r["cancel_flight"]
+            cr = r["cancel_result"]
+            fh.write(
+                f"### {cf.date} {cf.dep_icao}→{cf.arr_icao} "
+                f"({'morning' if r['morning'] else 'midday'} canceled)\n\n"
+            )
+            fh.write(f"- CANCEL: {_fmt_result(cr)}\n")
+            if r["replacement_flight"]:
+                rf: Flight = r["replacement_flight"]
+                rr = r["replacement_result"]
+                fh.write(f"- Replacement flown on {rf.date}: {_fmt_result(rr)}\n")
+            fh.write("\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/analyze_flight_log.py
+++ b/scripts/analyze_flight_log.py
@@ -1,0 +1,488 @@
+"""Retrospective Hewson analysis on a real flight log.
+
+Workflow:
+  CSV flight log → for each flight in the ERA5 window:
+    - load the monthly ERA5 GRIB at the 6-hourly analysis nearest brakes-off
+    - compute Hewson diagnostics on the European grid
+    - sample 12 points along the great-circle-approximated route
+    - aggregate (max gradient, max |adv|, TFP zero-crossings, etc.)
+    - apply the §3 advisory triggers
+    - write one markdown block per flight, sorted by "excitement"
+
+The output is intentionally rough — a tagging tool for the pilot to
+cross-reference with their own memory before we commit thresholds in
+code (Phase C advisory evaluators).
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import logging
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+
+import numpy as np
+
+from weatherbrief.airports import resolve_waypoints
+from weatherbrief.era5.loader import load_era5_fields
+from weatherbrief.frontal.detect import compute_hewson_diagnostics
+from weatherbrief.frontal.grid import (
+    build_terrain_mask,
+    compute_theta_e,
+    fill_terrain,
+)
+from weatherbrief.frontal.route_sampling import bilinear_sample
+
+logger = logging.getLogger("analyze_flight_log")
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+GRIB_DIR_DEFAULT = REPO_ROOT / "data" / "era5" / "hewson"
+AIRPORTS_DB_DEFAULT = REPO_ROOT / "data" / "nav.db"
+TERRAIN_CACHE = REPO_ROOT / "data" / "era5" / "terrain_mask.npz"
+
+
+def _prime_terrain_mask(flights: list["Flight"], era5_dir: Path) -> np.ndarray | None:
+    """Peek at the first available GRIB to get the grid, then build/load the mask."""
+    for flight in flights:
+        grib = era5_dir / f"era5_hewson_{flight.date.year}_{flight.date.month:02d}.grib"
+        if grib.exists():
+            f = load_era5_fields(grib, nearest_synoptic(flight.etd_utc).replace(tzinfo=None))
+            return get_terrain_mask(f["lat"], f["lon"])
+    logger.warning("No GRIB available to prime terrain mask — proceeding without")
+    return None
+
+
+def get_terrain_mask(lat: np.ndarray, lon: np.ndarray) -> np.ndarray:
+    """Build-or-load the terrain mask for this lat/lon grid. Cached on disk.
+
+    SRTM point lookups for ~19k cells take ~30s; one mask is shared by all
+    ERA5 flights on the same European 0.25° grid.
+    """
+    if TERRAIN_CACHE.exists():
+        with np.load(TERRAIN_CACHE) as npz:
+            cached_lat = npz["lat"]
+            cached_lon = npz["lon"]
+            if (cached_lat.shape == lat.shape and cached_lon.shape == lon.shape
+                    and np.allclose(cached_lat, lat) and np.allclose(cached_lon, lon)):
+                return npz["mask"]
+            logger.info("Terrain cache grid mismatch — rebuilding")
+
+    logger.info("Building terrain mask (one-off SRTM lookup)...")
+    mask = build_terrain_mask(lat, lon)
+    TERRAIN_CACHE.parent.mkdir(parents=True, exist_ok=True)
+    np.savez(TERRAIN_CACHE, mask=mask, lat=lat, lon=lon)
+    return mask
+
+
+def load_masked_fields(grib_path: Path, analysis_time: datetime, terrain_mask: np.ndarray | None) -> dict:
+    """Load ERA5 fields and apply terrain fill + θe re-derivation (matches build_case_from_era5)."""
+    f = load_era5_fields(grib_path, analysis_time.replace(tzinfo=None))
+    if terrain_mask is not None:
+        f["T850"] = fill_terrain(f["T850"], terrain_mask)
+        f["Td850"] = fill_terrain(f["Td850"], terrain_mask)
+        f["u850"] = fill_terrain(f["u850"], terrain_mask)
+        f["v850"] = fill_terrain(f["v850"], terrain_mask)
+        f["theta_e"] = compute_theta_e(f["T850"], f["Td850"])
+    return f
+
+# Thresholds from designs/future/hewson-fields-aviation-advisories.md §3
+GRAD_WARN = 4.0           # K/100km
+GRAD_TRIGGER = 6.0        # K/100km
+NEG_LAP_TRIGGER = 2.0     # K/(100km)²
+ADV_TRIGGER = 1.0         # K/h
+ADV_RAPID = 2.0           # K/h
+TEND_TRIGGER = 0.5        # K/h
+THETA_E_CONVECTIVE = 315.0  # K
+
+
+@dataclass
+class Flight:
+    date: date
+    etd_utc: datetime            # brakes-off UTC
+    eta_utc: datetime | None     # brakes-on UTC (may be None)
+    dep_icao: str
+    arr_icao: str
+
+
+# ---------------------------------------------------------------------------
+# CSV parsing
+
+
+def parse_csv(path: Path) -> tuple[list[Flight], dict[str, int]]:
+    """Parse a Flight-log CSV. Returns (valid_flights, skip_counts)."""
+    valid: list[Flight] = []
+    skips = {"missing_date_time": 0, "same_airport": 0, "bad_time": 0}
+
+    with path.open() as fh:
+        reader = csv.reader(fh)
+        next(reader, None)  # header
+        for row in reader:
+            if not row or not row[0].strip():
+                continue
+            try:
+                d = datetime.strptime(row[0].strip(), "%d/%m/%Y").date()
+            except ValueError:
+                skips["missing_date_time"] += 1
+                continue
+
+            if len(row) < 5:
+                skips["missing_date_time"] += 1
+                continue
+
+            dep = row[1].strip().upper()
+            arr = row[2].strip().upper()
+            off = row[3].strip().lower().rstrip("z")
+            on = row[4].strip().lower().rstrip("z")
+
+            if not dep or not arr or not off:
+                skips["missing_date_time"] += 1
+                continue
+            if dep == arr:
+                skips["same_airport"] += 1
+                continue
+
+            try:
+                etd = _parse_hhmm(d, off)
+            except ValueError:
+                skips["bad_time"] += 1
+                continue
+
+            eta: datetime | None = None
+            if on:
+                try:
+                    eta = _parse_hhmm(d, on)
+                    if eta < etd:
+                        eta += timedelta(days=1)
+                except ValueError:
+                    eta = None
+
+            valid.append(Flight(d, etd, eta, dep, arr))
+    return valid, skips
+
+
+def _parse_hhmm(d: date, hhmm: str) -> datetime:
+    hh, mm = hhmm.split(":")
+    return datetime(d.year, d.month, d.day, int(hh), int(mm), tzinfo=timezone.utc)
+
+
+# ---------------------------------------------------------------------------
+# Time + route helpers
+
+
+def nearest_synoptic(dt: datetime) -> datetime:
+    """Snap to nearest 6-hourly ERA5 analysis (00/06/12/18 UTC)."""
+    hour = dt.hour + dt.minute / 60.0
+    snap = round(hour / 6) * 6
+    base = dt.replace(hour=0, minute=0, second=0, microsecond=0)
+    if snap == 24:
+        base += timedelta(days=1)
+        snap = 0
+    return base.replace(hour=int(snap))
+
+
+def build_route_points(
+    dep: tuple[float, float], arr: tuple[float, float], n_mid: int = 10,
+) -> list[tuple[float, float]]:
+    """Linear interpolation in lat/lon — good enough for 200 nm legs within EU."""
+    lat_d, lon_d = dep
+    lat_a, lon_a = arr
+    return [
+        (lat_d + t * (lat_a - lat_d), lon_d + t * (lon_a - lon_d))
+        for t in np.linspace(0, 1, n_mid + 2)
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Hewson compute + sample
+
+
+def load_diag(grib_path: Path, analysis_time: datetime, terrain_mask: np.ndarray | None = None) -> dict:
+    f = load_masked_fields(grib_path, analysis_time, terrain_mask)
+    diag = compute_hewson_diagnostics(
+        f["theta_e"], f["lat"], f["lon"],
+        u=f["u850"], v=f["v850"],
+        terrain_mask=terrain_mask,
+    )
+    diag["theta_e"] = f["theta_e"]
+    diag["lat"] = f["lat"]
+    diag["lon"] = f["lon"]
+    return diag
+
+
+def sample_route(diag: dict, points: list[tuple[float, float]]) -> list[dict]:
+    out = []
+    for lat, lon in points:
+        out.append({
+            "theta_e":       bilinear_sample(diag["theta_e"], diag["lat"], diag["lon"], lat, lon),
+            "gradient":      bilinear_sample(diag["gradient"], diag["lat"], diag["lon"], lat, lon),
+            "tfp":           bilinear_sample(diag["tfp"], diag["lat"], diag["lon"], lat, lon),
+            "neg_laplacian": bilinear_sample(diag["neg_laplacian"], diag["lat"], diag["lon"], lat, lon),
+            "advection":     bilinear_sample(diag["advection"], diag["lat"], diag["lon"], lat, lon),
+        })
+    return out
+
+
+def aggregate(samples: list[dict]) -> dict:
+    theta_e = np.array([s["theta_e"] for s in samples])
+    grad = np.array([s["gradient"] for s in samples])
+    adv = np.array([s["advection"] for s in samples])
+    tfp = np.array([s["tfp"] for s in samples])
+    neg_lap = np.array([s["neg_laplacian"] for s in samples])
+
+    signs = np.sign(tfp)
+    crossings = int(np.sum(signs[:-1] * signs[1:] < 0))
+
+    adv_max_idx = int(np.nanargmax(np.abs(adv)))
+
+    return {
+        "theta_e_min": float(np.nanmin(theta_e)),
+        "theta_e_max": float(np.nanmax(theta_e)),
+        "theta_e_delta": float(np.nanmax(theta_e) - np.nanmin(theta_e)),
+        "grad_max": float(np.nanmax(grad)),
+        "grad_mean": float(np.nanmean(grad)),
+        "adv_max_abs": float(np.abs(adv)[adv_max_idx]),
+        "adv_max_signed": float(adv[adv_max_idx]),
+        "neg_lap_max_abs": float(np.nanmax(np.abs(neg_lap))),
+        "tfp_zero_crossings": crossings,
+    }
+
+
+def tendency_at(grib_path: Path, analysis: datetime, lat: float, lon: float, terrain_mask: np.ndarray | None = None) -> float:
+    """∂θe/∂t at one point using centered 12-h difference (±6h ERA5 step)."""
+    try:
+        f_prev = load_masked_fields(grib_path, analysis - timedelta(hours=6), terrain_mask)
+        f_next = load_masked_fields(grib_path, analysis + timedelta(hours=6), terrain_mask)
+    except ValueError:
+        return float("nan")
+    tp = bilinear_sample(f_prev["theta_e"], f_prev["lat"], f_prev["lon"], lat, lon)
+    tn = bilinear_sample(f_next["theta_e"], f_next["lat"], f_next["lon"], lat, lon)
+    return (tn - tp) / 12.0
+
+
+# ---------------------------------------------------------------------------
+# Advisory logic
+
+
+def fire_advisories(agg: dict, tendency: float) -> list[str]:
+    out: list[str] = []
+    if agg["grad_max"] > GRAD_TRIGGER:
+        out.append("air-mass-transition")
+    if agg["neg_lap_max_abs"] > NEG_LAP_TRIGGER:
+        out.append("sharp-edge")
+    if agg["adv_max_signed"] > ADV_RAPID:
+        out.append("deteriorating-warm-adv-rapid")
+    elif agg["adv_max_signed"] > ADV_TRIGGER:
+        out.append("deteriorating-warm-adv")
+    if agg["adv_max_signed"] < -ADV_RAPID:
+        out.append("improving-cold-adv-rapid")
+    elif agg["adv_max_signed"] < -ADV_TRIGGER:
+        out.append("improving-cold-adv")
+    if agg["theta_e_max"] > THETA_E_CONVECTIVE:
+        out.append("convective-outlook")
+    if not np.isnan(tendency) and abs(tendency) > TEND_TRIGGER:
+        out.append(f"destination-tendency-{'rising' if tendency > 0 else 'falling'}")
+    return out
+
+
+def physical_read(agg: dict, tendency: float, advisories: list[str]) -> str:
+    parts: list[str] = []
+    if agg["theta_e_delta"] > 10:
+        parts.append(f"Δθe {agg['theta_e_delta']:.1f} K along route — substantial air-mass contrast")
+    if "deteriorating-warm-adv-rapid" in advisories:
+        parts.append("rapid warm advection — frontal passage within 1–2h, ceilings dropping")
+    elif "deteriorating-warm-adv" in advisories:
+        parts.append("warm advection — stratiform cloud, ceilings lower over time, icing risk rising")
+    if "improving-cold-adv-rapid" in advisories:
+        parts.append("rapid cold advection — post-frontal, clearing behind, gusty")
+    elif "improving-cold-adv" in advisories:
+        parts.append("cold advection — clearing, showery, mechanical turbulence")
+    if "sharp-edge" in advisories or agg["tfp_zero_crossings"] >= 2:
+        parts.append(f"{agg['tfp_zero_crossings']} TFP zero-crossing(s) on route — narrow transition band")
+    if "convective-outlook" in advisories:
+        parts.append(f"high θe ({agg['theta_e_max']:.0f} K) — convective potential if lapse rate cooperates")
+    if agg["theta_e_min"] < 280:
+        parts.append("cold polar/arctic air — expect icing in cloud, possible showers")
+    if not parts:
+        mid = (agg["theta_e_min"] + agg["theta_e_max"]) / 2
+        parts.append(f"benign air mass (θe ≈ {mid:.0f} K), no significant gradients or advection")
+    return "; ".join(parts)
+
+
+def excitement_score(agg: dict, tendency: float) -> float:
+    """Rough 0–10ish score — max excites, for sorting report."""
+    return (
+        max(0.0, agg["grad_max"] - GRAD_WARN) / 2.0
+        + min(agg["adv_max_abs"], 4.0)
+        + min(abs(tendency) if not np.isnan(tendency) else 0.0, 2.0)
+        + min(agg["neg_lap_max_abs"], 4.0) / 2.0
+        + 0.5 * agg["tfp_zero_crossings"]
+    )
+
+
+# ---------------------------------------------------------------------------
+# One-flight analysis (shared with analyze_cancellations.py)
+
+
+def analyze_one_flight(
+    flight: Flight,
+    era5_dir: Path,
+    airports_db: Path,
+    terrain_mask: np.ndarray | None = None,
+) -> dict | None:
+    """Run the full Hewson pipeline for one flight. Returns None if data missing.
+
+    Output dict:
+      flight, analysis, agg, tendency, advisories, physical_read, score
+    """
+    grib_path = era5_dir / f"era5_hewson_{flight.date.year}_{flight.date.month:02d}.grib"
+    if not grib_path.exists():
+        logger.warning("No GRIB for %s — skipping", flight.date)
+        return None
+
+    try:
+        waypoints, _ = resolve_waypoints(
+            [flight.dep_icao, flight.arr_icao], str(airports_db),
+        )
+    except KeyError as e:
+        logger.warning("Unresolved ICAO %s→%s: %s", flight.dep_icao, flight.arr_icao, e)
+        return None
+
+    dep_ll = (waypoints[0].lat, waypoints[0].lon)
+    arr_ll = (waypoints[-1].lat, waypoints[-1].lon)
+
+    analysis = nearest_synoptic(flight.etd_utc)
+    try:
+        diag = load_diag(grib_path, analysis, terrain_mask)
+    except Exception as exc:
+        logger.warning("load_diag failed for %s: %s", flight.date, exc)
+        return None
+
+    route_pts = build_route_points(dep_ll, arr_ll, n_mid=10)
+    samples = sample_route(diag, route_pts)
+    agg = aggregate(samples)
+    dep_tend = tendency_at(grib_path, analysis, dep_ll[0], dep_ll[1], terrain_mask)
+
+    advisories = fire_advisories(agg, dep_tend)
+    return {
+        "flight": flight,
+        "analysis": analysis,
+        "agg": agg,
+        "tendency": dep_tend,
+        "advisories": advisories,
+        "physical_read": physical_read(agg, dep_tend, advisories),
+        "score": excitement_score(agg, dep_tend),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Main
+
+
+def main() -> None:
+    p = argparse.ArgumentParser()
+    p.add_argument("--csv", required=True)
+    p.add_argument("--output", default="flight_hewson_retrospective.md")
+    p.add_argument("--era5-dir", default=str(GRIB_DIR_DEFAULT))
+    p.add_argument("--airports-db", default=str(AIRPORTS_DB_DEFAULT))
+    p.add_argument("--limit", type=int, help="Max flights (for quick iteration)")
+    p.add_argument("--from-date", help="YYYY-MM-DD inclusive (default: 2025-02-01)")
+    p.add_argument("--to-date", help="YYYY-MM-DD inclusive (default: 2026-02-28)")
+    args = p.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(message)s")
+
+    from_date = date.fromisoformat(args.from_date) if args.from_date else date(2025, 2, 1)
+    to_date = date.fromisoformat(args.to_date) if args.to_date else date(2026, 2, 28)
+
+    flights, skips = parse_csv(Path(args.csv))
+    flights = [f for f in flights if from_date <= f.date <= to_date]
+    flights.sort(key=lambda f: f.etd_utc)
+    logger.info(
+        "Parsed: %d usable flights in [%s, %s]; skipped %s",
+        len(flights), from_date, to_date, skips,
+    )
+    if args.limit:
+        flights = flights[: args.limit]
+
+    era5_dir = Path(args.era5_dir)
+    airports_db = Path(args.airports_db)
+
+    # Prime the terrain mask from the first flight's GRIB (all ERA5 cycles
+    # share the same European 0.25° grid, so one mask serves all analyses).
+    terrain_mask = _prime_terrain_mask(flights, era5_dir)
+
+    results: list[dict] = []
+    for flight in flights:
+        r = analyze_one_flight(flight, era5_dir, airports_db, terrain_mask)
+        if r is None:
+            continue
+        results.append(r)
+        if len(results) % 10 == 0:
+            logger.info("...%d flights processed", len(results))
+
+    results.sort(key=lambda r: -r["score"])
+    _write_report(Path(args.output), results, from_date, to_date)
+    print(f"Wrote {args.output} ({len(results)} flights)")
+
+
+def _write_report(out: Path, results: list[dict], from_date: date, to_date: date) -> None:
+    n_fired = sum(1 for r in results if r["advisories"])
+    with out.open("w") as fh:
+        fh.write("# Flight Log × Hewson Retrospective\n\n")
+        fh.write(
+            f"Period: {from_date} → {to_date}. "
+            f"{len(results)} flights analyzed; {n_fired} trigger at least one advisory.\n\n"
+        )
+        fh.write(
+            "Thresholds (from `designs/future/hewson-fields-aviation-advisories.md` §3): "
+            f"|∇θe|>{GRAD_TRIGGER} K/100km, |adv|>{ADV_TRIGGER} K/h "
+            f"(rapid >{ADV_RAPID}), |−∇²θe|>{NEG_LAP_TRIGGER} K/(100km)², "
+            f"|∂θe/∂t|>{TEND_TRIGGER} K/h, θe>{THETA_E_CONVECTIVE} K for convection.\n\n"
+        )
+        fh.write(
+            "_Sorted by excitement score descending. For each flight, check the "
+            "box that best matches your own memory of that flight's weather._\n\n"
+        )
+        fh.write("---\n\n")
+
+        for i, r in enumerate(results, 1):
+            fl: Flight = r["flight"]
+            fh.write(
+                f"## #{i} — {fl.date} {fl.dep_icao} → {fl.arr_icao} "
+                f"[{fl.etd_utc.strftime('%H:%Mz')}"
+            )
+            if fl.eta_utc:
+                fh.write(f" → {fl.eta_utc.strftime('%H:%Mz')}")
+            fh.write("]\n")
+            fh.write(
+                f"*excitement {r['score']:.2f}  |  analysis {r['analysis'].strftime('%Hz')}*\n\n"
+            )
+            agg = r["agg"]
+            fh.write(
+                f"- θe range: {agg['theta_e_min']:.1f} → {agg['theta_e_max']:.1f} K "
+                f"(Δ{agg['theta_e_delta']:.1f})\n"
+            )
+            fh.write(
+                f"- |∇θe| max {agg['grad_max']:.2f} K/100km  (mean {agg['grad_mean']:.2f})\n"
+            )
+            fh.write(f"- −V·∇θe max {agg['adv_max_signed']:+.2f} K/h\n")
+            tend = r["tendency"]
+            tend_str = f"{tend:+.2f}" if not np.isnan(tend) else "NaN"
+            fh.write(f"- ∂θe/∂t at dep: {tend_str} K/h\n")
+            fh.write(
+                f"- |−∇²θe| max {agg['neg_lap_max_abs']:.2f};  "
+                f"TFP zero-crossings on route: {agg['tfp_zero_crossings']}\n"
+            )
+            adv_list = ", ".join(r["advisories"]) or "(none)"
+            fh.write(f"- **Advisories fired**: {adv_list}\n")
+            fh.write(f"- **Physical read**: {r['physical_read']}\n")
+            fh.write(
+                "- **Your memory?** `[ ] matches  [ ] false alarm  "
+                "[ ] don't remember  [ ] different (describe)`\n\n"
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/weatherbrief/frontal/cli.py
+++ b/src/weatherbrief/frontal/cli.py
@@ -2109,6 +2109,73 @@ def _cmd_charts(args: argparse.Namespace) -> None:
             print(f"  Zone overlay → {out}")
 
 
+def _cmd_route_hewson(args: argparse.Namespace) -> None:
+    """Sample Hewson diagnostic fields along a route of ICAO waypoints."""
+    from weatherbrief.airports import resolve_waypoints
+    from weatherbrief.frontal.case import load_case
+    from weatherbrief.frontal.route_sampling import sample_hewson_at_route
+
+    case = load_case(Path(args.case))
+    if args.model not in case.models:
+        print(
+            f"Error: model '{args.model}' not in case (available: {case.models})",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    codes = args.waypoints.split()
+    if len(codes) < 2:
+        print("Error: provide at least 2 waypoints", file=sys.stderr)
+        sys.exit(1)
+
+    waypoints, rejected = resolve_waypoints(codes, args.airports_db)
+    if rejected:
+        for r in rejected:
+            print(f"  (rejected {r.name}: {r.reason})", file=sys.stderr)
+
+    samples = sample_hewson_at_route(
+        case, args.model,
+        [(wp.lat, wp.lon) for wp in waypoints],
+        hours=args.hour,
+    )
+
+    # Thresholds from designs/future/hewson-fields-aviation-advisories.md §3.
+    # θe (raw) has no meaningful threshold — pass warn=None to skip coloring.
+    def _fmt(value: float, warn: float | None, alert: float | None, units: str) -> str:
+        if np.isnan(value):
+            return f"   NaN {units}"
+        label = f"{value:7.2f} {units}"
+        if warn is None or alert is None:
+            return label
+        mag = abs(value)
+        if mag >= alert:
+            return f"\033[91m{label}\033[0m"   # red
+        if mag >= warn:
+            return f"\033[93m{label}\033[0m"   # yellow
+        return label
+
+    header = (
+        f"Case: {case.case_name}  model={args.model}  hour={args.hour}"
+    )
+    print(header)
+    print("-" * len(header))
+    print(
+        f"{'ICAO':<6} {'lat':>7} {'lon':>8}  "
+        f"{'θe (K)':>14} {'|∇θe|':>22} {'−∇²θe':>22} "
+        f"{'TFP':>22} {'adv':>22} {'∂θe/∂t':>22}"
+    )
+    for wp, s in zip(waypoints, samples):
+        print(
+            f"{wp.icao:<6} {wp.lat:7.3f} {wp.lon:8.3f}  "
+            f"{_fmt(s['theta_e'],      None, None, 'K      '):>14} "
+            f"{_fmt(s['gradient'],     4,    8,    'K/100km'):>22} "
+            f"{_fmt(s['neg_laplacian'],2,    5,    'K/100² '):>22} "
+            f"{_fmt(s['tfp'],          2,    5,    'K/100² '):>22} "
+            f"{_fmt(s['advection'],    1,    2,    'K/h    '):>22} "
+            f"{_fmt(s['tendency'],     0.5,  1,    'K/h    '):>22}"
+        )
+
+
 def _cmd_redraw_zones(args: argparse.Namespace) -> None:
     """Redraw analysis_with_zones.png for a case using its current expected.yaml."""
     case_dir = Path(args.case)
@@ -2393,6 +2460,33 @@ def build_parser() -> argparse.ArgumentParser:
         help="Which expected.yaml entry to visualize (default: 0 = analysis)",
     )
 
+    # route-hewson
+    p_route_hewson = sub.add_parser(
+        "route-hewson",
+        help="Sample Hewson diagnostics along a route of ICAO waypoints",
+    )
+    p_route_hewson.add_argument(
+        "--case", required=True,
+        help="Calibration case dir (e.g. data/calibration/2023-11-02_era5_ciaran)",
+    )
+    p_route_hewson.add_argument(
+        "--model", default="era5",
+        help="Model key as present in the case (default: era5)",
+    )
+    p_route_hewson.add_argument(
+        "--waypoints", required=True,
+        help='Space-separated ICAO codes (e.g. "LFPG LFSB LIMC")',
+    )
+    p_route_hewson.add_argument(
+        "--hour", type=float, default=0.0,
+        help="Forecast hour offset from case start (fractional ok). Default 0.",
+    )
+    p_route_hewson.add_argument(
+        "--airports-db",
+        default="data/nav.db",
+        help="Path to euro_aip airports SQLite DB (default: data/nav.db)",
+    )
+
     # clear-cache
     p_clear = sub.add_parser("clear-cache", help="Delete cached grid data")
     p_clear.add_argument("--cache-dir")
@@ -2424,6 +2518,7 @@ def main() -> None:
         "charts": _cmd_charts,
         "redraw-zones": _cmd_redraw_zones,
         "plot-hewson": _cmd_plot_hewson,
+        "route-hewson": _cmd_route_hewson,
         "clear-cache": _cmd_clear_cache,
     }
     commands[args.command](args)

--- a/src/weatherbrief/frontal/route_sampling.py
+++ b/src/weatherbrief/frontal/route_sampling.py
@@ -1,0 +1,299 @@
+"""Sample Hewson diagnostic fields at route waypoints.
+
+The precompute layer (Phase B) does not exist yet — diagnostics are
+computed on demand from the Case's raw θe / u / v. That is fine: a
+European 0.25° grid evaluates in well under a second and a typical
+route hits only a handful of forecast hours.
+
+Three interpolation axes:
+    spatial   — bilinear on the Case's lat/lon grid
+    temporal  — linear between bounding available hours
+    (vertical — deferred; 850 hPa only until Phase B brings 925/700)
+
+Output shape matches the design doc §Phase A:
+    {lat, lon, hour, theta_e, gradient, tfp, neg_laplacian,
+     advection, tendency}
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Sequence
+
+import numpy as np
+
+from weatherbrief.frontal.case import Case
+from weatherbrief.frontal.detect import compute_hewson_diagnostics
+
+logger = logging.getLogger(__name__)
+
+
+# Diagnostic field keys exposed per waypoint. `theta_e` is the raw
+# air-mass label (§2.1); the rest are the Hewson derivatives.
+_FIELD_KEYS = (
+    "theta_e",
+    "gradient",
+    "tfp",
+    "neg_laplacian",
+    "advection",
+    "tendency",
+)
+
+
+@dataclass(frozen=True)
+class _HourGrids:
+    """Per-hour diagnostic grids + raw theta_e, keyed under _FIELD_KEYS.
+
+    Tendency is filled in separately because it needs adjacent hours.
+    """
+    theta_e: np.ndarray
+    gradient: np.ndarray
+    tfp: np.ndarray
+    neg_laplacian: np.ndarray
+    advection: np.ndarray
+    tendency: np.ndarray  # NaN-filled if neither neighbour is available
+
+
+def sample_hewson_at_route(
+    case: Case,
+    model: str,
+    waypoints: Sequence[tuple[float, float]],
+    hours: Sequence[float] | float | None = None,
+    *,
+    terrain_mask: np.ndarray | None = None,
+) -> list[dict]:
+    """Return per-waypoint Hewson diagnostics.
+
+    Parameters
+    ----------
+    case : loaded Case (see `load_case`).
+    model : model key present in the case (e.g. "era5", "ecmwf").
+    waypoints : iterable of (lat_deg, lon_deg) pairs.
+    hours : forecast hour(s) at which to sample. One of:
+        - None  → sample all waypoints at hour 0
+        - float → same hour for every waypoint
+        - sequence of floats → per-waypoint hour (must match len(waypoints))
+        Fractional hours are linearly interpolated between the two bounding
+        available hours.
+    terrain_mask : optional boolean (True=valid) matching the case grid.
+
+    Returns
+    -------
+    list[dict], one entry per waypoint, with keys:
+        lat, lon, hour, theta_e, gradient, tfp, neg_laplacian,
+        advection, tendency
+    Values are NaN when a waypoint sits outside the grid or the
+    requested hour is outside the available range.
+    """
+    wps = [(float(la), float(lo)) for la, lo in waypoints]
+    hour_list = _normalize_hours(hours, len(wps))
+
+    if model not in case.models:
+        raise ValueError(
+            f"model {model!r} not in case (available: {case.models})"
+        )
+
+    avail_hours = case.available_hours(model)
+    if not avail_hours:
+        raise ValueError(f"case has no available hours for model {model!r}")
+
+    # Unique integer hours we need to compute diagnostics for. For a
+    # fractional target hour h, we need ⌊h⌋ and ⌈h⌉ (both must be in
+    # avail_hours for the sample to be valid).
+    needed: set[int] = set()
+    for h in hour_list:
+        if h is None:
+            continue
+        lo, hi = _bracket(avail_hours, h)
+        if lo is not None:
+            needed.add(lo)
+        if hi is not None:
+            needed.add(hi)
+
+    grids_by_hour: dict[int, _HourGrids] = {
+        h: _compute_hour_grids(case, model, h, avail_hours, terrain_mask)
+        for h in sorted(needed)
+    }
+
+    results: list[dict] = []
+    for (wp_lat, wp_lon), h in zip(wps, hour_list):
+        entry: dict = {"lat": wp_lat, "lon": wp_lon, "hour": h}
+        if h is None:
+            for k in _FIELD_KEYS:
+                entry[k] = float("nan")
+            results.append(entry)
+            continue
+
+        lo, hi = _bracket(avail_hours, h)
+        if lo is None or hi is None:
+            for k in _FIELD_KEYS:
+                entry[k] = float("nan")
+            results.append(entry)
+            continue
+
+        if lo == hi:
+            sample = _sample_grids(grids_by_hour[lo], case.lat, case.lon,
+                                   wp_lat, wp_lon)
+        else:
+            w = (h - lo) / (hi - lo)
+            s_lo = _sample_grids(grids_by_hour[lo], case.lat, case.lon,
+                                 wp_lat, wp_lon)
+            s_hi = _sample_grids(grids_by_hour[hi], case.lat, case.lon,
+                                 wp_lat, wp_lon)
+            sample = {k: (1.0 - w) * s_lo[k] + w * s_hi[k] for k in _FIELD_KEYS}
+
+        entry.update(sample)
+        results.append(entry)
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Internals
+
+
+def _normalize_hours(
+    hours: Sequence[float] | float | None,
+    n_waypoints: int,
+) -> list[float | None]:
+    if hours is None:
+        return [0.0] * n_waypoints
+    if isinstance(hours, (int, float)):
+        return [float(hours)] * n_waypoints
+    out = [float(h) if h is not None else None for h in hours]
+    if len(out) != n_waypoints:
+        raise ValueError(
+            f"hours has length {len(out)} but there are {n_waypoints} waypoints"
+        )
+    return out
+
+
+def _bracket(
+    avail_hours: list[int], target: float
+) -> tuple[int | None, int | None]:
+    """Return (lo, hi) from avail_hours bracketing `target`.
+
+    If target is outside the range, returns (None, None). If target
+    coincides with an available hour, lo == hi.
+    """
+    if not avail_hours:
+        return None, None
+    lo_candidates = [h for h in avail_hours if h <= target]
+    hi_candidates = [h for h in avail_hours if h >= target]
+    if not lo_candidates or not hi_candidates:
+        return None, None
+    return max(lo_candidates), min(hi_candidates)
+
+
+def _compute_hour_grids(
+    case: Case,
+    model: str,
+    hour: int,
+    avail_hours: list[int],
+    terrain_mask: np.ndarray | None,
+) -> _HourGrids:
+    """Compute diagnostic grids + tendency for one integer hour."""
+    fields = case.fields(model, hour)
+    if fields is None:
+        raise ValueError(f"fields missing for model={model!r} hour={hour}")
+
+    diag = compute_hewson_diagnostics(
+        fields["theta_e"], case.lat, case.lon,
+        u=fields["u850"], v=fields["v850"],
+        terrain_mask=terrain_mask,
+    )
+
+    return _HourGrids(
+        theta_e=fields["theta_e"],
+        gradient=diag["gradient"],
+        tfp=diag["tfp"],
+        neg_laplacian=diag["neg_laplacian"],
+        advection=diag["advection"],
+        tendency=_tendency_grid(case, model, hour, avail_hours),
+    )
+
+
+def _tendency_grid(
+    case: Case,
+    model: str,
+    hour: int,
+    avail_hours: list[int],
+) -> np.ndarray:
+    """∂θe/∂t at `hour`, using centered/forward/backward diff.
+
+    Mirrors the fallback logic in `_cmd_plot_hewson`: prefer centered
+    difference, fall back to one-sided at the ends of the range. Returns
+    a NaN-filled grid when neither neighbour is available.
+    """
+    prev_h = max((h for h in avail_hours if h < hour), default=None)
+    next_h = min((h for h in avail_hours if h > hour), default=None)
+
+    if prev_h is not None and next_h is not None:
+        f_prev = case.fields(model, prev_h)["theta_e"]
+        f_next = case.fields(model, next_h)["theta_e"]
+        return (f_next - f_prev) / (next_h - prev_h)
+    if next_h is not None:
+        f_here = case.fields(model, hour)["theta_e"]
+        f_next = case.fields(model, next_h)["theta_e"]
+        return (f_next - f_here) / (next_h - hour)
+    if prev_h is not None:
+        f_prev = case.fields(model, prev_h)["theta_e"]
+        f_here = case.fields(model, hour)["theta_e"]
+        return (f_here - f_prev) / (hour - prev_h)
+
+    # Single hour in the case — no tendency possible
+    shape = case.fields(model, hour)["theta_e"].shape
+    return np.full(shape, np.nan, dtype=np.float64)
+
+
+def _sample_grids(
+    grids: _HourGrids,
+    lat_axis: np.ndarray,
+    lon_axis: np.ndarray,
+    wp_lat: float,
+    wp_lon: float,
+) -> dict[str, float]:
+    """Bilinear sample every field at one waypoint."""
+    return {
+        k: bilinear_sample(getattr(grids, k), lat_axis, lon_axis, wp_lat, wp_lon)
+        for k in _FIELD_KEYS
+    }
+
+
+def bilinear_sample(
+    grid: np.ndarray,
+    lat_axis: np.ndarray,
+    lon_axis: np.ndarray,
+    wp_lat: float,
+    wp_lon: float,
+) -> float:
+    """Bilinear interpolation on an ascending (lat, lon) grid.
+
+    Returns NaN when (wp_lat, wp_lon) falls outside the axes. Expects
+    lat_axis and lon_axis to be monotonically ascending (the convention
+    used throughout `frontal.grid`). No wrap-around on longitude —
+    European grids do not cross the antimeridian.
+    """
+    if not (lat_axis[0] <= wp_lat <= lat_axis[-1]):
+        return float("nan")
+    if not (lon_axis[0] <= wp_lon <= lon_axis[-1]):
+        return float("nan")
+
+    i = int(np.searchsorted(lat_axis, wp_lat, side="right")) - 1
+    i = min(max(i, 0), len(lat_axis) - 2)
+    j = int(np.searchsorted(lon_axis, wp_lon, side="right")) - 1
+    j = min(max(j, 0), len(lon_axis) - 2)
+
+    fy = (wp_lat - lat_axis[i]) / (lat_axis[i + 1] - lat_axis[i])
+    fx = (wp_lon - lon_axis[j]) / (lon_axis[j + 1] - lon_axis[j])
+
+    g00 = grid[i, j]
+    g01 = grid[i, j + 1]
+    g10 = grid[i + 1, j]
+    g11 = grid[i + 1, j + 1]
+
+    return float(
+        (1.0 - fy) * ((1.0 - fx) * g00 + fx * g01)
+        + fy * ((1.0 - fx) * g10 + fx * g11)
+    )

--- a/tests/test_frontal_route_sampling.py
+++ b/tests/test_frontal_route_sampling.py
@@ -1,0 +1,197 @@
+"""Tests for weatherbrief.frontal.route_sampling.
+
+Two goals:
+  1. Bilinear interpolation math is correct on synthetic fields with
+     known analytic values.
+  2. `sample_hewson_at_route` glues spatial + temporal interp together
+     correctly over a small synthetic Case.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from weatherbrief.frontal.case import Case
+from weatherbrief.frontal.route_sampling import (
+    bilinear_sample,
+    sample_hewson_at_route,
+)
+
+
+# ---------------------------------------------------------------------------
+# bilinear_sample
+
+
+class TestBilinearSample:
+    def _axes(self):
+        lat = np.linspace(45.0, 55.0, 11)   # 1° spacing
+        lon = np.linspace(0.0, 10.0, 11)
+        return lat, lon
+
+    def test_at_grid_node(self):
+        lat, lon = self._axes()
+        grid = np.outer(lat, lon)           # f(la,lo) = la*lo
+        # node value matches underlying function exactly
+        assert bilinear_sample(grid, lat, lon, 50.0, 5.0) == pytest.approx(250.0)
+
+    def test_linear_field_exact(self):
+        """Bilinear reproduces any linear field exactly."""
+        lat, lon = self._axes()
+        lat_grid, lon_grid = np.meshgrid(lat, lon, indexing="ij")
+        grid = 3.0 * lat_grid - 2.0 * lon_grid + 7.0
+
+        for wp in [(46.5, 1.25), (52.7, 8.3), (45.0, 0.0), (55.0, 10.0)]:
+            expected = 3.0 * wp[0] - 2.0 * wp[1] + 7.0
+            assert bilinear_sample(grid, lat, lon, *wp) == pytest.approx(expected, rel=1e-10)
+
+    def test_midpoint_of_cell(self):
+        """Midpoint of a cell = average of the four corners."""
+        lat, lon = self._axes()
+        grid = np.zeros((11, 11))
+        grid[5, 5] = 1.0
+        grid[5, 6] = 3.0
+        grid[6, 5] = 5.0
+        grid[6, 6] = 7.0
+        # midpoint between lat[5]=50, lat[6]=51 → 50.5; similarly 5.5
+        assert bilinear_sample(grid, lat, lon, 50.5, 5.5) == pytest.approx(
+            (1.0 + 3.0 + 5.0 + 7.0) / 4.0
+        )
+
+    def test_outside_grid_returns_nan(self):
+        lat, lon = self._axes()
+        grid = np.zeros((11, 11))
+        assert np.isnan(bilinear_sample(grid, lat, lon, 44.0, 5.0))
+        assert np.isnan(bilinear_sample(grid, lat, lon, 56.0, 5.0))
+        assert np.isnan(bilinear_sample(grid, lat, lon, 50.0, -0.01))
+        assert np.isnan(bilinear_sample(grid, lat, lon, 50.0, 10.01))
+
+
+# ---------------------------------------------------------------------------
+# sample_hewson_at_route
+#
+# Build a tiny synthetic Case in-memory so the glue logic is tested
+# end-to-end without needing an actual NPZ on disk.
+
+
+def _synthetic_case(n_hours: int = 3) -> Case:
+    """Build a Case whose fields(model, hour) returns known analytic grids.
+
+    θe is linear in lat + linear in hour, so:
+      - gradient is a known constant
+      - tendency is a known constant
+      - advection depends on u/v (zero wind → zero advection)
+    """
+    lat = np.linspace(45.0, 50.0, 21)       # 0.25° × 5°
+    lon = np.linspace(0.0, 5.0, 21)
+    lat_grid, _ = np.meshgrid(lat, lon, indexing="ij")
+
+    # θe varies 2 K per degree latitude, +1 K per hour
+    fields_by_hour: dict[int, dict] = {}
+    for h in range(n_hours):
+        theta_e = 290.0 + 2.0 * lat_grid + 1.0 * h
+        fields_by_hour[h] = {
+            "T850": theta_e - 40.0,                    # placeholder
+            "Td850": theta_e - 50.0,
+            "theta_e": theta_e,
+            "u850": np.zeros_like(theta_e),            # no advection
+            "v850": np.zeros_like(theta_e),
+        }
+
+    valid_times = np.array(
+        [np.datetime64("2024-01-01T00", "ns") + np.timedelta64(h, "h")
+         for h in range(n_hours)],
+        dtype="datetime64[ns]",
+    )
+
+    case = Case(
+        case_dir=None,  # fields() is overridden below; case_dir never used
+        case_name="synthetic",
+        source="synthetic",
+        resolution_deg=0.25,
+        lat=lat,
+        lon=lon,
+        models=["syn"],
+        valid_times={"syn": valid_times},
+        init_times={"syn": 0},
+    )
+
+    # Monkey-patch fields / available_hours — synthetic grids don't live on disk
+    case.fields = lambda model, hour, _src=fields_by_hour: _src.get(hour)  # type: ignore
+    case.available_hours = lambda model: list(range(n_hours))              # type: ignore
+    return case
+
+
+class TestSampleHewsonAtRoute:
+    def test_integer_hour_single_waypoint(self):
+        case = _synthetic_case()
+        out = sample_hewson_at_route(
+            case, "syn", [(47.5, 2.5)], hours=1,
+        )
+        assert len(out) == 1
+        entry = out[0]
+        assert entry["lat"] == 47.5
+        assert entry["lon"] == 2.5
+        assert entry["hour"] == 1.0
+        # θe = 290 + 2*47.5 + 1*1 = 386
+        assert entry["theta_e"] == pytest.approx(386.0, abs=1e-6)
+        # No wind → zero advection
+        assert entry["advection"] == pytest.approx(0.0, abs=1e-9)
+        # +1 K/h tendency (centered diff between h=0 and h=2)
+        assert entry["tendency"] == pytest.approx(1.0, abs=1e-6)
+        # Gradient: 2 K/deg ≈ 2/111 K/km → ~1.8 K/100km
+        # Just sanity-check the direction (non-zero, positive)
+        assert entry["gradient"] > 1.0
+        assert entry["gradient"] < 3.0
+
+    def test_fractional_hour_interpolates(self):
+        """Target hour 0.25 should return θe 25% of the way from h=0 to h=1."""
+        case = _synthetic_case()
+        wp = (47.0, 2.0)
+        out = sample_hewson_at_route(case, "syn", [wp], hours=0.25)
+        # θe at h=0: 290 + 94 = 384; at h=1: 385; 25% → 384.25
+        assert out[0]["theta_e"] == pytest.approx(384.25, abs=1e-6)
+
+    def test_per_waypoint_hour(self):
+        case = _synthetic_case()
+        wps = [(47.0, 2.0), (48.0, 3.0)]
+        out = sample_hewson_at_route(case, "syn", wps, hours=[0.0, 2.0])
+        # wp0: θe = 290 + 2*47 + 0 = 384
+        assert out[0]["theta_e"] == pytest.approx(384.0, abs=1e-6)
+        # wp1: θe = 290 + 2*48 + 2 = 388
+        assert out[1]["theta_e"] == pytest.approx(388.0, abs=1e-6)
+
+    def test_waypoint_outside_grid(self):
+        case = _synthetic_case()
+        out = sample_hewson_at_route(case, "syn", [(60.0, 2.0)], hours=0)
+        # Out-of-bounds waypoint: every field NaN but lat/lon/hour preserved
+        assert np.isnan(out[0]["theta_e"])
+        assert np.isnan(out[0]["gradient"])
+        assert out[0]["lat"] == 60.0
+
+    def test_hour_outside_range(self):
+        case = _synthetic_case(n_hours=3)
+        out = sample_hewson_at_route(case, "syn", [(47.0, 2.0)], hours=5.0)
+        assert np.isnan(out[0]["theta_e"])
+        assert out[0]["hour"] == 5.0
+
+    def test_unknown_model_raises(self):
+        case = _synthetic_case()
+        with pytest.raises(ValueError, match="not in case"):
+            sample_hewson_at_route(case, "nope", [(47.0, 2.0)])
+
+    def test_hours_length_mismatch_raises(self):
+        case = _synthetic_case()
+        with pytest.raises(ValueError, match="hours has length"):
+            sample_hewson_at_route(
+                case, "syn",
+                [(47.0, 2.0), (48.0, 3.0)],
+                hours=[0.0, 1.0, 2.0],
+            )
+
+    def test_default_hour_zero(self):
+        case = _synthetic_case()
+        out = sample_hewson_at_route(case, "syn", [(47.0, 2.0)])
+        # Default h=0 → θe = 290 + 94 + 0 = 384
+        assert out[0]["theta_e"] == pytest.approx(384.0, abs=1e-6)
+        assert out[0]["hour"] == 0.0


### PR DESCRIPTION
## Summary

- Implements Phase A of the Hewson aviation-advisories roadmap (#90): **per-waypoint sampling of Hewson diagnostics** along a route, with bilinear spatial interp + linear temporal interp.
- Exposes the sampler via a new `route-hewson` CLI subcommand that resolves ICAO codes through the existing euro_aip airport DB.
- Ships two retrospective analysis scripts that validate the signal against the author's real flight log + cancellation log — first pairwise validation gives **3/3 agreement** (cancelled days scored higher than their replacement days).
- Applies SRTM terrain masking (cached to `data/era5/terrain_mask.npz`) so Alpine / Pyrenean sub-surface extrapolation doesn't contaminate gradients.

## What's in the PR

| File | Role |
|---|---|
| `src/weatherbrief/frontal/route_sampling.py` | `sample_hewson_at_route()` + reusable `bilinear_sample()` |
| `src/weatherbrief/frontal/cli.py` | new `route-hewson` subcommand |
| `tests/test_frontal_route_sampling.py` | 12 tests — bilinear math + full-pipeline glue |
| `scripts/analyze_flight_log.py` | CSV flight log → Hewson retrospective markdown report |
| `scripts/analyze_cancellations.py` | freeform cancel.md → paired cancel-vs-replacement report |
| `designs/future/hewson-fields-aviation-advisories.md` | status flipped: Phase A done, ERA5 bulk fetch done |

## Validation highlights

Running against 1 year of ERA5 analyses (2025-02 → 2026-02):

- **83 flights** analysed; 51 fire ≥1 advisory.
- **10 cancellations**, 3 with replacement-day pairs.
- **Pairwise score test: 3/3 agreement** — every cancelled-day's excitement score exceeded its replacement-day's.
- Terrain mask (190 of 19,493 cells above 1500 m) keeps Alpine flights honest, though calibrated thresholds still need work (the excitement score currently over-indexes on summer convective outlook).

The retrospective reports are gitignored (`data/era5/`) but the scripts reproduce them deterministically from the CSV logs.

## Test plan

- [x] `pytest tests/test_frontal_route_sampling.py -q` → 12/12 pass
- [x] `route-hewson --case data/calibration/2023-11-02_era5_ciaran --model era5 --waypoints "EGLL LFPG EDDF LOWW" --hour 12` → physically sensible Storm Ciarán advection (cold behind front, warm ahead)
- [x] Full flight-log retrospective runs to completion (~2 min for 83 flights)
- [x] Full cancellation retrospective runs to completion and prints pairwise summary
- [x] Pre-existing test suite unchanged (3 pre-existing failures in `test_frontal_grid.py` also fail on main)

## Follow-ups (not in this PR)

- Phase B: multi-level NPZ + `Case.fields(level_hPa=...)` back-compat — separate PR on its own branch.
- p95-aggregator swap for `grad_max` in retrospective (one route point shouldn't dominate route-wide scores) — small cleanup, can go in Phase B PR or standalone.
- Debrief feature + pilot-owned calibration dataset: tracked in #92.

Related: #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)