### PR TITLE
feat(hewson): Phase D — Synoptic Forecast map (D.1 + D.2)

### DIFF
--- a/designs/future/hewson-fields-aviation-advisories.md
+++ b/designs/future/hewson-fields-aviation-advisories.md
@@ -626,17 +626,17 @@ Opens after Phase D so the map + cross-section surface has something to show moi
 | **Phase B.1** (multi-level Case storage) | ✅ Done (PR #94 open) — multi-level NPZ, back-compat, 10 tests |
 | Phase B.2 (CLI `--levels`, rebuild Ciarán at 3 levels) | 🟡 Small follow-up; can slot anywhere |
 | **Phase D.0** (precompute loop) | ✅ Done (2026-04-24) — `run_hewson_precompute_loop` + `weatherbrief.hewson.run_once()` + `python -m weatherbrief.hewson` CLI |
-| Phase D.1 (backend endpoint) | 🎯 **NEXT** — requires D.0 (done) |
-| Phase D.2 (map layer + tooltips) | Requires D.1 |
-| Phase D.3 (cross-section bands) | Requires D.0 |
+| **Phase D.1** (backend endpoints) | ✅ Done (2026-04-25, PR #96) — `/api/hewson-map`, `/api/hewson-map/manifest`, `/api/hewson-map/all-metrics`; admin-gated via `_synoptic_auth = require_admin` while calibrating |
+| **Phase D.2** (map layer + tooltips + ERA5 cases) | ✅ Done (2026-04-25, PR #96) — Synoptic Forecast tab on `/maps.html`, canvas grid overlay, cursor-following tooltip with all 6 metrics, default/storm scale toggle, briefing-style (i) modal with Discuss-with-AI prompts, `era5-case` CLI for historical events (Storm Ciarán test case) |
+| Phase D.3 (cross-section bands) | 🎯 **NEXT** — requires D.0 (done) |
 | Phase D.4 (stencil in GRIB era) | Gated on native-GRIB ingestion being live for the user's briefing model |
 | Phase C (advisory evaluators) | After Phase D, informed by what pilots actually use from the map/cross-section |
 | Phase E (moisture cross-check) | After Phase D — RH₉₂₅, LCC, TP, CAPE, debrief feature #92 |
 | Retrospective validation | ✅ Pairwise cancel test 3/3 (all pilot-cancellation days scored higher than replacement-flown days) — best calibration signal we have |
 
-## 12a. Quick pickup from fresh context (for Phase D.1 start)
+## 12a. Quick pickup from fresh context (for Phase D.3 start)
 
-Phase D.0 is done. The next session picks up D.1 — the backend endpoint that serves per-(model, init, level, hour, metric) slices to the forecast-page map.
+Phases D.0 / D.1 / D.2 are done and merged via PR #96. The next session picks up **D.3 — the cross-section bands** that overlay the same precomputed Hewson fields on the route cross-section canvas.
 
 ### What's already on main
 
@@ -646,46 +646,28 @@ Phase D.0 is done. The next session picks up D.1 — the backend endpoint that s
 - `route-hewson` CLI subcommand that resolves ICAO codes and prints per-waypoint values
 - Retrospective scripts: `scripts/analyze_flight_log.py` and `scripts/analyze_cancellations.py`
 - 1 year of ERA5 GRIBs at `data/era5/hewson/` (gitignored)
-- **Phase D.0**: `src/weatherbrief/hewson/` module (`precompute.py`, `cli.py`, `__main__.py`), `run_hewson_precompute_loop` in `scheduler.py` at 05 Z / 17 Z, NPZ snapshots at `${DATA_DIR}/hewson/<model>/<init_iso_z>.npz`. Back-compat-preserving `levels=` / `level_hPa=` kwargs added to `fetch_grid_fields` and `reshape_to_fields` in `frontal/grid.py`.
+- **Phase D.0**: `src/weatherbrief/hewson/` module — `precompute.py`, `cli.py`, `era5_case.py`, `__main__.py`. `run_hewson_precompute_loop` in `scheduler.py` at 05 Z / 17 Z. NPZ snapshots at `${DATA_DIR}/hewson/<model>/<init_iso_z>.npz`. Back-compat-preserving `levels=` / `level_hPa=` kwargs added to `fetch_grid_fields` and `reshape_to_fields` in `frontal/grid.py`.
+- **Phase D.1**: `src/weatherbrief/api/hewson_map.py` — three endpoints (`/api/hewson-map`, `/manifest`, `/all-metrics`). Lazy NPZ access, corrupt-file → 404, path-traversal guard, `Cache-Control: private, max-age=86400, immutable`. Admin-gated via `_synoptic_auth` alias.
+- **Phase D.2**: Synoptic Forecast tab on `/maps.html`. `web/ts/visualization/synoptic-map.ts` + `hewson-grid-layer.ts` (canvas overlay) + `hewson-colormaps.ts` (matplotlib-equivalent ramps with default/storm scale) + `hewson-metrics-catalog.ts` (per-level pilot-facing thresholds) + `hewson-info.ts` (briefing-style modal). Cursor-following tooltip reads `/all-metrics` cached per (model, init, level, hour). Progressive load: single-metric slice first, all-metrics in the background. Token-based stale-fetch cancellation.
+- **ERA5 historical cases**: `python -m weatherbrief.hewson era5-case --case <dir>` builds a synoptic snapshot from any calibration Case directory; surfaces in the same UI under model="era5". Storm Ciarán (2023-11-02) is the test case.
 
-### What Phase D.1 needs
+### What Phase D.3 needs
 
-Build an authenticated endpoint that serves one `(model, init, level, hour, metric)` slice from a precompute snapshot as JSON or binary.
+Cross-section bands per § 7.9. Sample the precompute snapshot at each waypoint × {925, 850, 700} via bilinear, draw 3 horizontal coloured bands at 2,500 / 5,000 / 10,000 ft on the route cross-section canvas. Reuse the same colormap and metric picker as the map.
 
 **Entry points to find first**:
-- `src/weatherbrief/hewson/precompute.py::load_snapshot(path)` — returns the dict of arrays; map endpoint just indexes into `snap[f"{metric}_{level}"][hour]`
-- `src/weatherbrief/hewson/precompute.py::snapshot_path(model, init_time_unix, ...)` — canonical disk location
-- `src/weatherbrief/api/packs.py` — pack-access auth pattern to reuse (§ 7.3 says "reuses pack-access auth pattern")
-- Existing gridded-layer frontends: today the forecast map is point-only, so this will be the first Canvas-overlay pattern (§ 7.5)
+- `web/ts/visualization/cross-section/renderer.ts` + `layer-registry.ts` — the existing layer pattern to follow (cloud / icing / CAT / inversion are sibling layers)
+- `src/weatherbrief/frontal/route_sampling.py::bilinear_sample` — already implemented; reuse for the per-waypoint × per-level lookup
+- `web/ts/visualization/hewson-colormaps.ts` — colormap and (vmin, vmax) ranges to reuse
+- `web/ts/data/hewson-metrics-catalog.ts` — pilot info for the cross-section's (i) modal
+- This PR's `web/ts/maps-main.ts` — for the metric/scale-picker UI patterns to mirror in the cross-section controls
 
-**Endpoint contract (§ 7.3 sketch)**:
-```
-GET /api/hewson-map?model=ecmwf&init=<t>&level=850&metric=advection&hour=24
-  → JSON or binary array of shape (n_lat, n_lon)
-```
+### Open questions deferred from D.1/D.2
 
-**Sanity-check the precompute output** before building the endpoint:
-```bash
-python -m weatherbrief.hewson precompute --models ecmwf --dry-run   # no-write test
-python -m weatherbrief.hewson precompute --models ecmwf             # real run
-python -m weatherbrief.hewson list -v                               # verify schema
-```
-
-### Key files for Phase D.1 pickup
-
-- `src/weatherbrief/hewson/precompute.py` — `load_snapshot`, `snapshot_path`, `resolve_output_dir`
-- `src/weatherbrief/api/packs.py` — pack-access auth + serialization patterns
-- `src/weatherbrief/api/app.py` — lifespan already wires `run_hewson_precompute_loop`
-- `web/ts/visualization/cross-section/renderer.ts` + `layer-registry.ts` — cross-section layer pattern to follow for § 7.9 (Phase D.3)
-- `designs/forecast-page.md` — where the map layer lives (point-marker pattern today; gridded-canvas layer is net new)
-- **This doc** — decisions and rationale; § 10a is the list of known gaps so the next pass doesn't re-discover them
-
-### Open questions left for Phase D.1+
-
-- Serialization: JSON array (~80 KB/slice, simple) or quantized int8 + scale (~20 KB, needs client-side dequant)? → start with JSON per § 7.2, revisit if map latency needs it.
-- Cache headers: `Cache-Control: max-age=...` based on init time, since a given `(model, init)` slice is immutable. Let the CDN do the work.
-- Map layer client: single gridded CanvasLayer for all 6 metrics (redraw on metric change), or 6 pre-rendered PNG tiles served statically? → start with JSON/binary + canvas (per § 7.5), revisit tiling if latency needs it.
-- Pilot-facing tooltip text: draw from § 2 directly (short form) or maintain a separate `docs/hewson-pilot-guide.md`? → start inline per § 7.4, promote to a doc if it grows.
+- ✅ Serialization: started with JSON. ~80 KB single metric, ~2.3 MB for all-metrics. Acceptable on local dev; would benefit from FastAPI `GZipMiddleware` (~250 KB compressed) for slow connections. Not in PR #96; easy follow-up.
+- ✅ Map client: single gridded CanvasLayer with redraw on metric change — chosen and shipped.
+- ✅ Pilot tooltip text: inline catalog (`hewson-metrics-catalog.ts`) — chosen and shipped.
+- Cross-section: 3 discrete bands (D.3 / Open-Meteo era) → continuous-altitude stencil (D.4 / GRIB era) — silent data-source upgrade when native GRIB ingestion lands.
 
 ## 13. Related docs
 

--- a/src/weatherbrief/api/app.py
+++ b/src/weatherbrief/api/app.py
@@ -45,6 +45,7 @@ from weatherbrief.api.credits import (
 from weatherbrief.api.feedback import router as feedback_router
 from weatherbrief.api.messages import admin_router as messages_admin_router, router as messages_router
 from weatherbrief.api.maps import router as maps_router
+from weatherbrief.api.hewson_map import router as hewson_map_router
 from weatherbrief.api.models import router as models_router
 from weatherbrief.api.tokens import router as tokens_router
 from weatherbrief.api.usage import router as usage_router
@@ -315,6 +316,7 @@ def create_app() -> FastAPI:
     app.include_router(messages_router, prefix="/api")
     app.include_router(messages_admin_router, prefix="/api")
     app.include_router(maps_router, prefix="/api")
+    app.include_router(hewson_map_router, prefix="/api")
     app.include_router(tokens_router, prefix="/api")
     app.include_router(models_router, prefix="/api")
     app.include_router(refresh_router, prefix="/api")

--- a/src/weatherbrief/api/hewson_map.py
+++ b/src/weatherbrief/api/hewson_map.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import logging
 import math
+import zipfile
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -97,7 +98,13 @@ def _nan_to_none(arr: np.ndarray) -> list:
 
 def _read_snapshot_meta(path: Path) -> dict[str, Any] | None:
     """Read the cheap metadata fields from a snapshot without touching the
-    bulky metric arrays. Returns ``None`` if the file can't be parsed."""
+    bulky metric arrays. Returns ``None`` if the file can't be parsed.
+
+    A partially-written NPZ (from a crashed precompute) raises
+    ``zipfile.BadZipFile`` from inside ``np.load``, which inherits from
+    ``Exception`` rather than ``OSError`` — so it must be caught
+    explicitly. ``EOFError`` covers truncated files too.
+    """
     try:
         with np.load(path) as npz:
             init_time_unix = int(npz["init_time_unix"])
@@ -106,7 +113,7 @@ def _read_snapshot_meta(path: Path) -> dict[str, Any] | None:
             valid_times = npz["valid_times"]
             lat = npz["lat"]
             lon = npz["lon"]
-    except (OSError, KeyError, ValueError):
+    except (OSError, KeyError, ValueError, zipfile.BadZipFile, EOFError):
         logger.warning("Hewson manifest: failed to parse %s", path, exc_info=True)
         return None
 
@@ -196,6 +203,32 @@ def _resolve_snapshot_path(model: str, init: str) -> tuple[Path, int]:
     return path, init_time_unix
 
 
+def _open_snapshot(path: Path):
+    """``np.load(path)`` with corrupt-file errors converted to a 404.
+
+    A snapshot whose zipfile is malformed (typically from a crashed
+    precompute mid-write) is treated as "missing" rather than 500ing —
+    the next clean precompute cycle replaces it.
+
+    ``np.load`` is lazy on ``.npz`` files: the returned ``NpzFile`` only
+    parses the zip catalog on first ``.files`` access. We touch ``.files``
+    here so the BadZipFile fires at this layer rather than deep inside a
+    handler.
+    """
+    try:
+        npz = np.load(path)
+        _ = npz.files  # force zip-catalog read
+        return npz
+    except (zipfile.BadZipFile, EOFError, OSError, ValueError):
+        # ValueError covers numpy's "not a valid npz/npy" path on garbage
+        # input; BadZipFile + EOFError cover truncated zips.
+        logger.warning("Hewson endpoint: corrupt snapshot at %s", path, exc_info=True)
+        raise HTTPException(
+            status_code=404,
+            detail=f"Snapshot at {path.name} is unreadable",
+        )
+
+
 def _resolve_hour_index(npz, hour: int) -> tuple[int, int, str]:
     """Validate the ``hour`` param against the snapshot's stride/horizon
     and return ``(idx, stride_hours, valid_time_iso)``."""
@@ -256,7 +289,7 @@ def get_slice(
     path, init_time_unix = _resolve_snapshot_path(model, init)
     key = f"{metric}_{level}"
     # Lazy NPZ access — only decompress the slice we need, not all 18+ stacks.
-    with np.load(path) as npz:
+    with _open_snapshot(path) as npz:
         if key not in npz.files:
             raise HTTPException(
                 status_code=404,
@@ -313,7 +346,7 @@ def get_all_metrics(
     _validate_common_params(model, level)
     path, init_time_unix = _resolve_snapshot_path(model, init)
 
-    with np.load(path) as npz:
+    with _open_snapshot(path) as npz:
         idx, stride_hours, valid_time_iso = _resolve_hour_index(npz, hour)
         lat = npz["lat"]
         lon = npz["lon"]

--- a/src/weatherbrief/api/hewson_map.py
+++ b/src/weatherbrief/api/hewson_map.py
@@ -36,7 +36,8 @@ from typing import Any
 import numpy as np
 from fastapi import APIRouter, Depends, HTTPException, Query, Response
 
-from flyfun_common.db import current_user_id
+from flyfun_common.db import current_user_id  # noqa: F401  (referenced in docstring)
+from weatherbrief.api.admin import require_admin
 from weatherbrief.hewson.precompute import (
     DEFAULT_LEVELS,
     DEFAULT_STRIDE_HOURS,
@@ -47,6 +48,12 @@ from weatherbrief.hewson.precompute import (
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/hewson-map", tags=["hewson-map"])
+
+
+# Synoptic Forecast is admin-only while we calibrate. To release publicly,
+# change this to ``current_user_id`` (one edit; the frontend tab visibility
+# gate in maps-main.ts also keys off ``user.is_admin``).
+_synoptic_auth = require_admin
 
 
 VALID_METRICS: tuple[str, ...] = (
@@ -151,7 +158,7 @@ def _read_snapshot_meta(path: Path) -> dict[str, Any] | None:
 
 @router.get("/manifest")
 def get_manifest(
-    _user_id: str = Depends(current_user_id),
+    _user_id: str = Depends(_synoptic_auth),
 ):
     """List every Hewson snapshot currently on disk, grouped by model.
 
@@ -296,7 +303,7 @@ def get_slice(
     level: int = Query(..., description="Pressure level in hPa: 925, 850, or 700"),
     metric: str = Query(..., description=" | ".join(VALID_METRICS)),
     hour: int = Query(..., ge=0, description="Forecast hour offset from init"),
-    _user_id: str = Depends(current_user_id),
+    _user_id: str = Depends(_synoptic_auth),
 ):
     """Return one ``(n_lat, n_lon)`` slice of a Hewson snapshot.
 
@@ -359,7 +366,7 @@ def get_all_metrics(
     init: str = Query(...),
     level: int = Query(...),
     hour: int = Query(..., ge=0),
-    _user_id: str = Depends(current_user_id),
+    _user_id: str = Depends(_synoptic_auth),
 ):
     """Return every metric grid for one (model, init, level, hour) in one
     response. Used by the cursor-following tooltip on the synoptic map: the

--- a/src/weatherbrief/api/hewson_map.py
+++ b/src/weatherbrief/api/hewson_map.py
@@ -162,7 +162,69 @@ def get_manifest(
 
 
 # ---------------------------------------------------------------------------
-# Slice
+# Shared param validation + snapshot lookup
+# ---------------------------------------------------------------------------
+
+
+def _validate_common_params(model: str, level: int) -> None:
+    """Apply the cheap syntactic checks shared by every read endpoint."""
+    if not model or "/" in model or "\\" in model or model.startswith("."):
+        raise HTTPException(
+            status_code=400,
+            detail=f"model must be a simple identifier; got {model!r}",
+        )
+    if level not in DEFAULT_LEVELS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"level must be one of {DEFAULT_LEVELS}; got {level}",
+        )
+
+
+def _resolve_snapshot_path(model: str, init: str) -> tuple[Path, int]:
+    """Parse the init timestamp and return ``(path, init_time_unix)``.
+
+    Raises 404 if the snapshot file isn't on disk; raises 400 from
+    ``_parse_init`` if the init string is malformed.
+    """
+    init_time_unix = _parse_init(init)
+    path = snapshot_path(model, init_time_unix)
+    if not path.exists():
+        raise HTTPException(
+            status_code=404,
+            detail=f"No snapshot for model={model} init={init}",
+        )
+    return path, init_time_unix
+
+
+def _resolve_hour_index(npz, hour: int) -> tuple[int, int, str]:
+    """Validate the ``hour`` param against the snapshot's stride/horizon
+    and return ``(idx, stride_hours, valid_time_iso)``."""
+    stride_hours = int(npz["stride_hours"]) if "stride_hours" in npz.files else 1
+    valid_times = npz["valid_times"]
+    n_time = valid_times.shape[0]
+
+    if hour % stride_hours != 0:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"hour={hour} is not aligned to this snapshot's stride "
+                f"({stride_hours} h). Valid hours are 0, {stride_hours}, "
+                f"{2 * stride_hours}, ..."
+            ),
+        )
+    idx = hour // stride_hours
+    if idx >= n_time:
+        max_hour = (n_time - 1) * stride_hours
+        raise HTTPException(
+            status_code=400,
+            detail=f"hour={hour} is past the snapshot horizon (max {max_hour})",
+        )
+    valid_time_iso = np.datetime_as_string(valid_times[idx], unit="s", timezone="UTC")
+    return idx, stride_hours, valid_time_iso
+
+
+# ---------------------------------------------------------------------------
+# Slice (one metric)
 # ---------------------------------------------------------------------------
 
 
@@ -184,33 +246,14 @@ def get_slice(
     The ``(model, init)`` tuple identifies an immutable snapshot file —
     response is cacheable for a long time.
     """
-    # Cheap syntactic checks first; missing snapshots fall through to 404
-    # below. Model is validated only for shape (no path separators) so ERA5
-    # / historical-event cases work without a hardcoded whitelist.
-    if not model or "/" in model or "\\" in model or model.startswith("."):
-        raise HTTPException(
-            status_code=400,
-            detail=f"model must be a simple identifier; got {model!r}",
-        )
-    if level not in DEFAULT_LEVELS:
-        raise HTTPException(
-            status_code=400,
-            detail=f"level must be one of {DEFAULT_LEVELS}; got {level}",
-        )
+    _validate_common_params(model, level)
     if metric not in VALID_METRICS:
         raise HTTPException(
             status_code=400,
             detail=f"metric must be one of {VALID_METRICS}; got {metric!r}",
         )
 
-    init_time_unix = _parse_init(init)
-    path = snapshot_path(model, init_time_unix)
-    if not path.exists():
-        raise HTTPException(
-            status_code=404,
-            detail=f"No snapshot for model={model} init={init}",
-        )
-
+    path, init_time_unix = _resolve_snapshot_path(model, init)
     key = f"{metric}_{level}"
     # Lazy NPZ access — only decompress the slice we need, not all 18+ stacks.
     with np.load(path) as npz:
@@ -219,31 +262,10 @@ def get_slice(
                 status_code=404,
                 detail=f"Snapshot is missing {key!r} (was it built with this level?)",
             )
-        stride_hours = int(npz["stride_hours"]) if "stride_hours" in npz.files else 1
-        valid_times = npz["valid_times"]
-        n_time = valid_times.shape[0]
-
-        if hour % stride_hours != 0:
-            raise HTTPException(
-                status_code=400,
-                detail=(
-                    f"hour={hour} is not aligned to this snapshot's stride "
-                    f"({stride_hours} h). Valid hours are 0, {stride_hours}, "
-                    f"{2 * stride_hours}, ..."
-                ),
-            )
-        idx = hour // stride_hours
-        if idx >= n_time:
-            max_hour = (n_time - 1) * stride_hours
-            raise HTTPException(
-                status_code=400,
-                detail=f"hour={hour} is past the snapshot horizon (max {max_hour})",
-            )
-
+        idx, stride_hours, valid_time_iso = _resolve_hour_index(npz, hour)
         slice_arr = npz[key][idx]
         lat = npz["lat"]
         lon = npz["lon"]
-        valid_time_iso = np.datetime_as_string(valid_times[idx], unit="s", timezone="UTC")
 
     # Slice for an immutable (model, init) snapshot — long cache is safe.
     response.headers["Cache-Control"] = "public, max-age=86400, immutable"
@@ -259,4 +281,67 @@ def get_slice(
         "lat": lat.tolist(),
         "lon": lon.tolist(),
         "values": _nan_to_none(slice_arr),
+    }
+
+
+# ---------------------------------------------------------------------------
+# All-metrics slice (one (model, init, level, hour), every metric in one call)
+# ---------------------------------------------------------------------------
+
+
+@router.get("/all-metrics")
+def get_all_metrics(
+    response: Response,
+    model: str = Query(...),
+    init: str = Query(...),
+    level: int = Query(...),
+    hour: int = Query(..., ge=0),
+    _user_id: str = Depends(current_user_id),
+):
+    """Return every metric grid for one (model, init, level, hour) in one
+    response. Used by the cursor-following tooltip on the synoptic map: the
+    frontend caches this once per hour change and reads all six values from
+    memory on mousemove.
+
+    Larger payload than the single-metric ``/`` endpoint (~6× depending on
+    NaN density), but saves five network round-trips every time the user
+    changes model / init / level / hour.
+    """
+    _validate_common_params(model, level)
+    path, init_time_unix = _resolve_snapshot_path(model, init)
+
+    with np.load(path) as npz:
+        idx, stride_hours, valid_time_iso = _resolve_hour_index(npz, hour)
+        lat = npz["lat"]
+        lon = npz["lon"]
+        metrics_out: dict[str, Any] = {}
+        missing: list[str] = []
+        for metric in VALID_METRICS:
+            key = f"{metric}_{level}"
+            if key not in npz.files:
+                missing.append(metric)
+                continue
+            metrics_out[metric] = _nan_to_none(npz[key][idx])
+
+    if not metrics_out:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Snapshot has no metrics at level={level} (was it built with this level?)",
+        )
+
+    response.headers["Cache-Control"] = "public, max-age=86400, immutable"
+
+    return {
+        "model": model,
+        "init_time": _format_init(init_time_unix),
+        "valid_time": valid_time_iso,
+        "level": level,
+        "hour": hour,
+        "stride_hours": stride_hours,
+        "lat": lat.tolist(),
+        "lon": lon.tolist(),
+        "metrics": metrics_out,
+        # Some legacy snapshots may be missing a metric; surface this so
+        # the client can hide tooltip rows for those.
+        "missing_metrics": missing,
     }

--- a/src/weatherbrief/api/hewson_map.py
+++ b/src/weatherbrief/api/hewson_map.py
@@ -28,7 +28,6 @@ rest of the API).
 from __future__ import annotations
 
 import logging
-import math
 import zipfile
 from datetime import datetime, timezone
 from pathlib import Path

--- a/src/weatherbrief/api/hewson_map.py
+++ b/src/weatherbrief/api/hewson_map.py
@@ -84,11 +84,18 @@ def _nan_to_none(arr: np.ndarray) -> list:
     JSON spec doesn't allow NaN; terrain-masked cells and tendency edges are
     NaN in the snapshot. Browser-side JSON parsers reject ``NaN`` literals,
     so we serialize as ``null``.
+
+    Vectorised path is ~10× faster than the equivalent double-loop over
+    ``arr.tolist()`` — matters for the all-metrics endpoint which hits this
+    six times per request on ~20k-element grids.
     """
-    return [
-        [None if not math.isfinite(v) else float(v) for v in row]
-        for row in arr.tolist()
-    ]
+    mask = ~np.isfinite(arr)
+    if not mask.any():
+        # Hot path on grids with no terrain holes / NaN edges.
+        return arr.tolist()
+    out = arr.astype(object)
+    out[mask] = None
+    return out.tolist()
 
 
 # ---------------------------------------------------------------------------

--- a/src/weatherbrief/api/hewson_map.py
+++ b/src/weatherbrief/api/hewson_map.py
@@ -1,0 +1,257 @@
+"""Hewson synoptic-view map endpoints.
+
+Reads the precomputed NPZ snapshots written by ``weatherbrief.hewson.precompute``
+and serves one ``(model, init, level, metric, hour)`` slice at a time to the
+forecast-page map (Phase D.1 of the Hewson rollout — see
+``designs/future/hewson-fields-aviation-advisories.md`` § 7.3 / § 12a).
+
+Two endpoints:
+
+  GET /api/hewson-map/manifest
+      → list of (model, init_time, levels, valid_times, grid bounds) tuples
+        for every snapshot currently on disk
+
+  GET /api/hewson-map
+      → one (n_lat, n_lon) slice as JSON, with lat/lon coords and the
+        valid_time the slice corresponds to
+
+Both require an authenticated user (``current_user_id`` Depends, same as the
+rest of the API).
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+from fastapi import APIRouter, Depends, HTTPException, Query, Response
+
+from flyfun_common.db import current_user_id
+from weatherbrief.hewson.precompute import (
+    DEFAULT_LEVELS,
+    DEFAULT_MODELS,
+    resolve_output_dir,
+    snapshot_path,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/hewson-map", tags=["hewson-map"])
+
+
+VALID_METRICS: tuple[str, ...] = (
+    "theta_e",
+    "gradient",
+    "neg_laplacian",
+    "tfp",
+    "advection",
+    "tendency",
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_init(init_str: str) -> int:
+    """ISO 8601 with Z → unix seconds. Raises HTTPException on bad input."""
+    try:
+        dt = datetime.fromisoformat(init_str.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=400,
+            detail=f"init must be ISO 8601 with Z (e.g. 2026-04-24T12:00:00Z); got {init_str!r}",
+        ) from exc
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return int(dt.timestamp())
+
+
+def _format_init(init_time_unix: int) -> str:
+    """Unix seconds → ISO 8601 Z (matches the on-disk filename stem)."""
+    dt = datetime.fromtimestamp(init_time_unix, tz=timezone.utc)
+    return dt.isoformat().replace("+00:00", "Z")
+
+
+def _nan_to_none(arr: np.ndarray) -> list:
+    """Convert (n_lat, n_lon) float array to nested list with NaN → None.
+
+    JSON spec doesn't allow NaN; terrain-masked cells and tendency edges are
+    NaN in the snapshot. Browser-side JSON parsers reject ``NaN`` literals,
+    so we serialize as ``null``.
+    """
+    return [
+        [None if not math.isfinite(v) else float(v) for v in row]
+        for row in arr.tolist()
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Manifest
+# ---------------------------------------------------------------------------
+
+
+def _read_snapshot_meta(path: Path) -> dict[str, Any] | None:
+    """Read the cheap metadata fields from a snapshot without touching the
+    bulky metric arrays. Returns ``None`` if the file can't be parsed."""
+    try:
+        with np.load(path) as npz:
+            init_time_unix = int(npz["init_time_unix"])
+            levels = [int(L) for L in npz["levels"]]
+            stride_hours = int(npz["stride_hours"]) if "stride_hours" in npz.files else 1
+            valid_times = npz["valid_times"]
+            lat = npz["lat"]
+            lon = npz["lon"]
+    except (OSError, KeyError, ValueError):
+        logger.warning("Hewson manifest: failed to parse %s", path, exc_info=True)
+        return None
+
+    valid_times_iso = [
+        np.datetime_as_string(t, unit="s", timezone="UTC") for t in valid_times
+    ]
+    return {
+        "init_time": _format_init(init_time_unix),
+        "init_time_unix": init_time_unix,
+        "levels": levels,
+        "stride_hours": stride_hours,
+        "valid_times": valid_times_iso,
+        "n_hours": len(valid_times_iso),
+        "lat_min": float(lat.min()),
+        "lat_max": float(lat.max()),
+        "lon_min": float(lon.min()),
+        "lon_max": float(lon.max()),
+        "n_lat": int(lat.size),
+        "n_lon": int(lon.size),
+    }
+
+
+@router.get("/manifest")
+def get_manifest(
+    _user_id: str = Depends(current_user_id),
+):
+    """List every Hewson snapshot currently on disk, grouped by model.
+
+    Used by the frontend to populate model/init/level/hour pickers without
+    needing to know the on-disk layout. Cheap: reads only metadata fields,
+    not the metric arrays.
+    """
+    root = resolve_output_dir()
+    if not root.exists():
+        return {"models": {}}
+
+    out: dict[str, list[dict[str, Any]]] = {}
+    for model in sorted(DEFAULT_MODELS):
+        subdir = root / model
+        if not subdir.is_dir():
+            continue
+        snaps: list[dict[str, Any]] = []
+        for path in sorted(subdir.glob("*.npz")):
+            meta = _read_snapshot_meta(path)
+            if meta is not None:
+                snaps.append(meta)
+        if snaps:
+            out[model] = snaps
+    return {"models": out}
+
+
+# ---------------------------------------------------------------------------
+# Slice
+# ---------------------------------------------------------------------------
+
+
+@router.get("")
+def get_slice(
+    response: Response,
+    model: str = Query(..., description="ecmwf | gfs | icon"),
+    init: str = Query(..., description="ISO 8601 with Z, e.g. 2026-04-24T12:00:00Z"),
+    level: int = Query(..., description="Pressure level in hPa: 925, 850, or 700"),
+    metric: str = Query(..., description=" | ".join(VALID_METRICS)),
+    hour: int = Query(..., ge=0, description="Forecast hour offset from init"),
+    _user_id: str = Depends(current_user_id),
+):
+    """Return one ``(n_lat, n_lon)`` slice of a Hewson snapshot.
+
+    Parameters are validated up-front; on success the response is small JSON
+    (≈80 KB at the default 0.25° grid — see § 7.2 of the design doc).
+
+    The ``(model, init)`` tuple identifies an immutable snapshot file —
+    response is cacheable for a long time.
+    """
+    if model not in DEFAULT_MODELS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"model must be one of {DEFAULT_MODELS}; got {model!r}",
+        )
+    if level not in DEFAULT_LEVELS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"level must be one of {DEFAULT_LEVELS}; got {level}",
+        )
+    if metric not in VALID_METRICS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"metric must be one of {VALID_METRICS}; got {metric!r}",
+        )
+
+    init_time_unix = _parse_init(init)
+    path = snapshot_path(model, init_time_unix)
+    if not path.exists():
+        raise HTTPException(
+            status_code=404,
+            detail=f"No snapshot for model={model} init={init}",
+        )
+
+    key = f"{metric}_{level}"
+    # Lazy NPZ access — only decompress the slice we need, not all 18+ stacks.
+    with np.load(path) as npz:
+        if key not in npz.files:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Snapshot is missing {key!r} (was it built with this level?)",
+            )
+        stride_hours = int(npz["stride_hours"]) if "stride_hours" in npz.files else 1
+        valid_times = npz["valid_times"]
+        n_time = valid_times.shape[0]
+
+        if hour % stride_hours != 0:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"hour={hour} is not aligned to this snapshot's stride "
+                    f"({stride_hours} h). Valid hours are 0, {stride_hours}, "
+                    f"{2 * stride_hours}, ..."
+                ),
+            )
+        idx = hour // stride_hours
+        if idx >= n_time:
+            max_hour = (n_time - 1) * stride_hours
+            raise HTTPException(
+                status_code=400,
+                detail=f"hour={hour} is past the snapshot horizon (max {max_hour})",
+            )
+
+        slice_arr = npz[key][idx]
+        lat = npz["lat"]
+        lon = npz["lon"]
+        valid_time_iso = np.datetime_as_string(valid_times[idx], unit="s", timezone="UTC")
+
+    # Slice for an immutable (model, init) snapshot — long cache is safe.
+    response.headers["Cache-Control"] = "public, max-age=86400, immutable"
+
+    return {
+        "model": model,
+        "init_time": _format_init(init_time_unix),
+        "valid_time": valid_time_iso,
+        "level": level,
+        "metric": metric,
+        "hour": hour,
+        "stride_hours": stride_hours,
+        "lat": lat.tolist(),
+        "lon": lon.tolist(),
+        "values": _nan_to_none(slice_arr),
+    }

