### PR TITLE
feat(hewson): Phase D.0 — synoptic-view precompute pipeline

### DIFF
--- a/designs/future/hewson-fields-aviation-advisories.md
+++ b/designs/future/hewson-fields-aviation-advisories.md
@@ -131,6 +131,28 @@ Matches what our briefings already use. Open-Meteo delivers 120–240 h for the 
 
 ECMWF's main runs; GFS and ICON also publish 00Z/12Z as primary. Between cycles, briefings read the last snapshot; 12 h staleness is fine for smooth advective fields.
 
+### 4.4a Snapshot temporal resolution: **3 h stride** (decided 2026-04-24, after live GFS validation)
+
+Open-Meteo delivers hourly; we decimate to every 3rd forecast hour before the Hewson compute loop. At 120 h horizon that is 40 timesteps per snapshot instead of 120.
+
+Tradeoffs considered on the real GFS 12 Z cycle:
+
+| Stride | Timesteps | NPZ size | Compute time | Slider UX | Advisory blur |
+|---|---|---|---|---|---|
+| 1 h | 120 | 139 MB | ~190 s | smoothest | ~15 km |
+| **3 h** | **40** | **46 MB** | **~65 s** | mainstream (matches Windy/SYNOP) | **~50 km** |
+| 6 h | 21 | 24 MB | ~30 s | sparse | ~100 km |
+
+**Picked 3 h** because:
+- ~50 km interpolation blur on a moving front is well inside the "±50–100 km TFP positional uncertainty" ceiling stated in § 8 (we cannot claim more precision than that anyway)
+- Matches SYNOP reporting cadence, which is also what pro forecaster tools ship
+- 3× size and 3× compute savings over 1 h, without the advisory-accuracy penalty 6 h introduces
+- Per-flight advisories and cross-section bands that want finer granularity compute from per-briefing GRIB at flight time (§ 6.2 stencil path), not from the synoptic-view snapshot
+
+**Not picked**: 1 h was expressive but expensive (139 MB × 12 snapshots = 1.7 GB peak on disk, ~13 min/cycle). 6 h was cheap but the spatial blur on fast-moving fronts was past the advisory error budget.
+
+The NPZ stores the stride in a `stride_hours` field so readers can self-describe without hard-coded assumptions. Overridable via `python -m weatherbrief.hewson precompute --stride-hours N` for debug / high-fidelity one-off runs.
+
 ### 4.5 Storage format: **NPZ now → Zarr when needed**
 
 **Start with NPZ** (numpy's native compressed binary zip):
@@ -163,41 +185,75 @@ Recent two cycles on disk per model; older cycles purged. Matches the existing p
 
 ## 5. Data-volume sizing
 
-Per model per cycle at **0.25° × 3 levels × 120 h × 6 fields × float16**:
+**Measured on the real GFS 2026-04-24 12 Z cycle** at `0.25° × 3 levels × 120 h horizon × 6 metrics × float32`, with **3 h stride** (see § 4.4a) so 40 timesteps land in the snapshot:
 
-| Metric | Value |
-|---|---|
-| Grid points per level per hour | 19,493 (101 lat × 193 lon) |
-| Values per snapshot | 1.78 M × 6 = 10.7 M |
-| Raw bytes (float16) | ~85 MB |
-| Compressed NPZ | ~25 MB |
-| Latest state, all 3 models | ~75 MB |
-| Daily write volume | ~150 MB |
-| Fetch wall-time per cycle | ~1.5 min |
-| Compute wall-time per cycle | ~5 min |
-| 48 h cache footprint | ~300 MB |
+| Metric | Measured (1 model, 3 h stride) | Full cycle (3 models) |
+|---|---|---|
+| Grid points per timestep per level | 19,493 (101 × 193) | — |
+| Timesteps (120 h / 3 h) | 40 | — |
+| Raw bytes (float32, 18 metric stacks) | ~57 MB | ~170 MB |
+| Compressed NPZ | **~46 MB** | ~140 MB (3 snapshots) |
+| Fetch wall-time | ~65 s | ~3 min |
+| Compute wall-time | ~65 s | ~3 min |
+| Full-cycle wall time | ~130 s | **~6.5 min** |
+| 48 h on-disk peak (2 cycles × 3 models) | — | **~550 MB** |
 
-Small enough that the "precompute" pipeline can keep everything in a handful of files and load the whole snapshot into memory when a briefing needs it.
+Earlier drafts of this section quoted "~25 MB compressed / ~300 MB peak / ~6.5 min total" — that was based on **float16 × 1 h stride** (which we intentionally avoid for precision) combined with a miscounting of the horizon (stated 120 h but math used 1 h). Above is the real footprint at the shipped defaults.
+
+**Historical calibration on real data**:
+- 1 h stride × float32 × 120 h = 139 MB / snapshot (single GFS run). Too big for the map payoff.
+- 3 h stride × float32 × 40 timesteps = **46 MB / snapshot** (measured). Shipped default.
+- 6 h stride × float32 × 21 timesteps ≈ 24 MB / snapshot. Considered; rejected because a 6 h gap blurs advection interpolation across ~100 km of front motion, which weakens the advisory-evaluator accuracy budget in § 8.
+
+Advisory evaluators and cross-section bands that need finer temporal resolution compute directly from per-briefing GRIB at flight time (§ 6.2 stencil path), not from this synoptic-view snapshot.
 
 ## 6. Architecture
 
-### 6.1 Precompute pipeline (hooks into existing 6 h frontal fetch)
+### 6.1 Precompute pipeline (dedicated scheduler loop)
 
-**Key decision (2026-04-24)**: don't stand up a new cron. The frontal-detection pipeline already fetches the full 0.25° European grid every 6 h to feed DWD frontal zones. Hewson computation piggybacks on that fetch — same grid, ~5 min of added compute, separate NPZ output. Source-agnostic: today the fetch is Open-Meteo; when native-GRIB ingestion for ECMWF/ICON/GFS lands it becomes a call-site swap.
+**Key decision (2026-04-24, revised)**: the frontal-detection module is CLI-only — there is **no existing 6 h cron** to piggyback on (the earlier draft of this section assumed one; that was wrong). Hewson precompute is therefore a **new, independent loop** inside `scheduler.py`, following the same pattern as the five existing loops (`run_retention_loop`, `run_verification_loop`, `run_standalone_verification_loop`, `run_digest_loop`, `run_ecmwf_watcher_loop`).
+
+**Timing**: fires at **05 Z** and **17 Z**, giving ~5 h after each 00 Z / 12 Z init for Open-Meteo to publish all three models, while keeping a 1 h margin before the 06 Z / 18 Z `run_standalone_verification_loop` full cycles (heavy forecast fetch + scoring) to avoid CPU/network overlap. Other loops in the scheduler are light enough not to matter (ECMWF watcher is disk-only, retention is once/day, etc.).
+
+**Disable switch**: `DISABLE_HEWSON_PRECOMPUTE=1` (mirrors the existing `DISABLE_*` flags).
+
+**Shared entry point**: the async loop and the `python -m weatherbrief.hewson precompute` CLI both call the same `weatherbrief.hewson.precompute.run_once(...)` — one implementation, two surfaces. Ad-hoc debugging, manual re-runs, and scheduled runs exercise identical code.
 
 ```
-existing 6 h frontal grid fetch (all models)
-  ↓  (grid already in memory for frontal zones)
-compute_hewson_diagnostics() for each (level ∈ {925, 850, 700}, hour)
-  ↓
-np.savez_compressed("data/hewson/<model>/<init>.npz",
-                     theta_e, gradient, neg_laplacian, tfp,
-                     advection, tendency)
-  ↓
-retain 48 h, purge older
+run_hewson_precompute_loop          ┐
+  (scheduler.py, 05 Z / 17 Z)       │→ weatherbrief.hewson.precompute.run_once(...)
+python -m weatherbrief.hewson       │      ↓
+  precompute [--model / --dry-run / │   fetch_grid_fields(levels=[925, 850, 700])
+   --force / --output-dir]          ┘      ↓
+                                        reshape_to_fields per (hour, level)
+                                           ↓
+                                        compute_hewson_diagnostics + tendency
+                                           ↓
+                                        np.savez_compressed(
+                                            "${DATA_DIR}/hewson/<model>/<init_iso_z>.npz",
+                                            theta_e_{925,850,700},
+                                            gradient_{925,850,700},
+                                            neg_laplacian_{925,850,700},
+                                            tfp_{925,850,700},
+                                            advection_{925,850,700},
+                                            tendency_{925,850,700},
+                                            valid_times, lat, lon,
+                                            init_time_unix, levels,
+                                            stride_hours,   # = 3 by default
+                                        )
+                                           ↓
+                                        purge_old_snapshots(retention_hours=48)
 ```
 
-Snapshot size at 0.25° × 101×193 × 3 levels × 6 metrics × float32 ≈ **1.4 MB raw / ~500 KB compressed**. With 48 h retention × 3 models × 2 cycles/day ≈ **~24 MB total on disk**. Trivial.
+**Source-agnostic**: the fetch goes through `fetch_grid_fields` in `frontal/grid.py`, so when native-GRIB ingestion for ECMWF/ICON/GFS lands it's a call-site swap inside that function — `run_once` and everything downstream is unchanged.
+
+**Filename format**: ISO 8601 with `Z` suffix (`2026-04-24T12:00:00Z.npz`) — matches the ECMWF watcher manifests, sortable, human-readable.
+
+**Data directory**: `${DATA_DIR:-data}/hewson/<model>/` — follows the convention used by `storage/snapshots.py`, `tasks/outputs.py`, etc. In production `DATA_DIR=/mnt/flyfun_data/weather/data`.
+
+**Terrain mask caching**: the SRTM3 build is ~seconds; we cache it to `${DATA_DIR}/hewson/terrain_mask.npz` on first run and load thereafter (shape + coords verified on load so grid changes invalidate the cache).
+
+Snapshot size at 0.25° × 101×193 × 3 levels × 40 timesteps × 6 metrics × float32 ≈ **57 MB raw / ~46 MB compressed** per model per cycle (measured on the 2026-04-24 12 Z GFS run at shipped defaults). With 48 h retention × 3 models × 2 cycles/day ≈ **~550 MB on disk peak**. See § 5 for the full table and § 4.4a for why 3 h stride not 1 h.
 
 ### 6.2 Read paths (on-demand)
 
@@ -502,11 +558,14 @@ What was pivotal about this session — we made the pipeline source-agnostic bef
 - Validates Phase B's precompute output end-to-end without advisory-wording churn
 - Sidesteps the current calibration blocker (moisture gap — see §10a.1)
 
-**Phase D.0 — Precompute cron** ([task #8]):
-- Hook into the existing 6 h frontal grid fetch (no new cron)
-- Compute `theta_e, gradient, neg_laplacian, tfp, advection, tendency` at **925/850/700 hPa only**
-- Save snapshot NPZ per `(model, init)` under `data/hewson/<model>/<init>.npz`, retain 48 h
-- Source-agnostic: swaps Open-Meteo → native GRIB later without contract change
+**Phase D.0 — Precompute loop** ✅ DONE (2026-04-24, [task #8]):
+- New `run_hewson_precompute_loop` in `scheduler.py`, firing at **05 Z** / **17 Z** (avoids collision with the 06 Z / 18 Z `run_standalone_verification_loop` full cycles — see §6.1)
+- New module `src/weatherbrief/hewson/` with `run_once()` as the shared entry point for the loop and the `python -m weatherbrief.hewson precompute` CLI (one implementation, two surfaces)
+- Generalised `fetch_grid_fields` / `reshape_to_fields` in `frontal/grid.py` to accept `levels=[925, 850, 700]` with 850-only back-compat for the frontal CLI
+- Computes `theta_e, gradient, neg_laplacian, tfp, advection, tendency` at **925/850/700 hPa**
+- Saves snapshot NPZ per `(model, init)` under `${DATA_DIR}/hewson/<model>/<init_iso_z>.npz`, retains 48 h
+- ISO 8601 Z filenames, terrain mask cached to disk, `DISABLE_HEWSON_PRECOMPUTE=1` escape hatch
+- Source-agnostic: when native-GRIB ingestion lands it's a call-site swap inside `fetch_grid_fields`
 
 **Phase D.1 — Backend endpoint** ([task #9]):
 - `GET /api/hewson-map?model=ecmwf&init=<t>&level=850&metric=advection&hour=24` → JSON or binary grid of shape (n_lat, n_lon)
@@ -559,15 +618,15 @@ Opens after Phase D so the map + cross-section surface has something to show moi
 | **Architecture consolidation (0.25°, ERA5 loader, unified Case)** | ✅ Done (PR #91, merged) |
 | Resolution decision | ✅ 0.25° — consistent across all three models (ECMWF order at 0.25°, GFS/ICON ingestion at 0.25°) |
 | Level decision | ✅ 925 / 850 / 700 hPa (3 levels; 500/400 explicitly rejected as upper-IFR out-of-scope) |
-| Cadence decision | ✅ 2×/day (00Z, 12Z) — hooks into existing 6h frontal fetch, not a new cron |
+| Cadence decision | ✅ 2×/day — dedicated scheduler loop fires at 05 Z / 17 Z (~5 h after each 00/12 Z init, 1 h buffer before 06/18 Z full-cycle verification) |
 | Storage decision | ✅ NPZ flat level-suffixed keys; ~24 MB total across 48h × 3 models |
 | Retention decision | ✅ 48 h cache |
 | ERA5 bulk fetch | ✅ Done (1 year, 2025-02 → 2026-02, ~700 MB on disk at `data/era5/hewson/`) |
 | **Phase A** (route sampling) | ✅ Done (PR #93 open) — `sample_hewson_at_route`, `route-hewson` CLI, retrospective scripts |
 | **Phase B.1** (multi-level Case storage) | ✅ Done (PR #94 open) — multi-level NPZ, back-compat, 10 tests |
 | Phase B.2 (CLI `--levels`, rebuild Ciarán at 3 levels) | 🟡 Small follow-up; can slot anywhere |
-| **Phase D.0** (precompute cron) | 🎯 **NEXT** — hooks into existing 6h frontal fetch |
-| Phase D.1 (backend endpoint) | Requires D.0 |
+| **Phase D.0** (precompute loop) | ✅ Done (2026-04-24) — `run_hewson_precompute_loop` + `weatherbrief.hewson.run_once()` + `python -m weatherbrief.hewson` CLI |
+| Phase D.1 (backend endpoint) | 🎯 **NEXT** — requires D.0 (done) |
 | Phase D.2 (map layer + tooltips) | Requires D.1 |
 | Phase D.3 (cross-section bands) | Requires D.0 |
 | Phase D.4 (stencil in GRIB era) | Gated on native-GRIB ingestion being live for the user's briefing model |
@@ -575,9 +634,9 @@ Opens after Phase D so the map + cross-section surface has something to show moi
 | Phase E (moisture cross-check) | After Phase D — RH₉₂₅, LCC, TP, CAPE, debrief feature #92 |
 | Retrospective validation | ✅ Pairwise cancel test 3/3 (all pilot-cancellation days scored higher than replacement-flown days) — best calibration signal we have |
 
-## 12a. Quick pickup from fresh context (for Phase D start)
+## 12a. Quick pickup from fresh context (for Phase D.1 start)
 
-After PRs #93 (Phase A) and #94 (Phase B) merge, the next session picks up here.
+Phase D.0 is done. The next session picks up D.1 — the backend endpoint that serves per-(model, init, level, hour, metric) slices to the forecast-page map.
 
 ### What's already on main
 
@@ -587,59 +646,46 @@ After PRs #93 (Phase A) and #94 (Phase B) merge, the next session picks up here.
 - `route-hewson` CLI subcommand that resolves ICAO codes and prints per-waypoint values
 - Retrospective scripts: `scripts/analyze_flight_log.py` and `scripts/analyze_cancellations.py`
 - 1 year of ERA5 GRIBs at `data/era5/hewson/` (gitignored)
+- **Phase D.0**: `src/weatherbrief/hewson/` module (`precompute.py`, `cli.py`, `__main__.py`), `run_hewson_precompute_loop` in `scheduler.py` at 05 Z / 17 Z, NPZ snapshots at `${DATA_DIR}/hewson/<model>/<init_iso_z>.npz`. Back-compat-preserving `levels=` / `level_hPa=` kwargs added to `fetch_grid_fields` and `reshape_to_fields` in `frontal/grid.py`.
 
-### What Phase D needs (starting with task #8 — precompute cron)
+### What Phase D.1 needs
 
-The job is to hook Hewson computation into the **existing 6h frontal grid fetch** so that every cycle produces a snapshot NPZ at `data/hewson/<model>/<init>.npz`.
+Build an authenticated endpoint that serves one `(model, init, level, hour, metric)` slice from a precompute snapshot as JSON or binary.
 
 **Entry points to find first**:
-- Existing frontal fetch pipeline — grep `fetch_grid_fields` in `src/weatherbrief/frontal/grid.py` and its callers
-- The cron / scheduler — look at how DWD frontal zones are currently refreshed every 6h (check `designs/fetch.md` and `data/frontal_cache/`)
-- Snapshot storage — the retrospective already writes `data/era5/terrain_mask.npz` as a cached artefact; follow that path pattern
+- `src/weatherbrief/hewson/precompute.py::load_snapshot(path)` — returns the dict of arrays; map endpoint just indexes into `snap[f"{metric}_{level}"][hour]`
+- `src/weatherbrief/hewson/precompute.py::snapshot_path(model, init_time_unix, ...)` — canonical disk location
+- `src/weatherbrief/api/packs.py` — pack-access auth pattern to reuse (§ 7.3 says "reuses pack-access auth pattern")
+- Existing gridded-layer frontends: today the forecast map is point-only, so this will be the first Canvas-overlay pattern (§ 7.5)
 
-**Snapshot schema** (confirmed §6.1):
-```python
-np.savez_compressed(
-    f"data/hewson/{model}/{init_iso}.npz",
-    # per level ∈ {925, 850, 700}:
-    theta_e_925=..., gradient_925=..., neg_laplacian_925=...,
-    tfp_925=..., advection_925=..., tendency_925=...,
-    theta_e_850=..., gradient_850=..., # ... same set ...
-    theta_e_700=..., gradient_700=..., # ... same set ...
-    valid_times=...,  # for temporal interp
-    lat=..., lon=...,
-)
+**Endpoint contract (§ 7.3 sketch)**:
+```
+GET /api/hewson-map?model=ecmwf&init=<t>&level=850&metric=advection&hour=24
+  → JSON or binary array of shape (n_lat, n_lon)
 ```
 
-**Reproduce Storm Ciarán to sanity-check**:
+**Sanity-check the precompute output** before building the endpoint:
 ```bash
-# Multi-level case (Phase B):
-python -m weatherbrief.frontal.cli new-case \
-    --source era5 --grib data/era5/era5_hewson_smoke_2023-11-02.grib \
-    --date 2023-11-02 --level 850
-
-# Plot:
-python -m weatherbrief.frontal.cli plot-hewson \
-    --case data/calibration/2023-11-02_era5 \
-    --model era5 --hour 12 --field theta_e
+python -m weatherbrief.hewson precompute --models ecmwf --dry-run   # no-write test
+python -m weatherbrief.hewson precompute --models ecmwf             # real run
+python -m weatherbrief.hewson list -v                               # verify schema
 ```
 
-### Key files for Phase D pickup
+### Key files for Phase D.1 pickup
 
-- `src/weatherbrief/frontal/detect.py` — `compute_hewson_diagnostics()` (math to call per-cycle)
-- `src/weatherbrief/frontal/grid.py` — `fetch_grid_fields`, `build_terrain_mask`
-- `src/weatherbrief/frontal/case.py` — Case/meta persistence pattern (reuse NPZ conventions)
-- `src/weatherbrief/frontal/route_sampling.py` — `bilinear_sample` for cross-section bands reading the snapshot
-- `web/ts/visualization/cross-section/renderer.ts` + `layer-registry.ts` — cross-section layer pattern to follow for §7.9
+- `src/weatherbrief/hewson/precompute.py` — `load_snapshot`, `snapshot_path`, `resolve_output_dir`
+- `src/weatherbrief/api/packs.py` — pack-access auth + serialization patterns
+- `src/weatherbrief/api/app.py` — lifespan already wires `run_hewson_precompute_loop`
+- `web/ts/visualization/cross-section/renderer.ts` + `layer-registry.ts` — cross-section layer pattern to follow for § 7.9 (Phase D.3)
 - `designs/forecast-page.md` — where the map layer lives (point-marker pattern today; gridded-canvas layer is net new)
-- **This doc** — decisions and rationale; §10a is the list of known gaps so the next pass doesn't re-discover them
+- **This doc** — decisions and rationale; § 10a is the list of known gaps so the next pass doesn't re-discover them
 
-### Open questions left for Phase D
+### Open questions left for Phase D.1+
 
-- How does the existing 6h frontal-zone refresh invoke itself? Find its entry point so Hewson piggybacks cleanly (vs adding a second scheduler).
-- Snapshot format: pure NPZ flat-keys (per §6.1) or migrate to Zarr now? → NPZ per §4.5 — Zarr only when the map serves subsets over the network.
-- Map layer client: single gridded CanvasLayer for all 6 metrics (redraw on metric change), or 6 pre-rendered PNG tiles served statically? → start with JSON/binary + canvas (per §7.5), revisit tiling if latency needs it.
-- Pilot-facing tooltip text: draw from §2 directly (short form) or maintain a separate `docs/hewson-pilot-guide.md`? → start inline per §7.4, promote to a doc if it grows.
+- Serialization: JSON array (~80 KB/slice, simple) or quantized int8 + scale (~20 KB, needs client-side dequant)? → start with JSON per § 7.2, revisit if map latency needs it.
+- Cache headers: `Cache-Control: max-age=...` based on init time, since a given `(model, init)` slice is immutable. Let the CDN do the work.
+- Map layer client: single gridded CanvasLayer for all 6 metrics (redraw on metric change), or 6 pre-rendered PNG tiles served statically? → start with JSON/binary + canvas (per § 7.5), revisit tiling if latency needs it.
+- Pilot-facing tooltip text: draw from § 2 directly (short form) or maintain a separate `docs/hewson-pilot-guide.md`? → start inline per § 7.4, promote to a doc if it grows.
 
 ## 13. Related docs
 

--- a/src/weatherbrief/api/app.py
+++ b/src/weatherbrief/api/app.py
@@ -189,10 +189,19 @@ async def lifespan(app: FastAPI):
         else:
             logger.info("ECMWF watcher skipped — %s does not exist", ecmwf_dir)
 
+    hewson_precompute_task = None
+    if os.environ.get("DISABLE_HEWSON_PRECOMPUTE", "").strip() not in ("1", "true"):
+        from weatherbrief.scheduler import run_hewson_precompute_loop
+
+        hewson_precompute_task = asyncio.create_task(
+            run_hewson_precompute_loop(app.state)
+        )
+
     yield
 
     for task in (scheduler_task, retention_task, verification_task,
-                 digest_task, standalone_task, ecmwf_watcher_task):
+                 digest_task, standalone_task, ecmwf_watcher_task,
+                 hewson_precompute_task):
         if task:
             task.cancel()
             with suppress(asyncio.CancelledError):

--- a/src/weatherbrief/frontal/cli.py
+++ b/src/weatherbrief/frontal/cli.py
@@ -134,6 +134,15 @@ def _run_analysis(
         )
         model_timeseries[model_key] = ts
 
+    # Surface the Open-Meteo call count so ad-hoc runs can see their own
+    # API consumption. This CLI intentionally does NOT call log_api_usage
+    # (ApiUsageRow) — that's reserved for automated paths (the briefing
+    # pipeline via tasks/fetch.py, and the scheduler loops in
+    # tasks/standalone_verification.py and hewson/precompute.py). If this
+    # pipeline is ever wired into an automated path, add log_api_usage
+    # with service="open_meteo", pipeline="frontal" at the call site there.
+    logger.info("Frontal analysis: %d Open-Meteo API calls", client.call_count)
+
     return {
         "lat": lat,
         "lon": lon,
@@ -142,6 +151,7 @@ def _run_analysis(
         "model_fields": model_fields,
         "model_init_times": model_init_times,
         "timestamps": model_timestamps,
+        "api_calls": client.call_count,
     }
 
 

--- a/src/weatherbrief/frontal/grid.py
+++ b/src/weatherbrief/frontal/grid.py
@@ -35,22 +35,13 @@ FRONTAL_GRID = {
     "resolution": 0.25,
 }
 
-# 850 hPa variables — the default for zone-scale frontal detection
-_GRID_VARIABLES = (
-    "temperature_850hPa,"
-    "dewpoint_850hPa,"
-    "wind_speed_850hPa,"
-    "wind_direction_850hPa"
-)
-
-
 def _variables_for_levels(levels: list[int]) -> str:
     """Open-Meteo comma-separated variable list for the given pressure levels.
 
     For each level L, requests temperature/dewpoint/wind-speed/wind-direction
     at ``{var}_{L}hPa``. Used when fetching multi-level grids for Hewson
-    precompute; callers fetching only 850 hPa can pass ``[850]`` or rely on
-    the ``_GRID_VARIABLES`` default.
+    precompute; frontal-CLI callers passing ``levels=None`` fall through to
+    the ``fetch_grid_fields`` default of ``[850]`` via this same function.
     """
     parts: list[str] = []
     for L in levels:

--- a/src/weatherbrief/frontal/grid.py
+++ b/src/weatherbrief/frontal/grid.py
@@ -227,9 +227,15 @@ def fill_terrain(field: np.ndarray, terrain_mask: np.ndarray) -> np.ndarray:
 def compute_theta_e(
     T850: np.ndarray, Td850: np.ndarray, pressure_hPa: float = 850.0,
 ) -> np.ndarray:
-    """Equivalent potential temperature from T and Td at 850hPa.
+    """Equivalent potential temperature from T and Td at the given pressure.
 
-    Uses MetPy (already a project dependency). Returns θe in Kelvin.
+    Uses MetPy (already a project dependency). ``pressure_hPa`` defaults
+    to 850 hPa for frontal-detection back-compat, but Hewson precompute
+    calls this with 925 / 850 / 700 hPa — the parameter must be passed
+    explicitly when the inputs are from another level or the θe values
+    will be wrong. The ``T850`` / ``Td850`` parameter names are historical
+    (the function originated as 850-only); the values may come from any
+    level the caller chooses. Returns θe in Kelvin.
     """
     import metpy.calc as mpcalc
     from metpy.units import units

--- a/src/weatherbrief/frontal/grid.py
+++ b/src/weatherbrief/frontal/grid.py
@@ -35,13 +35,34 @@ FRONTAL_GRID = {
     "resolution": 0.25,
 }
 
-# 850hPa variables — the only 4 we need for frontal detection
+# 850 hPa variables — the default for zone-scale frontal detection
 _GRID_VARIABLES = (
     "temperature_850hPa,"
     "dewpoint_850hPa,"
     "wind_speed_850hPa,"
     "wind_direction_850hPa"
 )
+
+
+def _variables_for_levels(levels: list[int]) -> str:
+    """Open-Meteo comma-separated variable list for the given pressure levels.
+
+    For each level L, requests temperature/dewpoint/wind-speed/wind-direction
+    at ``{var}_{L}hPa``. Used when fetching multi-level grids for Hewson
+    precompute; callers fetching only 850 hPa can pass ``[850]`` or rely on
+    the ``_GRID_VARIABLES`` default.
+    """
+    parts: list[str] = []
+    for L in levels:
+        parts.extend(
+            (
+                f"temperature_{L}hPa",
+                f"dewpoint_{L}hPa",
+                f"wind_speed_{L}hPa",
+                f"wind_direction_{L}hPa",
+            )
+        )
+    return ",".join(parts)
 
 # Chunk size for grid fetch. The hourly param is short (~90 chars) but each
 # coordinate pair takes ~12 chars plus URL-encoding overhead (%2C = 3 chars).
@@ -231,20 +252,34 @@ def fetch_grid_fields(
     model_key: str,
     lat: np.ndarray,
     lon: np.ndarray,
+    levels: list[int] | None = None,
+    forecast_days: int | None = None,
 ) -> tuple[dict[str, list], list[str], int]:
-    """Fetch 850hPa fields for the full frontal grid from Open-Meteo.
+    """Fetch pressure-level fields for the full frontal grid from Open-Meteo.
 
     Builds URLs and chunks requests using the client's HTTP infrastructure.
     Returns (raw_data, timestamps, init_time_unix):
         raw_data: {variable_name: [[hourly values per point], ...]}
         timestamps: list of ISO timestamp strings
         init_time_unix: model initialization time (unix seconds)
+
+    ``levels`` defaults to ``[850]`` — the single-level frontal detection
+    default. Pass ``[925, 850, 700]`` for Hewson precompute. Variable names
+    in the returned dict are level-suffixed (e.g. ``temperature_850hPa``,
+    ``temperature_700hPa``) so multi-level responses stay unambiguous.
+
+    ``forecast_days`` caps how many days of hourly data to pull; defaults
+    to ``min(endpoint.max_days, 4)`` which gives the frontal CLI its
+    usual ~72 h horizon. Hewson precompute passes ``5`` to reach the 120 h
+    §4.3 horizon.
     """
     from weatherbrief.fetch.model_status import fetch_model_metadata
     from weatherbrief.fetch.variables import MODEL_ENDPOINTS
 
     endpoint = MODEL_ENDPOINTS[model_key]
     points = build_grid_points(lat, lon)
+    levels = list(levels) if levels else [850]
+    hourly_vars = _variables_for_levels(levels)
 
     # Record model init time before fetch
     meta = fetch_model_metadata(models=[model_key])
@@ -254,6 +289,9 @@ def fetch_grid_fields(
     all_responses: list[dict] = []
     timestamps: list[str] | None = None
 
+    days = forecast_days if forecast_days is not None else min(endpoint.max_days, 4)
+    days = max(1, min(days, endpoint.max_days))
+
     for chunk_start in range(0, len(points), _GRID_CHUNK_SIZE):
         chunk = points[chunk_start : chunk_start + _GRID_CHUNK_SIZE]
         chunk_idx = chunk_start // _GRID_CHUNK_SIZE + 1
@@ -262,17 +300,17 @@ def fetch_grid_fields(
         params: dict[str, object] = {
             "latitude": ",".join(str(p[0]) for p in chunk),
             "longitude": ",".join(str(p[1]) for p in chunk),
-            "hourly": _GRID_VARIABLES,
+            "hourly": hourly_vars,
             "wind_speed_unit": "kn",
             "timezone": "UTC",
-            "forecast_days": min(endpoint.max_days, 4),  # ~72h + margin
+            "forecast_days": days,
         }
         if endpoint.model_param:
             params["models"] = endpoint.model_param
 
         logger.info(
-            "Fetching %s chunk %d/%d (%d points)",
-            model_key, chunk_idx, total_chunks, len(chunk),
+            "Fetching %s chunk %d/%d (%d points, levels=%s)",
+            model_key, chunk_idx, total_chunks, len(chunk), levels,
         )
         response_json = client.get_json(endpoint.base_url, params)
 
@@ -296,7 +334,7 @@ def fetch_grid_fields(
         )
 
     # Reshape: collect all hourly arrays per variable
-    variables = [v.strip() for v in _GRID_VARIABLES.split(",")]
+    variables = [v.strip() for v in hourly_vars.split(",")]
     raw_data: dict[str, list] = {v: [] for v in variables}
 
     for point_data in all_responses:
@@ -318,13 +356,32 @@ def reshape_to_fields(
     lon: np.ndarray,
     hour_index: int,
     terrain_mask: np.ndarray | None = None,
+    level_hPa: int = 850,
 ) -> dict | None:
     """Extract one forecast hour from raw response, reshape to 2D arrays.
 
     Returns dict with T850, Td850, theta_e, u850, v850 as (n_lat, n_lon)
     arrays, or None if too much data is missing.
+
+    ``level_hPa`` selects the pressure level to read from ``raw`` (which
+    may contain multiple levels from a single multi-level fetch). The
+    output dict keys retain the historical ``T850/Td850/u850/v850`` names
+    regardless of the source level — this matches the Case-storage
+    convention (see ``frontal/case.py``). The θe calculation uses the
+    selected level's pressure.
     """
     n_lat, n_lon = len(lat), len(lon)
+    t_var = f"temperature_{level_hPa}hPa"
+    td_var = f"dewpoint_{level_hPa}hPa"
+    ws_var = f"wind_speed_{level_hPa}hPa"
+    wd_var = f"wind_direction_{level_hPa}hPa"
+
+    missing = [v for v in (t_var, td_var, ws_var, wd_var) if v not in raw]
+    if missing:
+        raise KeyError(
+            f"reshape_to_fields: raw dict missing variables {missing} — "
+            f"did the fetch request level {level_hPa} hPa?"
+        )
 
     def _extract(var_name: str) -> np.ndarray:
         values = []
@@ -335,43 +392,49 @@ def reshape_to_fields(
                 values.append(np.nan)
         return np.array(values).reshape(n_lat, n_lon)
 
-    T850_raw = _extract("temperature_850hPa")
-    Td850_raw = _extract("dewpoint_850hPa")
-    ws_raw = _extract("wind_speed_850hPa")
-    wd_raw = _extract("wind_direction_850hPa")
+    T_raw = _extract(t_var)
+    Td_raw = _extract(td_var)
+    ws_raw = _extract(ws_var)
+    wd_raw = _extract(wd_var)
 
     # Prepare fields — resolve NaN before any computation
-    T850 = prepare_field(T850_raw)
-    Td850 = prepare_field(Td850_raw)
+    T = prepare_field(T_raw)
+    Td = prepare_field(Td_raw)
 
-    if any(f is None for f in (T850, Td850)):
-        logger.warning("Hour index %d: too much missing data, skipping", hour_index)
+    if any(f is None for f in (T, Td)):
+        logger.warning(
+            "Hour %d level %d hPa: too much missing T/Td data, skipping",
+            hour_index, level_hPa,
+        )
         return None
 
     # Convert wind to u/v BEFORE NaN fill — direction has circular
     # wraparound (359° ≈ 1°) so nearest-neighbor on raw direction can
     # introduce large jumps. Filling on Cartesian u/v is safe.
-    u850_raw, v850_raw = wind_to_uv(ws_raw, wd_raw)
-    u850 = prepare_field(u850_raw)
-    v850 = prepare_field(v850_raw)
+    u_raw, v_raw = wind_to_uv(ws_raw, wd_raw)
+    u = prepare_field(u_raw)
+    v = prepare_field(v_raw)
 
-    if any(f is None for f in (u850, v850)):
-        logger.warning("Hour index %d: too much missing wind data, skipping", hour_index)
+    if any(f is None for f in (u, v)):
+        logger.warning(
+            "Hour %d level %d hPa: too much missing wind data, skipping",
+            hour_index, level_hPa,
+        )
         return None
 
     # Fill terrain before θe computation (same field goes into detection)
     if terrain_mask is not None:
-        T850 = fill_terrain(T850, terrain_mask)
-        Td850 = fill_terrain(Td850, terrain_mask)
-        u850 = fill_terrain(u850, terrain_mask)
-        v850 = fill_terrain(v850, terrain_mask)
+        T = fill_terrain(T, terrain_mask)
+        Td = fill_terrain(Td, terrain_mask)
+        u = fill_terrain(u, terrain_mask)
+        v = fill_terrain(v, terrain_mask)
 
-    theta_e = compute_theta_e(T850, Td850)
+    theta_e = compute_theta_e(T, Td, pressure_hPa=float(level_hPa))
 
     return {
-        "T850": T850,
-        "Td850": Td850,
+        "T850": T,
+        "Td850": Td,
         "theta_e": theta_e,
-        "u850": u850,
-        "v850": v850,
+        "u850": u,
+        "v850": v,
     }

--- a/src/weatherbrief/hewson/__init__.py
+++ b/src/weatherbrief/hewson/__init__.py
@@ -1,0 +1,38 @@
+"""Hewson diagnostic field precompute.
+
+Produces NPZ snapshots of θe-derived diagnostic fields (gradient, neg-Laplacian,
+TFP, advection, tendency) on the 0.25° European grid at 925/850/700 hPa, one
+snapshot per (model, init cycle). Consumed by the interactive forecast map,
+cross-section overlay, and per-leg advisory evaluators.
+
+Entry points:
+    run_once(models, ...)           — library call used by the scheduler loop
+                                       and CLI alike (one function, two callers)
+    python -m weatherbrief.hewson precompute [flags]
+                                      — ad-hoc / debug invocation
+
+See designs/future/hewson-fields-aviation-advisories.md §6.1 for the snapshot
+schema and §4 for the resolution / level / cadence decisions.
+"""
+
+from weatherbrief.hewson.precompute import (
+    DEFAULT_LEVELS,
+    DEFAULT_MODELS,
+    SnapshotResult,
+    load_snapshot,
+    purge_old_snapshots,
+    resolve_output_dir,
+    run_once,
+    snapshot_path,
+)
+
+__all__ = [
+    "DEFAULT_LEVELS",
+    "DEFAULT_MODELS",
+    "SnapshotResult",
+    "load_snapshot",
+    "purge_old_snapshots",
+    "resolve_output_dir",
+    "run_once",
+    "snapshot_path",
+]

--- a/src/weatherbrief/hewson/__main__.py
+++ b/src/weatherbrief/hewson/__main__.py
@@ -1,0 +1,8 @@
+"""`python -m weatherbrief.hewson` entry point — delegates to cli.main()."""
+
+import sys
+
+from weatherbrief.hewson.cli import main
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/weatherbrief/hewson/cli.py
+++ b/src/weatherbrief/hewson/cli.py
@@ -1,0 +1,217 @@
+"""Ad-hoc CLI for Hewson snapshot precompute.
+
+Wraps ``precompute.run_once`` with argparse flags so debugging and manual
+reruns go through the exact same code path as the scheduler loop. No
+separate implementation — any change to the pipeline takes effect in both
+surfaces simultaneously.
+
+Usage:
+    python -m weatherbrief.hewson precompute
+    python -m weatherbrief.hewson precompute --model ecmwf --dry-run
+    python -m weatherbrief.hewson precompute --levels 925,850,700 --force
+    python -m weatherbrief.hewson list
+    python -m weatherbrief.hewson purge --retention-hours 24
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+from weatherbrief.hewson.precompute import (
+    DEFAULT_LEVELS,
+    DEFAULT_MODELS,
+    DEFAULT_RETENTION_HOURS,
+    DEFAULT_STRIDE_HOURS,
+    load_snapshot,
+    purge_old_snapshots,
+    resolve_output_dir,
+    run_once,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_levels(s: str) -> list[int]:
+    return [int(tok.strip()) for tok in s.split(",") if tok.strip()]
+
+
+def _parse_models(s: str) -> list[str]:
+    return [tok.strip() for tok in s.split(",") if tok.strip()]
+
+
+def _cmd_precompute(args: argparse.Namespace) -> int:
+    result = run_once(
+        models=args.models,
+        levels=args.levels,
+        output_dir=args.output_dir,
+        forecast_days=args.forecast_days,
+        stride_hours=args.stride_hours,
+        retention_hours=args.retention_hours,
+        dry_run=args.dry_run,
+        skip_existing=not args.force,
+    )
+    for model, path in result.snapshots.items():
+        if path is None:
+            print(f"  {model}: (dry-run, no file written)")
+        else:
+            print(f"  {model}: {path}")
+    for model, reason in result.skipped.items():
+        print(f"  {model}: skipped ({reason})")
+    print(
+        f"Done in {result.elapsed_seconds:.1f}s — "
+        f"{len([p for p in result.snapshots.values() if p])} written, "
+        f"{len(result.skipped)} skipped, {result.purged} purged"
+    )
+    return 0
+
+
+def _cmd_list(args: argparse.Namespace) -> int:
+    root = resolve_output_dir(args.output_dir)
+    if not root.exists():
+        print(f"No snapshot root at {root}")
+        return 0
+
+    print(f"Snapshot root: {root}")
+    total_bytes = 0
+    total_count = 0
+    for subdir in sorted(root.iterdir()):
+        if not subdir.is_dir():
+            continue
+        entries = sorted(subdir.glob("*.npz"))
+        if not entries:
+            continue
+        print(f"\n  {subdir.name}/")
+        for path in entries:
+            size_kb = path.stat().st_size / 1024
+            total_bytes += path.stat().st_size
+            total_count += 1
+            if args.verbose:
+                try:
+                    snap = load_snapshot(path)
+                    n_time = len(snap["valid_times"])
+                    levels = list(snap["levels"].tolist())
+                    stride = int(snap["stride_hours"]) if "stride_hours" in snap else 1
+                    print(
+                        f"    {path.name}  {size_kb:6.1f} KB  "
+                        f"({n_time} × {stride}h steps, levels={levels})"
+                    )
+                except Exception as e:
+                    print(f"    {path.name}  {size_kb:6.1f} KB  (unreadable: {e})")
+            else:
+                print(f"    {path.name}  {size_kb:6.1f} KB")
+    print(f"\nTotal: {total_count} snapshots, {total_bytes / (1024 * 1024):.1f} MB")
+    return 0
+
+
+def _cmd_purge(args: argparse.Namespace) -> int:
+    removed = purge_old_snapshots(
+        model=args.model,
+        output_dir=args.output_dir,
+        retention_hours=args.retention_hours,
+    )
+    print(f"Purged {removed} snapshot(s) older than {args.retention_hours} h")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python -m weatherbrief.hewson",
+        description="Hewson diagnostic snapshot precompute and maintenance.",
+    )
+    parser.add_argument(
+        "--log-level", default="INFO",
+        help="Python logging level (default: INFO)",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    # precompute
+    p_pc = sub.add_parser(
+        "precompute",
+        help="Fetch Open-Meteo, compute diagnostics, write NPZ snapshots.",
+    )
+    p_pc.add_argument(
+        "--models", type=_parse_models, default=list(DEFAULT_MODELS),
+        help=f"Comma-separated model keys (default: {','.join(DEFAULT_MODELS)})",
+    )
+    p_pc.add_argument(
+        "--levels", type=_parse_levels, default=list(DEFAULT_LEVELS),
+        help=f"Comma-separated pressure levels in hPa (default: "
+             f"{','.join(str(L) for L in DEFAULT_LEVELS)})",
+    )
+    p_pc.add_argument(
+        "--output-dir", type=Path, default=None,
+        help="Override snapshot root (default: ${DATA_DIR}/hewson)",
+    )
+    p_pc.add_argument(
+        "--forecast-days", type=int, default=5,
+        help="Forecast horizon in days (default: 5 per § 4.3)",
+    )
+    p_pc.add_argument(
+        "--stride-hours", type=int, default=DEFAULT_STRIDE_HOURS,
+        help=f"Decimation cadence — keep every Nth forecast hour "
+             f"(default: {DEFAULT_STRIDE_HOURS}). Set to 1 to keep every hour.",
+    )
+    p_pc.add_argument(
+        "--retention-hours", type=int, default=DEFAULT_RETENTION_HOURS,
+        help=f"Purge snapshots older than N hours after writing "
+             f"(default: {DEFAULT_RETENTION_HOURS})",
+    )
+    p_pc.add_argument(
+        "--dry-run", action="store_true",
+        help="Compute but do not write NPZ or purge old snapshots.",
+    )
+    p_pc.add_argument(
+        "--force", action="store_true",
+        help="Recompute even if a snapshot for the current init exists.",
+    )
+    p_pc.set_defaults(func=_cmd_precompute)
+
+    # list
+    p_ls = sub.add_parser("list", help="Show snapshots currently on disk.")
+    p_ls.add_argument("--output-dir", type=Path, default=None)
+    p_ls.add_argument(
+        "-v", "--verbose", action="store_true",
+        help="Also open each NPZ to show hours/levels.",
+    )
+    p_ls.set_defaults(func=_cmd_list)
+
+    # purge
+    p_pu = sub.add_parser("purge", help="Delete snapshots older than retention.")
+    p_pu.add_argument("--output-dir", type=Path, default=None)
+    p_pu.add_argument("--model", default=None, help="Restrict to one model.")
+    p_pu.add_argument(
+        "--retention-hours", type=int, default=DEFAULT_RETENTION_HOURS,
+    )
+    p_pu.set_defaults(func=_cmd_purge)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    # Match the web app: load .env so OPENMETEO_API_KEY, DATA_DIR, etc. are
+    # picked up from the project root without requiring the caller to source
+    # the env file manually. Without this the CLI runs as an anonymous
+    # Open-Meteo caller and gets rate-limited hard.
+    try:
+        from dotenv import load_dotenv
+
+        load_dotenv()
+    except ImportError:
+        pass  # dotenv is optional in minimal deployments
+
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(
+        level=getattr(logging, args.log_level.upper(), logging.INFO),
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/weatherbrief/hewson/cli.py
+++ b/src/weatherbrief/hewson/cli.py
@@ -88,8 +88,9 @@ def _cmd_list(args: argparse.Namespace) -> int:
             continue
         print(f"\n  {subdir.name}/")
         for path in entries:
-            size_kb = path.stat().st_size / 1024
-            total_bytes += path.stat().st_size
+            st = path.stat()
+            size_kb = st.st_size / 1024
+            total_bytes += st.st_size
             total_count += 1
             if args.verbose:
                 try:

--- a/src/weatherbrief/hewson/cli.py
+++ b/src/weatherbrief/hewson/cli.py
@@ -64,7 +64,9 @@ def _cmd_precompute(args: argparse.Namespace) -> int:
     print(
         f"Done in {result.elapsed_seconds:.1f}s — "
         f"{len([p for p in result.snapshots.values() if p])} written, "
-        f"{len(result.skipped)} skipped, {result.purged} purged"
+        f"{len(result.skipped)} skipped, {result.purged} purged, "
+        f"{result.api_calls_total} Open-Meteo API calls "
+        f"(not logged to DB — CLI runs do not hit ApiUsageRow)"
     )
     return 0
 

--- a/src/weatherbrief/hewson/precompute.py
+++ b/src/weatherbrief/hewson/precompute.py
@@ -313,8 +313,16 @@ def load_snapshot(path: Path | str) -> dict:
 
     Convenience wrapper for readers (map endpoint, cross-section bands,
     advisory evaluators). Keys mirror the NPZ file — see module docstring
-    for the schema. Arrays are materialized in memory on load; snapshots
-    are small (≲500 KB) so no memory-mapping complexity is needed.
+    for the schema. Arrays are materialized in memory on load.
+
+    Size note: a default snapshot is ~46 MB compressed (3 h stride × 40
+    timesteps × 3 levels × 6 metrics × float32, see § 5 of the design
+    doc). ``np.load`` decompresses each array on first access, which can
+    take ~100–300 ms for the full dict on a cold disk. Callers running
+    inside an async event loop (FastAPI route handlers etc.) must invoke
+    this from ``asyncio.to_thread`` or an equivalent threadpool offload,
+    or index the NPZ lazily (``with np.load(path) as npz: npz['metric_L'][h]``)
+    to decompress only the slice they need.
     """
     with np.load(Path(path)) as npz:
         return {k: npz[k] for k in npz.files}

--- a/src/weatherbrief/hewson/precompute.py
+++ b/src/weatherbrief/hewson/precompute.py
@@ -256,6 +256,10 @@ def _build_one_snapshot(
             fields = reshape_to_fields(raw, lat, lon, h, terrain_mask, level_hPa=L)
             if fields is None:
                 continue
+            # reshape_to_fields returns level-specific winds under the
+            # historical u850/v850 keys regardless of the actual level
+            # (see frontal/grid.py reshape_to_fields docstring) — values
+            # here are from level L, not 850 hPa.
             diag = compute_hewson_diagnostics(
                 fields["theta_e"], lat, lon,
                 fields["u850"], fields["v850"],

--- a/src/weatherbrief/hewson/precompute.py
+++ b/src/weatherbrief/hewson/precompute.py
@@ -1,0 +1,502 @@
+"""Hewson diagnostic snapshot precompute pipeline.
+
+Core flow, shared by the scheduler loop and the ``python -m weatherbrief.hewson
+precompute`` CLI:
+
+    1. build / load terrain mask (cached to disk)
+    2. for each model:
+         a. fetch multi-level grid (925/850/700 hPa) via Open-Meteo
+         b. reshape per (hour, level) into 2D fields
+         c. compute Hewson diagnostics (gradient / TFP / −∇²θe / advection)
+         d. derive tendency ∂θe/∂t across consecutive hours
+         e. write one NPZ per (model, init cycle) with level-suffixed keys
+    3. purge snapshots older than the retention window
+
+Snapshot schema (per designs/future/hewson-fields-aviation-advisories.md §6.1):
+
+    data/hewson/<model>/<init_iso_z>.npz
+        theta_e_{925,850,700}     (n_hour, n_lat, n_lon) float32, K
+        gradient_{925,850,700}    (n_hour, n_lat, n_lon) float32, K / 100 km
+        neg_laplacian_{925,850,700}
+        tfp_{925,850,700}
+        advection_{925,850,700}                           K / h
+        tendency_{925,850,700}                            K / h  (edges nan)
+        valid_times                                       (n_hour,) datetime64[ns]
+        lat, lon                                          1D coord arrays
+        init_time_unix                                    scalar int
+        levels                                            1D int array
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import numpy as np
+
+from weatherbrief.frontal.detect import compute_hewson_diagnostics
+from weatherbrief.frontal.grid import (
+    build_grid_coords,
+    build_terrain_mask,
+    fetch_grid_fields,
+    reshape_to_fields,
+)
+
+logger = logging.getLogger(__name__)
+
+
+DEFAULT_MODELS: tuple[str, ...] = ("ecmwf", "gfs", "icon")
+DEFAULT_LEVELS: tuple[int, ...] = (925, 850, 700)
+DEFAULT_FORECAST_DAYS = 5  # § 4.3 horizon
+DEFAULT_RETENTION_HOURS = 48  # § 4.6
+# Synoptic-view temporal resolution. Open-Meteo delivers hourly; we decimate
+# locally before the compute loop (3× compute speedup, ~3× smaller NPZ). The
+# map slider, cross-section bands, and advisory evaluators all interpolate
+# between bounding snapshot hours — 3 h gives ~50 km spatial blur on a moving
+# front (§ 8 quotes ±50–100 km inherent TFP positional uncertainty) so this
+# cadence is well inside the "qualitative, not pinpoint" error budget.
+# Per-flight briefings compute at a finer grain at briefing time (§ 6.2
+# stencil path) — they don't read the synoptic snapshot for leg advisories.
+DEFAULT_STRIDE_HOURS = 3
+
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+
+def resolve_output_dir(output_dir: Path | str | None = None) -> Path:
+    """Return the root directory where Hewson snapshots live.
+
+    Resolution order (matches ``storage/snapshots.py``):
+      1. explicit ``output_dir`` argument
+      2. ``DATA_DIR`` env var → ``{DATA_DIR}/hewson``
+      3. fallback ``data/hewson`` (dev convenience)
+    """
+    if output_dir is not None:
+        return Path(output_dir)
+    env = os.environ.get("DATA_DIR")
+    base = Path(env) if env else Path("data")
+    return base / "hewson"
+
+
+def _init_to_iso_z(init_time_unix: int) -> str:
+    """Unix seconds → ISO 8601 with ``Z`` suffix (filename-safe)."""
+    dt = datetime.fromtimestamp(init_time_unix, tz=timezone.utc)
+    # dt.isoformat() produces "+00:00"; swap for Z
+    return dt.isoformat().replace("+00:00", "Z")
+
+
+def snapshot_path(
+    model: str, init_time_unix: int, output_dir: Path | None = None,
+) -> Path:
+    """Canonical disk location for a (model, init) snapshot."""
+    return resolve_output_dir(output_dir) / model / f"{_init_to_iso_z(init_time_unix)}.npz"
+
+
+def _terrain_mask_path(output_dir: Path | None = None) -> Path:
+    return resolve_output_dir(output_dir) / "terrain_mask.npz"
+
+
+# ---------------------------------------------------------------------------
+# Terrain-mask caching
+# ---------------------------------------------------------------------------
+
+
+def _load_or_build_terrain_mask(
+    lat: np.ndarray, lon: np.ndarray, output_dir: Path | None,
+) -> np.ndarray:
+    """Return the terrain mask for the current grid.
+
+    First invocation per environment builds via SRTM3 (~seconds) and caches
+    to ``{DATA_DIR}/hewson/terrain_mask.npz``. Subsequent calls load from
+    disk and verify the shape matches the active grid.
+    """
+    cache_path = _terrain_mask_path(output_dir)
+    if cache_path.exists():
+        with np.load(cache_path) as npz:
+            mask = npz["mask"]
+            cached_lat = npz["lat"]
+            cached_lon = npz["lon"]
+        if (
+            mask.shape == (len(lat), len(lon))
+            and np.allclose(cached_lat, lat)
+            and np.allclose(cached_lon, lon)
+        ):
+            return mask
+        logger.info(
+            "Terrain-mask cache at %s stale (grid changed) — rebuilding",
+            cache_path,
+        )
+
+    mask = build_terrain_mask(lat, lon)
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    np.savez_compressed(cache_path, mask=mask, lat=lat, lon=lon)
+    return mask
+
+
+# ---------------------------------------------------------------------------
+# Tendency helper
+# ---------------------------------------------------------------------------
+
+
+def _tendency_k_per_hour(
+    theta_e_stack: np.ndarray, step_hours: int = 1,
+) -> np.ndarray:
+    """Centred-difference ∂θe/∂t in K/h from a (n_time, n_lat, n_lon) stack.
+
+    ``step_hours`` is the wall-clock spacing between consecutive stack
+    indices — 1 for hourly snapshots, 3 for a 3-h-cadence precompute. The
+    returned tendency is in **K per hour** regardless of stride (we divide
+    out the step) so callers read a uniform unit.
+
+    Edges fall back to one-sided differences. With <2 indices the tendency
+    is all-NaN — callers should treat as "unavailable".
+    """
+    n = theta_e_stack.shape[0]
+    tendency = np.full_like(theta_e_stack, np.nan, dtype=np.float32)
+    if step_hours <= 0:
+        raise ValueError(f"step_hours must be positive, got {step_hours}")
+    if n >= 2:
+        tendency[0] = (theta_e_stack[1] - theta_e_stack[0]) / step_hours
+        tendency[-1] = (theta_e_stack[-1] - theta_e_stack[-2]) / step_hours
+    if n >= 3:
+        tendency[1:-1] = (
+            (theta_e_stack[2:] - theta_e_stack[:-2]) / (2 * step_hours)
+        )
+    return tendency
+
+
+# ---------------------------------------------------------------------------
+# Result type
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SnapshotResult:
+    """Outcome of one ``run_once()`` call.
+
+    ``snapshots`` keys are model names; values are the written NPZ path (or
+    ``None`` for dry-run / fetch failure). ``skipped`` maps model → reason
+    for models that were skipped (already-fresh snapshot, fetch failure).
+    """
+
+    snapshots: dict[str, Path | None] = field(default_factory=dict)
+    skipped: dict[str, str] = field(default_factory=dict)
+    init_times: dict[str, int] = field(default_factory=dict)
+    elapsed_seconds: float = 0.0
+    purged: int = 0
+
+
+# ---------------------------------------------------------------------------
+# Per-model snapshot builder
+# ---------------------------------------------------------------------------
+
+
+def _build_one_snapshot(
+    client,
+    model: str,
+    lat: np.ndarray,
+    lon: np.ndarray,
+    terrain_mask: np.ndarray,
+    levels: list[int],
+    forecast_days: int,
+    stride_hours: int = DEFAULT_STRIDE_HOURS,
+) -> tuple[int, np.ndarray, dict[int, dict[str, np.ndarray]]] | None:
+    """Fetch + compute diagnostics for one model.
+
+    Fetches hourly data from Open-Meteo (its native cadence), then decimates
+    to every ``stride_hours``-th forecast hour before the Hewson compute loop
+    — this both shrinks the output NPZ and skips ``stride_hours - 1`` compute
+    passes per step. See ``DEFAULT_STRIDE_HOURS`` for the rationale.
+
+    Returns ``(init_time_unix, valid_times, per_level_stacks)`` where
+    ``per_level_stacks[L]`` is a dict of metric-name → (n_time, n_lat, n_lon)
+    float32 stacks. Returns ``None`` if Open-Meteo returns no usable data.
+    """
+    raw, timestamps, init_time = fetch_grid_fields(
+        client, model, lat, lon,
+        levels=levels, forecast_days=forecast_days,
+    )
+    if not timestamps:
+        logger.warning("Hewson precompute: %s returned no timestamps", model)
+        return None
+
+    if stride_hours < 1:
+        raise ValueError(f"stride_hours must be >= 1, got {stride_hours}")
+
+    # Decimate to stride_hours cadence. Anchored at the model init (index 0)
+    # so the series lands on synoptic hours when init is on a synoptic hour.
+    keep_indices = list(range(0, len(timestamps), stride_hours))
+    kept_timestamps = [timestamps[i] for i in keep_indices]
+
+    n_time = len(kept_timestamps)
+    n_lat, n_lon = len(lat), len(lon)
+    valid_times = np.array(
+        [np.datetime64(ts) for ts in kept_timestamps], dtype="datetime64[ns]",
+    )
+
+    # metric_name → (n_time, n_lat, n_lon) float32
+    per_level: dict[int, dict[str, np.ndarray]] = {
+        L: {
+            "theta_e": np.full((n_time, n_lat, n_lon), np.nan, dtype=np.float32),
+            "gradient": np.full((n_time, n_lat, n_lon), np.nan, dtype=np.float32),
+            "neg_laplacian": np.full((n_time, n_lat, n_lon), np.nan, dtype=np.float32),
+            "tfp": np.full((n_time, n_lat, n_lon), np.nan, dtype=np.float32),
+            "advection": np.full((n_time, n_lat, n_lon), np.nan, dtype=np.float32),
+        }
+        for L in levels
+    }
+
+    for i, h in enumerate(keep_indices):
+        for L in levels:
+            fields = reshape_to_fields(raw, lat, lon, h, terrain_mask, level_hPa=L)
+            if fields is None:
+                continue
+            diag = compute_hewson_diagnostics(
+                fields["theta_e"], lat, lon,
+                fields["u850"], fields["v850"],
+                terrain_mask=terrain_mask,
+            )
+            per_level[L]["theta_e"][i] = fields["theta_e"]
+            per_level[L]["gradient"][i] = diag["gradient"]
+            per_level[L]["neg_laplacian"][i] = diag["neg_laplacian"]
+            per_level[L]["tfp"][i] = diag["tfp"]
+            per_level[L]["advection"][i] = diag["advection"]
+
+    # Derive tendency across the decimated stack — step_hours matches stride
+    # so the result is still K per hour regardless of cadence.
+    for L in levels:
+        per_level[L]["tendency"] = _tendency_k_per_hour(
+            per_level[L]["theta_e"], step_hours=stride_hours,
+        )
+
+    return init_time, valid_times, per_level
+
+
+# ---------------------------------------------------------------------------
+# NPZ write
+# ---------------------------------------------------------------------------
+
+
+def _write_snapshot(
+    path: Path,
+    init_time_unix: int,
+    valid_times: np.ndarray,
+    lat: np.ndarray,
+    lon: np.ndarray,
+    levels: list[int],
+    stride_hours: int,
+    per_level: dict[int, dict[str, np.ndarray]],
+) -> None:
+    """Serialize a snapshot to NPZ with level-suffixed keys per § 6.1."""
+    data: dict[str, np.ndarray] = {
+        "valid_times": valid_times,
+        "lat": lat.astype(np.float64),
+        "lon": lon.astype(np.float64),
+        "init_time_unix": np.array(init_time_unix, dtype=np.int64),
+        "levels": np.array(levels, dtype=np.int32),
+        "stride_hours": np.array(stride_hours, dtype=np.int32),
+    }
+    for L in levels:
+        for metric, arr in per_level[L].items():
+            data[f"{metric}_{L}"] = arr
+    path.parent.mkdir(parents=True, exist_ok=True)
+    np.savez_compressed(path, **data)
+
+
+def load_snapshot(path: Path | str) -> dict:
+    """Load a precomputed snapshot, returning a dict of its contents.
+
+    Convenience wrapper for readers (map endpoint, cross-section bands,
+    advisory evaluators). Keys mirror the NPZ file — see module docstring
+    for the schema. Arrays are materialized in memory on load; snapshots
+    are small (≲500 KB) so no memory-mapping complexity is needed.
+    """
+    with np.load(Path(path)) as npz:
+        return {k: npz[k] for k in npz.files}
+
+
+# ---------------------------------------------------------------------------
+# Retention
+# ---------------------------------------------------------------------------
+
+
+def purge_old_snapshots(
+    model: str | None = None,
+    output_dir: Path | None = None,
+    retention_hours: int = DEFAULT_RETENTION_HOURS,
+    now: datetime | None = None,
+) -> int:
+    """Delete snapshots older than ``retention_hours``. Returns count deleted.
+
+    When ``model`` is None, iterates every per-model subdirectory under the
+    output root. Snapshots are identified by their ISO-8601-Z filename
+    (``<init>.npz``) so parsing is straightforward.
+    """
+    root = resolve_output_dir(output_dir)
+    if not root.exists():
+        return 0
+
+    now = now or datetime.now(timezone.utc)
+    cutoff = now - timedelta(hours=retention_hours)
+
+    if model is not None:
+        subdirs = [root / model]
+    else:
+        subdirs = [d for d in root.iterdir() if d.is_dir()]
+
+    removed = 0
+    for subdir in subdirs:
+        if not subdir.exists():
+            continue
+        for path in subdir.glob("*.npz"):
+            stem = path.stem  # "2026-04-24T12:00:00Z"
+            try:
+                # datetime.fromisoformat handles "+00:00" but not "Z" on 3.10.
+                # Replace Z → +00:00 for round-trip.
+                dt = datetime.fromisoformat(stem.replace("Z", "+00:00"))
+            except ValueError:
+                logger.warning(
+                    "Hewson purge: skipping unrecognised filename %s", path,
+                )
+                continue
+            if dt < cutoff:
+                path.unlink()
+                removed += 1
+    if removed:
+        logger.info("Hewson purge: removed %d snapshot(s)", removed)
+    return removed
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def run_once(
+    models: list[str] | tuple[str, ...] | None = None,
+    *,
+    levels: list[int] | tuple[int, ...] | None = None,
+    output_dir: Path | str | None = None,
+    forecast_days: int = DEFAULT_FORECAST_DAYS,
+    stride_hours: int = DEFAULT_STRIDE_HOURS,
+    retention_hours: int = DEFAULT_RETENTION_HOURS,
+    dry_run: bool = False,
+    skip_existing: bool = True,
+    client=None,
+) -> SnapshotResult:
+    """Fetch + compute + write one snapshot per model.
+
+    Single entry point shared by the scheduler loop and the ``hewson precompute``
+    CLI. Safe to call any time — Open-Meteo serves whatever init it currently
+    publishes, so calling twice in quick succession for the same cycle is a
+    no-op when ``skip_existing=True`` (default).
+
+    Parameters
+    ----------
+    models : list of model keys (default ``("ecmwf", "gfs", "icon")``).
+    levels : pressure levels in hPa (default ``(925, 850, 700)``).
+    output_dir : root dir for snapshots; defaults to ``${DATA_DIR}/hewson``.
+    forecast_days : horizon requested from Open-Meteo (default 5, § 4.3).
+    stride_hours : decimation cadence applied to hourly Open-Meteo output
+        before the compute loop (default 3, see ``DEFAULT_STRIDE_HOURS``).
+        Set to 1 to keep every hour.
+    retention_hours : purge window applied after writing (default 48).
+    dry_run : compute but do not write NPZ or purge.
+    skip_existing : if an NPZ for a model's current init already exists,
+        skip the fetch + compute. Disable for forced recomputation.
+    client : optional OpenMeteoClient (for testing / dependency injection).
+    """
+    from weatherbrief.fetch.open_meteo import OpenMeteoClient
+
+    import time
+
+    models = list(models) if models else list(DEFAULT_MODELS)
+    levels = sorted(int(L) for L in (levels if levels else DEFAULT_LEVELS))
+
+    started = time.monotonic()
+    result = SnapshotResult()
+
+    client = client or OpenMeteoClient()
+    lat, lon = build_grid_coords()
+    terrain_mask = _load_or_build_terrain_mask(lat, lon, output_dir)
+
+    for model in models:
+        try:
+            # Peek at init time first — lets us skip the grid fetch when the
+            # snapshot for this cycle is already on disk.
+            if skip_existing:
+                from weatherbrief.fetch.model_status import fetch_model_metadata
+
+                meta = fetch_model_metadata(models=[model])
+                if model in meta:
+                    expected_init = meta[model].last_init_time
+                    expected_path = snapshot_path(model, expected_init, output_dir)
+                    if expected_init and expected_path.exists():
+                        logger.info(
+                            "Hewson precompute: %s init %s already on disk, "
+                            "skipping", model, _init_to_iso_z(expected_init),
+                        )
+                        result.skipped[model] = "fresh"
+                        result.init_times[model] = expected_init
+                        continue
+
+            built = _build_one_snapshot(
+                client, model, lat, lon, terrain_mask,
+                levels, forecast_days, stride_hours,
+            )
+            if built is None:
+                result.skipped[model] = "no-data"
+                continue
+            init_time, valid_times, per_level = built
+            result.init_times[model] = init_time
+
+            if init_time == 0:
+                logger.warning(
+                    "Hewson precompute: %s has init_time=0 — skipping write",
+                    model,
+                )
+                result.skipped[model] = "no-init-time"
+                continue
+
+            path = snapshot_path(model, init_time, output_dir)
+            if dry_run:
+                logger.info(
+                    "Hewson precompute (dry-run): would write %s", path,
+                )
+                result.snapshots[model] = None
+            else:
+                _write_snapshot(
+                    path, init_time, valid_times, lat, lon,
+                    levels, stride_hours, per_level,
+                )
+                size_kb = path.stat().st_size / 1024
+                logger.info(
+                    "Hewson precompute: wrote %s "
+                    "(%d timesteps × %d levels, stride=%dh, %.1f KB)",
+                    path, len(valid_times), len(levels),
+                    stride_hours, size_kb,
+                )
+                result.snapshots[model] = path
+        except Exception:
+            logger.exception("Hewson precompute: %s failed", model)
+            result.skipped[model] = "error"
+
+    if not dry_run:
+        result.purged = purge_old_snapshots(
+            output_dir=output_dir, retention_hours=retention_hours,
+        )
+
+    result.elapsed_seconds = time.monotonic() - started
+    logger.info(
+        "Hewson precompute: done (%.1fs) — %d written, %d skipped, %d purged",
+        result.elapsed_seconds,
+        len([p for p in result.snapshots.values() if p is not None]),
+        len(result.skipped),
+        result.purged,
+    )
+    return result

--- a/src/weatherbrief/hewson/precompute.py
+++ b/src/weatherbrief/hewson/precompute.py
@@ -182,6 +182,12 @@ class SnapshotResult:
     ``snapshots`` keys are model names; values are the written NPZ path (or
     ``None`` for dry-run / fetch failure). ``skipped`` maps model → reason
     for models that were skipped (already-fresh snapshot, fetch failure).
+    ``api_calls_total`` is the aggregate HTTP call count from
+    ``OpenMeteoClient.call_count`` across all models in this run — read
+    once at end of ``run_once`` so the scheduler loop can push it to
+    ``ApiUsageRow`` via :func:`weatherbrief.api.usage.log_api_usage`
+    (matches the ``pipeline="verification"`` precedent in
+    ``tasks/standalone_verification.py``).
     """
 
     snapshots: dict[str, Path | None] = field(default_factory=dict)
@@ -189,6 +195,7 @@ class SnapshotResult:
     init_times: dict[str, int] = field(default_factory=dict)
     elapsed_seconds: float = 0.0
     purged: int = 0
+    api_calls_total: int = 0
 
 
 # ---------------------------------------------------------------------------
@@ -503,12 +510,15 @@ def run_once(
             output_dir=output_dir, retention_hours=retention_hours,
         )
 
+    result.api_calls_total = getattr(client, "call_count", 0)
     result.elapsed_seconds = time.monotonic() - started
     logger.info(
-        "Hewson precompute: done (%.1fs) — %d written, %d skipped, %d purged",
+        "Hewson precompute: done (%.1fs) — %d written, %d skipped, "
+        "%d purged, %d Open-Meteo API calls",
         result.elapsed_seconds,
         len([p for p in result.snapshots.values() if p is not None]),
         len(result.skipped),
         result.purged,
+        result.api_calls_total,
     )
     return result

--- a/src/weatherbrief/scheduler.py
+++ b/src/weatherbrief/scheduler.py
@@ -648,14 +648,46 @@ async def run_hewson_precompute_loop(app_state) -> None:
 
 
 def _run_hewson_precompute_once() -> None:
-    """Execute a single Hewson precompute cycle (called in a thread)."""
+    """Execute a single Hewson precompute cycle (called in a thread).
+
+    After the compute + write, persists the Open-Meteo call count to
+    ``ApiUsageRow`` via :func:`weatherbrief.api.usage.log_api_usage` so
+    the precompute's API consumption shows up in the shared usage
+    dashboard alongside the other pipelines (briefing / verification /
+    standalone). Matches the pattern in
+    :mod:`weatherbrief.tasks.standalone_verification`.
+    """
     from weatherbrief.hewson import run_once
 
     result = run_once()
     logger.info(
-        "Hewson precompute: %d written, %d skipped, %d purged (%.1fs)",
+        "Hewson precompute: %d written, %d skipped, %d purged, "
+        "%d Open-Meteo calls (%.1fs)",
         len([p for p in result.snapshots.values() if p is not None]),
         len(result.skipped),
         result.purged,
+        result.api_calls_total,
         result.elapsed_seconds,
     )
+
+    if result.api_calls_total > 0:
+        from flyfun_common.db import SessionLocal
+
+        from weatherbrief.api.usage import log_api_usage
+
+        db = SessionLocal()
+        try:
+            log_api_usage(
+                db,
+                service="open_meteo",
+                pipeline="hewson_precompute",
+                api_calls=result.api_calls_total,
+            )
+            db.commit()
+        except Exception:
+            db.rollback()
+            logger.error(
+                "Hewson precompute: failed to log API usage", exc_info=True,
+            )
+        finally:
+            db.close()

--- a/src/weatherbrief/scheduler.py
+++ b/src/weatherbrief/scheduler.py
@@ -41,6 +41,11 @@ _DIGEST_STARTUP_DELAY_SECONDS = 180  # let verification settle first
 _STANDALONE_STARTUP_DELAY_SECONDS = 240  # let other loops settle first
 _ECMWF_WATCHER_POLL_SECONDS = 300  # 5 minutes
 _ECMWF_WATCHER_STARTUP_DELAY_SECONDS = 15  # run early — other loops may need ready data
+# Hewson precompute fires once per init cycle. 05Z and 17Z pick up the 00Z /
+# 12Z inits after ~5 h — Open-Meteo has all 3 models published by then, and
+# we keep 1 h buffer before the 06Z / 18Z standalone-verification full cycles.
+_HEWSON_SAMPLE_HOURS_UTC = [5, 17]
+_HEWSON_STARTUP_DELAY_SECONDS = 300  # let other loops settle; Hewson is cold-cache anyway
 
 
 async def run_scheduler_loop(app_state) -> None:
@@ -592,3 +597,65 @@ def _run_ecmwf_watcher_once() -> list[datetime]:
     from weatherbrief.fetch.grib.ecmwf_watcher import check_ecmwf_completeness
 
     return check_ecmwf_completeness()
+
+
+# ---------------------------------------------------------------------------
+# Hewson precompute loop
+# ---------------------------------------------------------------------------
+
+
+async def run_hewson_precompute_loop(app_state) -> None:
+    """Fire Hewson diagnostic precompute at fixed UTC hours.
+
+    Runs at ``_HEWSON_SAMPLE_HOURS_UTC`` (05Z / 17Z by default), chosen to
+    sit ~5 h after each ``00Z/12Z`` init (Open-Meteo has all 3 models
+    published by then) and 1 h before the 06Z/18Z full-cycle verification
+    run (avoids CPU/network overlap). See
+    ``designs/future/hewson-fields-aviation-advisories.md`` § 6.1.
+
+    The heavy lifting is in :func:`weatherbrief.hewson.precompute.run_once`,
+    which is also the CLI entry point — so debugging and ad-hoc re-runs
+    exercise identical code.
+
+    Disableable via ``DISABLE_HEWSON_PRECOMPUTE=1``.
+    """
+    if os.environ.get("DISABLE_HEWSON_PRECOMPUTE", "").strip() in ("1", "true"):
+        logger.info("Hewson precompute disabled via env var")
+        return
+
+    logger.info(
+        "Hewson precompute loop started (sample hours: %s UTC)",
+        _HEWSON_SAMPLE_HOURS_UTC,
+    )
+    await asyncio.sleep(_HEWSON_STARTUP_DELAY_SECONDS)
+
+    while True:
+        try:
+            sleep_secs = _seconds_until_next_sample_hour(_HEWSON_SAMPLE_HOURS_UTC)
+            logger.info(
+                "Hewson precompute: sleeping %ds until next sample hour",
+                sleep_secs,
+            )
+            await asyncio.sleep(sleep_secs)
+            await asyncio.to_thread(_run_hewson_precompute_once)
+            # Advance past the current sample hour before the next loop so
+            # we don't re-trigger in the same minute.
+            await asyncio.sleep(60)
+        except Exception:
+            logger.error("Hewson precompute cycle failed", exc_info=True)
+            # Back off 15 min on failure (same as standalone verification)
+            await asyncio.sleep(900)
+
+
+def _run_hewson_precompute_once() -> None:
+    """Execute a single Hewson precompute cycle (called in a thread)."""
+    from weatherbrief.hewson import run_once
+
+    result = run_once()
+    logger.info(
+        "Hewson precompute: %d written, %d skipped, %d purged (%.1fs)",
+        len([p for p in result.snapshots.values() if p is not None]),
+        len(result.skipped),
+        result.purged,
+        result.elapsed_seconds,
+    )

--- a/tests/test_hewson_precompute.py
+++ b/tests/test_hewson_precompute.py
@@ -306,6 +306,33 @@ def test_run_once_writes_snapshot_with_expected_schema(
     )
 
 
+def test_run_once_captures_api_call_count(
+    tmp_path, patched_metadata, patched_terrain_mask,
+):
+    # Fake client counts fetch_grid_fields calls via ``self.calls`` — for
+    # the real client that would be ``OpenMeteoClient.call_count``. Either
+    # way, run_once should surface a non-zero total on the result.
+    class _Counting(_FakeOpenMeteoClient):
+        call_count = 0
+
+        def get_json(self, url, params):
+            type(self).call_count += 1
+            return super().get_json(url, params)
+
+    _Counting.call_count = 0
+    client = _Counting(n_hours=2)
+    result = run_once(
+        models=["gfs"],
+        output_dir=tmp_path,
+        forecast_days=1,
+        stride_hours=1,
+        skip_existing=False,
+        client=client,
+    )
+    assert result.api_calls_total > 0
+    assert result.api_calls_total == _Counting.call_count
+
+
 def test_run_once_stride_hours_decimates(
     tmp_path, patched_metadata, patched_terrain_mask,
 ):

--- a/tests/test_hewson_precompute.py
+++ b/tests/test_hewson_precompute.py
@@ -1,0 +1,368 @@
+"""Tests for Hewson snapshot precompute.
+
+Unit coverage for the pure helpers (path resolution, tendency math, purge)
+plus one end-to-end `run_once` run with a fake Open-Meteo client, verifying
+the NPZ schema defined in designs/future/hewson-fields-aviation-advisories.md
+§ 6.1 is what actually lands on disk.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+from weatherbrief.hewson.precompute import (
+    DEFAULT_LEVELS,
+    _init_to_iso_z,
+    _tendency_k_per_hour,
+    load_snapshot,
+    purge_old_snapshots,
+    resolve_output_dir,
+    run_once,
+    snapshot_path,
+)
+
+
+# ---------------------------------------------------------------------------
+# Path helpers
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_output_dir_explicit(tmp_path):
+    assert resolve_output_dir(tmp_path / "foo") == tmp_path / "foo"
+
+
+def test_resolve_output_dir_env(tmp_path, monkeypatch):
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    assert resolve_output_dir() == tmp_path / "hewson"
+
+
+def test_resolve_output_dir_fallback(monkeypatch):
+    monkeypatch.delenv("DATA_DIR", raising=False)
+    assert resolve_output_dir() == Path("data") / "hewson"
+
+
+def test_init_to_iso_z_format():
+    # 2026-04-24 12:00:00 UTC
+    dt = datetime(2026, 4, 24, 12, 0, 0, tzinfo=timezone.utc)
+    unix = int(dt.timestamp())
+    assert _init_to_iso_z(unix) == "2026-04-24T12:00:00Z"
+
+
+def test_snapshot_path_structure(tmp_path):
+    unix = int(datetime(2026, 4, 24, 0, 0, 0, tzinfo=timezone.utc).timestamp())
+    p = snapshot_path("ecmwf", unix, output_dir=tmp_path)
+    assert p == tmp_path / "ecmwf" / "2026-04-24T00:00:00Z.npz"
+
+
+# ---------------------------------------------------------------------------
+# Tendency
+# ---------------------------------------------------------------------------
+
+
+def test_tendency_centered_difference():
+    # θe ramping linearly at 2 K/h → tendency = 2 K/h everywhere (including
+    # edges via one-sided diff, since the slope is constant).
+    stack = np.stack([np.full((3, 3), 10.0 + 2.0 * h) for h in range(5)]).astype(
+        np.float32
+    )
+    tend = _tendency_k_per_hour(stack)
+    assert tend.shape == stack.shape
+    assert np.allclose(tend, 2.0)
+
+
+def test_tendency_edges_one_sided():
+    # θe piecewise: 0, 0, 10, 20, 30 — tendency at hour 0 is 0, hour 1 is
+    # (10-0)/2 = 5, hour 4 edge is 30-20 = 10.
+    vals = [0.0, 0.0, 10.0, 20.0, 30.0]
+    stack = np.stack([np.full((2, 2), v) for v in vals]).astype(np.float32)
+    tend = _tendency_k_per_hour(stack)
+    assert tend[0, 0, 0] == pytest.approx(0.0)
+    assert tend[1, 0, 0] == pytest.approx(5.0)
+    assert tend[-1, 0, 0] == pytest.approx(10.0)
+
+
+def test_tendency_single_hour_is_nan():
+    stack = np.full((1, 2, 2), 5.0, dtype=np.float32)
+    tend = _tendency_k_per_hour(stack)
+    assert np.all(np.isnan(tend))
+
+
+def test_tendency_scales_with_step_hours():
+    # θe ramping at 6 K/h, sampled every 3 h → stack values [0, 18, 36, 54].
+    # With step_hours=3 the computed tendency must still be 6 K/h.
+    stack = np.stack(
+        [np.full((2, 2), 6.0 * t) for t in (0, 3, 6, 9)]
+    ).astype(np.float32)
+    tend = _tendency_k_per_hour(stack, step_hours=3)
+    assert np.allclose(tend, 6.0)
+
+
+def test_tendency_rejects_nonpositive_step():
+    stack = np.zeros((3, 2, 2), dtype=np.float32)
+    with pytest.raises(ValueError):
+        _tendency_k_per_hour(stack, step_hours=0)
+
+
+# ---------------------------------------------------------------------------
+# Purge
+# ---------------------------------------------------------------------------
+
+
+def _touch_snapshot(root: Path, model: str, dt: datetime) -> Path:
+    """Create an empty NPZ-named file for retention tests."""
+    iso_z = dt.isoformat().replace("+00:00", "Z")
+    path = root / model / f"{iso_z}.npz"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"")
+    return path
+
+
+def test_purge_removes_old_keeps_fresh(tmp_path):
+    now = datetime(2026, 4, 24, 18, 0, 0, tzinfo=timezone.utc)
+    root = tmp_path / "hewson"
+    # Fresh: within 48 h cutoff
+    fresh = _touch_snapshot(root, "ecmwf", now - timedelta(hours=12))
+    # Stale: outside 48 h cutoff
+    stale = _touch_snapshot(root, "ecmwf", now - timedelta(hours=72))
+    # Another model, fresh
+    fresh2 = _touch_snapshot(root, "gfs", now - timedelta(hours=6))
+
+    removed = purge_old_snapshots(
+        output_dir=root, retention_hours=48, now=now,
+    )
+    assert removed == 1
+    assert fresh.exists()
+    assert fresh2.exists()
+    assert not stale.exists()
+
+
+def test_purge_scoped_to_model(tmp_path):
+    now = datetime(2026, 4, 24, 18, 0, 0, tzinfo=timezone.utc)
+    root = tmp_path / "hewson"
+    old_ecmwf = _touch_snapshot(root, "ecmwf", now - timedelta(hours=72))
+    old_gfs = _touch_snapshot(root, "gfs", now - timedelta(hours=72))
+
+    removed = purge_old_snapshots(
+        model="ecmwf", output_dir=root, retention_hours=48, now=now,
+    )
+    assert removed == 1
+    assert not old_ecmwf.exists()
+    assert old_gfs.exists()  # gfs scope untouched
+
+
+def test_purge_skips_unrecognised_filename(tmp_path, caplog):
+    now = datetime(2026, 4, 24, 18, 0, 0, tzinfo=timezone.utc)
+    root = tmp_path / "hewson"
+    (root / "ecmwf").mkdir(parents=True)
+    bogus = root / "ecmwf" / "garbage.npz"
+    bogus.write_bytes(b"")
+
+    removed = purge_old_snapshots(
+        output_dir=root, retention_hours=48, now=now,
+    )
+    assert removed == 0
+    assert bogus.exists()  # left in place
+
+
+def test_purge_no_root(tmp_path):
+    assert purge_old_snapshots(output_dir=tmp_path / "missing") == 0
+
+
+# ---------------------------------------------------------------------------
+# End-to-end run_once with a fake client
+# ---------------------------------------------------------------------------
+
+
+class _FakeOpenMeteoClient:
+    """Minimal stand-in for OpenMeteoClient returning synthetic grid data.
+
+    Returns a list of per-point ``{"hourly": {...}}`` dicts, one per
+    (latitude, longitude) pair in the request params. The values are a
+    smooth function of (lat, lon, hour) so the downstream gradient math
+    produces a non-trivial but reproducible result.
+    """
+
+    def __init__(self, n_hours: int = 3):
+        self.n_hours = n_hours
+        self.calls = 0
+
+    def get_json(self, url: str, params: dict) -> list[dict]:
+        self.calls += 1
+        lats = [float(x) for x in params["latitude"].split(",")]
+        lons = [float(x) for x in params["longitude"].split(",")]
+        # Each level has 4 variables
+        variables = [v.strip() for v in params["hourly"].split(",")]
+
+        # Fake time axis (ISO local strings — the client doesn't care about tz)
+        time_axis = [
+            f"2026-04-24T{h:02d}:00" for h in range(self.n_hours)
+        ]
+
+        out: list[dict] = []
+        for la, lo in zip(lats, lons):
+            hourly: dict[str, list] = {"time": time_axis}
+            for var in variables:
+                if var.startswith("temperature_"):
+                    # smooth N-S gradient: colder north
+                    level = int(var.split("_")[1].replace("hPa", ""))
+                    base = 15.0 if level == 925 else (10.0 if level == 850 else 0.0)
+                    hourly[var] = [base - (la - 45.0) * 0.2 for _ in range(self.n_hours)]
+                elif var.startswith("dewpoint_"):
+                    hourly[var] = [2.0 for _ in range(self.n_hours)]
+                elif var.startswith("wind_speed_"):
+                    hourly[var] = [20.0 for _ in range(self.n_hours)]
+                elif var.startswith("wind_direction_"):
+                    hourly[var] = [270.0 for _ in range(self.n_hours)]
+                else:
+                    hourly[var] = [0.0 for _ in range(self.n_hours)]
+            out.append({"hourly": hourly})
+        return out
+
+
+def _fake_model_metadata(models):
+    """Fake fetch_model_metadata return value — init at 2026-04-24 00:00Z."""
+
+    class _Meta:
+        last_init_time = int(
+            datetime(2026, 4, 24, 0, 0, 0, tzinfo=timezone.utc).timestamp()
+        )
+
+    return {m: _Meta() for m in models}
+
+
+@pytest.fixture
+def patched_metadata():
+    """Patch fetch_model_metadata both in hewson and frontal call sites."""
+    with patch(
+        "weatherbrief.hewson.precompute.fetch_model_metadata",
+        side_effect=_fake_model_metadata,
+        create=True,
+    ):
+        with patch(
+            "weatherbrief.fetch.model_status.fetch_model_metadata",
+            side_effect=_fake_model_metadata,
+        ):
+            yield
+
+
+@pytest.fixture
+def patched_terrain_mask():
+    """Replace build_terrain_mask with all-True to avoid SRTM lookups."""
+    def _all_true(lat, lon):
+        return np.ones((len(lat), len(lon)), dtype=bool)
+
+    with patch(
+        "weatherbrief.hewson.precompute.build_terrain_mask",
+        side_effect=_all_true,
+    ):
+        yield
+
+
+def test_run_once_writes_snapshot_with_expected_schema(
+    tmp_path, patched_metadata, patched_terrain_mask,
+):
+    client = _FakeOpenMeteoClient(n_hours=4)
+    result = run_once(
+        models=["gfs"],  # single model keeps fetch under 10 s
+        output_dir=tmp_path,
+        forecast_days=1,
+        stride_hours=1,  # keep every hour so all 4 timestamps land in NPZ
+        skip_existing=False,
+        client=client,
+    )
+
+    assert "gfs" in result.snapshots
+    path = result.snapshots["gfs"]
+    assert path is not None
+    assert path.exists()
+    assert path.name == "2026-04-24T00:00:00Z.npz"
+
+    snap = load_snapshot(path)
+    # Per-level metric keys (§ 6.1)
+    for L in DEFAULT_LEVELS:
+        for metric in (
+            "theta_e", "gradient", "neg_laplacian",
+            "tfp", "advection", "tendency",
+        ):
+            key = f"{metric}_{L}"
+            assert key in snap, f"missing key {key}"
+            # 4 hours × 101 lat × 193 lon per § 6.1 grid
+            assert snap[key].shape == (4, 101, 193), (
+                f"{key} shape {snap[key].shape} — expected (4, 101, 193)"
+            )
+    # Coordinate arrays and metadata
+    assert snap["lat"].shape == (101,)
+    assert snap["lon"].shape == (193,)
+    assert snap["valid_times"].shape == (4,)
+    assert snap["levels"].tolist() == sorted(DEFAULT_LEVELS)
+    assert int(snap["stride_hours"]) == 1
+    assert int(snap["init_time_unix"]) == int(
+        datetime(2026, 4, 24, 0, 0, 0, tzinfo=timezone.utc).timestamp()
+    )
+
+
+def test_run_once_stride_hours_decimates(
+    tmp_path, patched_metadata, patched_terrain_mask,
+):
+    # 7 hourly inputs × stride=3 → keep indices 0, 3, 6 → 3 timesteps.
+    client = _FakeOpenMeteoClient(n_hours=7)
+    result = run_once(
+        models=["gfs"],
+        output_dir=tmp_path,
+        forecast_days=1,
+        stride_hours=3,
+        skip_existing=False,
+        client=client,
+    )
+    snap = load_snapshot(result.snapshots["gfs"])
+    assert int(snap["stride_hours"]) == 3
+    # Every metric stack should have 3 timesteps now
+    for L in DEFAULT_LEVELS:
+        assert snap[f"theta_e_{L}"].shape == (3, 101, 193)
+    assert snap["valid_times"].shape == (3,)
+
+
+def test_run_once_dry_run_writes_nothing(
+    tmp_path, patched_metadata, patched_terrain_mask,
+):
+    client = _FakeOpenMeteoClient(n_hours=2)
+    result = run_once(
+        models=["gfs"],
+        output_dir=tmp_path,
+        forecast_days=1,
+        dry_run=True,
+        skip_existing=False,
+        client=client,
+    )
+    assert result.snapshots["gfs"] is None
+    # No NPZ on disk, but terrain_mask cache may be created
+    assert not any(
+        p for p in tmp_path.rglob("*.npz") if p.name != "terrain_mask.npz"
+    )
+
+
+def test_run_once_skips_when_snapshot_exists(
+    tmp_path, patched_metadata, patched_terrain_mask,
+):
+    # Pre-create the expected snapshot so the skip path fires
+    expected_init = int(
+        datetime(2026, 4, 24, 0, 0, 0, tzinfo=timezone.utc).timestamp()
+    )
+    existing = snapshot_path("gfs", expected_init, output_dir=tmp_path)
+    existing.parent.mkdir(parents=True, exist_ok=True)
+    existing.write_bytes(b"")
+
+    client = _FakeOpenMeteoClient(n_hours=2)
+    result = run_once(
+        models=["gfs"],
+        output_dir=tmp_path,
+        forecast_days=1,
+        client=client,
+    )
+    assert result.skipped.get("gfs") == "fresh"
+    assert client.calls == 0, "fetch should be short-circuited when fresh"

--- a/tests/test_hewson_precompute.py
+++ b/tests/test_hewson_precompute.py
@@ -237,17 +237,21 @@ def _fake_model_metadata(models):
 
 @pytest.fixture
 def patched_metadata():
-    """Patch fetch_model_metadata both in hewson and frontal call sites."""
+    """Patch fetch_model_metadata at its source module.
+
+    precompute.py imports fetch_model_metadata locally inside the functions
+    that need it (not at module scope), so patching the source module is
+    the only intercept that actually fires — a second patch on
+    ``weatherbrief.hewson.precompute.fetch_model_metadata`` would need
+    ``create=True`` because the attribute doesn't exist, and even with
+    ``create=True`` would only create an orphan attribute the production
+    code never looks up.
+    """
     with patch(
-        "weatherbrief.hewson.precompute.fetch_model_metadata",
+        "weatherbrief.fetch.model_status.fetch_model_metadata",
         side_effect=_fake_model_metadata,
-        create=True,
     ):
-        with patch(
-            "weatherbrief.fetch.model_status.fetch_model_metadata",
-            side_effect=_fake_model_metadata,
-        ):
-            yield
+        yield
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

Ships the first live Hewson diagnostic pipeline behind the forecast-page map — the precompute half of Phase D.0 from `designs/future/hewson-fields-aviation-advisories.md`.

- **New scheduler loop** `run_hewson_precompute_loop` fires at 05 Z / 17 Z. Timed to avoid collision with the 06/18 Z `run_standalone_verification_loop` full cycles. `DISABLE_HEWSON_PRECOMPUTE=1` escape hatch.
- **New `src/weatherbrief/hewson/` module** with a shared `run_once()` called by both the loop and the CLI (`python -m weatherbrief.hewson precompute`) — one pipeline, two surfaces.
- **3 h synoptic cadence** (measured-in, not guessed). Hourly Open-Meteo fetch decimated to 40 timesteps before compute: 46 MB NPZ per snapshot, ~6.5 min/cycle for 3 models, ~550 MB 48 h-peak on disk. Tradeoff analysis in design doc § 4.4a.
- **Generalised `fetch_grid_fields` / `reshape_to_fields`** in `frontal/grid.py` to accept `levels=[925,850,700]` — frontal CLI defaults to the old 850-only behavior.

## Test plan

- [x] `tests/test_hewson_precompute.py` — 18 unit tests (path helpers, tendency with step scaling, purge, end-to-end via fake OM client)
- [x] Full `frontal/hewson/open_meteo` scope: 65 tests passing
- [x] Real end-to-end GFS 12 Z cycle: 131 s wall time, 46 MB NPZ, all 23 schema keys present at correct shapes, value ranges match § 2 aviation thresholds (θe 275–336 K, advection ±17 K/h)
- [x] `create_app()` imports cleanly with new loop wired in
- [ ] Deploy to prod and confirm the first 05 Z cycle lands a snapshot for each of ecmwf / gfs / icon
- [ ] Verify disk footprint after 48 h of live cycles (~550 MB expected)

## Bugs caught during validation

- CLI was running as anonymous Open-Meteo caller (no `.env` loaded) → 10.5 min of rate-limit backoff on first attempt. Fixed by calling `load_dotenv()` in `hewson.cli.main()`, matching `create_app()`.
- Initial 1 h stride produced 139 MB snapshots and 1.7 GB peak on disk. 3 h stride shipped as default instead.
- Design doc § 5 claimed "~500 KB compressed / ~25 MB total" — an arithmetic mismatch (stride-1 vs horizon-120 h). Rewritten from real measurements.

## Scope boundary

This PR is precompute only. Phase D.1 (backend endpoint serving per-(model, init, level, hour, metric) slices) is now the **NEXT** step per § 12 — that's where the map UI plumbs in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)