### PR TITLE
feat(debrief): pilot post-flight judgement (#92 Phase 1)

### DIFF
--- a/alembic/versions/045_flight_debriefs.py
+++ b/alembic/versions/045_flight_debriefs.py
@@ -1,0 +1,39 @@
+"""Add flight_debriefs table for pilot post-flight judgement.
+
+Revision ID: 045
+Revises: 044
+Create Date: 2026-04-25
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "045"
+down_revision: Union[str, None] = "044"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "flight_debriefs",
+        sa.Column(
+            "flight_id",
+            sa.String(256),
+            sa.ForeignKey("flights.id", ondelete="CASCADE"),
+            primary_key=True,
+        ),
+        sa.Column("decision", sa.String(16), nullable=False),
+        sa.Column("reasons_json", sa.Text, nullable=True),
+        sa.Column("outcomes_json", sa.Text, nullable=True),
+        sa.Column("note", sa.Text, nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("flight_debriefs")

--- a/alembic/versions/046_fix_skipped_region_json.py
+++ b/alembic/versions/046_fix_skipped_region_json.py
@@ -1,0 +1,40 @@
+"""Backfill briefing_packs.models_skipped_region_json: '{}' → '[]'.
+
+Pre-2026-03-06 rows ended up with the literal JSON object ``'{}'`` instead
+of an empty list. The Pydantic model `BriefingPackMeta.models_skipped_region`
+is typed `list[str]`, so loading those rows 500s on `/packs/latest`.
+
+The correct value for those rows is `'[]'` — they predate the auto-skip
+feature (introduced in migration 016, Feb 2026), so semantically they
+"skipped nothing".
+
+The writer is no longer in the codebase; we keep the loader strict so
+any future bad data fails loudly instead of getting silently coerced.
+
+Revision ID: 046
+Revises: 045
+Create Date: 2026-04-25
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "046"
+down_revision: Union[str, None] = "045"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "UPDATE briefing_packs SET models_skipped_region_json = '[]' "
+        "WHERE models_skipped_region_json = '{}'"
+    )
+
+
+def downgrade() -> None:
+    # Intentionally a no-op: the original '{}' values were a bug, not a
+    # historical state we want to restore on rollback.
+    pass

