### PR TITLE
feat(frontal): Phase B — multi-level Case storage (925/850/700 hPa)

### DIFF
--- a/designs/future/hewson-fields-aviation-advisories.md
+++ b/designs/future/hewson-fields-aviation-advisories.md
@@ -181,34 +181,47 @@ Small enough that the "precompute" pipeline can keep everything in a handful of 
 
 ## 6. Architecture
 
-### 6.1 Precompute pipeline (offline, cron)
+### 6.1 Precompute pipeline (hooks into existing 6 h frontal fetch)
+
+**Key decision (2026-04-24)**: don't stand up a new cron. The frontal-detection pipeline already fetches the full 0.25° European grid every 6 h to feed DWD frontal zones. Hewson computation piggybacks on that fetch — same grid, ~5 min of added compute, separate NPZ output. Source-agnostic: today the fetch is Open-Meteo; when native-GRIB ingestion for ECMWF/ICON/GFS lands it becomes a call-site swap.
 
 ```
-scheduled twice a day per model
-  ↓
-fetch_multi_level_grid(model, init_time, levels=[925,850,700])
-  ↓  (Open-Meteo chunked, ~30 requests per model)
-compute_hewson_diagnostics() on each (level, hour)
+existing 6 h frontal grid fetch (all models)
+  ↓  (grid already in memory for frontal zones)
+compute_hewson_diagnostics() for each (level ∈ {925, 850, 700}, hour)
   ↓
 np.savez_compressed("data/hewson/<model>/<init>.npz",
-                     gradient=..., advection=..., ...)
+                     theta_e, gradient, neg_laplacian, tfp,
+                     advection, tendency)
   ↓
-retain last 2 cycles, purge older
+retain 48 h, purge older
 ```
 
-### 6.2 Briefing read path (on-demand)
+Snapshot size at 0.25° × 101×193 × 3 levels × 6 metrics × float32 ≈ **1.4 MB raw / ~500 KB compressed**. With 48 h retention × 3 models × 2 cycles/day ≈ **~24 MB total on disk**. Trivial.
+
+### 6.2 Read paths (on-demand)
+
+Three surfaces consume the precompute snapshot — each reads what it needs:
 
 ```
-briefing pipeline → load_snapshot(model, latest_init)
-  ↓
-sample_hewson_at_route(snapshot, route_points)
-  ↓                                  ↑
-  (tri-interpolation: lat/lon, log-p, hour)
-  ↓
-per-waypoint + per-leg summaries → advisory evaluators
-  ↓
-advisories.json + cross-section + map layer
+Map layer (§7):
+    /api/hewson-map → full (n_lat, n_lon) grid at one (model, init, level, hour, metric)
+
+Cross-section bands (§7.9, Open-Meteo era):
+    bilinear-sample snapshot at each waypoint × {925, 850, 700}
+    → 3 discrete-altitude bands overlaid on the existing cross-section canvas
+
+Cross-section stencil (§7.9, GRIB era):
+    per-briefing stencil in the native GRIB at each waypoint × all 25+ native pressure levels
+    → continuous-altitude Hewson on the cross-section
+    (Gated on native-GRIB ingestion; NOT from the precompute grid)
+
+Advisory evaluators (Phase C):
+    sample_hewson_at_route(snapshot, route_points) + altitude-appropriate level
+    → per-leg max/mean → §3 thresholds → advisories.json
 ```
+
+Rationale for the stencil split: the precompute is tuned for the map (3 levels is enough — pilot picks one at a time). The cross-section wants continuous altitude, which the 3-level precompute can't give. The briefing pipeline already parses the full-native-levels GRIB per route for cloud rendering — a stencil extraction around each waypoint at those same levels costs almost nothing.
 
 ### 6.3 Route sampling — three axes
 
@@ -269,10 +282,11 @@ One lookup into the precompute snapshot. ~1 ms response.
 ### 7.4 Frontend controls
 
 - **Metric dropdown**: θe, |∇θe|, −∇²θe, TFP, −V·∇θe, ∂θe/∂t (6 options; grouped by purpose)
-- **Level selector**: `925 / 850 / 700` hPa — with pilot-friendly labels `2,500 / 5,000 / 10,000 ft`
+- **Level selector**: `925 / 850 / 700` hPa — with pilot-friendly labels `2,500 / 5,000 / 10,000 ft`. Explicitly 3 levels, not 5: 500/400 hPa are upper-IFR and out of scope for GA.
 - **Time slider**: reuse the one from model-accuracy heatmap
 - **Opacity slider**: stack under existing per-airport markers
 - **Colormap**: baked per metric (diverging RdBu for advection/tendency, sequential YlOrRd for gradient) — **same mapping as the `plot-hewson` CLI** so debug + pilot-facing views are identical.
+- **Per-metric info popover** — a small (i) icon on the metric dropdown. Tapping opens the pilot-facing interpretation for that metric (ranges, decision rules), drawn from §2. This surfaces as "learning in context" so pilots can absorb meaning while they use the tool rather than reading a separate guide.
 
 ### 7.5 Rendering
 
@@ -283,6 +297,28 @@ At low zoom, cells are visible as pixelated boxes. Accepted — scientifically h
 ### 7.6 Legal
 
 Carry over the existing "advisory-only / not for operational use" disclaimer pattern from the rest of the briefing.
+
+### 7.9 Cross-section Hewson overlay
+
+Sibling to the map layer — overlays Hewson information on the existing route cross-section canvas (`web/ts/visualization/cross-section/renderer.ts`, layer-registry pattern). Adds new `CrossSectionLayer` implementations alongside the existing cloud / icing / CAT / inversion layers.
+
+**Two-phase build-out**:
+
+**Phase D.1 (Open-Meteo era — now)**:
+- Reads the **precompute snapshot** at each waypoint × {925, 850, 700} via bilinear-sample
+- Renders 3 horizontal **bands** at 2,500 / 5,000 / 10,000 ft, coloured by the selected metric
+- Same colormap as the map (consistency)
+- Metric picker shared with the map — changing the map metric changes the cross-section bands
+- Cost: <1 ms per briefing (just three bilinear samples per waypoint)
+
+**Phase D.2 (GRIB era — later, gated on native-GRIB ingestion)**:
+- Per-briefing **stencil** sampling: around each waypoint, extract a 3×3 (or 5×5 for cleaner 2nd derivatives) stencil from the briefing's already-loaded GRIB at each of the **25+ native pressure levels** the ingestion subsets
+- Compute Hewson diagnostics on the stencil per waypoint × per level
+- Gives **continuous-altitude Hewson** on the cross-section (not just 3 bands)
+- Cost: tens of ms even for a 20-waypoint route × 25 levels, because GRIB is already parsed and stencil math is trivial
+- Reuses the same `CrossSectionLayer` surfaces — UI doesn't change, data source upgrades silently
+
+The 3-level precompute is kept small on purpose: it exists to feed the map, and the map shows one level at a time anyway. Adding levels to the precompute just to support the cross-section would be wasteful when the cross-section can draw from richer per-briefing data.
 
 ## 8. Accuracy expectations
 
@@ -339,6 +375,48 @@ DTN, Baron, Meteologix, Weatherous → sophisticated interactive tools, but targ
 ### 10.5 Our angle
 
 Not trying to be MF or DWD. Building **GA-pilot-facing advisories with plain-English output, route-aware, tied to the pilot's actual flight**. Genuinely underserved because no commercial stack has both the aviation focus and the willingness to ship derived advisories.
