### PR TITLE
test(web): add Vitest framework with Phase 1+2 unit tests

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -15,7 +15,247 @@
         "@playwright/test": "^1.58.2",
         "@types/leaflet": "^1.9.21",
         "esbuild": "^0.27.3",
-        "typescript": "^5.9.3"
+        "jsdom": "^29.1.0",
+        "typescript": "^5.9.3",
+        "vitest": "^4.1.5"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
+      "integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
+      "integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
+      "integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -460,6 +700,60 @@
         "node": ">=18"
       }
     },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
+      "integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
     "node_modules/@playwright/test": {
       "version": "1.58.2",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
@@ -475,6 +769,313 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.17.tgz",
+      "integrity": "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.17.tgz",
+      "integrity": "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.17.tgz",
+      "integrity": "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.17.tgz",
+      "integrity": "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz",
+      "integrity": "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.17.tgz",
+      "integrity": "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
+      "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/geojson": {
       "version": "7946.0.16",
@@ -492,6 +1093,221 @@
       "dependencies": {
         "@types/geojson": "*"
       }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
+      "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
+      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.5",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
+      "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.5",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
+      "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
+      "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.27.3",
@@ -535,6 +1351,44 @@
         "@esbuild/win32-x64": "0.27.3"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
@@ -550,11 +1404,430 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.0.tgz",
+      "integrity": "sha512-YNUc7fB9QuvSSQWfrH0xF+TyABkxUwx8sswgIDaCrw4Hol8BghdZDkITtZheRJeMtzWlnTfsM3bBBusRvpO1wg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/leaflet": {
       "version": "1.9.4",
       "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
       "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
     },
     "node_modules/playwright": {
       "version": "1.58.2",
@@ -588,6 +1861,238 @@
         "node": ">=18"
       }
     },
+    "node_modules/postcss": {
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
+      "integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.127.0",
+        "@rolldown/pluginutils": "1.0.0-rc.17"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.17",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.0.29",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.29.tgz",
+      "integrity": "sha512-JIXCerhudr/N6OWLwLF1HVsTTUo7ry6qHa5eWZEkiMuxsIiAACL55tGLfqfHfoH7QaMQUW8fngD7u7TxWexYQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.29"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.29",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.29.tgz",
+      "integrity": "sha512-W99NuU7b1DcG3uJ3v9k9VztCH3WialNbBkBft5wCs8V8mexu0XQqaZEYb9l9RNNzK8+3EJ9PKWB0/RUtTQ/o+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -601,6 +2106,281 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.0.10",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
+      "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.10",
+        "rolldown": "1.0.0-rc.17",
+        "tinyglobby": "^0.2.16"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
+      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.5",
+        "@vitest/mocker": "4.1.5",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/runner": "4.1.5",
+        "@vitest/snapshot": "4.1.5",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.5",
+        "@vitest/browser-preview": "4.1.5",
+        "@vitest/browser-webdriverio": "4.1.5",
+        "@vitest/coverage-istanbul": "4.1.5",
+        "@vitest/coverage-v8": "4.1.5",
+        "@vitest/ui": "4.1.5",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/zustand": {
       "version": "5.0.11",

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -15,7 +15,6 @@
         "@playwright/test": "^1.58.2",
         "@types/leaflet": "^1.9.21",
         "esbuild": "^0.27.3",
-        "jsdom": "^29.1.0",
         "typescript": "^5.9.3",
         "vitest": "^4.1.5"
       }
@@ -26,6 +25,8 @@
       "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@asamuzakjp/generational-cache": "^1.0.1",
         "@csstools/css-calc": "^3.2.0",
@@ -43,6 +44,8 @@
       "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@asamuzakjp/generational-cache": "^1.0.1",
         "@asamuzakjp/nwsapi": "^2.3.9",
@@ -60,6 +63,8 @@
       "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
@@ -69,7 +74,9 @@
       "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
       "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@bramus/specificity": {
       "version": "2.4.2",
@@ -77,6 +84,8 @@
       "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "css-tree": "^3.0.0"
       },
@@ -100,6 +109,8 @@
         }
       ],
       "license": "MIT-0",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -120,6 +131,8 @@
         }
       ],
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -144,6 +157,8 @@
         }
       ],
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@csstools/color-helpers": "^6.0.2",
         "@csstools/css-calc": "^3.2.0"
@@ -172,6 +187,8 @@
         }
       ],
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -195,6 +212,8 @@
         }
       ],
       "license": "MIT-0",
+      "optional": true,
+      "peer": true,
       "peerDependencies": {
         "css-tree": "^3.2.1"
       },
@@ -220,6 +239,8 @@
         }
       ],
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -706,6 +727,8 @@
       "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
@@ -1223,6 +1246,8 @@
       "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "require-from-string": "^2.0.2"
       }
@@ -1250,6 +1275,8 @@
       "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "mdn-data": "2.27.1",
         "source-map-js": "^1.2.1"
@@ -1264,6 +1291,8 @@
       "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "whatwg-mimetype": "^5.0.0",
         "whatwg-url": "^16.0.0"
@@ -1277,7 +1306,9 @@
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
@@ -1295,6 +1326,8 @@
       "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -1410,6 +1443,8 @@
       "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@exodus/bytes": "^1.6.0"
       },
@@ -1422,7 +1457,9 @@
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/jsdom": {
       "version": "29.1.0",
@@ -1430,6 +1467,8 @@
       "integrity": "sha512-YNUc7fB9QuvSSQWfrH0xF+TyABkxUwx8sswgIDaCrw4Hol8BghdZDkITtZheRJeMtzWlnTfsM3bBBusRvpO1wg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@asamuzakjp/css-color": "^5.1.11",
         "@asamuzakjp/dom-selector": "^7.1.1",
@@ -1738,6 +1777,8 @@
       "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": "20 || >=22"
       }
@@ -1757,7 +1798,9 @@
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
       "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
       "dev": true,
-      "license": "CC0-1.0"
+      "license": "CC0-1.0",
+      "optional": true,
+      "peer": true
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -1795,6 +1838,8 @@
       "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "entities": "^8.0.0"
       },
@@ -1896,6 +1941,8 @@
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -1906,6 +1953,8 @@
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1950,6 +1999,8 @@
       "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "xmlchars": "^2.2.0"
       },
@@ -1993,7 +2044,9 @@
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -2045,6 +2098,8 @@
       "integrity": "sha512-JIXCerhudr/N6OWLwLF1HVsTTUo7ry6qHa5eWZEkiMuxsIiAACL55tGLfqfHfoH7QaMQUW8fngD7u7TxWexYQg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "tldts-core": "^7.0.29"
       },
@@ -2057,7 +2112,9 @@
       "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.29.tgz",
       "integrity": "sha512-W99NuU7b1DcG3uJ3v9k9VztCH3WialNbBkBft5wCs8V8mexu0XQqaZEYb9l9RNNzK8+3EJ9PKWB0/RUtTQ/o+Q==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/tough-cookie": {
       "version": "6.0.1",
@@ -2065,6 +2122,8 @@
       "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
       "dev": true,
       "license": "BSD-3-Clause",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "tldts": "^7.0.5"
       },
@@ -2078,6 +2137,8 @@
       "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "punycode": "^2.3.1"
       },
@@ -2113,6 +2174,8 @@
       "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=20.18.1"
       }
@@ -2306,6 +2369,8 @@
       "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "xml-name-validator": "^5.0.0"
       },
@@ -2319,6 +2384,8 @@
       "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=20"
       }
@@ -2329,6 +2396,8 @@
       "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=20"
       }
@@ -2339,6 +2408,8 @@
       "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@exodus/bytes": "^1.11.0",
         "tr46": "^6.0.0",
@@ -2371,6 +2442,8 @@
       "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
       "dev": true,
       "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2380,7 +2453,9 @@
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/zustand": {
       "version": "5.0.11",

--- a/web/package.json
+++ b/web/package.json
@@ -24,7 +24,10 @@
     "dev:user-costs": "npx esbuild ts/user-costs-main.ts --bundle --outfile=dist/user-costs.js --sourcemap --target=es2020 --watch=forever",
     "dev:pireps": "npx esbuild ts/pireps-main.ts --bundle --outfile=dist/pireps.js --sourcemap --target=es2020 --watch=forever",
     "dev:verification": "npx esbuild ts/verification-main.ts --bundle --outfile=dist/verification.js --sourcemap --target=es2020 --watch=forever",
-    "dev:maps": "npx esbuild ts/maps-main.ts --bundle --outfile=dist/maps.js --sourcemap --target=es2020 --watch=forever"
+    "dev:maps": "npx esbuild ts/maps-main.ts --bundle --outfile=dist/maps.js --sourcemap --target=es2020 --watch=forever",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:ui": "vitest --ui"
   },
   "dependencies": {
     "leaflet": "^1.9.4",
@@ -34,6 +37,8 @@
     "@playwright/test": "^1.58.2",
     "@types/leaflet": "^1.9.21",
     "esbuild": "^0.27.3",
-    "typescript": "^5.9.3"
+    "jsdom": "^29.1.0",
+    "typescript": "^5.9.3",
+    "vitest": "^4.1.5"
   }
 }

--- a/web/package.json
+++ b/web/package.json
@@ -37,7 +37,6 @@
     "@playwright/test": "^1.58.2",
     "@types/leaflet": "^1.9.21",
     "esbuild": "^0.27.3",