--- a/designs/INDEX.md
+++ b/designs/INDEX.md
@@ -128,3 +128,8 @@ Key exports: `compute_frontal_zones_dual`, `classify_front_type`, `build_zone_ti
 ### rzskewt
 Swift package for Skew-T log-P diagrams. Extracted to own repo: `github.com/roznet/rztskew`. Full atmospheric thermodynamics, Canvas rendering, 47 unit tests. Design docs live in that repo's `designs/` directory.
 Key exports: `SkewTView`, `SkewTRenderer`, `SoundingProfile`, `Thermodynamics`
+
+### debrief
+Pilot post-flight judgement (cancelled/flown) on past flights — Phase 1 of #92. Sidecar `flight_debriefs` table with shared 8-tag taxonomy, hybrid chips+text entry with auto-toggle, per-user summary stats panel, three-section flight list (future/recent/past). Debriefed flights' packs are exempt from T2 retention so calibration can re-analyse against ERA5 later.
+Key exports: `FlightDebrief`, `Decision`, `ConditionTag`, `OutcomeValue`, `compute_stats`, `upsert_debrief`, `list_debriefed_flight_ids`
+→ Full doc: debrief.md

--- a/designs/debrief.md
+++ b/designs/debrief.md
@@ -77,7 +77,7 @@ TS mirror in `web/ts/components/debrief-taxonomy.ts` must stay in sync
 ### Section assignment
 
 - **future**: `departure_time >= now`
-- **recent**: most-recent `RECENT_SECTION_CAP` (= 2) past undebriefed flights whose `departure_time` is newer than the user's most-recently-debriefed flight. Empty when caught up.
+- **recent**: most-recent `RECENT_SECTION_CAP` (= 2) past undebriefed flights whose `departure_time` is within the last `RECENT_SECTION_MAX_AGE_DAYS` (= 30) days. Independent of debrief history — debriefing one flight doesn't pull a third into the slot, but anything older than the window drops to Past so the nudge stays bounded.
 - **past**: everything else
 
 The cap is hard-coded in `api/flights.py` for Phase 1; revisit if usage

--- a/designs/debrief.md
+++ b/designs/debrief.md
@@ -1,0 +1,181 @@
+# Flight Debrief
+
+> Pilot post-flight judgement (cancelled / flown), captured against past flights to feed future Hewson advisory calibration (#90, #92).
+
+## Intent
+
+Every past flight is a labelled calibration sample. Pilot says what happened
+in two taps; the system stores tags and outcomes against the flight; future
+calibration work re-analyses against ERA5 reanalysis. This module owns the
+data side. The pilot-facing summary panel exists to make the feature
+*useful enough that the pilot fills it in* — calibration falls out.
+
+Phase 1 (this module): web-only data capture + per-user summary stats. No
+post-ETA prompts, no cross-user aggregation, no calibration harness changes.
+Calibration is a separate problem that consumes this data later.
+
+## Schema
+
+Sidecar table 1:1 with `flights`, JSON columns for the variable-shape parts:
+
+```
+flight_debriefs
+  flight_id      PK, FK → flights.id ON DELETE CASCADE
+  decision       'cancelled' | 'flown'
+  reasons_json   ['IMC','WIND',...]                  (cancelled only)
+  outcomes_json  {'icing':'worse','cloud':'consistent',...}  (flown only)
+  note           free text, ≤ 300 chars
+  created_at, updated_at
+```
+
+JSON over per-category columns because the taxonomy will evolve and
+per-user stats fit comfortably in Python (≤ a few hundred rows). When
+cross-user calibration export comes online, a one-shot script flattens
+JSON to CSV/Parquet. See discussion in PR conversation for the full
+trade-off table.
+
+`outcomes_json` keys = categories that were *queried* (an advisory was
+raised on the briefing). Default value `consistent` is stored explicitly
+so the per-category accuracy denominator is honest — categories absent
+from the dict were not queried and don't count.
+
+## Taxonomy
+
+Single shared vocabulary in `weatherbrief.debriefs.taxonomy`:
+
+| Tag | Cancel reason | Outcome category |
+|-----|---|---|
+| IMC | ✓ | ✓ |
+| ICE | ✓ | ✓ |
+| WIND | ✓ | ✓ |
+| TS | ✓ | ✓ |
+| TURB | ✓ | ✓ |
+| FRZ | ✓ | ✓ |
+| VIS | ✓ | ✓ |
+| OPS | ✓ | — (non-weather, no outcome to grade) |
+
+`OutcomeValue`: `consistent | better | worse`.
+
+`KEYWORD_MAP` maps each tag to phrases that the free-text note matches —
+used by the hybrid entry UX to auto-toggle chips as the pilot types. The
+TS mirror in `web/ts/components/debrief-taxonomy.ts` must stay in sync
+(small surface, hand-maintained).
+
+## API
+
+| Method | Path | Use |
+|---|---|---|
+| `GET` | `/api/flights/{id}/debrief` | Load — 404 if absent |
+| `PUT` | `/api/flights/{id}/debrief` | Upsert |
+| `DELETE` | `/api/flights/{id}/debrief` | Idempotent remove |
+| `GET` | `/api/debriefs/stats?window_days=90` | Per-user aggregate |
+
+`GET /api/flights` is extended with two new fields per flight:
+- `debrief: DebriefResponse | null` — owned past flights only
+- `section: 'future' | 'recent' | 'past'` — server-assigned bucket
+
+### Section assignment
+
+- **future**: `departure_time >= now`
+- **recent**: most-recent `RECENT_SECTION_CAP` (= 2) past undebriefed flights whose `departure_time` is newer than the user's most-recently-debriefed flight. Empty when caught up.
+- **past**: everything else
+
+The cap is hard-coded in `api/flights.py` for Phase 1; revisit if usage
+patterns suggest a different ceiling or a per-user setting.
+
+## Stats
+
+`compute_stats(flights, debriefs, window_days=90)` is a pure function
+returning `DebriefStats`:
+- Activity counts (flown / cancelled / pending)
+- Cancellation reason histogram
+- Per-category accuracy (consistent / better / worse counts)
+
+Window scoping: a flight is in-window when `departure_time` falls within
+the last `window_days`. Future flights are excluded. The default is 90;
+the API accepts 1..3650 so 6m / 1y / all selectors can be added on the
+client without touching the backend.
+
+OPS-only cancellations are counted in `cancelled_count` and
+`cancellation_reasons` but excluded from `category_accuracy` (OPS is not
+in `OUTCOME_CATEGORIES`).
+
+## Retention coupling
+
+`flight_debriefs` rows exempt **all** of a flight's `briefing_packs` from
+T2 retention. T1 still applies — heavy artifacts (`forecasts.json`,
+`cross_section.json`, `gramet.*`, `skewt/`) get stripped at the normal
+30-day boundary; lightweight `briefing.json` + DB row stay indefinitely.
+
+The exemption keeps every refresh of the briefing the pilot saw, so
+retrospective calibration can ask both "what did the system say at time
+T?" and "did the prediction get better with newer model runs?". PIREP
+exemption (full T1+T2 skip) is unchanged.
+
+## UI layout
+
+Flights list page (`web/flights.html`):
+
+```
+[ Future flights ]
+[ Recent — please debrief ]   ← per-row [Debrief →] button, accordion form
+[ Statistics (last 90 days) ]
+[ Past flights (collapsible) ]
+```
+
+Flight detail page (`web/flight.html`): a single Debrief section appears
+under "Latest Assessment" for owner past flights only:
+- No debrief: `[ Add debrief ]` button
+- Has debrief: read-only summary card + `[ Edit debrief ]` button
+
+Both surfaces share the same `debrief-form.ts` component.
+
+### Form behaviour
+
+Hybrid entry on the cancel form:
+- Chips multi-select (`IMC, ICE, WIND, ...`)
+- Free-text note below
+- As pilot types, `matchTagsInText` scans the note and auto-activates
+  matching chips with a soft visual indicator. Pilot can deselect.
+
+Outcome form (flown):
+- Defaults every queried category to `consistent`.
+- Pilot only flips the ones that weren't.
+- (Phase 1 wires `flaggedCategories=[]` placeholder; the briefing-side
+  hookup that derives flagged categories from advisories is a follow-up.)
+
+The "default consistent" choice biases data toward "very inconsistent
+only" — accepted trade-off. Phase 2 (post-ETA prompt) will record an
+explicit `✓ All consistent` tap as a different signal than no debrief at
+all. Stats panel surfaces a copy caveat acknowledging the bias.
+
+## Files
+
+- `src/weatherbrief/debriefs/taxonomy.py` — enums, keyword map, matcher
+- `src/weatherbrief/debriefs/stats.py` — aggregate computation
+- `src/weatherbrief/models/storage.py` — `FlightDebrief` Pydantic
+- `src/weatherbrief/db/models.py` — `FlightDebriefRow` ORM
+- `src/weatherbrief/storage/debriefs.py` — CRUD + bulk fetch
+- `src/weatherbrief/api/debriefs.py` — REST endpoints
+- `src/weatherbrief/api/flights.py` — section + debrief on list response
+- `src/weatherbrief/tasks/retention.py` — T2 exemption
+- `alembic/versions/045_flight_debriefs.py` — table create
+- `web/ts/components/debrief-{form,summary,stats,taxonomy}.ts`
+- `web/ts/adapters/debrief-adapter.ts`
+
+## Out of scope (deferred)
+
+- **Calibration harness**: separate problem, consumes this data via a
+  future export script.
+- **cancel.md backfill**: fresh start.
+- **Post-ETA prompts** (Phase 2)
+- **iOS UI** (Phase 2 — same data shape)
+- **Cross-user / aggregate stats** (Phase 3)
+- **`pack_id` FK on debrief**: exempt all packs of a debriefed flight
+  instead, simpler.
+- **`decided_at` separate field**: `created_at` covers it for Phase 1.
+- **`replaced_by_flight_id`, `package_flight_ids`**: dropped along with `postponed`.
+- **`postponed`, `no_show` decision states**: simplified to
+  `cancelled | flown` only.
+- **Audit history of debrief edits**.
+- **PIREP retention change**: separate decision, not in this module's scope.

--- a/src/weatherbrief/api/app.py
+++ b/src/weatherbrief/api/app.py
@@ -31,6 +31,7 @@ from flyfun_common.db import (
 from flyfun_common.db.models import UserPreferencesRow
 
 from weatherbrief.api.aircraft import router as aircraft_router
+from weatherbrief.api.debriefs import router as debriefs_router
 from weatherbrief.api.pireps import router as pireps_router
 from weatherbrief.api.flights import router as flights_router
 from weatherbrief.api.packs import refresh_router, router as packs_router
@@ -302,6 +303,7 @@ def create_app() -> FastAPI:
             return {"token": token}
 
     app.include_router(aircraft_router, prefix="/api")
+    app.include_router(debriefs_router, prefix="/api")
     app.include_router(pireps_router, prefix="/api")
     app.include_router(flights_router, prefix="/api")
     app.include_router(packs_router, prefix="/api")

--- a/src/weatherbrief/api/debriefs.py
+++ b/src/weatherbrief/api/debriefs.py
@@ -1,0 +1,186 @@
+"""API endpoints for flight debriefs and per-user summary stats."""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel, Field
+from sqlalchemy.orm import Session
+
+from flyfun_common.db import current_user_id, get_db
+
+from weatherbrief.db.models import FlightRow
+from weatherbrief.debriefs.stats import DEFAULT_WINDOW_DAYS, compute_stats, DebriefStats
+from weatherbrief.debriefs.taxonomy import ConditionTag, Decision, OutcomeValue
+from weatherbrief.models import FlightDebrief
+from weatherbrief.storage.debriefs import (
+    delete_debrief,
+    get_debrief,
+    list_debriefs_for_user,
+    upsert_debrief,
+)
+from weatherbrief.storage.flights import list_flights
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["debriefs"])
+
+
+# --- Request / response models ---
+
+
+class DebriefRequest(BaseModel):
+    """Body for PUT /flights/{id}/debrief — full upsert.
+
+    Validation runs through the FlightDebrief Pydantic model on the storage
+    layer; this shape just collects fields off the wire.
+    """
+
+    decision: Decision
+    reasons: list[ConditionTag] = Field(default_factory=list)
+    outcomes: dict[ConditionTag, OutcomeValue] = Field(default_factory=dict)
+    note: str | None = None
+
+
+class DebriefResponse(BaseModel):
+    """Wire shape for a stored debrief.
+
+    Tag/outcome enum values serialise as strings ("IMC", "consistent") so
+    the TS client doesn't have to know about Python enum names.
+    """
+
+    flight_id: str
+    decision: str
+    reasons: list[str] = Field(default_factory=list)
+    outcomes: dict[str, str] = Field(default_factory=dict)
+    note: str | None = None
+    created_at: str
+    updated_at: str
+
+    @classmethod
+    def from_model(cls, d: FlightDebrief) -> "DebriefResponse":
+        return cls(
+            flight_id=d.flight_id,
+            decision=d.decision.value,
+            reasons=[t.value for t in d.reasons],
+            outcomes={t.value: v.value for t, v in d.outcomes.items()},
+            note=d.note,
+            created_at=d.created_at.isoformat(),
+            updated_at=d.updated_at.isoformat(),
+        )
+
+
+class StatsCategoryResponse(BaseModel):
+    queried_count: int
+    consistent: int
+    better: int
+    worse: int
+
+
+class StatsResponse(BaseModel):
+    """Wire shape for /debriefs/stats."""
+
+    window_days: int
+    total_flights_in_window: int
+    flown_count: int
+    cancelled_count: int
+    monitoring_count: int
+    pending_debrief_count: int
+    cancellation_reasons: dict[str, int]
+    category_accuracy: dict[str, StatsCategoryResponse]
+
+    @classmethod
+    def from_stats(cls, s: DebriefStats) -> "StatsResponse":
+        return cls(
+            window_days=s.window_days,
+            total_flights_in_window=s.total_flights_in_window,
+            flown_count=s.flown_count,
+            cancelled_count=s.cancelled_count,
+            monitoring_count=s.monitoring_count,
+            pending_debrief_count=s.pending_debrief_count,
+            cancellation_reasons={k.value: v for k, v in s.cancellation_reasons.items()},
+            category_accuracy={
+                k.value: StatsCategoryResponse(
+                    queried_count=v.queried_count,
+                    consistent=v.consistent,
+                    better=v.better,
+                    worse=v.worse,
+                )
+                for k, v in s.category_accuracy.items()
+            },
+        )
+
+
+# --- Helpers ---
+
+
+def _load_owned_flight_or_404(db: Session, flight_id: str, user_id: str) -> FlightRow:
+    row = db.get(FlightRow, flight_id)
+    if row is None or row.user_id != user_id:
+        raise HTTPException(status_code=404, detail=f"Flight '{flight_id}' not found")
+    return row
+
+
+# --- Endpoints ---
+
+
+@router.get("/flights/{flight_id}/debrief", response_model=DebriefResponse)
+def get_flight_debrief(
+    flight_id: str,
+    user_id: str = Depends(current_user_id),
+    db: Session = Depends(get_db),
+):
+    """Load the debrief for a flight. 404 if no row exists."""
+    _load_owned_flight_or_404(db, flight_id, user_id)
+    d = get_debrief(db, flight_id)
+    if d is None:
+        raise HTTPException(status_code=404, detail="No debrief recorded for this flight")
+    return DebriefResponse.from_model(d)
+
+
+@router.put("/flights/{flight_id}/debrief", response_model=DebriefResponse)
+def upsert_flight_debrief(
+    flight_id: str,
+    req: DebriefRequest,
+    user_id: str = Depends(current_user_id),
+    db: Session = Depends(get_db),
+):
+    """Insert or update the debrief for a flight."""
+    _load_owned_flight_or_404(db, flight_id, user_id)
+    try:
+        saved = upsert_debrief(
+            db,
+            flight_id=flight_id,
+            decision=req.decision,
+            reasons=req.reasons,
+            outcomes=req.outcomes,
+            note=req.note,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc))
+    return DebriefResponse.from_model(saved)
+
+
+@router.delete("/flights/{flight_id}/debrief", status_code=204)
+def delete_flight_debrief(
+    flight_id: str,
+    user_id: str = Depends(current_user_id),
+    db: Session = Depends(get_db),
+):
+    """Remove the debrief for a flight. Idempotent."""
+    _load_owned_flight_or_404(db, flight_id, user_id)
+    delete_debrief(db, flight_id)
+
+
+@router.get("/debriefs/stats", response_model=StatsResponse)
+def get_user_debrief_stats(
+    window_days: int = Query(DEFAULT_WINDOW_DAYS, ge=1, le=3650),
+    user_id: str = Depends(current_user_id),
+    db: Session = Depends(get_db),
+):
+    """Aggregate stats for the current user's flights within ``window_days``."""
+    flights = list_flights(db, user_id)
+    debriefs = list_debriefs_for_user(db, user_id)
+    stats = compute_stats(flights, debriefs, window_days=window_days)
+    return StatsResponse.from_stats(stats)

--- a/src/weatherbrief/api/flights.py
+++ b/src/weatherbrief/api/flights.py
@@ -6,7 +6,7 @@ import hashlib
 import json
 import logging
 import re
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Request
@@ -19,7 +19,9 @@ from flyfun_common.db import current_user_id, get_db
 from flyfun_common.db.models import UserRow
 from weatherbrief.airports import RejectedWaypoint
 from weatherbrief.db.models import BriefingPackRow
-from weatherbrief.models import Flight
+from weatherbrief.models import Flight, FlightDebrief
+from weatherbrief.storage.debriefs import bulk_get_debriefs, get_debrief as _get_debrief
+from weatherbrief.api.debriefs import DebriefResponse
 from weatherbrief.storage.flights import (
     SubscriptionError,
     bulk_delete_flights as _bulk_delete_flights,
@@ -126,6 +128,15 @@ class FlightResponse(BaseModel):
     role: Literal["owner", "subscriber"] = "owner"
     owner_display_name: str | None = None  # set when role == "subscriber"
     is_subscribed: bool = False  # True when the viewer has subscribed to this flight
+    debrief: DebriefResponse | None = None  # owned past flights only
+    section: Literal["future", "recent", "past"] = "past"
+
+
+# Number of flights surfaced in the "recent" section as a debrief nudge,
+# and how far back to look. Hard-coded for Phase 1; revisit when usage
+# patterns suggest a larger window or a per-user setting.
+RECENT_SECTION_CAP = 2
+RECENT_SECTION_MAX_AGE_DAYS = 30
 
 
 def _rejected_waypoints_message(rejected: list[RejectedWaypoint]) -> str:
@@ -231,6 +242,8 @@ def _flight_to_response(
     role: Literal["owner", "subscriber"] | None = None,
     subscribed: bool | None = None,
     owner_display_name: str | None = None,
+    debrief: FlightDebrief | None = None,
+    section: Literal["future", "recent", "past"] | None = None,
 ) -> FlightResponse:
     # viewer_id is required: the role derivation below compares flight.user_id
     # against it, and with viewer_id=None we would silently classify the
@@ -252,6 +265,18 @@ def _flight_to_response(
             is_subscribed(db, flight.id, viewer_id)
             if effective_role == "subscriber"
             else False
+        )
+
+    # Owners see their own debriefs; subscribers don't see others' debriefs.
+    if debrief is None and effective_role == "owner":
+        debrief = _get_debrief(db, flight.id)
+    debrief_resp = DebriefResponse.from_model(debrief) if debrief else None
+
+    if section is None:
+        section = _classify_section(
+            flight,
+            has_debrief=debrief is not None,
+            recent_set=set(),  # single-flight call: no recent context available
         )
 
     return FlightResponse(
@@ -277,7 +302,64 @@ def _flight_to_response(
         role=effective_role,
         owner_display_name=owner_display_name,
         is_subscribed=subscribed,
+        debrief=debrief_resp,
+        section=section,
     )
+
+
+def _classify_section(
+    flight: Flight,
+    *,
+    has_debrief: bool,
+    recent_set: set[str],
+    now: datetime | None = None,
+) -> Literal["future", "recent", "past"]:
+    """Bucket a flight into one of the three list sections.
+
+    The ``recent`` decision needs cross-flight context (the user's debrief
+    history), so callers compute ``recent_set`` once via
+    ``_compute_recent_section`` and pass it in.
+    """
+    now = now or datetime.now(timezone.utc)
+    if flight.departure_time >= now:
+        return "future"
+    if flight.id in recent_set:
+        return "recent"
+    return "past"
+
+
+def _compute_recent_section(
+    owned_flights_with_debrief: list[tuple[Flight, FlightDebrief | None]],
+    *,
+    cap: int = RECENT_SECTION_CAP,
+    max_age_days: int = RECENT_SECTION_MAX_AGE_DAYS,
+    now: datetime | None = None,
+) -> set[str]:
+    """Pick which owned past undebriefed flights belong in ``recent``.
+
+    Rule: the most recent ``cap`` past flights without a debrief whose
+    ``departure_time`` is within the last ``max_age_days``. The cap is
+    independent of debrief history — debriefing one flight doesn't push
+    the next-most-recent undebriefed one out of the section, so a user
+    with two recent flights can debrief them both back-to-back. Anything
+    older than the window drops to the Past section so the nudge stays
+    bounded.
+
+    Pure function — input is the (flight, debrief) tuples for *owned*
+    flights only; subscribed flights never enter the recent section.
+    """
+    now = now or datetime.now(timezone.utc)
+    cutoff = now - timedelta(days=max_age_days)
+
+    candidates = [
+        f
+        for f, d in owned_flights_with_debrief
+        if d is None
+        and f.departure_time < now
+        and f.departure_time >= cutoff
+    ]
+    candidates.sort(key=lambda f: f.departure_time, reverse=True)
+    return {f.id for f in candidates[:cap]}
 
 
 def _get_latest_packs(db: Session, flight_ids: list[str]) -> dict[str, BriefingStatusInfo]:
@@ -322,29 +404,48 @@ def list_all_flights(
     user_id: str = Depends(current_user_id),
     db: Session = Depends(get_db),
 ):
-    """List owned + subscribed flights with latest briefing status.
+    """List owned + subscribed flights with latest briefing status, debrief, and section.
 
     Subscribed flights are filtered out when the owner has flipped them to
     private (see storage.flights.list_flights_with_role).
     """
     paired = list_flights_with_role(db, user_id)
     pack_status = _get_latest_packs(db, [f.id for f, _, _ in paired])
-    # `role == "subscriber"` implies is_subscribed=True by construction:
-    # list_flights_with_role only emits a non-owned flight when the viewer has
-    # an active subscription row. If that ever changes (e.g., public-flight
-    # discovery), the tuple should carry is_subscribed explicitly.
-    return [
-        _flight_to_response(
-            f,
-            db,
-            viewer_id=user_id,
-            latest_briefing=pack_status.get(f.id),
-            role=role,
-            subscribed=(role == "subscriber"),
-            owner_display_name=owner_name,
-        )
-        for f, role, owner_name in paired
+    debrief_map = _bulk_debriefs_for_owned(db, paired, user_id)
+
+    owned_pairs: list[tuple[Flight, FlightDebrief | None]] = [
+        (f, debrief_map.get(f.id)) for f, role, _ in paired if role == "owner"
     ]
+    recent_set = _compute_recent_section(owned_pairs)
+
+    out: list[FlightResponse] = []
+    for f, role, owner_name in paired:
+        debrief = debrief_map.get(f.id) if role == "owner" else None
+        section = _classify_section(f, has_debrief=debrief is not None, recent_set=recent_set)
+        out.append(
+            _flight_to_response(
+                f,
+                db,
+                viewer_id=user_id,
+                latest_briefing=pack_status.get(f.id),
+                role=role,
+                subscribed=(role == "subscriber"),
+                owner_display_name=owner_name,
+                debrief=debrief,
+                section=section,
+            )
+        )
+    return out
+
+
+def _bulk_debriefs_for_owned(
+    db: Session,
+    paired: list[tuple[Flight, str, str | None]],
+    viewer_id: str,
+) -> dict[str, FlightDebrief]:
+    """One query for all owned-flight debriefs in a list response."""
+    owned_ids = [f.id for f, role, _ in paired if role == "owner" and f.user_id == viewer_id]
+    return bulk_get_debriefs(db, owned_ids)
 
 
 @router.post("", response_model=FlightResponse, status_code=201)

--- a/src/weatherbrief/db/models.py
+++ b/src/weatherbrief/db/models.py
@@ -117,6 +117,42 @@ class FlightRow(Base):
     packs: Mapped[list[BriefingPackRow]] = relationship(
         back_populates="flight", cascade="all, delete-orphan"
     )
+    debrief: Mapped["FlightDebriefRow | None"] = relationship(
+        back_populates="flight", uselist=False, cascade="all, delete-orphan"
+    )
+
+
+class FlightDebriefRow(Base):
+    """Pilot post-flight judgement (cancelled / flown), one per flight.
+
+    Sidecar table — kept independent from FlightRow so the row can be
+    upserted without touching the flight definition. Cascade-deletes when
+    the flight is removed; the presence of any row exempts all of the
+    flight's packs from T2 retention (see tasks/retention.py).
+    """
+
+    __tablename__ = "flight_debriefs"
+
+    flight_id: Mapped[str] = mapped_column(
+        String(256), ForeignKey("flights.id", ondelete="CASCADE"), primary_key=True
+    )
+    decision: Mapped[str] = mapped_column(String(16), nullable=False)
+    reasons_json: Mapped[str | None] = mapped_column(Text, nullable=True)
+    outcomes_json: Mapped[str | None] = mapped_column(Text, nullable=True)
+    note: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+    )
+
+    flight: Mapped[FlightRow] = relationship(back_populates="debrief")
 
 
 class FlightSubscriptionRow(Base):

--- a/src/weatherbrief/debriefs/__init__.py
+++ b/src/weatherbrief/debriefs/__init__.py
@@ -1,0 +1,14 @@
+"""Flight debrief — pilot judgement captured against past flights.
+
+Single-pilot Phase 1: cancel-or-flew decision, controlled tag taxonomy,
+per-category outcome scoring (consistent / better / worse), free-text note.
+"""
+
+from weatherbrief.debriefs.taxonomy import (  # noqa: F401
+    KEYWORD_MAP,
+    OUTCOME_CATEGORIES,
+    ConditionTag,
+    Decision,
+    OutcomeValue,
+    match_tags_in_text,
+)

--- a/src/weatherbrief/debriefs/stats.py
+++ b/src/weatherbrief/debriefs/stats.py
@@ -1,0 +1,136 @@
+"""Per-user debrief summary statistics.
+
+Computes the panel shown between the Recent and Past sections of the
+flights list. ``window_days`` is parameterised even though the UI ships
+with a fixed 90-day default — this keeps adding 6m/1y/all selectors a
+client-side change.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from pydantic import BaseModel, Field
+
+from weatherbrief.debriefs.taxonomy import (
+    OUTCOME_CATEGORIES,
+    ConditionTag,
+    Decision,
+    OutcomeValue,
+)
+from weatherbrief.models import Flight, FlightDebrief
+
+DEFAULT_WINDOW_DAYS = 90
+
+
+class CategoryAccuracy(BaseModel):
+    """Outcome counts for one category, restricted to flown flights that
+    queried the category (i.e. the briefing raised an advisory)."""
+
+    queried_count: int = 0
+    consistent: int = 0
+    better: int = 0
+    worse: int = 0
+
+
+class DebriefStats(BaseModel):
+    """Summary stats for a user's debrief history within a time window.
+
+    Window scoping: a flight is in-window when its ``departure_time`` falls
+    within the last ``window_days``. Future flights are excluded.
+    OPS-only cancellations are counted as cancellations but do not affect
+    per-category accuracy (OPS is not in OUTCOME_CATEGORIES).
+    Monitor-only debriefs are tracked separately and excluded from both
+    the cancellation reasons and category accuracy aggregates — they are
+    not real go/no-go decisions.
+    """
+
+    window_days: int
+    total_flights_in_window: int = 0
+    flown_count: int = 0
+    cancelled_count: int = 0
+    monitoring_count: int = 0
+    pending_debrief_count: int = 0
+    cancellation_reasons: dict[ConditionTag, int] = Field(default_factory=dict)
+    category_accuracy: dict[ConditionTag, CategoryAccuracy] = Field(default_factory=dict)
+
+
+def compute_stats(
+    flights: list[Flight],
+    debriefs: list[FlightDebrief],
+    *,
+    window_days: int = DEFAULT_WINDOW_DAYS,
+    now: datetime | None = None,
+) -> DebriefStats:
+    """Aggregate ``flights`` + ``debriefs`` into a ``DebriefStats``.
+
+    Pure function — no DB access, easy to test.
+    """
+    now = now or datetime.now(timezone.utc)
+    cutoff = now - timedelta(days=window_days)
+
+    # Past flights (departure < now) within the window.
+    flights_in_window = [
+        f for f in flights
+        if f.departure_time < now and f.departure_time >= cutoff
+    ]
+    flight_id_set = {f.id for f in flights_in_window}
+
+    # Index debriefs by flight_id, keep only those whose flight is in-window.
+    debrief_by_flight = {
+        d.flight_id: d
+        for d in debriefs
+        if d.flight_id in flight_id_set
+    }
+
+    flown = 0
+    cancelled = 0
+    monitoring = 0
+    cancellation_reasons: dict[ConditionTag, int] = {}
+    category_accuracy: dict[ConditionTag, CategoryAccuracy] = {
+        cat: CategoryAccuracy() for cat in OUTCOME_CATEGORIES
+    }
+
+    for flight in flights_in_window:
+        d = debrief_by_flight.get(flight.id)
+        if d is None:
+            continue
+        if d.decision is Decision.CANCELLED:
+            cancelled += 1
+            for tag in d.reasons:
+                cancellation_reasons[tag] = cancellation_reasons.get(tag, 0) + 1
+        elif d.decision is Decision.FLOWN:
+            flown += 1
+            for tag, value in d.outcomes.items():
+                if tag not in category_accuracy:
+                    continue  # OPS or unknown — skip
+                acc = category_accuracy[tag]
+                acc.queried_count += 1
+                if value is OutcomeValue.CONSISTENT:
+                    acc.consistent += 1
+                elif value is OutcomeValue.BETTER:
+                    acc.better += 1
+                elif value is OutcomeValue.WORSE:
+                    acc.worse += 1
+        elif d.decision is Decision.MONITORING:
+            monitoring += 1
+            # Intentionally no contribution to reasons or accuracy — monitor
+            # flights aren't go/no-go decisions and shouldn't bias the data.
+
+    pending = len(flights_in_window) - flown - cancelled - monitoring
+
+    # Drop categories with zero queries to keep the panel compact.
+    pruned_accuracy = {
+        cat: acc for cat, acc in category_accuracy.items() if acc.queried_count > 0
+    }
+
+    return DebriefStats(
+        window_days=window_days,
+        total_flights_in_window=len(flights_in_window),
+        flown_count=flown,
+        cancelled_count=cancelled,
+        monitoring_count=monitoring,
+        pending_debrief_count=pending,
+        cancellation_reasons=cancellation_reasons,
+        category_accuracy=pruned_accuracy,
+    )

--- a/src/weatherbrief/debriefs/taxonomy.py
+++ b/src/weatherbrief/debriefs/taxonomy.py
@@ -1,0 +1,76 @@
+"""Controlled vocabulary for debrief tags and outcome categories.
+
+Single source of truth shared by the cancel-reason chips and the per-category
+outcome form. The TS mirror in ``web/ts/components/debrief-taxonomy.ts``
+must stay in sync.
+"""
+
+from __future__ import annotations
+
+import re
+from enum import Enum
+
+
+class Decision(str, Enum):
+    CANCELLED = "cancelled"
+    FLOWN = "flown"
+    MONITORING = "monitoring"  # flight created to watch weather, not intended to fly
+
+
+class ConditionTag(str, Enum):
+    """Weather/operational categories used by both cancel-reasons and outcomes.
+
+    OPS is the only non-weather member — used as a cancel reason but excluded
+    from outcome categories (no per-category accuracy to grade).
+    """
+
+    IMC = "IMC"
+    ICE = "ICE"
+    WIND = "WIND"
+    TS = "TS"
+    TURB = "TURB"
+    FRZ = "FRZ"
+    VIS = "VIS"
+    OPS = "OPS"
+
+
+class OutcomeValue(str, Enum):
+    CONSISTENT = "consistent"
+    BETTER = "better"
+    WORSE = "worse"
+
+
+OUTCOME_CATEGORIES: list[ConditionTag] = [t for t in ConditionTag if t != ConditionTag.OPS]
+
+
+# Phrases scanned in the free-text note to auto-toggle matching chips.
+# Lowercase, whole-word-ish matches (see _build_pattern). Conservative on purpose;
+# the chip is the source of truth — pilots can untoggle if a match is unwanted.
+KEYWORD_MAP: dict[ConditionTag, list[str]] = {
+    ConditionTag.IMC:  ["imc", "ifr", "overcast", "low ceiling", "ceiling"],
+    ConditionTag.ICE:  ["icing", "ice", "rime", "sld"],
+    ConditionTag.WIND: ["wind", "gust", "crosswind"],
+    ConditionTag.TS:   ["thunder", "thunderstorm", "cb", "storm", "lightning", "convect"],
+    ConditionTag.TURB: ["turb", "bumpy", "rough", "shear"],
+    ConditionTag.FRZ:  ["freezing rain", "fzra", "sleet", "freezing precip"],
+    ConditionTag.VIS:  ["visib", "fog", "haze", "mist", "smoke"],
+    ConditionTag.OPS:  ["fuel", "notam", "currency", "aircraft", "personal", "passenger"],
+}
+
+
+def _build_pattern(phrases: list[str]) -> re.Pattern[str]:
+    """Build a single regex matching any phrase as a word-boundary fragment."""
+    escaped = sorted((re.escape(p) for p in phrases), key=len, reverse=True)
+    return re.compile(r"(?<!\w)(?:" + "|".join(escaped) + r")", re.IGNORECASE)
+
+
+_TAG_PATTERNS: dict[ConditionTag, re.Pattern[str]] = {
+    tag: _build_pattern(phrases) for tag, phrases in KEYWORD_MAP.items()
+}
+
+
+def match_tags_in_text(text: str) -> set[ConditionTag]:
+    """Scan ``text`` for keyword matches and return the matching tag set."""
+    if not text:
+        return set()
+    return {tag for tag, pattern in _TAG_PATTERNS.items() if pattern.search(text)}

--- a/src/weatherbrief/models/__init__.py
+++ b/src/weatherbrief/models/__init__.py
@@ -82,5 +82,7 @@ from weatherbrief.models.observations import (  # noqa: F401
 from weatherbrief.models.storage import (  # noqa: F401
     BriefingPackMeta,
     Flight,
+    FlightDebrief,
     FlightProfile,
+    NOTE_MAX_LEN,
 )

--- a/src/weatherbrief/models/storage.py
+++ b/src/weatherbrief/models/storage.py
@@ -5,7 +5,14 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Optional
 
-from pydantic import BaseModel, Field, computed_field
+from pydantic import BaseModel, Field, computed_field, field_validator, model_validator
+
+from weatherbrief.debriefs.taxonomy import (
+    OUTCOME_CATEGORIES,
+    ConditionTag,
+    Decision,
+    OutcomeValue,
+)
 
 
 class FlightProfile(BaseModel):
@@ -80,3 +87,69 @@ class BriefingPackMeta(BaseModel):
     def is_historical(self) -> bool:
         """True when the briefing was generated for a past departure date."""
         return self.days_out < 0
+
+
+NOTE_MAX_LEN = 300
+
+
+class FlightDebrief(BaseModel):
+    """Pilot post-flight judgement against one flight.
+
+    Outcomes-dict keys are the categories that were *queried* at debrief
+    time (those with an advisory raised on the briefing); values default to
+    ``CONSISTENT``. Categories absent from the dict were not queried — they
+    do not count toward per-category accuracy stats.
+    """
+
+    flight_id: str
+    decision: Decision
+    reasons: list[ConditionTag] = Field(default_factory=list)
+    outcomes: dict[ConditionTag, OutcomeValue] = Field(default_factory=dict)
+    note: str | None = None
+    created_at: datetime
+    updated_at: datetime
+
+    @field_validator("reasons", mode="before")
+    @classmethod
+    def _dedupe_reasons(cls, v):
+        if isinstance(v, list):
+            seen: set = set()
+            out: list = []
+            for item in v:
+                key = item.value if isinstance(item, ConditionTag) else item
+                if key not in seen:
+                    seen.add(key)
+                    out.append(item)
+            return out
+        return v
+
+    @field_validator("note")
+    @classmethod
+    def _note_length(cls, v: str | None) -> str | None:
+        if v is None:
+            return None
+        v = v.strip()
+        if not v:
+            return None
+        if len(v) > NOTE_MAX_LEN:
+            raise ValueError(f"note must be at most {NOTE_MAX_LEN} characters")
+        return v
+
+    @model_validator(mode="after")
+    def _decision_shape(self) -> FlightDebrief:
+        if self.decision is Decision.FLOWN and self.reasons:
+            raise ValueError("reasons must be empty when decision is 'flown'")
+        if self.decision is Decision.CANCELLED and self.outcomes:
+            raise ValueError("outcomes must be empty when decision is 'cancelled'")
+        if self.decision is Decision.MONITORING:
+            # Monitoring flights aren't real go/no-go decisions, so neither
+            # field has meaning. Note is still allowed (pilot may want to
+            # remember why they set it up).
+            if self.reasons:
+                raise ValueError("reasons must be empty when decision is 'monitoring'")
+            if self.outcomes:
+                raise ValueError("outcomes must be empty when decision is 'monitoring'")
+        for tag in self.outcomes:
+            if tag not in OUTCOME_CATEGORIES:
+                raise ValueError(f"{tag.value} is not a valid outcome category")
+        return self

--- a/src/weatherbrief/storage/debriefs.py
+++ b/src/weatherbrief/storage/debriefs.py
@@ -1,0 +1,146 @@
+"""Flight debrief storage — sidecar table CRUD."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from weatherbrief.db.models import FlightDebriefRow, FlightRow
+from weatherbrief.debriefs.taxonomy import ConditionTag, Decision, OutcomeValue
+from weatherbrief.models import FlightDebrief
+
+
+def _row_to_model(row: FlightDebriefRow) -> FlightDebrief:
+    reasons: list[ConditionTag] = []
+    if row.reasons_json:
+        reasons = [ConditionTag(t) for t in json.loads(row.reasons_json)]
+
+    outcomes: dict[ConditionTag, OutcomeValue] = {}
+    if row.outcomes_json:
+        raw = json.loads(row.outcomes_json)
+        outcomes = {ConditionTag(k): OutcomeValue(v) for k, v in raw.items()}
+
+    return FlightDebrief(
+        flight_id=row.flight_id,
+        decision=Decision(row.decision),
+        reasons=reasons,
+        outcomes=outcomes,
+        note=row.note,
+        created_at=row.created_at if row.created_at.tzinfo else row.created_at.replace(tzinfo=timezone.utc),
+        updated_at=row.updated_at if row.updated_at.tzinfo else row.updated_at.replace(tzinfo=timezone.utc),
+    )
+
+
+def get_debrief(db: Session, flight_id: str) -> FlightDebrief | None:
+    """Load the debrief for a flight, or None if absent."""
+    row = db.get(FlightDebriefRow, flight_id)
+    return _row_to_model(row) if row else None
+
+
+def upsert_debrief(
+    db: Session,
+    *,
+    flight_id: str,
+    decision: Decision,
+    reasons: list[ConditionTag] | None = None,
+    outcomes: dict[ConditionTag, OutcomeValue] | None = None,
+    note: str | None = None,
+) -> FlightDebrief:
+    """Insert or replace the debrief for a flight.
+
+    On insert, ``created_at`` and ``updated_at`` are set to now.
+    On update, ``created_at`` is preserved and ``updated_at`` is bumped.
+    The Pydantic ``FlightDebrief`` is rebuilt for validation before write.
+    """
+    reasons_list = reasons or []
+    outcomes_dict = outcomes or {}
+
+    now = datetime.now(timezone.utc)
+    row = db.get(FlightDebriefRow, flight_id)
+
+    # Rebuild via the Pydantic model to enforce all decision-shape invariants
+    # (reasons-only-for-cancel, outcomes-only-for-flown, note length, etc.).
+    validated = FlightDebrief(
+        flight_id=flight_id,
+        decision=decision,
+        reasons=reasons_list,
+        outcomes=outcomes_dict,
+        note=note,
+        created_at=row.created_at if row else now,
+        updated_at=now,
+    )
+
+    reasons_json = json.dumps([t.value for t in validated.reasons]) if validated.reasons else None
+    outcomes_json = (
+        json.dumps({k.value: v.value for k, v in validated.outcomes.items()})
+        if validated.outcomes
+        else None
+    )
+
+    if row is None:
+        row = FlightDebriefRow(
+            flight_id=flight_id,
+            decision=validated.decision.value,
+            reasons_json=reasons_json,
+            outcomes_json=outcomes_json,
+            note=validated.note,
+            created_at=now,
+            updated_at=now,
+        )
+        db.add(row)
+    else:
+        row.decision = validated.decision.value
+        row.reasons_json = reasons_json
+        row.outcomes_json = outcomes_json
+        row.note = validated.note
+        row.updated_at = now
+
+    db.flush()
+    return _row_to_model(row)
+
+
+def delete_debrief(db: Session, flight_id: str) -> bool:
+    """Delete the debrief for a flight. Returns True if a row was removed."""
+    row = db.get(FlightDebriefRow, flight_id)
+    if row is None:
+        return False
+    db.delete(row)
+    db.flush()
+    return True
+
+
+def list_debriefs_for_user(
+    db: Session,
+    user_id: str,
+    *,
+    since: datetime | None = None,
+) -> list[FlightDebrief]:
+    """Load all debriefs owned by a user, optionally filtered by created_at >= since."""
+    stmt = (
+        select(FlightDebriefRow)
+        .join(FlightRow, FlightDebriefRow.flight_id == FlightRow.id)
+        .where(FlightRow.user_id == user_id)
+    )
+    if since is not None:
+        stmt = stmt.where(FlightDebriefRow.created_at >= since)
+    rows = db.execute(stmt).scalars().all()
+    return [_row_to_model(r) for r in rows]
+
+
+def list_debriefed_flight_ids(db: Session) -> set[str]:
+    """All flight IDs that have a debrief — used by retention exemption."""
+    rows = db.execute(select(FlightDebriefRow.flight_id)).scalars().all()
+    return set(rows)
+
+
+def bulk_get_debriefs(db: Session, flight_ids: list[str]) -> dict[str, FlightDebrief]:
+    """Load debriefs for a list of flight IDs in one query."""
+    if not flight_ids:
+        return {}
+    rows = db.execute(
+        select(FlightDebriefRow).where(FlightDebriefRow.flight_id.in_(flight_ids))
+    ).scalars().all()
+    return {r.flight_id: _row_to_model(r) for r in rows}

--- a/src/weatherbrief/tasks/retention.py
+++ b/src/weatherbrief/tasks/retention.py
@@ -25,6 +25,7 @@ from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
 from weatherbrief.db.models import BriefingPackRow, BriefingUsageRow, FlightRow, PirepRow, UserRow
+from weatherbrief.storage.debriefs import list_debriefed_flight_ids
 
 logger = logging.getLogger(__name__)
 
@@ -91,6 +92,11 @@ def run_retention(db: Session, config: RetentionConfig | None = None) -> Retenti
         ).scalars().all()
     )
 
+    # Flight IDs with a debrief — exempt all of their packs from T2 (the
+    # lightweight briefing.json is what calibration needs; T1 still strips
+    # heavy artifacts to save disk).
+    debriefed_flight_ids = list_debriefed_flight_ids(db)
+
     # Query all packs joined to their flight (for departure_time + user_id).
     stmt = (
         select(BriefingPackRow, FlightRow.departure_time, FlightRow.user_id)
@@ -109,11 +115,12 @@ def run_retention(db: Session, config: RetentionConfig | None = None) -> Retenti
 
         inactive = user_id in inactive_user_ids
         t2_days = config.t2_inactive_days if inactive else config.t2_active_days
+        is_debriefed = pack.flight_id in debriefed_flight_ids
 
         try:
             pack_dir = Path(pack.artifact_path) if pack.artifact_path else None
 
-            if age_days >= t2_days:
+            if age_days >= t2_days and not is_debriefed:
                 freed = _purge_full_pack(pack, pack_dir, config.dry_run)
                 stats.packs_t2 += 1
                 stats.bytes_freed += freed

--- a/tests/test_debrief_api.py
+++ b/tests/test_debrief_api.py
@@ -1,0 +1,280 @@
+"""Tests for /api/flights/{id}/debrief and /api/debriefs/stats."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import sessionmaker
+
+from flyfun_common.db import current_user_id, get_db, DEV_USER_ID
+from flyfun_common.db.models import UserPreferencesRow, UserRow
+from weatherbrief.api.app import create_app
+from weatherbrief.models import Flight
+from weatherbrief.storage.flights import save_flight
+
+
+_NOW = datetime.now(timezone.utc)
+
+
+@pytest.fixture
+def app_db():
+    from conftest import make_app_engine
+    engine = make_app_engine()
+    TestSession = sessionmaker(bind=engine)
+    s = TestSession()
+    s.add(UserRow(
+        id=DEV_USER_ID, provider="local", provider_sub="dev",
+        email="dev@localhost", display_name="Dev", approved=True,
+    ))
+    s.flush()
+    s.add(UserPreferencesRow(user_id=DEV_USER_ID))
+    s.commit()
+    s.close()
+    yield TestSession
+    engine.dispose()
+
+
+@pytest.fixture
+def client(app_db, tmp_path, monkeypatch):
+    monkeypatch.setenv("DATA_DIR", str(tmp_path / "data"))
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.setenv("JWT_SECRET", "test")
+    app = create_app()
+
+    def _override_get_db():
+        s = app_db()
+        try:
+            yield s
+            s.commit()
+        except Exception:
+            s.rollback()
+            raise
+        finally:
+            s.close()
+
+    app.dependency_overrides[get_db] = _override_get_db
+    app.dependency_overrides[current_user_id] = lambda: DEV_USER_ID
+
+    return TestClient(app, raise_server_exceptions=False)
+
+
+@pytest.fixture
+def past_flight(app_db):
+    """A flight in the past — admin/dev rules don't bite this fixture path."""
+    s = app_db()
+    dep = _NOW - timedelta(days=3)
+    h = hashlib.sha256(json.dumps(
+        {"alt": 8000, "ceil": 18000, "dur": 1.0, "time": dep.strftime("%H:%M"), "user": DEV_USER_ID},
+        sort_keys=True,
+    ).encode()).hexdigest()[:4]
+    flight = Flight(
+        id=f"egtk_lfat-{dep.strftime('%Y-%m-%d')}-{h}",
+        user_id=DEV_USER_ID,
+        route_name="egtk_lfat",
+        waypoints=["EGTK", "LFAT"],
+        departure_time=dep,
+        cruise_altitude_ft=8000,
+        flight_ceiling_ft=18000,
+        flight_duration_hours=1.0,
+        created_at=_NOW - timedelta(days=10),
+    )
+    save_flight(s, flight, DEV_USER_ID)
+    s.commit()
+    s.close()
+    return flight
+
+
+class TestDebriefCRUDApi:
+    def test_get_404_when_absent(self, client, past_flight):
+        r = client.get(f"/api/flights/{past_flight.id}/debrief")
+        assert r.status_code == 404
+
+    def test_put_creates_cancelled(self, client, past_flight):
+        r = client.put(
+            f"/api/flights/{past_flight.id}/debrief",
+            json={"decision": "cancelled", "reasons": ["IMC", "WIND"], "note": "too windy"},
+        )
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["decision"] == "cancelled"
+        assert set(body["reasons"]) == {"IMC", "WIND"}
+        assert body["outcomes"] == {}
+        assert body["note"] == "too windy"
+        assert body["created_at"]
+        assert body["updated_at"]
+
+    def test_put_creates_flown(self, client, past_flight):
+        r = client.put(
+            f"/api/flights/{past_flight.id}/debrief",
+            json={
+                "decision": "flown",
+                "outcomes": {"ICE": "worse", "IMC": "consistent"},
+                "note": "more icing than forecast",
+            },
+        )
+        assert r.status_code == 200
+        body = r.json()
+        assert body["outcomes"] == {"ICE": "worse", "IMC": "consistent"}
+        assert body["reasons"] == []
+
+    def test_put_creates_monitoring(self, client, past_flight):
+        r = client.put(
+            f"/api/flights/{past_flight.id}/debrief",
+            json={"decision": "monitoring", "note": "weather watch only"},
+        )
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["decision"] == "monitoring"
+        assert body["reasons"] == []
+        assert body["outcomes"] == {}
+        assert body["note"] == "weather watch only"
+
+    def test_put_monitoring_with_reasons_rejected(self, client, past_flight):
+        r = client.put(
+            f"/api/flights/{past_flight.id}/debrief",
+            json={"decision": "monitoring", "reasons": ["IMC"]},
+        )
+        assert r.status_code == 422
+
+    def test_put_monitoring_with_outcomes_rejected(self, client, past_flight):
+        r = client.put(
+            f"/api/flights/{past_flight.id}/debrief",
+            json={"decision": "monitoring", "outcomes": {"ICE": "worse"}},
+        )
+        assert r.status_code == 422
+
+    def test_put_then_get(self, client, past_flight):
+        client.put(
+            f"/api/flights/{past_flight.id}/debrief",
+            json={"decision": "cancelled", "reasons": ["IMC"]},
+        )
+        r = client.get(f"/api/flights/{past_flight.id}/debrief")
+        assert r.status_code == 200
+        assert r.json()["decision"] == "cancelled"
+
+    def test_put_replaces_decision(self, client, past_flight):
+        client.put(
+            f"/api/flights/{past_flight.id}/debrief",
+            json={"decision": "cancelled", "reasons": ["IMC"]},
+        )
+        r = client.put(
+            f"/api/flights/{past_flight.id}/debrief",
+            json={"decision": "flown", "outcomes": {"ICE": "consistent"}},
+        )
+        assert r.status_code == 200
+        assert r.json()["decision"] == "flown"
+        assert r.json()["reasons"] == []
+
+    def test_delete(self, client, past_flight):
+        client.put(
+            f"/api/flights/{past_flight.id}/debrief",
+            json={"decision": "cancelled", "reasons": ["IMC"]},
+        )
+        r = client.delete(f"/api/flights/{past_flight.id}/debrief")
+        assert r.status_code == 204
+        assert client.get(f"/api/flights/{past_flight.id}/debrief").status_code == 404
+
+    def test_delete_idempotent(self, client, past_flight):
+        # Never created — DELETE still returns 204.
+        r = client.delete(f"/api/flights/{past_flight.id}/debrief")
+        assert r.status_code == 204
+
+
+class TestValidationErrors:
+    def test_reasons_with_flown_rejected(self, client, past_flight):
+        r = client.put(
+            f"/api/flights/{past_flight.id}/debrief",
+            json={"decision": "flown", "reasons": ["IMC"]},
+        )
+        assert r.status_code == 422
+
+    def test_outcomes_with_cancelled_rejected(self, client, past_flight):
+        r = client.put(
+            f"/api/flights/{past_flight.id}/debrief",
+            json={"decision": "cancelled", "outcomes": {"ICE": "worse"}},
+        )
+        assert r.status_code == 422
+
+    def test_unknown_tag_rejected(self, client, past_flight):
+        r = client.put(
+            f"/api/flights/{past_flight.id}/debrief",
+            json={"decision": "cancelled", "reasons": ["BANANA"]},
+        )
+        assert r.status_code == 422
+
+
+class TestOwnership:
+    def test_unknown_flight_404(self, client):
+        r = client.get("/api/flights/nope-2026-01-01-aaaa/debrief")
+        assert r.status_code == 404
+
+    def test_put_unknown_flight_404(self, client):
+        r = client.put(
+            "/api/flights/nope-2026-01-01-aaaa/debrief",
+            json={"decision": "cancelled", "reasons": ["IMC"]},
+        )
+        assert r.status_code == 404
+
+
+class TestStatsEndpoint:
+    def test_empty_stats(self, client):
+        r = client.get("/api/debriefs/stats")
+        assert r.status_code == 200
+        body = r.json()
+        assert body["window_days"] == 90
+        assert body["flown_count"] == 0
+        assert body["cancelled_count"] == 0
+
+    def test_stats_after_debriefs(self, client, past_flight):
+        client.put(
+            f"/api/flights/{past_flight.id}/debrief",
+            json={"decision": "cancelled", "reasons": ["IMC", "WIND"]},
+        )
+        r = client.get("/api/debriefs/stats")
+        body = r.json()
+        assert body["cancelled_count"] == 1
+        assert body["cancellation_reasons"]["IMC"] == 1
+        assert body["cancellation_reasons"]["WIND"] == 1
+
+    def test_window_days_query(self, client, past_flight):
+        # 30d window: the past_flight (3d ago) is in window.
+        r = client.get("/api/debriefs/stats?window_days=30")
+        assert r.status_code == 200
+        assert r.json()["window_days"] == 30
+        assert r.json()["pending_debrief_count"] == 1
+
+    def test_window_days_bounds(self, client):
+        assert client.get("/api/debriefs/stats?window_days=0").status_code == 422
+        assert client.get("/api/debriefs/stats?window_days=99999").status_code == 422
+
+    def test_monitoring_in_stats(self, client, past_flight):
+        client.put(
+            f"/api/flights/{past_flight.id}/debrief",
+            json={"decision": "monitoring", "note": "weather watch"},
+        )
+        body = client.get("/api/debriefs/stats").json()
+        assert body["monitoring_count"] == 1
+        assert body["flown_count"] == 0
+        assert body["cancelled_count"] == 0
+        assert body["pending_debrief_count"] == 0
+
+
+class TestSectionMonitoring:
+    def test_monitoring_drops_out_of_recent(self, client, past_flight):
+        # Before debrief: flight is in recent (it's a past undebriefed flight).
+        body = client.get("/api/flights").json()
+        rec = next(f for f in body if f["id"] == past_flight.id)
+        assert rec["section"] == "recent"
+
+        # After monitoring debrief: flight moves to past.
+        client.put(
+            f"/api/flights/{past_flight.id}/debrief",
+            json={"decision": "monitoring"},
+        )
+        body = client.get("/api/flights").json()
+        rec = next(f for f in body if f["id"] == past_flight.id)
+        assert rec["section"] == "past"

--- a/tests/test_debrief_stats.py
+++ b/tests/test_debrief_stats.py
@@ -1,0 +1,185 @@
+"""Tests for the debrief stats aggregator."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from weatherbrief.debriefs.stats import compute_stats
+from weatherbrief.debriefs.taxonomy import ConditionTag, Decision, OutcomeValue
+from weatherbrief.models import Flight, FlightDebrief
+
+
+NOW = datetime(2026, 4, 25, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _flight(idx: int, days_ago: int) -> Flight:
+    dep = NOW - timedelta(days=days_ago)
+    return Flight(
+        id=f"flt-{idx}",
+        user_id="u1",
+        route_name=f"r{idx}",
+        departure_time=dep,
+        cruise_altitude_ft=8000,
+        flight_duration_hours=1.0,
+        created_at=dep - timedelta(days=1),
+    )
+
+
+def _debrief(
+    flight: Flight,
+    decision: Decision,
+    *,
+    reasons=None,
+    outcomes=None,
+) -> FlightDebrief:
+    return FlightDebrief(
+        flight_id=flight.id,
+        decision=decision,
+        reasons=reasons or [],
+        outcomes=outcomes or {},
+        created_at=flight.departure_time + timedelta(hours=2),
+        updated_at=flight.departure_time + timedelta(hours=2),
+    )
+
+
+class TestStatsBasics:
+    def test_empty(self):
+        s = compute_stats([], [], now=NOW)
+        assert s.flown_count == 0
+        assert s.cancelled_count == 0
+        assert s.pending_debrief_count == 0
+        assert s.total_flights_in_window == 0
+
+    def test_future_flights_excluded(self):
+        future = Flight(
+            id="future",
+            user_id="u1",
+            route_name="r",
+            departure_time=NOW + timedelta(days=1),
+            cruise_altitude_ft=8000,
+            flight_duration_hours=1.0,
+            created_at=NOW,
+        )
+        s = compute_stats([future], [], now=NOW)
+        assert s.total_flights_in_window == 0
+
+    def test_window_filter(self):
+        old = _flight(1, days_ago=200)  # outside default 90d window
+        recent = _flight(2, days_ago=10)
+        s = compute_stats([old, recent], [], now=NOW)
+        assert s.total_flights_in_window == 1
+
+    def test_pending_count(self):
+        f1 = _flight(1, days_ago=10)
+        f2 = _flight(2, days_ago=20)
+        s = compute_stats([f1, f2], [], now=NOW)
+        assert s.pending_debrief_count == 2
+
+
+class TestCancellationStats:
+    def test_cancellation_reasons_aggregate(self):
+        f1 = _flight(1, days_ago=5)
+        f2 = _flight(2, days_ago=10)
+        f3 = _flight(3, days_ago=15)
+        debriefs = [
+            _debrief(f1, Decision.CANCELLED, reasons=[ConditionTag.IMC, ConditionTag.WIND]),
+            _debrief(f2, Decision.CANCELLED, reasons=[ConditionTag.IMC]),
+            _debrief(f3, Decision.CANCELLED, reasons=[ConditionTag.OPS]),
+        ]
+        s = compute_stats([f1, f2, f3], debriefs, now=NOW)
+        assert s.cancelled_count == 3
+        assert s.cancellation_reasons[ConditionTag.IMC] == 2
+        assert s.cancellation_reasons[ConditionTag.WIND] == 1
+        assert s.cancellation_reasons[ConditionTag.OPS] == 1
+
+    def test_ops_excluded_from_accuracy(self):
+        # OPS-only cancellation must not influence category_accuracy.
+        f = _flight(1, days_ago=5)
+        d = _debrief(f, Decision.CANCELLED, reasons=[ConditionTag.OPS])
+        s = compute_stats([f], [d], now=NOW)
+        assert s.category_accuracy == {}
+
+
+class TestMonitoringStats:
+    def test_monitoring_counted_separately(self):
+        f1 = _flight(1, days_ago=5)
+        f2 = _flight(2, days_ago=10)
+        debriefs = [
+            _debrief(f1, Decision.MONITORING),
+            _debrief(f2, Decision.FLOWN),
+        ]
+        s = compute_stats([f1, f2], debriefs, now=NOW)
+        assert s.monitoring_count == 1
+        assert s.flown_count == 1
+        assert s.cancelled_count == 0
+        assert s.pending_debrief_count == 0
+
+    def test_monitoring_excluded_from_reasons_and_accuracy(self):
+        f = _flight(1, days_ago=5)
+        # Stats input must come from validated FlightDebrief models, but a
+        # belt-and-braces test on the aggregator: even if a monitoring
+        # debrief somehow had reasons or outcomes, the aggregator wouldn't
+        # touch them. Test by passing a flown alongside.
+        debriefs = [_debrief(f, Decision.MONITORING)]
+        s = compute_stats([f], debriefs, now=NOW)
+        assert s.cancellation_reasons == {}
+        assert s.category_accuracy == {}
+
+    def test_monitoring_does_not_count_as_pending(self):
+        # Three flights — one monitoring, two pending → pending=2 not 3.
+        f1, f2, f3 = _flight(1, 1), _flight(2, 2), _flight(3, 3)
+        debriefs = [_debrief(f1, Decision.MONITORING)]
+        s = compute_stats([f1, f2, f3], debriefs, now=NOW)
+        assert s.monitoring_count == 1
+        assert s.pending_debrief_count == 2
+
+
+class TestCategoryAccuracy:
+    def test_basic_aggregation(self):
+        f1, f2, f3 = _flight(1, 5), _flight(2, 10), _flight(3, 20)
+        debriefs = [
+            _debrief(f1, Decision.FLOWN, outcomes={
+                ConditionTag.ICE: OutcomeValue.CONSISTENT,
+                ConditionTag.IMC: OutcomeValue.WORSE,
+            }),
+            _debrief(f2, Decision.FLOWN, outcomes={
+                ConditionTag.ICE: OutcomeValue.WORSE,
+            }),
+            _debrief(f3, Decision.FLOWN, outcomes={
+                ConditionTag.ICE: OutcomeValue.BETTER,
+            }),
+        ]
+        s = compute_stats([f1, f2, f3], debriefs, now=NOW)
+        ice = s.category_accuracy[ConditionTag.ICE]
+        assert ice.queried_count == 3
+        assert ice.consistent == 1
+        assert ice.better == 1
+        assert ice.worse == 1
+
+        imc = s.category_accuracy[ConditionTag.IMC]
+        assert imc.queried_count == 1
+        assert imc.worse == 1
+
+    def test_unqueried_categories_pruned(self):
+        # If no flight queries TURB, it shouldn't appear in the dict.
+        f = _flight(1, 5)
+        d = _debrief(f, Decision.FLOWN, outcomes={ConditionTag.ICE: OutcomeValue.CONSISTENT})
+        s = compute_stats([f], [d], now=NOW)
+        assert ConditionTag.ICE in s.category_accuracy
+        assert ConditionTag.TURB not in s.category_accuracy
+
+
+class TestWindowSelector:
+    def test_custom_window_30d(self):
+        old = _flight(1, days_ago=60)  # outside 30d
+        recent = _flight(2, days_ago=10)
+        s = compute_stats([old, recent], [], window_days=30, now=NOW)
+        assert s.total_flights_in_window == 1
+        assert s.window_days == 30
+
+    def test_window_365d(self):
+        flights = [_flight(i, days_ago=300) for i in range(3)]
+        s = compute_stats(flights, [], window_days=365, now=NOW)
+        assert s.total_flights_in_window == 3

--- a/tests/test_debrief_storage.py
+++ b/tests/test_debrief_storage.py
@@ -1,0 +1,258 @@
+"""Tests for flight_debriefs storage (DB-backed)."""
+
+from __future__ import annotations
+
+import time
+from datetime import datetime, timezone
+
+import pytest
+from pydantic import ValidationError
+
+from flyfun_common.db import DEV_USER_ID
+from weatherbrief.debriefs.taxonomy import ConditionTag, Decision, OutcomeValue
+from weatherbrief.models import Flight
+from weatherbrief.storage.debriefs import (
+    delete_debrief,
+    get_debrief,
+    list_debriefed_flight_ids,
+    list_debriefs_for_user,
+    upsert_debrief,
+)
+from weatherbrief.storage.flights import save_flight
+
+
+@pytest.fixture
+def sample_flight():
+    return Flight(
+        id="egtk_lsgs-2026-02-21",
+        user_id=DEV_USER_ID,
+        route_name="egtk_lsgs",
+        departure_time=datetime(2026, 2, 21, 9, tzinfo=timezone.utc),
+        cruise_altitude_ft=8000,
+        flight_duration_hours=4.5,
+        created_at=datetime(2026, 2, 14, 10, 0, 0, tzinfo=timezone.utc),
+    )
+
+
+@pytest.fixture
+def saved_flight(db_session, dev_user, sample_flight):
+    save_flight(db_session, sample_flight, dev_user)
+    return sample_flight
+
+
+class TestDebriefCRUD:
+    def test_get_returns_none_when_absent(self, db_session, saved_flight):
+        assert get_debrief(db_session, saved_flight.id) is None
+
+    def test_insert_cancelled(self, db_session, saved_flight):
+        d = upsert_debrief(
+            db_session,
+            flight_id=saved_flight.id,
+            decision=Decision.CANCELLED,
+            reasons=[ConditionTag.IMC, ConditionTag.WIND],
+            note="too windy at LFAT",
+        )
+        assert d.flight_id == saved_flight.id
+        assert d.decision is Decision.CANCELLED
+        assert set(d.reasons) == {ConditionTag.IMC, ConditionTag.WIND}
+        assert d.outcomes == {}
+        assert d.note == "too windy at LFAT"
+
+        loaded = get_debrief(db_session, saved_flight.id)
+        assert loaded is not None
+        assert loaded.decision is Decision.CANCELLED
+        assert set(loaded.reasons) == {ConditionTag.IMC, ConditionTag.WIND}
+
+    def test_insert_flown(self, db_session, saved_flight):
+        d = upsert_debrief(
+            db_session,
+            flight_id=saved_flight.id,
+            decision=Decision.FLOWN,
+            outcomes={
+                ConditionTag.ICE: OutcomeValue.WORSE,
+                ConditionTag.IMC: OutcomeValue.CONSISTENT,
+            },
+            note="more icing than forecast around FL080",
+        )
+        assert d.decision is Decision.FLOWN
+        assert d.outcomes[ConditionTag.ICE] is OutcomeValue.WORSE
+        assert d.outcomes[ConditionTag.IMC] is OutcomeValue.CONSISTENT
+        assert d.reasons == []
+
+    def test_update_replaces_fields(self, db_session, saved_flight):
+        first = upsert_debrief(
+            db_session,
+            flight_id=saved_flight.id,
+            decision=Decision.CANCELLED,
+            reasons=[ConditionTag.IMC],
+        )
+        time.sleep(0.01)  # ensure updated_at advances on systems with coarse clocks
+        second = upsert_debrief(
+            db_session,
+            flight_id=saved_flight.id,
+            decision=Decision.CANCELLED,
+            reasons=[ConditionTag.WIND, ConditionTag.TS],
+            note="storm coming through",
+        )
+        assert set(second.reasons) == {ConditionTag.WIND, ConditionTag.TS}
+        assert second.note == "storm coming through"
+        assert second.created_at == first.created_at  # preserved
+        assert second.updated_at >= first.updated_at  # bumped
+
+    def test_decision_change_clears_other_field(self, db_session, saved_flight):
+        # Cancelled → flown: reasons must clear, outcomes can be set.
+        upsert_debrief(
+            db_session,
+            flight_id=saved_flight.id,
+            decision=Decision.CANCELLED,
+            reasons=[ConditionTag.IMC],
+        )
+        flown = upsert_debrief(
+            db_session,
+            flight_id=saved_flight.id,
+            decision=Decision.FLOWN,
+            outcomes={ConditionTag.ICE: OutcomeValue.BETTER},
+        )
+        assert flown.reasons == []
+        assert flown.outcomes[ConditionTag.ICE] is OutcomeValue.BETTER
+
+    def test_delete(self, db_session, saved_flight):
+        upsert_debrief(
+            db_session,
+            flight_id=saved_flight.id,
+            decision=Decision.CANCELLED,
+            reasons=[ConditionTag.IMC],
+        )
+        assert delete_debrief(db_session, saved_flight.id) is True
+        assert get_debrief(db_session, saved_flight.id) is None
+        # Idempotent: second delete returns False.
+        assert delete_debrief(db_session, saved_flight.id) is False
+
+
+class TestValidation:
+    def test_reasons_with_flown_rejected(self, db_session, saved_flight):
+        with pytest.raises(ValidationError):
+            upsert_debrief(
+                db_session,
+                flight_id=saved_flight.id,
+                decision=Decision.FLOWN,
+                reasons=[ConditionTag.IMC],
+            )
+
+    def test_outcomes_with_cancelled_rejected(self, db_session, saved_flight):
+        with pytest.raises(ValidationError):
+            upsert_debrief(
+                db_session,
+                flight_id=saved_flight.id,
+                decision=Decision.CANCELLED,
+                outcomes={ConditionTag.ICE: OutcomeValue.WORSE},
+            )
+
+    def test_monitoring_with_reasons_rejected(self, db_session, saved_flight):
+        with pytest.raises(ValidationError):
+            upsert_debrief(
+                db_session,
+                flight_id=saved_flight.id,
+                decision=Decision.MONITORING,
+                reasons=[ConditionTag.IMC],
+            )
+
+    def test_monitoring_with_outcomes_rejected(self, db_session, saved_flight):
+        with pytest.raises(ValidationError):
+            upsert_debrief(
+                db_session,
+                flight_id=saved_flight.id,
+                decision=Decision.MONITORING,
+                outcomes={ConditionTag.ICE: OutcomeValue.WORSE},
+            )
+
+    def test_monitoring_with_note_only(self, db_session, saved_flight):
+        d = upsert_debrief(
+            db_session,
+            flight_id=saved_flight.id,
+            decision=Decision.MONITORING,
+            note="set up to watch the front move through",
+        )
+        assert d.decision is Decision.MONITORING
+        assert d.reasons == []
+        assert d.outcomes == {}
+        assert d.note == "set up to watch the front move through"
+
+    def test_ops_in_outcomes_rejected(self, db_session, saved_flight):
+        with pytest.raises(ValidationError):
+            upsert_debrief(
+                db_session,
+                flight_id=saved_flight.id,
+                decision=Decision.FLOWN,
+                outcomes={ConditionTag.OPS: OutcomeValue.WORSE},
+            )
+
+    def test_note_max_length(self, db_session, saved_flight):
+        with pytest.raises(ValidationError):
+            upsert_debrief(
+                db_session,
+                flight_id=saved_flight.id,
+                decision=Decision.CANCELLED,
+                reasons=[ConditionTag.IMC],
+                note="x" * 301,
+            )
+
+    def test_reasons_dedupe(self, db_session, saved_flight):
+        d = upsert_debrief(
+            db_session,
+            flight_id=saved_flight.id,
+            decision=Decision.CANCELLED,
+            reasons=[ConditionTag.IMC, ConditionTag.IMC, ConditionTag.WIND],
+        )
+        assert d.reasons.count(ConditionTag.IMC) == 1
+        assert d.reasons.count(ConditionTag.WIND) == 1
+
+
+class TestUserListing:
+    def test_list_for_user(self, db_session, dev_user, sample_flight):
+        save_flight(db_session, sample_flight, dev_user)
+        upsert_debrief(
+            db_session,
+            flight_id=sample_flight.id,
+            decision=Decision.FLOWN,
+            outcomes={ConditionTag.IMC: OutcomeValue.CONSISTENT},
+        )
+        debriefs = list_debriefs_for_user(db_session, dev_user)
+        assert len(debriefs) == 1
+        assert debriefs[0].flight_id == sample_flight.id
+
+    def test_list_filters_by_since(self, db_session, dev_user, sample_flight):
+        save_flight(db_session, sample_flight, dev_user)
+        upsert_debrief(
+            db_session,
+            flight_id=sample_flight.id,
+            decision=Decision.CANCELLED,
+            reasons=[ConditionTag.IMC],
+        )
+        # Future cutoff → no rows.
+        future = datetime.now(timezone.utc).replace(year=2099)
+        assert list_debriefs_for_user(db_session, dev_user, since=future) == []
+
+    def test_debriefed_ids_set(self, db_session, dev_user, sample_flight):
+        save_flight(db_session, sample_flight, dev_user)
+        assert list_debriefed_flight_ids(db_session) == set()
+        upsert_debrief(
+            db_session,
+            flight_id=sample_flight.id,
+            decision=Decision.CANCELLED,
+            reasons=[ConditionTag.IMC],
+        )
+        assert list_debriefed_flight_ids(db_session) == {sample_flight.id}
+
+    def test_cascade_on_flight_delete(self, db_session, dev_user, sample_flight):
+        from weatherbrief.storage.flights import delete_flight
+
+        save_flight(db_session, sample_flight, dev_user)
+        upsert_debrief(
+            db_session,
+            flight_id=sample_flight.id,
+            decision=Decision.CANCELLED,
+            reasons=[ConditionTag.IMC],
+        )
+        delete_flight(db_session, sample_flight.id)
+        assert list_debriefed_flight_ids(db_session) == set()

--- a/tests/test_debrief_taxonomy.py
+++ b/tests/test_debrief_taxonomy.py
@@ -1,0 +1,74 @@
+"""Tests for the debrief tag taxonomy + keyword matcher."""
+
+from __future__ import annotations
+
+import pytest
+
+from weatherbrief.debriefs.taxonomy import (
+    OUTCOME_CATEGORIES,
+    ConditionTag,
+    Decision,
+    OutcomeValue,
+    match_tags_in_text,
+)
+
+
+class TestEnums:
+    def test_decision_values(self):
+        assert Decision.CANCELLED.value == "cancelled"
+        assert Decision.FLOWN.value == "flown"
+
+    def test_outcome_values(self):
+        assert {v.value for v in OutcomeValue} == {"consistent", "better", "worse"}
+
+    def test_outcome_categories_excludes_ops(self):
+        assert ConditionTag.OPS not in OUTCOME_CATEGORIES
+        # All other tags are present
+        for t in ConditionTag:
+            if t is not ConditionTag.OPS:
+                assert t in OUTCOME_CATEGORIES
+
+
+class TestKeywordMatching:
+    def test_empty_text(self):
+        assert match_tags_in_text("") == set()
+        assert match_tags_in_text(None) == set()  # type: ignore[arg-type]
+
+    def test_single_keyword(self):
+        assert ConditionTag.ICE in match_tags_in_text("icing forecast at FL080")
+
+    def test_multiple_keywords(self):
+        tags = match_tags_in_text("icy and gusty crosswind, fog at destination")
+        assert ConditionTag.WIND in tags
+        assert ConditionTag.VIS in tags
+
+    def test_case_insensitive(self):
+        assert ConditionTag.IMC in match_tags_in_text("IMC FORECAST")
+        assert ConditionTag.IMC in match_tags_in_text("imc forecast")
+
+    def test_word_boundary(self):
+        # "ice" matches but "thrice" should NOT (word-boundary check)
+        assert ConditionTag.ICE in match_tags_in_text("ice on wings")
+        assert ConditionTag.ICE not in match_tags_in_text("thrice over")
+
+    def test_multi_word_phrase(self):
+        assert ConditionTag.FRZ in match_tags_in_text("freezing rain reported")
+        assert ConditionTag.IMC in match_tags_in_text("low ceiling all day")
+
+    def test_no_match(self):
+        assert match_tags_in_text("calm sunny CAVOK") == set()
+
+    def test_ops_keywords(self):
+        assert ConditionTag.OPS in match_tags_in_text("aircraft maintenance issue")
+        assert ConditionTag.OPS in match_tags_in_text("notam restricted")
+
+    @pytest.mark.parametrize("text,expected", [
+        ("thunderstorm activity", ConditionTag.TS),
+        ("turbulence at FL100", ConditionTag.TURB),
+        ("rough air", ConditionTag.TURB),
+        ("very gusty", ConditionTag.WIND),
+        ("dense fog", ConditionTag.VIS),
+        ("rime icing", ConditionTag.ICE),
+    ])
+    def test_phrases(self, text, expected):
+        assert expected in match_tags_in_text(text)

--- a/tests/test_flights_api_sections.py
+++ b/tests/test_flights_api_sections.py
@@ -1,0 +1,240 @@
+"""Tests for the future/recent/past section assignment in /api/flights."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import sessionmaker
+
+from flyfun_common.db import current_user_id, get_db, DEV_USER_ID
+from flyfun_common.db.models import UserPreferencesRow, UserRow
+from weatherbrief.api.app import create_app
+from weatherbrief.api.flights import _classify_section, _compute_recent_section
+from weatherbrief.debriefs.taxonomy import ConditionTag, Decision
+from weatherbrief.models import Flight, FlightDebrief
+from weatherbrief.storage.debriefs import upsert_debrief
+from weatherbrief.storage.flights import save_flight
+
+
+_NOW = datetime(2026, 4, 25, 12, 0, 0, tzinfo=timezone.utc)
+
+
+# --- Pure function tests for the section logic ---
+
+
+def _flt(idx: int, days_offset: int) -> Flight:
+    """Build a Flight whose departure is days_offset days from _NOW (positive = future)."""
+    dep = _NOW + timedelta(days=days_offset)
+    return Flight(
+        id=f"f-{idx}",
+        user_id="u",
+        route_name="r",
+        departure_time=dep,
+        cruise_altitude_ft=8000,
+        flight_duration_hours=1.0,
+        created_at=dep - timedelta(days=1),
+    )
+
+
+def _dbf(flight: Flight, decision: Decision) -> FlightDebrief:
+    return FlightDebrief(
+        flight_id=flight.id,
+        decision=decision,
+        reasons=[ConditionTag.IMC] if decision is Decision.CANCELLED else [],
+        outcomes={},
+        created_at=flight.departure_time,
+        updated_at=flight.departure_time,
+    )
+
+
+class TestComputeRecentSection:
+    def test_empty(self):
+        assert _compute_recent_section([], now=_NOW) == set()
+
+    def test_no_debriefs_takes_two_most_recent_past(self):
+        f1, f2, f3 = _flt(1, -1), _flt(2, -2), _flt(3, -3)
+        pairs = [(f1, None), (f2, None), (f3, None)]
+        recent = _compute_recent_section(pairs, now=_NOW)
+        assert recent == {f1.id, f2.id}
+
+    def test_debriefed_flight_does_not_push_others_out(self):
+        # Two recent undebriefed flights — both should appear regardless
+        # of any older debriefed flight, so debriefing one doesn't cause
+        # the other to vanish.
+        f_dbf = _flt(0, -3)  # debriefed
+        f1 = _flt(1, -1)     # undebriefed, recent → in recent
+        f2 = _flt(2, -2)     # undebriefed, recent → in recent
+        pairs = [(f_dbf, _dbf(f_dbf, Decision.FLOWN)), (f1, None), (f2, None)]
+        assert _compute_recent_section(pairs, now=_NOW) == {f1.id, f2.id}
+
+    def test_older_than_max_age_excluded(self):
+        # A flight from > 30 days ago drops to Past, not Recent.
+        old = _flt(1, -45)
+        recent = _flt(2, -2)
+        pairs = [(old, None), (recent, None)]
+        assert _compute_recent_section(pairs, now=_NOW) == {recent.id}
+
+    def test_all_undebriefed_but_too_old(self):
+        old1, old2 = _flt(1, -60), _flt(2, -100)
+        pairs = [(old1, None), (old2, None)]
+        assert _compute_recent_section(pairs, now=_NOW) == set()
+
+    def test_all_caught_up(self):
+        f1, f2 = _flt(1, -1), _flt(2, -2)
+        pairs = [(f1, _dbf(f1, Decision.FLOWN)), (f2, _dbf(f2, Decision.FLOWN))]
+        assert _compute_recent_section(pairs, now=_NOW) == set()
+
+    def test_cap_default_two(self):
+        # 4 undebriefed past flights all within window → only 2 most recent.
+        flights = [_flt(i, -i) for i in range(1, 5)]
+        pairs = [(f, None) for f in flights]
+        assert _compute_recent_section(pairs, now=_NOW) == {flights[0].id, flights[1].id}
+
+    def test_future_flights_never_recent(self):
+        future = _flt(1, +3)
+        past = _flt(2, -3)
+        pairs = [(future, None), (past, None)]
+        assert _compute_recent_section(pairs, now=_NOW) == {past.id}
+
+    def test_max_age_boundary_inclusive(self):
+        # Exactly at the cutoff (30 days ago) is in.
+        f = _flt(1, -30)
+        pairs = [(f, None)]
+        assert _compute_recent_section(pairs, now=_NOW) == {f.id}
+
+
+class TestClassifySection:
+    def test_future(self):
+        f = _flt(1, +1)
+        assert _classify_section(f, has_debrief=False, recent_set=set(), now=_NOW) == "future"
+
+    def test_recent(self):
+        f = _flt(1, -1)
+        assert _classify_section(f, has_debrief=False, recent_set={f.id}, now=_NOW) == "recent"
+
+    def test_past(self):
+        f = _flt(1, -10)
+        assert _classify_section(f, has_debrief=True, recent_set=set(), now=_NOW) == "past"
+
+    def test_past_undebriefed_outside_recent(self):
+        f = _flt(1, -100)
+        assert _classify_section(f, has_debrief=False, recent_set=set(), now=_NOW) == "past"
+
+
+# --- Integration test against the real API ---
+
+
+@pytest.fixture
+def app_db():
+    from conftest import make_app_engine
+    engine = make_app_engine()
+    TestSession = sessionmaker(bind=engine)
+    s = TestSession()
+    s.add(UserRow(
+        id=DEV_USER_ID, provider="local", provider_sub="dev",
+        email="d@l", display_name="D", approved=True,
+    ))
+    s.flush()
+    s.add(UserPreferencesRow(user_id=DEV_USER_ID))
+    s.commit()
+    s.close()
+    yield TestSession
+    engine.dispose()
+
+
+@pytest.fixture
+def client(app_db, tmp_path, monkeypatch):
+    monkeypatch.setenv("DATA_DIR", str(tmp_path / "data"))
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.setenv("JWT_SECRET", "test")
+    app = create_app()
+
+    def _override_get_db():
+        s = app_db()
+        try:
+            yield s
+            s.commit()
+        except Exception:
+            s.rollback()
+            raise
+        finally:
+            s.close()
+
+    app.dependency_overrides[get_db] = _override_get_db
+    app.dependency_overrides[current_user_id] = lambda: DEV_USER_ID
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def _save_flight(app_db, *, route: str, days_offset: int, idx: int) -> Flight:
+    s = app_db()
+    dep = datetime.now(timezone.utc) + timedelta(days=days_offset)
+    h = hashlib.sha256(json.dumps(
+        {"alt": 8000, "ceil": 18000, "dur": 1.0, "time": dep.strftime("%H:%M"),
+         "user": DEV_USER_ID, "idx": idx},
+        sort_keys=True,
+    ).encode()).hexdigest()[:4]
+    f = Flight(
+        id=f"{route}-{dep.strftime('%Y-%m-%d')}-{h}",
+        user_id=DEV_USER_ID,
+        route_name=route,
+        waypoints=["EGTK", "LFAT"],
+        departure_time=dep,
+        cruise_altitude_ft=8000,
+        flight_ceiling_ft=18000,
+        flight_duration_hours=1.0,
+        created_at=datetime.now(timezone.utc) - timedelta(days=30),
+    )
+    save_flight(s, f, DEV_USER_ID)
+    s.commit()
+    s.close()
+    return f
+
+
+class TestApiSections:
+    def test_listing_includes_section_field(self, client, app_db):
+        _save_flight(app_db, route="rt1", days_offset=+5, idx=1)
+        _save_flight(app_db, route="rt2", days_offset=-3, idx=2)
+        body = client.get("/api/flights").json()
+        sections = {f["section"] for f in body}
+        assert "future" in sections
+        assert "past" in sections or "recent" in sections
+
+    def test_listing_includes_debrief_field(self, client, app_db):
+        f = _save_flight(app_db, route="r", days_offset=-3, idx=10)
+        client.put(
+            f"/api/flights/{f.id}/debrief",
+            json={"decision": "cancelled", "reasons": ["IMC"]},
+        )
+        body = client.get("/api/flights").json()
+        rec = next(x for x in body if x["id"] == f.id)
+        assert rec["debrief"] is not None
+        assert rec["debrief"]["decision"] == "cancelled"
+
+    def test_recent_section_caps_at_two(self, client, app_db):
+        # Four past flights, none debriefed → 2 in recent, 2 in past.
+        for i in range(4):
+            _save_flight(app_db, route=f"r{i}", days_offset=-(i + 1), idx=i)
+        body = client.get("/api/flights").json()
+        sections = [f["section"] for f in body]
+        assert sections.count("recent") == 2
+        assert sections.count("past") == 2
+
+    def test_recent_excludes_debriefed_keeps_undebriefed(self, client, app_db):
+        # Debriefing one recent flight does NOT push the other recent
+        # undebriefed flight out of the section — both are within the
+        # 30-day window and the other is still pending a debrief.
+        new_f = _save_flight(app_db, route="rN", days_offset=-1, idx=1)
+        old_f = _save_flight(app_db, route="rO", days_offset=-5, idx=2)
+        client.put(
+            f"/api/flights/{new_f.id}/debrief",
+            json={"decision": "flown"},
+        )
+        body = client.get("/api/flights").json()
+        recent_ids = [f["id"] for f in body if f["section"] == "recent"]
+        assert old_f.id in recent_ids
+        # The debriefed one drops to past.
+        assert new_f.id not in recent_ids

--- a/tests/test_retention.py
+++ b/tests/test_retention.py
@@ -419,3 +419,97 @@ class TestRunRetention:
         assert stats.packs_t1 == 1
         assert stats.packs_t2 == 1
         assert stats.errors == 0
+
+
+class TestDebriefExemption:
+    """Flights with a debrief skip T2 entirely; T1 still applies."""
+
+    def _add_debrief(self, db_session, flight_id, decision="cancelled"):
+        from weatherbrief.debriefs.taxonomy import ConditionTag, Decision
+        from weatherbrief.storage.debriefs import upsert_debrief
+
+        upsert_debrief(
+            db_session,
+            flight_id=flight_id,
+            decision=Decision(decision),
+            reasons=[ConditionTag.IMC] if decision == "cancelled" else None,
+        )
+
+    def test_t2_age_pack_kept_when_debriefed(self, db_session, dev_user, tmp_path):
+        """A pack older than t2 with a debrief survives — only T1 applies."""
+        pack_dir = _make_pack_dir(tmp_path)
+        user = db_session.get(UserRow, dev_user)
+        user.last_login_at = _now()
+        _insert_flight(db_session, dev_user, departure_days_ago=200)
+        pack = _insert_pack(db_session, "flight-1", pack_dir)
+        pack_id = pack.id
+        self._add_debrief(db_session, "flight-1")
+
+        config = RetentionConfig(t1_days=30, t2_active_days=180, t2_inactive_days=90)
+        stats = run_retention(db_session, config)
+
+        # Pack row + dir survive (T2 skipped); heavy artifacts removed (T1 applied).
+        assert stats.packs_t2 == 0
+        assert stats.packs_t1 == 1
+        db_session.expire_all()
+        assert db_session.get(BriefingPackRow, pack_id) is not None
+        assert pack_dir.exists()
+        assert (pack_dir / "briefing.json").exists()
+        assert not (pack_dir / "cross_section.json").exists()
+
+    def test_t1_still_strips_when_debriefed(self, db_session, dev_user, tmp_path):
+        """At T1 age (no T2 yet), debriefed packs lose heavy artifacts as normal."""
+        pack_dir = _make_pack_dir(tmp_path)
+        user = db_session.get(UserRow, dev_user)
+        user.last_login_at = _now()
+        _insert_flight(db_session, dev_user, departure_days_ago=40)
+        _insert_pack(db_session, "flight-1", pack_dir)
+        self._add_debrief(db_session, "flight-1", decision="flown")
+
+        config = RetentionConfig(t1_days=30, t2_active_days=180, t2_inactive_days=90)
+        stats = run_retention(db_session, config)
+
+        assert stats.packs_t1 == 1
+        assert stats.packs_t2 == 0
+        assert not (pack_dir / "cross_section.json").exists()
+        assert (pack_dir / "briefing.json").exists()
+
+    def test_undebriefed_old_pack_still_purged(self, db_session, dev_user, tmp_path):
+        """Sanity: without a debrief, the same old pack still gets T2."""
+        pack_dir = _make_pack_dir(tmp_path)
+        user = db_session.get(UserRow, dev_user)
+        user.last_login_at = _now()
+        _insert_flight(db_session, dev_user, departure_days_ago=200)
+        pack = _insert_pack(db_session, "flight-1", pack_dir)
+        pack_id = pack.id
+
+        config = RetentionConfig(t1_days=30, t2_active_days=180, t2_inactive_days=90)
+        stats = run_retention(db_session, config)
+
+        assert stats.packs_t2 == 1
+        db_session.expire_all()
+        assert db_session.get(BriefingPackRow, pack_id) is None
+
+    def test_debrief_exempts_all_packs_for_flight(self, db_session, dev_user, tmp_path):
+        """Multiple packs (refreshes) for the same flight all survive T2."""
+        user = db_session.get(UserRow, dev_user)
+        user.last_login_at = _now()
+        _insert_flight(db_session, dev_user, departure_days_ago=200)
+
+        (tmp_path / "p1").mkdir()
+        (tmp_path / "p2").mkdir()
+        dir1 = _make_pack_dir(tmp_path / "p1")
+        dir2 = _make_pack_dir(tmp_path / "p2")
+        p1 = _insert_pack(db_session, "flight-1", dir1)
+        p2 = _insert_pack(db_session, "flight-1", dir2)
+        p1_id, p2_id = p1.id, p2.id
+
+        self._add_debrief(db_session, "flight-1")
+
+        config = RetentionConfig(t1_days=30, t2_active_days=180, t2_inactive_days=90)
+        stats = run_retention(db_session, config)
+
+        assert stats.packs_t2 == 0
+        db_session.expire_all()
+        assert db_session.get(BriefingPackRow, p1_id) is not None
+        assert db_session.get(BriefingPackRow, p2_id) is not None

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -4462,3 +4462,369 @@ label {
   font-size: 0.75rem;
   max-width: 280px;
 }
+
+/* --- Debrief --- */
+
+.recent-flights-section {
+  margin: 12px 0;
+}
+.recent-flights-toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  background: none;
+  border: none;
+  color: var(--amber);
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  cursor: pointer;
+  padding: 6px 8px;
+  margin-bottom: 0.25rem;
+}
+.recent-flights-toggle::before {
+  content: '\25BC';
+  font-size: 0.6rem;
+  transition: transform 0.15s;
+}
+.recent-flights-section.collapsed .recent-flights-toggle::before {
+  transform: rotate(-90deg);
+}
+.recent-flights-toggle:hover {
+  filter: brightness(1.1);
+}
+.recent-flights-section.collapsed .recent-flights-list {
+  display: none;
+}
+
+.debrief-stats-section {
+  margin: 16px 0;
+}
+
+.debrief-stats {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 12px 16px;
+  box-shadow: var(--shadow);
+}
+.debrief-stats-header {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 8px;
+}
+.debrief-stats-row {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+  padding: 6px 0;
+  border-top: 1px solid var(--border);
+}
+.debrief-stats-row:first-of-type { border-top: 0; }
+.debrief-stats-label {
+  flex: 0 0 130px;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: var(--text-muted);
+}
+.debrief-stats-value { flex: 1; }
+.debrief-stats-empty {
+  color: var(--text-muted);
+  font-style: italic;
+  font-size: 0.9rem;
+}
+.debrief-stats-reason {
+  display: inline-block;
+  padding: 2px 8px;
+  margin: 0 4px 4px 0;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  font-size: 0.85rem;
+}
+.debrief-stats-caveat {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  font-style: italic;
+  margin-top: 6px;
+}
+.debrief-acc-row {
+  display: grid;
+  grid-template-columns: 110px 1fr 100px;
+  gap: 8px;
+  align-items: center;
+  padding: 4px 0;
+}
+.debrief-acc-label { font-size: 0.85rem; }
+.debrief-acc-bar {
+  height: 14px;
+  background: var(--border);
+  border-radius: 7px;
+  overflow: hidden;
+  display: flex;
+}
+.debrief-acc-seg { display: block; height: 100%; }
+.debrief-acc-consistent { background: var(--green); }
+.debrief-acc-better { background: var(--primary); }
+.debrief-acc-worse { background: var(--red); }
+.debrief-acc-counts {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+.debrief-acc-count-consistent { color: var(--green); font-weight: 600; }
+.debrief-acc-count-better { color: var(--primary); font-weight: 600; }
+.debrief-acc-count-worse { color: var(--red); font-weight: 600; }
+
+/* Debrief pill (in flight rows + summary header) */
+.debrief-pill {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 10px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  vertical-align: middle;
+  white-space: nowrap;
+}
+.debrief-pill-pending {
+  background: var(--bg);
+  color: var(--text-muted);
+  border: 1px dashed var(--border);
+}
+.debrief-pill-cancelled {
+  background: var(--amber-bg);
+  color: var(--amber);
+}
+.debrief-pill-flown {
+  background: var(--green-bg);
+  color: var(--green);
+}
+.debrief-pill-worse {
+  background: var(--red-bg);
+  color: var(--red);
+}
+.debrief-pill-better {
+  background: rgba(37, 99, 235, 0.12);
+  color: var(--primary);
+}
+.debrief-pill-monitoring {
+  background: var(--bg);
+  color: var(--text-muted);
+  border: 1px solid var(--border);
+}
+
+/* Read-only summary card */
+.debrief-summary {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 8px 12px;
+  margin: 6px 0;
+}
+.debrief-summary-header { margin-bottom: 6px; }
+.debrief-summary-empty {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  font-style: italic;
+}
+.debrief-summary-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+.debrief-summary-note {
+  font-size: 0.85rem;
+  font-style: italic;
+  color: var(--text-muted);
+  margin-top: 6px;
+  padding-left: 8px;
+  border-left: 2px solid var(--border);
+}
+.debrief-tag {
+  display: inline-block;
+  padding: 1px 6px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+.debrief-outcome-tag {
+  display: inline-block;
+  padding: 1px 6px;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+.debrief-outcome-tag.debrief-outcome-worse {
+  background: var(--red-bg);
+  color: var(--red);
+}
+.debrief-outcome-tag.debrief-outcome-better {
+  background: rgba(37, 99, 235, 0.12);
+  color: var(--primary);
+}
+
+/* Form */
+.debrief-host {
+  /* Empty by default — debrief-form mounts here. */
+}
+.debrief-form {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 12px 14px;
+  margin-top: 10px;
+}
+.debrief-decision {
+  display: flex;
+  gap: 6px;
+  margin-bottom: 10px;
+  align-items: center;
+}
+.debrief-decision-btn {
+  flex: 1;
+  padding: 8px;
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--text);
+  border-radius: var(--radius);
+  cursor: pointer;
+  font-size: 0.9rem;
+  font-weight: 500;
+}
+.debrief-decision-btn.active {
+  background: var(--primary);
+  color: #fff;
+  border-color: var(--primary);
+}
+.debrief-info-btn {
+  flex: 0 0 auto;
+}
+.debrief-loading {
+  padding: 16px;
+  font-size: 0.9rem;
+  color: var(--text-muted);
+  font-style: italic;
+  text-align: center;
+}
+.debrief-section {
+  margin: 10px 0;
+}
+.debrief-section-label {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  margin-bottom: 6px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+.debrief-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.debrief-chip {
+  padding: 6px 12px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  cursor: pointer;
+  font-size: 0.85rem;
+  color: var(--text);
+}
+.debrief-chip.active {
+  background: var(--primary);
+  color: #fff;
+  border-color: var(--primary);
+}
+.debrief-empty {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  font-style: italic;
+  padding: 8px;
+}
+.debrief-outcome-row {
+  display: grid;
+  grid-template-columns: 110px 1fr;
+  gap: 8px;
+  align-items: center;
+  padding: 4px 0;
+}
+.debrief-outcome-cat {
+  font-size: 0.85rem;
+  font-weight: 500;
+}
+.debrief-outcome-buttons {
+  display: flex;
+  gap: 4px;
+  flex-wrap: wrap;
+}
+.debrief-outcome-btn {
+  padding: 4px 10px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.8rem;
+  color: var(--text);
+}
+.debrief-outcome-btn.active.outcome-consistent {
+  background: var(--green);
+  color: #fff;
+  border-color: var(--green);
+}
+.debrief-outcome-btn.active.outcome-better {
+  background: var(--primary);
+  color: #fff;
+  border-color: var(--primary);
+}
+.debrief-outcome-btn.active.outcome-worse {
+  background: var(--red);
+  color: #fff;
+  border-color: var(--red);
+}
+.debrief-note-label {
+  display: block;
+  margin: 12px 0 8px;
+}
+.debrief-note-label > span:first-child {
+  display: block;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  margin-bottom: 4px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+.debrief-note {
+  width: 100%;
+  padding: 6px 8px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: var(--surface);
+  color: var(--text);
+  font-family: inherit;
+  font-size: 0.9rem;
+  resize: vertical;
+}
+.debrief-note-count {
+  display: block;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  text-align: right;
+  margin-top: 2px;
+}
+.debrief-note-count.over { color: var(--red); }
+.debrief-actions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+  margin-top: 12px;
+}
+.debrief-actions .btn-primary,
+.debrief-actions .btn-secondary {
+  padding: 6px 14px;
+  font-size: 0.9rem;
+}

--- a/web/flight.html
+++ b/web/flight.html
@@ -37,6 +37,14 @@
       </div>
     </div>
 
+    <!-- Debrief (past flights only — managed by flight-main) -->
+    <div class="section" id="debrief-section" style="display: none;">
+      <h3>Pilot Debrief</h3>
+      <div id="debrief-banner"></div>
+      <div id="debrief-summary"></div>
+      <div id="debrief-host" data-flight-id=""></div>
+    </div>
+
     <!-- Briefing history -->
     <div class="section">
       <h3>Briefing History</h3>

--- a/web/ts/adapters/debrief-adapter.ts
+++ b/web/ts/adapters/debrief-adapter.ts
@@ -1,0 +1,38 @@
+/** API client for flight debriefs. */
+
+import type { DebriefResponse, DebriefStats, OutcomeValue, ConditionTagId, DebriefDecision } from '../store/types';
+import { apiFetch } from '../utils';
+
+export interface DebriefRequest {
+  decision: DebriefDecision;
+  reasons?: ConditionTagId[];
+  outcomes?: Partial<Record<ConditionTagId, OutcomeValue>>;
+  note?: string | null;
+}
+
+export async function fetchDebrief(flightId: string): Promise<DebriefResponse | null> {
+  try {
+    return await apiFetch<DebriefResponse>(`/flights/${encodeURIComponent(flightId)}/debrief`);
+  } catch (e: unknown) {
+    if (e instanceof Error && e.message.startsWith('API 404:')) return null;
+    throw e;
+  }
+}
+
+export async function saveDebrief(flightId: string, body: DebriefRequest): Promise<DebriefResponse> {
+  return apiFetch<DebriefResponse>(
+    `/flights/${encodeURIComponent(flightId)}/debrief`,
+    { method: 'PUT', body: JSON.stringify(body) },
+  );
+}
+
+export async function deleteDebrief(flightId: string): Promise<void> {
+  await apiFetch<void>(
+    `/flights/${encodeURIComponent(flightId)}/debrief`,
+    { method: 'DELETE' },
+  );
+}
+
+export async function fetchDebriefStats(windowDays = 90): Promise<DebriefStats> {
+  return apiFetch<DebriefStats>(`/debriefs/stats?window_days=${windowDays}`);
+}

--- a/web/ts/components/debrief-form.ts
+++ b/web/ts/components/debrief-form.ts
@@ -1,0 +1,364 @@
+/** Debrief form — renders a hybrid chips + text input + per-category outcomes.
+ *
+ * One self-contained component; renders into a host element and reports
+ * outcomes back via the supplied callbacks. Intentionally framework-free
+ * (this codebase has no React/Vue) — the surface is straightforward
+ * imperative DOM building.
+ */
+
+import type {
+  ConditionTagId,
+  DebriefDecision,
+  DebriefResponse,
+  OutcomeValue,
+} from '../store/types';
+import {
+  ALL_TAGS,
+  OUTCOME_CATEGORIES,
+  TAG_DESCRIPTIONS,
+  TAG_LABELS,
+  matchTagsInText,
+} from './debrief-taxonomy';
+import { saveDebrief, deleteDebrief, type DebriefRequest } from '../adapters/debrief-adapter';
+import { escapeHtml } from '../utils';
+import { showPopupContent } from './info-popup';
+import { t } from '../i18n/i18n';
+
+const NOTE_MAX_LEN = 300;
+
+export interface DebriefFormOptions {
+  /** Existing debrief to seed the form (edit mode), or null for create. */
+  existing: DebriefResponse | null;
+  /** Categories the briefing flagged at the time — controls which outcome rows render.
+   *  Empty array → outcome section shows "All consistent" only. */
+  flaggedCategories: ConditionTagId[];
+  /** Called after a successful save with the saved debrief. */
+  onSaved: (d: DebriefResponse) => void;
+  /** Called after a successful delete. */
+  onDeleted?: () => void;
+  /** Called when the user dismisses without saving. */
+  onCancelled?: () => void;
+}
+
+interface FormState {
+  decision: DebriefDecision;
+  reasons: Set<ConditionTagId>;
+  outcomes: Map<ConditionTagId, OutcomeValue>;
+  note: string;
+  flagged: ConditionTagId[];
+}
+
+/** Mount the form into ``host``. Returns a cleanup function. */
+export function renderDebriefForm(host: HTMLElement, opts: DebriefFormOptions): () => void {
+  const state: FormState = initialState(opts);
+
+  const root = document.createElement('div');
+  root.className = 'debrief-form';
+  host.innerHTML = '';
+  host.appendChild(root);
+
+  const render = () => {
+    root.innerHTML = template(state, opts);
+    wireEvents(root, state, opts, render);
+  };
+  render();
+
+  return () => { host.innerHTML = ''; };
+}
+
+function initialState(opts: DebriefFormOptions): FormState {
+  const existing = opts.existing;
+  const decision: DebriefDecision = existing?.decision ?? 'flown';
+  const reasons = new Set<ConditionTagId>(existing?.reasons ?? []);
+  const outcomes = new Map<ConditionTagId, OutcomeValue>();
+  if (existing?.outcomes) {
+    for (const [k, v] of Object.entries(existing.outcomes)) {
+      if (v) outcomes.set(k as ConditionTagId, v);
+    }
+  }
+  // For categories the briefing flagged but the pilot hasn't recorded yet,
+  // default to consistent so the form's "exception only" flow is honest.
+  // (When editing an old debrief, we trust whatever was stored — including
+  // explicit consistents and any categories the briefing no longer flags.)
+  const flagged = Array.from(new Set([...opts.flaggedCategories, ...outcomes.keys()]));
+  for (const cat of opts.flaggedCategories) {
+    if (!outcomes.has(cat)) outcomes.set(cat, 'consistent');
+  }
+  return {
+    decision,
+    reasons,
+    outcomes,
+    note: existing?.note ?? '',
+    flagged,
+  };
+}
+
+function decisionBody(s: FormState): string {
+  switch (s.decision) {
+    case 'cancelled': return cancelledBody(s);
+    case 'flown':     return flownBody(s);
+    case 'monitoring': return monitoringBody();
+  }
+}
+
+function monitoringBody(): string {
+  return `
+    <div class="debrief-section">
+      <div class="debrief-section-label">Monitor only</div>
+      <div class="debrief-empty">This flight was set up to watch the weather, not to be flown. It won't appear in the recent-debrief nudge or count toward flown/cancelled stats. Add a note if you want to remember why.</div>
+    </div>
+  `;
+}
+
+function template(s: FormState, opts: DebriefFormOptions): string {
+  const infoLabel = escapeHtml(t('debrief.infoBtn'));
+  const decisionToggle = `
+    <div class="debrief-decision">
+      <button type="button" class="debrief-decision-btn ${s.decision === 'flown' ? 'active' : ''}" data-decision="flown">✓ Flown</button>
+      <button type="button" class="debrief-decision-btn ${s.decision === 'cancelled' ? 'active' : ''}" data-decision="cancelled">✕ Cancelled</button>
+      <button type="button" class="debrief-decision-btn ${s.decision === 'monitoring' ? 'active' : ''}" data-decision="monitoring">👁 Monitor only</button>
+      <button type="button" class="metric-info-btn debrief-info-btn" title="${infoLabel}" aria-label="${infoLabel}">i</button>
+    </div>
+  `;
+
+  const body = decisionBody(s);
+
+  const noteCount = s.note.length;
+  const noteRemaining = NOTE_MAX_LEN - noteCount;
+  const noteTooLong = noteRemaining < 0;
+
+  return `
+    ${decisionToggle}
+    ${body}
+    <label class="debrief-note-label">
+      <span>Note (optional)</span>
+      <textarea class="debrief-note" rows="2" maxlength="${NOTE_MAX_LEN + 50}"
+        placeholder="What happened? Mention any condition by name and we'll flag the tag.">${escapeHtml(s.note)}</textarea>
+      <span class="debrief-note-count ${noteTooLong ? 'over' : ''}">${noteRemaining} chars left</span>
+    </label>
+    <div class="debrief-actions">
+      <button type="button" class="btn-secondary debrief-cancel">Cancel</button>
+      ${opts.existing ? `<button type="button" class="btn-secondary debrief-delete">Delete debrief</button>` : ''}
+      <button type="button" class="btn-primary debrief-save" ${noteTooLong ? 'disabled' : ''}>Save</button>
+    </div>
+  `;
+}
+
+function infoCardContent(decision: DebriefDecision): string {
+  if (decision === 'cancelled') {
+    return `
+      <h2>About this debrief — Cancelled</h2>
+      <p>You're recording <strong>why</strong> you decided not to fly. This becomes a calibration sample we can use to tune the system's advisories — your "no-go" calls are the most valuable signal we collect.</p>
+      <h3>Two ways to enter</h3>
+      <ul>
+        <li><strong>Tap the chips</strong> for the conditions that drove the decision (multi-select — pick all that apply).</li>
+        <li><strong>Or type a note</strong>. As you type, words like <em>icing</em>, <em>gusty</em>, <em>fog</em> auto-select the matching chip — you can always tap to remove one if it's not what you meant.</li>
+        <li>Use both if you want — chips are the structured signal, the note is your free-form context.</li>
+      </ul>
+      <h3>Tags</h3>
+      <p><strong>OPS</strong> = non-weather (aircraft, NOTAM, fuel, personal). It's still recorded but excluded from per-category accuracy stats.</p>
+      <p>Everything else (IMC, ICE, WIND, TS, TURB, FRZ, VIS) maps to a forecast category we can grade.</p>
+    `;
+  }
+  if (decision === 'monitoring') {
+    return `
+      <h2>About this debrief — Monitor only</h2>
+      <p>You set this flight up to <strong>watch the weather</strong>, not to actually fly it — research, what-if planning, or keeping an eye on a route you might fly later.</p>
+      <p>Marking it <em>Monitor only</em> means:</p>
+      <ul>
+        <li>It <strong>disappears from the "please debrief" nudge</strong> — no pressure to record an outcome.</li>
+        <li>It does <strong>not</strong> count toward your <em>flown</em> or <em>cancelled</em> stats. It also doesn't bias the per-category accuracy data — there was no real go/no-go decision to grade.</li>
+        <li>It <em>does</em> show in your "Monitor only" tally so you can see how many briefings were research vs. real flights.</li>
+      </ul>
+      <p>The note is optional — handy for remembering why you set this one up.</p>
+    `;
+  }
+  return `
+    <h2>About this debrief — Flown</h2>
+    <p>You're telling us <strong>how the forecast held up</strong> against what you actually flew. This is the calibration data — for every advisory the system raised, did reality match?</p>
+    <h3>What you'll see</h3>
+    <ul>
+      <li>One row per <strong>advisory category that was flagged</strong> on this briefing (icing, turbulence, etc.). Categories the system didn't flag aren't shown — there's nothing to grade.</li>
+      <li>Each row defaults to <strong>As forecast</strong>. Only flip the ones that were actually different.</li>
+      <li><strong>↓ Better</strong> = the system was too pessimistic (forecast worse than reality).</li>
+      <li><strong>↑ Worse</strong> = the system was too optimistic (forecast better than reality — the dangerous miss).</li>
+    </ul>
+    <p>Add a free-form note for anything not covered — surprises, deviations, gotchas the categories don't fit.</p>
+    <p class="muted"><em>If no rows appear, the briefing didn't flag anything for this flight (all green) — just leave a note if anything stood out.</em></p>
+  `;
+}
+
+function cancelledBody(s: FormState): string {
+  const chips = ALL_TAGS.map((t) => {
+    const active = s.reasons.has(t);
+    return `<button type="button" class="debrief-chip ${active ? 'active' : ''}" data-tag="${t}" title="${escapeHtml(TAG_DESCRIPTIONS[t])}">${escapeHtml(TAG_LABELS[t])}</button>`;
+  }).join('');
+  return `
+    <div class="debrief-section">
+      <div class="debrief-section-label">Why cancelled? (tap all that apply)</div>
+      <div class="debrief-chips">${chips}</div>
+    </div>
+  `;
+}
+
+function flownBody(s: FormState): string {
+  if (s.flagged.length === 0) {
+    return `
+      <div class="debrief-section">
+        <div class="debrief-section-label">Outcome</div>
+        <div class="debrief-empty">No advisories were raised on this flight — nothing to grade. Add a note if anything stood out.</div>
+      </div>
+    `;
+  }
+  const rows = s.flagged.map((cat) => {
+    const value = s.outcomes.get(cat) ?? 'consistent';
+    const buttons = (['consistent', 'better', 'worse'] as OutcomeValue[]).map((v) => {
+      const cls = `debrief-outcome-btn outcome-${v} ${value === v ? 'active' : ''}`;
+      const label = v === 'consistent' ? '✓ As forecast' : v === 'better' ? '↓ Better' : '↑ Worse';
+      return `<button type="button" class="${cls}" data-cat="${cat}" data-value="${v}">${label}</button>`;
+    }).join('');
+    return `
+      <div class="debrief-outcome-row" data-cat="${cat}">
+        <div class="debrief-outcome-cat">${escapeHtml(TAG_LABELS[cat])}</div>
+        <div class="debrief-outcome-buttons">${buttons}</div>
+      </div>
+    `;
+  }).join('');
+  return `
+    <div class="debrief-section">
+      <div class="debrief-section-label">Outcome (only categories flagged by the briefing)</div>
+      ${rows}
+    </div>
+  `;
+}
+
+function wireEvents(
+  root: HTMLElement,
+  s: FormState,
+  opts: DebriefFormOptions,
+  rerender: () => void,
+): void {
+  // Info button
+  root.querySelector('.debrief-info-btn')?.addEventListener('click', () => {
+    showPopupContent(infoCardContent(s.decision));
+  });
+
+  // Decision toggle
+  root.querySelectorAll<HTMLButtonElement>('.debrief-decision-btn').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      const d = btn.dataset.decision as DebriefDecision;
+      if (s.decision === d) return;
+      s.decision = d;
+      // Clear the inactive side's data so a wrong-shape submit can't happen.
+      if (d === 'flown') {
+        s.reasons.clear();
+      } else {
+        s.outcomes.clear();
+      }
+      rerender();
+    });
+  });
+
+  // Cancel-reason chips
+  root.querySelectorAll<HTMLButtonElement>('.debrief-chip').forEach((chip) => {
+    chip.addEventListener('click', () => {
+      const tag = chip.dataset.tag as ConditionTagId;
+      if (s.reasons.has(tag)) s.reasons.delete(tag);
+      else s.reasons.add(tag);
+      rerender();
+    });
+  });
+
+  // Outcome buttons
+  root.querySelectorAll<HTMLButtonElement>('.debrief-outcome-btn').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      const cat = btn.dataset.cat as ConditionTagId;
+      const value = btn.dataset.value as OutcomeValue;
+      s.outcomes.set(cat, value);
+      rerender();
+    });
+  });
+
+  // Note input — auto-toggle matching chips on input.
+  const noteEl = root.querySelector<HTMLTextAreaElement>('.debrief-note');
+  if (noteEl) {
+    noteEl.addEventListener('input', () => {
+      s.note = noteEl.value;
+      // Update char counter without re-render to keep cursor in place.
+      const counter = root.querySelector<HTMLElement>('.debrief-note-count');
+      if (counter) {
+        const remaining = NOTE_MAX_LEN - s.note.length;
+        counter.textContent = `${remaining} chars left`;
+        counter.classList.toggle('over', remaining < 0);
+      }
+      // Auto-toggle chips on the cancel form.
+      if (s.decision === 'cancelled') {
+        const matched = matchTagsInText(s.note);
+        let changed = false;
+        for (const tag of matched) {
+          if (!s.reasons.has(tag)) {
+            s.reasons.add(tag);
+            changed = true;
+          }
+        }
+        if (changed) {
+          // Lightweight chip refresh — only flip the .active class.
+          root.querySelectorAll<HTMLButtonElement>('.debrief-chip').forEach((chip) => {
+            const t = chip.dataset.tag as ConditionTagId;
+            chip.classList.toggle('active', s.reasons.has(t));
+          });
+        }
+      }
+    });
+  }
+
+  // Cancel
+  root.querySelector('.debrief-cancel')?.addEventListener('click', () => {
+    opts.onCancelled?.();
+  });
+
+  // Delete
+  root.querySelector('.debrief-delete')?.addEventListener('click', async () => {
+    if (!opts.existing) return;
+    if (!confirm('Delete this debrief? This cannot be undone.')) return;
+    try {
+      await deleteDebrief(opts.existing.flight_id);
+      opts.onDeleted?.();
+    } catch (e) {
+      alert(`Could not delete: ${(e as Error).message}`);
+    }
+  });
+
+  // Save
+  root.querySelector('.debrief-save')?.addEventListener('click', async () => {
+    const flightId = opts.existing?.flight_id ?? root.closest<HTMLElement>('[data-flight-id]')?.dataset.flightId;
+    if (!flightId) {
+      alert('Internal error: no flight id on container');
+      return;
+    }
+    const body = buildRequest(s);
+    try {
+      const saved = await saveDebrief(flightId, body);
+      opts.onSaved(saved);
+    } catch (e) {
+      alert(`Could not save: ${(e as Error).message}`);
+    }
+  });
+}
+
+function buildRequest(s: FormState): DebriefRequest {
+  const note = s.note.trim() ? s.note.trim() : null;
+  if (s.decision === 'cancelled') {
+    return { decision: 'cancelled', reasons: Array.from(s.reasons), note };
+  }
+  if (s.decision === 'monitoring') {
+    return { decision: 'monitoring', note };
+  }
+  // Flown — only emit outcomes for categories that were flagged.
+  const outcomes: Partial<Record<ConditionTagId, OutcomeValue>> = {};
+  for (const cat of s.flagged) {
+    if (!OUTCOME_CATEGORIES.includes(cat)) continue;  // belt-and-braces
+    outcomes[cat] = s.outcomes.get(cat) ?? 'consistent';
+  }
+  return { decision: 'flown', outcomes, note };
+}

--- a/web/ts/components/debrief-form.ts
+++ b/web/ts/components/debrief-form.ts
@@ -250,6 +250,9 @@ function wireEvents(
       if (s.decision === d) return;
       s.decision = d;
       // Clear the inactive side's data so a wrong-shape submit can't happen.
+      // Asymmetric on purpose: cancelled and monitoring both leave outcomes
+      // empty, and we keep reasons across cancelled↔monitoring so the chips
+      // round-trip if the user toggles between the two.
       if (d === 'flown') {
         s.reasons.clear();
       } else {

--- a/web/ts/components/debrief-stats.ts
+++ b/web/ts/components/debrief-stats.ts
@@ -1,0 +1,84 @@
+/** Stats panel — activity + cancellation reasons + per-category accuracy. */
+
+import type { ConditionTagId, DebriefStats } from '../store/types';
+import { TAG_LABELS } from './debrief-taxonomy';
+import { escapeHtml } from '../utils';
+
+export function renderDebriefStats(s: DebriefStats): string {
+  if (s.total_flights_in_window === 0) {
+    return `
+      <div class="debrief-stats">
+        <div class="debrief-stats-empty">No flights in the last ${s.window_days} days.</div>
+      </div>
+    `;
+  }
+
+  const monitoringPart = s.monitoring_count > 0
+    ? ` · <strong>${s.monitoring_count}</strong> monitor only`
+    : '';
+  const activity = `
+    <div class="debrief-stats-row">
+      <div class="debrief-stats-label">Activity</div>
+      <div class="debrief-stats-value">
+        <strong>${s.flown_count}</strong> flown ·
+        <strong>${s.cancelled_count}</strong> cancelled ·
+        <strong>${s.pending_debrief_count}</strong> pending${monitoringPart}
+      </div>
+    </div>
+  `;
+
+  const reasonItems = Object.entries(s.cancellation_reasons)
+    .sort((a, b) => (b[1] ?? 0) - (a[1] ?? 0))
+    .map(([tag, count]) => `<span class="debrief-stats-reason">${escapeHtml(tag)} ×${count}</span>`)
+    .join(' ');
+  const reasons = s.cancelled_count > 0
+    ? `
+      <div class="debrief-stats-row">
+        <div class="debrief-stats-label">Cancelled</div>
+        <div class="debrief-stats-value">${reasonItems || '<em>no tags</em>'}</div>
+      </div>
+    `
+    : '';
+
+  const accuracyEntries = Object.entries(s.category_accuracy);
+  const accuracy = accuracyEntries.length > 0
+    ? `
+      <div class="debrief-stats-row">
+        <div class="debrief-stats-label">Forecast accuracy</div>
+        <div class="debrief-stats-value">
+          ${accuracyEntries.map(([tag, cat]) => accuracyBar(tag as ConditionTagId, cat!)).join('')}
+        </div>
+      </div>
+      <div class="debrief-stats-caveat">Based on flagged exceptions only — categories not flagged are assumed consistent.</div>
+    `
+    : '';
+
+  return `
+    <div class="debrief-stats">
+      <div class="debrief-stats-header">Last ${s.window_days} days</div>
+      ${activity}
+      ${reasons}
+      ${accuracy}
+    </div>
+  `;
+}
+
+function accuracyBar(tag: ConditionTagId, c: { queried_count: number; consistent: number; better: number; worse: number }): string {
+  const total = Math.max(c.queried_count, 1);
+  const pct = (n: number) => (n / total) * 100;
+  return `
+    <div class="debrief-acc-row">
+      <div class="debrief-acc-label">${escapeHtml(TAG_LABELS[tag])}</div>
+      <div class="debrief-acc-bar" title="${c.queried_count} flights">
+        <span class="debrief-acc-seg debrief-acc-consistent" style="width:${pct(c.consistent)}%"></span>
+        <span class="debrief-acc-seg debrief-acc-better" style="width:${pct(c.better)}%"></span>
+        <span class="debrief-acc-seg debrief-acc-worse" style="width:${pct(c.worse)}%"></span>
+      </div>
+      <div class="debrief-acc-counts">
+        <span class="debrief-acc-count-consistent">${c.consistent}</span> ·
+        <span class="debrief-acc-count-better">${c.better}</span> ·
+        <span class="debrief-acc-count-worse">${c.worse}</span>
+      </div>
+    </div>
+  `;
+}

--- a/web/ts/components/debrief-summary.ts
+++ b/web/ts/components/debrief-summary.ts
@@ -1,0 +1,81 @@
+/** Read-only summary card for an existing debrief. */
+
+import type { ConditionTagId, DebriefResponse, OutcomeValue } from '../store/types';
+import { OUTCOME_LABELS, TAG_LABELS } from './debrief-taxonomy';
+import { escapeHtml } from '../utils';
+
+export function renderDebriefSummary(d: DebriefResponse): string {
+  let decisionPill: string;
+  if (d.decision === 'cancelled') {
+    decisionPill = `<span class="debrief-pill debrief-pill-cancelled">✕ Cancelled</span>`;
+  } else if (d.decision === 'monitoring') {
+    decisionPill = `<span class="debrief-pill debrief-pill-monitoring">👁 Monitor only</span>`;
+  } else {
+    decisionPill = `<span class="debrief-pill debrief-pill-flown">✓ Flown</span>`;
+  }
+
+  let body = '';
+  if (d.decision === 'monitoring') {
+    body = `<div class="debrief-summary-empty">Watching weather only — not a real go/no-go decision.</div>`;
+  } else if (d.decision === 'cancelled') {
+    if (d.reasons.length === 0) {
+      body = `<div class="debrief-summary-empty">No reason recorded.</div>`;
+    } else {
+      const tags = d.reasons.map((t) =>
+        `<span class="debrief-tag" title="${escapeHtml(TAG_LABELS[t])}">${escapeHtml(t)}</span>`,
+      ).join('');
+      body = `<div class="debrief-summary-tags">${tags}</div>`;
+    }
+  } else {
+    // Flown — show categories where the outcome is NOT consistent (the
+    // signal). If everything is consistent, show a single confirmation line.
+    const flagged = Object.entries(d.outcomes).filter(([, v]) => v !== 'consistent');
+    if (flagged.length === 0) {
+      const queriedCount = Object.keys(d.outcomes).length;
+      body = queriedCount
+        ? `<div class="debrief-summary-empty">All ${queriedCount} flagged ${queriedCount === 1 ? 'category' : 'categories'} as forecast.</div>`
+        : `<div class="debrief-summary-empty">No advisories were graded.</div>`;
+    } else {
+      const items = flagged.map(([cat, val]) => {
+        const v = val as OutcomeValue;
+        const arrow = v === 'better' ? '↓' : '↑';
+        return `<span class="debrief-outcome-tag debrief-outcome-${v}" title="${escapeHtml(OUTCOME_LABELS[v])}">${arrow} ${escapeHtml(TAG_LABELS[cat as ConditionTagId])}</span>`;
+      }).join('');
+      body = `<div class="debrief-summary-tags">${items}</div>`;
+    }
+  }
+
+  const note = d.note
+    ? `<div class="debrief-summary-note">“${escapeHtml(d.note)}”</div>`
+    : '';
+
+  return `
+    <div class="debrief-summary">
+      <div class="debrief-summary-header">${decisionPill}</div>
+      ${body}
+      ${note}
+    </div>
+  `;
+}
+
+/** Compact one-line pill for use in list rows. */
+export function renderDebriefPill(d: DebriefResponse | null | undefined): string {
+  if (!d) return `<span class="debrief-pill debrief-pill-pending" title="No debrief recorded yet">◼ Debrief</span>`;
+  if (d.decision === 'monitoring') {
+    return `<span class="debrief-pill debrief-pill-monitoring" title="Monitor only — not a real flight">👁</span>`;
+  }
+  if (d.decision === 'cancelled') {
+    const reasons = d.reasons.length ? ` ${d.reasons.join(' · ')}` : '';
+    return `<span class="debrief-pill debrief-pill-cancelled">✕${escapeHtml(reasons)}</span>`;
+  }
+  // Flown — surface "worse" / "better" if any, else green check.
+  const worseCount = Object.values(d.outcomes).filter((v) => v === 'worse').length;
+  const betterCount = Object.values(d.outcomes).filter((v) => v === 'better').length;
+  if (worseCount > 0) {
+    return `<span class="debrief-pill debrief-pill-worse">↑ Worse · ${worseCount}</span>`;
+  }
+  if (betterCount > 0) {
+    return `<span class="debrief-pill debrief-pill-better">↓ Better · ${betterCount}</span>`;
+  }
+  return `<span class="debrief-pill debrief-pill-flown">✓ As forecast</span>`;
+}

--- a/web/ts/components/debrief-taxonomy.ts
+++ b/web/ts/components/debrief-taxonomy.ts
@@ -1,0 +1,113 @@
+/** TS mirror of src/weatherbrief/debriefs/taxonomy.py.
+ *
+ * Keep in sync — both define the canonical condition tags and keyword
+ * map. Drift is caught at code review (small file, no obvious harm
+ * mechanism) since runtime cross-validation would mean an extra fetch.
+ */
+
+import type { ConditionTagId, OutcomeValue } from '../store/types';
+
+export const ALL_TAGS: ConditionTagId[] = [
+  'IMC', 'ICE', 'WIND', 'TS', 'TURB', 'FRZ', 'VIS', 'OPS',
+];
+
+/** Categories that can be graded as outcomes (everything except OPS). */
+export const OUTCOME_CATEGORIES: ConditionTagId[] = ALL_TAGS.filter((t) => t !== 'OPS');
+
+export const TAG_LABELS: Record<ConditionTagId, string> = {
+  IMC:  'IMC',
+  ICE:  'Icing',
+  WIND: 'Wind',
+  TS:   'Thunderstorm',
+  TURB: 'Turbulence',
+  FRZ:  'Freezing precip',
+  VIS:  'Visibility',
+  OPS:  'Operational',
+};
+
+export const TAG_DESCRIPTIONS: Record<ConditionTagId, string> = {
+  IMC:  'Low ceilings / IFR conditions',
+  ICE:  'Airframe icing',
+  WIND: 'Strong / gusty / crosswind',
+  TS:   'Thunderstorms or convective build-up',
+  TURB: 'Turbulence (any intensity)',
+  FRZ:  'Freezing rain / sleet',
+  VIS:  'Reduced visibility, fog, mist',
+  OPS:  'Non-weather (aircraft, pilot, NOTAM, fuel, …)',
+};
+
+export const OUTCOME_LABELS: Record<OutcomeValue, string> = {
+  consistent: 'As forecast',
+  better: 'Better than forecast',
+  worse: 'Worse than forecast',
+};
+
+/** Phrase → tag map. Lowercase substrings; matched with a word-boundary
+ *  check by ``matchTagsInText`` below. Mirrors KEYWORD_MAP in Python. */
+const KEYWORD_MAP: Record<ConditionTagId, string[]> = {
+  IMC:  ['imc', 'ifr', 'overcast', 'low ceiling', 'ceiling'],
+  ICE:  ['icing', 'ice', 'rime', 'sld'],
+  WIND: ['wind', 'gust', 'crosswind'],
+  TS:   ['thunder', 'thunderstorm', 'cb', 'storm', 'lightning', 'convect'],
+  TURB: ['turb', 'bumpy', 'rough', 'shear'],
+  FRZ:  ['freezing rain', 'fzra', 'sleet', 'freezing precip'],
+  VIS:  ['visib', 'fog', 'haze', 'mist', 'smoke'],
+  OPS:  ['fuel', 'notam', 'currency', 'aircraft', 'personal', 'passenger'],
+};
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+const TAG_PATTERNS: Record<ConditionTagId, RegExp> = (() => {
+  const out: Partial<Record<ConditionTagId, RegExp>> = {};
+  for (const tag of ALL_TAGS) {
+    const phrases = [...KEYWORD_MAP[tag]].sort((a, b) => b.length - a.length);
+    const alt = phrases.map(escapeRegex).join('|');
+    out[tag] = new RegExp(`(?<!\\w)(?:${alt})`, 'i');
+  }
+  return out as Record<ConditionTagId, RegExp>;
+})();
+
+/** Scan ``text`` for keyword hits and return matching tags. */
+export function matchTagsInText(text: string): Set<ConditionTagId> {
+  const out = new Set<ConditionTagId>();
+  if (!text) return out;
+  for (const tag of ALL_TAGS) {
+    if (TAG_PATTERNS[tag].test(text)) out.add(tag);
+  }
+  return out;
+}
+
+/** Advisory id → debrief tag. Per-id rather than per-category because some
+ *  categories (e.g. ``airport``) cover both wind and visibility-style
+ *  concerns. ``model`` advisories aren't weather phenomena → no mapping. */
+const ADVISORY_TAG_MAP: Record<string, ConditionTagId> = {
+  icing_escape:      'ICE',
+  fiki_icing:        'ICE',
+  vmc_cruise:        'IMC',
+  cloud_top:         'IMC',
+  vfr_feasibility:   'IMC',
+  ifr_feasibility:   'IMC',
+  flight_category:   'IMC',
+  turbulence:        'TURB',
+  mountain_wind:     'TURB',
+  convective:        'TS',
+  airport_wind:      'WIND',
+};
+
+/** From an advisory manifest, return the set of tags whose advisory came
+ *  back AMBER or RED (anything worse than green). GREEN/UNAVAILABLE don't
+ *  count — there's nothing for the pilot to grade. */
+export function flaggedTagsFromAdvisories(manifest: {
+  advisories: Array<{ advisory_id: string; aggregate_status: string }>;
+} | null | undefined): ConditionTagId[] {
+  if (!manifest?.advisories) return [];
+  const out = new Set<ConditionTagId>();
+  for (const adv of manifest.advisories) {
+    if (adv.aggregate_status !== 'amber' && adv.aggregate_status !== 'red') continue;
+    const tag = ADVISORY_TAG_MAP[adv.advisory_id];
+    if (tag) out.add(tag);
+  }
+  return [...out];
+}

--- a/web/ts/components/debrief-taxonomy.ts
+++ b/web/ts/components/debrief-taxonomy.ts
@@ -81,7 +81,12 @@ export function matchTagsInText(text: string): Set<ConditionTagId> {
 
 /** Advisory id → debrief tag. Per-id rather than per-category because some
  *  categories (e.g. ``airport``) cover both wind and visibility-style
- *  concerns. ``model`` advisories aren't weather phenomena → no mapping. */
+ *  concerns. ``model`` advisories aren't weather phenomena → no mapping.
+ *
+ *  Phase 2 gap: no advisory currently maps to FRZ or VIS, so those tags
+ *  can't be auto-flagged on the outcome form even when the pilot
+ *  experienced them. Either add advisory ids covering freezing precip /
+ *  visibility, or surface those two tags via a separate hookup path. */
 const ADVISORY_TAG_MAP: Record<string, ConditionTagId> = {
   icing_escape:      'ICE',
   fiki_icing:        'ICE',

--- a/web/ts/flight-main.ts
+++ b/web/ts/flight-main.ts
@@ -11,7 +11,10 @@ import { initTheme } from './theme';
 import { initI18n, t } from './i18n/i18n';
 import { localToUtc, utcToLocal } from './utils/timezone';
 import { interpretAndConfirmRoute } from './components/route-interpret';
-import { createFlight, moveFlight } from './adapters/api-adapter';
+import { createFlight, fetchRouteAdvisories, moveFlight } from './adapters/api-adapter';
+import { flaggedTagsFromAdvisories } from './components/debrief-taxonomy';
+import { initInfoPopup } from './components/info-popup';
+import type { ConditionTagId } from './store/types';
 
 async function init(): Promise<void> {
   await initI18n();
@@ -23,6 +26,7 @@ async function init(): Promise<void> {
   }
   initTheme();
   renderUserInfo(user);
+  initInfoPopup();
 
   const store = flightDetailStore;
 
@@ -353,18 +357,49 @@ async function init(): Promise<void> {
     });
   }
 
+  const refreshFlight = () => {
+    void store.getState().loadFlight(flightId);
+  };
+
+  // Cached flagged categories for the latest pack — null until resolved.
+  // Pre-fetched after packs land so opening the debrief form is instant.
+  let flaggedCategories: ConditionTagId[] = [];
+
+  const loadFlaggedCategories = async () => {
+    const packs = store.getState().packs;
+    const latest = packs.length > 0 ? packs[0] : null;
+    if (!latest || !latest.has_advisories) {
+      flaggedCategories = [];
+      return;
+    }
+    try {
+      const manifest = await fetchRouteAdvisories(flightId, latest.fetch_timestamp);
+      flaggedCategories = flaggedTagsFromAdvisories(manifest);
+    } catch {
+      flaggedCategories = [];
+    }
+  };
+
   // --- Subscribe to state changes ---
   store.subscribe((state, prev) => {
     if (state.flight !== prev.flight || state.editing !== prev.editing || state.waypoints !== prev.waypoints) {
       ui.renderHeader(state.flight, state.editing);
       ui.renderFlightInfo(state.flight, state.editing, profiles, state.waypoints, aircraftList);
       ui.renderSharingBanner(state.flight);
+      ui.renderDebriefSection(state.flight, flaggedCategories, refreshFlight);
       wireSharingControls();
       if (state.editing) {
         wireEditForm();
       } else {
         wireEditButtons();
       }
+    }
+    if (state.packs !== prev.packs) {
+      // Re-fetch flagged categories whenever packs change, then re-render
+      // the debrief section so the form reflects the current advisories.
+      void loadFlaggedCategories().then(() => {
+        ui.renderDebriefSection(store.getState().flight, flaggedCategories, refreshFlight);
+      });
     }
     if (state.waypoints !== prev.waypoints) {
       if (mapInset && state.waypoints.length > 0) {
@@ -395,6 +430,7 @@ async function init(): Promise<void> {
   ui.renderHeader(s.flight, s.editing);
   ui.renderFlightInfo(s.flight, s.editing, profiles, s.waypoints);
   ui.renderSharingBanner(s.flight);
+  ui.renderDebriefSection(s.flight, flaggedCategories, refreshFlight);
   wireSharingControls();
   wireEditButtons();
 
@@ -406,6 +442,12 @@ async function init(): Promise<void> {
   ui.renderLatestAssessment(latestPack);
   ui.renderBriefingHistory(s.packs, flightId);
   ui.renderLoading(s.loading);
+
+  // Pre-fetch advisories for the latest pack and refresh the debrief form
+  // host with the resolved flagged categories.
+  void loadFlaggedCategories().then(() => {
+    ui.renderDebriefSection(store.getState().flight, flaggedCategories, refreshFlight);
+  });
 
   // Invalidate map size after layout settles
   requestAnimationFrame(() => {

--- a/web/ts/flights-main.ts
+++ b/web/ts/flights-main.ts
@@ -13,6 +13,7 @@ import { escapeHtml, redirectToLogin, renderUserInfo, initModelCatalog } from '.
 import { showWelcomeWizard } from './components/welcome-wizard';
 import { initTheme } from './theme';
 import { initI18n, t } from './i18n/i18n';
+import { initInfoPopup } from './components/info-popup';
 import {
   buildTimezoneOptions, localToUtc, utcToLocal, nearestMinuteOption,
 } from './utils/timezone';
@@ -365,6 +366,7 @@ async function init(): Promise<void> {
   }
   initTheme();
   renderUserInfo(user, 'flights');
+  initInfoPopup();
 
   const store = flightsStore;
 
@@ -394,12 +396,20 @@ async function init(): Promise<void> {
     onClearSelection: () => store.getState().clearSelection(),
   };
 
+  const refreshAfterDebrief = () => {
+    // Re-load flights so the debriefed row moves out of "recent" and the
+    // stats panel updates.
+    void store.getState().loadFlights();
+    void store.getState().loadDebriefStats();
+  };
+
   store.subscribe((state, prev) => {
     if (
       state.flights !== prev.flights ||
       state.latestPacks !== prev.latestPacks ||
       state.activeRefreshes !== prev.activeRefreshes ||
-      state.selectedIds !== prev.selectedIds
+      state.selectedIds !== prev.selectedIds ||
+      state.debriefStats !== prev.debriefStats
     ) {
       ui.renderFlightList(
         state.flights,
@@ -411,6 +421,8 @@ async function init(): Promise<void> {
         (id) => store.getState().deleteFlight(id),
         selectionHandlers,
         (id) => store.getState().unsubscribeFlight(id),
+        state.debriefStats,
+        refreshAfterDebrief,
       );
     }
     if (state.flights !== prev.flights) {
@@ -599,6 +611,8 @@ async function init(): Promise<void> {
     // Start polling active refreshes after flights load
     store.getState().pollActiveRefreshes();
   });
+  // Stats are independent of the flights load — fire and forget.
+  store.getState().loadDebriefStats();
 
   // Poll active refreshes every 5 seconds
   const refreshPollInterval = setInterval(() => {

--- a/web/ts/i18n/locales/en.json
+++ b/web/ts/i18n/locales/en.json
@@ -607,5 +607,12 @@
   "messages.loadFailed": "Failed to load messages.",
   "messages.category.feature": "New",
   "messages.category.change": "Change",
-  "messages.category.fix": "Fix"
+  "messages.category.fix": "Fix",
+
+  "debrief.openCta": "Debrief →",
+  "debrief.recentHeader": "Recent — please debrief",
+  "debrief.editCta": "Edit debrief",
+  "debrief.addCta": "Add debrief",
+  "debrief.loading": "Loading advisories…",
+  "debrief.infoBtn": "About this form"
 }

--- a/web/ts/managers/flight-detail-ui.ts
+++ b/web/ts/managers/flight-detail-ui.ts
@@ -1,12 +1,14 @@
 /** DOM management for the Flight Detail page. */
 
-import type { FlightResponse, PackMeta } from '../store/types';
+import type { ConditionTagId, DebriefResponse, FlightResponse, PackMeta } from '../store/types';
 import type { WaypointInfo } from '../adapters/api-adapter';
 import type { AircraftResponse } from '../adapters/aircraft-adapter';
 import type { ProfileResponse } from '../adapters/profiles-adapter';
-import { $, escapeHtml, formatDate, formatDepartureTime, formatAlt, flightTitle, flightRoute } from '../utils';
+import { $, escapeHtml, formatDate, formatDepartureTime, formatAlt, flightTitle, flightRoute, isFlightPast } from '../utils';
 import { getDateLocale, t } from '../i18n/i18n';
 import { buildTimezoneOptions, utcToLocal } from '../utils/timezone';
+import { renderDebriefForm } from '../components/debrief-form';
+import { renderDebriefSummary } from '../components/debrief-summary';
 
 // --- Assessment badge ---
 
@@ -469,5 +471,64 @@ export function renderError(error: string | null): void {
     el.textContent = error || '';
     el.style.display = error ? 'block' : 'none';
   }
+}
+
+// --- Debrief section ---
+
+/** Render the debrief panel — banner / summary / editor — for a past flight.
+ *
+ * Hides the entire section for future or non-owned flights. The editor
+ * mounts into ``#debrief-host`` on demand (clicking Add/Edit). After save
+ * or delete, ``onChanged`` is invoked so the page can refetch.
+ */
+export function renderDebriefSection(
+  flight: FlightResponse | null,
+  flaggedCategories: ConditionTagId[],
+  onChanged: () => void,
+): void {
+  const section = $('debrief-section');
+  const banner = $('debrief-banner');
+  const summary = $('debrief-summary');
+  const host = $('debrief-host') as HTMLElement | null;
+  if (!section || !banner || !summary || !host) return;
+
+  // Visibility rules: owner + past flight only.
+  const isOwner = flight?.role === 'owner';
+  const isPast = flight && isFlightPast(
+    flight.target_date, flight.target_time_utc, flight.flight_duration_hours, flight.departure_time,
+  );
+  if (!flight || !isOwner || !isPast) {
+    section.style.display = 'none';
+    return;
+  }
+
+  section.style.display = 'block';
+  host.dataset.flightId = flight.id;
+
+  const debrief = flight.debrief ?? null;
+  if (debrief) {
+    banner.innerHTML = `<button type="button" class="btn btn-secondary" id="debrief-edit-btn">${t('debrief.editCta')}</button>`;
+    summary.innerHTML = renderDebriefSummary(debrief);
+  } else {
+    banner.innerHTML = `<button type="button" class="btn btn-primary" id="debrief-edit-btn">${t('debrief.addCta')}</button>`;
+    summary.innerHTML = '';
+  }
+
+  const openEditor = () => {
+    if (host.dataset.open === '1') {
+      host.dataset.open = '';
+      host.innerHTML = '';
+      return;
+    }
+    host.dataset.open = '1';
+    renderDebriefForm(host, {
+      existing: debrief,
+      flaggedCategories,
+      onSaved: () => { host.dataset.open = ''; host.innerHTML = ''; onChanged(); },
+      onDeleted: () => { host.dataset.open = ''; host.innerHTML = ''; onChanged(); },
+      onCancelled: () => { host.dataset.open = ''; host.innerHTML = ''; },
+    });
+  };
+  document.getElementById('debrief-edit-btn')?.addEventListener('click', openEditor);
 }
 

--- a/web/ts/managers/flights-ui.ts
+++ b/web/ts/managers/flights-ui.ts
@@ -1,9 +1,13 @@
 /** DOM management for the Flights list page. */
 
-import type { FlightResponse, PackMeta } from '../store/types';
-import type { RefreshEntry } from '../adapters/api-adapter';
+import type { DebriefStats, FlightResponse, PackMeta } from '../store/types';
+import { fetchRouteAdvisories, type RefreshEntry } from '../adapters/api-adapter';
 import { $, escapeHtml, formatDate, formatDepartureTime, formatAlt, isFlightPast, flightTitle, flightRoute } from '../utils';
 import { t, getDateLocale } from '../i18n/i18n';
+import { renderDebriefForm } from '../components/debrief-form';
+import { renderDebriefPill, renderDebriefSummary } from '../components/debrief-summary';
+import { renderDebriefStats } from '../components/debrief-stats';
+import { flaggedTagsFromAdvisories } from '../components/debrief-taxonomy';
 
 /** Assessment badge color class. */
 function assessmentClass(assessment: string | null): string {
@@ -18,6 +22,9 @@ function assessmentClass(assessment: string | null): string {
 
 /** Track whether the past-flights section is expanded. */
 let pastExpanded = false;
+
+/** Recent section starts expanded — it's the nudge to debrief. */
+let recentExpanded = true;
 
 /** Render a single flight card. */
 function renderFlightCard(
@@ -78,6 +85,20 @@ function renderFlightCard(
          <input type="checkbox" class="flight-select-checkbox" data-id="${escapeHtml(f.id)}"${checkedAttr}>
        </label>`;
 