--- a/src/weatherbrief/api/hewson_map.py
+++ b/src/weatherbrief/api/hewson_map.py
@@ -5,7 +5,7 @@ and serves one ``(model, init, level, metric, hour)`` slice at a time to the
 forecast-page map (Phase D.1 of the Hewson rollout — see
 ``designs/future/hewson-fields-aviation-advisories.md`` § 7.3 / § 12a).
 
-Two endpoints:
+Three endpoints:
 
   GET /api/hewson-map/manifest
       → list of (model, init_time, levels, valid_times, grid bounds) tuples
@@ -15,7 +15,13 @@ Two endpoints:
       → one (n_lat, n_lon) slice as JSON, with lat/lon coords and the
         valid_time the slice corresponds to
 
-Both require an authenticated user (``current_user_id`` Depends, same as the
+  GET /api/hewson-map/all-metrics
+      → all six metric grids for one (model, init, level, hour) in a
+        single response — feeds the cursor-following tooltip on the
+        Synoptic Forecast tab, fetched in the background after the
+        single-metric slice has rendered
+
+All require an authenticated user (``current_user_id`` Depends, same as the
 rest of the API).
 """
 
@@ -34,6 +40,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Response
 from flyfun_common.db import current_user_id
 from weatherbrief.hewson.precompute import (
     DEFAULT_LEVELS,
+    DEFAULT_STRIDE_HOURS,
     resolve_output_dir,
     snapshot_path,
 )
@@ -116,7 +123,7 @@ def _read_snapshot_meta(path: Path) -> dict[str, Any] | None:
         with np.load(path) as npz:
             init_time_unix = int(npz["init_time_unix"])
             levels = [int(L) for L in npz["levels"]]
-            stride_hours = int(npz["stride_hours"]) if "stride_hours" in npz.files else 1
+            stride_hours = int(npz["stride_hours"]) if "stride_hours" in npz.files else DEFAULT_STRIDE_HOURS
             valid_times = npz["valid_times"]
             lat = npz["lat"]
             lon = npz["lon"]
@@ -253,7 +260,7 @@ def _open_snapshot(path: Path):
 def _resolve_hour_index(npz, hour: int) -> tuple[int, int, str]:
     """Validate the ``hour`` param against the snapshot's stride/horizon
     and return ``(idx, stride_hours, valid_time_iso)``."""
-    stride_hours = int(npz["stride_hours"]) if "stride_hours" in npz.files else 1
+    stride_hours = int(npz["stride_hours"]) if "stride_hours" in npz.files else DEFAULT_STRIDE_HOURS
     valid_times = npz["valid_times"]
     n_time = valid_times.shape[0]
 

--- a/src/weatherbrief/api/hewson_map.py
+++ b/src/weatherbrief/api/hewson_map.py
@@ -191,10 +191,20 @@ def _resolve_snapshot_path(model: str, init: str) -> tuple[Path, int]:
     """Parse the init timestamp and return ``(path, init_time_unix)``.
 
     Raises 404 if the snapshot file isn't on disk; raises 400 from
-    ``_parse_init`` if the init string is malformed.
+    ``_parse_init`` if the init string is malformed; raises 400 if the
+    constructed path escapes the snapshot root (belt-and-suspenders on
+    top of the syntactic checks in ``_validate_common_params``).
     """
     init_time_unix = _parse_init(init)
     path = snapshot_path(model, init_time_unix)
+    root = resolve_output_dir()
+    # Resolve both before comparing — protects against symlinks / .. that
+    # somehow slipped past the syntactic guards in _validate_common_params.
+    if not path.resolve().is_relative_to(root.resolve()):
+        raise HTTPException(
+            status_code=400,
+            detail=f"invalid model {model!r}",
+        )
     if not path.exists():
         raise HTTPException(
             status_code=404,

--- a/src/weatherbrief/api/hewson_map.py
+++ b/src/weatherbrief/api/hewson_map.py
@@ -33,7 +33,6 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Response
 from flyfun_common.db import current_user_id
 from weatherbrief.hewson.precompute import (
     DEFAULT_LEVELS,
-    DEFAULT_MODELS,
     resolve_output_dir,
     snapshot_path,
 )
@@ -139,23 +138,26 @@ def get_manifest(
     Used by the frontend to populate model/init/level/hour pickers without
     needing to know the on-disk layout. Cheap: reads only metadata fields,
     not the metric arrays.
+
+    Scans every subdirectory under the snapshot root (not just the live
+    forecast models) so ERA5 / historical-event cases dropped in by the
+    ``era5-case`` CLI surface automatically. The ``terrain_mask.npz`` file
+    that lives alongside the per-model dirs is filtered out by checking
+    for ``.npz`` siblings inside the subdirectory.
     """
     root = resolve_output_dir()
     if not root.exists():
         return {"models": {}}
 
     out: dict[str, list[dict[str, Any]]] = {}
-    for model in sorted(DEFAULT_MODELS):
-        subdir = root / model
-        if not subdir.is_dir():
-            continue
+    for subdir in sorted(p for p in root.iterdir() if p.is_dir()):
         snaps: list[dict[str, Any]] = []
         for path in sorted(subdir.glob("*.npz")):
             meta = _read_snapshot_meta(path)
             if meta is not None:
                 snaps.append(meta)
         if snaps:
-            out[model] = snaps
+            out[subdir.name] = snaps
     return {"models": out}
 
 
@@ -182,10 +184,13 @@ def get_slice(
     The ``(model, init)`` tuple identifies an immutable snapshot file —
     response is cacheable for a long time.
     """
-    if model not in DEFAULT_MODELS:
+    # Cheap syntactic checks first; missing snapshots fall through to 404
+    # below. Model is validated only for shape (no path separators) so ERA5
+    # / historical-event cases work without a hardcoded whitelist.
+    if not model or "/" in model or "\\" in model or model.startswith("."):
         raise HTTPException(
             status_code=400,
-            detail=f"model must be one of {DEFAULT_MODELS}; got {model!r}",
+            detail=f"model must be a simple identifier; got {model!r}",
         )
     if level not in DEFAULT_LEVELS:
         raise HTTPException(

--- a/src/weatherbrief/api/hewson_map.py
+++ b/src/weatherbrief/api/hewson_map.py
@@ -268,7 +268,10 @@ def get_slice(
         lon = npz["lon"]
 
     # Slice for an immutable (model, init) snapshot — long cache is safe.
-    response.headers["Cache-Control"] = "public, max-age=86400, immutable"
+    # ``private`` (not ``public``): the response is auth-gated, so shared
+    # proxies / CDNs must not store it. ``immutable`` is still correct
+    # because the (model, init) tuple identifies a frozen snapshot.
+    response.headers["Cache-Control"] = "private, max-age=86400, immutable"
 
     return {
         "model": model,
@@ -329,7 +332,10 @@ def get_all_metrics(
             detail=f"Snapshot has no metrics at level={level} (was it built with this level?)",
         )
 
-    response.headers["Cache-Control"] = "public, max-age=86400, immutable"
+    # ``private`` (not ``public``): the response is auth-gated, so shared
+    # proxies / CDNs must not store it. ``immutable`` is still correct
+    # because the (model, init) tuple identifies a frozen snapshot.
+    response.headers["Cache-Control"] = "private, max-age=86400, immutable"
 
     return {
         "model": model,

--- a/src/weatherbrief/api/hewson_map.py
+++ b/src/weatherbrief/api/hewson_map.py
@@ -210,11 +210,13 @@ def _open_snapshot(path: Path):
     precompute mid-write) is treated as "missing" rather than 500ing —
     the next clean precompute cycle replaces it.
 
-    ``np.load`` is lazy on ``.npz`` files: the returned ``NpzFile`` only
-    parses the zip catalog on first ``.files`` access. We touch ``.files``
-    here so the BadZipFile fires at this layer rather than deep inside a
-    handler.
+    Current numpy raises BadZipFile / ValueError synchronously from
+    ``np.load`` itself for malformed npz, so the explicit ``.files``
+    touch is belt-and-braces — but if a future numpy version makes the
+    parse lazy, the touch ensures the failure surfaces here. We close
+    the partially-opened ``NpzFile`` defensively in that case.
     """
+    npz = None
     try:
         npz = np.load(path)
         _ = npz.files  # force zip-catalog read
@@ -222,6 +224,8 @@ def _open_snapshot(path: Path):
     except (zipfile.BadZipFile, EOFError, OSError, ValueError):
         # ValueError covers numpy's "not a valid npz/npy" path on garbage
         # input; BadZipFile + EOFError cover truncated zips.
+        if npz is not None:
+            npz.close()
         logger.warning("Hewson endpoint: corrupt snapshot at %s", path, exc_info=True)
         raise HTTPException(
             status_code=404,

--- a/src/weatherbrief/hewson/cli.py
+++ b/src/weatherbrief/hewson/cli.py
@@ -11,6 +11,8 @@ Usage:
     python -m weatherbrief.hewson precompute --levels 925,850,700 --force
     python -m weatherbrief.hewson list
     python -m weatherbrief.hewson purge --retention-hours 24
+    python -m weatherbrief.hewson era5-case \
+        --case data/calibration/2023-11-02_era5_ciaran --label ciaran
 """
 
 from __future__ import annotations
@@ -110,6 +112,18 @@ def _cmd_list(args: argparse.Namespace) -> int:
     return 0
 
 
+def _cmd_era5_case(args: argparse.Namespace) -> int:
+    from weatherbrief.hewson.era5_case import build_synoptic_from_case
+
+    out_path = build_synoptic_from_case(
+        case_dir=args.case,
+        output_dir=args.output_dir,
+        levels=args.levels,
+    )
+    print(f"Wrote {out_path}")
+    return 0
+
+
 def _cmd_purge(args: argparse.Namespace) -> int:
     removed = purge_old_snapshots(
         model=args.model,
@@ -190,6 +204,26 @@ def build_parser() -> argparse.ArgumentParser:
         "--retention-hours", type=int, default=DEFAULT_RETENTION_HOURS,
     )
     p_pu.set_defaults(func=_cmd_purge)
+
+    # era5-case
+    p_e5 = sub.add_parser(
+        "era5-case",
+        help="Build a synoptic snapshot from an existing ERA5 calibration Case "
+             "(historical events, dev-only).",
+    )
+    p_e5.add_argument(
+        "--case", type=Path, required=True,
+        help="Path to a Case directory (must contain meta.json and raw/era5.npz).",
+    )
+    p_e5.add_argument(
+        "--levels", type=_parse_levels, default=None,
+        help="Restrict to a subset of levels (default: all in the case).",
+    )
+    p_e5.add_argument(
+        "--output-dir", type=Path, default=None,
+        help="Override snapshot root (default: ${DATA_DIR}/hewson)",
+    )
+    p_e5.set_defaults(func=_cmd_era5_case)
 
     return parser
 

--- a/src/weatherbrief/hewson/era5_case.py
+++ b/src/weatherbrief/hewson/era5_case.py
@@ -114,6 +114,10 @@ def build_synoptic_from_case(
             fields = case.fields(ERA5_MODEL_KEY, hour, level_hPa=L)
             if fields is None:
                 continue
+            # ``case.fields(..., level_hPa=L)`` always returns the legacy
+            # ``u850``/``v850`` keys regardless of the requested level —
+            # the values are from level L (see Case.fields docstring in
+            # frontal/case.py). Diagnostics are correctly computed at L.
             diag = compute_hewson_diagnostics(
                 fields["theta_e"], case.lat, case.lon,
                 fields["u850"], fields["v850"],

--- a/src/weatherbrief/hewson/era5_case.py
+++ b/src/weatherbrief/hewson/era5_case.py
@@ -24,8 +24,8 @@ from weatherbrief.frontal.case import Case, load_case
 from weatherbrief.frontal.detect import compute_hewson_diagnostics
 from weatherbrief.frontal.grid import build_terrain_mask
 from weatherbrief.hewson.precompute import (
-    _tendency_k_per_hour,
-    _write_snapshot,
+    tendency_k_per_hour,
+    write_snapshot,
     resolve_output_dir,
     snapshot_path,
 )
@@ -131,7 +131,7 @@ def build_synoptic_from_case(
 
     # Tendency across the time stack — one-sided at edges per the live path.
     for L in levels:
-        per_level[L]["tendency"] = _tendency_k_per_hour(
+        per_level[L]["tendency"] = tendency_k_per_hour(
             per_level[L]["theta_e"], step_hours=stride_hours,
         )
 
@@ -143,7 +143,7 @@ def build_synoptic_from_case(
 
     out_path = snapshot_path(ERA5_MODEL_KEY, init_time_unix, output_dir)
 
-    _write_snapshot(
+    write_snapshot(
         out_path,
         init_time_unix,
         np.asarray(valid_times, dtype="datetime64[ns]"),

--- a/src/weatherbrief/hewson/era5_case.py
+++ b/src/weatherbrief/hewson/era5_case.py
@@ -118,6 +118,16 @@ def build_synoptic_from_case(
             # ``u850``/``v850`` keys regardless of the requested level —
             # the values are from level L (see Case.fields docstring in
             # frontal/case.py). Diagnostics are correctly computed at L.
+            # Assert the contract so a future Case.fields() rename
+            # (e.g. switching to neutral ``u``/``v``) fails loudly here
+            # rather than silently miscomputing diagnostics for non-850
+            # levels.
+            if "u850" not in fields or "v850" not in fields:
+                raise RuntimeError(
+                    f"Case.fields() returned unexpected keys "
+                    f"{sorted(fields.keys())!r}; era5_case.py expects the "
+                    f"legacy u850/v850 convention. Update both modules in lockstep.",
+                )
             diag = compute_hewson_diagnostics(
                 fields["theta_e"], case.lat, case.lon,
                 fields["u850"], fields["v850"],

--- a/src/weatherbrief/hewson/era5_case.py
+++ b/src/weatherbrief/hewson/era5_case.py
@@ -1,0 +1,158 @@
+"""Build a synoptic-snapshot NPZ from an existing ERA5 calibration Case.
+
+Lets the dev server display historical events (storms, memorable flying days)
+on the Synoptic Forecast tab without running the live precompute pipeline.
+
+Reads a ``Case`` directory (e.g. ``data/calibration/2023-11-02_era5_ciaran``)
+that already has T / Td / theta_e / u / v on disk, computes Hewson diagnostics
+per (hour, level), and writes one NPZ in the same schema as the live
+precompute snapshots so the existing endpoints + UI consume it unchanged.
+
+Single-level cases are supported — e.g. the original Ciarán case has only
+850 hPa. The frontend reads ``levels`` from the snapshot to know which level
+buttons to enable.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import numpy as np
+
+from weatherbrief.frontal.case import Case, load_case
+from weatherbrief.frontal.detect import compute_hewson_diagnostics
+from weatherbrief.frontal.grid import build_terrain_mask
+from weatherbrief.hewson.precompute import (
+    _tendency_k_per_hour,
+    _write_snapshot,
+    resolve_output_dir,
+    snapshot_path,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# Reuse the "era5" model namespace under ${DATA_DIR}/hewson/era5/.
+ERA5_MODEL_KEY = "era5"
+
+
+def build_synoptic_from_case(
+    case_dir: Path | str,
+    output_dir: Path | str | None = None,
+    levels: list[int] | None = None,
+) -> Path:
+    """Compute Hewson diagnostics over a Case and write a synoptic snapshot.
+
+    The output filename is the ISO Z timestamp of the case's first valid
+    time — matches the live precompute path convention so the
+    ``/api/hewson-map`` slice endpoint can find it via the same
+    ``(model, init)`` lookup.
+
+    Parameters
+    ----------
+    case_dir : path to a Case directory (must have ``meta.json`` and
+        ``raw/era5.npz``).
+    output_dir : override the snapshot root (mostly for tests).
+    levels : restrict to a subset of levels present in the case. Defaults
+        to all of them.
+
+    Returns
+    -------
+    Path to the written NPZ at ``${DATA_DIR}/hewson/era5/<init_iso_z>.npz``.
+    """
+    case_dir = Path(case_dir)
+    case = load_case(case_dir)
+
+    if ERA5_MODEL_KEY not in case.models:
+        raise ValueError(
+            f"Case {case_dir} has models {case.models} — expected {ERA5_MODEL_KEY!r}. "
+            f"This builder only handles ERA5 cases.",
+        )
+
+    available_levels = case.available_levels(ERA5_MODEL_KEY)
+    if levels is None:
+        levels = available_levels
+    else:
+        for L in levels:
+            if L not in available_levels:
+                raise ValueError(
+                    f"Level {L} hPa not in case (available: {available_levels})",
+                )
+    levels = sorted(int(L) for L in levels)
+
+    hours = case.available_hours(ERA5_MODEL_KEY)
+    if not hours:
+        raise ValueError(f"Case {case_dir} has no hours for {ERA5_MODEL_KEY!r}")
+
+    valid_times = case.valid_times[ERA5_MODEL_KEY]
+    n_time = len(hours)
+    n_lat, n_lon = len(case.lat), len(case.lon)
+
+    # Stride between consecutive hours (used by the tendency calculation
+    # and persisted in the snapshot so the frontend slider can adapt).
+    if n_time >= 2:
+        stride_hours = max(int(hours[1] - hours[0]), 1)
+    else:
+        stride_hours = 6  # safe default for ERA5
+
+    terrain_mask = build_terrain_mask(case.lat, case.lon)
+
+    per_level: dict[int, dict[str, np.ndarray]] = {
+        L: {
+            "theta_e": np.full((n_time, n_lat, n_lon), np.nan, dtype=np.float32),
+            "gradient": np.full((n_time, n_lat, n_lon), np.nan, dtype=np.float32),
+            "neg_laplacian": np.full((n_time, n_lat, n_lon), np.nan, dtype=np.float32),
+            "tfp": np.full((n_time, n_lat, n_lon), np.nan, dtype=np.float32),
+            "advection": np.full((n_time, n_lat, n_lon), np.nan, dtype=np.float32),
+        }
+        for L in levels
+    }
+
+    for i, hour in enumerate(hours):
+        for L in levels:
+            fields = case.fields(ERA5_MODEL_KEY, hour, level_hPa=L)
+            if fields is None:
+                continue
+            diag = compute_hewson_diagnostics(
+                fields["theta_e"], case.lat, case.lon,
+                fields["u850"], fields["v850"],
+                terrain_mask=terrain_mask,
+            )
+            per_level[L]["theta_e"][i] = fields["theta_e"]
+            per_level[L]["gradient"][i] = diag["gradient"]
+            per_level[L]["neg_laplacian"][i] = diag["neg_laplacian"]
+            per_level[L]["tfp"][i] = diag["tfp"]
+            per_level[L]["advection"][i] = diag["advection"]
+
+    # Tendency across the time stack — one-sided at edges per the live path.
+    for L in levels:
+        per_level[L]["tendency"] = _tendency_k_per_hour(
+            per_level[L]["theta_e"], step_hours=stride_hours,
+        )
+
+    # ERA5 cases have init_time=0 (no real model run). Use the first valid
+    # time as the "init" so the snapshot filename and manifest sort sensibly
+    # — the front-end treats it as just a label.
+    first_valid = valid_times[0]
+    init_time_unix = int(np.datetime64(first_valid, "s").astype("int64"))
+
+    out_path = snapshot_path(ERA5_MODEL_KEY, init_time_unix, output_dir)
+
+    _write_snapshot(
+        out_path,
+        init_time_unix,
+        np.asarray(valid_times, dtype="datetime64[ns]"),
+        case.lat,
+        case.lon,
+        levels,
+        stride_hours,
+        per_level,
+    )
+
+    size_kb = out_path.stat().st_size / 1024
+    logger.info(
+        "ERA5 synoptic case: wrote %s (%d × %dh steps, levels=%s, %.1f KB)",
+        out_path, n_time, stride_hours, levels, size_kb,
+    )
+    return out_path

--- a/src/weatherbrief/hewson/precompute.py
+++ b/src/weatherbrief/hewson/precompute.py
@@ -143,7 +143,7 @@ def _load_or_build_terrain_mask(
 # ---------------------------------------------------------------------------
 
 
-def _tendency_k_per_hour(
+def tendency_k_per_hour(
     theta_e_stack: np.ndarray, step_hours: int = 1,
 ) -> np.ndarray:
     """Centred-difference ∂θe/∂t in K/h from a (n_time, n_lat, n_lon) stack.
@@ -281,7 +281,7 @@ def _build_one_snapshot(
     # Derive tendency across the decimated stack — step_hours matches stride
     # so the result is still K per hour regardless of cadence.
     for L in levels:
-        per_level[L]["tendency"] = _tendency_k_per_hour(
+        per_level[L]["tendency"] = tendency_k_per_hour(
             per_level[L]["theta_e"], step_hours=stride_hours,
         )
 
@@ -293,7 +293,7 @@ def _build_one_snapshot(
 # ---------------------------------------------------------------------------
 
 
-def _write_snapshot(
+def write_snapshot(
     path: Path,
     init_time_unix: int,
     valid_times: np.ndarray,
@@ -489,7 +489,7 @@ def run_once(
                 )
                 result.snapshots[model] = None
             else:
-                _write_snapshot(
+                write_snapshot(
                     path, init_time, valid_times, lat, lon,
                     levels, stride_hours, per_level,
                 )

--- a/tests/test_api_hewson_map.py
+++ b/tests/test_api_hewson_map.py
@@ -1,0 +1,390 @@
+"""Tests for /api/hewson-map endpoints (Phase D.1)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import numpy as np
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import sessionmaker
+
+from flyfun_common.db import current_user_id, get_db, DEV_USER_ID
+from flyfun_common.db.models import UserPreferencesRow, UserRow
+from weatherbrief.api.app import create_app
+from weatherbrief.hewson.precompute import snapshot_path
+
+
+# ---------------------------------------------------------------------------
+# Synthetic snapshot fixture (mirrors weatherbrief.hewson.precompute schema)
+# ---------------------------------------------------------------------------
+
+
+_INIT_DT = datetime(2026, 4, 24, 12, 0, 0, tzinfo=timezone.utc)
+_INIT_UNIX = int(_INIT_DT.timestamp())
+_INIT_ISO = "2026-04-24T12:00:00Z"
+_LEVELS = (925, 850, 700)
+_STRIDE_HOURS = 3
+_N_TIME = 4  # forecast hours 0, 3, 6, 9
+_LAT = np.linspace(40.0, 60.0, 5)
+_LON = np.linspace(-10.0, 20.0, 7)
+_METRICS = ("theta_e", "gradient", "neg_laplacian", "tfp", "advection", "tendency")
+
+
+def _write_synthetic_snapshot(out_dir: Path, model: str = "ecmwf") -> Path:
+    """Write a small but schema-correct NPZ a test can read."""
+    n_time = _N_TIME
+    n_lat = _LAT.size
+    n_lon = _LON.size
+    init_naive = _INIT_DT.replace(tzinfo=None)
+    valid_times = np.array(
+        [
+            np.datetime64(init_naive + timedelta(hours=h * _STRIDE_HOURS))
+            for h in range(n_time)
+        ],
+        dtype="datetime64[ns]",
+    )
+    # Each cell carries a known value: metric-tag * 100 + level offset + h*10 + lat_idx + lon_idx*0.01
+    data: dict = {
+        "valid_times": valid_times,
+        "lat": _LAT.astype(np.float64),
+        "lon": _LON.astype(np.float64),
+        "init_time_unix": np.array(_INIT_UNIX, dtype=np.int64),
+        "levels": np.array(_LEVELS, dtype=np.int32),
+        "stride_hours": np.array(_STRIDE_HOURS, dtype=np.int32),
+    }
+    metric_tag = {m: i for i, m in enumerate(_METRICS)}
+    level_offset = {925: 0, 850: 1, 700: 2}
+    for metric in _METRICS:
+        for L in _LEVELS:
+            arr = np.full((n_time, n_lat, n_lon), np.nan, dtype=np.float32)
+            for h in range(n_time):
+                for i in range(n_lat):
+                    for j in range(n_lon):
+                        arr[h, i, j] = (
+                            metric_tag[metric] * 100
+                            + level_offset[L]
+                            + h * 10
+                            + i
+                            + j * 0.01
+                        )
+            # Plant a NaN in (0,0) of one variant so we can verify NaN→null.
+            if metric == "tendency" and L == 850:
+                arr[0, 0, 0] = np.nan
+            data[f"{metric}_{L}"] = arr
+
+    path = snapshot_path(model, _INIT_UNIX, output_dir=out_dir)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    np.savez_compressed(path, **data)
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Test client (mirrors tests/test_api.py pattern)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def app_db():
+    from conftest import make_app_engine
+    engine = make_app_engine()
+    TestSession = sessionmaker(bind=engine)
+    session = TestSession()
+    session.add(UserRow(
+        id=DEV_USER_ID, provider="local", provider_sub="dev",
+        email="dev@localhost", display_name="Dev User", approved=True,
+    ))
+    session.flush()
+    session.add(UserPreferencesRow(user_id=DEV_USER_ID))
+    session.commit()
+    session.close()
+    yield TestSession
+    engine.dispose()
+
+
+@pytest.fixture
+def client(app_db, tmp_path, monkeypatch):
+    monkeypatch.setenv("DATA_DIR", str(tmp_path / "data"))
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.setenv("JWT_SECRET", "test-secret-for-hewson-map")
+    monkeypatch.setenv("DISABLE_SCHEDULER", "1")
+    monkeypatch.setenv("DISABLE_RETENTION", "1")
+    monkeypatch.setenv("DISABLE_VERIFICATION", "1")
+    monkeypatch.setenv("DISABLE_DIGEST", "1")
+    monkeypatch.setenv("DISABLE_STANDALONE_VERIFICATION", "1")
+    monkeypatch.setenv("DISABLE_ECMWF_WATCHER", "1")
+    monkeypatch.setenv("DISABLE_HEWSON_PRECOMPUTE", "1")
+
+    app = create_app()
+
+    def _override_get_db():
+        session = app_db()
+        try:
+            yield session
+            session.commit()
+        except Exception:
+            session.rollback()
+            raise
+        finally:
+            session.close()
+
+    app.dependency_overrides[get_db] = _override_get_db
+    app.dependency_overrides[current_user_id] = lambda: DEV_USER_ID
+
+    return TestClient(app, raise_server_exceptions=False)
+
+
+@pytest.fixture
+def client_anon(app_db, tmp_path, monkeypatch):
+    """Same as ``client`` but without an auth override — for 401 checks."""
+    monkeypatch.setenv("DATA_DIR", str(tmp_path / "data"))
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.setenv("JWT_SECRET", "test-secret-for-hewson-map")
+    monkeypatch.setenv("DISABLE_SCHEDULER", "1")
+    monkeypatch.setenv("DISABLE_RETENTION", "1")
+    monkeypatch.setenv("DISABLE_VERIFICATION", "1")
+    monkeypatch.setenv("DISABLE_DIGEST", "1")
+    monkeypatch.setenv("DISABLE_STANDALONE_VERIFICATION", "1")
+    monkeypatch.setenv("DISABLE_ECMWF_WATCHER", "1")
+    monkeypatch.setenv("DISABLE_HEWSON_PRECOMPUTE", "1")
+
+    app = create_app()
+
+    def _override_get_db():
+        session = app_db()
+        try:
+            yield session
+            session.commit()
+        except Exception:
+            session.rollback()
+            raise
+        finally:
+            session.close()
+
+    app.dependency_overrides[get_db] = _override_get_db
+    return TestClient(app, raise_server_exceptions=False)
+
+
+@pytest.fixture
+def hewson_data_dir(tmp_path):
+    """Where ``DATA_DIR`` points; precompute snapshots land at ``{DATA_DIR}/hewson``."""
+    return tmp_path / "data"
+
+
+# ---------------------------------------------------------------------------
+# Slice endpoint
+# ---------------------------------------------------------------------------
+
+
+def test_get_slice_happy_path(client, hewson_data_dir):
+    _write_synthetic_snapshot(hewson_data_dir / "hewson")
+
+    resp = client.get(
+        "/api/hewson-map",
+        params={
+            "model": "ecmwf",
+            "init": _INIT_ISO,
+            "level": 850,
+            "metric": "advection",
+            "hour": 6,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+
+    assert body["model"] == "ecmwf"
+    assert body["init_time"] == _INIT_ISO
+    assert body["level"] == 850
+    assert body["metric"] == "advection"
+    assert body["hour"] == 6
+    assert body["stride_hours"] == _STRIDE_HOURS
+    assert body["lat"] == _LAT.tolist()
+    assert body["lon"] == _LON.tolist()
+
+    values = body["values"]
+    assert len(values) == _LAT.size
+    assert len(values[0]) == _LON.size
+
+    # advection tag = 4, level 850 offset = 1, hour 6 → idx 2 → h_factor 20
+    # Expected (0,0): 4*100 + 1 + 20 + 0 + 0 = 421
+    assert values[0][0] == pytest.approx(421.0, abs=1e-3)
+    # (lat_idx=2, lon_idx=3): 421 + 2 + 0.03 = 423.03
+    assert values[2][3] == pytest.approx(423.03, abs=1e-3)
+
+    # Cache-Control header
+    assert "max-age=" in resp.headers.get("cache-control", "")
+    assert "immutable" in resp.headers.get("cache-control", "")
+
+
+def test_get_slice_nan_becomes_null(client, hewson_data_dir):
+    _write_synthetic_snapshot(hewson_data_dir / "hewson")
+
+    resp = client.get(
+        "/api/hewson-map",
+        params={
+            "model": "ecmwf", "init": _INIT_ISO,
+            "level": 850, "metric": "tendency", "hour": 0,
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    # The fixture plants NaN at [0][0] for tendency_850 hour=0
+    assert body["values"][0][0] is None
+    # Other cells are still finite numbers
+    assert body["values"][0][1] is not None
+
+
+def test_get_slice_valid_time_matches_init_plus_offset(client, hewson_data_dir):
+    _write_synthetic_snapshot(hewson_data_dir / "hewson")
+
+    resp = client.get(
+        "/api/hewson-map",
+        params={
+            "model": "ecmwf", "init": _INIT_ISO,
+            "level": 700, "metric": "gradient", "hour": 9,
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    # init = 2026-04-24T12:00:00Z + 9h = 2026-04-24T21:00:00Z
+    assert body["valid_time"] == "2026-04-24T21:00:00Z"
+
+
+def test_get_slice_404_when_snapshot_missing(client):
+    resp = client.get(
+        "/api/hewson-map",
+        params={
+            "model": "ecmwf", "init": _INIT_ISO,
+            "level": 850, "metric": "advection", "hour": 0,
+        },
+    )
+    assert resp.status_code == 404
+    assert "no snapshot" in resp.json()["detail"].lower()
+
+
+def test_get_slice_400_invalid_model(client):
+    resp = client.get(
+        "/api/hewson-map",
+        params={
+            "model": "wrf", "init": _INIT_ISO,
+            "level": 850, "metric": "advection", "hour": 0,
+        },
+    )
+    assert resp.status_code == 400
+    assert "model" in resp.json()["detail"].lower()
+
+
+def test_get_slice_400_invalid_level(client):
+    resp = client.get(
+        "/api/hewson-map",
+        params={
+            "model": "ecmwf", "init": _INIT_ISO,
+            "level": 500, "metric": "advection", "hour": 0,
+        },
+    )
+    assert resp.status_code == 400
+    assert "level" in resp.json()["detail"].lower()
+
+
+def test_get_slice_400_invalid_metric(client):
+    resp = client.get(
+        "/api/hewson-map",
+        params={
+            "model": "ecmwf", "init": _INIT_ISO,
+            "level": 850, "metric": "humidity", "hour": 0,
+        },
+    )
+    assert resp.status_code == 400
+    assert "metric" in resp.json()["detail"].lower()
+
+
+def test_get_slice_400_misaligned_hour(client, hewson_data_dir):
+    _write_synthetic_snapshot(hewson_data_dir / "hewson")
+    # stride is 3 h, so hour=4 is invalid
+    resp = client.get(
+        "/api/hewson-map",
+        params={
+            "model": "ecmwf", "init": _INIT_ISO,
+            "level": 850, "metric": "advection", "hour": 4,
+        },
+    )
+    assert resp.status_code == 400
+    assert "stride" in resp.json()["detail"].lower()
+
+
+def test_get_slice_400_hour_past_horizon(client, hewson_data_dir):
+    _write_synthetic_snapshot(hewson_data_dir / "hewson")
+    # snapshot has 4 timesteps × 3 h = max hour 9; ask for 12
+    resp = client.get(
+        "/api/hewson-map",
+        params={
+            "model": "ecmwf", "init": _INIT_ISO,
+            "level": 850, "metric": "advection", "hour": 12,
+        },
+    )
+    assert resp.status_code == 400
+    assert "horizon" in resp.json()["detail"].lower()
+
+
+def test_get_slice_400_bad_init_format(client):
+    resp = client.get(
+        "/api/hewson-map",
+        params={
+            "model": "ecmwf", "init": "yesterday",
+            "level": 850, "metric": "advection", "hour": 0,
+        },
+    )
+    assert resp.status_code == 400
+
+
+def test_get_slice_requires_auth(client_anon, hewson_data_dir):
+    _write_synthetic_snapshot(hewson_data_dir / "hewson")
+    resp = client_anon.get(
+        "/api/hewson-map",
+        params={
+            "model": "ecmwf", "init": _INIT_ISO,
+            "level": 850, "metric": "advection", "hour": 0,
+        },
+    )
+    assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Manifest endpoint
+# ---------------------------------------------------------------------------
+
+
+def test_manifest_lists_snapshots(client, hewson_data_dir):
+    _write_synthetic_snapshot(hewson_data_dir / "hewson", model="ecmwf")
+    _write_synthetic_snapshot(hewson_data_dir / "hewson", model="gfs")
+
+    resp = client.get("/api/hewson-map/manifest")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert set(body["models"].keys()) == {"ecmwf", "gfs"}
+
+    ecmwf = body["models"]["ecmwf"]
+    assert len(ecmwf) == 1
+    snap = ecmwf[0]
+    assert snap["init_time"] == _INIT_ISO
+    assert snap["levels"] == list(_LEVELS)
+    assert snap["stride_hours"] == _STRIDE_HOURS
+    assert snap["n_hours"] == _N_TIME
+    assert snap["n_lat"] == _LAT.size
+    assert snap["n_lon"] == _LON.size
+    assert snap["lat_min"] == pytest.approx(_LAT.min())
+    assert snap["lat_max"] == pytest.approx(_LAT.max())
+    assert len(snap["valid_times"]) == _N_TIME
+    assert snap["valid_times"][0].startswith("2026-04-24T12:00:00")
+
+
+def test_manifest_empty_when_no_data_dir(client):
+    resp = client.get("/api/hewson-map/manifest")
+    assert resp.status_code == 200
+    assert resp.json() == {"models": {}}
+
+
+def test_manifest_requires_auth(client_anon):
+    resp = client_anon.get("/api/hewson-map/manifest")
+    assert resp.status_code == 401

--- a/tests/test_api_hewson_map.py
+++ b/tests/test_api_hewson_map.py
@@ -263,11 +263,25 @@ def test_get_slice_404_when_snapshot_missing(client):
     assert "no snapshot" in resp.json()["detail"].lower()
 
 
-def test_get_slice_400_invalid_model(client):
+def test_get_slice_404_unknown_model(client):
+    """Unknown models return 404 (no snapshot on disk), not 400. The frontend
+    discovers valid models via /manifest, which scans subdirs dynamically."""
     resp = client.get(
         "/api/hewson-map",
         params={
             "model": "wrf", "init": _INIT_ISO,
+            "level": 850, "metric": "advection", "hour": 0,
+        },
+    )
+    assert resp.status_code == 404
+
+
+def test_get_slice_400_unsafe_model(client):
+    """Path-like model names are rejected at the syntactic check."""
+    resp = client.get(
+        "/api/hewson-map",
+        params={
+            "model": "../etc", "init": _INIT_ISO,
             "level": 850, "metric": "advection", "hour": 0,
         },
     )

--- a/tests/test_api_hewson_map.py
+++ b/tests/test_api_hewson_map.py
@@ -490,6 +490,21 @@ def test_all_metrics_requires_auth(client_anon, hewson_data_dir):
     assert resp.status_code == 401
 
 
+def test_all_metrics_400_unsafe_model(client):
+    """Path-like model names are rejected at the syntactic check —
+    same guard as the slice endpoint, separately exercised so a
+    regression to _validate_common_params is caught on both routes."""
+    resp = client.get(
+        "/api/hewson-map/all-metrics",
+        params={
+            "model": "../etc", "init": _INIT_ISO,
+            "level": 850, "hour": 0,
+        },
+    )
+    assert resp.status_code == 400
+    assert "model" in resp.json()["detail"].lower()
+
+
 # ---------------------------------------------------------------------------
 # Manifest endpoint
 # ---------------------------------------------------------------------------

--- a/tests/test_api_hewson_map.py
+++ b/tests/test_api_hewson_map.py
@@ -104,18 +104,23 @@ def app_db():
 
 
 @pytest.fixture
-def client(app_db, tmp_path, monkeypatch):
+def hewson_env(tmp_path, monkeypatch):
+    """Common env-var setup shared by client/client_anon. Adding a new
+    DISABLE_* flag should only require touching this one place."""
     monkeypatch.setenv("DATA_DIR", str(tmp_path / "data"))
     monkeypatch.setenv("ENVIRONMENT", "production")
     monkeypatch.setenv("JWT_SECRET", "test-secret-for-hewson-map")
-    monkeypatch.setenv("DISABLE_SCHEDULER", "1")
-    monkeypatch.setenv("DISABLE_RETENTION", "1")
-    monkeypatch.setenv("DISABLE_VERIFICATION", "1")
-    monkeypatch.setenv("DISABLE_DIGEST", "1")
-    monkeypatch.setenv("DISABLE_STANDALONE_VERIFICATION", "1")
-    monkeypatch.setenv("DISABLE_ECMWF_WATCHER", "1")
-    monkeypatch.setenv("DISABLE_HEWSON_PRECOMPUTE", "1")
+    for flag in (
+        "DISABLE_SCHEDULER", "DISABLE_RETENTION", "DISABLE_VERIFICATION",
+        "DISABLE_DIGEST", "DISABLE_STANDALONE_VERIFICATION",
+        "DISABLE_ECMWF_WATCHER", "DISABLE_HEWSON_PRECOMPUTE",
+    ):
+        monkeypatch.setenv(flag, "1")
 
+
+def _build_test_app(app_db):
+    """Construct an app + dep overrides for the DB; auth override is
+    applied by the caller (only ``client`` wants it)."""
     app = create_app()
 
     def _override_get_db():
@@ -130,39 +135,20 @@ def client(app_db, tmp_path, monkeypatch):
             session.close()
 
     app.dependency_overrides[get_db] = _override_get_db
-    app.dependency_overrides[current_user_id] = lambda: DEV_USER_ID
+    return app
 
+
+@pytest.fixture
+def client(app_db, hewson_env):
+    app = _build_test_app(app_db)
+    app.dependency_overrides[current_user_id] = lambda: DEV_USER_ID
     return TestClient(app, raise_server_exceptions=False)
 
 
 @pytest.fixture
-def client_anon(app_db, tmp_path, monkeypatch):
+def client_anon(app_db, hewson_env):
     """Same as ``client`` but without an auth override — for 401 checks."""
-    monkeypatch.setenv("DATA_DIR", str(tmp_path / "data"))
-    monkeypatch.setenv("ENVIRONMENT", "production")
-    monkeypatch.setenv("JWT_SECRET", "test-secret-for-hewson-map")
-    monkeypatch.setenv("DISABLE_SCHEDULER", "1")
-    monkeypatch.setenv("DISABLE_RETENTION", "1")
-    monkeypatch.setenv("DISABLE_VERIFICATION", "1")
-    monkeypatch.setenv("DISABLE_DIGEST", "1")
-    monkeypatch.setenv("DISABLE_STANDALONE_VERIFICATION", "1")
-    monkeypatch.setenv("DISABLE_ECMWF_WATCHER", "1")
-    monkeypatch.setenv("DISABLE_HEWSON_PRECOMPUTE", "1")
-
-    app = create_app()
-
-    def _override_get_db():
-        session = app_db()
-        try:
-            yield session
-            session.commit()
-        except Exception:
-            session.rollback()
-            raise
-        finally:
-            session.close()
-
-    app.dependency_overrides[get_db] = _override_get_db
+    app = _build_test_app(app_db)
     return TestClient(app, raise_server_exceptions=False)
 
 
@@ -359,6 +345,112 @@ def test_get_slice_requires_auth(client_anon, hewson_data_dir):
         params={
             "model": "ecmwf", "init": _INIT_ISO,
             "level": 850, "metric": "advection", "hour": 0,
+        },
+    )
+    assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# All-metrics endpoint (cursor-tooltip backend)
+# ---------------------------------------------------------------------------
+
+
+def test_all_metrics_happy_path(client, hewson_data_dir):
+    _write_synthetic_snapshot(hewson_data_dir / "hewson")
+    resp = client.get(
+        "/api/hewson-map/all-metrics",
+        params={
+            "model": "ecmwf", "init": _INIT_ISO,
+            "level": 850, "hour": 6,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+
+    assert body["model"] == "ecmwf"
+    assert body["init_time"] == _INIT_ISO
+    assert body["level"] == 850
+    assert body["hour"] == 6
+    assert body["stride_hours"] == _STRIDE_HOURS
+    assert body["lat"] == _LAT.tolist()
+    assert body["lon"] == _LON.tolist()
+
+    # All 6 metrics present, none missing.
+    assert set(body["metrics"].keys()) == set(_METRICS)
+    assert body["missing_metrics"] == []
+
+    # Spot-check shape and a known cell. advection tag=4, level 850 offset=1,
+    # hour 6 → idx=2 → h_factor=20. Expected (0,0): 4*100 + 1 + 20 + 0 = 421.
+    adv = body["metrics"]["advection"]
+    assert len(adv) == _LAT.size
+    assert len(adv[0]) == _LON.size
+    assert adv[0][0] == pytest.approx(421.0, abs=1e-3)
+
+    # NaN cell from the fixture (tendency at 850, hour 0, [0][0]) is null in
+    # this hour=6 response slot — at hour=6 the value is finite (the fixture
+    # only plants NaN at hour 0).
+    assert body["metrics"]["tendency"][0][0] is not None
+
+    # Auth-gated → private cache directive.
+    cache = resp.headers.get("cache-control", "")
+    assert "private" in cache and "immutable" in cache
+
+
+def test_all_metrics_partial_when_metric_key_missing(client, hewson_data_dir, tmp_path):
+    """A snapshot missing one metric for the level still returns 200; the
+    missing metric appears in `missing_metrics` but other metrics render."""
+    # Build a normal snapshot and delete one metric stack from it before
+    # the endpoint reads it. Easiest: rewrite the NPZ without the dropped key.
+    path = _write_synthetic_snapshot(hewson_data_dir / "hewson")
+    with np.load(path) as npz:
+        keep = {k: npz[k] for k in npz.files if k != "tendency_850"}
+    np.savez_compressed(path, **keep)
+
+    resp = client.get(
+        "/api/hewson-map/all-metrics",
+        params={
+            "model": "ecmwf", "init": _INIT_ISO,
+            "level": 850, "hour": 0,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert "tendency" not in body["metrics"]
+    assert "tendency" in body["missing_metrics"]
+    # Other metrics still present.
+    assert "gradient" in body["metrics"]
+    assert "advection" in body["metrics"]
+
+
+def test_all_metrics_404_when_snapshot_missing(client):
+    resp = client.get(
+        "/api/hewson-map/all-metrics",
+        params={
+            "model": "ecmwf", "init": _INIT_ISO,
+            "level": 850, "hour": 0,
+        },
+    )
+    assert resp.status_code == 404
+
+
+def test_all_metrics_400_invalid_level(client):
+    resp = client.get(
+        "/api/hewson-map/all-metrics",
+        params={
+            "model": "ecmwf", "init": _INIT_ISO,
+            "level": 500, "hour": 0,
+        },
+    )
+    assert resp.status_code == 400
+
+
+def test_all_metrics_requires_auth(client_anon, hewson_data_dir):
+    _write_synthetic_snapshot(hewson_data_dir / "hewson")
+    resp = client_anon.get(
+        "/api/hewson-map/all-metrics",
+        params={
+            "model": "ecmwf", "init": _INIT_ISO,
+            "level": 850, "hour": 0,
         },
     )
     assert resp.status_code == 401

--- a/tests/test_api_hewson_map.py
+++ b/tests/test_api_hewson_map.py
@@ -350,6 +350,40 @@ def test_get_slice_requires_auth(client_anon, hewson_data_dir):
     assert resp.status_code == 401
 
 
+def test_corrupt_snapshot_returns_404(client, hewson_data_dir):
+    """A truncated/corrupt NPZ (e.g. from a precompute crash mid-write)
+    must surface as 404, not a 500. Manifest must skip it silently."""
+    target = snapshot_path("ecmwf", _INIT_UNIX, output_dir=hewson_data_dir / "hewson")
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_bytes(b"not a valid zip")
+
+    # Slice endpoint
+    resp = client.get(
+        "/api/hewson-map",
+        params={
+            "model": "ecmwf", "init": _INIT_ISO,
+            "level": 850, "metric": "advection", "hour": 0,
+        },
+    )
+    assert resp.status_code == 404
+
+    # All-metrics endpoint
+    resp = client.get(
+        "/api/hewson-map/all-metrics",
+        params={
+            "model": "ecmwf", "init": _INIT_ISO,
+            "level": 850, "hour": 0,
+        },
+    )
+    assert resp.status_code == 404
+
+    # Manifest must not 500 — corrupt files are skipped, others (none here)
+    # would still be listed. Empty result for ecmwf is fine.
+    resp = client.get("/api/hewson-map/manifest")
+    assert resp.status_code == 200
+    assert "ecmwf" not in resp.json()["models"]
+
+
 # ---------------------------------------------------------------------------
 # All-metrics endpoint (cursor-tooltip backend)
 # ---------------------------------------------------------------------------

--- a/tests/test_api_hewson_map.py
+++ b/tests/test_api_hewson_map.py
@@ -140,6 +140,29 @@ def _build_test_app(app_db):
 
 @pytest.fixture
 def client(app_db, hewson_env):
+    """Authenticated *admin* client — Synoptic Forecast is admin-gated
+    while it's being calibrated, so the slice / manifest / all-metrics
+    endpoints all require ``require_admin``. Override both to give the
+    dev user admin access."""
+    from weatherbrief.api.admin import require_admin
+    app = _build_test_app(app_db)
+    app.dependency_overrides[current_user_id] = lambda: DEV_USER_ID
+    app.dependency_overrides[require_admin] = lambda: DEV_USER_ID
+    return TestClient(app, raise_server_exceptions=False)
+
+
+@pytest.fixture
+def client_non_admin(app_db, hewson_env, monkeypatch):
+    """Authenticated but non-admin — for 403 admin-gate checks.
+
+    ``require_admin`` decodes the JWT itself (not via Depends), so we
+    monkey-patch the underlying ``_decode_user_id`` to return the dev
+    user. ``require_admin`` then proceeds to its real admin-email check,
+    finds the dev user isn't in the admin list, and raises 403."""
+    monkeypatch.setattr(
+        "weatherbrief.api.admin._decode_user_id",
+        lambda request, db: DEV_USER_ID,
+    )
     app = _build_test_app(app_db)
     app.dependency_overrides[current_user_id] = lambda: DEV_USER_ID
     return TestClient(app, raise_server_exceptions=False)
@@ -348,6 +371,21 @@ def test_get_slice_requires_auth(client_anon, hewson_data_dir):
         },
     )
     assert resp.status_code == 401
+
+
+def test_get_slice_requires_admin(client_non_admin, hewson_data_dir):
+    """While Synoptic Forecast is admin-gated, an authenticated non-admin
+    user gets 403, not the slice. Flipping _synoptic_auth in
+    src/weatherbrief/api/hewson_map.py will retire this test."""
+    _write_synthetic_snapshot(hewson_data_dir / "hewson")
+    resp = client_non_admin.get(
+        "/api/hewson-map",
+        params={
+            "model": "ecmwf", "init": _INIT_ISO,
+            "level": 850, "metric": "advection", "hour": 0,
+        },
+    )
+    assert resp.status_code == 403
 
 
 def test_corrupt_snapshot_returns_404(client, hewson_data_dir):

--- a/tests/test_hewson_era5_case.py
+++ b/tests/test_hewson_era5_case.py
@@ -1,0 +1,221 @@
+"""Tests for weatherbrief.hewson.era5_case.build_synoptic_from_case.
+
+Builds a synthetic ERA5 Case in tmp_path (single 850 hPa level, mirroring
+the on-disk Ciarán case shape), runs the builder, and verifies the
+resulting NPZ matches the synoptic-snapshot schema consumed by the
+/api/hewson-map endpoints + the SynopticMap frontend.
+
+build_terrain_mask is monkey-patched: it depends on SRTM data which we
+don't want in unit tests, and it isn't part of what this module is
+testing.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from weatherbrief.frontal.case import save_case_meta, save_model_fields
+
+
+# ---------------------------------------------------------------------------
+# Synthetic Case builder
+# ---------------------------------------------------------------------------
+
+
+# Small grid keeps tests fast — large enough that the gradient/Laplacian
+# stencils have valid interior points.
+_LAT = np.linspace(40.0, 50.0, 11)
+_LON = np.linspace(-5.0, 5.0, 11)
+_INIT = datetime(2023, 11, 2, 0, 0, 0, tzinfo=timezone.utc)
+
+
+def _build_synthetic_era5_case(case_dir: Path, n_time: int = 4) -> None:
+    """Write a Case directory with ``n_time`` 6-hourly steps at 850 hPa."""
+    valid_times = np.array(
+        [np.datetime64(_INIT.replace(tzinfo=None) + timedelta(hours=6 * i))
+         for i in range(n_time)],
+        dtype="datetime64[ns]",
+    )
+
+    fields_by_time = []
+    for i in range(n_time):
+        # Linear-in-x θe ramp so gradient is non-zero (and easy to predict).
+        lon2d, lat2d = np.meshgrid(_LON, _LAT)
+        theta_e = 290.0 + 0.5 * lon2d + 0.1 * i  # rises over time too
+        T = theta_e - 5.0
+        Td = theta_e - 8.0
+        u = np.full_like(theta_e, 10.0)   # 10 m/s westerly
+        v = np.zeros_like(theta_e)
+        fields_by_time.append({
+            "T850": T, "Td850": Td, "theta_e": theta_e,
+            "u850": u, "v850": v,
+        })
+
+    save_case_meta(
+        case_dir,
+        case_name="2023-11-02_synthetic_era5",
+        source="era5",
+        lat=_LAT, lon=_LON,
+        models=["era5"],
+        init_times={"era5": 0},
+    )
+    save_model_fields(case_dir, "era5", fields_by_time, valid_times)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def patched_terrain_mask(monkeypatch):
+    """Replace build_terrain_mask with a synthetic all-valid mask so tests
+    don't depend on SRTM data being available. Convention (per
+    frontal/grid.py): True = below 1500m = valid."""
+    def _fake_mask(lat, lon):
+        return np.ones((len(lat), len(lon)), dtype=bool)
+    monkeypatch.setattr(
+        "weatherbrief.hewson.era5_case.build_terrain_mask",
+        _fake_mask,
+    )
+
+
+def test_writes_snapshot_at_init_named_path(tmp_path, patched_terrain_mask):
+    """Output filename is the ISO Z timestamp of the first valid time —
+    matches the live precompute path convention so the slice endpoint can
+    find it via the same (model, init) lookup."""
+    from weatherbrief.hewson.era5_case import build_synoptic_from_case
+
+    case_dir = tmp_path / "ciaran"
+    _build_synthetic_era5_case(case_dir)
+
+    out_path = build_synoptic_from_case(
+        case_dir, output_dir=tmp_path / "hewson",
+    )
+
+    assert out_path.exists()
+    assert out_path.parent.name == "era5"
+    assert out_path.name == "2023-11-02T00:00:00Z.npz"
+
+
+def test_snapshot_schema(tmp_path, patched_terrain_mask):
+    """NPZ contains all the keys the /api/hewson-map endpoints expect:
+    levels, stride_hours, init_time_unix, lat/lon, valid_times, and one
+    (n_time, n_lat, n_lon) stack per (metric, level) combination."""
+    from weatherbrief.hewson.era5_case import build_synoptic_from_case
+
+    case_dir = tmp_path / "case"
+    _build_synthetic_era5_case(case_dir, n_time=4)
+
+    out_path = build_synoptic_from_case(case_dir, output_dir=tmp_path / "hewson")
+
+    with np.load(out_path) as npz:
+        # Required scalar / coord arrays
+        assert int(npz["init_time_unix"]) == int(_INIT.timestamp())
+        assert npz["levels"].tolist() == [850]
+        assert int(npz["stride_hours"]) == 6
+        assert npz["lat"].tolist() == _LAT.tolist()
+        assert npz["lon"].tolist() == _LON.tolist()
+        assert npz["valid_times"].shape == (4,)
+
+        # All 6 metric stacks at 850 hPa with the right shape
+        for metric in ("theta_e", "gradient", "neg_laplacian", "tfp",
+                       "advection", "tendency"):
+            arr = npz[f"{metric}_850"]
+            assert arr.shape == (4, len(_LAT), len(_LON))
+            assert arr.dtype == np.float32
+
+
+def test_tendency_uses_stride_hours(tmp_path, patched_terrain_mask):
+    """Tendency in K/h must come out independent of stride. Our θe ramps
+    by 0.1 K per index (i.e. 0.1 K per 6 h step) → ∂θe/∂t ≈ 1/60 K/h.
+    Allow some slack for edge effects and interior points."""
+    from weatherbrief.hewson.era5_case import build_synoptic_from_case
+
+    case_dir = tmp_path / "case"
+    _build_synthetic_era5_case(case_dir, n_time=4)
+
+    out_path = build_synoptic_from_case(case_dir, output_dir=tmp_path / "hewson")
+    with np.load(out_path) as npz:
+        tend = npz["tendency_850"]
+        # Interior cell, interior time — should be the centred-diff value
+        # (theta_e_at_t+1 - theta_e_at_t-1) / (2 * stride_hours)
+        # = (0.1 - (-0.1)) / 12 ≈ 0.01667
+        v = float(tend[1, 5, 5])
+        assert v == pytest.approx(0.0167, abs=1e-3)
+
+
+def test_single_timestep_tendency_is_nan(tmp_path, patched_terrain_mask):
+    """ERA5 cases with only one analysis stamp produce NaN tendency. The
+    builder must not raise; downstream code treats NaN as 'unavailable'."""
+    from weatherbrief.hewson.era5_case import build_synoptic_from_case
+
+    case_dir = tmp_path / "case"
+    _build_synthetic_era5_case(case_dir, n_time=1)
+
+    out_path = build_synoptic_from_case(case_dir, output_dir=tmp_path / "hewson")
+    with np.load(out_path) as npz:
+        # Other metrics should still be finite at interior points.
+        theta_e = npz["theta_e_850"]
+        assert np.isfinite(theta_e[0, 5, 5])
+        # Tendency requires >= 2 timesteps — all-NaN.
+        assert np.all(np.isnan(npz["tendency_850"]))
+        # stride_hours falls back to the safe default (6) for single-step.
+        assert int(npz["stride_hours"]) == 6
+
+
+def test_rejects_non_era5_case(tmp_path, patched_terrain_mask):
+    """The builder is ERA5-only; an Open-Meteo case should be rejected
+    with a clear message rather than producing nonsense."""
+    from weatherbrief.hewson.era5_case import build_synoptic_from_case
+
+    case_dir = tmp_path / "om_case"
+    valid_times = np.array(
+        [np.datetime64(_INIT.replace(tzinfo=None) + timedelta(hours=h))
+         for h in (0, 6)],
+        dtype="datetime64[ns]",
+    )
+    fields = [{
+        "T850": np.zeros((len(_LAT), len(_LON))),
+        "Td850": np.zeros((len(_LAT), len(_LON))),
+        "theta_e": np.zeros((len(_LAT), len(_LON))),
+        "u850": np.zeros((len(_LAT), len(_LON))),
+        "v850": np.zeros((len(_LAT), len(_LON))),
+    } for _ in range(2)]
+    save_case_meta(
+        case_dir,
+        case_name="om", source="open_meteo",
+        lat=_LAT, lon=_LON,
+        models=["ecmwf"],
+        init_times={"ecmwf": int(_INIT.timestamp())},
+    )
+    save_model_fields(case_dir, "ecmwf", fields, valid_times)
+
+    with pytest.raises(ValueError, match="era5"):
+        build_synoptic_from_case(case_dir, output_dir=tmp_path / "hewson")
+
+
+def test_levels_subset(tmp_path, patched_terrain_mask):
+    """When ``levels=`` restricts to a subset of what's in the case, only
+    those levels appear in the output. Asking for a missing level raises."""
+    from weatherbrief.hewson.era5_case import build_synoptic_from_case
+
+    case_dir = tmp_path / "case"
+    _build_synthetic_era5_case(case_dir, n_time=2)
+
+    # 850 is in the case → OK
+    out_path = build_synoptic_from_case(
+        case_dir, output_dir=tmp_path / "hewson", levels=[850],
+    )
+    with np.load(out_path) as npz:
+        assert npz["levels"].tolist() == [850]
+
+    # 700 is not in the case → ValueError
+    with pytest.raises(ValueError, match="700"):
+        build_synoptic_from_case(
+            case_dir, output_dir=tmp_path / "hewson", levels=[700],
+        )

--- a/tests/test_hewson_precompute.py
+++ b/tests/test_hewson_precompute.py
@@ -18,7 +18,7 @@ import pytest
 from weatherbrief.hewson.precompute import (
     DEFAULT_LEVELS,
     _init_to_iso_z,
-    _tendency_k_per_hour,
+    tendency_k_per_hour,
     load_snapshot,
     purge_old_snapshots,
     resolve_output_dir,
@@ -70,7 +70,7 @@ def test_tendency_centered_difference():
     stack = np.stack([np.full((3, 3), 10.0 + 2.0 * h) for h in range(5)]).astype(
         np.float32
     )
-    tend = _tendency_k_per_hour(stack)
+    tend = tendency_k_per_hour(stack)
     assert tend.shape == stack.shape
     assert np.allclose(tend, 2.0)
 
@@ -80,7 +80,7 @@ def test_tendency_edges_one_sided():
     # (10-0)/2 = 5, hour 4 edge is 30-20 = 10.
     vals = [0.0, 0.0, 10.0, 20.0, 30.0]
     stack = np.stack([np.full((2, 2), v) for v in vals]).astype(np.float32)
-    tend = _tendency_k_per_hour(stack)
+    tend = tendency_k_per_hour(stack)
     assert tend[0, 0, 0] == pytest.approx(0.0)
     assert tend[1, 0, 0] == pytest.approx(5.0)
     assert tend[-1, 0, 0] == pytest.approx(10.0)
@@ -88,7 +88,7 @@ def test_tendency_edges_one_sided():
 
 def test_tendency_single_hour_is_nan():
     stack = np.full((1, 2, 2), 5.0, dtype=np.float32)
-    tend = _tendency_k_per_hour(stack)
+    tend = tendency_k_per_hour(stack)
     assert np.all(np.isnan(tend))
 
 
@@ -98,14 +98,14 @@ def test_tendency_scales_with_step_hours():
     stack = np.stack(
         [np.full((2, 2), 6.0 * t) for t in (0, 3, 6, 9)]
     ).astype(np.float32)
-    tend = _tendency_k_per_hour(stack, step_hours=3)
+    tend = tendency_k_per_hour(stack, step_hours=3)
     assert np.allclose(tend, 6.0)
 
 
 def test_tendency_rejects_nonpositive_step():
     stack = np.zeros((3, 2, 2), dtype=np.float32)
     with pytest.raises(ValueError):
-        _tendency_k_per_hour(stack, step_hours=0)
+        tendency_k_per_hour(stack, step_hours=0)
 
 
 # ---------------------------------------------------------------------------

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -2238,7 +2238,8 @@ label {
   position: fixed;
   inset: 0;
   background: rgba(0, 0, 0, 0.5);
-  z-index: 300;
+  /* Above Leaflet panes (max ~700) and the synoptic-legend (1000) */
+  z-index: 9999;
   justify-content: center;
   align-items: flex-start;
   padding: 3rem 1rem;

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -2317,6 +2317,25 @@ label {
   line-height: 1.5;
 }
 
+.popup-section ul,
+.popup-section ol {
+  font-size: 0.85rem;
+  line-height: 1.5;
+  margin: 0.3rem 0 0.4rem;
+  padding-left: 1.2rem;
+}
+.popup-section ul li,
+.popup-section ol li {
+  margin: 0.15rem 0;
+}
+.popup-section ul {
+  list-style-type: disc;
+}
+.popup-section ul li::marker {
+  color: var(--text-muted);
+  font-size: 0.75em;
+}
+
 .popup-limitations {
   opacity: 0.8;
 }

--- a/web/maps.html
+++ b/web/maps.html
@@ -239,14 +239,12 @@
     <div id="panel-synoptic" class="tab-panel">
       <div class="maps-controls synoptic-controls" id="controls-synoptic">
         <label>Model</label>
-        <div class="btn-group" id="syn-model-picker">
-          <button class="btn-toggle active" data-model="ecmwf">ECMWF</button>
-          <button class="btn-toggle" data-model="gfs">GFS</button>
-          <button class="btn-toggle" data-model="icon">ICON</button>
-        </div>
+        <!-- Buttons populated from /api/hewson-map/manifest at first tab show -->
+        <div class="btn-group" id="syn-model-picker"></div>
         <label>Init</label>
         <select id="syn-init-picker"></select>
         <label>Level</label>
+        <!-- Hardcoded buttons; disabled per-snapshot based on the manifest's "levels" array -->
         <div class="btn-group" id="syn-level-picker">
           <button class="btn-toggle" data-level="925">925 hPa<br><span style="font-size:0.7em;opacity:0.7">2,500 ft</span></button>
           <button class="btn-toggle active" data-level="850">850 hPa<br><span style="font-size:0.7em;opacity:0.7">5,000 ft</span></button>

--- a/web/maps.html
+++ b/web/maps.html
@@ -46,7 +46,7 @@
 
     .map-legend {
       position: absolute; bottom: 30px; left: 10px; z-index: 1000;
-      background: var(--card-bg); border: 1px solid var(--border);
+      background: var(--surface); border: 1px solid var(--border);
       border-radius: 6px; padding: 0.5rem 0.7rem; font-size: 0.75rem;
       max-width: 200px; color: var(--text);
     }
@@ -85,6 +85,41 @@
       width: 100%; border: none; border-radius: 8px;
       height: calc(100vh - 200px); min-height: 500px;
     }
+
+    /* Synoptic Forecast tab */
+    .synoptic-controls input[type="range"] { vertical-align: middle; }
+    .synoptic-controls .range-with-value {
+      display: inline-flex; align-items: center; gap: 0.4rem;
+    }
+    .synoptic-controls .range-value {
+      font-variant-numeric: tabular-nums; min-width: 3.5rem;
+      color: var(--text); font-weight: 600;
+    }
+    .synoptic-info-btn {
+      cursor: pointer; font-weight: 700; width: 18px; height: 18px;
+      border-radius: 50%; border: 1.5px solid var(--text-muted);
+      color: var(--text-muted); background: transparent;
+      display: inline-flex; align-items: center; justify-content: center;
+      font-size: 0.7rem; padding: 0;
+    }
+    .synoptic-info-btn:hover { color: var(--text); border-color: var(--text); }
+
+    .synoptic-legend {
+      position: absolute; bottom: 30px; left: 10px; z-index: 1000;
+      background: var(--surface); border: 1px solid var(--border);
+      border-radius: 6px; padding: 0.5rem 0.7rem;
+      font-size: 0.75rem; color: var(--text);
+      width: 230px;
+    }
+    .synoptic-legend-title { font-weight: 600; margin-bottom: 0.3rem; }
+    .synoptic-legend-bar {
+      height: 12px; width: 100%; border-radius: 3px;
+      border: 1px solid var(--border);
+    }
+    .synoptic-legend-ticks {
+      display: flex; justify-content: space-between;
+      margin-top: 0.2rem; font-variant-numeric: tabular-nums;
+    }
   </style>
 </head>
 <body>
@@ -112,6 +147,7 @@
     <div class="settings-tabs" id="tabs">
       <button class="tab-btn active" data-tab="forecast">Forecast Overview</button>
       <button class="tab-btn" data-tab="verification">Model Accuracy Map</button>
+      <button class="tab-btn" data-tab="synoptic">Synoptic Forecast</button>
       <button class="tab-btn" data-tab="stats">Accuracy Stats</button>
     </div>
 
@@ -197,6 +233,57 @@
         <div id="map-container-verif" style="width:100%; height:calc(100vh - 280px); min-height:400px; border-radius:8px; border:1px solid var(--border); overflow:hidden;"></div>
       </div>
       <div class="map-info" id="map-info-verif"></div>
+    </div>
+
+    <!-- Tab: Synoptic Forecast (Hewson gridded fields) -->
+    <div id="panel-synoptic" class="tab-panel">
+      <div class="maps-controls synoptic-controls" id="controls-synoptic">
+        <label>Model</label>
+        <div class="btn-group" id="syn-model-picker">
+          <button class="btn-toggle active" data-model="ecmwf">ECMWF</button>
+          <button class="btn-toggle" data-model="gfs">GFS</button>
+          <button class="btn-toggle" data-model="icon">ICON</button>
+        </div>
+        <label>Init</label>
+        <select id="syn-init-picker"></select>
+        <label>Level</label>
+        <div class="btn-group" id="syn-level-picker">
+          <button class="btn-toggle" data-level="925">925 hPa<br><span style="font-size:0.7em;opacity:0.7">2,500 ft</span></button>
+          <button class="btn-toggle active" data-level="850">850 hPa<br><span style="font-size:0.7em;opacity:0.7">5,000 ft</span></button>
+          <button class="btn-toggle" data-level="700">700 hPa<br><span style="font-size:0.7em;opacity:0.7">10,000 ft</span></button>
+        </div>
+        <label>Field</label>
+        <select id="syn-metric-picker">
+          <optgroup label="Air-mass character">
+            <option value="theta_e">θe — equivalent potential T</option>
+          </optgroup>
+          <optgroup label="Boundaries (frontal zones)">
+            <option value="gradient" selected>|∇θe| — boundary intensity</option>
+            <option value="neg_laplacian">−∇²θe — sharpness</option>
+            <option value="tfp">TFP — front side</option>
+          </optgroup>
+          <optgroup label="Time changes">
+            <option value="advection">−V·∇θe — warm/cold advection</option>
+            <option value="tendency">∂θe/∂t — local tendency</option>
+          </optgroup>
+        </select>
+        <button class="synoptic-info-btn" id="syn-info-btn" title="What does this field mean?">i</button>
+        <label>Hour</label>
+        <span class="range-with-value">
+          <input type="range" id="syn-hour-slider" min="0" max="0" step="3" value="0" style="width:200px">
+          <span class="range-value" id="syn-hour-value">+0 h</span>
+        </span>
+        <label>Opacity</label>
+        <span class="range-with-value">
+          <input type="range" id="syn-opacity-slider" min="0" max="100" value="50" style="width:120px">
+          <span class="range-value" id="syn-opacity-value">50%</span>
+        </span>
+      </div>
+
+      <div class="map-wrapper">
+        <div id="map-container-synoptic" style="width:100%; height:calc(100vh - 280px); min-height:400px; border-radius:8px; border:1px solid var(--border); overflow:hidden; position:relative;"></div>
+      </div>
+      <div class="map-info" id="map-info-synoptic"></div>
     </div>
 
     <!-- Tab: Accuracy Stats (embedded verification page) -->

--- a/web/maps.html
+++ b/web/maps.html
@@ -120,6 +120,31 @@
       display: flex; justify-content: space-between;
       margin-top: 0.2rem; font-variant-numeric: tabular-nums;
     }
+
+    /* Cursor-following tooltip on the synoptic map. */
+    .synoptic-hover-tip {
+      position: absolute; pointer-events: none; z-index: 1100;
+      background: var(--surface); border: 1px solid var(--border);
+      border-radius: 6px; padding: 0.4rem 0.6rem;
+      font-size: 0.75rem; color: var(--text);
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+      min-width: 180px; max-width: 240px;
+      font-variant-numeric: tabular-nums;
+    }
+    .synoptic-hover-header {
+      font-weight: 600; margin-bottom: 0.3rem;
+      padding-bottom: 0.25rem; border-bottom: 1px solid var(--border);
+      font-size: 0.75rem;
+    }
+    .synoptic-hover-cell {
+      font-weight: 400; color: var(--text-muted); font-size: 0.7rem;
+    }
+    .synoptic-hover-row {
+      display: flex; justify-content: space-between; gap: 0.5rem;
+      line-height: 1.35;
+    }
+    .synoptic-hover-label { color: var(--text-muted); }
+    .synoptic-hover-value { font-weight: 600; }
   </style>
 </head>
 <body>
@@ -266,6 +291,11 @@
           </optgroup>
         </select>
         <button class="synoptic-info-btn" id="syn-info-btn" title="What does this field mean?">i</button>
+        <label>Scale</label>
+        <div class="btn-group" id="syn-scale-picker" title="Default = advisory thresholds. Storm = wider range so extreme events stand out.">
+          <button class="btn-toggle active" data-scale="default">Default</button>
+          <button class="btn-toggle" data-scale="storm">Storm</button>
+        </div>
         <label>Hour</label>
         <span class="range-with-value">
           <input type="range" id="syn-hour-slider" min="0" max="0" step="3" value="0" style="width:200px">

--- a/web/ts/adapters/hewson-map-adapter.ts
+++ b/web/ts/adapters/hewson-map-adapter.ts
@@ -46,6 +46,28 @@ export interface HewsonSliceParams {
   hour: number;
 }
 
+export interface HewsonAllMetricsSlice {
+  model: string;
+  init_time: string;
+  valid_time: string;
+  level: number;
+  hour: number;
+  stride_hours: number;
+  lat: number[];
+  lon: number[];
+  /** Per-metric (n_lat, n_lon) grid. Cells outside the grid mask come back as null. */
+  metrics: Record<string, (number | null)[][]>;
+  /** Metrics that weren't present in this snapshot (e.g. legacy snapshots). */
+  missing_metrics: string[];
+}
+
+export interface HewsonAllMetricsParams {
+  model: string;
+  init: string;
+  level: number;
+  hour: number;
+}
+
 // --- Fetch functions ---
 
 export async function fetchHewsonManifest(): Promise<HewsonManifest> {
@@ -67,6 +89,26 @@ export async function fetchHewsonSlice(p: HewsonSliceParams): Promise<HewsonSlic
     let detail: string | undefined;
     try { detail = (await resp.json())?.detail; } catch { /* ignore */ }
     throw new Error(detail ?? `Hewson slice: ${resp.status}`);
+  }
+  return resp.json();
+}
+
+export async function fetchHewsonAllMetrics(
+  p: HewsonAllMetricsParams,
+): Promise<HewsonAllMetricsSlice> {
+  const qs = new URLSearchParams({
+    model: p.model,
+    init: p.init,
+    level: String(p.level),
+    hour: String(p.hour),
+  });
+  const resp = await fetch(
+    `${apiBase}/hewson-map/all-metrics?${qs}`, { credentials: 'include' },
+  );
+  if (!resp.ok) {
+    let detail: string | undefined;
+    try { detail = (await resp.json())?.detail; } catch { /* ignore */ }
+    throw new Error(detail ?? `Hewson all-metrics: ${resp.status}`);
   }
   return resp.json();
 }

--- a/web/ts/adapters/hewson-map-adapter.ts
+++ b/web/ts/adapters/hewson-map-adapter.ts
@@ -1,0 +1,72 @@
+/** API adapter for the Hewson synoptic map (/api/hewson-map). */
+
+import { API_BASE } from '../utils';
+
+const apiBase = API_BASE;
+
+// --- Types ---
+
+export interface HewsonManifestSnapshot {
+  init_time: string;          // ISO 8601 with Z
+  init_time_unix: number;
+  levels: number[];
+  stride_hours: number;
+  valid_times: string[];      // length = n_hours
+  n_hours: number;
+  lat_min: number;
+  lat_max: number;
+  lon_min: number;
+  lon_max: number;
+  n_lat: number;
+  n_lon: number;
+}
+
+export interface HewsonManifest {
+  models: Record<string, HewsonManifestSnapshot[]>;
+}
+
+export interface HewsonSlice {
+  model: string;
+  init_time: string;
+  valid_time: string;
+  level: number;
+  metric: string;
+  hour: number;
+  stride_hours: number;
+  lat: number[];                       // n_lat
+  lon: number[];                       // n_lon
+  values: (number | null)[][];         // (n_lat, n_lon)
+}
+
+export interface HewsonSliceParams {
+  model: string;
+  init: string;        // ISO 8601 with Z
+  level: number;
+  metric: string;
+  hour: number;
+}
+
+// --- Fetch functions ---
+
+export async function fetchHewsonManifest(): Promise<HewsonManifest> {
+  const resp = await fetch(`${apiBase}/hewson-map/manifest`, { credentials: 'include' });
+  if (!resp.ok) throw new Error(`Hewson manifest: ${resp.status}`);
+  return resp.json();
+}
+
+export async function fetchHewsonSlice(p: HewsonSliceParams): Promise<HewsonSlice> {
+  const qs = new URLSearchParams({
+    model: p.model,
+    init: p.init,
+    level: String(p.level),
+    metric: p.metric,
+    hour: String(p.hour),
+  });
+  const resp = await fetch(`${apiBase}/hewson-map?${qs}`, { credentials: 'include' });
+  if (!resp.ok) {
+    let detail: string | undefined;
+    try { detail = (await resp.json())?.detail; } catch { /* ignore */ }
+    throw new Error(detail ?? `Hewson slice: ${resp.status}`);
+  }
+  return resp.json();
+}

--- a/web/ts/components/info-popup.ts
+++ b/web/ts/components/info-popup.ts
@@ -101,8 +101,18 @@ function wirePopupButtons(): void {
     btn.addEventListener('click', () => {
       navigator.clipboard.writeText(prompt).then(() => {
         if (toast) {
+          toast.textContent = 'Prompt copied! Paste it into the chat.';
           toast.hidden = false;
           setTimeout(() => { toast.hidden = true; }, 3000);
+        }
+      }).catch(() => {
+        // Clipboard can reject (permission denied, insecure context).
+        // Surface that to the pilot so they don't open the AI chat with
+        // an empty buffer.
+        if (toast) {
+          toast.textContent = 'Copy failed — paste manually from the modal.';
+          toast.hidden = false;
+          setTimeout(() => { toast.hidden = true; }, 4000);
         }
       });
     });

--- a/web/ts/components/info-popup.ts
+++ b/web/ts/components/info-popup.ts
@@ -56,7 +56,9 @@ export function showLayerInfo(layerId: string, metricId: string): void {
   wirePopupButtons();
 }
 
-/** Show the popup with arbitrary HTML content. Used by advisory info buttons. */
+/** Show the popup with arbitrary HTML content. Used by advisory info buttons
+ * and the synoptic-tab Hewson info popups. If the supplied HTML includes a
+ * .popup-discuss-ai block, the AI-prompt buttons will be wired automatically. */
 export function showPopupContent(html: string): void {
   if (!popupEl || !backdropEl) return;
 
@@ -66,11 +68,7 @@ export function showPopupContent(html: string): void {
   `;
 
   backdropEl.classList.add('active');
-
-  const closeBtn = popupEl.querySelector('.metric-popup-close');
-  if (closeBtn) {
-    closeBtn.addEventListener('click', hideMetricInfo);
-  }
+  wirePopupButtons();
 }
 
 export function hideMetricInfo(): void {

--- a/web/ts/data/hewson-metrics-catalog.ts
+++ b/web/ts/data/hewson-metrics-catalog.ts
@@ -209,7 +209,7 @@ export const HEWSON_CATALOG: Record<HewsonMetric, HewsonCatalogEntry> = {
       { range: 'TFP < 0', label: 'Cold-air side', risk: 'low', meaning: 'You are between the front line and the cold-side boundary.' },
     ],
     pilot_notes: `<p>Combined with wind direction and the −V·∇θe map, TFP tells you whether the front is moving toward you or away. Two pilots in the same TFP-positive area can experience very different weather depending on whether they're flying with or against the front's motion.</p>`,
-    limitations: `TFP at <strong>850</strong> is canonical (Hewson's original work). At <strong>925</strong> it is noisier (bumpy boundary-layer θe). At <strong>700</strong> the field is smoother but the front is <em>aloft</em> — surface position can be displaced 50–150 km from the 700 zero-contour because fronts tilt with height (warm fronts slope forward, cold fronts slope backward).`,
+    limitations: `TFP at <strong>850</strong> is canonical (Hewson's original work). At <strong>925</strong> it is noisier (bumpy boundary-layer θe). At <strong>700</strong> the field is smoother but the front is <em>aloft</em> — surface position can be displaced 50–150 km from the 700 zero-contour because fronts tilt with height. Both warm and cold fronts tilt backward toward the cold air mass with altitude — warm fronts gently (~1:100–200), cold fronts more steeply (~1:50–75).`,
     llm_prompt: 'explain the Thermal Front Parameter (TFP) from Hewson 1998 — its mathematical definition as the directional derivative of |∇θe| along the gradient, what its zero crossing represents, why it is a position indicator rather than a tendency indicator, and how forecasters use the locating equation alongside it',
   },
 

--- a/web/ts/data/hewson-metrics-catalog.ts
+++ b/web/ts/data/hewson-metrics-catalog.ts
@@ -272,12 +272,40 @@ export const HEWSON_CATALOG: Record<HewsonMetric, HewsonCatalogEntry> = {
       <p>The first term is what advection alone predicts. The rest captures <strong>diurnal heating/cooling, latent heat release in convection, and radiative cooling</strong>. The interesting case is when ∂θe/∂t and −V·∇θe <em>disagree</em> — that tells you the air mass itself is being modified, not just being moved.</p>
     `,
     what_map_shows: `Diverging — where θe is rising or falling. Computed by central differences across the snapshot's 3 h timesteps.`,
-    flat_thresholds: [
-      { range: '> 1 K/h', label: 'Rising fast', risk: 'high', meaning: 'Warm sector arriving, or daytime heating in the boundary layer.' },
-      { range: '0 to 1 K/h', label: 'Rising', risk: 'low', meaning: 'Slow warming. Cross-check with advection.' },
-      { range: '≈ 0', label: 'Stable', risk: 'none', meaning: 'Current pattern persists.' },
-      { range: '−1 to 0 K/h', label: 'Falling', risk: 'low', meaning: 'Slow cooling.' },
-      { range: '< −1 K/h', label: 'Falling fast', risk: 'high', meaning: 'Post-frontal clearing, evening cooling, or cold pool spreading.' },
+    level_thresholds: [
+      {
+        level: 925, altitude_label: '~2,500 ft',
+        note: 'Diurnal cycle is large here — ±1–2 K/h just from sun/night, with no synoptic change. Treat tendency at 925 hPa as "advection + diurnal"; subtract the time-of-day effect mentally before reading it as an air-mass signal.',
+        rows: [
+          { range: '> 2 K/h', label: 'Rising fast', risk: 'high', meaning: 'Warm sector arrival OR strong daytime heating; cross-check with −V·∇θe to tell which.' },
+          { range: '0 to 2 K/h', label: 'Rising', risk: 'low', meaning: 'Likely diurnal; significant only if persisting overnight or against the sun.' },
+          { range: '≈ 0', label: 'Stable', risk: 'none', meaning: 'Current pattern persists.' },
+          { range: '−2 to 0 K/h', label: 'Falling', risk: 'low', meaning: 'Likely diurnal cooling; overnight or cold-pool drainage.' },
+          { range: '< −2 K/h', label: 'Falling fast', risk: 'high', meaning: 'Post-frontal clearing or strong cold-pool spread (compare with advection).' },
+        ],
+      },
+      {
+        level: 850, altitude_label: '~5,000 ft',
+        note: 'Above the boundary layer — virtually all signal is genuine air-mass change. The "advection vs tendency" comparison is most reliable here.',
+        rows: [
+          { range: '> 1 K/h', label: 'Rising fast', risk: 'high', meaning: 'Warm sector arriving — ceilings likely to drop over the next 1–3 h.' },
+          { range: '0 to 1 K/h', label: 'Rising', risk: 'low', meaning: 'Slow warming. Cross-check with advection.' },
+          { range: '≈ 0', label: 'Stable', risk: 'none', meaning: 'Current pattern persists.' },
+          { range: '−1 to 0 K/h', label: 'Falling', risk: 'low', meaning: 'Slow cooling.' },
+          { range: '< −1 K/h', label: 'Falling fast', risk: 'high', meaning: 'Post-frontal clearing, evening cooling, or cold pool spreading.' },
+        ],
+      },
+      {
+        level: 700, altitude_label: '~10,000 ft',
+        note: 'Free troposphere — small magnitudes are still meaningful. Fast 700 tendency typically leads the surface signal by 6–12 h.',
+        rows: [
+          { range: '> 0.7 K/h', label: 'Rising fast', risk: 'high', meaning: 'Strong upper-level warming; warm-air advection often precedes a surface front.' },
+          { range: '0 to 0.7 K/h', label: 'Rising', risk: 'low', meaning: 'Gradual upper-level warming.' },
+          { range: '≈ 0', label: 'Stable', risk: 'none', meaning: 'Current pattern persists.' },
+          { range: '−0.7 to 0 K/h', label: 'Falling', risk: 'low', meaning: 'Gradual upper-level cooling.' },
+          { range: '< −0.7 K/h', label: 'Falling fast', risk: 'high', meaning: 'Strong upper-level cooling — often after an occluded front.' },
+        ],
+      },
     ],
     pilot_notes: `
       <p>Compare ∂θe/∂t to −V·∇θe at the same point:</p>

--- a/web/ts/data/hewson-metrics-catalog.ts
+++ b/web/ts/data/hewson-metrics-catalog.ts
@@ -59,6 +59,8 @@ export interface HewsonCatalogEntry {
   /** Where this field can mislead. */
   limitations?: string;
   wikipedia?: string;
+  /** "explain how/why ..." continuation pasted into the AI prompt. */
+  llm_prompt?: string;
 }
 
 export const HEWSON_CATALOG: Record<HewsonMetric, HewsonCatalogEntry> = {
@@ -115,6 +117,7 @@ export const HEWSON_CATALOG: Record<HewsonMetric, HewsonCatalogEntry> = {
     `,
     limitations: `θe at one level can't see vertical structure (need multiple levels). It's also free-atmosphere weather — local boundary-layer phenomena (fog at 1,500 ft, low stratus) won't appear in θe at 850.`,
     wikipedia: 'https://en.wikipedia.org/wiki/Equivalent_potential_temperature',
+    llm_prompt: 'explain how θe (equivalent potential temperature) is conserved through dry and moist adiabatic processes, why it works as an air-mass tracer for VFR/IFR planning, and how comparing θe at 925, 850 and 700 hPa over the same point reveals air-mass character and convective potential',
   },
 
   // -------------------------------------------------------------------------
@@ -168,6 +171,7 @@ export const HEWSON_CATALOG: Record<HewsonMetric, HewsonCatalogEntry> = {
     `,
     limitations: `These thresholds are at our 0.25° grid with the smoothing in compute_hewson_diagnostics. Higher-resolution / less-smoothed data can produce stronger raw values for the same physical front.`,
     wikipedia: 'https://en.wikipedia.org/wiki/Weather_front',
+    llm_prompt: 'explain how the magnitude of the θe gradient identifies frontal zones in synoptic analysis, why Hewson 1998 placed the "classical front" threshold at 4–6 K/100 km at 850 hPa, and how grid resolution and smoothing scale affect the raw values pilots see on a forecast map',
   },
 
   // -------------------------------------------------------------------------
@@ -185,6 +189,8 @@ export const HEWSON_CATALOG: Record<HewsonMetric, HewsonCatalogEntry> = {
     ],
     pilot_notes: `<p>High −∇²θe combined with high |∇θe| = sharp <em>and</em> strong front — least friendly for VFR. (Note: "expect SIGMETs in the area" is the right framing — SIGMETs are issued for specific phenomena, not gradient magnitudes.)</p>`,
     limitations: `At 925 the field is noisy from coastline / terrain artefacts — interpret cautiously. At 850 and 700 it's the cleanest "is this front sharp?" signal.`,
+    wikipedia: 'https://en.wikipedia.org/wiki/Frontogenesis',
+    llm_prompt: 'explain how the negative Laplacian of θe distinguishes sharp narrow-band fronts (squall-line type) from broad gradient zones, and how this maps to Hewson\'s frontogenesis framework where second derivatives identify zones of locally maximum gradient',
   },
 
   // -------------------------------------------------------------------------
@@ -193,12 +199,7 @@ export const HEWSON_CATALOG: Record<HewsonMetric, HewsonCatalogEntry> = {
     unit: 'K / (100 km)²',
     vibe: 'Where exactly is the front line drawn?',
     what_it_is: `
-      <p>Hewson's locator for the front <em>line</em>. Defined as the gradient of |∇θe| projected onto the direction of ∇θe. Geometrically:</p>
-      <ul>
-        <li>TFP <strong>maximum</strong>: warm-side boundary of the frontal zone</li>
-        <li>TFP <strong>zero crossing</strong> (going + → − as you move warm→cold): <strong>the front line itself</strong></li>
-        <li>TFP <strong>minimum</strong>: cold-side boundary of the frontal zone</li>
-      </ul>
+      <p>Hewson's locator for the front <em>line</em>. Mathematically: the gradient of |∇θe| projected onto the direction of ∇θe. The function reaches its <strong>maximum</strong> on the warm-side boundary of the frontal zone, <strong>zero-crosses</strong> (positive → negative as you move warm→cold) at the front line itself, and reaches its <strong>minimum</strong> on the cold-side boundary.</p>
       <p>So TFP is a <strong>position indicator</strong>, not a tendency indicator. Whether conditions are deteriorating or improving for you depends on which way the front is moving — that's an advection question. Use −V·∇θe and ∂θe/∂t for tendency; use TFP to see <em>where the front line is</em>.</p>
     `,
     what_map_shows: `Diverging field. The <strong>zero contour</strong> (going + → −) is the analyzed front line; the sign tells you which side of the frontal zone you're on.`,
@@ -209,6 +210,7 @@ export const HEWSON_CATALOG: Record<HewsonMetric, HewsonCatalogEntry> = {
     ],
     pilot_notes: `<p>Combined with wind direction and the −V·∇θe map, TFP tells you whether the front is moving toward you or away. Two pilots in the same TFP-positive area can experience very different weather depending on whether they're flying with or against the front's motion.</p>`,
     limitations: `TFP at <strong>850</strong> is canonical (Hewson's original work). At <strong>925</strong> it is noisier (bumpy boundary-layer θe). At <strong>700</strong> the field is smoother but the front is <em>aloft</em> — surface position can be displaced 50–150 km from the 700 zero-contour because fronts tilt with height (warm fronts slope forward, cold fronts slope backward).`,
+    llm_prompt: 'explain the Thermal Front Parameter (TFP) from Hewson 1998 — its mathematical definition as the directional derivative of |∇θe| along the gradient, what its zero crossing represents, why it is a position indicator rather than a tendency indicator, and how forecasters use the locating equation alongside it',
   },
 
   // -------------------------------------------------------------------------
@@ -256,6 +258,7 @@ export const HEWSON_CATALOG: Record<HewsonMetric, HewsonCatalogEntry> = {
       <p>Useful pattern: warm advection at 700 + 850 with cold advection at 925 = warm front aloft over cold pool → high icing, persistent IFR.</p>
     `,
     wikipedia: 'https://en.wikipedia.org/wiki/Advection',
+    llm_prompt: 'explain how horizontal advection of θe (−V·∇θe) predicts ceilings, visibility and icing trends ahead of warm and cold fronts, why the sign convention works the way it does (positive = warm advection), and how to recognise occluded or stationary boundaries from a high-gradient / low-advection signature',
   },
 
   // -------------------------------------------------------------------------
@@ -285,5 +288,6 @@ export const HEWSON_CATALOG: Record<HewsonMetric, HewsonCatalogEntry> = {
       </ul>
     `,
     limitations: `At <strong>925</strong> the diurnal cycle is large — expect ±1–2 K/h just from sun/night, even without synoptic change. At <strong>850 and 700</strong>, virtually all signal is genuine air-mass change.`,
+    llm_prompt: 'explain how the local tendency ∂θe/∂t differs from the advection term −V·∇θe in the full θe budget equation, how their disagreement reveals diabatic processes (daytime heating, latent heat release in convection, radiative cooling), and what operational situations make this decomposition useful for thunderstorm and overnight-cooling forecasting',
   },
 };

--- a/web/ts/data/hewson-metrics-catalog.ts
+++ b/web/ts/data/hewson-metrics-catalog.ts
@@ -1,0 +1,289 @@
+/** Hewson synoptic-field metrics catalog — pilot-facing explanations, with
+ * per-level thresholds and operational interpretation.
+ *
+ * Source of truth for the (i) info popovers on the Synoptic Forecast tab.
+ * Kept separate from web/ts/data/metrics-catalog.json because each Hewson
+ * metric has level-specific thresholds (925 vs 850 vs 700 hPa) that don't
+ * fit the single-table schema used by the cross-section / Skew-T metrics.
+ *
+ * Numerical thresholds and physical reasoning come from § 2 + § 4 of
+ * designs/future/hewson-fields-aviation-advisories.md, with corrections
+ * from a 2026-04-25 Claude Desktop review:
+ *   - θe value bands recalibrated (UK summer day at 850 ≈ 305-315 K, NOT
+ *     tropical); tropical threshold raised to ~335 K at 850
+ *   - |∇θe| thresholds aligned with Hewson 1998 — classical front at
+ *     850 hPa is 4-6 K/100 km, not 8+
+ *   - TFP rewritten as a position indicator (zero crossing = front line),
+ *     not a tendency indicator — earlier text conflated spatial position
+ *     with temporal evolution
+ *   - Icing claim qualified to the 0 to -15 °C overrunning layer
+ *   - Occlusion / stationary boundary pattern called out
+ *   - ∂θe/∂t reframed around the ∂θe/∂t vs −V·∇θe decomposition (the
+ *     diagnostic value is in the disagreement)
+ */
+
+import type { HewsonMetric } from '../visualization/hewson-colormaps';
+
+export interface HewsonLevelThresholds {
+  /** Pressure level in hPa. */
+  level: number;
+  /** Pilot-facing altitude label (e.g. "5,000 ft"). */
+  altitude_label: string;
+  /** Optional contextual note for this level. */
+  note?: string;
+  /** Threshold rows specific to this level. */
+  rows: Array<{
+    range: string;        // e.g. "< 2", "2–4", "> 8"
+    label: string;        // e.g. "Benign", "Classical front"
+    risk: 'none' | 'low' | 'moderate' | 'high' | 'severe';
+    meaning: string;
+  }>;
+}
+
+export interface HewsonCatalogEntry {
+  name: string;
+  unit: string;
+  vibe: string;                // Italic subtitle — short, evocative
+  what_it_is: string;          // Definition (HTML allowed for <em>, <code>, <br>)
+  what_map_shows: string;      // What the user is looking at on screen
+  /** Optional set of per-level threshold tables. */
+  level_thresholds?: HewsonLevelThresholds[];
+  /** Optional flat threshold table (when not level-dependent). */
+  flat_thresholds?: Array<{
+    range: string; label: string; risk: 'none' | 'low' | 'moderate' | 'high' | 'severe'; meaning: string;
+  }>;
+  /** Multi-level usage paragraph (HTML — list / paragraphs allowed). */
+  multi_level_usage?: string;
+  /** Operational notes — pilot rules, sign conventions, caveats. */
+  pilot_notes?: string;
+  /** Where this field can mislead. */
+  limitations?: string;
+  wikipedia?: string;
+}
+
+export const HEWSON_CATALOG: Record<HewsonMetric, HewsonCatalogEntry> = {
+  // -------------------------------------------------------------------------
+  theta_e: {
+    name: 'θe — equivalent potential temperature',
+    unit: 'K',
+    vibe: "An air mass's thermodynamic fingerprint",
+    what_it_is: `
+      <p>The temperature an air parcel would have if you took it through this thought experiment:</p>
+      <ol>
+        <li>Lift it dry-adiabatically (~1 °C / 100 m of cooling) until it hits 100 % humidity — the LCL (lifting condensation level).</li>
+        <li>Keep lifting it <em>moist</em>-adiabatically — much slower cooling, since condensation releases latent heat — until <strong>all</strong> its water vapour has condensed out and fallen as precipitation.</li>
+        <li>Then lower it dry-adiabatically (it's bone-dry now) back to a reference pressure of 1000 hPa.</li>
+      </ol>
+      <p>The number combines <strong>temperature, moisture, and pressure</strong> into one quantity that is conserved under both dry and moist adiabatic processes. Two parcels with the same θe are the <em>same air mass</em> thermodynamically, even if one is currently warm-and-dry and the other cold-and-saturated. That's why θe is the right variable for tracking "tropical vs polar", "maritime vs continental".</p>
+    `,
+    what_map_shows: `A horizontal slice of θe at the chosen level. Smooth where one air mass dominates; gradients (color "ribbons") reveal frontal zones, dry intrusions, and moisture tongues — even ones the surface chart never draws.`,
+    level_thresholds: [
+      {
+        level: 925, altitude_label: '~2,500 ft',
+        rows: [
+          { range: '< 290', label: 'Polar / arctic', risk: 'low', meaning: 'Cold continental or arctic origin. Showers + in-cloud icing in winter.' },
+          { range: '295–330', label: 'Mid-latitude', risk: 'none', meaning: 'Ordinary European boundary-layer air across the year.' },
+          { range: '> 335', label: 'Tropical / subtropical', risk: 'high', meaning: 'Warm humid airmass — convection-prone.' },
+        ],
+      },
+      {
+        level: 850, altitude_label: '~5,000 ft',
+        note: 'The classical synoptic level. A normal UK summer afternoon sits around 305–315 K — not tropical. Tropical / convection-prone air starts around 335 K here.',
+        rows: [
+          { range: '< 285', label: 'Polar', risk: 'low', meaning: 'Cold polar / arctic. Showers, in-cloud icing.' },
+          { range: '290–325', label: 'Mid-latitude', risk: 'none', meaning: 'Ordinary mid-latitude air. UK summer ≈ 305–315 K.' },
+          { range: '> 335', label: 'Tropical / subtropical', risk: 'high', meaning: 'Operationally convection-prone — Mediterranean / Saharan / tropical maritime origin.' },
+        ],
+      },
+      {
+        level: 700, altitude_label: '~10,000 ft',
+        rows: [
+          { range: '< 275', label: 'Polar', risk: 'low', meaning: 'Cold mid-tropospheric air aloft.' },
+          { range: '280–310', label: 'Mid-latitude', risk: 'none', meaning: 'Free-troposphere European air.' },
+          { range: '> 320', label: 'Tropical / subtropical', risk: 'high', meaning: 'Tropical mid-troposphere — leads warm advection at lower levels by 6–24 h.' },
+        ],
+      },
+    ],
+    multi_level_usage: `
+      <ul>
+        <li><strong>925</strong> for boundary-layer weather (fog, sea-breeze fronts, low ceilings, cold pools)</li>
+        <li><strong>850</strong> to track the actual frontal system bringing the weather</li>
+        <li><strong>700</strong> to anticipate what's coming next — upper-level patterns lead the surface by 6–24 h</li>
+      </ul>
+      <p>A 15–20 K change between waypoints at any level = you're crossing between air masses, drawn front or not.</p>
+      <p><strong>Note on convective instability.</strong> When θe decreases with height (∂θe/∂z &lt; 0), the column is "convectively unstable" — lifting it produces buoyancy. This map doesn't show vertical structure; you'd need multi-level θe at the same point. Compare 925 vs 850 vs 700 mentally on the same column to spot it.</p>
+    `,
+    limitations: `θe at one level can't see vertical structure (need multiple levels). It's also free-atmosphere weather — local boundary-layer phenomena (fog at 1,500 ft, low stratus) won't appear in θe at 850.`,
+    wikipedia: 'https://en.wikipedia.org/wiki/Equivalent_potential_temperature',
+  },
+
+  // -------------------------------------------------------------------------
+  gradient: {
+    name: '|∇θe| — boundary intensity',
+    unit: 'K / 100 km',
+    vibe: 'How fast the air mass changes as you fly across',
+    what_it_is: `<p>The magnitude of the spatial rate-of-change of θe — the textbook scalar for <strong>frontal zone intensity</strong>. A strong gradient is the operational definition of a front.</p>`,
+    what_map_shows: `Always positive (it's a magnitude). Large values trace the elongated zones where two different air masses meet — drawn fronts, dry-line edges, sea-breeze boundaries, pre-frontal moisture tongues.`,
+    level_thresholds: [
+      {
+        level: 925, altitude_label: '~2,500 ft',
+        note: 'Surface effects (coastlines, terrain edges) generate strong but shallow gradients that aren\'t true fronts — Med vs Atlantic in summer often hits 6–8 K/100 km without a real front.',
+        rows: [
+          { range: '< 2', label: 'Negligible', risk: 'none', meaning: 'Uniform boundary-layer air.' },
+          { range: '2–4', label: 'Weak gradient', risk: 'low', meaning: 'Minor wind shift, scattered low cloud.' },
+          { range: '6–8', label: 'Classical front', risk: 'moderate', meaning: 'Cloud band, possible precipitation. Could also be coast/terrain.' },
+          { range: '> 8', label: 'Strong front', risk: 'high', meaning: 'Well-defined surface signature.' },
+          { range: '> 12', label: 'Very sharp', risk: 'severe', meaning: 'Sharp surface boundary. Expect SIGMETs in the area.' },
+        ],
+      },
+      {
+        level: 850, altitude_label: '~5,000 ft',
+        note: 'The Hewson reference level. Literature thresholds for "classical front" with typical analysis-grade smoothing are 4–6 K/100 km; that lines up with this table.',
+        rows: [
+          { range: '< 1', label: 'Negligible', risk: 'none', meaning: 'Uniform air mass.' },
+          { range: '1–3', label: 'Weak gradient', risk: 'low', meaning: 'Minor cloud band.' },
+          { range: '4–6', label: 'Classical front', risk: 'moderate', meaning: 'Stratus / nimbostratus, precipitation, wind shift, low-level turbulence.' },
+          { range: '> 6', label: 'Strong / sharp', risk: 'high', meaning: 'Well-organized front, shear with altitude.' },
+          { range: '> 9', label: 'Very sharp', risk: 'severe', meaning: 'Pronounced front. Expect SIGMETs in the area.' },
+        ],
+      },
+      {
+        level: 700, altitude_label: '~10,000 ft',
+        note: 'Mixing is more efficient up here — true frontal gradients are weaker than at 850.',
+        rows: [
+          { range: '< 1', label: 'Negligible', risk: 'none', meaning: 'Smooth mid-troposphere.' },
+          { range: '1–2', label: 'Weak gradient', risk: 'low', meaning: 'Minor baroclinic zone.' },
+          { range: '3–5', label: 'Classical front', risk: 'moderate', meaning: 'Lifted front or jet-entrance zone.' },
+          { range: '> 5', label: 'Strong baroclinic', risk: 'high', meaning: 'Strong upper-level forcing, often leads the surface.' },
+          { range: '> 7', label: 'Very sharp', risk: 'severe', meaning: 'Intense baroclinic zone aloft.' },
+        ],
+      },
+    ],
+    multi_level_usage: `
+      <ul>
+        <li>Signal at <strong>all three</strong> levels = deep, well-organized front. Classical frontal weather: cloud, precip, shear.</li>
+        <li>Signal <strong>only at 925</strong> = shallow / coastal effect — local weather impact only.</li>
+        <li>Signal at <strong>700 ahead of 850/925</strong> = upper-level / lifted front, leads the surface; scattered showers possible but not a full frontal passage.</li>
+      </ul>
+    `,
+    limitations: `These thresholds are at our 0.25° grid with the smoothing in compute_hewson_diagnostics. Higher-resolution / less-smoothed data can produce stronger raw values for the same physical front.`,
+    wikipedia: 'https://en.wikipedia.org/wiki/Weather_front',
+  },
+
+  // -------------------------------------------------------------------------
+  neg_laplacian: {
+    name: '−∇²θe — sharpness',
+    unit: 'K / (100 km)²',
+    vibe: 'Squall line vs gentle ramp',
+    what_it_is: `<p>The negative Laplacian of θe — its second spatial derivative. Tells you whether the gradient is <strong>concentrated</strong> (positive — narrow front) or <strong>spread out</strong> (≈ 0, or negative — broad ramp). Positive values mark where the gradient peaks locally.</p>`,
+    what_map_shows: `Diverging signal. Positive (red) = narrow-band fronts. Near-zero = smooth ramps. Negative (blue) = inside a broad transition.`,
+    flat_thresholds: [
+      { range: '> 2', label: 'Sharp', risk: 'high', meaning: 'Narrow-band precipitation, quick wind shift over a few nm.' },
+      { range: '0–2', label: 'Mild peak', risk: 'low', meaning: 'Discernible front edge, transition not abrupt.' },
+      { range: '≈ 0', label: 'Smooth', risk: 'none', meaning: 'If there\'s weather, spread over 100+ km.' },
+      { range: '< 0', label: 'Plateau', risk: 'none', meaning: 'You are inside a broad transition, not at its edge.' },
+    ],
+    pilot_notes: `<p>High −∇²θe combined with high |∇θe| = sharp <em>and</em> strong front — least friendly for VFR. (Note: "expect SIGMETs in the area" is the right framing — SIGMETs are issued for specific phenomena, not gradient magnitudes.)</p>`,
+    limitations: `At 925 the field is noisy from coastline / terrain artefacts — interpret cautiously. At 850 and 700 it's the cleanest "is this front sharp?" signal.`,
+  },
+
+  // -------------------------------------------------------------------------
+  tfp: {
+    name: 'TFP — thermal front parameter',
+    unit: 'K / (100 km)²',
+    vibe: 'Where exactly is the front line drawn?',
+    what_it_is: `
+      <p>Hewson's locator for the front <em>line</em>. Defined as the gradient of |∇θe| projected onto the direction of ∇θe. Geometrically:</p>
+      <ul>
+        <li>TFP <strong>maximum</strong>: warm-side boundary of the frontal zone</li>
+        <li>TFP <strong>zero crossing</strong> (going + → − as you move warm→cold): <strong>the front line itself</strong></li>
+        <li>TFP <strong>minimum</strong>: cold-side boundary of the frontal zone</li>
+      </ul>
+      <p>So TFP is a <strong>position indicator</strong>, not a tendency indicator. Whether conditions are deteriorating or improving for you depends on which way the front is moving — that's an advection question. Use −V·∇θe and ∂θe/∂t for tendency; use TFP to see <em>where the front line is</em>.</p>
+    `,
+    what_map_shows: `Diverging field. The <strong>zero contour</strong> (going + → −) is the analyzed front line; the sign tells you which side of the frontal zone you're on.`,
+    flat_thresholds: [
+      { range: 'TFP > 0', label: 'Warm-air side', risk: 'low', meaning: 'You are between the front line and the warm-side boundary of the frontal zone.' },
+      { range: 'TFP ≈ 0', label: 'Front line', risk: 'high', meaning: 'You are crossing the front itself — peak gradient in the zone.' },
+      { range: 'TFP < 0', label: 'Cold-air side', risk: 'low', meaning: 'You are between the front line and the cold-side boundary.' },
+    ],
+    pilot_notes: `<p>Combined with wind direction and the −V·∇θe map, TFP tells you whether the front is moving toward you or away. Two pilots in the same TFP-positive area can experience very different weather depending on whether they're flying with or against the front's motion.</p>`,
+    limitations: `TFP at <strong>850</strong> is canonical (Hewson's original work). At <strong>925</strong> it is noisier (bumpy boundary-layer θe). At <strong>700</strong> the field is smoother but the front is <em>aloft</em> — surface position can be displaced 50–150 km from the 700 zero-contour because fronts tilt with height (warm fronts slope forward, cold fronts slope backward).`,
+  },
+
+  // -------------------------------------------------------------------------
+  advection: {
+    name: '−V·∇θe — warm/cold advection',
+    unit: 'K / h',
+    vibe: 'What kind of air is on its way',
+    what_it_is: `
+      <p>The rate of change of θe at a fixed point caused by horizontal wind alone. <strong>Sign convention:</strong> −V·∇θe &gt; 0 means wind is blowing from high-θe air toward low-θe air → warm air is being brought in (warm advection). The "−" in the formula gives this intuitive sign.</p>
+      <p>This is the most flight-relevant Hewson field — sign and magnitude both matter.</p>
+    `,
+    what_map_shows: `Diverging field; <strong>red = warm advection, blue = cold advection</strong>. Hot spots are leading edges of advancing air masses.`,
+    flat_thresholds: [
+      { range: '> 2 K/h', label: 'Rapid warm', risk: 'severe', meaning: 'Frontal passage within 1–2 h. Warm sector arriving fast.' },
+      { range: '1 to 2 K/h', label: 'Warm advection', risk: 'high', meaning: 'Significant tendency — change over 3–6 h. Ceilings dropping, icing rising.' },
+      { range: '−1 to 1 K/h', label: 'Negligible', risk: 'low', meaning: 'Quasi-stationary regime. Watch for occlusions if |∇θe| is high.' },
+      { range: '−2 to −1 K/h', label: 'Cold advection', risk: 'moderate', meaning: 'Polar air arriving — improving visibility, gusty unstable showers.' },
+      { range: '< −2 K/h', label: 'Rapid cold', risk: 'high', meaning: 'Cold front passage within 1–2 h. Wind shift, possible squalls.' },
+    ],
+    pilot_notes: `
+      <p><strong>Warm advection (red, &gt; 0):</strong></p>
+      <ul>
+        <li>Moist warm air overrunning colder air → stratiform cloud, persistent rain</li>
+        <li>Ceilings <em>lower over time</em>; visibility reduces</li>
+        <li><strong>Icing risk rises in the 0 to −15 °C layer</strong> where warm moist air overruns sub-freezing air — typically 3,000–10,000 ft for a classical warm front. Above the warm sector (FL180+) you may be in cirrus with no significant icing.</li>
+        <li>Wind typically backs (rotates CCW) with height</li>
+        <li><em>Rule:</em> "depart before the warm front arrives"</li>
+      </ul>
+      <p><strong>Cold advection (blue, &lt; 0):</strong></p>
+      <ul>
+        <li>Polar / drier air replacing warmer air → improving visibility, unstable showery weather</li>
+        <li><strong>Icing risk drops</strong> as moisture clears</li>
+        <li>Gusty winds, mechanical turbulence</li>
+        <li>Wind typically veers (rotates CW) with height</li>
+        <li><em>Rule:</em> "wait for the cold front to clear, then VMC"</li>
+      </ul>
+      <p><strong>Pattern to watch for: occluded / stationary boundaries.</strong> If |∇θe| is high but −V·∇θe is <strong>near zero</strong>, the front isn't moving — suspect an <strong>occlusion</strong> or stationary boundary (common over the UK and Alps). Conditions don't follow either warm-front or cold-front rules cleanly.</p>
+    `,
+    multi_level_usage: `
+      <ul>
+        <li><strong>925</strong> advection: what's hitting the surface <em>now</em> — ceilings, visibility, low-level winds.</li>
+        <li><strong>850</strong> advection: classical "front pattern" — best 6–12 h indicator.</li>
+        <li><strong>700</strong> advection: leads the surface by 6–24 h. Strong 700 without 850 yet = "incoming, decide now."</li>
+      </ul>
+      <p>Useful pattern: warm advection at 700 + 850 with cold advection at 925 = warm front aloft over cold pool → high icing, persistent IFR.</p>
+    `,
+    wikipedia: 'https://en.wikipedia.org/wiki/Advection',
+  },
+
+  // -------------------------------------------------------------------------
+  tendency: {
+    name: '∂θe/∂t — local tendency',
+    unit: 'K / h',
+    vibe: 'What is actually happening here, vs what advection predicts',
+    what_it_is: `
+      <p>The <strong>observed</strong> rate of change of θe at a fixed point. The full decomposition is:</p>
+      <p style="font-family:monospace;text-align:center">∂θe/∂t = −V·∇θe + (diabatic + vertical terms)</p>
+      <p>The first term is what advection alone predicts. The rest captures <strong>diurnal heating/cooling, latent heat release in convection, and radiative cooling</strong>. The interesting case is when ∂θe/∂t and −V·∇θe <em>disagree</em> — that tells you the air mass itself is being modified, not just being moved.</p>
+    `,
+    what_map_shows: `Diverging — where θe is rising or falling. Computed by central differences across the snapshot's 3 h timesteps.`,
+    flat_thresholds: [
+      { range: '> 1 K/h', label: 'Rising fast', risk: 'high', meaning: 'Warm sector arriving, or daytime heating in the boundary layer.' },
+      { range: '0 to 1 K/h', label: 'Rising', risk: 'low', meaning: 'Slow warming. Cross-check with advection.' },
+      { range: '≈ 0', label: 'Stable', risk: 'none', meaning: 'Current pattern persists.' },
+      { range: '−1 to 0 K/h', label: 'Falling', risk: 'low', meaning: 'Slow cooling.' },
+      { range: '< −1 K/h', label: 'Falling fast', risk: 'high', meaning: 'Post-frontal clearing, evening cooling, or cold pool spreading.' },
+    ],
+    pilot_notes: `
+      <p>Compare ∂θe/∂t to −V·∇θe at the same point:</p>
+      <ul>
+        <li><strong>Tendency &gt; advection</strong>: diabatic warming on top of advection. Daytime CAPE building under a warm-advection regime → thunderstorm risk <em>amplified</em> beyond what advection alone suggests.</li>
+        <li><strong>Tendency &lt; advection</strong>: cooling beyond what advection brings — radiative cooling at night, evaporation from precip, cold pools spreading.</li>
+        <li><strong>Tendency ≈ advection</strong>: pure advective regime. The air is being moved, not modified.</li>
+      </ul>
+    `,
+    limitations: `At <strong>925</strong> the diurnal cycle is large — expect ±1–2 K/h just from sun/night, even without synoptic change. At <strong>850 and 700</strong>, virtually all signal is genuine air-mass change.`,
+  },
+};

--- a/web/ts/data/hewson-metrics-catalog.ts
+++ b/web/ts/data/hewson-metrics-catalog.ts
@@ -140,6 +140,7 @@ export const HEWSON_CATALOG: Record<HewsonMetric, HewsonCatalogEntry> = {
         rows: [
           { range: '< 2', label: 'Negligible', risk: 'none', meaning: 'Uniform boundary-layer air.' },
           { range: '2–4', label: 'Weak gradient', risk: 'low', meaning: 'Minor wind shift, scattered low cloud.' },
+          { range: '4–6', label: 'Moderate gradient', risk: 'low', meaning: 'Discernible boundary, but at this level often a coastal/terrain effect rather than a true front.' },
           { range: '6–8', label: 'Classical front', risk: 'moderate', meaning: 'Cloud band, possible precipitation. Could also be coast/terrain.' },
           { range: '> 8', label: 'Strong front', risk: 'high', meaning: 'Well-defined surface signature.' },
           { range: '> 12', label: 'Very sharp', risk: 'severe', meaning: 'Sharp surface boundary. Expect SIGMETs in the area.' },

--- a/web/ts/data/hewson-metrics-catalog.ts
+++ b/web/ts/data/hewson-metrics-catalog.ts
@@ -84,7 +84,9 @@ export const HEWSON_CATALOG: Record<HewsonMetric, HewsonCatalogEntry> = {
         level: 925, altitude_label: '~2,500 ft',
         rows: [
           { range: '< 290', label: 'Polar / arctic', risk: 'low', meaning: 'Cold continental or arctic origin. Showers + in-cloud icing in winter.' },
+          { range: '290–295', label: 'Cold transition', risk: 'low', meaning: 'Winter cold pool or post-frontal cold air. Stable, often clear and chilly.' },
           { range: '295–330', label: 'Mid-latitude', risk: 'none', meaning: 'Ordinary European boundary-layer air across the year.' },
+          { range: '330–335', label: 'Warm transition', risk: 'moderate', meaning: 'Pre-tropical surface air; building CAPE if a trigger is around.' },
           { range: '> 335', label: 'Tropical / subtropical', risk: 'high', meaning: 'Warm humid airmass — convection-prone.' },
         ],
       },
@@ -93,7 +95,9 @@ export const HEWSON_CATALOG: Record<HewsonMetric, HewsonCatalogEntry> = {
         note: 'The classical synoptic level. A normal UK summer afternoon sits around 305–315 K — not tropical. Tropical / convection-prone air starts around 335 K here.',
         rows: [
           { range: '< 285', label: 'Polar', risk: 'low', meaning: 'Cold polar / arctic. Showers, in-cloud icing.' },
+          { range: '285–290', label: 'Cold transition', risk: 'low', meaning: 'Cold-shoulder mid-latitude air — winter cold pool or post-frontal regime.' },
           { range: '290–325', label: 'Mid-latitude', risk: 'none', meaning: 'Ordinary mid-latitude air. UK summer ≈ 305–315 K.' },
+          { range: '325–335', label: 'Warm transition', risk: 'moderate', meaning: 'Pre-convective regime — CAPE building, but not yet tropical. Watch for thunderstorm triggers.' },
           { range: '> 335', label: 'Tropical / subtropical', risk: 'high', meaning: 'Operationally convection-prone — Mediterranean / Saharan / tropical maritime origin.' },
         ],
       },
@@ -101,7 +105,9 @@ export const HEWSON_CATALOG: Record<HewsonMetric, HewsonCatalogEntry> = {
         level: 700, altitude_label: '~10,000 ft',
         rows: [
           { range: '< 275', label: 'Polar', risk: 'low', meaning: 'Cold mid-tropospheric air aloft.' },
+          { range: '275–280', label: 'Cold transition', risk: 'low', meaning: 'Cool free troposphere — stable, often post-frontal.' },
           { range: '280–310', label: 'Mid-latitude', risk: 'none', meaning: 'Free-troposphere European air.' },
+          { range: '310–320', label: 'Warm transition', risk: 'moderate', meaning: 'Pre-tropical mid-troposphere — often the leading signal of warm advection 6–24 h ahead of the surface.' },
           { range: '> 320', label: 'Tropical / subtropical', risk: 'high', meaning: 'Tropical mid-troposphere — leads warm advection at lower levels by 6–24 h.' },
         ],
       },

--- a/web/ts/helpers/hewson-info.ts
+++ b/web/ts/helpers/hewson-info.ts
@@ -88,6 +88,22 @@ export function renderHewsonInfo(metric: HewsonMetric): string {
       ${entry.wikipedia ? `<div class="popup-section popup-learn-more">
         <a href="${entry.wikipedia}" target="_blank" rel="noopener noreferrer">Learn more on Wikipedia ↗</a>
       </div>` : ''}
+      <div class="popup-section popup-discuss-ai" data-metric-name="${escapeAttr(entry.name)}"${entry.llm_prompt ? ` data-llm-prompt="${escapeAttr(entry.llm_prompt)}"` : ''}>
+        <div class="popup-discuss-header">
+          <span class="popup-discuss-label">Discuss with AI</span>
+          <span class="popup-discuss-hint">A prompt is copied to clipboard — just paste it in the new chat</span>
+        </div>
+        <div class="popup-discuss-buttons">
+          <a href="https://claude.ai/new" target="_blank" rel="noopener noreferrer" class="popup-ai-btn popup-ai-claude" data-ai="claude">Claude</a>
+          <a href="https://chatgpt.com/" target="_blank" rel="noopener noreferrer" class="popup-ai-btn popup-ai-chatgpt" data-ai="chatgpt">ChatGPT</a>
+          <a href="https://gemini.google.com/app" target="_blank" rel="noopener noreferrer" class="popup-ai-btn popup-ai-gemini" data-ai="gemini">Gemini</a>
+        </div>
+        <div class="popup-discuss-toast" hidden>Prompt copied! Paste it into the chat.</div>
+      </div>
     </div>
   `;
+}
+
+function escapeAttr(s: string): string {
+  return s.replace(/"/g, '&quot;').replace(/&(?!quot;)/g, '&amp;');
 }

--- a/web/ts/helpers/hewson-info.ts
+++ b/web/ts/helpers/hewson-info.ts
@@ -86,7 +86,7 @@ export function renderHewsonInfo(metric: HewsonMetric): string {
         <p>${entry.limitations}</p>
       </div>` : ''}
       ${entry.wikipedia ? `<div class="popup-section popup-learn-more">
-        <a href="${entry.wikipedia}" target="_blank" rel="noopener noreferrer">Learn more on Wikipedia ↗</a>
+        <a href="${escapeAttr(entry.wikipedia)}" target="_blank" rel="noopener noreferrer">Learn more on Wikipedia ↗</a>
       </div>` : ''}
       <div class="popup-section popup-discuss-ai" data-metric-name="${escapeAttr(entry.name)}"${entry.llm_prompt ? ` data-llm-prompt="${escapeAttr(entry.llm_prompt)}"` : ''}>
         <div class="popup-discuss-header">

--- a/web/ts/helpers/hewson-info.ts
+++ b/web/ts/helpers/hewson-info.ts
@@ -105,5 +105,6 @@ export function renderHewsonInfo(metric: HewsonMetric): string {
 }
 
 function escapeAttr(s: string): string {
-  return s.replace(/"/g, '&quot;').replace(/&(?!quot;)/g, '&amp;');
+  // Standard order: & first (so &amp; doesn't double-escape), then quotes.
+  return s.replace(/&/g, '&amp;').replace(/"/g, '&quot;');
 }

--- a/web/ts/helpers/hewson-info.ts
+++ b/web/ts/helpers/hewson-info.ts
@@ -1,0 +1,93 @@
+/** Render a Hewson metric's info popup using the same HTML structure /
+ * CSS classes as the briefing-page metric popup (popup-section, popup-vibe,
+ * popup-threshold-table) so it inherits the existing modal styling.
+ *
+ * Consumed by maps-main.ts via showPopupContent(html) from
+ * components/info-popup.ts.
+ */
+
+import {
+  HEWSON_CATALOG,
+  type HewsonCatalogEntry,
+  type HewsonLevelThresholds,
+} from '../data/hewson-metrics-catalog';
+import type { HewsonMetric } from '../visualization/hewson-colormaps';
+
+type Risk = 'none' | 'low' | 'moderate' | 'high' | 'severe';
+
+function riskClass(risk: Risk): string {
+  // Match the existing CSS classes used by metrics-helper.ts
+  switch (risk) {
+    case 'none': return 'risk-none';
+    case 'low': return 'risk-low';
+    case 'moderate': return 'risk-moderate';
+    case 'high': return 'risk-high';
+    case 'severe': return 'risk-severe';
+  }
+}
+
+function renderThresholdTable(rows: HewsonLevelThresholds['rows']): string {
+  return `<table class="popup-threshold-table">
+    <tbody>
+      ${rows.map((r) => `<tr class="${riskClass(r.risk)}">
+        <td class="popup-thr-range">${r.range}</td>
+        <td class="popup-thr-label">${r.label}</td>
+        <td>${r.meaning}</td>
+      </tr>`).join('')}
+    </tbody>
+  </table>`;
+}
+
+function renderLevelThresholds(levels: HewsonLevelThresholds[]): string {
+  return levels.map((lvl) => `
+    <div class="popup-section">
+      <h4>${lvl.level} hPa <span class="popup-unit">(${lvl.altitude_label})</span></h4>
+      ${lvl.note ? `<p style="margin-bottom:0.4rem">${lvl.note}</p>` : ''}
+      ${renderThresholdTable(lvl.rows)}
+    </div>
+  `).join('');
+}
+
+export function renderHewsonInfo(metric: HewsonMetric): string {
+  const entry: HewsonCatalogEntry | undefined = HEWSON_CATALOG[metric];
+  if (!entry) return `<p>No information available for this metric.</p>`;
+
+  const thresholdsHtml = entry.level_thresholds
+    ? `<div class="popup-section"><h4>Thresholds by level</h4></div>${renderLevelThresholds(entry.level_thresholds)}`
+    : entry.flat_thresholds
+      ? `<div class="popup-section"><h4>Thresholds</h4>${renderThresholdTable(entry.flat_thresholds)}</div>`
+      : '';
+
+  return `
+    <div class="popup-header">
+      <h3>${entry.name}${entry.unit ? ` <span class="popup-unit">(${entry.unit})</span>` : ''}</h3>
+      <p class="popup-vibe">${entry.vibe}</p>
+    </div>
+    <div class="popup-body">
+      <div class="popup-section">
+        <h4>What it is</h4>
+        ${entry.what_it_is}
+      </div>
+      <div class="popup-section">
+        <h4>What the map shows</h4>
+        <p>${entry.what_map_shows}</p>
+      </div>
+      ${thresholdsHtml}
+      ${entry.multi_level_usage ? `<div class="popup-section">
+        <h4>Multi-level usage</h4>
+        ${entry.multi_level_usage}
+      </div>` : ''}
+      ${entry.pilot_notes ? `<div class="popup-section">
+        <h4>Pilot notes</h4>
+        ${entry.pilot_notes}
+      </div>` : ''}
+      ${entry.limitations ? `<div class="popup-section popup-limitations">
+        <h4>Limitations</h4>
+        <p>${entry.limitations}</p>
+      </div>` : ''}
+      ${entry.wikipedia ? `<div class="popup-section popup-learn-more">
+        <a href="${entry.wikipedia}" target="_blank" rel="noopener noreferrer">Learn more on Wikipedia ↗</a>
+      </div>` : ''}
+    </div>
+  `;
+}

--- a/web/ts/maps-main.ts
+++ b/web/ts/maps-main.ts
@@ -351,6 +351,17 @@ async function loadSynoptic(): Promise<void> {
   //     all six values without round-tripping per mousemove. We don't await —
   //     the canvas is already rendered above; this just enables hover when
   //     it lands. Errors are non-fatal; map remains interactive without hover.
+  fetchAllMetricsInBackground(myToken);
+}
+
+/** Fire an /all-metrics fetch in the background and wire its response to
+ * synActiveGrid + the hover layer. On success drops the "loading hover…"
+ * suffix from the info bar. Stale responses (token mismatch) are silently
+ * discarded; failures leave the map interactive without hover. Used by
+ * both loadSynoptic() and changeActiveMetric() (which discards the
+ * original load's all-metrics by bumping the token). */
+function fetchAllMetricsInBackground(myToken: number): void {
+  if (!synInit) return;
   fetchHewsonAllMetrics({
     model: synModel,
     init: synInit,
@@ -360,6 +371,7 @@ async function loadSynoptic(): Promise<void> {
     if (myToken !== synLoadToken) return;  // stale response — discard
     synActiveGrid = grid;
     synopticMap?.setHoverGrid(grid);
+    const info = $('map-info-synoptic');
     if (info) {
       const validDt = new Date(grid.valid_time);
       const validLabel = validDt.toUTCString().slice(0, 22);
@@ -422,21 +434,10 @@ async function changeActiveMetric(): Promise<void> {
   }
 
   // We discarded the in-flight all-metrics from the previous loadSynoptic()
-  // by bumping the token; refetch so hover recovers without making the
-  // user wiggle a control.
-  fetchHewsonAllMetrics({
-    model: synModel,
-    init: synInit,
-    level: synLevel,
-    hour: synHour,
-  }).then((grid) => {
-    if (myToken !== synLoadToken) return;
-    synActiveGrid = grid;
-    synopticMap?.setHoverGrid(grid);
-  }).catch((err) => {
-    if (myToken !== synLoadToken) return;
-    console.warn('Hewson all-metrics background fetch failed:', err);
-  });
+  // by bumping the token; refetch so hover recovers (and the info-bar's
+  // "loading hover…" suffix is cleared) without making the user wiggle a
+  // control.
+  fetchAllMetricsInBackground(myToken);
 }
 
 function showSynopticInfo(): void {

--- a/web/ts/maps-main.ts
+++ b/web/ts/maps-main.ts
@@ -206,7 +206,7 @@ function wireVerificationControls(): void {
 
 // --- Synoptic tab ---
 
-function currentSynapshot(): HewsonManifestSnapshot | null {
+function currentSnapshot(): HewsonManifestSnapshot | null {
   if (!synManifest || !synInit) return null;
   const list = synManifest.models[synModel] ?? [];
   return list.find((s) => s.init_time === synInit) ?? null;
@@ -259,7 +259,7 @@ function repopulateInitPicker(): void {
 function reconfigureLevelPicker(): void {
   const group = $('syn-level-picker');
   if (!group) return;
-  const snap = currentSynapshot();
+  const snap = currentSnapshot();
   const available = new Set(snap?.levels ?? [925, 850, 700]);
   let activeStillValid = false;
   for (const btn of group.querySelectorAll<HTMLButtonElement>('button')) {
@@ -283,7 +283,7 @@ function reconfigureHourSlider(): void {
   const slider = $('syn-hour-slider') as HTMLInputElement | null;
   const valEl = $('syn-hour-value');
   if (!slider) return;
-  const snap = currentSynapshot();
+  const snap = currentSnapshot();
   if (!snap) {
     slider.min = '0'; slider.max = '0'; slider.step = '3'; slider.value = '0';
     if (valEl) valEl.textContent = '+0 h';

--- a/web/ts/maps-main.ts
+++ b/web/ts/maps-main.ts
@@ -5,14 +5,33 @@ import {
   fetchForecastMap, fetchVerificationMap, fetchAvailableHours,
   type ForecastMapResponse, type VerificationMapResponse,
 } from './adapters/maps-adapter';
+import {
+  fetchHewsonManifest, fetchHewsonSlice,
+  type HewsonManifest, type HewsonManifestSnapshot,
+} from './adapters/hewson-map-adapter';
 import { WeatherMap, type ForecastMetric, type VerifMetric } from './visualization/weather-map';
+import { SynopticMap } from './visualization/synoptic-map';
+import { type HewsonMetric } from './visualization/hewson-colormaps';
+import { initInfoPopup, showPopupContent } from './components/info-popup';
+import { renderHewsonInfo } from './helpers/hewson-info';
 import { redirectToLogin, renderUserInfo, $ } from './utils';
 import { initI18n } from './i18n/i18n';
 
 let forecastMap: WeatherMap | null = null;
 let verifMap: WeatherMap | null = null;
-let currentTab: 'forecast' | 'verification' | 'stats' = 'forecast';
+let synopticMap: SynopticMap | null = null;
+type Tab = 'forecast' | 'verification' | 'synoptic' | 'stats';
+let currentTab: Tab = 'forecast';
 let statsLoaded = false;
+
+// Synoptic state
+let synManifest: HewsonManifest | null = null;
+let synModel = 'ecmwf';
+let synInit: string | null = null;       // ISO 8601 with Z, picked from manifest
+let synLevel = 850;
+let synMetric: HewsonMetric = 'gradient';
+let synHour = 0;
+let synOpacity = 0.5;
 
 // Forecast state
 let forecastData: ForecastMapResponse | null = null;
@@ -170,9 +189,185 @@ function wireVerificationControls(): void {
   });
 }
 
+// --- Synoptic tab ---
+
+function currentSynapshot(): HewsonManifestSnapshot | null {
+  if (!synManifest || !synInit) return null;
+  const list = synManifest.models[synModel] ?? [];
+  return list.find((s) => s.init_time === synInit) ?? null;
+}
+
+function repopulateInitPicker(): void {
+  const sel = $('syn-init-picker') as HTMLSelectElement | null;
+  if (!sel || !synManifest) return;
+  const list = synManifest.models[synModel] ?? [];
+  // Newest first
+  const sorted = [...list].sort((a, b) => b.init_time_unix - a.init_time_unix);
+  sel.innerHTML = '';
+  for (const snap of sorted) {
+    const opt = document.createElement('option');
+    opt.value = snap.init_time;
+    // Compact label: "24 Apr 12Z"
+    const dt = new Date(snap.init_time);
+    const dd = String(dt.getUTCDate()).padStart(2, '0');
+    const mon = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'][dt.getUTCMonth()];
+    const hh = String(dt.getUTCHours()).padStart(2, '0');
+    opt.textContent = `${dd} ${mon} ${hh}Z`;
+    sel.appendChild(opt);
+  }
+  // Pick newest if current init isn't in this model's list
+  if (!sorted.find((s) => s.init_time === synInit)) {
+    synInit = sorted[0]?.init_time ?? null;
+  }
+  if (synInit) sel.value = synInit;
+  reconfigureHourSlider();
+}
+
+function reconfigureHourSlider(): void {
+  const slider = $('syn-hour-slider') as HTMLInputElement | null;
+  const valEl = $('syn-hour-value');
+  if (!slider) return;
+  const snap = currentSynapshot();
+  if (!snap) {
+    slider.min = '0'; slider.max = '0'; slider.step = '3'; slider.value = '0';
+    if (valEl) valEl.textContent = '+0 h';
+    return;
+  }
+  const max = (snap.n_hours - 1) * snap.stride_hours;
+  slider.min = '0';
+  slider.max = String(max);
+  slider.step = String(snap.stride_hours);
+  // Clamp existing hour to the new range, snapped to stride
+  let h = Math.min(synHour, max);
+  h = Math.round(h / snap.stride_hours) * snap.stride_hours;
+  synHour = h;
+  slider.value = String(h);
+  if (valEl) valEl.textContent = `+${h} h`;
+}
+
+async function loadSynoptic(): Promise<void> {
+  if (!synopticMap) return;
+  const info = $('map-info-synoptic');
+  if (!synInit) {
+    if (info) info.textContent = 'No precomputed snapshot available for this model.';
+    synopticMap.clear();
+    return;
+  }
+  if (info) info.textContent = 'Loading…';
+  try {
+    const slice = await fetchHewsonSlice({
+      model: synModel,
+      init: synInit,
+      level: synLevel,
+      metric: synMetric,
+      hour: synHour,
+    });
+    synopticMap.setSlice(slice);
+    synopticMap.setOpacity(synOpacity);
+    if (info) {
+      const validDt = new Date(slice.valid_time);
+      const validLabel = validDt.toUTCString().slice(0, 22);
+      info.textContent = `${synModel.toUpperCase()} ${slice.init_time.slice(0, 13)}Z · valid ${validLabel} (+${synHour} h) · ${slice.level} hPa`;
+    }
+  } catch (err) {
+    if (info) info.textContent = `Failed: ${err instanceof Error ? err.message : err}`;
+  }
+}
+
+function showSynopticInfo(): void {
+  showPopupContent(renderHewsonInfo(synMetric));
+}
+
+function wireSynopticControls(): void {
+  wireButtonGroup('syn-model-picker', 'model', (v) => {
+    synModel = v;
+    repopulateInitPicker();
+    loadSynoptic();
+  });
+
+  const initSel = $('syn-init-picker') as HTMLSelectElement | null;
+  initSel?.addEventListener('change', () => {
+    synInit = initSel.value || null;
+    reconfigureHourSlider();
+    loadSynoptic();
+  });
+
+  wireButtonGroup('syn-level-picker', 'level', (v) => {
+    synLevel = parseInt(v);
+    loadSynoptic();
+  });
+
+  const metricSel = $('syn-metric-picker') as HTMLSelectElement | null;
+  metricSel?.addEventListener('change', () => {
+    synMetric = metricSel.value as HewsonMetric;
+    loadSynoptic();
+  });
+
+  const hourSlider = $('syn-hour-slider') as HTMLInputElement | null;
+  const hourVal = $('syn-hour-value');
+  hourSlider?.addEventListener('input', () => {
+    synHour = parseInt(hourSlider.value);
+    if (hourVal) hourVal.textContent = `+${synHour} h`;
+  });
+  hourSlider?.addEventListener('change', () => {
+    synHour = parseInt(hourSlider.value);
+    loadSynoptic();
+  });
+
+  const opSlider = $('syn-opacity-slider') as HTMLInputElement | null;
+  const opVal = $('syn-opacity-value');
+  opSlider?.addEventListener('input', () => {
+    const pct = parseInt(opSlider.value);
+    synOpacity = pct / 100;
+    if (opVal) opVal.textContent = `${pct}%`;
+    synopticMap?.setOpacity(synOpacity);
+  });
+
+  $('syn-info-btn')?.addEventListener('click', (e) => {
+    e.stopPropagation();
+    showSynopticInfo();
+  });
+}
+
+async function initSynopticTab(): Promise<void> {
+  // Lazy map init — Leaflet needs the panel visible first.
+  if (!synopticMap) {
+    const container = $('map-container-synoptic');
+    if (container) {
+      synopticMap = new SynopticMap(container);
+      synopticMap.init();
+    }
+  } else {
+    synopticMap.invalidateSize();
+  }
+
+  if (!synManifest) {
+    const info = $('map-info-synoptic');
+    if (info) info.textContent = 'Looking up available snapshots…';
+    try {
+      synManifest = await fetchHewsonManifest();
+    } catch (err) {
+      if (info) info.textContent = `Failed to load manifest: ${err instanceof Error ? err.message : err}`;
+      return;
+    }
+    // Pick the first model that has data — fallback if ECMWF isn't precomputed yet
+    const modelsWithData = Object.keys(synManifest.models);
+    if (modelsWithData.length === 0) {
+      if (info) info.textContent = 'No Hewson snapshots on disk yet — run the precompute loop.';
+      return;
+    }
+    if (!modelsWithData.includes(synModel)) {
+      synModel = modelsWithData[0];
+      setActive('syn-model-picker', synModel, 'model');
+    }
+    repopulateInitPicker();
+  }
+  loadSynoptic();
+}
+
 // --- Tab switching ---
 
-function switchTab(tab: 'forecast' | 'verification' | 'stats'): void {
+function switchTab(tab: Tab): void {
   currentTab = tab;
 
   // Tab buttons
@@ -205,6 +400,8 @@ function switchTab(tab: 'forecast' | 'verification' | 'stats'): void {
       if (!verifData) loadVerification();
       else rerender();
     }, 50);
+  } else if (tab === 'synoptic') {
+    setTimeout(() => { initSynopticTab(); }, 50);
   } else if (tab === 'stats') {
     if (!statsLoaded) {
       const frame = $('stats-frame') as HTMLIFrameElement | null;
@@ -240,15 +437,19 @@ async function main(): Promise<void> {
   forecastMap = new WeatherMap(container);
   forecastMap.init();
 
+  // Set up the briefing-style info modal (used by the synoptic tab's (i)).
+  initInfoPopup();
+
   // Wire controls
   wireForecastControls();
   wireVerificationControls();
+  wireSynopticControls();
 
   // Tab clicks
   $('tabs')?.addEventListener('click', (e) => {
     const btn = (e.target as HTMLElement).closest('.tab-btn') as HTMLElement | null;
     if (!btn) return;
-    const tab = btn.getAttribute('data-tab') as 'forecast' | 'verification' | 'stats';
+    const tab = btn.getAttribute('data-tab') as Tab;
     if (tab) switchTab(tab);
   });
 

--- a/web/ts/maps-main.ts
+++ b/web/ts/maps-main.ts
@@ -399,9 +399,12 @@ async function changeActiveMetric(): Promise<void> {
     return;
   }
 
-  // All-metrics not ready — fast-fetch the single new metric.
+  // All-metrics not ready — fast-fetch the single new metric. Bump the
+  // token so any in-flight loadSynoptic() fetch (carrying the previous
+  // metric for this hour) is discarded when it lands; otherwise it could
+  // overwrite the canvas with the wrong metric for the active picker.
   if (!synInit) return;
-  const myToken = synLoadToken;  // don't bump; we're piggybacking on the in-flight load
+  const myToken = ++synLoadToken;
   try {
     const slice = await fetchHewsonSlice({
       model: synModel,
@@ -415,7 +418,25 @@ async function changeActiveMetric(): Promise<void> {
     synopticMap.setOpacity(synOpacity);
   } catch (err) {
     console.warn('Hewson metric refetch failed:', err);
+    return;
   }
+
+  // We discarded the in-flight all-metrics from the previous loadSynoptic()
+  // by bumping the token; refetch so hover recovers without making the
+  // user wiggle a control.
+  fetchHewsonAllMetrics({
+    model: synModel,
+    init: synInit,
+    level: synLevel,
+    hour: synHour,
+  }).then((grid) => {
+    if (myToken !== synLoadToken) return;
+    synActiveGrid = grid;
+    synopticMap?.setHoverGrid(grid);
+  }).catch((err) => {
+    if (myToken !== synLoadToken) return;
+    console.warn('Hewson all-metrics background fetch failed:', err);
+  });
 }
 
 function showSynopticInfo(): void {

--- a/web/ts/maps-main.ts
+++ b/web/ts/maps-main.ts
@@ -393,7 +393,15 @@ async function changeActiveMetric(): Promise<void> {
 
   if (synActiveGrid) {
     const values = synActiveGrid.metrics[synMetric];
-    if (!values) return;
+    if (!values) {
+      // Snapshot is missing this metric (legacy build). Clear the canvas
+      // and surface an explicit message — silently returning would leave
+      // the picker showing one metric and the map showing another.
+      synopticMap.clear();
+      const info = $('map-info-synoptic');
+      if (info) info.textContent = `Metric "${synMetric}" not available in this snapshot.`;
+      return;
+    }
     const single = {
       model: synActiveGrid.model,
       init_time: synActiveGrid.init_time,

--- a/web/ts/maps-main.ts
+++ b/web/ts/maps-main.ts
@@ -606,6 +606,16 @@ async function main(): Promise<void> {
   }
   renderUserInfo(user, 'maps');
 
+  // Synoptic Forecast is admin-gated while it's being calibrated.
+  // Hide the tab button entirely for non-admins so they don't see a
+  // 403-throwing dead end. To release publicly, drop this gate (and
+  // change _synoptic_auth in src/weatherbrief/api/hewson_map.py from
+  // require_admin back to current_user_id).
+  if (!user.is_admin) {
+    document.querySelector('#tabs .tab-btn[data-tab="synoptic"]')?.remove();
+    $('panel-synoptic')?.remove();
+  }
+
   // Experimental banner toggle
   $('experimental-toggle')?.addEventListener('click', () => {
     const detail = $('experimental-detail');

--- a/web/ts/maps-main.ts
+++ b/web/ts/maps-main.ts
@@ -6,12 +6,13 @@ import {
   type ForecastMapResponse, type VerificationMapResponse,
 } from './adapters/maps-adapter';
 import {
-  fetchHewsonManifest, fetchHewsonSlice,
+  fetchHewsonManifest, fetchHewsonSlice, fetchHewsonAllMetrics,
   type HewsonManifest, type HewsonManifestSnapshot,
+  type HewsonAllMetricsSlice,
 } from './adapters/hewson-map-adapter';
 import { WeatherMap, type ForecastMetric, type VerifMetric } from './visualization/weather-map';
 import { SynopticMap } from './visualization/synoptic-map';
-import { type HewsonMetric } from './visualization/hewson-colormaps';
+import { type HewsonMetric, type ColorScale, vRangeFor } from './visualization/hewson-colormaps';
 import { initInfoPopup, showPopupContent } from './components/info-popup';
 import { renderHewsonInfo } from './helpers/hewson-info';
 import { redirectToLogin, renderUserInfo, $ } from './utils';
@@ -32,6 +33,20 @@ let synLevel = 850;
 let synMetric: HewsonMetric = 'gradient';
 let synHour = 0;
 let synOpacity = 0.5;
+let synScale: ColorScale = 'default';
+// Cached multi-metric grid for the active (model, init, level, hour) — used
+// by the cursor tooltip and (when present) lets metric-change skip a
+// network call. Fetched in the background after the fast initial render.
+let synActiveGrid: HewsonAllMetricsSlice | null = null;
+// "Token" identifying the current (model, init, level, hour) request. Async
+// fetches check this on completion and discard their results if the user
+// has moved on — prevents a stale all-metrics response from poisoning the
+// hover cache after the user changed hour mid-fetch.
+let synLoadToken = 0;
+
+function currentLoadKey(): string {
+  return `${synModel}|${synInit}|${synLevel}|${synHour}`;
+}
 
 // Forecast state
 let forecastData: ForecastMapResponse | null = null;
@@ -292,9 +307,101 @@ async function loadSynoptic(): Promise<void> {
   if (!synInit) {
     if (info) info.textContent = 'No precomputed snapshot available for this model.';
     synopticMap.clear();
+    synActiveGrid = null;
     return;
   }
+
+  // Bump the token, invalidating any in-flight fetches.
+  const myToken = ++synLoadToken;
+  // Tear down stale hover state — no all-metrics for the new (model, init,
+  // level, hour) yet, so the tooltip should disable until the background
+  // fetch completes.
+  synActiveGrid = null;
+  synopticMap.setHoverGrid(null);
+
   if (info) info.textContent = 'Loading…';
+
+  // --- 1. Fast path: single-metric slice (~80 KB) for the canvas overlay.
+  let firstSlice;
+  try {
+    firstSlice = await fetchHewsonSlice({
+      model: synModel,
+      init: synInit,
+      level: synLevel,
+      metric: synMetric,
+      hour: synHour,
+    });
+  } catch (err) {
+    if (myToken !== synLoadToken) return;
+    if (info) info.textContent = `Failed: ${err instanceof Error ? err.message : err}`;
+    return;
+  }
+  if (myToken !== synLoadToken) return;  // user moved on
+
+  const { vmin, vmax } = vRangeFor(synMetric, synScale);
+  synopticMap.setSlice(firstSlice, vmin, vmax);
+  synopticMap.setOpacity(synOpacity);
+  if (info) {
+    const validDt = new Date(firstSlice.valid_time);
+    const validLabel = validDt.toUTCString().slice(0, 22);
+    info.textContent = `${synModel.toUpperCase()} ${firstSlice.init_time.slice(0, 13)}Z · valid ${validLabel} (+${synHour} h) · ${firstSlice.level} hPa · loading hover…`;
+  }
+
+  // --- 2. Background: all-metrics (~2.3 MB) so the cursor tooltip can read
+  //     all six values without round-tripping per mousemove. We don't await —
+  //     the canvas is already rendered above; this just enables hover when
+  //     it lands. Errors are non-fatal; map remains interactive without hover.
+  fetchHewsonAllMetrics({
+    model: synModel,
+    init: synInit,
+    level: synLevel,
+    hour: synHour,
+  }).then((grid) => {
+    if (myToken !== synLoadToken) return;  // stale response — discard
+    synActiveGrid = grid;
+    synopticMap?.setHoverGrid(grid);
+    if (info) {
+      const validDt = new Date(grid.valid_time);
+      const validLabel = validDt.toUTCString().slice(0, 22);
+      info.textContent = `${synModel.toUpperCase()} ${grid.init_time.slice(0, 13)}Z · valid ${validLabel} (+${synHour} h) · ${grid.level} hPa`;
+    }
+  }).catch((err) => {
+    if (myToken !== synLoadToken) return;
+    console.warn('Hewson all-metrics background fetch failed:', err);
+    // Leave the canvas + status as-is; hover just stays disabled.
+  });
+}
+
+/** Render a different metric using the cached all-metrics grid (no
+ * network), or fall back to a single-metric refetch if the cache isn't
+ * ready yet (background load still in flight). */
+async function changeActiveMetric(): Promise<void> {
+  if (!synopticMap) return;
+  const { vmin, vmax } = vRangeFor(synMetric, synScale);
+
+  if (synActiveGrid) {
+    const values = synActiveGrid.metrics[synMetric];
+    if (!values) return;
+    const single = {
+      model: synActiveGrid.model,
+      init_time: synActiveGrid.init_time,
+      valid_time: synActiveGrid.valid_time,
+      level: synActiveGrid.level,
+      metric: synMetric,
+      hour: synActiveGrid.hour,
+      stride_hours: synActiveGrid.stride_hours,
+      lat: synActiveGrid.lat,
+      lon: synActiveGrid.lon,
+      values,
+    };
+    synopticMap.setSlice(single, vmin, vmax);
+    synopticMap.setOpacity(synOpacity);
+    return;
+  }
+
+  // All-metrics not ready — fast-fetch the single new metric.
+  if (!synInit) return;
+  const myToken = synLoadToken;  // don't bump; we're piggybacking on the in-flight load
   try {
     const slice = await fetchHewsonSlice({
       model: synModel,
@@ -303,15 +410,11 @@ async function loadSynoptic(): Promise<void> {
       metric: synMetric,
       hour: synHour,
     });
-    synopticMap.setSlice(slice);
+    if (myToken !== synLoadToken) return;
+    synopticMap.setSlice(slice, vmin, vmax);
     synopticMap.setOpacity(synOpacity);
-    if (info) {
-      const validDt = new Date(slice.valid_time);
-      const validLabel = validDt.toUTCString().slice(0, 22);
-      info.textContent = `${synModel.toUpperCase()} ${slice.init_time.slice(0, 13)}Z · valid ${validLabel} (+${synHour} h) · ${slice.level} hPa`;
-    }
   } catch (err) {
-    if (info) info.textContent = `Failed: ${err instanceof Error ? err.message : err}`;
+    console.warn('Hewson metric refetch failed:', err);
   }
 }
 
@@ -341,7 +444,7 @@ function wireSynopticControls(): void {
   const metricSel = $('syn-metric-picker') as HTMLSelectElement | null;
   metricSel?.addEventListener('change', () => {
     synMetric = metricSel.value as HewsonMetric;
-    loadSynoptic();
+    changeActiveMetric();
   });
 
   const hourSlider = $('syn-hour-slider') as HTMLInputElement | null;
@@ -367,6 +470,15 @@ function wireSynopticControls(): void {
   $('syn-info-btn')?.addEventListener('click', (e) => {
     e.stopPropagation();
     showSynopticInfo();
+  });
+
+  wireButtonGroup('syn-scale-picker', 'scale', (v) => {
+    synScale = v as ColorScale;
+    // No refetch needed — just rescale the existing canvas + legend.
+    if (synopticMap) {
+      const { vmin, vmax } = vRangeFor(synMetric, synScale);
+      synopticMap.setVRange(synMetric, vmin, vmax);
+    }
   });
 }
 

--- a/web/ts/maps-main.ts
+++ b/web/ts/maps-main.ts
@@ -197,6 +197,21 @@ function currentSynapshot(): HewsonManifestSnapshot | null {
   return list.find((s) => s.init_time === synInit) ?? null;
 }
 
+function repopulateModelPicker(): void {
+  const group = $('syn-model-picker');
+  if (!group || !synManifest) return;
+  const models = Object.keys(synManifest.models).sort();
+  group.innerHTML = '';
+  for (const m of models) {
+    const btn = document.createElement('button');
+    btn.className = 'btn-toggle';
+    btn.dataset.model = m;
+    if (m === synModel) btn.classList.add('active');
+    btn.textContent = m.toUpperCase();
+    group.appendChild(btn);
+  }
+}
+
 function repopulateInitPicker(): void {
   const sel = $('syn-init-picker') as HTMLSelectElement | null;
   if (!sel || !synManifest) return;
@@ -207,12 +222,14 @@ function repopulateInitPicker(): void {
   for (const snap of sorted) {
     const opt = document.createElement('option');
     opt.value = snap.init_time;
-    // Compact label: "24 Apr 12Z"
+    // Compact label: "24 Apr 12Z" — for ERA5 the date can be any year.
     const dt = new Date(snap.init_time);
     const dd = String(dt.getUTCDate()).padStart(2, '0');
     const mon = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'][dt.getUTCMonth()];
     const hh = String(dt.getUTCHours()).padStart(2, '0');
-    opt.textContent = `${dd} ${mon} ${hh}Z`;
+    const yr = dt.getUTCFullYear();
+    const thisYr = new Date().getUTCFullYear();
+    opt.textContent = yr === thisYr ? `${dd} ${mon} ${hh}Z` : `${dd} ${mon} ${yr} ${hh}Z`;
     sel.appendChild(opt);
   }
   // Pick newest if current init isn't in this model's list
@@ -220,7 +237,31 @@ function repopulateInitPicker(): void {
     synInit = sorted[0]?.init_time ?? null;
   }
   if (synInit) sel.value = synInit;
+  reconfigureLevelPicker();
   reconfigureHourSlider();
+}
+
+function reconfigureLevelPicker(): void {
+  const group = $('syn-level-picker');
+  if (!group) return;
+  const snap = currentSynapshot();
+  const available = new Set(snap?.levels ?? [925, 850, 700]);
+  let activeStillValid = false;
+  for (const btn of group.querySelectorAll<HTMLButtonElement>('button')) {
+    const lvl = parseInt(btn.dataset.level || '0');
+    const ok = available.has(lvl);
+    btn.disabled = !ok;
+    btn.classList.toggle('disabled', !ok);
+    if (lvl === synLevel && ok) activeStillValid = true;
+  }
+  // If the current level isn't in the snapshot, pick the first available.
+  if (!activeStillValid && snap) {
+    const fallback = snap.levels.includes(850) ? 850 : snap.levels[0];
+    if (fallback !== undefined) {
+      synLevel = fallback;
+      setActive('syn-level-picker', String(synLevel), 'level');
+    }
+  }
 }
 
 function reconfigureHourSlider(): void {
@@ -356,10 +397,8 @@ async function initSynopticTab(): Promise<void> {
       if (info) info.textContent = 'No Hewson snapshots on disk yet — run the precompute loop.';
       return;
     }
-    if (!modelsWithData.includes(synModel)) {
-      synModel = modelsWithData[0];
-      setActive('syn-model-picker', synModel, 'model');
-    }
+    if (!modelsWithData.includes(synModel)) synModel = modelsWithData[0];
+    repopulateModelPicker();
     repopulateInitPicker();
   }
   loadSynoptic();

--- a/web/ts/visualization/hewson-colormaps.ts
+++ b/web/ts/visualization/hewson-colormaps.ts
@@ -60,19 +60,23 @@ const PuOr_r = [
 ];
 
 export const COLORMAPS: Record<HewsonMetric, ColormapSpec> = {
-  // θe spans roughly 270–325 K in European weather; this default keeps the
-  // diverging midpoint near 295 K which is close to the climatological mean.
+  // θe at 850 hPa runs ~285-325 K in mid-latitudes, with tropical /
+  // convection-prone air starting around 335 K (per Hewson catalog
+  // calibration in hewson-metrics-catalog.ts). vmax=340 keeps the full
+  // tropical range visible without clipping.
   theta_e: {
     type: 'diverging',
     ramp: RdYlBu_r,
     defaultVmin: 270,
-    defaultVmax: 320,
+    defaultVmax: 340,
     unit: 'K',
     label: 'θe (equivalent potential temperature)',
     blurb:
-      '> 320 K = tropical/subtropical air (convection risk). 290–310 K normal mid-latitude. < 280 K cold polar.',
+      '> 335 K tropical/subtropical · 290–325 K mid-latitude · < 285 K polar (thresholds at 850 hPa).',
   },
   // Gradient is one-sided; CLI uses vmax=10 K/100 km for thermal fronts.
+  // Hewson 1998 thresholds (at 850 hPa): 4–6 K/100 km is "classical front",
+  // > 9 is sharp. See hewson-metrics-catalog.ts for the full per-level table.
   gradient: {
     type: 'sequential',
     ramp: YlOrRd,
@@ -81,7 +85,7 @@ export const COLORMAPS: Record<HewsonMetric, ColormapSpec> = {
     unit: 'K / 100 km',
     label: '|∇θe| (boundary intensity)',
     blurb:
-      '< 2 benign · 2–4 noticeable · 4–8 significant boundary (cloud/precip) · > 8 classical front · > 12 sharp front (SIGMET-worthy).',
+      '< 1 negligible · 1–3 weak · 4–6 classical front · > 6 strong · > 9 very sharp (thresholds at 850 hPa).',
   },
   // 2nd-derivative fields use ±2 K/(100 km)² as the "sharp transition" gate.
   neg_laplacian: {

--- a/web/ts/visualization/hewson-colormaps.ts
+++ b/web/ts/visualization/hewson-colormaps.ts
@@ -23,16 +23,34 @@ export interface ColormapSpec {
   type: 'sequential' | 'diverging';
   /** 9 evenly-spaced hex anchors in [0, 1]. */
   ramp: string[];
-  /** Default lower bound for color mapping. */
+  /** Default lower bound for color mapping (calibrated to advisory triggers). */
   defaultVmin: number;
   /** Default upper bound. For diverging metrics this is the symmetric |max|. */
   defaultVmax: number;
+  /** Storm-scale lower bound — wider range so extreme events have visual headroom. */
+  stormVmin: number;
+  /** Storm-scale upper bound. */
+  stormVmax: number;
   /** Pilot-facing units (used in legend). */
   unit: string;
   /** Pilot-facing display name (legend title, popovers). */
   label: string;
   /** Short pilot-facing interpretation drawn from § 2 of the design doc. */
   blurb: string;
+}
+
+/** Which colormap range preset to use. */
+export type ColorScale = 'default' | 'storm';
+
+/** Resolve (vmin, vmax) for a metric × scale. */
+export function vRangeFor(
+  metric: HewsonMetric,
+  scale: ColorScale,
+): { vmin: number; vmax: number } {
+  const spec = COLORMAPS[metric];
+  return scale === 'storm'
+    ? { vmin: spec.stormVmin, vmax: spec.stormVmax }
+    : { vmin: spec.defaultVmin, vmax: spec.defaultVmax };
 }
 
 // Matplotlib RdBu_r (cold blue → white → warm red).
@@ -63,12 +81,15 @@ export const COLORMAPS: Record<HewsonMetric, ColormapSpec> = {
   // θe at 850 hPa runs ~285-325 K in mid-latitudes, with tropical /
   // convection-prone air starting around 335 K (per Hewson catalog
   // calibration in hewson-metrics-catalog.ts). vmax=340 keeps the full
-  // tropical range visible without clipping.
+  // tropical range visible without clipping. Storm scale is identical —
+  // θe magnitudes don't extend much beyond 340 even in extremes.
   theta_e: {
     type: 'diverging',
     ramp: RdYlBu_r,
     defaultVmin: 270,
     defaultVmax: 340,
+    stormVmin: 270,
+    stormVmax: 340,
     unit: 'K',
     label: 'θe (equivalent potential temperature)',
     blurb:
@@ -77,22 +98,30 @@ export const COLORMAPS: Record<HewsonMetric, ColormapSpec> = {
   // Gradient is one-sided; CLI uses vmax=10 K/100 km for thermal fronts.
   // Hewson 1998 thresholds (at 850 hPa): 4–6 K/100 km is "classical front",
   // > 9 is sharp. See hewson-metrics-catalog.ts for the full per-level table.
+  // Storm scale: vmax=20, so Ciarán-class peaks (~45) saturate but rare events
+  // have visual headroom over routine fronts.
   gradient: {
     type: 'sequential',
     ramp: YlOrRd,
     defaultVmin: 0,
     defaultVmax: 10,
+    stormVmin: 0,
+    stormVmax: 20,
     unit: 'K / 100 km',
     label: '|∇θe| (boundary intensity)',
     blurb:
       '< 1 negligible · 1–3 weak · 4–6 classical front · > 6 strong · > 9 very sharp (thresholds at 850 hPa).',
   },
   // 2nd-derivative fields use ±2 K/(100 km)² as the "sharp transition" gate.
+  // Storm scale ±5 — Ciarán's peaks reach ±13, but ±5 keeps sharp/smooth
+  // separation visible for routine fronts.
   neg_laplacian: {
     type: 'diverging',
     ramp: RdBu_r,
     defaultVmin: -2,
     defaultVmax: 2,
+    stormVmin: -5,
+    stormVmax: 5,
     unit: 'K / (100 km)²',
     label: '−∇²θe (sharpness)',
     blurb:
@@ -103,27 +132,36 @@ export const COLORMAPS: Record<HewsonMetric, ColormapSpec> = {
     ramp: PuOr_r,
     defaultVmin: -2,
     defaultVmax: 2,
+    stormVmin: -5,
+    stormVmax: 5,
     unit: 'K / (100 km)²',
     label: 'TFP (front side)',
     blurb:
       'TFP > 0 warm side, conditions deteriorating · ≈ 0 at sharpest part · < 0 cold side, improving.',
   },
-  // Advection thresholds from § 2.5: 1 K/h significant, 2 K/h rapid.
+  // Advection thresholds from § 2.5: 1 K/h significant, 2 K/h rapid. Storm
+  // scale ±5: Ciarán hit ±21 K/h but ±5 still places "1 K/h significant"
+  // visibly in the middle of the bar, with extreme storms saturating.
   advection: {
     type: 'diverging',
     ramp: RdBu_r,
     defaultVmin: -2,
     defaultVmax: 2,
+    stormVmin: -5,
+    stormVmax: 5,
     unit: 'K / h',
     label: '−V·∇θe (warm/cold advection)',
     blurb:
       'Red = warm advection (ceilings drop, icing risk rises). Blue = cold advection (clearing, gusty showers).',
   },
+  // Tendency rarely reaches advection-scale magnitudes; ±3 covers Ciarán's ±4.6.
   tendency: {
     type: 'diverging',
     ramp: RdBu_r,
     defaultVmin: -2,
     defaultVmax: 2,
+    stormVmin: -3,
+    stormVmax: 3,
     unit: 'K / h',
     label: '∂θe/∂t (tendency)',
     blurb:

--- a/web/ts/visualization/hewson-colormaps.ts
+++ b/web/ts/visualization/hewson-colormaps.ts
@@ -137,7 +137,7 @@ export const COLORMAPS: Record<HewsonMetric, ColormapSpec> = {
     unit: 'K / (100 km)²',
     label: 'TFP (front side)',
     blurb:
-      'TFP > 0 warm side, conditions deteriorating · ≈ 0 at sharpest part · < 0 cold side, improving.',
+      'TFP > 0 warm-air side · TFP ≈ 0 at the front line (zero crossing) · TFP < 0 cold-air side — position indicator, not tendency.',
   },
   // Advection thresholds from § 2.5: 1 K/h significant, 2 K/h rapid. Storm
   // scale ±5: Ciarán hit ±21 K/h but ±5 still places "1 K/h significant"

--- a/web/ts/visualization/hewson-colormaps.ts
+++ b/web/ts/visualization/hewson-colormaps.ts
@@ -1,0 +1,185 @@
+/** Hewson metric colormaps (matplotlib-equivalent: RdBu_r, YlOrRd, RdYlBu_r, PuOr_r).
+ *
+ * The same colormap-per-metric mapping as the ``plot-hewson`` CLI
+ * (src/weatherbrief/frontal/cli.py), so the map and the debug plots stay
+ * visually consistent — pilots and devs see the same colors for the same
+ * physics. See § 7.4 of designs/future/hewson-fields-aviation-advisories.md.
+ *
+ * Each ramp is 9 hex anchor colors evenly spaced in [0, 1]; we interpolate
+ * linearly in sRGB between anchors. Good enough for cell rendering — we
+ * don't need perceptual accuracy here.
+ */
+
+export type HewsonMetric =
+  | 'theta_e'
+  | 'gradient'
+  | 'neg_laplacian'
+  | 'tfp'
+  | 'advection'
+  | 'tendency';
+
+export interface ColormapSpec {
+  /** ``sequential`` for one-sided ramps (gradient), ``diverging`` for ±. */
+  type: 'sequential' | 'diverging';
+  /** 9 evenly-spaced hex anchors in [0, 1]. */
+  ramp: string[];
+  /** Default lower bound for color mapping. */
+  defaultVmin: number;
+  /** Default upper bound. For diverging metrics this is the symmetric |max|. */
+  defaultVmax: number;
+  /** Pilot-facing units (used in legend). */
+  unit: string;
+  /** Pilot-facing display name (legend title, popovers). */
+  label: string;
+  /** Short pilot-facing interpretation drawn from § 2 of the design doc. */
+  blurb: string;
+}
+
+// Matplotlib RdBu_r (cold blue → white → warm red).
+const RdBu_r = [
+  '#053061', '#2166ac', '#4393c3', '#92c5de', '#f7f7f7',
+  '#fddbc7', '#f4a582', '#d6604d', '#67001f',
+];
+
+// Matplotlib YlOrRd (yellow → orange → red, sequential).
+const YlOrRd = [
+  '#ffffcc', '#ffeda0', '#fed976', '#feb24c', '#fd8d3c',
+  '#fc4e2a', '#e31a1c', '#bd0026', '#800026',
+];
+
+// Matplotlib RdYlBu_r (cold blue → yellow → warm red).
+const RdYlBu_r = [
+  '#313695', '#4575b4', '#74add1', '#abd9e9', '#ffffbf',
+  '#fee090', '#fdae61', '#f46d43', '#a50026',
+];
+
+// Matplotlib PuOr_r (purple → white → orange).
+const PuOr_r = [
+  '#2d004b', '#542788', '#8073ac', '#b2abd2', '#f7f7f7',
+  '#fee0b6', '#fdb863', '#e08214', '#7f3b08',
+];
+
+export const COLORMAPS: Record<HewsonMetric, ColormapSpec> = {
+  // θe spans roughly 270–325 K in European weather; this default keeps the
+  // diverging midpoint near 295 K which is close to the climatological mean.
+  theta_e: {
+    type: 'diverging',
+    ramp: RdYlBu_r,
+    defaultVmin: 270,
+    defaultVmax: 320,
+    unit: 'K',
+    label: 'θe (equivalent potential temperature)',
+    blurb:
+      '> 320 K = tropical/subtropical air (convection risk). 290–310 K normal mid-latitude. < 280 K cold polar.',
+  },
+  // Gradient is one-sided; CLI uses vmax=10 K/100 km for thermal fronts.
+  gradient: {
+    type: 'sequential',
+    ramp: YlOrRd,
+    defaultVmin: 0,
+    defaultVmax: 10,
+    unit: 'K / 100 km',
+    label: '|∇θe| (boundary intensity)',
+    blurb:
+      '< 2 benign · 2–4 noticeable · 4–8 significant boundary (cloud/precip) · > 8 classical front · > 12 sharp front (SIGMET-worthy).',
+  },
+  // 2nd-derivative fields use ±2 K/(100 km)² as the "sharp transition" gate.
+  neg_laplacian: {
+    type: 'diverging',
+    ramp: RdBu_r,
+    defaultVmin: -2,
+    defaultVmax: 2,
+    unit: 'K / (100 km)²',
+    label: '−∇²θe (sharpness)',
+    blurb:
+      '> 2 sharp (narrow-band weather) · ≈ 0 smooth gradient · < 0 inside a broad transition.',
+  },
+  tfp: {
+    type: 'diverging',
+    ramp: PuOr_r,
+    defaultVmin: -2,
+    defaultVmax: 2,
+    unit: 'K / (100 km)²',
+    label: 'TFP (front side)',
+    blurb:
+      'TFP > 0 warm side, conditions deteriorating · ≈ 0 at sharpest part · < 0 cold side, improving.',
+  },
+  // Advection thresholds from § 2.5: 1 K/h significant, 2 K/h rapid.
+  advection: {
+    type: 'diverging',
+    ramp: RdBu_r,
+    defaultVmin: -2,
+    defaultVmax: 2,
+    unit: 'K / h',
+    label: '−V·∇θe (warm/cold advection)',
+    blurb:
+      'Red = warm advection (ceilings drop, icing risk rises). Blue = cold advection (clearing, gusty showers).',
+  },
+  tendency: {
+    type: 'diverging',
+    ramp: RdBu_r,
+    defaultVmin: -2,
+    defaultVmax: 2,
+    unit: 'K / h',
+    label: '∂θe/∂t (tendency)',
+    blurb:
+      'Rising = warm sector arriving. Falling = post-frontal clearing or evening cooling.',
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Color sampling
+// ---------------------------------------------------------------------------
+
+/** Hex "#rrggbb" → [r, g, b] in 0–255. */
+function hexToRgb(hex: string): [number, number, number] {
+  const v = parseInt(hex.slice(1), 16);
+  return [(v >> 16) & 0xff, (v >> 8) & 0xff, v & 0xff];
+}
+
+function rgbToHex(r: number, g: number, b: number): string {
+  return '#' + [r, g, b].map((c) => Math.round(c).toString(16).padStart(2, '0')).join('');
+}
+
+/** Sample a 9-anchor ramp at t ∈ [0, 1] with linear sRGB interpolation. */
+function sampleRamp(ramp: string[], t: number): string {
+  if (!Number.isFinite(t)) return '#888';
+  const x = Math.max(0, Math.min(1, t));
+  const n = ramp.length - 1;
+  const idx = x * n;
+  const lo = Math.floor(idx);
+  const hi = Math.min(lo + 1, n);
+  const frac = idx - lo;
+  const a = hexToRgb(ramp[lo]);
+  const b = hexToRgb(ramp[hi]);
+  return rgbToHex(
+    a[0] + (b[0] - a[0]) * frac,
+    a[1] + (b[1] - a[1]) * frac,
+    a[2] + (b[2] - a[2]) * frac,
+  );
+}
+
+/** Map a value to a hex color using the metric's ramp and the supplied range.
+ *
+ * For ``diverging`` metrics, ``vmin``/``vmax`` are typically symmetric ±V; the
+ * midpoint of the ramp lands at 0. Returns a transparent gray for non-finite
+ * input (matches the NaN cells in the precompute snapshot).
+ */
+export function colorFor(
+  metric: HewsonMetric,
+  value: number | null,
+  vmin: number,
+  vmax: number,
+): string {
+  if (value === null || !Number.isFinite(value)) return 'rgba(0,0,0,0)';
+  if (vmax === vmin) return sampleRamp(COLORMAPS[metric].ramp, 0.5);
+  const t = (value - vmin) / (vmax - vmin);
+  return sampleRamp(COLORMAPS[metric].ramp, t);
+}
+
+/** Generate a CSS linear-gradient string for a colorbar legend. */
+export function gradientCss(metric: HewsonMetric): string {
+  const ramp = COLORMAPS[metric].ramp;
+  const stops = ramp.map((c, i) => `${c} ${(i / (ramp.length - 1)) * 100}%`);
+  return `linear-gradient(to right, ${stops.join(', ')})`;
+}

--- a/web/ts/visualization/hewson-grid-layer.ts
+++ b/web/ts/visualization/hewson-grid-layer.ts
@@ -1,0 +1,153 @@
+/** HewsonGridLayer — paints one colored rect per (lat, lon) cell of a
+ * Hewson snapshot onto a canvas overlay.
+ *
+ * Templated on the FogOfWarLayer pattern in pirep-map.ts: a custom Leaflet
+ * pane between tiles and markers, sized to the map's container, redrawn on
+ * move/zoom/resize. Per § 7.5 of the design doc, the rendering is
+ * intentionally pixelated at low zoom — it shows the actual 0.25° grid
+ * resolution rather than pretending to interpolated precision.
+ */
+
+import * as L from 'leaflet';
+import type { HewsonSlice } from '../adapters/hewson-map-adapter';
+import { COLORMAPS, colorFor, type HewsonMetric } from './hewson-colormaps';
+
+export interface RenderState {
+  slice: HewsonSlice;
+  vmin: number;
+  vmax: number;
+}
+
+export class HewsonGridLayer extends L.Layer {
+  private canvas: HTMLCanvasElement | null = null;
+  private pane: HTMLElement | null = null;
+  private state: RenderState | null = null;
+  private opacity = 0.5;
+
+  /** Replace the slice and trigger a redraw. */
+  setSlice(slice: HewsonSlice, vmin?: number, vmax?: number): void {
+    const spec = COLORMAPS[slice.metric as HewsonMetric] ?? COLORMAPS.gradient;
+    this.state = {
+      slice,
+      vmin: vmin ?? spec.defaultVmin,
+      vmax: vmax ?? spec.defaultVmax,
+    };
+    this.redraw();
+  }
+
+  /** Override the (vmin, vmax) without changing the slice. */
+  setVRange(vmin: number, vmax: number): void {
+    if (!this.state) return;
+    this.state = { ...this.state, vmin, vmax };
+    this.redraw();
+  }
+
+  /** 0…1 — applied uniformly to the whole grid via canvas globalAlpha. */
+  setOpacity(o: number): void {
+    this.opacity = Math.max(0, Math.min(1, o));
+    if (this.canvas) this.canvas.style.opacity = String(this.opacity);
+  }
+
+  clear(): void {
+    this.state = null;
+    this.redraw();
+  }
+
+  onAdd(map: L.Map): this {
+    if (!map.getPane('hewsonGridPane')) {
+      this.pane = map.createPane('hewsonGridPane');
+      this.pane.style.zIndex = '350';
+      this.pane.style.pointerEvents = 'none';
+    } else {
+      this.pane = map.getPane('hewsonGridPane')!;
+    }
+
+    this.canvas = L.DomUtil.create('canvas', '', this.pane) as HTMLCanvasElement;
+    this.canvas.style.position = 'absolute';
+    this.canvas.style.top = '0';
+    this.canvas.style.left = '0';
+    this.canvas.style.opacity = String(this.opacity);
+
+    map.on('move zoom viewreset resize', this.redraw, this);
+    this.redraw();
+    return this;
+  }
+
+  onRemove(map: L.Map): this {
+    map.off('move zoom viewreset resize', this.redraw, this);
+    if (this.canvas?.parentNode) this.canvas.parentNode.removeChild(this.canvas);
+    this.canvas = null;
+    return this;
+  }
+
+  private redraw = (): void => {
+    const map = (this as any)._map as L.Map | undefined;
+    if (!map || !this.canvas) return;
+
+    const size = map.getSize();
+    const dpr = window.devicePixelRatio || 1;
+    this.canvas.width = size.x * dpr;
+    this.canvas.height = size.y * dpr;
+    this.canvas.style.width = size.x + 'px';
+    this.canvas.style.height = size.y + 'px';
+
+    // Re-align canvas to the map container origin (so panning works).
+    const topLeft = map.containerPointToLayerPoint([0, 0]);
+    L.DomUtil.setPosition(this.canvas, topLeft);
+
+    const ctx = this.canvas.getContext('2d')!;
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    ctx.clearRect(0, 0, size.x, size.y);
+
+    if (!this.state) return;
+
+    const { slice, vmin, vmax } = this.state;
+    const lat = slice.lat;
+    const lon = slice.lon;
+    const values = slice.values;
+    const metric = slice.metric as HewsonMetric;
+    if (lat.length < 2 || lon.length < 2) return;
+
+    const dLat = Math.abs(lat[1] - lat[0]);
+    const dLon = Math.abs(lon[1] - lon[0]);
+    const halfLat = dLat / 2;
+    const halfLon = dLon / 2;
+
+    // Quick viewport cull — skip cells that are completely off-screen.
+    const bounds = map.getBounds();
+    const viewW = bounds.getWest() - dLon;
+    const viewE = bounds.getEast() + dLon;
+    const viewS = bounds.getSouth() - dLat;
+    const viewN = bounds.getNorth() + dLat;
+
+    for (let i = 0; i < lat.length; i++) {
+      const la = lat[i];
+      if (la < viewS || la > viewN) continue;
+
+      // Compute container Y for the cell's north/south edges once per row.
+      const ptN = map.latLngToContainerPoint([la + halfLat, lon[0]]);
+      const ptS = map.latLngToContainerPoint([la - halfLat, lon[0]]);
+      const yTop = Math.min(ptN.y, ptS.y);
+      const yBot = Math.max(ptN.y, ptS.y);
+      // +1 px to swallow sub-pixel seams between adjacent rows.
+      const h = yBot - yTop + 1;
+
+      const row = values[i];
+      for (let j = 0; j < lon.length; j++) {
+        const lo = lon[j];
+        if (lo < viewW || lo > viewE) continue;
+        const v = row[j];
+        if (v === null || !Number.isFinite(v)) continue;
+
+        const ptW = map.latLngToContainerPoint([la, lo - halfLon]);
+        const ptE = map.latLngToContainerPoint([la, lo + halfLon]);
+        const xLeft = Math.min(ptW.x, ptE.x);
+        const xRight = Math.max(ptW.x, ptE.x);
+        const w = xRight - xLeft + 1;
+
+        ctx.fillStyle = colorFor(metric, v, vmin, vmax);
+        ctx.fillRect(xLeft, yTop, w, h);
+      }
+    }
+  };
+}

--- a/web/ts/visualization/hewson-grid-layer.ts
+++ b/web/ts/visualization/hewson-grid-layer.ts
@@ -131,6 +131,27 @@ export class HewsonGridLayer extends L.Layer {
     const viewS = bounds.getSouth() - dLat;
     const viewN = bounds.getNorth() + dLat;
 
+    // Precompute column edge X coordinates once per redraw. In Web Mercator
+    // the X-projection depends only on longitude, so the same xLeft/xRight
+    // applies to every row. At the default zoom (~20k cells visible) this
+    // collapses ~40k projection calls per pan frame down to ~400.
+    const colCount = lon.length;
+    const xLeft = new Float32Array(colCount);
+    const xRight = new Float32Array(colCount);
+    const colVisible = new Uint8Array(colCount);
+    for (let j = 0; j < colCount; j++) {
+      const lo = lon[j];
+      colVisible[j] = lo >= viewW && lo <= viewE ? 1 : 0;
+      if (!colVisible[j]) continue;
+      // lat[0] is fine here — Web Mercator X is independent of latitude.
+      const ptW = map.latLngToContainerPoint([lat[0], lo - halfLon]);
+      const ptE = map.latLngToContainerPoint([lat[0], lo + halfLon]);
+      const xl = Math.min(ptW.x, ptE.x);
+      const xr = Math.max(ptW.x, ptE.x);
+      xLeft[j] = xl;
+      xRight[j] = xr;
+    }
+
     for (let i = 0; i < lat.length; i++) {
       const la = lat[i];
       if (la < viewS || la > viewN) continue;
@@ -144,20 +165,14 @@ export class HewsonGridLayer extends L.Layer {
       const h = yBot - yTop + 1;
 
       const row = values[i];
-      for (let j = 0; j < lon.length; j++) {
-        const lo = lon[j];
-        if (lo < viewW || lo > viewE) continue;
+      for (let j = 0; j < colCount; j++) {
+        if (!colVisible[j]) continue;
         const v = row[j];
         if (v === null || !Number.isFinite(v)) continue;
 
-        const ptW = map.latLngToContainerPoint([la, lo - halfLon]);
-        const ptE = map.latLngToContainerPoint([la, lo + halfLon]);
-        const xLeft = Math.min(ptW.x, ptE.x);
-        const xRight = Math.max(ptW.x, ptE.x);
-        const w = xRight - xLeft + 1;
-
+        const w = xRight[j] - xLeft[j] + 1;
         ctx.fillStyle = colorFor(metric, v, vmin, vmax);
-        ctx.fillRect(xLeft, yTop, w, h);
+        ctx.fillRect(xLeft[j], yTop, w, h);
       }
     }
   };

--- a/web/ts/visualization/hewson-grid-layer.ts
+++ b/web/ts/visualization/hewson-grid-layer.ts
@@ -89,10 +89,18 @@ export class HewsonGridLayer extends L.Layer {
 
     const size = map.getSize();
     const dpr = window.devicePixelRatio || 1;
-    this.canvas.width = size.x * dpr;
-    this.canvas.height = size.y * dpr;
-    this.canvas.style.width = size.x + 'px';
-    this.canvas.style.height = size.y + 'px';
+    const newW = size.x * dpr;
+    const newH = size.y * dpr;
+    // Setting width/height clears the canvas — even when assigned the same
+    // value. Leaflet fires `move` continuously during pan, so reallocating
+    // the GPU texture every frame is wasted work. Only resize when the
+    // viewport actually changes; otherwise just clear in place.
+    if (this.canvas.width !== newW || this.canvas.height !== newH) {
+      this.canvas.width = newW;
+      this.canvas.height = newH;
+      this.canvas.style.width = size.x + 'px';
+      this.canvas.style.height = size.y + 'px';
+    }
 
     // Re-align canvas to the map container origin (so panning works).
     const topLeft = map.containerPointToLayerPoint([0, 0]);

--- a/web/ts/visualization/hewson-grid-layer.ts
+++ b/web/ts/visualization/hewson-grid-layer.ts
@@ -23,6 +23,7 @@ export class HewsonGridLayer extends L.Layer {
   private pane: HTMLElement | null = null;
   private state: RenderState | null = null;
   private opacity = 0.5;
+  private map: L.Map | null = null;
 
   /** Replace the slice and trigger a redraw. */
   setSlice(slice: HewsonSlice, vmin?: number, vmax?: number): void {
@@ -54,6 +55,7 @@ export class HewsonGridLayer extends L.Layer {
   }
 
   onAdd(map: L.Map): this {
+    this.map = map;
     if (!map.getPane('hewsonGridPane')) {
       this.pane = map.createPane('hewsonGridPane');
       this.pane.style.zIndex = '350';
@@ -77,11 +79,12 @@ export class HewsonGridLayer extends L.Layer {
     map.off('move zoom viewreset resize', this.redraw, this);
     if (this.canvas?.parentNode) this.canvas.parentNode.removeChild(this.canvas);
     this.canvas = null;
+    this.map = null;
     return this;
   }
 
   private redraw = (): void => {
-    const map = (this as any)._map as L.Map | undefined;
+    const map = this.map;
     if (!map || !this.canvas) return;
 
     const size = map.getSize();

--- a/web/ts/visualization/synoptic-map.ts
+++ b/web/ts/visualization/synoptic-map.ts
@@ -16,7 +16,11 @@ const HEWSON_METRIC_ORDER: HewsonMetric[] = [
 
 const LIGHT_TILES = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
 const DARK_TILES = 'https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png';
-const ATTR = '&copy; <a href="https://www.openstreetmap.org/copyright">OSM</a>';
+// CARTO's terms require their attribution alongside OSM when serving from
+// basemaps.cartocdn.com. Mirror the per-theme split used in
+// route-map-inset.ts / route-map/renderer.ts.
+const LIGHT_ATTR = '&copy; <a href="https://www.openstreetmap.org/copyright">OSM</a>';
+const DARK_ATTR = '&copy; <a href="https://www.openstreetmap.org/copyright">OSM</a> &copy; <a href="https://carto.com/">CARTO</a>';
 
 function isDark(): boolean {
   return document.documentElement.dataset.theme === 'dark';
@@ -45,8 +49,9 @@ export class SynopticMap {
       zoomControl: true,
     });
 
-    this.tileLayer = L.tileLayer(isDark() ? DARK_TILES : LIGHT_TILES, {
-      attribution: ATTR,
+    const dark = isDark();
+    this.tileLayer = L.tileLayer(dark ? DARK_TILES : LIGHT_TILES, {
+      attribution: dark ? DARK_ATTR : LIGHT_ATTR,
       maxZoom: 18,
     }).addTo(this.map);
 
@@ -67,8 +72,16 @@ export class SynopticMap {
     this.map.on('click', this.handleMouseMove);
 
     document.addEventListener('theme-changed', () => {
-      if (!this.tileLayer) return;
-      this.tileLayer.setUrl(isDark() ? DARK_TILES : LIGHT_TILES);
+      if (!this.tileLayer || !this.map) return;
+      const dark = isDark();
+      this.tileLayer.setUrl(dark ? DARK_TILES : LIGHT_TILES);
+      // Update attribution on theme switch — getAttribution() override
+      // mirrors route-map-inset.ts so the control reflects the active tile
+      // provider after a swap.
+      this.tileLayer.getAttribution = () => dark ? DARK_ATTR : LIGHT_ATTR;
+      this.map.attributionControl.removeAttribution(LIGHT_ATTR);
+      this.map.attributionControl.removeAttribution(DARK_ATTR);
+      this.map.attributionControl.addAttribution(dark ? DARK_ATTR : LIGHT_ATTR);
     });
   }
 

--- a/web/ts/visualization/synoptic-map.ts
+++ b/web/ts/visualization/synoptic-map.ts
@@ -6,9 +6,13 @@
  */
 
 import * as L from 'leaflet';
-import type { HewsonSlice } from '../adapters/hewson-map-adapter';
+import type { HewsonAllMetricsSlice, HewsonSlice } from '../adapters/hewson-map-adapter';
 import { COLORMAPS, gradientCss, type HewsonMetric } from './hewson-colormaps';
 import { HewsonGridLayer } from './hewson-grid-layer';
+
+const HEWSON_METRIC_ORDER: HewsonMetric[] = [
+  'theta_e', 'gradient', 'neg_laplacian', 'tfp', 'advection', 'tendency',
+];
 
 const LIGHT_TILES = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
 const DARK_TILES = 'https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png';
@@ -24,6 +28,9 @@ export class SynopticMap {
   private tileLayer: L.TileLayer | null = null;
   private gridLayer: HewsonGridLayer | null = null;
   private legendEl: HTMLElement | null = null;
+  // Hover state — populated via setHoverGrid(); cleared when no grid is loaded.
+  private hoverGrid: HewsonAllMetricsSlice | null = null;
+  private hoverEl: HTMLElement | null = null;
 
   constructor(container: HTMLElement) {
     this.container = container;
@@ -46,6 +53,19 @@ export class SynopticMap {
     this.gridLayer = new HewsonGridLayer();
     this.gridLayer.addTo(this.map);
 
+    // Cursor-following tooltip — wired once at init, hidden until hoverGrid
+    // is populated by setHoverGrid().
+    this.hoverEl = document.createElement('div');
+    this.hoverEl.className = 'synoptic-hover-tip';
+    this.hoverEl.style.display = 'none';
+    this.container.appendChild(this.hoverEl);
+
+    this.map.on('mousemove', this.handleMouseMove);
+    this.map.on('mouseout', this.hideHover);
+    // Mobile: tap to show the values at that point. The next mousemove
+    // (e.g. on map drag) re-positions; the next mouseout hides.
+    this.map.on('click', this.handleMouseMove);
+
     document.addEventListener('theme-changed', () => {
       if (!this.tileLayer) return;
       this.tileLayer.setUrl(isDark() ? DARK_TILES : LIGHT_TILES);
@@ -67,14 +87,110 @@ export class SynopticMap {
     this.gridLayer?.setOpacity(o);
   }
 
-  setVRange(vmin: number, vmax: number): void {
+  /** Update the (vmin, vmax) of the current slice without re-fetching.
+   * Refreshes both the canvas and the legend. ``metric`` is needed for the
+   * legend title / unit; pass the metric currently rendered. */
+  setVRange(metric: HewsonMetric, vmin: number, vmax: number): void {
     this.gridLayer?.setVRange(vmin, vmax);
+    this.renderLegend(metric, vmin, vmax);
   }
 
   clear(): void {
     this.gridLayer?.clear();
     this.removeLegend();
+    this.hoverGrid = null;
+    this.hideHover();
   }
+
+  /** Cache the all-metrics grid for cursor-tooltip lookups. Pass null to
+   * disable hover (e.g. between hour changes while a refetch is in flight). */
+  setHoverGrid(grid: HewsonAllMetricsSlice | null): void {
+    this.hoverGrid = grid;
+    if (!grid) this.hideHover();
+  }
+
+  // -------------------------------------------------------------------------
+  // Cursor tooltip
+  // -------------------------------------------------------------------------
+
+  private handleMouseMove = (e: L.LeafletMouseEvent): void => {
+    if (!this.hoverGrid || !this.hoverEl) return;
+    const grid = this.hoverGrid;
+
+    // Snap to the nearest grid cell. lat/lon arrays are uniform (0.25°
+    // by default) so a direct linear lookup is cheap and exact.
+    const lat = grid.lat;
+    const lon = grid.lon;
+    const dLat = lat.length >= 2 ? Math.abs(lat[1] - lat[0]) : 0.25;
+    const dLon = lon.length >= 2 ? Math.abs(lon[1] - lon[0]) : 0.25;
+
+    const i = Math.round((e.latlng.lat - lat[0]) / (lat[lat.length - 1] - lat[0]) * (lat.length - 1));
+    const j = Math.round((e.latlng.lng - lon[0]) / (lon[lon.length - 1] - lon[0]) * (lon.length - 1));
+    if (i < 0 || i >= lat.length || j < 0 || j >= lon.length) {
+      this.hideHover();
+      return;
+    }
+
+    // Check at least one metric has a finite value here — otherwise we're
+    // in a terrain-mask hole or off-data, so don't show a tooltip.
+    let anyFinite = false;
+    for (const m of HEWSON_METRIC_ORDER) {
+      const grid2d = grid.metrics[m];
+      const v = grid2d?.[i]?.[j];
+      if (v !== null && v !== undefined && Number.isFinite(v)) {
+        anyFinite = true;
+        break;
+      }
+    }
+    if (!anyFinite) {
+      this.hideHover();
+      return;
+    }
+
+    // Build the tooltip rows.
+    const cellLat = lat[i];
+    const cellLon = lon[j];
+    const rows = HEWSON_METRIC_ORDER
+      .filter((m) => grid.metrics[m] !== undefined)
+      .map((m) => {
+        const v = grid.metrics[m][i][j];
+        const spec = COLORMAPS[m];
+        const label = spec?.label.split(' ')[0] ?? m;  // "θe", "|∇θe|", ...
+        const unit = spec?.unit ?? '';
+        const text = (v === null || !Number.isFinite(v))
+          ? '—'
+          : `${formatValue(m, v as number)} ${unit}`;
+        return `<div class="synoptic-hover-row"><span class="synoptic-hover-label">${escapeHtml(label)}</span><span class="synoptic-hover-value">${escapeHtml(text)}</span></div>`;
+      })
+      .join('');
+
+    const dms = (v: number, pos: string, neg: string) =>
+      `${Math.abs(v).toFixed(2)}°${v >= 0 ? pos : neg}`;
+    const header = `${dms(cellLat, 'N', 'S')}, ${dms(cellLon, 'E', 'W')}<br><span class="synoptic-hover-cell">cell @ ${cellLat.toFixed(2)}, ${cellLon.toFixed(2)}</span>`;
+
+    this.hoverEl.innerHTML = `<div class="synoptic-hover-header">${header}</div>${rows}`;
+    this.hoverEl.style.display = 'block';
+
+    // Position relative to the container — Leaflet's containerPoint is the
+    // cursor position in the map container's local coordinate system.
+    const cp = e.containerPoint;
+    const tipW = this.hoverEl.offsetWidth;
+    const tipH = this.hoverEl.offsetHeight;
+    const containerRect = this.container.getBoundingClientRect();
+    // Default offset: 12 px to the right and below the cursor. Flip when
+    // the cursor approaches the right or bottom edge so the tooltip stays
+    // fully visible.
+    let x = cp.x + 12;
+    let y = cp.y + 12;
+    if (x + tipW > containerRect.width - 6) x = cp.x - 12 - tipW;
+    if (y + tipH > containerRect.height - 6) y = cp.y - 12 - tipH;
+    this.hoverEl.style.left = `${x}px`;
+    this.hoverEl.style.top = `${y}px`;
+  };
+
+  private hideHover = (): void => {
+    if (this.hoverEl) this.hoverEl.style.display = 'none';
+  };
 
   private renderLegend(
     metric: HewsonMetric,
@@ -119,4 +235,12 @@ function escapeHtml(s: string): string {
   return s.replace(/[&<>"']/g, (c) =>
     ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]!),
   );
+}
+
+/** Round to a metric-appropriate number of decimals for the tooltip. */
+function formatValue(metric: HewsonMetric, v: number): string {
+  // θe magnitudes ~ 280–340 K; show 1 decimal.
+  // Everything else is small (K/h, K/100km, K/(100km)²) — 2 decimals.
+  const decimals = metric === 'theta_e' ? 1 : 2;
+  return v.toFixed(decimals);
 }

--- a/web/ts/visualization/synoptic-map.ts
+++ b/web/ts/visualization/synoptic-map.ts
@@ -1,0 +1,122 @@
+/** Synoptic map — Leaflet map + HewsonGridLayer + colorbar legend.
+ *
+ * Sibling of WeatherMap (visualization/weather-map.ts) but slim: no airport
+ * markers, no per-metric color matrix — just the gridded canvas overlay.
+ * Lives in the "Synoptic Forecast" tab on the forecast page.
+ */
+
+import * as L from 'leaflet';
+import type { HewsonSlice } from '../adapters/hewson-map-adapter';
+import { COLORMAPS, gradientCss, type HewsonMetric } from './hewson-colormaps';
+import { HewsonGridLayer } from './hewson-grid-layer';
+
+const LIGHT_TILES = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
+const DARK_TILES = 'https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png';
+const ATTR = '&copy; <a href="https://www.openstreetmap.org/copyright">OSM</a>';
+
+function isDark(): boolean {
+  return document.documentElement.dataset.theme === 'dark';
+}
+
+export class SynopticMap {
+  private container: HTMLElement;
+  private map: L.Map | null = null;
+  private tileLayer: L.TileLayer | null = null;
+  private gridLayer: HewsonGridLayer | null = null;
+  private legendEl: HTMLElement | null = null;
+
+  constructor(container: HTMLElement) {
+    this.container = container;
+  }
+
+  init(): void {
+    if (this.map) return;
+
+    this.map = L.map(this.container, {
+      center: [48, 10],
+      zoom: 5,
+      zoomControl: true,
+    });
+
+    this.tileLayer = L.tileLayer(isDark() ? DARK_TILES : LIGHT_TILES, {
+      attribution: ATTR,
+      maxZoom: 18,
+    }).addTo(this.map);
+
+    this.gridLayer = new HewsonGridLayer();
+    this.gridLayer.addTo(this.map);
+
+    document.addEventListener('theme-changed', () => {
+      if (!this.tileLayer) return;
+      this.tileLayer.setUrl(isDark() ? DARK_TILES : LIGHT_TILES);
+    });
+  }
+
+  invalidateSize(): void {
+    this.map?.invalidateSize();
+  }
+
+  /** Replace the rendered slice. Builds/refreshes the legend. */
+  setSlice(slice: HewsonSlice, vmin?: number, vmax?: number): void {
+    if (!this.gridLayer) return;
+    this.gridLayer.setSlice(slice, vmin, vmax);
+    this.renderLegend(slice.metric as HewsonMetric, vmin, vmax);
+  }
+
+  setOpacity(o: number): void {
+    this.gridLayer?.setOpacity(o);
+  }
+
+  setVRange(vmin: number, vmax: number): void {
+    this.gridLayer?.setVRange(vmin, vmax);
+  }
+
+  clear(): void {
+    this.gridLayer?.clear();
+    this.removeLegend();
+  }
+
+  private renderLegend(
+    metric: HewsonMetric,
+    vmin?: number,
+    vmax?: number,
+  ): void {
+    const spec = COLORMAPS[metric];
+    if (!spec) return;
+    const lo = vmin ?? spec.defaultVmin;
+    const hi = vmax ?? spec.defaultVmax;
+    const mid = (lo + hi) / 2;
+
+    if (!this.legendEl) {
+      this.legendEl = document.createElement('div');
+      this.legendEl.className = 'synoptic-legend';
+      this.container.appendChild(this.legendEl);
+    }
+
+    const fmt = (v: number) =>
+      Math.abs(v) >= 100 ? v.toFixed(0) : v.toFixed(1);
+
+    this.legendEl.innerHTML = `
+      <div class="synoptic-legend-title">${escapeHtml(spec.label)}</div>
+      <div class="synoptic-legend-bar" style="background:${gradientCss(metric)}"></div>
+      <div class="synoptic-legend-ticks">
+        <span>${fmt(lo)}</span>
+        <span>${fmt(mid)}</span>
+        <span>${fmt(hi)} ${escapeHtml(spec.unit)}</span>
+      </div>
+    `;
+  }
+
+  private removeLegend(): void {
+    if (this.legendEl?.parentNode) {
+      this.legendEl.parentNode.removeChild(this.legendEl);
+    }
+    this.legendEl = null;
+  }
+}
+
+function escapeHtml(s: string): string {
+  return s.replace(/[&<>"']/g, (c) =>
+    ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]!),
+  );
+}

--- a/web/ts/visualization/synoptic-map.ts
+++ b/web/ts/visualization/synoptic-map.ts
@@ -118,12 +118,9 @@ export class SynopticMap {
     const grid = this.hoverGrid;
 
     // Snap to the nearest grid cell. lat/lon arrays are uniform (0.25°
-    // by default) so a direct linear lookup is cheap and exact.
+    // by default) so a direct linear index calculation is cheap and exact.
     const lat = grid.lat;
     const lon = grid.lon;
-    const dLat = lat.length >= 2 ? Math.abs(lat[1] - lat[0]) : 0.25;
-    const dLon = lon.length >= 2 ? Math.abs(lon[1] - lon[0]) : 0.25;
-
     const i = Math.round((e.latlng.lat - lat[0]) / (lat[lat.length - 1] - lat[0]) * (lat.length - 1));
     const j = Math.round((e.latlng.lng - lon[0]) / (lon[lon.length - 1] - lon[0]) * (lon.length - 1));
     if (i < 0 || i >= lat.length || j < 0 || j >= lon.length) {

--- a/web/ts/visualization/synoptic-map.ts
+++ b/web/ts/visualization/synoptic-map.ts
@@ -163,11 +163,14 @@ export class SynopticMap {
     const rows = HEWSON_METRIC_ORDER
       .filter((m) => grid.metrics[m] !== undefined)
       .map((m) => {
-        const v = grid.metrics[m][i][j];
+        // Defensive: a malformed response with fewer rows than lat.length
+        // would otherwise throw a TypeError inside a Leaflet mouse handler.
+        const row = grid.metrics[m]?.[i];
+        const v = row !== undefined ? row[j] : null;
         const spec = COLORMAPS[m];
         const label = spec?.label.split(' ')[0] ?? m;  // "θe", "|∇θe|", ...
         const unit = spec?.unit ?? '';
-        const text = (v === null || !Number.isFinite(v))
+        const text = (v === null || v === undefined || !Number.isFinite(v))
           ? '—'
           : `${formatValue(m, v as number)} ${unit}`;
         return `<div class="synoptic-hover-row"><span class="synoptic-hover-label">${escapeHtml(label)}</span><span class="synoptic-hover-value">${escapeHtml(text)}</span></div>`;


### PR DESCRIPTION
## Summary
Phase D of the Hewson synoptic-fields rollout: backend endpoints + a new "Synoptic Forecast" tab on `/maps.html` with a Leaflet canvas overlay rendering θe, |∇θe|, −∇²θe, TFP, advection, and tendency at 925/850/700 hPa over Europe. Closes Phase D.1 + D.2 of `designs/future/hewson-fields-aviation-advisories.md`.

**Admin-gated for now.** Two single-edit gates (one backend, one frontend) make the public release a one-line change once we've validated the calibration with real flight feedback. See "Releasing publicly" below.

## What ships

### Backend (`src/weatherbrief/api/hewson_map.py`, `src/weatherbrief/hewson/era5_case.py`)
- `GET /api/hewson-map?model=&init=&level=&metric=&hour=` — one (n_lat, n_lon) JSON slice
- `GET /api/hewson-map/manifest` — every snapshot on disk, metadata only (scans subdirs dynamically so ERA5 / historical-event cases surface alongside live forecasts)
- `GET /api/hewson-map/all-metrics?...` — all 6 metric grids in one response, used by the cursor tooltip
- `python -m weatherbrief.hewson era5-case --case <calibration-dir>` — builds a synoptic snapshot from any existing ERA5 Case so historical events (storms, memorable flying days) appear in the UI alongside live forecasts. Storm Ciarán (2023-11-02) is the test case
- All endpoints: lazy NPZ access, corrupt-snapshot → 404 (not 500), path-traversal guard, `Cache-Control: private, max-age=86400, immutable`

### Frontend (`web/ts/visualization/`, `web/ts/maps-main.ts`)
- New "Synoptic Forecast" tab on `/maps.html` — first gridded canvas overlay in the codebase (templated on `FogOfWarLayer` from `pirep-map.ts`)
- Controls: dynamic model picker (populated from manifest), init dropdown, level buttons (925/850/700 with ft labels), 6-metric dropdown grouped by purpose, hour slider snapped to stride, opacity slider, default/storm scale toggle
- **Cursor-following tooltip** showing all 6 metric values at the hovered grid cell
- **Progressive load**: single-metric slice (~80 KB) renders the canvas immediately; all-metrics (~2.3 MB) fetched in the background to enable the tooltip — token-based stale-fetch cancellation prevents race conditions
- Briefing-style **(i) info modal** for each metric with level-specific threshold tables, multi-level usage notes, "Discuss with AI" prompts (Claude / ChatGPT / Gemini), Wikipedia links

### Pilot info catalog (`web/ts/data/hewson-metrics-catalog.ts`)
Per-level threshold tables for all 6 metrics, calibrated against Hewson 1998 and the design doc § 2 / § 4.1. Highlights from the calibration pass:
- θe value bands recalibrated — UK summer 850 hPa ≈ 305-315 K, **not** tropical; tropical / convection-prone air starts ≈ 335 K
- |∇θe| "classical front" at 850 hPa = **4-6 K/100 km** (matches Hewson 1998 with analysis-grade smoothing); thresholds shifted per-level (925 raised for coastal effects, 700 lowered for free-troposphere mixing)
- TFP rewritten as a **position indicator** (zero crossing = front line) — earlier text had conflated spatial position with temporal evolution
- Icing claim qualified to the **0 to −15 °C overrunning layer**
- ∂θe/∂t reframed around the advection-vs-tendency decomposition (the diagnostic value is in the disagreement)
- Both warm and cold fronts tilt **backward** toward the cold air with altitude (warm gently ~1:100, cold steeply ~1:50)

### Tests
- 23 backend tests (`tests/test_api_hewson_map.py`): happy paths for slice/manifest/all-metrics, NaN→null serialization, valid_time arithmetic, all 400/404/401/403 paths, corrupt-snapshot → 404, partial-snapshot → 200 with `missing_metrics`, path-traversal guard, admin-gate
- 6 ERA5 case-builder tests (`tests/test_hewson_era5_case.py`): filename convention, NPZ schema, tendency-across-stride, single-step edge case, non-ERA5 rejection, levels= subset
- 19 precompute helper tests (`tests/test_hewson_precompute.py`)

## Releasing publicly
When ready to expose to all authenticated users:

**Backend**: `src/weatherbrief/api/hewson_map.py`
```python
_synoptic_auth = require_admin   # → change to current_user_id
```

**Frontend**: `web/ts/maps-main.ts` — remove the `if (!user.is_admin) { ... }` block that strips the tab from the DOM.

The `test_get_slice_requires_admin` test can be retired at the same time.

## Review history
16 review rounds with `claude[bot]` between PR open and merge. Notable correctness fixes from review feedback:
- TFP geometry rewritten as position-indicator only (round 3 — caught a real meteorological error)
- Cache-Control flipped from `public` to `private` on auth-gated endpoints (round 3)
- Race condition in `changeActiveMetric` token-bumping (round 3)
- Corrupt-snapshot → 404 not 500 (rounds 6/7)
- ERA5-case test coverage gap filled (round 8)
- Front-tilt direction corrected (round 10 — both fronts tilt backward, not forward/backward)
- Canvas perf: precompute X edges once per redraw, not per cell × per frame (round 11)
- θe threshold table gaps filled with Cold/Warm transition rows (round 12)
- 925 hPa gradient table gap filled (round 14)

## Test plan
- [x] `pytest tests/test_api_hewson_map.py tests/test_hewson_era5_case.py tests/test_hewson_precompute.py` — 48/48 passing
- [x] `npx tsc --noEmit` — clean
- [x] Smoke-tested locally against a real ECMWF snapshot and the Storm Ciarán ERA5 case
- [x] Admin user sees the tab; non-admin doesn't (DOM-removed)
- [ ] Reviewer (deploy): first 05 Z / 17 Z cycle in production produces snapshots; admin can see them in `/maps.html`

## Out of scope (follow-ups)
- **Phase D.3** — cross-section bands using the same precompute snapshots at each waypoint
- **Phase D.4** — stencil-in-GRIB continuous-altitude version (gated on native-GRIB ingestion)
- **Phase C** — six advisory evaluators that turn the fields into per-leg pilot text
- **Phase E** — moisture cross-check (RH, LCC, CAPE) to suppress dry-front false alarms
- **GZip middleware** — would shrink the 2.3 MB all-metrics response to ~250 KB on the wire (one-line FastAPI middleware add); fine without it on local network

🤖 Generated with [Claude Code](https://claude.com/claude-code)