+
+## 10a. Known limitations — what Hewson alone does not tell you
+
+Surfaced during the 2026-04-24 retrospective pass. None are blockers for shipping Phase D, but each points at a follow-up track.
+
+### 10a.1 Hewson ≠ cloud
+
+`|∇θe|` measures thermal air-mass boundaries at one pressure level. It **doesn't** directly measure cloud presence. A dry cold front and a moist cold front produce the same gradient magnitude; only one comes with IFR ceilings.
+
+Implication: a loud map might overlay a **dry** synoptic feature that had no operational impact. Or: a boring map might hide **local IMC** (morning stratus, fog). In the 27/28-Apr retrospective pair, the actual blocker on the 27th was local IMC at LFMD which the 850 hPa θe field simply didn't see — it's above the stratus layer.
+
+**Fix track (Phase E moisture cross-check)**:
+- Compute `RH₉₂₅` from existing T + q (zero new fetch — we already have what we need)
+- Fetch ERA5 / briefing-pipeline **low cloud cover (LCC)** and **total precipitation (TP)** — single-level fields, small additional bytes
+- Optionally **CAPE** for convective outlook
+- Combined filter: "Hewson loud **and** LCC > X **and** RH₉₂₅ > Y" → real weather. "Hewson loud, moisture low" → dry ribbon, probably flyable.
+
+### 10a.2 850 hPa is too high for low IMC
+
+850 hPa ≈ 5,000 ft. A morning stratus layer at 1,500 ft or fog below the inversion won't show in `θe₈₅₀`. The map is fundamentally about **free-atmosphere** weather, not boundary-layer weather.
+
+Implication: never claim the map tells you about local ceilings/vis. That's METAR/TAF territory. Hewson's job is to say "a significant weather *system* is approaching/over your route" — surface conditions need separate inputs.
+
+### 10a.3 Route-aggregator sensitive to single cells
+
+The retrospective scripts use `grad_max` (max across 12 route sample points) to summarise a route — which is dominated by one outlier cell. The route-mean / P95 is more honest. Proposed tweak for the analysis scripts:
+
+```
+grad_summary = P95(sample_points)   # instead of max(…)
+```
+
+Single-line change; keep the pair-wise cancel test (currently 3/3) as regression.
+
+### 10a.4 Excitement score over-indexes on summer θe
+
+Current score fires `convective-outlook` at `θe > 315 K`, which flags most summer flights regardless of actual convection. `θe` alone can't predict convection without **lapse rate** (which we'd need a second pressure level to compute, or CAPE). Two options:
+- Raise threshold to `θe > 325 K` (tuned to pilot-calibrated cancellations)
+- Drop the convective term from the score until we have CAPE
+
+Both park until we do the Phase E moisture work.
+
+---
 
 ## 11. Phased rollout
 
@@ -414,90 +492,154 @@ What was pivotal about this session — we made the pipeline source-agnostic bef
 - Cadence 00Z + 12Z per model
 - Retention: 48 h (see `fetch.md` for the existing retention pattern)
 