+  // Owner-only debrief pill (read-only summary). Only shown for past flights
+  // — future ones can't have been flown yet.
+  let debriefPill = '';
+  if (!isShared && past && f.debrief) {
+    debriefPill = ` ${renderDebriefPill(f.debrief)}`;
+  }
+
+  // Recent-section CTA: clicking expands an inline form below the row.
+  // Only rendered for owner-past-undebriefed flights in the recent section.
+  const isRecent = f.section === 'recent';
+  const debriefAction = isRecent && !isShared && !f.debrief
+    ? `<button class="btn btn-secondary btn-debrief" data-id="${escapeHtml(f.id)}">${t('debrief.openCta')}</button>`
+    : '';
+
   return `
     <div class="flight-card${selectedClass}${isShared ? ' flight-card-shared' : ''}" data-id="${escapeHtml(f.id)}">
       ${selectControl}
@@ -85,7 +106,7 @@ function renderFlightCard(
         <div class="flight-header">
           ${sharedBadge}${pastBadge}<span class="flight-route">${escapeHtml(title)}</span>
           <span class="flight-date">${formatDate(f.target_date)} ${formatDepartureTime(f.departure_time)}</span>
-          <span class="flight-alt">${formatAlt(f.cruise_altitude_ft)}</span>
+          <span class="flight-alt">${formatAlt(f.cruise_altitude_ft)}</span>${debriefPill}
         </div>
         ${ownerLine}
         ${routeLine}
@@ -94,8 +115,10 @@ function renderFlightCard(
         </div>
         <div class="flight-actions">
           <button class="btn btn-primary btn-briefing" data-id="${escapeHtml(f.id)}">${t('flights.btnBriefing')}</button>
+          ${debriefAction}
           ${ownerOnlyActions}
         </div>
+        <div class="debrief-host" data-flight-id="${escapeHtml(f.id)}"></div>
       </div>
     </div>
   `;