-    "jsdom": "^29.1.0",
     "typescript": "^5.9.3",
     "vitest": "^4.1.5"
   }

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from '@playwright/test';
 
 export default defineConfig({
   testDir: './tests',
+  testMatch: '*.spec.ts',
   timeout: 30_000,
   retries: 0,
   use: {

--- a/web/tests/unit/compare-zone-access.test.ts
+++ b/web/tests/unit/compare-zone-access.test.ts
@@ -1,0 +1,141 @@
+/** Tests for compare-mode zone accessor.
+ *
+ * The accessor normalizes per-layer zone shapes (icing/cloud/CAT/inversion/
+ * convective) into a uniform { baseFt, topFt, severity } slice for the
+ * cross-model overlay/consensus renderers. A regression here would make
+ * compare-mode silently render an empty band for the affected layer.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { getZonesForLayer } from '../../ts/visualization/cross-section/compare-zone-access';
+import {
+  makeVizPoint, makeIcingZone, makeCloudLayer, makeCatLayer, makeInversion,
+  makeSfipZone,
+} from './fixtures/viz-point';
+
+describe('getZonesForLayer', () => {
+  it('returns empty for unknown layer id', () => {
+    expect(getZonesForLayer('does-not-exist', makeVizPoint())).toEqual([]);
+  });
+
+  it('icing-bands filters out risk=none and exposes severity', () => {
+    const p = makeVizPoint({
+      icingZones: [
+        makeIcingZone({ baseFt: 1000, topFt: 2000, risk: 'none' }),
+        makeIcingZone({ baseFt: 4000, topFt: 8000, risk: 'moderate' }),
+      ],
+    });
+    const slices = getZonesForLayer('icing-bands', p);
+    expect(slices).toEqual([{ baseFt: 4000, topFt: 8000, severity: 'moderate' }]);
+  });
+
+  it('icing-ogimet-nwp-bands reads icingOgimetNwpZones', () => {
+    const p = makeVizPoint({
+      icingOgimetNwpZones: [makeIcingZone({ baseFt: 5000, topFt: 9000, risk: 'light' })],
+    });
+    expect(getZonesForLayer('icing-ogimet-nwp-bands', p)).toEqual([
+      { baseFt: 5000, topFt: 9000, severity: 'light' },
+    ]);
+  });
+
+  it('sfip-bands filters none and exposes risk as severity', () => {
+    const p = makeVizPoint({
+      sfipZones: [
+        makeSfipZone({ risk: 'none' }),
+        makeSfipZone({ baseFt: 4000, topFt: 8000, risk: 'severe' }),
+      ],
+    });
+    expect(getZonesForLayer('sfip-bands', p)).toEqual([
+      { baseFt: 4000, topFt: 8000, severity: 'severe' },
+    ]);
+  });
+
+  it('cloud-bands does NOT filter (covers low-coverage layers too) and uses coverage as severity', () => {
+    const p = makeVizPoint({
+      cloudLayers: [
+        makeCloudLayer({ baseFt: 1000, topFt: 3000, coverage: 'sct' }),
+        makeCloudLayer({ baseFt: 5000, topFt: 9000, coverage: 'ovc' }),
+      ],
+    });
+    const slices = getZonesForLayer('cloud-bands', p);
+    expect(slices).toEqual([
+      { baseFt: 1000, topFt: 3000, severity: 'sct' },
+      { baseFt: 5000, topFt: 9000, severity: 'ovc' },
+    ]);
+  });
+
+  it('nwp-cloud-bands handles null nwpCloudLayers', () => {
+    const p = makeVizPoint({ nwpCloudLayers: null });
+    expect(getZonesForLayer('nwp-cloud-bands', p)).toEqual([]);
+  });
+
+  it('nwp-cloud-bands maps coverage to severity', () => {
+    const p = makeVizPoint({
+      nwpCloudLayers: [makeCloudLayer({ baseFt: 5000, topFt: 9000, coverage: 'bkn' })],
+    });
+    expect(getZonesForLayer('nwp-cloud-bands', p)).toEqual([
+      { baseFt: 5000, topFt: 9000, severity: 'bkn' },
+    ]);
+  });
+
+  it('cat-bands filters none and exposes risk', () => {
+    const p = makeVizPoint({
+      catLayers: [
+        makeCatLayer({ risk: 'none' }),
+        makeCatLayer({ baseFt: 18000, topFt: 22000, risk: 'moderate' }),
+      ],
+    });
+    expect(getZonesForLayer('cat-bands', p)).toEqual([
+      { baseFt: 18000, topFt: 22000, severity: 'moderate' },
+    ]);
+  });
+
+  it('inversion-bands always uses severity="inversion" (no filtering)', () => {
+    const p = makeVizPoint({
+      inversions: [
+        makeInversion({ baseFt: 0, topFt: 1500, strengthC: 0.5 }),
+        makeInversion({ baseFt: 4000, topFt: 6000, strengthC: 5.0 }),
+      ],
+    });
+    expect(getZonesForLayer('inversion-bands', p)).toEqual([
+      { baseFt: 0, topFt: 1500, severity: 'inversion' },
+      { baseFt: 4000, topFt: 6000, severity: 'inversion' },
+    ]);
+  });
+
+  it('thermo-convective-bg synthesizes a single zone from per-point fields', () => {
+    const p = makeVizPoint({
+      convectiveRisk: 'high',
+      convectiveBaseFt: 4000,
+      convectiveTopFt: 35000,
+    });
+    expect(getZonesForLayer('thermo-convective-bg', p)).toEqual([
+      { baseFt: 4000, topFt: 35000, severity: 'high' },
+    ]);
+  });
+
+  it('thermo-convective-bg returns empty when risk=none', () => {
+    const p = makeVizPoint({ convectiveRisk: 'none', convectiveBaseFt: 4000, convectiveTopFt: 30000 });
+    expect(getZonesForLayer('thermo-convective-bg', p)).toEqual([]);
+  });
+
+  it('thermo-convective-bg returns empty when base/top missing', () => {
+    const p = makeVizPoint({ convectiveRisk: 'high', convectiveBaseFt: null, convectiveTopFt: null });
+    expect(getZonesForLayer('thermo-convective-bg', p)).toEqual([]);
+  });
+
+  it('nwp-convective-bg synthesizes from nwp* fields', () => {
+    const p = makeVizPoint({
+      nwpConvectiveRisk: 'moderate',
+      nwpConvectiveBaseFt: 3000,
+      nwpConvectiveTopFt: 25000,
+    });
+    expect(getZonesForLayer('nwp-convective-bg', p)).toEqual([
+      { baseFt: 3000, topFt: 25000, severity: 'moderate' },
+    ]);
+  });
+
+  it('nwp-convective-bg returns empty when risk=none', () => {
+    expect(getZonesForLayer('nwp-convective-bg', makeVizPoint())).toEqual([]);
+  });
+});

--- a/web/tests/unit/fixtures/viz-point.ts
+++ b/web/tests/unit/fixtures/viz-point.ts
@@ -1,0 +1,134 @@
+/** Minimal VizPoint builders for unit tests.
+ *
+ * Tests should override only the fields they care about. The default
+ * VizPoint represents a clear, calm point at sea level.
+ */
+
+import type {
+  VizPoint, VizCloudLayer, VizIcingZone, VizSfipZone, VizSldZone,
+  VizCATLayer, VizInversionLayer, AltitudeLines, VizCloudDiag,
+} from '../../../ts/visualization/types';
+
+export function makeAltitudeLines(overrides: Partial<AltitudeLines> = {}): AltitudeLines {
+  return {
+    freezingLevelFt: null,
+    minus10cLevelFt: null,
+    minus20cLevelFt: null,
+    lclAltitudeFt: null,
+    lfcAltitudeFt: null,
+    elAltitudeFt: null,
+    ...overrides,
+  };
+}
+
+export function makeVizPoint(overrides: Partial<VizPoint> = {}): VizPoint {
+  return {
+    distanceNm: 0,
+    lat: 0,
+    lon: 0,
+    time: '2026-04-29T12:00:00Z',
+    altitudeLines: makeAltitudeLines(),
+    cloudLayers: [],
+    icingZones: [],
+    icingOgimetNwpZones: [],
+    sfipZones: [],
+    iengIcingZones: [],
+    sldZones: [],
+    catLayers: [],
+    eShearLayers: [],
+    inversions: [],
+    convectiveRisk: 'none',
+    convectiveBaseFt: null,
+    convectiveTopFt: null,
+    cinSurfaceJkg: 0,
+    nwpConvectiveRisk: 'none',
+    nwpConvectiveBaseFt: null,
+    nwpConvectiveTopFt: null,
+    nwpConvectiveCoverPct: null,
+    nwpConvectiveMethod: null,
+    hasNwpConvective: false,
+    cloudCoverTotalPct: 0,
+    cloudCoverLowPct: 0,
+    cloudCoverMidPct: 0,
+    headwindKt: 0,
+    crosswindKt: 0,
+    capeSurfaceJkg: 0,
+    worstModelAgreement: 'good',
+    nwpCloudLayers: null,
+    nwpCloudDiag: null,
+    soundingCeilingFt: null,
+    terrainElevationFt: 0,
+    temperatureC: null,
+    precipitationMm: null,
+    ...overrides,
+  };
+}
+
+export function makeCloudLayer(overrides: Partial<VizCloudLayer> = {}): VizCloudLayer {
+  return {
+    baseFt: 3000,
+    topFt: 6000,
+    coverage: 'bkn',
+    ...overrides,
+  };
+}
+
+export function makeIcingZone(overrides: Partial<VizIcingZone> = {}): VizIcingZone {
+  return {
+    baseFt: 4000,
+    topFt: 8000,
+    risk: 'light',
+    type: 'mixed',
+    ...overrides,
+  };
+}
+
+export function makeSfipZone(overrides: Partial<VizSfipZone> = {}): VizSfipZone {
+  return {
+    baseFt: 4000,
+    topFt: 8000,
+    risk: 'light',
+    type: 'rime',
+    meanSfip100: null,
+    variant: 'full',
+    ...overrides,
+  };
+}
+
+export function makeSldZone(overrides: Partial<VizSldZone> = {}): VizSldZone {
+  return {
+    baseFt: 2000,
+    topFt: 5000,
+    risk: 'light',
+    mechanism: 'warm-nose',
+    ...overrides,
+  };
+}
+
+export function makeCatLayer(overrides: Partial<VizCATLayer> = {}): VizCATLayer {
+  return {
+    baseFt: 15000,
+    topFt: 20000,
+    risk: 'light',
+    ...overrides,
+  };
+}
+
+export function makeInversion(overrides: Partial<VizInversionLayer> = {}): VizInversionLayer {
+  return {
+    baseFt: 1500,
+    topFt: 3000,
+    strengthC: 2.5,
+    ...overrides,
+  };
+}
+
+export function makeNwpCloudDiag(overrides: Partial<VizCloudDiag> = {}): VizCloudDiag {
+  return {
+    low: { coverPct: null, baseFt: null, topFt: null },
+    mid: { coverPct: null, baseFt: null, topFt: null },
+    high: { coverPct: null, baseFt: null, topFt: null },
+    ceilingFt: null,
+    ...overrides,
+  };
+}

--- a/web/tests/unit/hewson-colormaps.test.ts
+++ b/web/tests/unit/hewson-colormaps.test.ts
@@ -1,0 +1,113 @@
+/** Tests for Hewson colormap value→color mapping and range resolution. */
+
+import { describe, it, expect } from 'vitest';
+import {
+  colorFor, vRangeFor, gradientCss, COLORMAPS,
+  type HewsonMetric,
+} from '../../ts/visualization/hewson-colormaps';
+
+describe('vRangeFor', () => {
+  it('returns the metric-specific default range', () => {
+    const r = vRangeFor('theta_e', 'default');
+    expect(r.vmin).toBe(COLORMAPS.theta_e.defaultVmin);
+    expect(r.vmax).toBe(COLORMAPS.theta_e.defaultVmax);
+  });
+
+  it('returns the storm range for storm scale', () => {
+    const r = vRangeFor('gradient', 'storm');
+    expect(r.vmin).toBe(COLORMAPS.gradient.stormVmin);
+    expect(r.vmax).toBe(COLORMAPS.gradient.stormVmax);
+  });
+
+  it('storm range is at least as wide as default (gradient)', () => {
+    const def = vRangeFor('gradient', 'default');
+    const storm = vRangeFor('gradient', 'storm');
+    expect(storm.vmax - storm.vmin).toBeGreaterThanOrEqual(def.vmax - def.vmin);
+  });
+});
+
+describe('colorFor', () => {
+  it('returns transparent rgba for null', () => {
+    expect(colorFor('gradient', null, 0, 10)).toBe('rgba(0,0,0,0)');
+  });
+
+  it('returns transparent rgba for NaN/Infinity', () => {
+    expect(colorFor('gradient', NaN, 0, 10)).toBe('rgba(0,0,0,0)');
+    expect(colorFor('gradient', Infinity, 0, 10)).toBe('rgba(0,0,0,0)');
+  });
+
+  it('produces valid hex colors at boundary and midpoint', () => {
+    for (const v of [0, 5, 10]) {
+      const c = colorFor('gradient', v, 0, 10);
+      expect(c).toMatch(/^#[0-9a-f]{6}$/);
+    }
+  });
+
+  it('first anchor at vmin, last anchor at vmax', () => {
+    const c0 = colorFor('gradient', 0, 0, 10);
+    expect(c0).toBe(COLORMAPS.gradient.ramp[0]);
+    const c1 = colorFor('gradient', 10, 0, 10);
+    expect(c1).toBe(COLORMAPS.gradient.ramp[COLORMAPS.gradient.ramp.length - 1]);
+  });
+
+  it('clamps below vmin to first anchor', () => {
+    const cBelow = colorFor('gradient', -100, 0, 10);
+    expect(cBelow).toBe(COLORMAPS.gradient.ramp[0]);
+  });
+
+  it('clamps above vmax to last anchor', () => {
+    const cAbove = colorFor('gradient', 1000, 0, 10);
+    expect(cAbove).toBe(COLORMAPS.gradient.ramp[COLORMAPS.gradient.ramp.length - 1]);
+  });
+
+  it('handles vmax==vmin by returning the ramp midpoint', () => {
+    // 9 anchors → midpoint is index 4
+    const c = colorFor('gradient', 5, 5, 5);
+    expect(c).toBe(COLORMAPS.gradient.ramp[4]);
+  });
+
+  it('produces monotone ramp for sequential metric (gradient)', () => {
+    // Sample a few points and ensure the colors differ — quick sanity check
+    // that interpolation is wired correctly.
+    const c0 = colorFor('gradient', 0, 0, 10);
+    const c5 = colorFor('gradient', 5, 0, 10);
+    const c10 = colorFor('gradient', 10, 0, 10);
+    expect(new Set([c0, c5, c10]).size).toBe(3);
+  });
+});
+
+describe('gradientCss', () => {
+  it('returns a linear-gradient with stops at evenly spaced percentages', () => {
+    for (const metric of Object.keys(COLORMAPS) as HewsonMetric[]) {
+      const css = gradientCss(metric);
+      expect(css).toMatch(/^linear-gradient\(to right,/);
+      const ramp = COLORMAPS[metric].ramp;
+      expect(css).toContain(`${ramp[0]} 0%`);
+      expect(css).toContain(`${ramp[ramp.length - 1]} 100%`);
+    }
+  });
+});
+
+describe('COLORMAPS catalog integrity', () => {
+  it('every metric has a 9-anchor ramp', () => {
+    for (const [name, spec] of Object.entries(COLORMAPS)) {
+      expect(spec.ramp.length, `${name} ramp length`).toBe(9);
+    }
+  });
+
+  it('every anchor is a 7-char hex color', () => {
+    for (const spec of Object.values(COLORMAPS)) {
+      for (const hex of spec.ramp) {
+        expect(hex).toMatch(/^#[0-9a-f]{6}$/i);
+      }
+    }
+  });
+
+  it('storm range includes default range for sequential metrics', () => {
+    for (const [name, spec] of Object.entries(COLORMAPS)) {
+      if (spec.type !== 'sequential') continue;
+      expect(spec.stormVmin, `${name} stormVmin`).toBeLessThanOrEqual(spec.defaultVmin);
+      expect(spec.stormVmax, `${name} stormVmax`).toBeGreaterThanOrEqual(spec.defaultVmax);
+    }
+  });
+});

--- a/web/tests/unit/layer-registry.test.ts
+++ b/web/tests/unit/layer-registry.test.ts
@@ -1,0 +1,172 @@
+/** Tests for cross-section layer registry: compact-mode collapsing,
+ *  preferred-method resolution, preset application.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  getAllLayers, getDefaultEnabled, getLayerGroups,
+  getPreferredLayerForGroup, getCompactLayerOverrides,
+  getPreset, getPresets,
+} from '../../ts/visualization/cross-section/layer-registry';
+
+describe('getAllLayers', () => {
+  it('returns at least the canonical 13 band/line layer ids', () => {
+    const ids = new Set(getAllLayers().map((l) => l.id));
+    // Spot-check a few; if any of these disappear, callers (incl. tooltip
+    // registry) have probably been silently broken.
+    for (const id of [
+      'cloud-bands', 'nwp-cloud-bands', 'soft-cloud-bands', 'soft-nwp-cloud-bands',
+      'icing-bands', 'icing-ogimet-nwp-bands', 'sfip-bands', 'ieng-icing-bands', 'sld-bands',
+      'cat-bands', 'e-shear-bands', 'inversion-bands',
+      'thermo-convective-bg', 'nwp-convective-bg',
+      'terrain', 'freezing-level', 'cruise-altitude',
+    ]) {
+      expect(ids.has(id), `missing layer id ${id}`).toBe(true);
+    }
+  });
+
+  it('all layer ids are unique', () => {
+    const ids = getAllLayers().map((l) => l.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});
+
+describe('getDefaultEnabled', () => {
+  it('returns one entry per registered layer', () => {
+    const defaults = getDefaultEnabled();
+    expect(Object.keys(defaults).length).toBe(getAllLayers().length);
+  });
+
+  it('matches each layer.defaultEnabled', () => {
+    const defaults = getDefaultEnabled();
+    for (const layer of getAllLayers()) {
+      expect(defaults[layer.id]).toBe(layer.defaultEnabled);
+    }
+  });
+});
+
+describe('getCompactLayerOverrides', () => {
+  it('enables exactly the preferred layer per group, disables siblings', () => {
+    const overrides = getCompactLayerOverrides({
+      clouds: 'soft_nwp',
+      icing: 'ogimet_nwp',
+      turbulence: 'ri',
+      convection: 'nwp',
+    });
+
+    // Clouds: only soft-nwp-cloud-bands enabled
+    expect(overrides['soft-nwp-cloud-bands']).toBe(true);
+    expect(overrides['soft-cloud-bands']).toBe(false);
+    expect(overrides['nwp-cloud-bands']).toBe(false);
+    expect(overrides['cloud-bands']).toBe(false);
+
+    // Icing: only ogimet-nwp
+    expect(overrides['icing-ogimet-nwp-bands']).toBe(true);
+    expect(overrides['icing-bands']).toBe(false);
+    expect(overrides['sfip-bands']).toBe(false);
+    expect(overrides['ieng-icing-bands']).toBe(false);
+
+    // Turbulence: only cat-bands
+    expect(overrides['cat-bands']).toBe(true);
+    expect(overrides['e-shear-bands']).toBe(false);
+
+    // Convection: only nwp-convective-bg
+    expect(overrides['nwp-convective-bg']).toBe(true);
+    expect(overrides['thermo-convective-bg']).toBe(false);
+  });
+
+  it('falsy preferred method disables all in that group', () => {
+    const overrides = getCompactLayerOverrides({
+      clouds: 'unknown-method',
+      icing: 'ogimet_nwp',
+      turbulence: 'ri',
+      convection: 'nwp',
+    });
+    expect(overrides['soft-nwp-cloud-bands']).toBe(false);
+    expect(overrides['soft-cloud-bands']).toBe(false);
+    expect(overrides['nwp-cloud-bands']).toBe(false);
+    expect(overrides['cloud-bands']).toBe(false);
+  });
+});
+
+describe('getPreferredLayerForGroup', () => {
+  const allLayers = getAllLayers();
+  const cloudGroupLayers = allLayers.filter((l) => l.group === 'clouds');
+  const icingGroupLayers = allLayers.filter((l) => l.group === 'icing');
+
+  it('returns the layer matching the preferred method', () => {
+    expect(getPreferredLayerForGroup('clouds', cloudGroupLayers, 'soft_nwp').id)
+      .toBe('soft-nwp-cloud-bands');
+    expect(getPreferredLayerForGroup('icing', icingGroupLayers, 'ogimet_nwp').id)
+      .toBe('icing-ogimet-nwp-bands');
+  });
+
+  it('falls back to defaultEnabled layer when method unknown', () => {
+    const fallback = getPreferredLayerForGroup('clouds', cloudGroupLayers, 'totally-bogus');
+    // First defaultEnabled cloud layer
+    expect(fallback.defaultEnabled || fallback === cloudGroupLayers[0]).toBe(true);
+  });
+
+  it('falls back when method is undefined', () => {
+    const fallback = getPreferredLayerForGroup('icing', icingGroupLayers, undefined);
+    expect(fallback).toBeDefined();
+    expect(icingGroupLayers).toContain(fallback);
+  });
+});
+
+describe('getLayerGroups', () => {
+  it('returns groups in stable display order', () => {
+    const groups = getLayerGroups().map((g) => g.group);
+    // Order asserted in layer-registry.ts
+    const expected = ['terrain', 'reference', 'temperature', 'clouds', 'icing', 'turbulence', 'convection'];
+    // Filter expected to match what's actually present (some groups may be absent if no layers)
+    for (const g of expected) {
+      const idxActual = groups.indexOf(g as typeof groups[number]);
+      if (idxActual === -1) continue;
+      // Just check 'clouds' comes before 'icing' before 'turbulence' before 'convection'
+    }
+    expect(groups.indexOf('clouds')).toBeLessThan(groups.indexOf('icing'));
+    expect(groups.indexOf('icing')).toBeLessThan(groups.indexOf('turbulence'));
+    expect(groups.indexOf('turbulence')).toBeLessThan(groups.indexOf('convection'));
+  });
+
+  it('every group entry has at least one layer', () => {
+    for (const g of getLayerGroups()) {
+      expect(g.layers.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('presets', () => {
+  it('GRAMET preset is registered', () => {
+    const preset = getPreset('gramet');
+    expect(preset).toBeDefined();
+    expect(preset!.id).toBe('gramet');
+    expect(preset!.themeId).toBe('gramet');
+  });
+
+  it('GRAMET enables soft NWP clouds and Ogimet-NWP icing', () => {
+    const preset = getPreset('gramet')!;
+    expect(preset.enabledLayers['soft-nwp-cloud-bands']).toBe(true);
+    expect(preset.enabledLayers['icing-ogimet-nwp-bands']).toBe(true);
+    expect(preset.enabledLayers['nwp-convective-bg']).toBe(true);
+    expect(preset.enabledLayers['cat-bands']).toBe(true);
+  });
+
+  it('GRAMET excludes SLD and DD-only layers', () => {
+    const preset = getPreset('gramet')!;
+    expect(preset.enabledLayers['sld-bands']).toBe(false);
+    expect(preset.enabledLayers['icing-bands']).toBe(false);
+    expect(preset.enabledLayers['cloud-bands']).toBe(false);
+    expect(preset.enabledLayers['thermo-convective-bg']).toBe(false);
+  });
+
+  it('getPreset returns undefined for unknown preset', () => {
+    expect(getPreset('does-not-exist')).toBeUndefined();
+  });
+
+  it('getPresets includes GRAMET', () => {
+    const ids = getPresets().map((p) => p.id);
+    expect(ids).toContain('gramet');
+  });
+});

--- a/web/tests/unit/route-graph-metrics.test.ts
+++ b/web/tests/unit/route-graph-metrics.test.ts
@@ -1,0 +1,152 @@
+/** Tests for the route-graph metric registry. */
+
+import { describe, it, expect } from 'vitest';
+import {
+  ROUTE_GRAPH_METRICS, getMetricById, getMetricOptions, METRIC_NONE,
+} from '../../ts/visualization/route-graph/metrics';
+import { makeVizPoint, makeAltitudeLines, makeNwpCloudDiag } from './fixtures/viz-point';
+
+function metric(id: string) {
+  const m = getMetricById(id);
+  if (!m) throw new Error(`metric ${id} not found`);
+  return m;
+}
+
+describe('getMetricById', () => {
+  it('returns the matching metric', () => {
+    expect(getMetricById('headwind')?.id).toBe('headwind');
+    expect(getMetricById('cape')?.id).toBe('cape');
+  });
+
+  it('returns undefined for METRIC_NONE', () => {
+    expect(getMetricById(METRIC_NONE)).toBeUndefined();
+  });
+
+  it('returns undefined for unknown id', () => {
+    expect(getMetricById('does-not-exist')).toBeUndefined();
+  });
+});
+
+describe('getMetricOptions', () => {
+  it('omits "none" by default', () => {
+    const opts = getMetricOptions(false);
+    expect(opts.find((o) => o.id === METRIC_NONE)).toBeUndefined();
+    expect(opts.length).toBe(ROUTE_GRAPH_METRICS.length);
+  });
+
+  it('prepends "none" when requested', () => {
+    const opts = getMetricOptions(true);
+    expect(opts[0].id).toBe(METRIC_NONE);
+    expect(opts.length).toBe(ROUTE_GRAPH_METRICS.length + 1);
+  });
+});
+
+describe('headwind metric', () => {
+  it('reads headwindKt directly', () => {
+    expect(metric('headwind').getValue(makeVizPoint({ headwindKt: 12 }))).toBe(12);
+  });
+
+  it('formats positive as HW and negative as TW', () => {
+    const m = metric('headwind');
+    expect(m.formatValue!(15)).toBe('15 kt HW');
+    expect(m.formatValue!(-15)).toBe('15 kt TW');
+    expect(m.formatValue!(0)).toBe('0 kt HW');
+  });
+});
+
+describe('ceiling-dd metric (sounding ceiling AGL)', () => {
+  const m = () => metric('ceiling-dd');
+
+  it('returns null when soundingCeilingFt is null', () => {
+    const p = makeVizPoint({ soundingCeilingFt: null, terrainElevationFt: 1000 });
+    expect(m().getValue(p)).toBeNull();
+  });
+
+  it('subtracts terrain elevation to compute AGL', () => {
+    const p = makeVizPoint({ soundingCeilingFt: 4000, terrainElevationFt: 1000 });
+    expect(m().getValue(p)).toBe(3000);
+  });
+
+  it('clamps negative AGL to 0', () => {
+    // Terrain higher than reported ceiling — shouldn't return negative.
+    const p = makeVizPoint({ soundingCeilingFt: 800, terrainElevationFt: 1000 });
+    expect(m().getValue(p)).toBe(0);
+  });
+
+  it('returns null when AGL exceeds 5000 ft cap', () => {
+    // Ceiling well above the route → not interesting for plotting.
+    const p = makeVizPoint({ soundingCeilingFt: 8000, terrainElevationFt: 1000 });
+    expect(m().getValue(p)).toBeNull();
+  });
+
+  it('keeps values exactly at 5000 ft AGL', () => {
+    const p = makeVizPoint({ soundingCeilingFt: 6000, terrainElevationFt: 1000 });
+    expect(m().getValue(p)).toBe(5000);
+  });
+});
+
+describe('ceiling-nwp metric', () => {
+  const m = () => metric('ceiling-nwp');
+
+  it('returns null when nwpCloudDiag is null', () => {
+    const p = makeVizPoint({ nwpCloudDiag: null });
+    expect(m().getValue(p)).toBeNull();
+  });
+
+  it('returns null when ceilingFt is null inside diag', () => {
+    const p = makeVizPoint({ nwpCloudDiag: makeNwpCloudDiag({ ceilingFt: null }) });
+    expect(m().getValue(p)).toBeNull();
+  });
+
+  it('subtracts terrain elevation', () => {
+    const p = makeVizPoint({
+      terrainElevationFt: 500,
+      nwpCloudDiag: makeNwpCloudDiag({ ceilingFt: 3500 }),
+    });
+    expect(m().getValue(p)).toBe(3000);
+  });
+
+  it('returns null above 5000 ft AGL cap', () => {
+    const p = makeVizPoint({
+      terrainElevationFt: 500,
+      nwpCloudDiag: makeNwpCloudDiag({ ceilingFt: 9500 }),
+    });
+    expect(m().getValue(p)).toBeNull();
+  });
+});
+
+describe('freezing-level metric', () => {
+  const m = () => metric('freezing-level');
+
+  it('reads from altitudeLines.freezingLevelFt', () => {
+    const p = makeVizPoint({ altitudeLines: makeAltitudeLines({ freezingLevelFt: 6500 }) });
+    expect(m().getValue(p)).toBe(6500);
+  });
+
+  it('returns null when missing', () => {
+    expect(m().getValue(makeVizPoint())).toBeNull();
+  });
+
+  it('formats with thousands separator and ft suffix', () => {
+    expect(m().formatValue!(6500)).toMatch(/6,500\s*ft/);
+  });
+});
+
+describe('precipitation/cape/cloud-cover/temperature metrics', () => {
+  it('precipitation reads precipitationMm', () => {
+    expect(metric('precipitation').getValue(makeVizPoint({ precipitationMm: 1.2 }))).toBe(1.2);
+  });
+
+  it('cape reads capeSurfaceJkg', () => {
+    expect(metric('cape').getValue(makeVizPoint({ capeSurfaceJkg: 800 }))).toBe(800);
+  });
+
+  it('cloud-cover reads cloudCoverTotalPct', () => {
+    expect(metric('cloud-cover').getValue(makeVizPoint({ cloudCoverTotalPct: 75 }))).toBe(75);
+  });
+
+  it('temperature reads temperatureC, allows null', () => {
+    expect(metric('temperature').getValue(makeVizPoint({ temperatureC: -3 }))).toBe(-3);
+    expect(metric('temperature').getValue(makeVizPoint({ temperatureC: null }))).toBeNull();
+  });
+});

--- a/web/tests/unit/route-map-metrics.test.ts
+++ b/web/tests/unit/route-map-metrics.test.ts
@@ -1,0 +1,225 @@
+/** Tests for route-map metric registry — altitude-dependent value extraction.
+ *
+ * Tested through the public MapMetric API (no internal helper imports), so
+ * that refactors of the internal `worstRiskAtAlt` / `cloudAtAlt` /
+ * `tempAtAltitude` helpers don't break these tests as long as the
+ * user-visible behavior is preserved.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { getMapMetricById, MAP_METRICS } from '../../ts/visualization/route-map/metrics';
+import {
+  makeVizPoint, makeAltitudeLines, makeIcingZone, makeCloudLayer,
+  makeCatLayer, makeSfipZone,
+} from './fixtures/viz-point';
+
+function getMetric(id: string) {
+  const m = getMapMetricById(id);
+  if (!m) throw new Error(`map metric ${id} not found`);
+  return m;
+}
+
+describe('MAP_METRICS registry', () => {
+  it('all metrics have unique IDs', () => {
+    const ids = MAP_METRICS.map((m) => m.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('altitudeDependent flag is set correctly', () => {
+    expect(getMetric('icing-risk-at-level').altitudeDependent).toBe(true);
+    expect(getMetric('cloud-at-level').altitudeDependent).toBe(true);
+    expect(getMetric('temp-at-level').altitudeDependent).toBe(true);
+    expect(getMetric('cape').altitudeDependent).toBe(false);
+    expect(getMetric('cloud-cover-total').altitudeDependent).toBe(false);
+  });
+});
+
+describe('icing-risk-at-level', () => {
+  const m = () => getMetric('icing-risk-at-level');
+
+  it('returns 0 when no zones intersect the altitude', () => {
+    const point = makeVizPoint({
+      icingZones: [makeIcingZone({ baseFt: 4000, topFt: 8000, risk: 'moderate' })],
+    });
+    expect(m().getValue(point, 10000)).toBe(0);
+  });
+
+  it('picks the worst risk among overlapping zones', () => {
+    const point = makeVizPoint({
+      icingZones: [
+        makeIcingZone({ baseFt: 4000, topFt: 8000, risk: 'light' }),
+        makeIcingZone({ baseFt: 5000, topFt: 7000, risk: 'severe' }),
+      ],
+    });
+    // RISK_ORDER: severe = 3
+    expect(m().getValue(point, 6000)).toBe(3);
+  });
+
+  it('inclusive at zone boundaries', () => {
+    const point = makeVizPoint({
+      icingZones: [makeIcingZone({ baseFt: 4000, topFt: 8000, risk: 'moderate' })],
+    });
+    expect(m().getValue(point, 4000)).toBe(2); // moderate=2
+    expect(m().getValue(point, 8000)).toBe(2);
+  });
+});
+
+describe('cat-risk-at-level', () => {
+  const m = () => getMetric('cat-risk-at-level');
+
+  it('reads from catLayers (not icingZones)', () => {
+    const point = makeVizPoint({
+      catLayers: [makeCatLayer({ baseFt: 18000, topFt: 22000, risk: 'severe' })],
+      icingZones: [makeIcingZone({ baseFt: 18000, topFt: 22000, risk: 'none' })],
+    });
+    expect(m().getValue(point, 20000)).toBe(3); // severe
+  });
+});
+
+describe('sfip-at-level', () => {
+  const m = () => getMetric('sfip-at-level');
+
+  it('returns null when no zones intersect', () => {
+    const point = makeVizPoint({
+      sfipZones: [makeSfipZone({ baseFt: 4000, topFt: 8000, meanSfip100: 60 })],
+    });
+    expect(m().getValue(point, 10000)).toBeNull();
+  });
+
+  it('picks the highest SFIP score among overlapping zones', () => {
+    const point = makeVizPoint({
+      sfipZones: [
+        makeSfipZone({ baseFt: 4000, topFt: 8000, meanSfip100: 30 }),
+        makeSfipZone({ baseFt: 5000, topFt: 7000, meanSfip100: 70 }),
+      ],
+    });
+    expect(m().getValue(point, 6000)).toBe(70);
+  });
+
+  it('skips zones with null SFIP score', () => {
+    const point = makeVizPoint({
+      sfipZones: [
+        makeSfipZone({ baseFt: 4000, topFt: 8000, meanSfip100: null }),
+        makeSfipZone({ baseFt: 4000, topFt: 8000, meanSfip100: 25 }),
+      ],
+    });
+    expect(m().getValue(point, 6000)).toBe(25);
+  });
+
+  it('color thresholds map SFIP to risk colors', () => {
+    expect(m().getColor(10)).toBe('#22c55e');  // <=20 green
+    expect(m().getColor(20)).toBe('#22c55e');
+    expect(m().getColor(35)).toBe('#facc15');  // <=50 yellow
+    expect(m().getColor(70)).toBe('#f97316');  // <=80 orange
+    expect(m().getColor(90)).toBe('#ef4444');  // >80 red
+  });
+});
+
+describe('cloud-at-level', () => {
+  const m = () => getMetric('cloud-at-level');
+
+  it('returns 0 when altitude is between layers', () => {
+    const point = makeVizPoint({
+      cloudLayers: [makeCloudLayer({ baseFt: 1000, topFt: 3000, coverage: 'bkn' })],
+    });
+    expect(m().getValue(point, 5000)).toBe(0);
+  });
+
+  it('coverage weights: sct=30, bkn=70, ovc=100', () => {
+    const sct = makeVizPoint({
+      cloudLayers: [makeCloudLayer({ baseFt: 0, topFt: 5000, coverage: 'sct' })],
+    });
+    expect(m().getValue(sct, 2500)).toBeCloseTo(30, 5);
+
+    const bkn = makeVizPoint({
+      cloudLayers: [makeCloudLayer({ baseFt: 0, topFt: 5000, coverage: 'bkn' })],
+    });
+    expect(m().getValue(bkn, 2500)).toBeCloseTo(70, 5);
+
+    const ovc = makeVizPoint({
+      cloudLayers: [makeCloudLayer({ baseFt: 0, topFt: 5000, coverage: 'ovc' })],
+    });
+    expect(m().getValue(ovc, 2500)).toBe(100);
+  });
+
+  it('picks the heaviest coverage among overlapping layers', () => {
+    const point = makeVizPoint({
+      cloudLayers: [
+        makeCloudLayer({ baseFt: 0, topFt: 5000, coverage: 'sct' }),
+        makeCloudLayer({ baseFt: 1000, topFt: 4000, coverage: 'ovc' }),
+      ],
+    });
+    expect(m().getValue(point, 2000)).toBe(100); // ovc wins
+  });
+});
+
+describe('temp-at-level', () => {
+  const m = () => getMetric('temp-at-level');
+
+  it('returns null when freezing level unknown', () => {
+    expect(m().getValue(makeVizPoint(), 5000)).toBeNull();
+  });
+
+  it('returns 0 at the freezing level', () => {
+    const p = makeVizPoint({ altitudeLines: makeAltitudeLines({ freezingLevelFt: 8000 }) });
+    expect(m().getValue(p, 8000)).toBe(0);
+  });
+
+  it('interpolates linearly between 0°C and -10°C', () => {
+    const p = makeVizPoint({
+      altitudeLines: makeAltitudeLines({
+        freezingLevelFt: 8000,
+        minus10cLevelFt: 13000,
+      }),
+    });
+    // Halfway between 8000 (0°C) and 13000 (-10°C) → -5°C
+    expect(m().getValue(p, 10500)).toBeCloseTo(-5, 5);
+  });
+
+  it('extrapolates below freezing level using ~2°C/1000ft lapse', () => {
+    const p = makeVizPoint({ altitudeLines: makeAltitudeLines({ freezingLevelFt: 8000 }) });
+    // 1000 ft below freezing should be ~+2°C
+    expect(m().getValue(p, 7000)).toBeCloseTo(2, 5);
+  });
+
+  it('extrapolates above the highest known reference', () => {
+    const p = makeVizPoint({
+      altitudeLines: makeAltitudeLines({
+        freezingLevelFt: 8000,
+        minus10cLevelFt: 13000,
+      }),
+    });
+    // 1000 ft above -10°C reference should be ~-12°C
+    expect(m().getValue(p, 14000)).toBeCloseTo(-12, 5);
+  });
+});
+
+describe('nwp-ceiling', () => {
+  const m = () => getMetric('nwp-ceiling');
+
+  it('returns null when nwpCloudDiag missing', () => {
+    expect(m().getValue(makeVizPoint())).toBeNull();
+  });
+
+  it('width is inverted: low ceiling → thick line', () => {
+    const wLow = m().getWidth(0);
+    const wHigh = m().getWidth(5000);
+    expect(wLow).toBeGreaterThan(wHigh);
+    expect(wLow).toBeCloseTo(25, 1);
+    expect(wHigh).toBeCloseTo(3, 1);
+  });
+});
+
+describe('headwind-only / tailwind-only', () => {
+  it('headwind clamps negative to 0', () => {
+    const m = getMetric('headwind');
+    expect(m.getValue(makeVizPoint({ headwindKt: -10 }))).toBe(0);
+    expect(m.getValue(makeVizPoint({ headwindKt: 15 }))).toBe(15);
+  });
+
+  it('tailwind reads positive when headwind is negative', () => {
+    const m = getMetric('tailwind');
+    expect(m.getValue(makeVizPoint({ headwindKt: -20 }))).toBe(20);
+    expect(m.getValue(makeVizPoint({ headwindKt: 15 }))).toBe(0);
+  });
+});

--- a/web/tests/unit/scales.test.ts
+++ b/web/tests/unit/scales.test.ts
@@ -1,0 +1,201 @@
+/** Tests for shared visualization color/width scales. */
+
+import { describe, it, expect } from 'vitest';
+import {
+  riskMapColor, cloudCoverMapColor, headwindMapColor, capeMapColor,
+  freezingLevelMapColor, ceilingMapColor, temperatureMapColor,
+  crosswindMapColor, agreementMapColor, linearWidth, altitudeToPressureHpa,
+} from '../../ts/visualization/scales';
+
+describe('riskMapColor', () => {
+  it('maps known risk levels to expected hex colors', () => {
+    expect(riskMapColor('none')).toBe('#22c55e');
+    expect(riskMapColor('light')).toBe('#facc15');
+    expect(riskMapColor('moderate')).toBe('#f97316');
+    expect(riskMapColor('severe')).toBe('#ef4444');
+    expect(riskMapColor('extreme')).toBe('#991b1b');
+  });
+
+  it('falls back to green for unknown risk', () => {
+    expect(riskMapColor('totally-unknown')).toBe('#22c55e');
+  });
+});
+
+describe('cloudCoverMapColor', () => {
+  it('uses lightest gray at 0%', () => {
+    expect(cloudCoverMapColor(0)).toBe('rgb(220, 220, 230)');
+  });
+
+  it('uses darkest gray at 100%', () => {
+    expect(cloudCoverMapColor(100)).toBe('rgb(60, 60, 70)');
+  });
+
+  it('clamps values outside 0-100', () => {
+    expect(cloudCoverMapColor(-50)).toBe(cloudCoverMapColor(0));
+    expect(cloudCoverMapColor(150)).toBe(cloudCoverMapColor(100));
+  });
+});
+
+describe('headwindMapColor', () => {
+  it('returns white at 0 kt', () => {
+    expect(headwindMapColor(0)).toBe('rgb(255, 255, 255)');
+  });
+
+  it('shifts toward red for headwind (positive kt)', () => {
+    const c = headwindMapColor(30);
+    // r=255 fixed, g and b drop equally
+    expect(c).toMatch(/^rgb\(255, \d+, \d+\)$/);
+    const match = c.match(/rgb\(255, (\d+), (\d+)\)/)!;
+    expect(match[1]).toBe(match[2]); // g === b
+    expect(parseInt(match[1])).toBeLessThan(100);
+  });
+
+  it('shifts toward green for tailwind (negative kt)', () => {
+    const c = headwindMapColor(-30);
+    // tailwind keeps r low, g high — clearly different from headwind
+    const match = c.match(/rgb\((\d+), (\d+), (\d+)\)/)!;
+    const [, r, g, b] = match.map(Number);
+    expect(g).toBeGreaterThan(r);
+    expect(g).toBeGreaterThan(b);
+  });
+
+  it('clamps magnitude at 30 kt', () => {
+    expect(headwindMapColor(60)).toBe(headwindMapColor(30));
+    expect(headwindMapColor(-60)).toBe(headwindMapColor(-30));
+  });
+});
+
+describe('capeMapColor', () => {
+  it('returns green at 0 J/kg', () => {
+    expect(capeMapColor(0)).toBe('#22c55e');
+  });
+
+  it('returns dark red at >= 2000 J/kg', () => {
+    expect(capeMapColor(2000)).toBe('#dc2626');
+    expect(capeMapColor(5000)).toBe('#dc2626');
+  });
+
+  it('produces a continuous ramp through midpoint', () => {
+    // At t=0.5 (jkg=1000) the two branches meet — color should be valid rgb
+    const c = capeMapColor(1000);
+    expect(c).toMatch(/^rgb\(\d+, \d+, \d+\)$/);
+  });
+});
+
+describe('ceilingMapColor', () => {
+  it('returns green for null (treats absent as VFR)', () => {
+    expect(ceilingMapColor(null)).toBe('#22c55e');
+  });
+
+  it('uses METAR category boundaries', () => {
+    // Category boundaries are exactly the kind of off-by-one bug worth pinning.
+    expect(ceilingMapColor(199)).toBe('#8e24aa');     // LIFR-purple < 200
+    expect(ceilingMapColor(200)).toBe('#dc3545');     // LIFR-red 200..499
+    expect(ceilingMapColor(499)).toBe('#dc3545');
+    expect(ceilingMapColor(500)).toBe('#dc3545');     // IFR-red 500..999
+    expect(ceilingMapColor(999)).toBe('#dc3545');
+    expect(ceilingMapColor(1000)).toBe('#f59e0b');    // MVFR-amber 1000..2999
+    expect(ceilingMapColor(2999)).toBe('#f59e0b');
+    expect(ceilingMapColor(3000)).toBe('#22c55e');    // VFR-green >= 3000
+  });
+});
+
+describe('temperatureMapColor', () => {
+  it('returns valid rgb for cold/temperate/hot', () => {
+    expect(temperatureMapColor(-20)).toMatch(/^rgb\(\d+, \d+, \d+\)$/);
+    expect(temperatureMapColor(0)).toMatch(/^rgb\(\d+, \d+, \d+\)$/);
+    expect(temperatureMapColor(40)).toMatch(/^rgb\(\d+, \d+, \d+\)$/);
+  });
+
+  it('clamps below -20°C to coldest color', () => {
+    expect(temperatureMapColor(-50)).toBe(temperatureMapColor(-20));
+  });
+
+  it('clamps above +40°C to hottest color', () => {
+    expect(temperatureMapColor(60)).toBe(temperatureMapColor(40));
+  });
+});
+
+describe('freezingLevelMapColor', () => {
+  it('darkest blue at 0 ft (cold)', () => {
+    expect(freezingLevelMapColor(0)).toBe('rgb(30, 60, 200)');
+  });
+
+  it('lightest blue at 15000 ft (warm)', () => {
+    expect(freezingLevelMapColor(15000)).toBe('rgb(205, 235, 255)');
+  });
+
+  it('clamps above 15000', () => {
+    expect(freezingLevelMapColor(25000)).toBe(freezingLevelMapColor(15000));
+  });
+});
+
+describe('crosswindMapColor', () => {
+  it('white at 0 kt', () => {
+    expect(crosswindMapColor(0)).toBe('rgb(255, 255, 255)');
+  });
+
+  it('uses absolute value (sign-independent)', () => {
+    expect(crosswindMapColor(15)).toBe(crosswindMapColor(-15));
+  });
+
+  it('clamps at 25 kt', () => {
+    expect(crosswindMapColor(50)).toBe(crosswindMapColor(25));
+  });
+});
+
+describe('agreementMapColor', () => {
+  it('maps known agreement levels', () => {
+    expect(agreementMapColor('good')).toBe('#22c55e');
+    expect(agreementMapColor('moderate')).toBe('#f97316');
+    expect(agreementMapColor('poor')).toBe('#ef4444');
+  });
+
+  it('falls back to green for unknown', () => {
+    expect(agreementMapColor('???')).toBe('#22c55e');
+  });
+});
+
+describe('linearWidth', () => {
+  it('returns minW at value=0', () => {
+    expect(linearWidth(0, 30, 3, 25)).toBe(3);
+  });
+
+  it('returns maxW at value=max', () => {
+    expect(linearWidth(30, 30, 3, 25)).toBe(25);
+  });
+
+  it('interpolates linearly', () => {
+    expect(linearWidth(15, 30, 3, 25)).toBe(14);
+  });
+
+  it('uses absolute value (sign-independent)', () => {
+    expect(linearWidth(-30, 30, 3, 25)).toBe(25);
+  });
+
+  it('clamps above max', () => {
+    expect(linearWidth(60, 30, 3, 25)).toBe(25);
+  });
+});
+
+describe('altitudeToPressureHpa', () => {
+  it('returns ~1013 hPa at sea level', () => {
+    expect(altitudeToPressureHpa(0)).toBeCloseTo(1013.25, 1);
+  });
+
+  it('returns ~700 hPa at ~10000 ft', () => {
+    // Standard atmosphere: 10000 ft ≈ 697 hPa
+    expect(altitudeToPressureHpa(10000)).toBeGreaterThan(690);
+    expect(altitudeToPressureHpa(10000)).toBeLessThan(710);
+  });
+
+  it('returns ~500 hPa at ~18000 ft', () => {
+    expect(altitudeToPressureHpa(18000)).toBeGreaterThan(490);
+    expect(altitudeToPressureHpa(18000)).toBeLessThan(510);
+  });
+
+  it('is monotonically decreasing', () => {
+    expect(altitudeToPressureHpa(0)).toBeGreaterThan(altitudeToPressureHpa(5000));
+    expect(altitudeToPressureHpa(5000)).toBeGreaterThan(altitudeToPressureHpa(15000));
+  });
+});

--- a/web/tests/unit/segment-style.test.ts
+++ b/web/tests/unit/segment-style.test.ts
@@ -1,0 +1,90 @@
+/** Tests for route-map segment style computation. */
+
+import { describe, it, expect } from 'vitest';
+import { computeSegmentStyles } from '../../ts/visualization/route-map/segment-style';
+import type { MapMetric } from '../../ts/visualization/route-map/metrics';
+import { makeVizPoint } from './fixtures/viz-point';
+
+/** Build a stub MapMetric where getValue/getColor/getWidth are caller-controlled. */
+function stubMetric(
+  getValue: (idx: number) => number | null,
+  getColor: (v: number) => string = (v) => `c-${v}`,
+  getWidth: (v: number) => number = (v) => v,
+): MapMetric {
+  let callIdx = 0;
+  return {
+    id: 'stub',
+    label: 'stub',
+    unit: '',
+    altitudeDependent: false,
+    getValue: () => getValue(callIdx++),
+    getColor,
+    getWidth,
+    formatValue: (v) => String(v),
+    legendStops: [],
+  };
+}
+
+describe('computeSegmentStyles', () => {
+  it('returns N-1 segments for N points', () => {
+    const points = [makeVizPoint({ distanceNm: 0 }), makeVizPoint({ distanceNm: 10 }), makeVizPoint({ distanceNm: 20 })];
+    const styles = computeSegmentStyles(points, null, null, 5000);
+    expect(styles).toHaveLength(2);
+  });
+
+  it('returns empty array for single point', () => {
+    const styles = computeSegmentStyles([makeVizPoint()], null, null, 5000);
+    expect(styles).toHaveLength(0);
+  });
+
+  it('uses default color/weight when no metrics provided', () => {
+    const points = [makeVizPoint(), makeVizPoint()];
+    const styles = computeSegmentStyles(points, null, null, 5000);
+    expect(styles[0]).toEqual({ color: '#2563eb', weight: 15 });
+  });
+
+  it('averages endpoint values when both available', () => {
+    const points = [makeVizPoint(), makeVizPoint()];
+    let captured: number | null = null;
+    const colorMetric = stubMetric(
+      (i) => [10, 20][i] ?? null,
+      (v) => { captured = v; return '#abc'; },
+    );
+    const styles = computeSegmentStyles(points, colorMetric, null, 0);
+    expect(captured).toBe(15);
+    expect(styles[0].color).toBe('#abc');
+  });
+
+  it('uses available endpoint when other is null', () => {
+    const points = [makeVizPoint(), makeVizPoint()];
+    let captured: number | null = null;
+    const colorMetric = stubMetric(
+      (i) => [null, 42][i] ?? null,
+      (v) => { captured = v; return '#fff'; },
+    );
+    computeSegmentStyles(points, colorMetric, null, 0);
+    expect(captured).toBe(42);
+  });
+
+  it('falls back to default color when both endpoints null', () => {
+    const points = [makeVizPoint(), makeVizPoint()];
+    const colorMetric = stubMetric(() => null);
+    const styles = computeSegmentStyles(points, colorMetric, null, 0);
+    expect(styles[0].color).toBe('#2563eb');
+  });
+
+  it('color and width metrics evaluated independently', () => {
+    const points = [makeVizPoint(), makeVizPoint()];
+    const colorMetric = stubMetric(
+      (i) => [5, 15][i] ?? null,
+      (v) => `color-${v}`,
+    );
+    const widthMetric = stubMetric(
+      (i) => [100, 200][i] ?? null,
+      undefined,
+      (v) => v / 10,
+    );
+    const styles = computeSegmentStyles(points, colorMetric, widthMetric, 0);
+    expect(styles[0]).toEqual({ color: 'color-10', weight: 15 }); // (100+200)/2/10
+  });
+});

--- a/web/tests/unit/tooltip-formatters.test.ts
+++ b/web/tests/unit/tooltip-formatters.test.ts
@@ -1,0 +1,268 @@
+/** Tests for cross-section per-layer tooltip formatters.
+ *
+ * Why these tests exist: a previous refactor renamed cross-section layer
+ * IDs and silently dropped tooltip lines for the renamed layers because
+ * the tooltip registry's `id` / `enabledBy` aliases lost their backing
+ * layer. The "structural" tests below check that every band-style layer
+ * registered in `layer-registry.ts` is still reachable from the tooltip
+ * registry — either as a primary `id` or via an `enabledBy` alias.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { LAYER_TOOLTIPS } from '../../ts/visualization/cross-section/tooltip-formatters';
+import { getAllLayers } from '../../ts/visualization/cross-section/layer-registry';
+import {
+  makeVizPoint, makeAltitudeLines, makeCloudLayer, makeIcingZone,
+  makeSfipZone, makeSldZone, makeCatLayer, makeInversion,
+} from './fixtures/viz-point';
+
+function findDef(id: string) {
+  const def = LAYER_TOOLTIPS.find((d) => d.id === id);
+  if (!def) throw new Error(`No tooltip def for ${id}`);
+  return def;
+}
+
+/** Run a layer's formatLine against the first matching zone at a given altitude. */
+function format(id: string, point: Parameters<ReturnType<typeof findDef>['getZones']>[0], hoverAltFt: number): string | null {
+  const def = findDef(id);
+  const zones = def.getZones(point);
+  for (const z of zones) {
+    if (hoverAltFt >= z.baseFt && hoverAltFt <= z.topFt) {
+      return def.formatLine(z, hoverAltFt);
+    }
+  }
+  return null;
+}
+
+describe('LAYER_TOOLTIPS registry — structural integrity', () => {
+  it('registers exactly the band-style layers that need tooltips', () => {
+    // Every band-style layer (anything except the proximity-based lines and
+    // terrain) MUST be reachable from the tooltip registry, otherwise the
+    // hover tooltip will silently drop that row.
+    const PROXIMITY_OR_TERRAIN_LAYERS = new Set([
+      'terrain',
+      'freezing-level', 'minus-10c', 'minus-20c',
+      'lcl', 'lfc', 'el',
+      'cruise-altitude',
+    ]);
+
+    const layerIds = getAllLayers()
+      .map((l) => l.id)
+      .filter((id) => !PROXIMITY_OR_TERRAIN_LAYERS.has(id));
+
+    const reachable = new Set<string>();
+    for (const def of LAYER_TOOLTIPS) {
+      reachable.add(def.id);
+      for (const alias of def.enabledBy ?? []) reachable.add(alias);
+    }
+
+    for (const id of layerIds) {
+      expect(reachable.has(id), `layer "${id}" has no tooltip entry or enabledBy alias`).toBe(true);
+    }
+  });
+
+  it('aliases soft-cloud-bands → cloud-bands tooltip', () => {
+    // Specific guard for the historical regression: enabling only
+    // soft-cloud-bands must still produce a DD cloud tooltip line.
+    const cloudDD = findDef('cloud-bands');
+    expect(cloudDD.enabledBy).toContain('soft-cloud-bands');
+  });
+
+  it('aliases soft-nwp-cloud-bands → nwp-cloud-bands tooltip', () => {
+    const cloudNWP = findDef('nwp-cloud-bands');
+    expect(cloudNWP.enabledBy).toContain('soft-nwp-cloud-bands');
+  });
+});
+
+describe('cloud-bands (DD)', () => {
+  it('formats with DD and temperature when present', () => {
+    const point = makeVizPoint({
+      cloudLayers: [makeCloudLayer({
+        baseFt: 3000, topFt: 6000, coverage: 'bkn',
+        meanDewpointDepressionC: 1.2, meanTemperatureC: -5,
+      })],
+    });
+    expect(format('cloud-bands', point, 4500)).toBe('3,000 ft–FL060 bkn (DD 1.2°C, T -5°C)');
+  });
+
+  it('drops empty extras when DD/temperature missing', () => {
+    const point = makeVizPoint({
+      cloudLayers: [makeCloudLayer({ baseFt: 3000, topFt: 6000, coverage: 'sct' })],
+    });
+    expect(format('cloud-bands', point, 4500)).toBe('3,000 ft–FL060 sct');
+  });
+});
+
+describe('nwp-cloud-bands (NWP)', () => {
+  it('shows [band] tag only when source is grib', () => {
+    const grib = makeVizPoint({
+      nwpCloudLayers: [makeCloudLayer({
+        baseFt: 5000, topFt: 9000, coverage: 'ovc',
+        meanCloudCoverPct: 90, meanTemperatureC: -2, source: 'grib',
+      })],
+    });
+    expect(format('nwp-cloud-bands', grib, 7000)).toBe(
+      'NWP: ovc FL050–FL090 (CC 90%, T -2°C) [band]',
+    );
+
+    const nwp3d = makeVizPoint({
+      nwpCloudLayers: [makeCloudLayer({
+        baseFt: 5000, topFt: 9000, coverage: 'bkn',
+        meanCloudCoverPct: 65, meanTemperatureC: -2, source: 'nwp_3d',
+      })],
+    });
+    expect(format('nwp-cloud-bands', nwp3d, 7000)).toBe(
+      'NWP: bkn FL050–FL090 (CC 65%, T -2°C)',
+    );
+  });
+
+  it('returns null when no nwpCloudLayers present', () => {
+    const point = makeVizPoint({ nwpCloudLayers: null });
+    expect(format('nwp-cloud-bands', point, 5000)).toBeNull();
+  });
+});
+
+describe('icing layers', () => {
+  it('icing-bands filters none and renders +SLD when sldRisk', () => {
+    const point = makeVizPoint({
+      icingZones: [
+        makeIcingZone({ baseFt: 1000, topFt: 2000, risk: 'none', type: 'mixed' }),
+        makeIcingZone({
+          baseFt: 4000, topFt: 8000, risk: 'moderate', type: 'rime',
+          meanIcingIndex: 4, meanTemperatureC: -3, sldRisk: true,
+        }),
+      ],
+    });
+    // The "none" zone is filtered out by getZones; only the moderate zone
+    // is matched at 6000 ft.
+    expect(format('icing-bands', point, 6000)).toBe('4,000 ft–FL080 moderate rime (idx 4, T -3°C) +SLD');
+  });
+
+  it('icing-ogimet-nwp-bands renders header in registry', () => {
+    expect(findDef('icing-ogimet-nwp-bands').header).toBe('Icing (Ogimet-NWP)');
+  });
+
+  it('sfip-bands shows SFIP score and [proxy] only for non-full variants', () => {
+    const fullVariant = makeVizPoint({
+      sfipZones: [makeSfipZone({
+        baseFt: 4000, topFt: 8000, risk: 'light', type: 'mixed',
+        meanSfip100: 35, variant: 'full', meanTemperatureC: -4,
+      })],
+    });
+    expect(format('sfip-bands', fullVariant, 6000)).toBe(
+      '4,000 ft–FL080 SFIP 35/100 mixed (T -4°C)',
+    );
+
+    const proxyVariant = makeVizPoint({
+      sfipZones: [makeSfipZone({
+        baseFt: 4000, topFt: 8000, risk: 'light', type: 'mixed',
+        meanSfip100: 28, variant: 'interp_no_vv', meanTemperatureC: -4,
+      })],
+    });
+    expect(format('sfip-bands', proxyVariant, 6000)).toBe(
+      '4,000 ft–FL080 SFIP 28/100 mixed (T -4°C) [proxy]',
+    );
+  });
+
+  it('sld-bands shows mechanism', () => {
+    const point = makeVizPoint({
+      sldZones: [makeSldZone({ baseFt: 2000, topFt: 5000, risk: 'moderate', mechanism: 'warm-nose' })],
+    });
+    expect(format('sld-bands', point, 3500)).toBe('2,000 ft–FL050 moderate warm-nose');
+  });
+});
+
+describe('turbulence layers', () => {
+  it('cat-bands shows Ri when populated', () => {
+    const point = makeVizPoint({
+      catLayers: [makeCatLayer({
+        baseFt: 15000, topFt: 20000, risk: 'moderate', richardsonNumber: 0.18,
+      })],
+    });
+    expect(format('cat-bands', point, 17000)).toBe('FL150–FL200 CAT moderate (Ri 0.18)');
+  });
+
+  it('cat-bands omits Ri when not populated', () => {
+    const point = makeVizPoint({
+      catLayers: [makeCatLayer({ baseFt: 15000, topFt: 20000, risk: 'light' })],
+    });
+    expect(format('cat-bands', point, 17000)).toBe('FL150–FL200 CAT light');
+  });
+
+  it('e-shear-bands renders separately from cat-bands', () => {
+    const point = makeVizPoint({
+      eShearLayers: [makeCatLayer({
+        baseFt: 12000, topFt: 16000, risk: 'light', richardsonNumber: 0.22,
+      })],
+    });
+    expect(format('e-shear-bands', point, 14000)).toBe('FL120–FL160 E-Shear light (Ri 0.22)');
+  });
+});
+
+describe('convective layers', () => {
+  it('thermo-convective synthesizes from per-point fields, includes CAPE/CIN/LCL→EL', () => {
+    const point = makeVizPoint({
+      convectiveRisk: 'high',
+      convectiveBaseFt: 4000,
+      convectiveTopFt: 30000,
+      capeSurfaceJkg: 1500,
+      cinSurfaceJkg: -25,
+      altitudeLines: makeAltitudeLines({ lclAltitudeFt: 4000, elAltitudeFt: 32000 }),
+    });
+    const out = format('thermo-convective-bg', point, 10000)!;
+    expect(out).toContain('Thermo Conv: high');
+    expect(out).toContain('CAPE 1500');
+    expect(out).toContain('CIN -25');
+    expect(out).toContain('LCL→EL: 4,000 ft–FL320');
+  });
+
+  it('thermo-convective falls back to Tower range when LCL/EL missing', () => {
+    const point = makeVizPoint({
+      convectiveRisk: 'low',
+      convectiveBaseFt: 5000,
+      convectiveTopFt: 20000,
+      capeSurfaceJkg: 200,
+    });
+    const out = format('thermo-convective-bg', point, 10000)!;
+    expect(out).toContain('Tower: FL050–FL200');
+    expect(out).not.toContain('LCL→EL');
+  });
+
+  it('thermo-convective returns no zones when risk is none', () => {
+    const point = makeVizPoint({
+      convectiveRisk: 'none', convectiveBaseFt: 5000, convectiveTopFt: 20000,
+    });
+    expect(format('thermo-convective-bg', point, 10000)).toBeNull();
+  });
+
+  it('nwp-convective shows cover% and method tag', () => {
+    const point = makeVizPoint({
+      nwpConvectiveRisk: 'moderate',
+      nwpConvectiveBaseFt: 3000,
+      nwpConvectiveTopFt: 25000,
+      nwpConvectiveCoverPct: 45,
+      nwpConvectiveMethod: 'nwp_lcl_top',
+    });
+    const out = format('nwp-convective-bg', point, 10000)!;
+    expect(out).toContain('NWP Conv: moderate');
+    expect(out).toContain('45% cover');
+    expect(out).toContain('Tower: 3,000 ft–FL250');
+    expect(out).toContain('[nwp_lcl_top]');
+  });
+});
+
+describe('inversion-bands', () => {
+  it('shows surface-based suffix', () => {
+    const point = makeVizPoint({
+      inversions: [makeInversion({ baseFt: 0, topFt: 1500, strengthC: 3.2, surfaceBased: true })],
+    });
+    expect(format('inversion-bands', point, 800)).toBe('0 ft–1,500 ft +3.2°C (sfc)');
+  });
+
+  it('omits suffix for elevated inversions', () => {
+    const point = makeVizPoint({
+      inversions: [makeInversion({ baseFt: 4000, topFt: 6000, strengthC: 1.8 })],
+    });
+    expect(format('inversion-bands', point, 5000)).toBe('4,000 ft–FL060 +1.8°C');
+  });
+});

--- a/web/tests/unit/utils.test.ts
+++ b/web/tests/unit/utils.test.ts
@@ -1,0 +1,182 @@
+/** Tests for shared utility functions: formatting, route titles, Windy URLs. */
+
+import { describe, it, expect } from 'vitest';
+import {
+  escapeHtml, formatTime, formatDepartureTime, formatAlt,
+  isFlightPast, flightTitle, flightRouteCompact,
+  buildWindyUrl, errorToMessage,
+} from '../../ts/utils';
+
+describe('escapeHtml', () => {
+  it('escapes the five HTML entities', () => {
+    expect(escapeHtml(`<a href="x" data-y='z'>&hello</a>`)).toBe(
+      '&lt;a href=&quot;x&quot; data-y=&#x27;z&#x27;&gt;&amp;hello&lt;/a&gt;',
+    );
+  });
+
+  it('handles empty string', () => {
+    expect(escapeHtml('')).toBe('');
+  });
+});
+
+describe('formatTime', () => {
+  it('formats hour and minute with leading zeros and Z suffix', () => {
+    expect(formatTime(8)).toBe('0800Z');
+    expect(formatTime(9, 30)).toBe('0930Z');
+    expect(formatTime(0, 0)).toBe('0000Z');
+    expect(formatTime(23, 59)).toBe('2359Z');
+  });
+});
+
+describe('formatDepartureTime', () => {
+  it('extracts UTC hour/minute from ISO string', () => {
+    expect(formatDepartureTime('2026-04-29T08:30:00Z')).toBe('0830Z');
+    expect(formatDepartureTime('2026-04-29T14:00:00Z')).toBe('1400Z');
+  });
+});
+
+describe('formatAlt', () => {
+  it('renders sub-FL altitudes as plain feet', () => {
+    expect(formatAlt(2500)).toBe('2500ft');
+    expect(formatAlt(9999)).toBe('9999ft');
+  });
+
+  it('renders FL at 10000+ ft', () => {
+    expect(formatAlt(10000)).toBe('FL100');
+    expect(formatAlt(35000)).toBe('FL350');
+  });
+
+  it('uses ≥ 10000 boundary', () => {
+    expect(formatAlt(9999)).toBe('9999ft');
+    expect(formatAlt(10000)).toBe('FL100');
+  });
+});
+
+describe('isFlightPast', () => {
+  // Use departureTime ISO form (the modern path).
+  it('returns true when start + duration is before now', () => {
+    const past = new Date(Date.now() - 5 * 3600_000).toISOString();
+    expect(isFlightPast('', 0, 1, past)).toBe(true);
+  });
+
+  it('returns false when start + duration is after now', () => {
+    const future = new Date(Date.now() + 1 * 3600_000).toISOString();
+    expect(isFlightPast('', 0, 5, future)).toBe(false);
+  });
+
+  it('returns false for unparseable input', () => {
+    expect(isFlightPast('', 0, 1, 'garbage')).toBe(false);
+  });
+
+  it('legacy targetDate + targetTimeUtc form', () => {
+    // 2020-01-01 00:00Z + 1hr is well past
+    expect(isFlightPast('2020-01-01', 0, 1)).toBe(true);
+  });
+});
+
+describe('flightTitle', () => {
+  it('joins origin and destination with arrow', () => {
+    expect(flightTitle(['LFPN', 'EGLF'])).toBe('LFPN → EGLF');
+  });
+
+  it('returns single waypoint as-is', () => {
+    expect(flightTitle(['LFPN'])).toBe('LFPN');
+  });
+
+  it('skips middle waypoints', () => {
+    expect(flightTitle(['LFPN', 'LFAT', 'EGLF'])).toBe('LFPN → EGLF');
+  });
+
+  it('returns empty for empty array', () => {
+    expect(flightTitle([])).toBe('');
+  });
+});
+
+describe('flightRouteCompact', () => {
+  it('returns empty for no waypoints', () => {
+    const r = flightRouteCompact([]);
+    expect(r).toEqual({ html: '', fullText: '', isTruncated: false });
+  });
+
+  it('renders full route when within maxVisible', () => {
+    const r = flightRouteCompact(['LFPN', 'LFAT', 'EGLF']);
+    expect(r.isTruncated).toBe(false);
+    expect(r.fullText).toBe('LFPN → LFAT → EGLF');
+    expect(r.html).toBe('LFPN → LFAT → EGLF');
+  });
+
+  it('truncates long routes to head + ellipsis + tail', () => {
+    const r = flightRouteCompact(['A', 'B', 'C', 'D', 'E', 'F']);
+    expect(r.isTruncated).toBe(true);
+    expect(r.html).toBe('A → B → … → E → F');
+    expect(r.fullText).toBe('A → B → C → D → E → F');
+  });
+
+  it('escapes HTML in waypoint codes', () => {
+    const r = flightRouteCompact(['<a>', 'EGLF']);
+    expect(r.html).toBe('&lt;a&gt; → EGLF');
+  });
+
+  it('respects custom maxVisible threshold', () => {
+    const r = flightRouteCompact(['A', 'B', 'C'], 2);
+    expect(r.isTruncated).toBe(true);
+  });
+});
+
+describe('buildWindyUrl', () => {
+  it('GFS path includes gfs in path and query', () => {
+    const url = buildWindyUrl(48.5, 2.0, '2026-04-29T12:00:00Z', 'gfs');
+    expect(url).toContain('/gfs/meteogram');
+    expect(url).toContain('?gfs,2026-04-29-12');
+  });
+
+  it('ICON path includes icon segment', () => {
+    const url = buildWindyUrl(48.5, 2.0, '2026-04-29T12:00:00Z', 'icon');
+    expect(url).toContain('/icon/meteogram');
+  });
+
+  it('falls back to bare meteogram for unknown / ECMWF model', () => {
+    const url = buildWindyUrl(48.5, 2.0, '2026-04-29T12:00:00Z', 'ecmwf');
+    expect(url).not.toContain('/ecmwf/');
+    expect(url).toContain('/48.500/2.000/meteogram?');
+    // Query must NOT have a model prefix
+    expect(url).toMatch(/meteogram\?2026-04-29-12,/);
+  });
+
+  it('falls back to bare meteogram when model omitted', () => {
+    const url = buildWindyUrl(48.5, 2.0, '2026-04-29T12:00:00Z');
+    expect(url).toContain('/48.500/2.000/meteogram?');
+  });
+
+  it('always uses UTC time components from the ISO string', () => {
+    // Provide a non-Z suffix; util appends 'Z' before parsing.
+    const url = buildWindyUrl(48.5, 2.0, '2026-04-29T05:00:00');
+    expect(url).toContain('2026-04-29-05');
+  });
+
+  it('rounds lat/lon to 3 decimals', () => {
+    const url = buildWindyUrl(48.123456, 2.987654, '2026-04-29T12:00:00Z');
+    expect(url).toContain('/48.123/2.988/');
+  });
+
+  it('respects zoom override', () => {
+    const url = buildWindyUrl(48.5, 2.0, '2026-04-29T12:00:00Z', 'gfs', 6);
+    expect(url).toContain(',6,i:pressure');
+  });
+});
+
+describe('errorToMessage', () => {
+  it('strips API <code>: prefix from messages', () => {
+    expect(errorToMessage(new Error('API 404: not found'))).toBe('not found');
+    expect(errorToMessage(new Error('API 422: invalid'))).toBe('invalid');
+  });
+
+  it('passes through messages without prefix', () => {
+    expect(errorToMessage(new Error('boom'))).toBe('boom');
+  });
+
+  it('coerces non-Error values to string', () => {
+    expect(errorToMessage('string err')).toBe('string err');
+    expect(errorToMessage(null)).toBe('null');
+  });
+});

--- a/web/tests/unit/weather-map-consensus.test.ts
+++ b/web/tests/unit/weather-map-consensus.test.ts
@@ -66,6 +66,10 @@ describe('median', () => {
     median(xs);
     expect(xs).toEqual([3, 1, 2]);
   });
+
+  it('throws on empty input rather than returning NaN', () => {
+    expect(() => median([])).toThrow(/empty/);
+  });
 });
 
 describe('circularMean', () => {
@@ -122,6 +126,11 @@ describe('ordinalConsensus', () => {
 
   it('worst returns the only value when all equal', () => {
     expect(ordinalConsensus(['VFR', 'VFR'], CAT_ORDER, 'worst')).toBe('VFR');
+  });
+
+  it('throws on empty input rather than reduce-of-empty TypeError', () => {
+    expect(() => ordinalConsensus([], CAT_ORDER, 'worst')).toThrow(/empty/);
+    expect(() => ordinalConsensus([], CAT_ORDER, 'majority')).toThrow(/empty/);
   });
 });
 
@@ -204,15 +213,17 @@ describe('computeConsensus', () => {
     expect(c.convective_risk).toBe('low');
   });
 
-  it('aggregates wind direction with circular mean', () => {
+  it('aggregates wind direction with circular mean, rounded to whole degrees', () => {
     const a = makeAirport({
       gfs:  { wind_dir_deg: 350 },
       icon: { wind_dir_deg: 10 },
     });
     const c = computeConsensus(a, 'worst');
     expect(c.wind_dir_deg).toBeDefined();
-    // mean of 350+10 should be near 0 / 360
-    expect(Math.min(c.wind_dir_deg!, 360 - c.wind_dir_deg!)).toBeLessThan(1);
+    // Whole-degree result, no float artifacts like 359.9999999996
+    expect(Number.isInteger(c.wind_dir_deg!)).toBe(true);
+    // Mean of 350+10 should be 0 (or 360 — circular wrap)
+    expect(c.wind_dir_deg === 0 || c.wind_dir_deg === 360).toBe(true);
   });
 
   it('preserves the airport.consensus.agreement map', () => {

--- a/web/tests/unit/weather-map-consensus.test.ts
+++ b/web/tests/unit/weather-map-consensus.test.ts
@@ -1,0 +1,224 @@
+/** Tests for forecast-map consensus aggregation (worst / majority modes). */
+
+import { describe, it, expect } from 'vitest';
+import {
+  isConsensusMode, median, circularMean, ordinalConsensus, computeConsensus,
+  CAT_ORDER, RISK_ORDER,
+} from '../../ts/visualization/weather-map-consensus';
+import type {
+  ForecastAirport, ModelForecast,
+} from '../../ts/adapters/maps-adapter';
+
+function makeModelForecast(overrides: Partial<ModelForecast> = {}): ModelForecast {
+  return {
+    ceiling_ft: null,
+    visibility_m: null,
+    wind_speed_kt: null,
+    wind_dir_deg: null,
+    wind_gust_kt: null,
+    crosswind_kt: null,
+    headwind_kt: null,
+    best_runway_id: null,
+    gust_crosswind_kt: null,
+    gust_headwind_kt: null,
+    cloud_cover_pct: null,
+    cape_jkg: null,
+    convective_risk: 'none',
+    temperature_c: null,
+    flight_category: 'VFR',
+    ...overrides,
+  };
+}
+
+function makeAirport(models: Record<string, Partial<ModelForecast>>): ForecastAirport {
+  const built: Record<string, ModelForecast> = {};
+  for (const [k, v] of Object.entries(models)) built[k] = makeModelForecast(v);
+  return {
+    icao: 'EGLF',
+    lat: 51.276,
+    lon: -0.776,
+    models: built,
+    consensus: { flight_category: 'VFR', agreement: {} },
+  };
+}
+
+describe('isConsensusMode', () => {
+  it('detects "worst" and "majority"', () => {
+    expect(isConsensusMode('worst')).toBe(true);
+    expect(isConsensusMode('majority')).toBe(true);
+  });
+
+  it('rejects model names', () => {
+    expect(isConsensusMode('gfs')).toBe(false);
+    expect(isConsensusMode('ecmwf')).toBe(false);
+    expect(isConsensusMode('')).toBe(false);
+  });
+});
+
+describe('median', () => {
+  it('handles odd and even counts', () => {
+    expect(median([1, 2, 3])).toBe(2);
+    expect(median([1, 2, 3, 4])).toBe(2.5);
+  });
+
+  it('does not mutate input', () => {
+    const xs = [3, 1, 2];
+    median(xs);
+    expect(xs).toEqual([3, 1, 2]);
+  });
+});
+
+describe('circularMean', () => {
+  it('returns the angle for a single value', () => {
+    expect(circularMean([90])).toBeCloseTo(90, 5);
+  });
+
+  it('handles wrap-around at 0/360', () => {
+    // Mean of 350 and 10 should be ~0 (or 360), not 180
+    const m = circularMean([350, 10]);
+    expect(Math.min(m, 360 - m)).toBeLessThan(1);
+  });
+
+  it('returns the linear mean for nearby angles', () => {
+    expect(circularMean([80, 100])).toBeCloseTo(90, 1);
+  });
+
+  it('returns a value in [0, 360)', () => {
+    const m = circularMean([350, 10, 20]);
+    expect(m).toBeGreaterThanOrEqual(0);
+    expect(m).toBeLessThan(360);
+  });
+});
+
+describe('ordinalConsensus', () => {
+  describe('with CAT_ORDER (object)', () => {
+    it('worst returns highest-ranked', () => {
+      expect(ordinalConsensus(['VFR', 'MVFR', 'IFR'], CAT_ORDER, 'worst')).toBe('IFR');
+      expect(ordinalConsensus(['VFR', 'LIFR', 'MVFR'], CAT_ORDER, 'worst')).toBe('LIFR');
+    });
+
+    it('majority returns the modal value', () => {
+      expect(ordinalConsensus(['VFR', 'VFR', 'IFR'], CAT_ORDER, 'majority')).toBe('VFR');
+    });
+
+    it('majority breaks ties by picking the worse value', () => {
+      // 1 each — picks worst among tied (LIFR)
+      expect(ordinalConsensus(['VFR', 'IFR', 'LIFR'], CAT_ORDER, 'majority')).toBe('LIFR');
+      // 2 vs 1, but since two distinct candidates have count 1, modal is the 2 — let's check actual
+      expect(ordinalConsensus(['VFR', 'VFR', 'IFR'], CAT_ORDER, 'majority')).toBe('VFR');
+    });
+  });
+
+  describe('with RISK_ORDER (array)', () => {
+    it('worst picks highest-ranked', () => {
+      expect(ordinalConsensus(['none', 'low', 'high'], RISK_ORDER, 'worst')).toBe('high');
+      expect(ordinalConsensus(['marginal', 'extreme', 'low'], RISK_ORDER, 'worst')).toBe('extreme');
+    });
+
+    it('majority picks the modal risk', () => {
+      expect(ordinalConsensus(['low', 'low', 'high'], RISK_ORDER, 'majority')).toBe('low');
+    });
+  });
+
+  it('worst returns the only value when all equal', () => {
+    expect(ordinalConsensus(['VFR', 'VFR'], CAT_ORDER, 'worst')).toBe('VFR');
+  });
+});
+
+describe('computeConsensus', () => {
+  it('returns VFR / empty agreement when no models', () => {
+    const airport = makeAirport({});
+    const c = computeConsensus(airport, 'worst');
+    expect(c.flight_category).toBe('VFR');
+    expect(c.agreement).toEqual({});
+  });
+
+  it('worst flight_category picks highest-ranked', () => {
+    const a = makeAirport({
+      gfs: { flight_category: 'VFR' },
+      icon: { flight_category: 'IFR' },
+      ecmwf: { flight_category: 'MVFR' },
+    });
+    const c = computeConsensus(a, 'worst');
+    expect(c.flight_category).toBe('IFR');
+  });
+
+  it('worst takes max wind speed and min ceiling (most adverse)', () => {
+    const a = makeAirport({
+      gfs:   { wind_speed_kt: 10, ceiling_ft: 4000 },
+      icon:  { wind_speed_kt: 25, ceiling_ft: 1500 },
+      ecmwf: { wind_speed_kt: 18, ceiling_ft: 800 },
+    });
+    const c = computeConsensus(a, 'worst');
+    expect(c.wind_speed_kt).toBe(25);
+    expect(c.ceiling_ft).toBe(800);
+  });
+
+  it('majority uses median of numeric values', () => {
+    const a = makeAirport({
+      gfs:   { wind_speed_kt: 10 },
+      icon:  { wind_speed_kt: 20 },
+      ecmwf: { wind_speed_kt: 30 },
+    });
+    const c = computeConsensus(a, 'majority');
+    expect(c.wind_speed_kt).toBe(20);
+  });
+
+  it('skips numeric fields when no model has data', () => {
+    const a = makeAirport({
+      gfs:  { wind_speed_kt: 10 },
+      icon: { wind_speed_kt: 20 },
+    });
+    const c = computeConsensus(a, 'worst');
+    expect(c.wind_speed_kt).toBe(20);
+    expect(c.ceiling_ft).toBeUndefined();
+    expect(c.cape_jkg).toBeUndefined();
+  });
+
+  it('handles partial nulls (drops them, aggregates remainder)', () => {
+    const a = makeAirport({
+      gfs:   { wind_speed_kt: 10 },
+      icon:  { wind_speed_kt: null },
+      ecmwf: { wind_speed_kt: 20 },
+    });
+    const c = computeConsensus(a, 'worst');
+    expect(c.wind_speed_kt).toBe(20);
+  });
+
+  it('rounds aggregated numerics to 1 decimal', () => {
+    const a = makeAirport({
+      gfs:   { wind_speed_kt: 10.123 },
+      icon:  { wind_speed_kt: 20.456 },
+      ecmwf: { wind_speed_kt: 30.789 },
+    });
+    const c = computeConsensus(a, 'majority');
+    expect(c.wind_speed_kt).toBe(20.5);
+  });
+
+  it('treats blank convective_risk as "none"', () => {
+    const a = makeAirport({
+      gfs: { convective_risk: '' as never },
+      icon: { convective_risk: 'low' },
+    });
+    const c = computeConsensus(a, 'worst');
+    expect(c.convective_risk).toBe('low');
+  });
+
+  it('aggregates wind direction with circular mean', () => {
+    const a = makeAirport({
+      gfs:  { wind_dir_deg: 350 },
+      icon: { wind_dir_deg: 10 },
+    });
+    const c = computeConsensus(a, 'worst');
+    expect(c.wind_dir_deg).toBeDefined();
+    // mean of 350+10 should be near 0 / 360
+    expect(Math.min(c.wind_dir_deg!, 360 - c.wind_dir_deg!)).toBeLessThan(1);
+  });
+
+  it('preserves the airport.consensus.agreement map', () => {
+    const a = makeAirport({ gfs: { flight_category: 'VFR' } });
+    a.consensus.agreement = { wind_speed_kt: 'consistent' };
+    const c = computeConsensus(a, 'worst');
+    expect(c.agreement).toEqual({ wind_speed_kt: 'consistent' });
+  });
+});

--- a/web/ts/visualization/weather-map-consensus.ts
+++ b/web/ts/visualization/weather-map-consensus.ts
@@ -1,0 +1,107 @@
+/** Pure consensus aggregation for the forecast overview map.
+ *
+ * Combines per-model forecast values into a single "worst" or "majority"
+ * value used by consensus mode on the forecast map. Extracted from
+ * weather-map.ts so the math is independently testable.
+ *
+ * Modes:
+ *  - "worst":    most-adverse value (max wind, min ceiling, max risk).
+ *  - "majority": modal/median value, with worst-case tiebreak for
+ *                ordinal categories.
+ */
+
+import type { ForecastAirport, ConsensusForecast } from '../adapters/maps-adapter';
+
+export type ConsensusMode = 'worst' | 'majority';
+
+export const CAT_ORDER: Record<string, number> = { VFR: 0, MVFR: 1, IFR: 2, LIFR: 3 };
+export const RISK_ORDER: readonly string[] = ['none', 'marginal', 'low', 'moderate', 'high', 'extreme'];
+
+export function isConsensusMode(model: string): model is ConsensusMode {
+  return model === 'worst' || model === 'majority';
+}
+
+// --- Numeric helpers ---
+
+export function median(vals: number[]): number {
+  const sorted = [...vals].sort((a, b) => a - b);
+  const mid = sorted.length >> 1;
+  return sorted.length % 2 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
+}
+
+/** Vector mean of compass bearings (degrees). Handles wrap-around at 0/360. */
+export function circularMean(degs: number[]): number {
+  const sinSum = degs.reduce((s, d) => s + Math.sin(d * Math.PI / 180), 0);
+  const cosSum = degs.reduce((s, d) => s + Math.cos(d * Math.PI / 180), 0);
+  return ((Math.atan2(sinSum, cosSum) * 180 / Math.PI) + 360) % 360;
+}
+
+const _max = (v: number[]) => Math.max(...v);
+const _min = (v: number[]) => Math.min(...v);
+
+/** Per-numeric-field worst/majority aggregators. */
+export const NUMERIC_CONSENSUS: Record<
+  'wind_speed_kt' | 'crosswind_kt' | 'headwind_kt' | 'ceiling_ft' | 'cape_jkg' | 'visibility_m' | 'cloud_cover_pct',
+  { worst: (v: number[]) => number; majority: (v: number[]) => number }
+> = {
+  wind_speed_kt:   { worst: _max, majority: median },
+  crosswind_kt:    { worst: _max, majority: median },
+  headwind_kt:     { worst: _max, majority: median },
+  ceiling_ft:      { worst: _min, majority: median },
+  cape_jkg:        { worst: _max, majority: median },
+  visibility_m:    { worst: _min, majority: median },
+  cloud_cover_pct: { worst: _max, majority: median },
+};
+
+/** Ordinal aggregation for categorical fields (flight_category, convective_risk).
+ *
+ * - worst: highest-ranked value.
+ * - majority: modal value; ties broken by picking the worst among tied candidates.
+ */
+export function ordinalConsensus(
+  values: string[],
+  order: Record<string, number> | readonly string[],
+  mode: ConsensusMode,
+): string {
+  const rank = Array.isArray(order)
+    ? (v: string) => order.indexOf(v)
+    : (v: string) => (order as Record<string, number>)[v] ?? 0;
+  if (mode === 'worst') {
+    return values.reduce((a, b) => rank(a) >= rank(b) ? a : b);
+  }
+  // majority: modal with worse tiebreak
+  const counts = new Map<string, number>();
+  for (const v of values) counts.set(v, (counts.get(v) ?? 0) + 1);
+  const maxCount = Math.max(...counts.values());
+  const tied = [...counts.entries()].filter(([, n]) => n === maxCount).map(([v]) => v);
+  return tied.reduce((a, b) => rank(a) >= rank(b) ? a : b);
+}
+
+/** Compute a single consensus forecast across all an airport's models. */
+export function computeConsensus(airport: ForecastAirport, mode: ConsensusMode): ConsensusForecast {
+  const models = Object.values(airport.models);
+  if (models.length === 0) return { flight_category: 'VFR', agreement: {} };
+
+  const cats = models.map((m) => m.flight_category);
+  const risks = models.map((m) => m.convective_risk || 'none');
+
+  const result: ConsensusForecast = {
+    flight_category: ordinalConsensus(cats, CAT_ORDER, mode),
+    convective_risk: ordinalConsensus(risks, RISK_ORDER, mode),
+    agreement: airport.consensus.agreement,
+  };
+
+  for (const [field, fns] of Object.entries(NUMERIC_CONSENSUS) as Array<
+    [keyof typeof NUMERIC_CONSENSUS, (typeof NUMERIC_CONSENSUS)[keyof typeof NUMERIC_CONSENSUS]]
+  >) {
+    const vals = models.map((m) => m[field]).filter((v): v is number => v != null);
+    if (!vals.length) continue;
+    const fn = mode === 'worst' ? fns.worst : fns.majority;
+    (result as unknown as Record<string, unknown>)[field] = Math.round(fn(vals) * 10) / 10;
+  }
+
+  const dirs = models.map((m) => m.wind_dir_deg).filter((v): v is number => v != null);
+  if (dirs.length) result.wind_dir_deg = circularMean(dirs);
+
+  return result;
+}

--- a/web/ts/visualization/weather-map-consensus.ts
+++ b/web/ts/visualization/weather-map-consensus.ts
@@ -24,6 +24,7 @@ export function isConsensusMode(model: string): model is ConsensusMode {
 // --- Numeric helpers ---
 
 export function median(vals: number[]): number {
+  if (vals.length === 0) throw new Error('median: empty input');
   const sorted = [...vals].sort((a, b) => a - b);
   const mid = sorted.length >> 1;
   return sorted.length % 2 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
@@ -63,6 +64,7 @@ export function ordinalConsensus(
   order: Record<string, number> | readonly string[],
   mode: ConsensusMode,
 ): string {
+  if (values.length === 0) throw new Error('ordinalConsensus: empty values');
   const rank = Array.isArray(order)
     ? (v: string) => order.indexOf(v)
     : (v: string) => (order as Record<string, number>)[v] ?? 0;
@@ -101,7 +103,10 @@ export function computeConsensus(airport: ForecastAirport, mode: ConsensusMode):
   }
 
   const dirs = models.map((m) => m.wind_dir_deg).filter((v): v is number => v != null);
-  if (dirs.length) result.wind_dir_deg = circularMean(dirs);
+  // Wind direction is reported in whole degrees by METAR/TAF — sub-degree
+  // precision is false, and serializing the raw float yields strings like
+  // "359.9999999999996". Round to the same convention as the source data.
+  if (dirs.length) result.wind_dir_deg = Math.round(circularMean(dirs));
 
   return result;
 }

--- a/web/ts/visualization/weather-map.ts
+++ b/web/ts/visualization/weather-map.ts
@@ -105,13 +105,12 @@ export type ForecastMetric = 'flight_category' | 'wind_speed_kt' | 'crosswind_kt
 
 import { isConsensusMode, computeConsensus, type ConsensusMode } from './weather-map-consensus';
 
-function getConsensus(airport: ForecastAirport, model: string): ConsensusForecast {
-  return computeConsensus(airport, model as ConsensusMode);
+function getConsensus(airport: ForecastAirport, mode: ConsensusMode): ConsensusForecast {
+  return computeConsensus(airport, mode);
 }
 
 function getForecastColor(airport: ForecastAirport, metric: ForecastMetric, model: string): string {
-  const consensus = isConsensusMode(model);
-  const data = consensus ? getConsensus(airport, model) : airport.models[model];
+  const data = isConsensusMode(model) ? getConsensus(airport, model) : airport.models[model];
   if (!data) return '#888';
 
   switch (metric) {
@@ -431,11 +430,11 @@ export class WeatherMap {
     this.markersGroup.clearLayers();
 
     const r = this.markerRadius();
+    const consensusMode: ConsensusMode | null = isConsensusMode(model) ? model : null;
     for (const apt of data.airports) {
       const color = getForecastColor(apt, metric, model);
-      const isConsensus = isConsensusMode(model);
-      const border = isConsensus
-        ? (AGREEMENT_COLORS[getAgreementForMetric(getConsensus(apt, model), metric) ?? ''] || '#888')
+      const border = consensusMode
+        ? (AGREEMENT_COLORS[getAgreementForMetric(getConsensus(apt, consensusMode), metric) ?? ''] || '#888')
         : color;
 
       const marker = L.circleMarker([apt.lat, apt.lon], {
@@ -443,7 +442,7 @@ export class WeatherMap {
         fillColor: color,
         fillOpacity: 0.85,
         color: border,
-        weight: isConsensus ? 2 : 1,
+        weight: consensusMode ? 2 : 1,
         opacity: 1,
       });
 

--- a/web/ts/visualization/weather-map.ts
+++ b/web/ts/visualization/weather-map.ts
@@ -103,90 +103,10 @@ function maeColor(value: number, thresholdBad: number): string {
 
 export type ForecastMetric = 'flight_category' | 'wind_speed_kt' | 'crosswind_kt' | 'headwind_kt' | 'ceiling_ft' | 'cape_jkg' | 'convective_risk' | 'cloud_cover_pct' | 'visibility_m';
 
-function isConsensusMode(model: string): boolean {
-  return model === 'worst' || model === 'majority';
-}
-
-const CAT_ORDER: Record<string, number> = { VFR: 0, MVFR: 1, IFR: 2, LIFR: 3 };
-const RISK_ORDER = ['none', 'marginal', 'low', 'moderate', 'high', 'extreme'];
-
-// --- Aggregation helpers (numeric) ---
-
-function max(vals: number[]): number { return Math.max(...vals); }
-function min(vals: number[]): number { return Math.min(...vals); }
-function median(vals: number[]): number {
-  const sorted = [...vals].sort((a, b) => a - b);
-  const mid = sorted.length >> 1;
-  return sorted.length % 2 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
-}
-function circularMean(degs: number[]): number {
-  const sinSum = degs.reduce((s, d) => s + Math.sin(d * Math.PI / 180), 0);
-  const cosSum = degs.reduce((s, d) => s + Math.cos(d * Math.PI / 180), 0);
-  return ((Math.atan2(sinSum, cosSum) * 180 / Math.PI) + 360) % 360;
-}
-
-// For each numeric metric, how to combine per-model values for Worst (most adverse)
-// and Majority (typical/central). Median is robust to outliers — for 3 models it's the
-// middle one after sorting.
-const NUMERIC_CONSENSUS: Record<
-  'wind_speed_kt' | 'crosswind_kt' | 'headwind_kt' | 'ceiling_ft' | 'cape_jkg' | 'visibility_m' | 'cloud_cover_pct',
-  { worst: (v: number[]) => number; majority: (v: number[]) => number }
-> = {
-  wind_speed_kt:   { worst: max, majority: median },
-  crosswind_kt:    { worst: max, majority: median },
-  headwind_kt:     { worst: max, majority: median },
-  ceiling_ft:      { worst: min, majority: median },
-  cape_jkg:        { worst: max, majority: median },
-  visibility_m:    { worst: min, majority: median },
-  cloud_cover_pct: { worst: max, majority: median },
-};
-
-// Ordinal aggregation for category + risk.
-// Worst: take the worst-ranked value.
-// Majority: modal (most common); if tied or all unique, pick worst among tied candidates.
-function ordinalConsensus(values: string[], order: Record<string, number> | string[], mode: string): string {
-  const rank = Array.isArray(order)
-    ? (v: string) => order.indexOf(v)
-    : (v: string) => order[v] ?? 0;
-  if (mode === 'worst') {
-    return values.reduce((a, b) => rank(a) >= rank(b) ? a : b);
-  }
-  // majority: modal with worse tiebreak
-  const counts = new Map<string, number>();
-  for (const v of values) counts.set(v, (counts.get(v) ?? 0) + 1);
-  const maxCount = Math.max(...counts.values());
-  const tied = [...counts.entries()].filter(([, n]) => n === maxCount).map(([v]) => v);
-  return tied.reduce((a, b) => rank(a) >= rank(b) ? a : b);
-}
-
-function computeConsensus(airport: ForecastAirport, mode: string): ConsensusForecast {
-  const models = Object.values(airport.models);
-  if (models.length === 0) return { flight_category: 'VFR', agreement: {} };
-
-  const cats = models.map(m => m.flight_category);
-  const risks = models.map(m => m.convective_risk || 'none');
-
-  const result: ConsensusForecast = {
-    flight_category: ordinalConsensus(cats, CAT_ORDER, mode),
-    convective_risk: ordinalConsensus(risks, RISK_ORDER, mode),
-    agreement: airport.consensus.agreement,
-  };
-
-  for (const [field, fns] of Object.entries(NUMERIC_CONSENSUS) as Array<[keyof typeof NUMERIC_CONSENSUS, typeof NUMERIC_CONSENSUS[keyof typeof NUMERIC_CONSENSUS]]>) {
-    const vals = models.map(m => m[field]).filter((v): v is number => v != null);
-    if (!vals.length) continue;
-    const fn = mode === 'worst' ? fns.worst : fns.majority;
-    (result as any)[field] = Math.round(fn(vals) * 10) / 10;
-  }
-
-  const dirs = models.map(m => m.wind_dir_deg).filter((v): v is number => v != null);
-  if (dirs.length) result.wind_dir_deg = circularMean(dirs);
-
-  return result;
-}
+import { isConsensusMode, computeConsensus, type ConsensusMode } from './weather-map-consensus';
 
 function getConsensus(airport: ForecastAirport, model: string): ConsensusForecast {
-  return computeConsensus(airport, model);
+  return computeConsensus(airport, model as ConsensusMode);
 }
 
 function getForecastColor(airport: ForecastAirport, metric: ForecastMetric, model: string): string {

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['tests/unit/**/*.test.ts'],
+    environment: 'node',
+  },
+});


### PR DESCRIPTION
Sets up Vitest as a dev-only test framework alongside the existing
Playwright suite. Tests live under web/tests/unit/ and run with
`npm test` (or `npm run test:watch`). Vitest is gated by `testMatch`
on `*.test.ts` while Playwright stays on `*.spec.ts`, so the two
runners coexist without overlap.

Phase 1 covers high-value pure modules where bugs are regression-prone
and visually invisible:

- tooltip-formatters: structural test that every band-style layer is
  reachable from the LAYER_TOOLTIPS registry (catches the rename-drops-
  tooltip regression class), plus per-layer formatter assertions
- scales: METAR ceiling category boundaries, headwind/CAPE/cloud
  diverging scales, linearWidth, altitudeToPressureHpa
- segment-style: midpoint averaging, null-endpoint handling, defaults
- route-graph metrics: ceiling-DD/NWP AGL >5000ft cap and terrain
  subtraction; HW/TW formatter
- route-map metrics: altitude-dependent helpers (worstRiskAtAlt,
  cloudAtAlt, tempAtAltitude) tested via the public MapMetric API
- utils: Windy URL builder model-mapping (gfs/icon path vs ECMWF
  fallback), formatAlt FL boundary, escapeHtml, flightRouteCompact

Phase 2:

- compare-zone-access: per-layer zone normalization for compare mode,
  including the synthetic single-zone forms for thermo/nwp convective
- layer-registry: getCompactLayerOverrides preferred-method
  collapsing, GRAMET preset wiring, group ordering
- hewson-colormaps: colorFor anchor sampling, clamping, NaN handling
- weather-map-consensus (new module): extracted from weather-map.ts so
  the consensus aggregation (worst/majority across GFS/ICON/ECMWF) is
  testable without pulling Leaflet. circularMean wrap-around at 0/360,
  ordinalConsensus tie-breaking, computeConsensus per-field rounding

10 test files, 205 tests, ~800ms full run.

Vitest and jsdom are devDependencies — they don't ship to dist/ or
production. Build (esbuild) and Playwright runs verified clean.