-### Phase C — Advisory evaluators
+### Phase D — Interactive map + cross-section overlay (NEXT)
+
+**Goal**: ship forecast-page visualization per §7 (map overlay) + §7.9 (cross-section bands), so pilots can see the Hewson fields *now*, without waiting for the advisory-text calibration loop.
+
+**Rationale for D before C**: the map + cross-section expose the raw signal with pilot-facing tooltips (§7.4, §2). This:
+- Gives pilots useful information from day one (teaching intuition by display)
+- Lets us observe which fields actually matter for *their* decisions before we commit thresholds in code (Phase C)
+- Validates Phase B's precompute output end-to-end without advisory-wording churn
+- Sidesteps the current calibration blocker (moisture gap — see §10a.1)
+
+**Phase D.0 — Precompute cron** ([task #8]):
+- Hook into the existing 6 h frontal grid fetch (no new cron)
+- Compute `theta_e, gradient, neg_laplacian, tfp, advection, tendency` at **925/850/700 hPa only**
+- Save snapshot NPZ per `(model, init)` under `data/hewson/<model>/<init>.npz`, retain 48 h
+- Source-agnostic: swaps Open-Meteo → native GRIB later without contract change
+
+**Phase D.1 — Backend endpoint** ([task #9]):
+- `GET /api/hewson-map?model=ecmwf&init=<t>&level=850&metric=advection&hour=24` → JSON or binary grid of shape (n_lat, n_lon)
+- Reuses pack-access auth pattern from `packs.py`
+
+**Phase D.2 — Map layer** ([task #10]):
+- First **gridded** Leaflet CanvasLayer on the forecast page (today the forecast map is point-only, so this is the reusable pattern for future gridded overlays)
+- Controls per §7.4: metric dropdown, 3-level selector with ft labels, hour slider, opacity
+- Per-metric info popover tied to §2 pilot interpretations
+
+**Phase D.3 — Cross-section bands** ([task #11]):
+- New `CrossSectionLayer` implementations per §7.9 Phase D.1
+- Bilinear-samples the precompute snapshot at each waypoint × {925, 850, 700}
+- Draws 3 horizontal bands at 2,500 / 5,000 / 10,000 ft, shared colormap with map
+- Shares metric picker with the map — changing one changes the other
+
+**Phase D.4 — Stencil-in-GRIB era** ([task #12], later, gated on native-GRIB ingestion):
+- Per-briefing stencil sampling at all 25+ native pressure levels per §7.9 Phase D.2
+- Turns the cross-section's 3 discrete bands into continuous altitude — silently, via data-source swap
+
+### Phase C — Advisory evaluators (after D)
 
 **Goal**: the six advisories from §3 wired into `evaluate_all()`.
 
 - Six new evaluators in `src/weatherbrief/advisories/evaluators/` following the existing registry pattern (see `designs/advisories.md`)
-- Tri-axis sampling: for each route point × flight altitude (mapped to pressure level) × ETA → get Hewson field values
-- Per-leg aggregation: max / mean / integral of each field across segment sample points
-- Threshold logic per §3 table
+- Tri-axis sampling: for each route point × flight altitude (mapped to pressure level) × ETA → get Hewson field values (reuses `sample_hewson_at_route` from Phase A)
+- Per-leg aggregation: max / mean / **P95** of each field across segment sample points (P95 not max — see §10a.3)
+- Threshold logic per §3 table, refined with pilot feedback from Phase D telemetry
 - Integration: new advisories show up alongside the existing 14 in the briefing
 
-### Phase D — Interactive map layer
+### Phase E — Moisture cross-check + stretch (future)
 
-**Goal**: forecast-page visualization per §7.
+Opens after Phase D so the map + cross-section surface has something to show moisture *on*.
 
-- Backend `/api/hewson-map?model=...&init=...&level=...&metric=...&hour=...` endpoint
-- Frontend layer on `WeatherMap` component (see `designs/forecast-page.md`)
-- Metric / level / time / opacity controls
-- Colormap synced with `plot-hewson` CLI debug plot
-
-**Phase ordering note**: C and D are independent after B. For early pilot feedback, **ship D first** — the map is more visually compelling and helps validate Phase B output without the advisory-wording churn.
-
-### Phase E (future, speculative)
-
+- **RH₉₂₅** derived from existing T/q — zero new fetch (§10a.1)
+- **Low cloud cover (LCC)** + **total precipitation (TP)** fetched alongside existing pipeline variables — small delta
+- **CAPE** for convection
+- **Combined filter for Phase C advisories**: "Hewson signal ∧ moisture present" → real weather; "Hewson ∧ dry" → suppress advisory (or show as educational)
 - **600 hPa** added if demand justifies
 - **METAR-trend validation** track in the verification digest
-- **Native GRIB** ingest (ECMWF Cycle 50r1 already on the droplet, ICON-EU full) to remove Open-Meteo interpolation layer
-- **Cross-section layer** for advection / tendency (new layer in `visualization`)
+- **Debrief feature** (issue #92) — pilot-owned dataset for real-time calibration
 - **Surface θe** for convective outlook (needs 2 m T + Td)
-- **wetter3.de archive integration** — replace live DWD download with archive pull when case `--date` is in the past (currently the new-case CLI downloads today's DWD chart regardless of case date)
+- **wetter3.de archive integration** — replace live DWD download with archive pull when case `--date` is in the past
 
 ## 12. Status snapshot
 
 | Item | Status |
 |---|---|
-| **Phase 1 + 2 (Hewson diagnostics + CLI)** | ✅ Done (2026-04-24) |
-| **Architecture consolidation (0.25°, ERA5 loader, unified Case)** | ✅ Done (2026-04-24) |
-| Resolution decision | ✅ 0.25° |
-| Level decision | ✅ 925 / 850 / 700 hPa |
-| Cadence decision | ✅ 2×/day (00Z, 12Z) |
-| Storage decision | ✅ NPZ (Zarr deferred) |
+| **Phase 1 + 2 (Hewson diagnostics + CLI)** | ✅ Done (PR #91, merged) |
+| **Architecture consolidation (0.25°, ERA5 loader, unified Case)** | ✅ Done (PR #91, merged) |
+| Resolution decision | ✅ 0.25° — consistent across all three models (ECMWF order at 0.25°, GFS/ICON ingestion at 0.25°) |
+| Level decision | ✅ 925 / 850 / 700 hPa (3 levels; 500/400 explicitly rejected as upper-IFR out-of-scope) |
+| Cadence decision | ✅ 2×/day (00Z, 12Z) — hooks into existing 6h frontal fetch, not a new cron |
+| Storage decision | ✅ NPZ flat level-suffixed keys; ~24 MB total across 48h × 3 models |
 | Retention decision | ✅ 48 h cache |
-| ERA5 smoke test | ✅ Storm Ciarán 2023-11-02 validated |
-| ERA5 bulk fetch | ⏳ In flight on server — 2025-02 → 2026-02 (1 year, ~700 MB, covers summer convective + winter cyclonic) |
-| **Phase A** (route sampling) | Next up — unblocked |
-| Phase B (multi-level + precompute) | 🟡 Storage done (2026-04-24) — CLI surface + Ciarán rebuild next; live-precompute gated on Phase D |
-| Phase C (advisory evaluators) | Requires Phase B |
-| Phase D (map layer) | Requires Phase B; can ship before C |
-| wetter3.de archive (retrospective DWD charts) | Known gap — not blocking |
+| ERA5 bulk fetch | ✅ Done (1 year, 2025-02 → 2026-02, ~700 MB on disk at `data/era5/hewson/`) |
+| **Phase A** (route sampling) | ✅ Done (PR #93 open) — `sample_hewson_at_route`, `route-hewson` CLI, retrospective scripts |
+| **Phase B.1** (multi-level Case storage) | ✅ Done (PR #94 open) — multi-level NPZ, back-compat, 10 tests |
+| Phase B.2 (CLI `--levels`, rebuild Ciarán at 3 levels) | 🟡 Small follow-up; can slot anywhere |
+| **Phase D.0** (precompute cron) | 🎯 **NEXT** — hooks into existing 6h frontal fetch |
+| Phase D.1 (backend endpoint) | Requires D.0 |
+| Phase D.2 (map layer + tooltips) | Requires D.1 |
+| Phase D.3 (cross-section bands) | Requires D.0 |
+| Phase D.4 (stencil in GRIB era) | Gated on native-GRIB ingestion being live for the user's briefing model |
+| Phase C (advisory evaluators) | After Phase D, informed by what pilots actually use from the map/cross-section |
+| Phase E (moisture cross-check) | After Phase D — RH₉₂₅, LCC, TP, CAPE, debrief feature #92 |
+| Retrospective validation | ✅ Pairwise cancel test 3/3 (all pilot-cancellation days scored higher than replacement-flown days) — best calibration signal we have |
 
-## 12a. Quick pickup from fresh context
+## 12a. Quick pickup from fresh context (for Phase D start)
 
-If you're resuming this work in a new session, here's the minimum to load:
+After PRs #93 (Phase A) and #94 (Phase B) merge, the next session picks up here.
 
-```bash
-# From repo root
-# 1. Read the current state of the case pipeline
-python -m weatherbrief.frontal.cli --help
-# → see new-case / plot-hewson / score / redraw-zones
+### What's already on main
 
-# 2. Reproduce Storm Ciarán end-to-end (GRIB already on disk):
-python -m weatherbrief.frontal.cli plot-hewson \
-    --case data/calibration/2023-11-02_era5_ciaran \
-    --model era5 --hour 12 --field theta_e
-# → data/calibration/2023-11-02_era5_ciaran/hewson_era5_theta_e_T12.png
+- Hewson diagnostics math (`compute_hewson_diagnostics`) + `plot-hewson` CLI
+- Multi-level Case storage (NPZ with level-suffixed keys)
+- Route sampling library: `sample_hewson_at_route(case, model, waypoints, hours)` and `bilinear_sample` helper in `src/weatherbrief/frontal/route_sampling.py`
+- `route-hewson` CLI subcommand that resolves ICAO codes and prints per-waypoint values
+- Retrospective scripts: `scripts/analyze_flight_log.py` and `scripts/analyze_cancellations.py`
+- 1 year of ERA5 GRIBs at `data/era5/hewson/` (gitignored)
 
-# 3. To re-fetch ERA5 (server-side):
-ssh brice@server
-cd /mnt/data/downloads/era5_download
-. venv/bin/activate
-python smoke_era5_hewson.py --output-dir ./data/ --date 2024-01-22
-# rsync -avz brice@server:/mnt/data/downloads/era5_download/data/era5_hewson_smoke_2024-01-22.grib data/era5/
+### What Phase D needs (starting with task #8 — precompute cron)
+
+The job is to hook Hewson computation into the **existing 6h frontal grid fetch** so that every cycle produces a snapshot NPZ at `data/hewson/<model>/<init>.npz`.
+
+**Entry points to find first**:
+- Existing frontal fetch pipeline — grep `fetch_grid_fields` in `src/weatherbrief/frontal/grid.py` and its callers
+- The cron / scheduler — look at how DWD frontal zones are currently refreshed every 6h (check `designs/fetch.md` and `data/frontal_cache/`)
+- Snapshot storage — the retrospective already writes `data/era5/terrain_mask.npz` as a cached artefact; follow that path pattern
+
+**Snapshot schema** (confirmed §6.1):
+```python
+np.savez_compressed(
+    f"data/hewson/{model}/{init_iso}.npz",
+    # per level ∈ {925, 850, 700}:
+    theta_e_925=..., gradient_925=..., neg_laplacian_925=...,
+    tfp_925=..., advection_925=..., tendency_925=...,
+    theta_e_850=..., gradient_850=..., # ... same set ...
+    theta_e_700=..., gradient_700=..., # ... same set ...
+    valid_times=...,  # for temporal interp
+    lat=..., lon=...,
+)
 ```
 
-**Key files** for Phase A pickup:
-- `src/weatherbrief/frontal/case.py` — Case abstraction (start here)
-- `src/weatherbrief/frontal/detect.py` — `compute_hewson_diagnostics()` (math we're sampling)
-- `src/weatherbrief/frontal/cli.py:_cmd_plot_hewson` — closest existing CLI pattern
-- `src/weatherbrief/era5/loader.py` — if touching level logic
-- This doc — decisions and rationale
+**Reproduce Storm Ciarán to sanity-check**:
+```bash
+# Multi-level case (Phase B):
+python -m weatherbrief.frontal.cli new-case \
+    --source era5 --grib data/era5/era5_hewson_smoke_2023-11-02.grib \
+    --date 2023-11-02 --level 850
 
-**Open questions** intentionally left for Phase A:
-- How to resolve waypoints (ICAO/IATA codes vs lat/lon tuples)? Use `rzflight`'s `KnownAirports`.
-- Per-leg aggregation: sample N points between waypoints? N = 10 gives ~5 nm resolution on a 50 nm leg, matches our 0.25° grid.
-- Tendency when adjacent hours not present? Forward or backward diff — already handled in `_cmd_plot_hewson`.
+# Plot:
+python -m weatherbrief.frontal.cli plot-hewson \
+    --case data/calibration/2023-11-02_era5 \
+    --model era5 --hour 12 --field theta_e
+```
+
+### Key files for Phase D pickup
+
+- `src/weatherbrief/frontal/detect.py` — `compute_hewson_diagnostics()` (math to call per-cycle)
+- `src/weatherbrief/frontal/grid.py` — `fetch_grid_fields`, `build_terrain_mask`
+- `src/weatherbrief/frontal/case.py` — Case/meta persistence pattern (reuse NPZ conventions)
+- `src/weatherbrief/frontal/route_sampling.py` — `bilinear_sample` for cross-section bands reading the snapshot
+- `web/ts/visualization/cross-section/renderer.ts` + `layer-registry.ts` — cross-section layer pattern to follow for §7.9
+- `designs/forecast-page.md` — where the map layer lives (point-marker pattern today; gridded-canvas layer is net new)
+- **This doc** — decisions and rationale; §10a is the list of known gaps so the next pass doesn't re-discover them
+
+### Open questions left for Phase D
+
+- How does the existing 6h frontal-zone refresh invoke itself? Find its entry point so Hewson piggybacks cleanly (vs adding a second scheduler).
+- Snapshot format: pure NPZ flat-keys (per §6.1) or migrate to Zarr now? → NPZ per §4.5 — Zarr only when the map serves subsets over the network.
+- Map layer client: single gridded CanvasLayer for all 6 metrics (redraw on metric change), or 6 pre-rendered PNG tiles served statically? → start with JSON/binary + canvas (per §7.5), revisit tiling if latency needs it.
+- Pilot-facing tooltip text: draw from §2 directly (short form) or maintain a separate `docs/hewson-pilot-guide.md`? → start inline per §7.4, promote to a doc if it grows.
 
 ## 13. Related docs
 

--- a/designs/future/hewson-fields-aviation-advisories.md
+++ b/designs/future/hewson-fields-aviation-advisories.md
@@ -398,25 +398,18 @@ What was pivotal about this session — we made the pipeline source-agnostic bef
 
 **Goal**: production-grade precompute at 0.25° × 925/850/700 hPa.
 
-**What exists:**
-- `scripts/smoke_era5_hewson.py` on the ERA5 server (`brice@server:/mnt/data/downloads/era5_download/`) — proven to fetch one day × 3 levels × 4 times in ~1 min
-- `load_era5_fields(grib, timestamp, level_hPa)` accepts any of 925/850/700 — multi-level is a call-site change, not a loader change
+**Shipped (2026-04-24):**
+- `scripts/smoke_era5_hewson.py` on the ERA5 server — proven to fetch one day × 3 levels × 4 times in ~1 min
+- `scripts/download_era5_hewson.py` on the server — monthly loop, one GRIB per month
+- Bulk fetch done: 1 year 2025-02 → 2026-02 (~700 MB, rsynced to `data/era5/hewson/`)
+- `load_era5_fields(grib, timestamp, level_hPa)` accepts any of 925/850/700
+- **Multi-level Case storage**: `build_case_from_era5(..., level_hPa: int | list[int])`, `Case.fields(model, hour, level_hPa=...)`, `Case.available_levels(model)`. NPZ uses flat level-suffixed keys (`T_925, T_850, T_700, Td_*, theta_e_*, u_*, v_*`) for multi-level; legacy single-level 850 format preserved for back-compat (cases with no `levels` field in meta.json default to `[850]`). Inner dict keys stay `T850, Td850, theta_e, u850, v850` regardless of actual level — `850` is historical, values are from the requested level. Tests in `tests/test_frontal_case.py`.
 
-**What to build:**
-- `scripts/download_era5_hewson.py` — adapt `download_era5_t850.py` on the server. Loop over months (configurable `--from-month YYYY-MM --to-month YYYY-MM`), with `--max-concurrent` like the Z500 downloader. Store as one monthly GRIB per file (same pattern).
-- Bulk fetch on server: **Oct 2024 → Mar 2025** (6 months, winter/spring — captures Atlantic cyclone season). Expected size ~150-200 MB. Wall-time ~1 hour.
-- Rsync to local `data/era5/hewson/`
-- Extend `build_case_from_era5` to accept `level_hPa: list[int]` and store multi-level NPZ:
-  ```
-  raw/era5.npz:
-      T_925, Td_925, theta_e_925, u_925, v_925,   # 925 hPa
-      T_850, Td_850, theta_e_850, u_850, v_850,   # 850 hPa
-      T_700, Td_700, theta_e_700, u_700, v_700,   # 700 hPa
-      valid_times
-  ```
-- `Case.fields(model, hour, level_hPa=850)` optional level argument (defaults to 850 for back-compat)
+**Still to build:**
+- CLI: `new-case --source era5 --levels 925,850,700` — wire the list arg through to `build_case_from_era5` (currently accessible only via library).
+- Rebuild the Ciarán case at 3 levels to prove the path end-to-end on a real debug case.
 
-**Live-data precompute** (future split-off):
+**Live-data precompute** (future split-off, gated on Phase D):
 - New `src/weatherbrief/hewson/precompute.py` runs on cron: fetch → compute → NPZ snapshot per model per cycle
 - Cadence 00Z + 12Z per model
 - Retention: 48 h (see `fetch.md` for the existing retention pattern)
@@ -463,9 +456,9 @@ What was pivotal about this session — we made the pipeline source-agnostic bef
 | Storage decision | ✅ NPZ (Zarr deferred) |
 | Retention decision | ✅ 48 h cache |
 | ERA5 smoke test | ✅ Storm Ciarán 2023-11-02 validated |
-| ERA5 bulk fetch | ✅ Done (1 year, 2025-02 → 2026-02, on `/mnt/data/downloads/era5_download/data/hewson/` — pending rsync to `data/era5/hewson/`) |
-| **Phase A** (route sampling) | ✅ Done (2026-04-24) — `route_sampling.py`, `route-hewson` CLI, unit tests all green |
-| Phase B (multi-level + precompute) | Requires Phase A |
+| ERA5 bulk fetch | ⏳ In flight on server — 2025-02 → 2026-02 (1 year, ~700 MB, covers summer convective + winter cyclonic) |
+| **Phase A** (route sampling) | Next up — unblocked |
+| Phase B (multi-level + precompute) | 🟡 Storage done (2026-04-24) — CLI surface + Ciarán rebuild next; live-precompute gated on Phase D |
 | Phase C (advisory evaluators) | Requires Phase B |
 | Phase D (map layer) | Requires Phase B; can ship before C |
 | wetter3.de archive (retrospective DWD charts) | Known gap — not blocking |

--- a/src/weatherbrief/frontal/case.py
+++ b/src/weatherbrief/frontal/case.py
@@ -5,15 +5,20 @@ specific date: raw grid data, reference charts, zone annotations.
 
 Layout:
     data/calibration/<case>/
-        meta.json                    # source, grid, models, valid_times
+        meta.json                    # source, grid, models, valid_times, levels
         raw/
             <model>.npz              # per-model: (n_time, n_lat, n_lon) arrays
         reference/                   # DWD / ICON forecast charts
         expected.yaml                # zone-level front annotations
 
-NPZ contents per model:
+NPZ contents per model, single-level (legacy, 850 hPa only):
     T850, Td850, theta_e, u850, v850  — (n_time, n_lat, n_lon) float32
     valid_times                        — (n_time,) datetime64[ns]
+
+NPZ contents per model, multi-level (when ``meta["levels"][model]``
+contains more than one entry — Phase B):
+    T_<L>, Td_<L>, theta_e_<L>, u_<L>, v_<L>   for each L in levels
+    valid_times
 
 For Open-Meteo cases, <model> is ecmwf / gfs / icon. The NPZ carries
 hourly forecast data from a single init cycle.
@@ -59,6 +64,7 @@ class Case:
     models: list[str]                       # e.g. ["ecmwf", "gfs", "icon"] or ["era5"]
     valid_times: dict[str, np.ndarray]      # model → (n_time,) datetime64[ns]
     init_times: dict[str, int]              # model → unix seconds; 0 for ERA5
+    levels: dict[str, list[int]] = field(default_factory=dict)  # model → sorted hPa levels present
     _meta: dict = field(default_factory=dict, repr=False)
     # Cache of available_hours results per model — lazy, computed once.
     _hours_cache: dict[str, list[int]] = field(default_factory=dict, repr=False)
@@ -86,36 +92,36 @@ class Case:
         self._hours_cache[model] = hours
         return hours
 
-    def fields(self, model: str, hour: int) -> dict | None:
-        """Return field dict for one model × one hour-offset, or None."""
+    def available_levels(self, model: str) -> list[int]:
+        """Pressure levels (hPa, sorted) available for this model."""
+        return list(self.levels.get(model, [850]))
+
+    def fields(self, model: str, hour: int, level_hPa: int | None = None) -> dict | None:
+        """Return field dict for one model × one hour-offset × one level, or None.
+
+        ``level_hPa`` defaults to 850 if present, else the first available level.
+        Returned dict always uses the legacy key names (``T850, Td850, theta_e,
+        u850, v850``) regardless of the actual level — the ``850`` in the key is
+        historical; the values are from the requested level.
+        """
         idx = self._index_at_hour(model, hour)
         if idx is None:
             return None
+        level_hPa = self._resolve_level(model, level_hPa)
         npz = np.load(self.case_dir / "raw" / f"{model}.npz")
         try:
-            return {
-                "T850": npz["T850"][idx].astype(np.float64),
-                "Td850": npz["Td850"][idx].astype(np.float64),
-                "theta_e": npz["theta_e"][idx].astype(np.float64),
-                "u850": npz["u850"][idx].astype(np.float64),
-                "v850": npz["v850"][idx].astype(np.float64),
-            }
+            return _read_level_slice(npz, idx, level_hPa)
         finally:
             npz.close()
 
-    def fields_all_hours(self, model: str) -> dict[int, dict]:
-        """Return {hour_offset: fields_dict} for every available hour."""
+    def fields_all_hours(self, model: str, level_hPa: int | None = None) -> dict[int, dict]:
+        """Return {hour_offset: fields_dict} for every available hour at one level."""
+        level_hPa = self._resolve_level(model, level_hPa)
         npz = np.load(self.case_dir / "raw" / f"{model}.npz")
         try:
             hours = self.available_hours(model)
             return {
-                hours[i]: {
-                    "T850": npz["T850"][i].astype(np.float64),
-                    "Td850": npz["Td850"][i].astype(np.float64),
-                    "theta_e": npz["theta_e"][i].astype(np.float64),
-                    "u850": npz["u850"][i].astype(np.float64),
-                    "v850": npz["v850"][i].astype(np.float64),
-                }
+                hours[i]: _read_level_slice(npz, i, level_hPa)
                 for i in range(len(hours))
             }
         finally:
@@ -134,6 +140,46 @@ class Case:
             return hours.index(hour)
         except ValueError:
             return None
+
+    def _resolve_level(self, model: str, level_hPa: int | None) -> int:
+        avail = self.available_levels(model)
+        if level_hPa is None:
+            return 850 if 850 in avail else avail[0]
+        if level_hPa not in avail:
+            raise ValueError(
+                f"Level {level_hPa} hPa not in case levels {avail} for model {model!r}"
+            )
+        return level_hPa
+
+
+def _read_level_slice(npz, idx: int, level_hPa: int) -> dict:
+    """Read one (time, level) slice from an open NPZ, normalising keys.
+
+    Supports both legacy (``T850, Td850, theta_e, u850, v850``) and the new
+    multi-level format (``T_<L>, Td_<L>, theta_e_<L>, u_<L>, v_<L>``). The
+    returned dict always uses the legacy keys so downstream code works
+    unchanged — the values are from the requested ``level_hPa``.
+    """
+    if f"T_{level_hPa}" in npz.files:
+        return {
+            "T850": npz[f"T_{level_hPa}"][idx].astype(np.float64),
+            "Td850": npz[f"Td_{level_hPa}"][idx].astype(np.float64),
+            "theta_e": npz[f"theta_e_{level_hPa}"][idx].astype(np.float64),
+            "u850": npz[f"u_{level_hPa}"][idx].astype(np.float64),
+            "v850": npz[f"v_{level_hPa}"][idx].astype(np.float64),
+        }
+    # Legacy single-level 850 format.
+    if level_hPa != 850:
+        raise ValueError(
+            f"NPZ only has legacy 850 hPa fields; cannot read level {level_hPa}"
+        )
+    return {
+        "T850": npz["T850"][idx].astype(np.float64),
+        "Td850": npz["Td850"][idx].astype(np.float64),
+        "theta_e": npz["theta_e"][idx].astype(np.float64),
+        "u850": npz["u850"][idx].astype(np.float64),
+        "v850": npz["v850"][idx].astype(np.float64),
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -160,23 +206,33 @@ def load_case(case_dir: str | Path) -> Case:
     lat = np.asarray(meta["lat"], dtype=np.float64)
     lon = np.asarray(meta["lon"], dtype=np.float64)
 
+    levels_meta = meta.get("levels", {})
     valid_times: dict[str, np.ndarray] = {}
     init_times: dict[str, int] = {}
+    levels: dict[str, list[int]] = {}
     for model in meta["models"]:
         npz_path = case_dir / "raw" / f"{model}.npz"
         if not npz_path.exists():
             raise FileNotFoundError(f"Missing raw data: {npz_path}")
+        model_levels = [int(L) for L in levels_meta.get(model, [850])]
         with np.load(npz_path) as npz:
             vt = npz["valid_times"]
-            if npz["T850"].shape[1:] != (len(lat), len(lon)):
+            shape_key = "T850" if "T850" in npz.files else f"T_{model_levels[0]}"
+            if shape_key not in npz.files:
                 raise ValueError(
-                    f"Shape mismatch in {npz_path}: T850 is "
-                    f"{npz['T850'].shape[1:]} but grid is "
+                    f"NPZ {npz_path} missing expected key {shape_key!r} — "
+                    f"levels in meta: {model_levels}"
+                )
+            if npz[shape_key].shape[1:] != (len(lat), len(lon)):
+                raise ValueError(
+                    f"Shape mismatch in {npz_path}: {shape_key} is "
+                    f"{npz[shape_key].shape[1:]} but grid is "
                     f"({len(lat)}, {len(lon)}). "
                     f"Case is from a different grid resolution."
                 )
         valid_times[model] = vt
         init_times[model] = meta.get("init_times", {}).get(model, 0)
+        levels[model] = sorted(model_levels)
 
     return Case(
         case_dir=case_dir,
@@ -188,6 +244,7 @@ def load_case(case_dir: str | Path) -> Case:
         models=list(meta["models"]),
         valid_times=valid_times,
         init_times=init_times,
+        levels=levels,
         _meta=meta,
     )
 
@@ -201,8 +258,13 @@ def save_case_meta(
     lon: np.ndarray,
     models: list[str],
     init_times: dict[str, int] | None = None,
+    levels: dict[str, list[int]] | None = None,
 ) -> None:
-    """Write meta.json for a case."""
+    """Write meta.json for a case.
+
+    ``levels`` maps model → list of pressure levels (hPa) stored in the NPZ.
+    When omitted, legacy single-level 850 hPa is assumed.
+    """
     case_dir.mkdir(parents=True, exist_ok=True)
     resolution = float(np.diff(lat).mean())
     meta = {
@@ -214,6 +276,7 @@ def save_case_meta(
         "lon": lon.tolist(),
         "models": models,
         "init_times": init_times or {},
+        "levels": {m: sorted(int(L) for L in (levels or {}).get(m, [850])) for m in models},
     }
     (case_dir / "meta.json").write_text(json.dumps(meta, indent=2))
 
@@ -223,6 +286,7 @@ def save_model_fields(
     model: str,
     fields_by_time: list[dict],
     valid_times: np.ndarray,
+    levels: list[int] | None = None,
 ) -> None:
     """Write raw/<model>.npz with the model's field timeseries.
 
@@ -230,29 +294,56 @@ def save_model_fields(
     ----------
     case_dir : case root directory (created if missing)
     model : model identifier (ecmwf, gfs, icon, era5)
-    fields_by_time : list of dicts (one per time) with keys
-        T850, Td850, theta_e, u850, v850 (all 2D arrays, same shape)
+    fields_by_time : list of dicts (one per time).
+        - Single level (``levels=None`` or ``[850]``): each dict has
+          ``T850, Td850, theta_e, u850, v850`` (2D arrays, legacy format).
+        - Multi level: each dict is keyed by pressure level (int), and
+          ``fields_by_time[i][L]`` is itself a dict with
+          ``T850, Td850, theta_e, u850, v850`` — the ``850`` suffix in the
+          inner keys is historical; values are at level ``L``.
     valid_times : (n_time,) np.datetime64 array matching fields_by_time
+    levels : list of pressure levels (hPa) present in ``fields_by_time``.
+        Defaults to ``[850]`` (legacy single-level).
     """
     raw_dir = case_dir / "raw"
     raw_dir.mkdir(parents=True, exist_ok=True)
 
-    def _stack(key: str) -> np.ndarray:
+    levels = sorted(int(L) for L in (levels or [850]))
+    is_multi = levels != [850]
+
+    def _stack_flat(key: str) -> np.ndarray:
         return np.stack([f[key] for f in fields_by_time], axis=0).astype(np.float32)
 
-    np.savez_compressed(
-        raw_dir / f"{model}.npz",
-        T850=_stack("T850"),
-        Td850=_stack("Td850"),
-        theta_e=_stack("theta_e"),
-        u850=_stack("u850"),
-        v850=_stack("v850"),
-        valid_times=valid_times.astype("datetime64[ns]"),
-    )
+    def _stack_at(level: int, key: str) -> np.ndarray:
+        return np.stack(
+            [f[level][key] for f in fields_by_time], axis=0,
+        ).astype(np.float32)
+
+    if is_multi:
+        data: dict[str, np.ndarray] = {"valid_times": valid_times.astype("datetime64[ns]")}
+        for L in levels:
+            data[f"T_{L}"] = _stack_at(L, "T850")
+            data[f"Td_{L}"] = _stack_at(L, "Td850")
+            data[f"theta_e_{L}"] = _stack_at(L, "theta_e")
+            data[f"u_{L}"] = _stack_at(L, "u850")
+            data[f"v_{L}"] = _stack_at(L, "v850")
+        np.savez_compressed(raw_dir / f"{model}.npz", **data)
+    else:
+        np.savez_compressed(
+            raw_dir / f"{model}.npz",
+            T850=_stack_flat("T850"),
+            Td850=_stack_flat("Td850"),
+            theta_e=_stack_flat("theta_e"),
+            u850=_stack_flat("u850"),
+            v850=_stack_flat("v850"),
+            valid_times=valid_times.astype("datetime64[ns]"),
+        )
+
     logger.info(
-        "Wrote %s (%d timesteps, %.1f KB)",
+        "Wrote %s (%d timesteps, %d level(s), %.1f KB)",
         raw_dir / f"{model}.npz",
         len(fields_by_time),
+        len(levels),
         (raw_dir / f"{model}.npz").stat().st_size / 1024,
     )
 
@@ -290,6 +381,7 @@ def build_case_from_open_meteo(
         lon=lon,
         models=models,
         init_times=init_times,
+        levels={m: [850] for m in models},
     )
 
     for model, raw in raw_responses.items():
@@ -326,22 +418,23 @@ def build_case_from_era5(
     grib_path: str | Path,
     *,
     case_name: str,
-    level_hPa: int = 850,
+    level_hPa: int | list[int] = 850,
     terrain_mask: np.ndarray | None = None,
 ) -> None:
     """Build a case from an ERA5 GRIB.
 
-    Currently single-level (the level_hPa argument, default 850). All
-    timestamps present in the GRIB are stored under model key "era5".
+    ``level_hPa`` is either a single int (legacy single-level storage, default
+    850) or a list of ints (multi-level storage — one NPZ holding all levels).
+    All timestamps present in the GRIB are stored under model key ``era5``.
     """
     import xarray as xr
 
     from weatherbrief.era5.loader import load_era5_fields
-    from weatherbrief.frontal.grid import fill_terrain
+    from weatherbrief.frontal.grid import compute_theta_e, fill_terrain
 
     grib_path = Path(grib_path)
-
-    from weatherbrief.frontal.grid import compute_theta_e
+    levels = [level_hPa] if isinstance(level_hPa, int) else sorted(int(L) for L in level_hPa)
+    is_multi = levels != [850]
 
     # Peek at the GRIB to learn which timestamps are present
     with xr.open_dataset(str(grib_path), engine="cfgrib") as ds:
@@ -354,48 +447,63 @@ def build_case_from_era5(
     lat: np.ndarray | None = None
     lon: np.ndarray | None = None
 
+    def _apply_terrain_and_rederive(f: dict) -> dict:
+        """Fill terrain on T/Td/u/v and re-derive θe for consistency."""
+        if terrain_mask is None:
+            return {
+                "T850": f["T850"], "Td850": f["Td850"],
+                "theta_e": f["theta_e"],
+                "u850": f["u850"], "v850": f["v850"],
+            }
+        T = fill_terrain(f["T850"], terrain_mask)
+        Td = fill_terrain(f["Td850"], terrain_mask)
+        u = fill_terrain(f["u850"], terrain_mask)
+        v = fill_terrain(f["v850"], terrain_mask)
+        return {
+            "T850": T, "Td850": Td,
+            "theta_e": compute_theta_e(T, Td),
+            "u850": u, "v850": v,
+        }
+
     for t in timestamps:
-        f = load_era5_fields(grib_path, t, level_hPa=level_hPa)
+        per_level: dict[int, dict] = {}
+        for L in levels:
+            f = load_era5_fields(grib_path, t, level_hPa=L)
 
-        # First iteration: capture coords + validate terrain_mask shape
-        # up front rather than letting fill_terrain fail deep inside
-        # scipy. Avoids a separate pre-load of timestamps[0].
-        if lat is None:
-            lat = f["lat"]
-            lon = f["lon"]
-            if terrain_mask is not None and terrain_mask.shape != f["T850"].shape:
-                raise ValueError(
-                    f"terrain_mask shape {terrain_mask.shape} does not match "
-                    f"ERA5 grid shape {f['T850'].shape}. Rebuild the mask "
-                    f"with build_terrain_mask(case_lat, case_lon) using the "
-                    f"GRIB's own coordinates, or ensure the GRIB domain "
-                    f"matches FRONTAL_GRID."
+            # First iteration overall: capture coords + validate terrain_mask
+            # shape up front rather than letting fill_terrain fail deep inside
+            # scipy. Avoids a separate pre-load of timestamps[0].
+            if lat is None:
+                lat = f["lat"]
+                lon = f["lon"]
+                if terrain_mask is not None and terrain_mask.shape != f["T850"].shape:
+                    raise ValueError(
+                        f"terrain_mask shape {terrain_mask.shape} does not match "
+                        f"ERA5 grid shape {f['T850'].shape}. Rebuild the mask "
+                        f"with build_terrain_mask(case_lat, case_lon) using the "
+                        f"GRIB's own coordinates, or ensure the GRIB domain "
+                        f"matches FRONTAL_GRID."
+                    )
+                save_case_meta(
+                    case_dir,
+                    case_name=case_name,
+                    source="era5",
+                    lat=lat,
+                    lon=lon,
+                    models=["era5"],
+                    init_times={"era5": 0},  # ERA5 has no init time concept
+                    levels={"era5": levels},
                 )
-            save_case_meta(
-                case_dir,
-                case_name=case_name,
-                source="era5",
-                lat=lat,
-                lon=lon,
-                models=["era5"],
-                init_times={"era5": 0},  # ERA5 has no init time concept
-            )
 
-        # Apply terrain fill to keep derivatives clean at high-elevation cells
-        if terrain_mask is not None:
-            f["T850"] = fill_terrain(f["T850"], terrain_mask)
-            f["Td850"] = fill_terrain(f["Td850"], terrain_mask)
-            f["u850"] = fill_terrain(f["u850"], terrain_mask)
-            f["v850"] = fill_terrain(f["v850"], terrain_mask)
-            # re-derive theta_e after terrain fill for consistency
-            f["theta_e"] = compute_theta_e(f["T850"], f["Td850"])
-        fields_by_time.append({
-            "T850": f["T850"], "Td850": f["Td850"],
-            "theta_e": f["theta_e"],
-            "u850": f["u850"], "v850": f["v850"],
-        })
+            per_level[L] = _apply_terrain_and_rederive(f)
+
+        if is_multi:
+            fields_by_time.append(per_level)
+        else:
+            fields_by_time.append(per_level[levels[0]])
 
     save_model_fields(
         case_dir, "era5", fields_by_time,
         np.array(timestamps, dtype="datetime64[ns]"),
+        levels=levels,
     )

--- a/tests/test_frontal_case.py
+++ b/tests/test_frontal_case.py
@@ -1,0 +1,229 @@
+"""Tests for weatherbrief.frontal.case — multi-level storage + back-compat."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from weatherbrief.frontal.case import (
+    load_case,
+    save_case_meta,
+    save_model_fields,
+)
+
+
+def _sample_fields(n_lat: int = 5, n_lon: int = 7, offset: float = 0.0) -> dict:
+    """One timestep of T/Td/theta_e/u/v arrays with a known offset."""
+    la, lo = np.meshgrid(
+        np.linspace(0, 1, n_lat), np.linspace(0, 1, n_lon), indexing="ij",
+    )
+    return {
+        "T850": (la + offset).astype(np.float32),
+        "Td850": (la + 0.5 * lo + offset).astype(np.float32),
+        "theta_e": (290 + 10 * la + offset).astype(np.float32),
+        "u850": (5 * lo + offset).astype(np.float32),
+        "v850": (2 * la + offset).astype(np.float32),
+    }
+
+
+def _write_case(
+    case_dir: Path,
+    *,
+    levels_spec: dict[str, list[int]] | None,
+    fields_by_time_per_model: dict[str, list[dict]],
+    save_fn_kwargs: dict[str, dict] | None = None,
+) -> None:
+    """Minimal case-writer for tests. ``levels_spec=None`` omits the field."""
+    lat = np.linspace(45.0, 46.0, 5)
+    lon = np.linspace(0.0, 1.5, 7)
+    models = list(fields_by_time_per_model.keys())
+
+    kwargs: dict = dict(
+        case_name=case_dir.name,
+        source="test",
+        lat=lat, lon=lon,
+        models=models,
+        init_times={m: 0 for m in models},
+    )
+    if levels_spec is not None:
+        kwargs["levels"] = levels_spec
+    save_case_meta(case_dir, **kwargs)
+
+    # Override meta.json if caller wants to simulate legacy (no levels field).
+    if levels_spec is None:
+        import json
+        meta_path = case_dir / "meta.json"
+        meta = json.loads(meta_path.read_text())
+        meta.pop("levels", None)
+        meta_path.write_text(json.dumps(meta, indent=2))
+
+    vt = np.array(
+        [np.datetime64("2025-01-01T00") + np.timedelta64(i, "h")
+         for i in range(len(next(iter(fields_by_time_per_model.values()))))],
+        dtype="datetime64[ns]",
+    )
+    sf_kwargs = save_fn_kwargs or {}
+    for m, f_list in fields_by_time_per_model.items():
+        save_model_fields(case_dir, m, f_list, vt, **sf_kwargs.get(m, {}))
+
+
+# ---------------------------------------------------------------------------
+# Back-compat: legacy single-level 850 cases
+
+
+class TestLegacyBackCompat:
+    def test_loads_case_without_levels_field(self, tmp_path):
+        """An existing case whose meta.json has no `levels` field loads and
+        defaults to [850] — our Storm Ciarán case is in this shape."""
+        case = tmp_path / "legacy"
+        _write_case(
+            case,
+            levels_spec=None,
+            fields_by_time_per_model={"era5": [_sample_fields()]},
+        )
+        c = load_case(case)
+        assert c.available_levels("era5") == [850]
+        assert c.levels == {"era5": [850]}
+
+    def test_legacy_fields_roundtrip(self, tmp_path):
+        case = tmp_path / "legacy"
+        original = _sample_fields(offset=3.0)
+        _write_case(
+            case,
+            levels_spec=None,
+            fields_by_time_per_model={"era5": [original]},
+        )
+        c = load_case(case)
+        out = c.fields("era5", 0)
+        assert np.allclose(out["T850"], original["T850"])
+        assert np.allclose(out["theta_e"], original["theta_e"])
+
+    def test_legacy_raises_on_non_850_level(self, tmp_path):
+        case = tmp_path / "legacy"
+        _write_case(
+            case,
+            levels_spec=None,
+            fields_by_time_per_model={"era5": [_sample_fields()]},
+        )
+        c = load_case(case)
+        with pytest.raises(ValueError, match="not in case levels"):
+            c.fields("era5", 0, level_hPa=925)
+
+
+# ---------------------------------------------------------------------------
+# Multi-level (Phase B)
+
+
+class TestMultiLevel:
+    def _multi_fields(self, offset: float = 0.0) -> dict:
+        """Per-timestep dict keyed by level, each with the full inner field set."""
+        return {
+            925: _sample_fields(offset=offset + 0.0),
+            850: _sample_fields(offset=offset + 10.0),
+            700: _sample_fields(offset=offset + 20.0),
+        }
+
+    def test_save_multi_level_creates_suffixed_keys(self, tmp_path):
+        case = tmp_path / "multi"
+        _write_case(
+            case,
+            levels_spec={"era5": [925, 850, 700]},
+            fields_by_time_per_model={"era5": [self._multi_fields()]},
+            save_fn_kwargs={"era5": {"levels": [925, 850, 700]}},
+        )
+        with np.load(case / "raw" / "era5.npz") as npz:
+            keys = set(npz.files)
+        for L in (925, 850, 700):
+            for pfx in ("T", "Td", "theta_e", "u", "v"):
+                assert f"{pfx}_{L}" in keys, f"missing {pfx}_{L}"
+        # Legacy keys MUST NOT leak in multi-level mode
+        assert "T850" not in keys
+        assert "theta_e" not in keys
+
+    def test_loads_and_reports_levels(self, tmp_path):
+        case = tmp_path / "multi"
+        _write_case(
+            case,
+            levels_spec={"era5": [925, 850, 700]},
+            fields_by_time_per_model={"era5": [self._multi_fields()]},
+            save_fn_kwargs={"era5": {"levels": [925, 850, 700]}},
+        )
+        c = load_case(case)
+        assert c.available_levels("era5") == [700, 850, 925]
+        assert c.levels["era5"] == [700, 850, 925]
+
+    def test_fields_default_level_is_850(self, tmp_path):
+        """Without ``level_hPa`` arg, fields() returns the 850 slice."""
+        case = tmp_path / "multi"
+        fields = self._multi_fields()
+        _write_case(
+            case,
+            levels_spec={"era5": [925, 850, 700]},
+            fields_by_time_per_model={"era5": [fields]},
+            save_fn_kwargs={"era5": {"levels": [925, 850, 700]}},
+        )
+        c = load_case(case)
+        out = c.fields("era5", 0)
+        assert np.allclose(out["T850"], fields[850]["T850"])
+        assert np.allclose(out["theta_e"], fields[850]["theta_e"])
+
+    def test_fields_selects_requested_level(self, tmp_path):
+        case = tmp_path / "multi"
+        fields = self._multi_fields()
+        _write_case(
+            case,
+            levels_spec={"era5": [925, 850, 700]},
+            fields_by_time_per_model={"era5": [fields]},
+            save_fn_kwargs={"era5": {"levels": [925, 850, 700]}},
+        )
+        c = load_case(case)
+        out_925 = c.fields("era5", 0, level_hPa=925)
+        out_700 = c.fields("era5", 0, level_hPa=700)
+        # Inner keys are always T850 etc. regardless of actual level (known wart)
+        assert np.allclose(out_925["T850"], fields[925]["T850"])
+        assert np.allclose(out_700["T850"], fields[700]["T850"])
+        # Sanity: different levels give different values (offsets differ)
+        assert not np.allclose(out_925["T850"], out_700["T850"])
+
+    def test_fields_all_hours_multi_level(self, tmp_path):
+        case = tmp_path / "multi"
+        per_time = [self._multi_fields(offset=0.0), self._multi_fields(offset=1.0)]
+        _write_case(
+            case,
+            levels_spec={"era5": [925, 850, 700]},
+            fields_by_time_per_model={"era5": per_time},
+            save_fn_kwargs={"era5": {"levels": [925, 850, 700]}},
+        )
+        c = load_case(case)
+        all_h = c.fields_all_hours("era5", level_hPa=700)
+        assert list(all_h.keys()) == [0, 1]
+        assert np.allclose(all_h[0]["T850"], per_time[0][700]["T850"])
+        assert np.allclose(all_h[1]["T850"], per_time[1][700]["T850"])
+
+    def test_unknown_level_raises(self, tmp_path):
+        case = tmp_path / "multi"
+        _write_case(
+            case,
+            levels_spec={"era5": [925, 850, 700]},
+            fields_by_time_per_model={"era5": [self._multi_fields()]},
+            save_fn_kwargs={"era5": {"levels": [925, 850, 700]}},
+        )
+        c = load_case(case)
+        with pytest.raises(ValueError, match="not in case levels"):
+            c.fields("era5", 0, level_hPa=500)
+
+    def test_single_level_list_uses_legacy_format(self, tmp_path):
+        """``levels=[850]`` alone still writes the legacy format — the new
+        storage only kicks in when more than one level is requested."""
+        case = tmp_path / "single850"
+        _write_case(
+            case,
+            levels_spec={"era5": [850]},
+            fields_by_time_per_model={"era5": [_sample_fields()]},
+            save_fn_kwargs={"era5": {"levels": [850]}},
+        )
+        with np.load(case / "raw" / "era5.npz") as npz:
+            assert "T850" in npz.files
+            assert "T_850" not in npz.files


### PR DESCRIPTION
## Summary

Extends the `Case` abstraction to hold **multiple pressure levels** per model in a single NPZ, with full back-compat for existing single-level cases. No existing callers need to change. Based on main (stacks on #93 only conceptually — each PR is independent).

The in-flight 1-year ERA5 monthly GRIBs (2025-02 → 2026-02) already contain 925/850/700 hPa fields — this PR unlocks reading all three in unified case format for downstream work (Phase C advisory evaluators, Phase D map layer).

## API additions

- \`build_case_from_era5(..., level_hPa: int | list[int] = 850)\` accepts a list; each timestep is loaded + terrain-filled + θe re-derived per level.
- \`Case.fields(model, hour, level_hPa=None)\` — optional level arg, defaults to 850 if present.
- \`Case.fields_all_hours(model, level_hPa=None)\` — same.
- \`Case.available_levels(model) -> list[int]\`.
- \`save_case_meta(..., levels: dict[str, list[int]] | None)\` persists levels per model.
- \`save_model_fields(..., levels: list[int] | None)\` writes legacy format for \`[850]\`, level-suffixed otherwise.

## Storage format

Multi-level NPZ (flat, per the \"keep storage simple\" decision):
\`\`\`
T_925, Td_925, theta_e_925, u_925, v_925,
T_850, Td_850, theta_e_850, u_850, v_850,
T_700, Td_700, theta_e_700, u_700, v_700,
valid_times
\`\`\`

Single-level NPZ (legacy, still written for \`levels=[850]\`):
\`\`\`
T850, Td850, theta_e, u850, v850, valid_times
\`\`\`

Inner dict keys returned by \`Case.fields()\` always stay \`T850, Td850, theta_e, u850, v850\` regardless of actual level — the \`850\` in the key is historical (matches what \`load_era5_fields\` already returns), and downstream detect.py / CLI / retrospective scripts keep working unchanged.

## Back-compat

- Cases whose \`meta.json\` has no \`levels\` field default to \`[850]\` — the Storm Ciarán case is in this shape and was verified loadable.
- NPZ with legacy keys is read directly; NPZ with \`T_{L}, ...\` is read via the level-aware path. Detection by key inspection.

## Test plan

- [x] \`tests/test_frontal_case.py\` — 10 new tests
  - Legacy case loads + returns 850 fields; non-850 raises
  - Multi-level save produces suffixed keys, legacy keys absent
  - \`Case.fields()\` defaults to 850 on multi-level cases
  - \`Case.fields(level_hPa=925 or 700)\` returns the right slice
  - \`fields_all_hours(level_hPa=...)\` picks the right level per hour
  - Unknown level raises with clear message
  - \`levels=[850]\` alone still writes the legacy format
- [x] 53 existing frontal tests still pass (case / detect / zones / tracking / cache)
- [x] End-to-end smoke: built multi-level case from the existing Ciarán smoke GRIB, verified **925 → 850 → 700 hPa temperatures decrease monotonically** (9.75 → 5.64 → -2.83 °C at hour 12) — physics sanity-check passes.

## Follow-ups (not in this PR)

- CLI surface: \`new-case --source era5 --levels 925,850,700\` — 5-line change, will add when Phase C starts consuming multi-level.
- Rebuild the Storm Ciarán calibration case at 3 levels now that the storage exists.
- Phase C: advisory evaluators using level-appropriate data (altitude → pressure mapping).

Related: #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)