@@ -121,6 +144,8 @@ export function renderFlightList(
   onDelete: (id: string) => void,
   selection: SelectionHandlers,
   onUnsubscribe?: (id: string) => void,
+  stats?: DebriefStats | null,
+  onDebriefChanged?: () => void,
 ): void {
   const container = $('flight-list');
   if (!container) return;
@@ -135,20 +160,43 @@ export function renderFlightList(
     return;
   }
 
-  // Split into active and past flights
-  const active: FlightResponse[] = [];
+  // Bucket by server-supplied section (falls back to past/active split for
+  // older API responses missing the field).
+  const future: FlightResponse[] = [];
+  const recent: FlightResponse[] = [];
   const past: FlightResponse[] = [];
   for (const f of flights) {
-    if (isFlightPast(f.target_date, f.target_time_utc, f.flight_duration_hours, f.departure_time)) {
-      past.push(f);
-    } else {
-      active.push(f);
-    }
+    const s = f.section
+      ?? (isFlightPast(f.target_date, f.target_time_utc, f.flight_duration_hours, f.departure_time)
+        ? 'past' : 'future');
+    if (s === 'future') future.push(f);
+    else if (s === 'recent') recent.push(f);
+    else past.push(f);
   }
 
-  const activeCards = active.map(f =>
+  const futureCards = future.map(f =>
     renderFlightCard(f, latestPacks[f.id], activeRefreshes[f.id], selectedIds.has(f.id)),
   ).join('');
+
+  let recentSection = '';
+  if (recent.length > 0) {
+    const expandedClass = recentExpanded ? '' : ' collapsed';
+    const recentCards = recent.map(f =>
+      renderFlightCard(f, latestPacks[f.id], activeRefreshes[f.id], selectedIds.has(f.id)),
+    ).join('');
+    recentSection = `
+      <div class="recent-flights-section${expandedClass}">
+        <button class="recent-flights-toggle" id="recent-flights-toggle">
+          ${t('debrief.recentHeader')} (${recent.length})
+        </button>
+        <div class="recent-flights-list">${recentCards}</div>
+      </div>
+    `;
+  }
+
+  const statsSection = stats
+    ? `<div class="debrief-stats-section">${renderDebriefStats(stats)}</div>`
+    : '';
 
   let pastSection = '';
   if (past.length > 0) {
@@ -166,7 +214,7 @@ export function renderFlightList(
     `;
   }
 
-  container.innerHTML = activeCards + pastSection;
+  container.innerHTML = futureCards + recentSection + statsSection + pastSection;
 
   // Wire toggle
   const toggleBtn = document.getElementById('past-flights-toggle');
@@ -174,6 +222,13 @@ export function renderFlightList(
     pastExpanded = !pastExpanded;
     const section = toggleBtn.closest('.past-flights-section');
     section?.classList.toggle('collapsed', !pastExpanded);
+  });
+
+  const recentToggleBtn = document.getElementById('recent-flights-toggle');
+  recentToggleBtn?.addEventListener('click', () => {
+    recentExpanded = !recentExpanded;
+    const section = recentToggleBtn.closest('.recent-flights-section');
+    section?.classList.toggle('collapsed', !recentExpanded);
   });
 
   // Wire up event listeners
@@ -214,7 +269,52 @@ export function renderFlightList(
     box.addEventListener('click', (e) => e.stopPropagation());
   });
 
+  // Wire debrief CTAs (Recent section).
+  container.querySelectorAll('.btn-debrief').forEach((btn) => {
+    btn.addEventListener('click', async () => {
+      const id = (btn as HTMLElement).dataset.id!;
+      const flight = flights.find(f => f.id === id);
+      if (!flight) return;
+      const card = (btn as HTMLElement).closest('.flight-card');
+      const host = card?.querySelector('.debrief-host') as HTMLElement | null;
+      if (!host) return;
+      // Toggle: if already open, close it.
+      if (host.dataset.open === '1') {
+        host.dataset.open = '';
+        host.innerHTML = '';
+        return;
+      }
+      host.dataset.open = '1';
+      host.innerHTML = `<div class="debrief-loading">${escapeHtml(t('debrief.loading'))}</div>`;
+      // Lazy-fetch advisories for the latest pack so the form knows which
+      // categories to surface as outcome questions. Empty list if the pack
+      // doesn't have advisories or the call fails.
+      const pack = latestPacks[id];
+      let flaggedCategories: ReturnType<typeof flaggedTagsFromAdvisories> = [];
+      if (pack && pack.has_advisories) {
+        try {
+          const manifest = await fetchRouteAdvisories(id, pack.fetch_timestamp);
+          flaggedCategories = flaggedTagsFromAdvisories(manifest);
+        } catch {
+          flaggedCategories = [];
+        }
+      }
+      // Bail if user closed it while we were fetching.
+      if (host.dataset.open !== '1') return;
+      renderDebriefForm(host, {
+        existing: flight.debrief ?? null,
+        flaggedCategories,
+        onSaved: () => { host.dataset.open = ''; host.innerHTML = ''; onDebriefChanged?.(); },
+        onDeleted: () => { host.dataset.open = ''; host.innerHTML = ''; onDebriefChanged?.(); },
+        onCancelled: () => { host.dataset.open = ''; host.innerHTML = ''; },
+      });
+    });
+  });
+
   // Subscribed flights aren't bulk-deletable — exclude them from "select all"/"select all past".
+  // "Active" here = future + recent (everything pre-departure plus the recent
+  // undebriefed window the pilot can still act on).
+  const active = [...future, ...recent];
   const selectableActive = active.filter(f => f.role !== 'subscriber').map(f => f.id);
   const selectablePast = past.filter(f => f.role !== 'subscriber').map(f => f.id);
   renderSelectionBar(

--- a/web/ts/store/flights-store.ts
+++ b/web/ts/store/flights-store.ts
@@ -1,9 +1,10 @@
 /** Zustand vanilla store for the Flights management page. */
 
 import { createStore } from 'zustand/vanilla';
-import type { FlightResponse, PackMeta } from './types';
+import type { DebriefStats, FlightResponse, PackMeta } from './types';
 import type { RefreshEntry } from '../adapters/api-adapter';
 import * as api from '../adapters/api-adapter';
+import { fetchDebriefStats } from '../adapters/debrief-adapter';
 import { errorToMessage } from '../utils';
 
 export interface FlightsState {
@@ -11,6 +12,7 @@ export interface FlightsState {
   flights: FlightResponse[];
   latestPacks: Record<string, PackMeta | null>; // flight_id → latest pack
   activeRefreshes: Record<string, RefreshEntry>; // flight_id → active refresh entry
+  debriefStats: DebriefStats | null;
 
   // UI state
   loading: boolean;
@@ -19,6 +21,7 @@ export interface FlightsState {
 
   // Actions
   loadFlights: () => Promise<void>;
+  loadDebriefStats: () => Promise<void>;
   pollActiveRefreshes: () => Promise<void>;
   createFlight: (waypoints: string[], targetDate: string, opts?: {
     routeName?: string;
@@ -42,6 +45,7 @@ export const flightsStore = createStore<FlightsState>((set, get) => ({
   flights: [],
   latestPacks: {},
   activeRefreshes: {},
+  debriefStats: null,
   loading: false,
   error: null,
   selectedIds: new Set(),
@@ -69,6 +73,15 @@ export const flightsStore = createStore<FlightsState>((set, get) => ({
     }
   },
 
+  loadDebriefStats: async () => {
+    try {
+      const stats = await fetchDebriefStats();
+      set({ debriefStats: stats });
+    } catch {
+      // Non-critical — leave stats null on failure (panel just doesn't render).
+    }
+  },
+
   pollActiveRefreshes: async () => {
     try {
       const entries = await api.fetchActiveRefreshes();
@@ -76,7 +89,18 @@ export const flightsStore = createStore<FlightsState>((set, get) => ({
       for (const e of entries) {
         map[e.flight_id] = e;
       }
-      set({ activeRefreshes: map });
+      // Skip set() if contents are identical — otherwise a fresh empty {}
+      // every 5s churns object identity and triggers a full list re-render,
+      // which wipes inline state (e.g. an open debrief form).
+      const current = get().activeRefreshes;
+      const currentKeys = Object.keys(current);
+      const newKeys = Object.keys(map);
+      const sameShape =
+        currentKeys.length === newKeys.length &&
+        newKeys.every((k) => current[k]?.status === map[k]?.status);
+      if (!sameShape) {
+        set({ activeRefreshes: map });
+      }
     } catch {
       // Non-critical — silently ignore polling errors
     }

--- a/web/ts/store/types.ts
+++ b/web/ts/store/types.ts
@@ -30,6 +30,40 @@ export interface FlightResponse {
   role: 'owner' | 'subscriber';
   owner_display_name: string | null;
   is_subscribed: boolean;
+  debrief?: DebriefResponse | null;
+  section?: 'future' | 'recent' | 'past';
+}
+
+export type DebriefDecision = 'cancelled' | 'flown' | 'monitoring';
+export type ConditionTagId = 'IMC' | 'ICE' | 'WIND' | 'TS' | 'TURB' | 'FRZ' | 'VIS' | 'OPS';
+export type OutcomeValue = 'consistent' | 'better' | 'worse';
+
+export interface DebriefResponse {
+  flight_id: string;
+  decision: DebriefDecision;
+  reasons: ConditionTagId[];
+  outcomes: Partial<Record<ConditionTagId, OutcomeValue>>;
+  note: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface DebriefStatsCategory {
+  queried_count: number;
+  consistent: number;
+  better: number;
+  worse: number;
+}
+
+export interface DebriefStats {
+  window_days: number;
+  total_flights_in_window: number;
+  flown_count: number;
+  cancelled_count: number;
+  monitoring_count: number;
+  pending_debrief_count: number;
+  cancellation_reasons: Partial<Record<ConditionTagId, number>>;
+  category_accuracy: Partial<Record<ConditionTagId, DebriefStatsCategory>>;
 }
 
 export interface CreateFlightRequest {


### PR DESCRIPTION
Closes #92.

## Summary
- Sidecar `flight_debriefs` table capturing **flown / cancelled / monitor-only** + reason chips, per-category outcomes, free-text note. Shared 8-tag taxonomy (IMC/ICE/WIND/TS/TURB/FRZ/VIS/OPS).
- Three-section flights list: **Future / Recent (collapsible) / Past**, with per-user stats panel between Recent and Past. Recent surfaces up to 2 undebriefed past flights from the last 30 days as a gentle nudge.
- Hybrid entry on cancel form: chips + free-text with keyword auto-toggle (typing "icing" lights up the ICE chip).
- Outcome form is **advisory-driven**: only categories the briefing flagged amber/red are surfaced for grading; default `consistent` so the pilot only flips exceptions.
- **Monitor only** (👁) for "set up to watch the weather, didn't intend to fly" — drops out of the nudge, doesn't pollute flown/cancelled stats or per-category accuracy.
- Retention coupling: any flight with a debrief is exempt from T2 (full pack delete). T1 still strips heavy artifacts; lightweight `briefing.json` + DB row stay indefinitely so calibration can later ask "what did the system tell the pilot at briefing time?".
- Info popups (`(i)` button on the form) explain each decision mode.

Also fixes pre-existing 500s on `/packs/latest`: 108 old rows had `models_skipped_region_json='{}'` (a dict) where the Pydantic model expects `list[str]`. Migration 046 backfills `'{}' → '[]'`. The loader stays strict so any new bad data fails loudly.

## Out of scope (deferred to Phase 2/3)
- Post-ETA prompt
- iOS UI (same data shape, different surface)
- Calibration harness changes / DB-backed analyser
- Cross-user / aggregate stats
- cancel.md backfill
- PIREP retention change

See `designs/debrief.md` for the full design.

## Test plan
- [x] 111 new pytest cases pass (taxonomy, storage, stats, API, retention exemption, section assignment, monitor-only validation)
- [x] Existing test suites still green (ran touched-area tests)
- [x] `tsc --noEmit` clean
- [x] All web bundles build
- [x] Smoke-tested live on dev server: cancel debrief, flown debrief, monitor-only debrief, stats panel, retention exemption, the 500-fix migration applied cleanly
- [ ] Reviewer: verify the rebase is clean against current main (rebased onto `1109d5fa` from PR #96)
- [ ] Reviewer: sanity-check the advisory → tag mapping in `web/ts/components/debrief-taxonomy.ts` (`ADVISORY_TAG_MAP`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)