### PR TITLE
perf(grib): instrument enrichment for sub-stage timing + memory checkpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@ venv/
 # Runtime data (snapshots)
 /data
 
+# Local profiling artifacts (scripts/profile_refresh.py output)
+/profiles
+
 .DS_Store
 .env
 .env.triage

--- a/designs/plans/refresh-pipeline-performance.md
+++ b/designs/plans/refresh-pipeline-performance.md
@@ -1,0 +1,411 @@
+# Refresh pipeline performance investigation
+
+## Why
+
+Briefing refreshes take ~2 minutes (sometimes longer). User wants to be sure
+there are no easy optimisations missed before treating the latency as
+intrinsic. This document captures the full investigation, numbers measured,
+issues uncovered, the planned fixes, and what's still open.
+
+## Driver: how we measure
+
+Script: `scripts/profile_refresh.py`
+
+- Loads a flight from the local DB by id (uses `_load_flight_or_404` to
+  hydrate the `Flight` model with parsed waypoints).
+- Mirrors `_prepare_refresh()` for option construction so the run matches
+  the production refresh path (GRAMET on, LLM digest on, GRIB enrichment
+  on, Skew-T off — that's the API default).
+- Wraps `execute_briefing()` in:
+  - a `progress_callback` that records per-stage wall-clock from existing
+    `_notify()` boundaries
+  - a `pyinstrument.Profiler(interval=0.01, async_mode='disabled')`
+- Writes pack to `profiles/_packs/{flight_id}/{ts}/` (kept separate from
+  real `data/packs/`).
+- Outputs:
+  - per-stage timing summary to stdout
+  - HTML flamegraph: `profiles/{flight_id}_{ts}.html`
+  - text flamegraph (top 1% frames): `profiles/{flight_id}_{ts}.txt`
+
+Flags: `--clear-grib-cache`, `--force-live` (override historical mode),
+`--no-llm`, `--no-gramet`.
+
+Test flight used throughout: `lsgs_lsgl_lfqb_lfqa_egkb_egtf-2026-05-04-55bf`
+(LSGS → LSGL → LFQB → LFQA → EGKB → EGTF, 6 waypoints, FL160, 3h, D+3
+European multi-leg). Pipeline interpolates this to 50 route points along
+~370 nm.
+
+## Instrumentation added during this work
+
+Surgical, zero-behavior-change additions inside `fetch/grib/__init__.py`:
+
+- `_grib_time_reset()` / `_grib_time(label)` context manager — accumulates
+  per-label wall-clock across an `enrich_forecasts` call; thread-safe with
+  a lock so the in-Phase-1 ThreadPoolExecutor can record its own legs.
+- `_grib_gc()` — wraps `gc.collect()` to track cumulative GC time and call
+  count without changing memory behaviour. **gc.collect() stays — it's
+  load-bearing for memory, not just defensive.**
+- `_grib_time_summary()` — single INFO log line at end of enrichment:
+  ```
+  GRIB timing: phase1_parallel=… ecmwf_total=… icon_prefetch=… gc=…s/N
+  ```
+- Improved 404 logging in `icon_eu_fetch.py` — `_format_failure_summary`
+  appends `(404=N,network=M)` to per-fhour aggregate lines so failure
+  modes are visible in prod logs without raising the log level.
+
+These additions are safe to deploy as part of Phase A (see plan below).
+
+## Profile runs and headline numbers
+
+Three runs on the same test flight, all D+3 European, all warm Open-Meteo
+(paid API key, fast network), with different GRIB cache states:
+
+| Run | Cache state | ICON state | Total | GRIB | Peak RSS |
+|---|---|---|---|---|---|
+| 1 — warm | populated | broken (404s) | 92.3s | 32.0s | ~924 MB |
+| 2 — cold | cleared | broken (404s) | 88.2s | 33.9s | similar |
+| 3 — ICON fixed | populated | **working fully** | 208.2s | **144.4s** | **3317 MB** |
+
+The cold/warm delta in runs 1+2 is within noise (4s) — confirms **GRIB
+enrichment is decode-bound, not download-bound**. Cache barely matters.
+
+Run 3 is the eye-opener: **fixing ICON downloads more than doubles the
+pipeline (96s → 208s) and triples peak memory (924 MB → 3.3 GB)**. That
+finding drove the staged plan in this document.
+
+## Detailed stage breakdown — Run 1 (broken ICON, 96s baseline)
+
+```
+Stage                 Sec   %     Notes
+──────────────────────────────────────────────────────────────
+route_interpolation   0.00  —
+elevation_profile     0.13  0.1%
+fetch_forecasts       3.14  3.4%  3 models (ecmwf/gfs/icon)
+grib_enrichment      32.43 33.7%  ┐
+  ecmwf_a2_decode    27.22         │ 10 steps × 2.72s, sequential
+  ecmwf_a1_decode     4.66         │ 10 steps × 0.47s, sequential
+  gfs_total           7.91         │ overlapped with ECMWF
+    gfs_clwmr_decode 5.98         │ 4 fhours
+    gfs_cloud_diag   4.30         │ 4 fhours
+  icon_prefetch      4.74         │ failed fast (404s)
+  gc                 1.36 / 8     │ ⟵ NOT load-bearing for perf
+route_analysis      18.85 19.6%   ┐
+  metpy.xarray wrapper 8.43       │ pure overhead
+  compute_derived_levels 10.99
+  compute_indices     4.67
+  compute_stability   1.56
+waypoint_analysis     0.02  —
+route_advisories      0.27  0.3%
+save_snapshot         0.00  —
+fetch_gramet          3.36  3.5%  HTTPS wait
+llm_digest           38.73 40.2%  Anthropic API HTTP wait
+──────────────────────────────────────────────────────────────
+Total                96.26 100%
+```
+
+Open-Meteo serial fetches are 3.1s total, not the bottleneck I initially
+suspected. Paid API key + warm DNS + 3 active models = cheap.
+
+## Detailed stage breakdown — Run 3 (ICON working, 208s)
+
+```
+GRIB timing:
+  phase1_parallel    111.88s
+    icon_prefetch    111.87s   ⟵ NEW BOTTLENECK
+      icon_prefetch_var  108.98s / 36 calls (~3.0s × 36 var-fhours)
+      icon_prefetch_cloud_diag  2.49s / 4
+    ecmwf_total      35.59s    (overlapped, finished at ~35s)
+      ecmwf_a2_decode 30.18s / 10
+      ecmwf_a1_decode  5.28s / 10
+    gfs_total         8.21s    (overlapped, finished at ~8s)
+      gfs_clwmr_decode  5.99s
+      gfs_cloud_diag_decode  4.13s
+  phase2_icon_decode 31.94s    ⟵ 2nd new cost
+    icon_chunked_decode 28.91s / 4 fhours (~7.2s/fhour)
+    icon_cloud_diag_decode 0.44s / 4
+  propagate_all       0.05s
+  gc                  3.47s / 20
+
+route_analysis       20.05s
+fetch_gramet          3.63s
+llm_digest           36.88s
+──────────────────────────
+Total               208.24s
+```
+
+Key shape: with ICON working, **Phase 1 is dominated entirely by ICON
+download**. ECMWF (35s) and GFS (8s) become "free" within the overlap.
+Means **ECMWF parallelisation saves nothing** as long as ICON download is
+the long pole.
+
+## The ICON cycle/horizon bug (discovered during profiling)
+
+Two wrong constants in `fetch/grib/icon_eu_fetch.py` (verified empirically
+by curl-ing DWD opendata directory listings):
+
+| Constant | Code value | Reality (DWD) |
+|---|---|---|
+| `ICON_EU_MAIN_CYCLES` | `{0, 12}` | `{0, 6, 12, 18}` |
+| `ICON_EU_MODEL_LEVEL_MAX_HOUR_SHORT` | `78` | `48` (hourly to ~30h, then 6-hourly to 48h) |
+
+Behaviour today (with bug):
+- For a flight ≥ 49h out, code may pick a short cycle (03/09/15/21z),
+  thinking the horizon is 78h. Real horizon is 48h.
+- Code then requests f049+ files that don't exist → all 40 levels return 404
+  per variable → variable enrichment fails for those fhours.
+- Some hours within real horizon still succeed, so prod ICON enrichment
+  is **partial**, not entirely broken.
+
+Fix is two-line constant correction. **Held back until Step 2(b) is done**
+because activating it on prod increases memory pressure (see below).
+
+The improved 404 logging is independent of the constant change and ships
+in Phase A.
+
+## Phase A smoke-test findings (worth recording)
+
+After deploying the instrumentation locally and running the test flight,
+two things surfaced that update our model of the memory peak:
+
+1. **The memory peak is in Phase 1 prefetch, not Phase 2 decode.** With
+   12z (a main cycle even in buggy code) freshly published, ICON
+   downloaded all 36 variable-fhours sequentially. RSS climbed from
+   510 MB baseline to **3118 MB at end of Phase 1**, then *dropped* to
+   3053 MB by the end of Phase 2 decode. So Step 2(b) ("stream var_bytes
+   one at a time during decode") will help, but **most of the bloat is
+   already there before decode starts**. The leak is in the prefetch
+   loop itself, where 36 sequential `bz2.decompress` + bytearray
+   accumulations cause glibc/macOS malloc fragmentation. Linux glibc may
+   reclaim more aggressively, which would explain prod's ~2.2 GB peak
+   vs our ~3.1 GB on macOS.
+
+2. **`get_cached(run_dir, filename)` reads the entire file just to
+   check existence.** It's used as `if get_cached(...) is not None:
+   continue` to skip already-cached variables. On a warm-cache refresh
+   this reads ~70 MB × 36 var-fhours = 2.5 GB into briefly-held bytes
+   objects, only to discard them. Even if they free promptly, the
+   `ru_maxrss` peak still reflects the high-water mark.
+
+   Fix: add `is_cached(run_dir, filename) -> bool` that just calls
+   `path.exists()` + TTL check, and route the prefetch loop to it.
+   Zero behaviour change, removes a per-refresh memory spike on warm
+   cache. Worth doing as part of Phase A or as a tiny standalone PR
+   ahead of Phase B.
+
+These updates change the Step 2(b) design slightly: streaming is still
+worth doing, but **the bigger memory win is fixing the prefetch loop**
+to either (a) call `bz2.decompress` once and write to disk before
+moving to the next variable rather than buffering the whole result,
+or (b) explicitly free each `data`/`per_var` reference plus call
+gc.collect between variables (matching the decode loop pattern), or
+(c) avoid the bytearray buffer growth by writing each level's
+decompressed bytes to disk as it arrives rather than accumulating.
+
+## Memory analysis
+
+Prod baseline today (`docker logs weatherbrief --since 24h | grep peak=`):
+- peak ranges 1.8 GB → 2.2 GB
+- worst single request growth: +1363 MB
+- most requests are small (+0–250 MB) — cache hits dominate
+
+Prod is **already** hitting the ICON cycle bug right now (logs show
+"Found ICON-EU run: 20260501 09z (horizon 78h)" followed by f031+ all-failed
+warnings). So prod memory baseline is **with partially-failing ICON**.
+
+Local test with the cycle fix (full ICON working) hit **3317 MB peak on
+macOS**. Linux's glibc allocator releases pages more aggressively than
+macOS, so prod might land 2.0–2.5 GB. But the 3 GB Docker cap is in play.
+
+Plausible peak attribution:
+- Per-fhour ICON decode holds `var_bytes` dict with 9 variables × ~70 MB
+  decompressed = ~630 MB.
+- Plus xarray decode workspace (cfgrib opens temp files, allocates
+  numpy arrays per pressure level).
+- Plus existing pipeline working set (~1.0–1.5 GB).
+- Held simultaneously across `_decode_and_merge_icon_eu`'s per-fhour loop.
+
+## Plan
+
+### Phase A — instrument and observe (zero behaviour change)
+
+Goal: measure prod memory and timing in detail before making any change
+that affects what data flows through the pipeline.
+
+Ship as one PR/deploy:
+
+1. ✅ Sub-stage timing (`_grib_time` + `_grib_time_summary`) — already in
+   local tree.
+2. ✅ Improved 404 logging (`_format_failure_summary`) — already in local
+   tree.
+3. ⏳ Add memory checkpoints in `fetch/grib/__init__.py`:
+   - start/end of `enrich_forecasts`
+   - start/end of `_prefetch_icon_eu_data` (per fhour aggregate)
+   - inside `_decode_and_merge_icon_eu` (per fhour, before/after decode)
+   - inside `decode_icon_eu_per_point_chunked` (per variable)
+4. ⏳ **Revert the cycle/horizon constants** in `icon_eu_fetch.py` for
+   this phase. Prod continues to silently 404 on long-range short cycles,
+   but we get visibility before behaviour changes.
+
+Deploy. Watch ~24h of prod refreshes. Capture:
+- per-stage timings under prod network conditions (DWD will be faster)
+- exact per-fhour memory delta during ICON decode
+- 404 mix (`404=` vs `network=`) to see what actually fails today
+
+### Phase B — design + verify Step 2(b) locally
+
+Once Phase A data is in:
+
+1. Refactor `_decode_and_merge_icon_eu` so it loads `var_bytes[var]`
+   from disk **one variable at a time** into the chunked decoder, frees
+   it, moves on. The compressed bytes are already cached on disk — we're
+   just changing the in-memory shape from "load-all-9-variables-then-decode"
+   to "load-one-decode-free-loop".
+2. May need `decode_icon_eu_per_point_chunked` to accept a callable or
+   generator instead of a dict.
+3. Local profile run with cycle fix + streaming. Confirm peak RSS drops
+   from 3.3 GB to ≤1.5 GB on macOS. (Linux will be lower.)
+4. If still too high, also stream per-fhour to ensure decoded points
+   from fhour N are released before fhour N+1 starts loading.
+
+### Phase C — combined deploy
+
+Ship together:
+- Cycle/horizon fix (`{0, 6, 12, 18}`, `48`)
+- Step 2(b) memory streaming refactor
+- Phase A instrumentation still in place to verify prod memory stays
+  under 2 GB peak with full ICON working
+
+Watch first few refreshes carefully. Rollback path: revert cycle fix
+(line-level revert restores Phase A behaviour).
+
+### Step 2(b) success criteria
+
+- ICON enrichment fully complete on long-range flights (no `_failed`
+  warnings for fhours within the real horizon).
+- Prod peak RSS stays ≤2 GB on a D+3 European refresh.
+- Pipeline total ≤ ~150s on a D+3 refresh (we accept the ICON cost
+  is real and unavoidable; targeting under that with later phases).
+
+## Other optimisation candidates (parking lot)
+
+Captured here so we don't lose them. Sequenced **after ICON Phase C** —
+some only become worth doing once ICON download stops being the long pole.
+
+### O-1. Parallelise ICON download across variables (–60 to –80s, after Phase C only)
+
+`fetch_icon_eu_per_variable` loops variables sequentially; each variable
+does 40 parallel downloads then waits before the next variable starts.
+A 360-file ThreadPoolExecutor (max_workers ~16–24) would shrink ICON
+prefetch from ~110s to ~30s — **but** memory peak goes up if not paired
+with the streaming decode from Step 2(b). This is the natural follow-on
+once 2(b) lands.
+
+Risk: DWD rate limiting. Test with 16 workers first.
+
+### O-2. Parallelise ECMWF a2 decode steps (–15s, after ICON optimised)
+
+`_enrich_ecmwf_inner` decodes 10 steps sequentially (~3s each).
+ThreadPoolExecutor with workers=2 would halve that. Worth nothing right
+now because ICON download (~110s) is the long pole; ECMWF (~35s) hides
+inside that overlap. Becomes worthwhile once ICON drops below ~30s.
+
+Memory: each cfgrib decode peaks ~270 MB → workers=2 means ~540 MB peak.
+OK with current 3 GB cap. workers=4 would breach.
+
+### O-3. Vectorise MetPy in `compute_derived_levels_extended` (–8 to –12s)
+
+`analysis/sounding/thermodynamics.py:319` (and `:162`). 8.43s of self-time
+in `metpy.xarray.py:1285` — that's the `@parse_grid_arguments` decorator
+converting Python lists → pint Quantity → xarray on every call. Hoist
+that conversion outside the per-(point, model) loop and call MetPy once
+per batch.
+
+Risk: medium. Need to verify thermodynamic outputs match exactly.
+Existing tests in `test_clouds.py`, `test_convective.py`, `test_comparison.py`
+should catch regressions; a numerical-equivalence test would help.
+
+Independent of all GRIB work — can land in parallel with ICON Phase C
+if convenient.
+
+### O-4. Overlap GRAMET + LLM digest (–3s)
+
+`pipeline.py` sections 5 (GRAMET), 7 (LLM digest) are sequential and
+share no state. Both are HTTP I/O. ThreadPoolExecutor or asyncio.gather
+saves the GRAMET 3s by overlapping it with the LLM 38s.
+
+Trivial change. Ship anytime.
+
+### O-5. LLM digest streaming (deferred, UX change)
+
+LLM digest is 30–40s of HTTP wait at the very end. Anthropic API supports
+streaming — could begin rendering partial digest as tokens arrive. Changes
+UX semantics (digest text shown progressively) and would need frontend
+work for SSE. Defer until everything else is exhausted.
+
+## Things to investigate later (not yet ranked)
+
+These came up during the read-through but aren't load-bearing right now:
+
+- **Why ECMWF a2 decode takes 2.7s per step (10 steps × 25 levels each).**
+  Most of the time is presumably cfgrib opening the file + reading the
+  multi-grid (Europe + Nordic) sub-datasets. Worth checking if a single
+  open + multi-grid extraction would be faster than the current
+  per-grid-loop pattern.
+
+- **`gc.collect()` real cost** — measured at 1.36s in Run 1 (8 calls)
+  and 3.47s in Run 3 (20 calls). Modest but not zero. The user
+  confirmed they're load-bearing for memory; we keep them. Worth
+  remembering in any memory-related work.
+
+- **Spatial interpolation cost** — `analysis/spatial_interpolation.py`
+  was logged but not timed: "filled 300 (point, level) CLW/ICMR gaps,
+  filled 15 cloud diagnostics gaps". Probably small; should be timed
+  inside route_analysis.
+
+- **Cross-section .json size on disk** — separate from speed, but worth
+  checking how big `cross_section.json` lands as briefing.json+forecasts.json
+  scale up. May tie into account-deletion tests.
+
+- **Open-Meteo per-model parallelisation** — 3.1s today, not worth
+  parallelising (the savings would be ~2s). But if more models are
+  added (e.g. UKMO once it's stable), revisit.
+
+- **Profile pyinstrument with `async_mode='enabled'`** — current runs use
+  `disabled` so we only see main-thread frames. The GRIB worker threads
+  are reduced to `lock.acquire`. The new sub-stage timing data already
+  covers this gap, but a thread-aware profile would be useful if we
+  hit something unexpected during Phase B.
+
+## Open questions before Phase A deploy
+
+1. The Phase A instrumentation adds ~10 INFO log lines per refresh (memory
+   checkpoints + GRIB timing summary). Acceptable for prod? They're
+   bounded, not per-route-point.
+
+2. Confirm the 4 cycle/horizon constants live in `icon_eu_fetch.py`
+   only — yes (confirmed; no other module re-exports them). Reverting
+   them is a single-file diff.
+
+## Verification plan (across phases)
+
+- Phase A: deploy. Verify GRIB timing log appears, memory checkpoints
+  produce sensible numbers, no behaviour change vs prior. ≥10 prod
+  refreshes captured before next change.
+- Phase B: local profile shows peak ≤ 1.5 GB on macOS for the test flight,
+  total time within 10% of pre-change Run 3 (we expect ~210s with same
+  ICON download cost; 2(b) is memory-only, not speed).
+- Phase C: deploy. First 5 prod refreshes:
+  - peak RSS ≤ 2 GB
+  - ICON enrichment hourly count climbs (no fhour-level all-failed
+    warnings except where ICON-EU domain genuinely doesn't cover)
+  - GRIB timing summary shows expected shape (icon_prefetch and
+    phase2_icon_decode both populated; no `404=` failures except
+    network blips)
+
+## Files touched (running list)
+
+- `src/weatherbrief/fetch/grib/__init__.py` — instrumentation already in.
+- `src/weatherbrief/fetch/grib/icon_eu_fetch.py` — improved 404 logging
+  in. Cycle/horizon constants change **needs to be reverted for Phase A**.
+- `scripts/profile_refresh.py` — driver script; new file, kept.
+- `designs/plans/refresh-pipeline-performance.md` — this document.

--- a/scripts/profile_refresh.py
+++ b/scripts/profile_refresh.py
@@ -1,0 +1,232 @@
+"""Profile a briefing refresh: per-stage wall-clock + pyinstrument flamegraph.
+
+Loads a flight from the local DB, builds RouteConfig + BriefingOptions to
+mirror the production refresh path, then runs ``execute_briefing`` wrapped
+in a stage-timing collector and a pyinstrument profiler.
+
+Outputs:
+- per-stage timing summary to stdout
+- pyinstrument HTML to ``profiles/{flight_id}_{ts}.html``
+- briefing pack written under ``profiles/_packs/{flight_id}/{ts}/``
+  (kept separate from real ``data/packs/`` to avoid mixing with real data)
+
+Usage:
+    python scripts/profile_refresh.py <flight-id> [--force-live] [--clear-grib-cache]
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import shutil
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+# Project paths
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from dotenv import load_dotenv
+load_dotenv(ROOT / ".env")
+
+from pyinstrument import Profiler
+
+from weatherbrief.api.flights import _load_flight_or_404
+from weatherbrief.api.packs import _prepare_refresh
+from weatherbrief.db import SessionLocal, init_shared_db
+from weatherbrief.pipeline import BriefingOptions, execute_briefing
+
+
+def _stage_recorder():
+    """Return (callback, finalize) — finalize() returns list of (stage, seconds)."""
+    starts: dict[str, float] = {}
+    order: list[str] = []
+    last_stage: list[str | None] = [None]
+    last_t: list[float] = [time.perf_counter()]
+    durations: list[tuple[str, float]] = []
+
+    def callback(stage: str, detail: str | None = None) -> None:
+        now = time.perf_counter()
+        # Record duration of the previous stage
+        if last_stage[0] is not None:
+            durations.append((_stage_label(last_stage[0], None), now - last_t[0]))
+        # Compose stage label including the model name when present
+        last_stage[0] = stage
+        last_t[0] = now
+        # For per-model fetch_forecasts notifications, fold detail into label
+        if stage == "fetch_forecasts" and detail:
+            last_stage[0] = f"fetch_forecasts:{detail}"
+        elif stage == "grib_enrichment" and detail:
+            last_stage[0] = f"grib_enrichment:{detail}"
+        if stage in starts:
+            return
+        starts[stage] = now
+        order.append(stage)
+
+    def finalize(end_t: float) -> list[tuple[str, float]]:
+        if last_stage[0] is not None:
+            durations.append((_stage_label(last_stage[0], None), end_t - last_t[0]))
+        return durations
+
+    return callback, finalize
+
+
+def _stage_label(stage: str, detail: str | None) -> str:
+    if detail:
+        return f"{stage}:{detail}"
+    return stage
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0] if __doc__ else "")
+    parser.add_argument("flight_id", help="Flight ID to profile")
+    parser.add_argument(
+        "--force-live", action="store_true",
+        help="Force historical_mode=False even if departure has passed (enables GRAMET + LLM)",
+    )
+    parser.add_argument(
+        "--clear-grib-cache", action="store_true",
+        help="Delete GFS + ICON-EU cached GRIB before running (tests cold-cache path)",
+    )
+    parser.add_argument(
+        "--no-llm", action="store_true",
+        help="Skip LLM digest stage",
+    )
+    parser.add_argument(
+        "--no-gramet", action="store_true",
+        help="Skip GRAMET fetch",
+    )
+    parser.add_argument(
+        "--user-id", default="dev-user-001",
+        help="User ID owning the flight (default: dev-user-001)",
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+
+    init_shared_db()
+    db = SessionLocal()
+    try:
+        try:
+            flight = _load_flight_or_404(db, args.flight_id, viewer_id=args.user_id)
+        except Exception as exc:
+            print(f"Flight {args.flight_id} not found: {exc}", file=sys.stderr)
+            return 1
+
+        db_path = os.environ.get("AIRPORTS_DB", "") or str(ROOT / "data" / "nav.db")
+
+        # Mirror _prepare_refresh, but route the pack into profiles/_packs/...
+        route, fetch_ts, pack_path, options, _meta = _prepare_refresh(
+            flight, db_path, args.user_id, args.flight_id, db=db,
+            is_privileged=True,
+        )
+    finally:
+        db.close()
+
+    # Redirect output_dir into ./profiles/_packs/ so we don't pollute data/packs/
+    safe_ts = fetch_ts.isoformat().replace(":", "-").replace("+", "p")
+    pack_path = ROOT / "profiles" / "_packs" / args.flight_id / safe_ts
+    pack_path.mkdir(parents=True, exist_ok=True)
+    options.output_dir = pack_path
+
+    if args.force_live:
+        options.historical_mode = False
+        options.as_of_time = None
+        # Re-enable services that historical mode would have stripped
+        options.fetch_gramet = not args.no_gramet
+        options.generate_llm_digest = not args.no_llm
+    if args.no_llm:
+        options.generate_llm_digest = False
+    if args.no_gramet:
+        options.fetch_gramet = False
+
+    if args.clear_grib_cache:
+        data_dir = options.data_dir
+        if data_dir is None:
+            from weatherbrief.storage.snapshots import DEFAULT_DATA_DIR
+            data_dir = DEFAULT_DATA_DIR
+        for sub in ("gfs", "icon-eu"):
+            cache = Path(data_dir) / ".cache" / "grib" / sub
+            if cache.exists():
+                print(f"clearing cache: {cache}")
+                shutil.rmtree(cache)
+
+    print(f"flight: {args.flight_id}")
+    print(f"route: {route.name}")
+    print(f"departure: {flight.departure_time}")
+    print(f"waypoints: {[w.icao for w in route.waypoints]}")
+    print(f"cruise_altitude_ft: {route.cruise_altitude_ft}")
+    print(f"flight_duration_hours: {route.flight_duration_hours}")
+    print(f"options: enrich_grib={options.enrich_grib} "
+          f"fetch_gramet={options.fetch_gramet} "
+          f"generate_llm_digest={options.generate_llm_digest} "
+          f"historical_mode={options.historical_mode}")
+    print(f"pack_dir: {pack_path}")
+    print()
+
+    record, finalize = _stage_recorder()
+
+    profiler = Profiler(interval=0.01, async_mode="disabled")
+    profiler.start()
+    t0 = time.perf_counter()
+    try:
+        result = execute_briefing(
+            route=route,
+            departure_time=flight.departure_time,
+            options=options,
+            progress_callback=record,
+        )
+    finally:
+        t_end = time.perf_counter()
+        profiler.stop()
+
+    durations = finalize(t_end)
+    total = t_end - t0
+
+    print()
+    print("=" * 70)
+    print(f"TOTAL elapsed: {total:.2f}s")
+    print("=" * 70)
+    print(f"{'stage':<40} {'seconds':>10} {'pct':>6}")
+    print("-" * 70)
+    # Aggregate by base stage label so multiple fetch_forecasts:* lines stack
+    agg: dict[str, float] = {}
+    order: list[str] = []
+    for stage, secs in durations:
+        if stage not in agg:
+            order.append(stage)
+            agg[stage] = 0.0
+        agg[stage] += secs
+    for stage in order:
+        secs = agg[stage]
+        pct = 100.0 * secs / total
+        print(f"{stage:<40} {secs:>10.2f} {pct:>5.1f}%")
+    print("-" * 70)
+
+    # pyinstrument output
+    profiles_dir = ROOT / "profiles"
+    profiles_dir.mkdir(exist_ok=True)
+    html_path = profiles_dir / f"{args.flight_id}_{safe_ts}.html"
+    html_path.write_text(profiler.output_html())
+    txt_path = profiles_dir / f"{args.flight_id}_{safe_ts}.txt"
+    txt_path.write_text(profiler.output_text(unicode=True, color=False, show_all=False))
+    print(f"\npyinstrument html: {html_path}")
+    print(f"pyinstrument txt:  {txt_path}")
+    print(f"open: file://{html_path}")
+
+    print(f"\nbriefing errors: {result.errors}")
+    print(f"models_fetched: {result.models_fetched}")
+    print(f"grib_init_times: {result.grib_init_times}")
+    print(f"open_meteo_calls: {result.usage.open_meteo_calls}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/profile_refresh.py
+++ b/scripts/profile_refresh.py
@@ -169,6 +169,7 @@ def main() -> int:
     profiler = Profiler(interval=0.01, async_mode="disabled")
     profiler.start()
     t0 = time.perf_counter()
+    result = None
     try:
         result = execute_briefing(
             route=route,
@@ -179,40 +180,42 @@ def main() -> int:
     finally:
         t_end = time.perf_counter()
         profiler.stop()
+        # Always emit the profile artifacts and timing table — they're most
+        # useful exactly when execute_briefing raises.
+        durations = finalize(t_end)
+        total = t_end - t0
 
-    durations = finalize(t_end)
-    total = t_end - t0
+        print()
+        print("=" * 70)
+        print(f"TOTAL elapsed: {total:.2f}s")
+        print("=" * 70)
+        print(f"{'stage':<40} {'seconds':>10} {'pct':>6}")
+        print("-" * 70)
+        # Sum durations by full label; per-model entries (fetch_forecasts:gfs,
+        # fetch_forecasts:ecmwf, ...) appear as separate rows by design.
+        agg: dict[str, float] = {}
+        order: list[str] = []
+        for stage, secs in durations:
+            if stage not in agg:
+                order.append(stage)
+                agg[stage] = 0.0
+            agg[stage] += secs
+        for stage in order:
+            secs = agg[stage]
+            pct = 100.0 * secs / total if total > 0 else 0.0
+            print(f"{stage:<40} {secs:>10.2f} {pct:>5.1f}%")
+        print("-" * 70)
 
-    print()
-    print("=" * 70)
-    print(f"TOTAL elapsed: {total:.2f}s")
-    print("=" * 70)
-    print(f"{'stage':<40} {'seconds':>10} {'pct':>6}")
-    print("-" * 70)
-    # Aggregate by base stage label so multiple fetch_forecasts:* lines stack
-    agg: dict[str, float] = {}
-    order: list[str] = []
-    for stage, secs in durations:
-        if stage not in agg:
-            order.append(stage)
-            agg[stage] = 0.0
-        agg[stage] += secs
-    for stage in order:
-        secs = agg[stage]
-        pct = 100.0 * secs / total
-        print(f"{stage:<40} {secs:>10.2f} {pct:>5.1f}%")
-    print("-" * 70)
-
-    # pyinstrument output
-    profiles_dir = ROOT / "profiles"
-    profiles_dir.mkdir(exist_ok=True)
-    html_path = profiles_dir / f"{args.flight_id}_{safe_ts}.html"
-    html_path.write_text(profiler.output_html())
-    txt_path = profiles_dir / f"{args.flight_id}_{safe_ts}.txt"
-    txt_path.write_text(profiler.output_text(unicode=True, color=False, show_all=False))
-    print(f"\npyinstrument html: {html_path}")
-    print(f"pyinstrument txt:  {txt_path}")
-    print(f"open: file://{html_path}")
+        # pyinstrument output
+        profiles_dir = ROOT / "profiles"
+        profiles_dir.mkdir(exist_ok=True)
+        html_path = profiles_dir / f"{args.flight_id}_{safe_ts}.html"
+        html_path.write_text(profiler.output_html())
+        txt_path = profiles_dir / f"{args.flight_id}_{safe_ts}.txt"
+        txt_path.write_text(profiler.output_text(unicode=True, color=False, show_all=False))
+        print(f"\npyinstrument html: {html_path}")
+        print(f"pyinstrument txt:  {txt_path}")
+        print(f"open: file://{html_path}")
 
     print(f"\nbriefing errors: {result.errors}")
     print(f"models_fetched: {result.models_fetched}")

--- a/scripts/profile_refresh.py
+++ b/scripts/profile_refresh.py
@@ -42,8 +42,6 @@ from weatherbrief.pipeline import BriefingOptions, execute_briefing
 
 def _stage_recorder():
     """Return (callback, finalize) — finalize() returns list of (stage, seconds)."""
-    starts: dict[str, float] = {}
-    order: list[str] = []
     last_stage: list[str | None] = [None]
     last_t: list[float] = [time.perf_counter()]
     durations: list[tuple[str, float]] = []
@@ -53,18 +51,14 @@ def _stage_recorder():
         # Record duration of the previous stage
         if last_stage[0] is not None:
             durations.append((_stage_label(last_stage[0], None), now - last_t[0]))
-        # Compose stage label including the model name when present
-        last_stage[0] = stage
         last_t[0] = now
         # For per-model fetch_forecasts notifications, fold detail into label
         if stage == "fetch_forecasts" and detail:
             last_stage[0] = f"fetch_forecasts:{detail}"
         elif stage == "grib_enrichment" and detail:
             last_stage[0] = f"grib_enrichment:{detail}"
-        if stage in starts:
-            return
-        starts[stage] = now
-        order.append(stage)
+        else:
+            last_stage[0] = stage
 
     def finalize(end_t: float) -> list[tuple[str, float]]:
         if last_stage[0] is not None:

--- a/src/weatherbrief/fetch/grib/__init__.py
+++ b/src/weatherbrief/fetch/grib/__init__.py
@@ -184,9 +184,16 @@ def _grib_rss_mark(label: str) -> None:
 def _submit_with_context(pool: ThreadPoolExecutor, fn, /, *args, **kwargs):
     """Submit *fn* to *pool* with the caller's ContextVars copied in.
 
-    ThreadPoolExecutor.submit doesn't propagate contextvars by default;
-    without this, worker threads see _GRIB_TIMER as the default None and
-    timing/RSS calls become silent no-ops.
+    ``ThreadPoolExecutor.submit`` does **not** propagate contextvars in any
+    current Python (verified on 3.13.11: a plain ``pool.submit`` worker sees
+    ContextVar defaults, not the caller's bound values; nested submits lose
+    them at every level). Without this wrapper, worker threads see
+    ``_GRIB_TIMER`` as the default ``None`` and ``_grib_time``/``_grib_gc``
+    /``_grib_rss_mark`` calls become silent no-ops — losing the per-fhour
+    sub-stage timings the instrumentation exists to capture.
+
+    Apply at *every* ``submit`` site that needs the timer, including nested
+    pools (e.g. the inner GFS pool inside an outer Phase-1 worker).
     """
     ctx = contextvars.copy_context()
     return pool.submit(ctx.run, fn, *args, **kwargs)
@@ -653,17 +660,19 @@ def _enrich_gfs_inner(
         return None
 
     # Run both enrichment paths in parallel — they write to different fields
-    # (CLWMR/ICMR on PressureLevelData vs nwp_cloud_diagnostics on HourlyForecast)
+    # (CLWMR/ICMR on PressureLevelData vs nwp_cloud_diagnostics on HourlyForecast).
+    # Use _submit_with_context so per-fhour _grib_time(...) calls in the inner
+    # workers see the same _GRIB_TIMER as the outer enrich_forecasts call.
     with _grib_time("gfs_workers"):
         with ThreadPoolExecutor(max_workers=2) as pool:
-            pool.submit(
-                _enrich_clwmr_icmr,
+            _submit_with_context(
+                pool, _enrich_clwmr_icmr,
                 gfs_sections, all_forecasts, route_points,
                 init_date, init_hour, forecast_hours,
                 run_dir, idx_by_fhour, point_lats, point_lons, session,
             )
-            pool.submit(
-                _enrich_cloud_diagnostics,
+            _submit_with_context(
+                pool, _enrich_cloud_diagnostics,
                 gfs_sections, all_forecasts, route_points,
                 init_date, init_hour, forecast_hours,
                 run_dir, idx_by_fhour, point_lats, point_lons, session,

--- a/src/weatherbrief/fetch/grib/__init__.py
+++ b/src/weatherbrief/fetch/grib/__init__.py
@@ -6,6 +6,7 @@ existing cross-section forecasts from GFS and ICON-EU GRIB2 data.
 
 from __future__ import annotations
 
+import contextvars
 import gc
 import logging
 import threading
@@ -19,10 +20,13 @@ from typing import Callable
 import requests
 from requests.adapters import HTTPAdapter
 
+from weatherbrief.process_rss import current_rss_mb as _read_rss_mb
+
 from weatherbrief.fetch.grib.cache import (
     cache_dir_for_run,
     cache_key,  # route-independent: keyed by (fhour, variable) only
     get_cached,
+    is_cached,
     purge_old_runs,
     put_cached,
 )
@@ -52,139 +56,140 @@ _M_TO_FT = 3.28084
 
 
 # ---------------------------------------------------------------------------
-# Sub-stage timing instrumentation (one-shot, for refresh-pipeline profiling).
-# Single-refresh-at-a-time assumed; multi-refresh would interleave but the
-# numbers still aggregate truthfully, the labels just reflect both runs.
+# Sub-stage timing + memory instrumentation for refresh-pipeline profiling.
+#
+# State lives on a per-call _GribTimer instance, propagated to inner functions
+# (and into Phase-1 ThreadPoolExecutor workers) via a ContextVar. This makes
+# the instrumentation correct under concurrent refreshes — the API runs
+# refresh pipelines in a ``ThreadPoolExecutor(max_workers=2)``, so two
+# enrich_forecasts() can be in flight at once without their counters mixing.
+#
+# Worker threads spawned by Phase-1 ThreadPoolExecutor must run inside the
+# parent's contextvars copy — see _submit_with_context() below.
 # ---------------------------------------------------------------------------
 
-_grib_timing_lock = threading.Lock()
-_grib_timing_data: dict[str, float] = {}
-_grib_timing_counts: dict[str, int] = {}
-_grib_gc_seconds: float = 0.0
-_grib_gc_count: int = 0
+
+class _GribTimer:
+    """Per-enrich_forecasts call: timing, gc, and RSS accumulators."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self.timings: dict[str, float] = {}
+        self.timing_counts: dict[str, int] = {}
+        self.gc_seconds: float = 0.0
+        self.gc_count: int = 0
+        self.rss_baseline: float | None = _read_rss_mb()
+        self.rss_max: dict[str, float] = {}
+        self.rss_count: dict[str, int] = {}
+
+    def _record_time(self, label: str, secs: float) -> None:
+        with self._lock:
+            self.timings[label] = self.timings.get(label, 0.0) + secs
+            self.timing_counts[label] = self.timing_counts.get(label, 0) + 1
+
+    @contextmanager
+    def time(self, label: str):
+        t0 = _time_mod.perf_counter()
+        try:
+            yield
+        finally:
+            self._record_time(label, _time_mod.perf_counter() - t0)
+
+    def gc(self) -> None:
+        """gc.collect() with cumulative timing accounting."""
+        t0 = _time_mod.perf_counter()
+        gc.collect()
+        elapsed = _time_mod.perf_counter() - t0
+        with self._lock:
+            self.gc_seconds += elapsed
+            self.gc_count += 1
+
+    def rss_mark(self, label: str) -> None:
+        """Record current RSS under *label*. Keeps max-per-label across calls."""
+        rss = _read_rss_mb()
+        if rss is None:
+            return
+        with self._lock:
+            prior = self.rss_max.get(label)
+            self.rss_max[label] = rss if prior is None else max(prior, rss)
+            self.rss_count[label] = self.rss_count.get(label, 0) + 1
+
+    def log_summary(self) -> None:
+        # Snapshot under lock, format outside — avoids holding the lock through
+        # logger formatting and matches the locking discipline used for writes.
+        with self._lock:
+            timings = dict(self.timings)
+            counts = dict(self.timing_counts)
+            gc_secs = self.gc_seconds
+            gc_n = self.gc_count
+            rss_max = dict(self.rss_max)
+            rss_count = dict(self.rss_count)
+            baseline = self.rss_baseline
+
+        if timings:
+            items = sorted(timings.items(), key=lambda kv: -kv[1])
+            parts = [f"{label}={secs:.2f}s/{counts.get(label, 0)}" for label, secs in items]
+            parts.append(f"gc={gc_secs:.2f}s/{gc_n}")
+            logger.info("GRIB timing: %s", " ".join(parts))
+
+        if rss_max:
+            items = sorted(rss_max.items(), key=lambda kv: -kv[1])
+            parts = []
+            if baseline is not None:
+                parts.append(f"baseline={int(baseline)}MB")
+            for label, rss in items:
+                n = rss_count.get(label, 0)
+                if baseline is not None:
+                    parts.append(f"{label}={int(rss)}MB(+{int(rss - baseline)}/{n})")
+                else:
+                    parts.append(f"{label}={int(rss)}MB/{n}")
+            logger.info("GRIB RSS: %s", " ".join(parts))
 
 
-def _grib_time_reset() -> None:
-    global _grib_gc_seconds, _grib_gc_count
-    with _grib_timing_lock:
-        _grib_timing_data.clear()
-        _grib_timing_counts.clear()
-        _grib_gc_seconds = 0.0
-        _grib_gc_count = 0
+_GRIB_TIMER: contextvars.ContextVar[_GribTimer | None] = contextvars.ContextVar(
+    "_grib_timer", default=None,
+)
 
 
-def _grib_time_record(label: str, secs: float) -> None:
-    with _grib_timing_lock:
-        _grib_timing_data[label] = _grib_timing_data.get(label, 0.0) + secs
-        _grib_timing_counts[label] = _grib_timing_counts.get(label, 0) + 1
+def _timer() -> _GribTimer | None:
+    return _GRIB_TIMER.get()
 
 
 @contextmanager
 def _grib_time(label: str):
-    t0 = _time_mod.perf_counter()
-    try:
+    """Time a block under the active per-call timer; no-op if none is active."""
+    t = _timer()
+    if t is None:
         yield
-    finally:
-        _grib_time_record(label, _time_mod.perf_counter() - t0)
+        return
+    with t.time(label):
+        yield
 
 
 def _grib_gc() -> None:
-    """gc.collect() with cumulative timing accounting."""
-    global _grib_gc_seconds, _grib_gc_count
-    t0 = _time_mod.perf_counter()
-    gc.collect()
-    elapsed = _time_mod.perf_counter() - t0
-    with _grib_timing_lock:
-        _grib_gc_seconds += elapsed
-        _grib_gc_count += 1
-
-
-def _grib_time_summary() -> None:
-    if not _grib_timing_data:
+    """gc.collect() with cumulative timing accounting (or plain gc.collect if no timer)."""
+    t = _timer()
+    if t is None:
+        gc.collect()
         return
-    items = sorted(_grib_timing_data.items(), key=lambda kv: -kv[1])
-    parts = []
-    for label, secs in items:
-        n = _grib_timing_counts.get(label, 0)
-        parts.append(f"{label}={secs:.2f}s/{n}")
-    parts.append(f"gc={_grib_gc_seconds:.2f}s/{_grib_gc_count}")
-    logger.info("GRIB timing: %s", " ".join(parts))
-
-
-# ---------------------------------------------------------------------------
-# Memory checkpoints — bounded number of INFO logs per refresh, used to
-# locate the peak inside ICON-EU enrichment without raising verbosity.
-# Tracks RSS samples per label (max + count) and a baseline at reset.
-# ---------------------------------------------------------------------------
-
-_grib_rss_lock = threading.Lock()
-_grib_rss_baseline: float | None = None
-_grib_rss_max: dict[str, float] = {}
-_grib_rss_count: dict[str, int] = {}
-
-
-def _read_rss_mb() -> float | None:
-    """Return current process RSS in MB, or None if unavailable.
-
-    Linux: reads /proc/self/status (cheap). macOS: shells out to ps.
-    Mirrors weatherbrief.pipeline._current_rss_mb (kept local to avoid a
-    circular import — pipeline already imports from this module's tree).
-    """
-    import os
-    import subprocess
-    import sys
-
-    try:
-        with open("/proc/self/status") as f:
-            for line in f:
-                if line.startswith("VmRSS:"):
-                    return int(line.split()[1]) / 1024
-    except OSError:
-        pass
-    if sys.platform == "darwin":
-        try:
-            out = subprocess.check_output(
-                ["ps", "-o", "rss=", "-p", str(os.getpid())], timeout=1,
-            )
-            return int(out.strip()) / 1024
-        except Exception:
-            return None
-    return None
-
-
-def _grib_rss_reset() -> None:
-    global _grib_rss_baseline
-    with _grib_rss_lock:
-        _grib_rss_baseline = _read_rss_mb()
-        _grib_rss_max.clear()
-        _grib_rss_count.clear()
+    t.gc()
 
 
 def _grib_rss_mark(label: str) -> None:
-    """Record current RSS under *label*. Keeps max-per-label across calls."""
-    rss = _read_rss_mb()
-    if rss is None:
-        return
-    with _grib_rss_lock:
-        prior = _grib_rss_max.get(label)
-        _grib_rss_max[label] = rss if prior is None else max(prior, rss)
-        _grib_rss_count[label] = _grib_rss_count.get(label, 0) + 1
+    t = _timer()
+    if t is not None:
+        t.rss_mark(label)
 
 
-def _grib_rss_summary() -> None:
-    if not _grib_rss_max:
-        return
-    baseline = _grib_rss_baseline
-    items = sorted(_grib_rss_max.items(), key=lambda kv: -kv[1])
-    parts = []
-    for label, rss in items:
-        n = _grib_rss_count.get(label, 0)
-        if baseline is not None:
-            parts.append(f"{label}={int(rss)}MB(+{int(rss - baseline)}/{n})")
-        else:
-            parts.append(f"{label}={int(rss)}MB/{n}")
-    base_str = f" baseline={int(baseline)}MB" if baseline is not None else ""
-    logger.info("GRIB RSS:%s %s", base_str, " ".join(parts))
+def _submit_with_context(pool: ThreadPoolExecutor, fn, /, *args, **kwargs):
+    """Submit *fn* to *pool* with the caller's ContextVars copied in.
+
+    ThreadPoolExecutor.submit doesn't propagate contextvars by default;
+    without this, worker threads see _GRIB_TIMER as the default None and
+    timing/RSS calls become silent no-ops.
+    """
+    ctx = contextvars.copy_context()
+    return pool.submit(ctx.run, fn, *args, **kwargs)
 
 
 def _grib_session() -> requests.Session:
@@ -269,9 +274,38 @@ def enrich_forecasts(
     grib_init_times: dict[str, int] = {}
     grib_skip_reasons: dict[str, str] = {}
 
-    _grib_time_reset()
-    _grib_rss_reset()
-    _grib_rss_mark("enrich_start")
+    timer = _GribTimer()
+    token = _GRIB_TIMER.set(timer)
+    try:
+        return _enrich_forecasts_inner(
+            timer, cross_sections, all_forecasts, route_points,
+            departure_time, data_dir=data_dir,
+            flight_duration_hours=flight_duration_hours,
+            progress_callback=progress_callback,
+            as_of_time=as_of_time,
+        )
+    finally:
+        timer.log_summary()
+        _GRIB_TIMER.reset(token)
+
+
+def _enrich_forecasts_inner(
+    timer: _GribTimer,
+    cross_sections: list[RouteCrossSection],
+    all_forecasts: list[WaypointForecast],
+    route_points: list[RoutePoint],
+    departure_time: datetime,
+    *,
+    data_dir: Path,
+    flight_duration_hours: float = 0.0,
+    progress_callback: Callable[[str, str | None], None] | None = None,
+    as_of_time: datetime | None = None,
+) -> tuple[dict[str, int], dict[str, str]]:
+    """Inner body of enrich_forecasts; assumes _GRIB_TIMER is set to *timer*."""
+    grib_init_times: dict[str, int] = {}
+    grib_skip_reasons: dict[str, str] = {}
+
+    timer.rss_mark("enrich_start")
 
     # Download GFS and ICON-EU in parallel (network-bound), but decode
     # sequentially (memory-bound). ICON-EU decode peaks at ~270MB per
@@ -295,25 +329,28 @@ def enrich_forecasts(
 
     # Phase 1: Download/decode in parallel — GFS (download+decode),
     # ICON-EU (download-only), ECMWF GRIB (local disk decode).
+    # Workers must run inside the parent's contextvars copy so timing/RSS
+    # marks land on this call's timer, not on whichever refresh happens to
+    # be running in the sibling pipeline thread.
     with _grib_time("phase1_parallel"):
         with ThreadPoolExecutor(max_workers=3) as pool:
-            gfs_future = pool.submit(
-                _enrich_gfs,
+            gfs_future = _submit_with_context(
+                pool, _enrich_gfs,
                 cross_sections, all_forecasts, route_points,
                 departure_time, data_dir=data_dir,
                 flight_duration_hours=flight_duration_hours,
                 as_of_time=as_of_time,
             )
-            ecmwf_future = pool.submit(
-                _enrich_ecmwf,
+            ecmwf_future = _submit_with_context(
+                pool, _enrich_ecmwf,
                 cross_sections, all_forecasts, route_points,
                 departure_time,
                 flight_duration_hours=flight_duration_hours,
                 as_of_time=as_of_time,
             )
             if icon_ctx is not None:
-                icon_dl_future = pool.submit(
-                    _prefetch_icon_eu_data, icon_ctx,
+                icon_dl_future = _submit_with_context(
+                    pool, _prefetch_icon_eu_data, icon_ctx,
                 )
             else:
                 icon_dl_future = None
@@ -322,7 +359,7 @@ def enrich_forecasts(
             ecmwf_grib_ts = ecmwf_future.result()
             if icon_dl_future is not None:
                 icon_dl_future.result()  # ensure downloads are cached
-    _grib_rss_mark("after_phase1")
+    timer.rss_mark("after_phase1")
 
     if ecmwf_grib_ts is not None:
         grib_init_times["ecmwf"] = ecmwf_grib_ts
@@ -335,7 +372,7 @@ def enrich_forecasts(
             )
         else:
             icon_skip = icon_ctx  # None
-    _grib_rss_mark("after_phase2")
+    timer.rss_mark("after_phase2")
 
     if gfs_ts is not None:
         grib_init_times["gfs"] = gfs_ts
@@ -349,10 +386,7 @@ def enrich_forecasts(
         from weatherbrief.fetch.grib.fill import propagate_all
         propagate_all(cross_sections, all_forecasts)
 
-    _grib_rss_mark("enrich_end")
-    _grib_time_summary()
-    _grib_rss_summary()
-
+    timer.rss_mark("enrich_end")
     return grib_init_times, grib_skip_reasons
 
 
@@ -1189,12 +1223,12 @@ def _prefetch_icon_eu_data_inner(ctx: _IconEuContext) -> None:
     for fhour in ctx.forecast_hours:
         # Model-level data (P, QC, QI) — per variable
         legacy_ck = cache_key(fhour, "ICON_EU_QC_QI_P")
-        if get_cached(ctx.run_dir, legacy_ck) is not None:
+        if is_cached(ctx.run_dir, legacy_ck):
             continue  # legacy cache hit, skip per-var download
 
         for var in ICON_EU_VARIABLES:
             ck = cache_key(fhour, f"ICON_EU_{var.upper()}")
-            if get_cached(ctx.run_dir, ck) is not None:
+            if is_cached(ctx.run_dir, ck):
                 continue
             try:
                 with _grib_time("icon_prefetch_var"):
@@ -1212,7 +1246,7 @@ def _prefetch_icon_eu_data_inner(ctx: _IconEuContext) -> None:
 
         # Single-level cloud diagnostics
         diag_ck = cache_key(fhour, "ICON_EU_CLOUD_DIAG")
-        if get_cached(ctx.run_dir, diag_ck) is None:
+        if not is_cached(ctx.run_dir, diag_ck):
             try:
                 with _grib_time("icon_prefetch_cloud_diag"):
                     fetched = fetch_icon_eu_single_level(

--- a/src/weatherbrief/fetch/grib/__init__.py
+++ b/src/weatherbrief/fetch/grib/__init__.py
@@ -8,7 +8,10 @@ from __future__ import annotations
 
 import gc
 import logging
+import threading
+import time as _time_mod
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Callable
@@ -46,6 +49,142 @@ logger = logging.getLogger(__name__)
 _POOL_MAXSIZE = 12
 
 _M_TO_FT = 3.28084
+
+
+# ---------------------------------------------------------------------------
+# Sub-stage timing instrumentation (one-shot, for refresh-pipeline profiling).
+# Single-refresh-at-a-time assumed; multi-refresh would interleave but the
+# numbers still aggregate truthfully, the labels just reflect both runs.
+# ---------------------------------------------------------------------------
+
+_grib_timing_lock = threading.Lock()
+_grib_timing_data: dict[str, float] = {}
+_grib_timing_counts: dict[str, int] = {}
+_grib_gc_seconds: float = 0.0
+_grib_gc_count: int = 0
+
+
+def _grib_time_reset() -> None:
+    global _grib_gc_seconds, _grib_gc_count
+    with _grib_timing_lock:
+        _grib_timing_data.clear()
+        _grib_timing_counts.clear()
+        _grib_gc_seconds = 0.0
+        _grib_gc_count = 0
+
+
+def _grib_time_record(label: str, secs: float) -> None:
+    with _grib_timing_lock:
+        _grib_timing_data[label] = _grib_timing_data.get(label, 0.0) + secs
+        _grib_timing_counts[label] = _grib_timing_counts.get(label, 0) + 1
+
+
+@contextmanager
+def _grib_time(label: str):
+    t0 = _time_mod.perf_counter()
+    try:
+        yield
+    finally:
+        _grib_time_record(label, _time_mod.perf_counter() - t0)
+
+
+def _grib_gc() -> None:
+    """gc.collect() with cumulative timing accounting."""
+    global _grib_gc_seconds, _grib_gc_count
+    t0 = _time_mod.perf_counter()
+    gc.collect()
+    elapsed = _time_mod.perf_counter() - t0
+    with _grib_timing_lock:
+        _grib_gc_seconds += elapsed
+        _grib_gc_count += 1
+
+
+def _grib_time_summary() -> None:
+    if not _grib_timing_data:
+        return
+    items = sorted(_grib_timing_data.items(), key=lambda kv: -kv[1])
+    parts = []
+    for label, secs in items:
+        n = _grib_timing_counts.get(label, 0)
+        parts.append(f"{label}={secs:.2f}s/{n}")
+    parts.append(f"gc={_grib_gc_seconds:.2f}s/{_grib_gc_count}")
+    logger.info("GRIB timing: %s", " ".join(parts))
+
+
+# ---------------------------------------------------------------------------
+# Memory checkpoints — bounded number of INFO logs per refresh, used to
+# locate the peak inside ICON-EU enrichment without raising verbosity.
+# Tracks RSS samples per label (max + count) and a baseline at reset.
+# ---------------------------------------------------------------------------
+
+_grib_rss_lock = threading.Lock()
+_grib_rss_baseline: float | None = None
+_grib_rss_max: dict[str, float] = {}
+_grib_rss_count: dict[str, int] = {}
+
+
+def _read_rss_mb() -> float | None:
+    """Return current process RSS in MB, or None if unavailable.
+
+    Linux: reads /proc/self/status (cheap). macOS: shells out to ps.
+    Mirrors weatherbrief.pipeline._current_rss_mb (kept local to avoid a
+    circular import — pipeline already imports from this module's tree).
+    """
+    import os
+    import subprocess
+    import sys
+
+    try:
+        with open("/proc/self/status") as f:
+            for line in f:
+                if line.startswith("VmRSS:"):
+                    return int(line.split()[1]) / 1024
+    except OSError:
+        pass
+    if sys.platform == "darwin":
+        try:
+            out = subprocess.check_output(
+                ["ps", "-o", "rss=", "-p", str(os.getpid())], timeout=1,
+            )
+            return int(out.strip()) / 1024
+        except Exception:
+            return None
+    return None
+
+
+def _grib_rss_reset() -> None:
+    global _grib_rss_baseline
+    with _grib_rss_lock:
+        _grib_rss_baseline = _read_rss_mb()
+        _grib_rss_max.clear()
+        _grib_rss_count.clear()
+
+
+def _grib_rss_mark(label: str) -> None:
+    """Record current RSS under *label*. Keeps max-per-label across calls."""
+    rss = _read_rss_mb()
+    if rss is None:
+        return
+    with _grib_rss_lock:
+        prior = _grib_rss_max.get(label)
+        _grib_rss_max[label] = rss if prior is None else max(prior, rss)
+        _grib_rss_count[label] = _grib_rss_count.get(label, 0) + 1
+
+
+def _grib_rss_summary() -> None:
+    if not _grib_rss_max:
+        return
+    baseline = _grib_rss_baseline
+    items = sorted(_grib_rss_max.items(), key=lambda kv: -kv[1])
+    parts = []
+    for label, rss in items:
+        n = _grib_rss_count.get(label, 0)
+        if baseline is not None:
+            parts.append(f"{label}={int(rss)}MB(+{int(rss - baseline)}/{n})")
+        else:
+            parts.append(f"{label}={int(rss)}MB/{n}")
+    base_str = f" baseline={int(baseline)}MB" if baseline is not None else ""
+    logger.info("GRIB RSS:%s %s", base_str, " ".join(parts))
 
 
 def _grib_session() -> requests.Session:
@@ -130,6 +269,10 @@ def enrich_forecasts(
     grib_init_times: dict[str, int] = {}
     grib_skip_reasons: dict[str, str] = {}
 
+    _grib_time_reset()
+    _grib_rss_reset()
+    _grib_rss_mark("enrich_start")
+
     # Download GFS and ICON-EU in parallel (network-bound), but decode
     # sequentially (memory-bound). ICON-EU decode peaks at ~270MB per
     # variable; overlapping with GFS decode caused OOM.
@@ -142,52 +285,57 @@ def enrich_forecasts(
     icon_skip: str | None = None
 
     # Prepare ICON-EU context (run discovery, domain check, etc.)
-    icon_ctx = _prepare_icon_eu(
-        cross_sections, route_points, departure_time,
-        data_dir=data_dir,
-        flight_duration_hours=flight_duration_hours,
-        as_of_time=as_of_time,
-    )
+    with _grib_time("icon_prepare"):
+        icon_ctx = _prepare_icon_eu(
+            cross_sections, route_points, departure_time,
+            data_dir=data_dir,
+            flight_duration_hours=flight_duration_hours,
+            as_of_time=as_of_time,
+        )
 
     # Phase 1: Download/decode in parallel — GFS (download+decode),
     # ICON-EU (download-only), ECMWF GRIB (local disk decode).
-    with ThreadPoolExecutor(max_workers=3) as pool:
-        gfs_future = pool.submit(
-            _enrich_gfs,
-            cross_sections, all_forecasts, route_points,
-            departure_time, data_dir=data_dir,
-            flight_duration_hours=flight_duration_hours,
-            as_of_time=as_of_time,
-        )
-        ecmwf_future = pool.submit(
-            _enrich_ecmwf,
-            cross_sections, all_forecasts, route_points,
-            departure_time,
-            flight_duration_hours=flight_duration_hours,
-            as_of_time=as_of_time,
-        )
-        if icon_ctx is not None:
-            icon_dl_future = pool.submit(
-                _prefetch_icon_eu_data, icon_ctx,
+    with _grib_time("phase1_parallel"):
+        with ThreadPoolExecutor(max_workers=3) as pool:
+            gfs_future = pool.submit(
+                _enrich_gfs,
+                cross_sections, all_forecasts, route_points,
+                departure_time, data_dir=data_dir,
+                flight_duration_hours=flight_duration_hours,
+                as_of_time=as_of_time,
             )
-        else:
-            icon_dl_future = None
+            ecmwf_future = pool.submit(
+                _enrich_ecmwf,
+                cross_sections, all_forecasts, route_points,
+                departure_time,
+                flight_duration_hours=flight_duration_hours,
+                as_of_time=as_of_time,
+            )
+            if icon_ctx is not None:
+                icon_dl_future = pool.submit(
+                    _prefetch_icon_eu_data, icon_ctx,
+                )
+            else:
+                icon_dl_future = None
 
-        gfs_ts = gfs_future.result()
-        ecmwf_grib_ts = ecmwf_future.result()
-        if icon_dl_future is not None:
-            icon_dl_future.result()  # ensure downloads are cached
+            gfs_ts = gfs_future.result()
+            ecmwf_grib_ts = ecmwf_future.result()
+            if icon_dl_future is not None:
+                icon_dl_future.result()  # ensure downloads are cached
+    _grib_rss_mark("after_phase1")
 
     if ecmwf_grib_ts is not None:
         grib_init_times["ecmwf"] = ecmwf_grib_ts
 
     # Phase 2: Decode ICON-EU sequentially (memory-heavy, GFS is done).
-    if icon_ctx is not None:
-        icon_ts, icon_skip = _decode_and_merge_icon_eu(
-            icon_ctx, cross_sections, all_forecasts, route_points,
-        )
-    else:
-        icon_skip = icon_ctx  # None
+    with _grib_time("phase2_icon_decode"):
+        if icon_ctx is not None:
+            icon_ts, icon_skip = _decode_and_merge_icon_eu(
+                icon_ctx, cross_sections, all_forecasts, route_points,
+            )
+        else:
+            icon_skip = icon_ctx  # None
+    _grib_rss_mark("after_phase2")
 
     if gfs_ts is not None:
         grib_init_times["gfs"] = gfs_ts
@@ -197,8 +345,13 @@ def enrich_forecasts(
         grib_skip_reasons["icon"] = icon_skip
 
     # Forward-fill all GRIB-enriched fields to interpolated hours
-    from weatherbrief.fetch.grib.fill import propagate_all
-    propagate_all(cross_sections, all_forecasts)
+    with _grib_time("propagate_all"):
+        from weatherbrief.fetch.grib.fill import propagate_all
+        propagate_all(cross_sections, all_forecasts)
+
+    _grib_rss_mark("enrich_end")
+    _grib_time_summary()
+    _grib_rss_summary()
 
     return grib_init_times, grib_skip_reasons
 
@@ -228,6 +381,26 @@ def _enrich_ecmwf(
     Returns:
         GRIB init Unix timestamp, or None if no ECMWF data found.
     """
+    with _grib_time("ecmwf_total"):
+        return _enrich_ecmwf_inner(
+            cross_sections, all_forecasts, route_points,
+            departure_time,
+            flight_duration_hours=flight_duration_hours,
+            as_of_time=as_of_time,
+            ecmwf_data_dir=ecmwf_data_dir,
+        )
+
+
+def _enrich_ecmwf_inner(
+    cross_sections: list[RouteCrossSection],
+    all_forecasts: list[WaypointForecast],
+    route_points: list[RoutePoint],
+    departure_time: datetime,
+    *,
+    flight_duration_hours: float = 0.0,
+    as_of_time: datetime | None = None,
+    ecmwf_data_dir: Path | None = None,
+) -> int | None:
     from weatherbrief.fetch.grib.decode import (
         build_ecmwf_cloud_diagnostics,
         build_ecmwf_surface_snapshot,
@@ -246,7 +419,8 @@ def _enrich_ecmwf(
         return None
 
     grib_dir = ecmwf_data_dir or ecmwf_grib_dir()
-    all_files = scan_ecmwf_files(grib_dir)
+    with _grib_time("ecmwf_scan"):
+        all_files = scan_ecmwf_files(grib_dir)
     if not all_files:
         logger.info("No ECMWF GRIB data available in %s", grib_dir)
         return None
@@ -301,9 +475,10 @@ def _enrich_ecmwf(
 
         # Decode pressure levels (a2)
         if "a2" in parts:
-            pl_data, pl_covered = decode_ecmwf_pressure_per_point(
-                parts["a2"], point_lats, point_lons,
-            )
+            with _grib_time("ecmwf_a2_decode"):
+                pl_data, pl_covered = decode_ecmwf_pressure_per_point(
+                    parts["a2"], point_lats, point_lons,
+                )
             # Only merge covered points — set uncovered to empty
             for i, cov in enumerate(pl_covered):
                 if not cov:
@@ -318,9 +493,10 @@ def _enrich_ecmwf(
 
         # Decode surface diagnostics (a1)
         if "a1" in parts:
-            sfc_data, sfc_covered = decode_ecmwf_surface_per_point(
-                parts["a1"], point_lats, point_lons,
-            )
+            with _grib_time("ecmwf_a1_decode"):
+                sfc_data, sfc_covered = decode_ecmwf_surface_per_point(
+                    parts["a1"], point_lats, point_lons,
+                )
             diagnostics = [
                 build_ecmwf_cloud_diagnostics(raw) if cov else None
                 for raw, cov in zip(sfc_data, sfc_covered)
@@ -384,6 +560,25 @@ def _enrich_gfs(
 
     Returns the GRIB init Unix timestamp, or None if enrichment was skipped.
     """
+    with _grib_time("gfs_total"):
+        return _enrich_gfs_inner(
+            cross_sections, all_forecasts, route_points,
+            departure_time, data_dir=data_dir,
+            flight_duration_hours=flight_duration_hours,
+            as_of_time=as_of_time,
+        )
+
+
+def _enrich_gfs_inner(
+    cross_sections: list[RouteCrossSection],
+    all_forecasts: list[WaypointForecast],
+    route_points: list[RoutePoint],
+    departure_time: datetime,
+    *,
+    data_dir: Path,
+    flight_duration_hours: float = 0.0,
+    as_of_time: datetime | None = None,
+) -> int | None:
     from weatherbrief.fetch.grib.grib_fetch import compute_flight_window_hours
 
     gfs_sections = [cs for cs in cross_sections if cs.model == ModelSource.GFS]
@@ -393,7 +588,8 @@ def _enrich_gfs(
 
     session = _grib_session()
 
-    run_info = find_latest_run(departure_time, session=session, as_of_time=as_of_time)
+    with _grib_time("gfs_find_run"):
+        run_info = find_latest_run(departure_time, session=session, as_of_time=as_of_time)
     if run_info is None:
         logger.warning("No GFS model run found for enrichment")
         return None
@@ -410,12 +606,13 @@ def _enrich_gfs(
     point_lons = [rp.lon for rp in route_points]
 
     # Fetch .idx text (shared by both enrichment paths)
-    idx_by_fhour: dict[int, str] = {}
-    for fhour in forecast_hours:
-        try:
-            idx_by_fhour[fhour] = fetch_idx(init_date, init_hour, fhour, session=session)
-        except Exception:
-            logger.warning("Failed to fetch .idx for f%03d", fhour, exc_info=True)
+    with _grib_time("gfs_idx_fetch"):
+        idx_by_fhour: dict[int, str] = {}
+        for fhour in forecast_hours:
+            try:
+                idx_by_fhour[fhour] = fetch_idx(init_date, init_hour, fhour, session=session)
+            except Exception:
+                logger.warning("Failed to fetch .idx for f%03d", fhour, exc_info=True)
 
     if not idx_by_fhour:
         logger.warning("No .idx files retrieved for enrichment")
@@ -423,20 +620,21 @@ def _enrich_gfs(
 
     # Run both enrichment paths in parallel — they write to different fields
     # (CLWMR/ICMR on PressureLevelData vs nwp_cloud_diagnostics on HourlyForecast)
-    with ThreadPoolExecutor(max_workers=2) as pool:
-        pool.submit(
-            _enrich_clwmr_icmr,
-            gfs_sections, all_forecasts, route_points,
-            init_date, init_hour, forecast_hours,
-            run_dir, idx_by_fhour, point_lats, point_lons, session,
-        )
-        pool.submit(
-            _enrich_cloud_diagnostics,
-            gfs_sections, all_forecasts, route_points,
-            init_date, init_hour, forecast_hours,
-            run_dir, idx_by_fhour, point_lats, point_lons, session,
-        )
-        # ThreadPoolExecutor.__exit__ waits for all futures to complete
+    with _grib_time("gfs_workers"):
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            pool.submit(
+                _enrich_clwmr_icmr,
+                gfs_sections, all_forecasts, route_points,
+                init_date, init_hour, forecast_hours,
+                run_dir, idx_by_fhour, point_lats, point_lons, session,
+            )
+            pool.submit(
+                _enrich_cloud_diagnostics,
+                gfs_sections, all_forecasts, route_points,
+                init_date, init_hour, forecast_hours,
+                run_dir, idx_by_fhour, point_lats, point_lons, session,
+            )
+            # ThreadPoolExecutor.__exit__ waits for all futures to complete
 
     return _run_info_to_timestamp(init_date, init_hour)
 
@@ -466,9 +664,10 @@ def _fetch_clwmr_icmr_for_fhour(
             if not ranges:
                 logger.warning("No CLWMR/ICMR found in .idx for f%03d", fhour)
                 return None
-            grib_bytes = fetch_byte_ranges(
-                init_date, init_hour, fhour, ranges, session=session,
-            )
+            with _grib_time("gfs_clwmr_download"):
+                grib_bytes = fetch_byte_ranges(
+                    init_date, init_hour, fhour, ranges, session=session,
+                )
             if not grib_bytes:
                 return None
             put_cached(run_dir, ck, grib_bytes)
@@ -480,7 +679,8 @@ def _fetch_clwmr_icmr_for_fhour(
             logger.warning("Failed to fetch GRIB2 f%03d", fhour, exc_info=True)
             return None
 
-    return decode_grib_per_point(grib_bytes, point_lats, point_lons)
+    with _grib_time("gfs_clwmr_decode"):
+        return decode_grib_per_point(grib_bytes, point_lats, point_lons)
 
 
 def _enrich_clwmr_icmr(
@@ -524,7 +724,7 @@ def _enrich_clwmr_icmr(
             valid_utc=valid_utc,
         )
         del decoded_points
-        gc.collect()
+        _grib_gc()
 
     if total_enriched:
         logger.info(
@@ -559,9 +759,10 @@ def _fetch_cloud_diag_for_fhour(
             if not ranges:
                 logger.warning("No cloud diag found in .idx for f%03d", fhour)
                 return None
-            grib_bytes = fetch_cloud_diag_ranges(
-                init_date, init_hour, fhour, ranges, session=session,
-            )
+            with _grib_time("gfs_cloud_diag_download"):
+                grib_bytes = fetch_cloud_diag_ranges(
+                    init_date, init_hour, fhour, ranges, session=session,
+                )
             if not grib_bytes:
                 return None
             put_cached(run_dir, ck, grib_bytes)
@@ -573,7 +774,8 @@ def _fetch_cloud_diag_for_fhour(
             logger.warning("Failed to fetch cloud diag f%03d", fhour, exc_info=True)
             return None
 
-    return decode_cloud_diag_per_point(grib_bytes, point_lats, point_lons)
+    with _grib_time("gfs_cloud_diag_decode"):
+        return decode_cloud_diag_per_point(grib_bytes, point_lats, point_lons)
 
 
 def _apply_cloud_diagnostics_to_sections(
@@ -869,7 +1071,7 @@ def _enrich_cloud_diagnostics(
         )
         del decoded_points
         del diagnostics_per_point
-        gc.collect()
+        _grib_gc()
 
     if total_enriched:
         logger.info("GRIB2 enrichment: %d hourly entries enriched with cloud diagnostics", total_enriched)
@@ -973,6 +1175,11 @@ def _prefetch_icon_eu_data(ctx: _IconEuContext) -> None:
 
     Runs in a background thread while GFS enrichment proceeds.
     """
+    with _grib_time("icon_prefetch"):
+        _prefetch_icon_eu_data_inner(ctx)
+
+
+def _prefetch_icon_eu_data_inner(ctx: _IconEuContext) -> None:
     from weatherbrief.fetch.grib.icon_eu_fetch import (
         ICON_EU_VARIABLES,
         fetch_icon_eu_per_variable,
@@ -990,12 +1197,13 @@ def _prefetch_icon_eu_data(ctx: _IconEuContext) -> None:
             if get_cached(ctx.run_dir, ck) is not None:
                 continue
             try:
-                per_var = fetch_icon_eu_per_variable(
-                    ctx.init_date, ctx.init_hour, fhour,
-                    levels=ctx.levels,
-                    variables=[var],
-                    session=ctx.session,
-                )
+                with _grib_time("icon_prefetch_var"):
+                    per_var = fetch_icon_eu_per_variable(
+                        ctx.init_date, ctx.init_hour, fhour,
+                        levels=ctx.levels,
+                        variables=[var],
+                        session=ctx.session,
+                    )
                 data = per_var.get(var)
                 if data:
                     put_cached(ctx.run_dir, ck, data)
@@ -1006,9 +1214,10 @@ def _prefetch_icon_eu_data(ctx: _IconEuContext) -> None:
         diag_ck = cache_key(fhour, "ICON_EU_CLOUD_DIAG")
         if get_cached(ctx.run_dir, diag_ck) is None:
             try:
-                fetched = fetch_icon_eu_single_level(
-                    ctx.init_date, ctx.init_hour, [fhour], session=ctx.session,
-                )
+                with _grib_time("icon_prefetch_cloud_diag"):
+                    fetched = fetch_icon_eu_single_level(
+                        ctx.init_date, ctx.init_hour, [fhour], session=ctx.session,
+                    )
                 grib_bytes = fetched.get(fhour)
                 if grib_bytes:
                     put_cached(ctx.run_dir, diag_ck, grib_bytes)
@@ -1045,9 +1254,10 @@ def _decode_and_merge_icon_eu(
         legacy_ck = cache_key(fhour, "ICON_EU_QC_QI_P")
         legacy_bytes = get_cached(ctx.run_dir, legacy_ck)
         if legacy_bytes is not None:
-            decoded = decode_icon_eu_per_point(legacy_bytes, ctx.point_lats, ctx.point_lons)
+            with _grib_time("icon_legacy_decode"):
+                decoded = decode_icon_eu_per_point(legacy_bytes, ctx.point_lats, ctx.point_lons)
             del legacy_bytes
-            gc.collect()
+            _grib_gc()
             return decoded, empty_clc
 
         # Load per-variable data from cache (already downloaded by prefetch)
@@ -1061,16 +1271,19 @@ def _decode_and_merge_icon_eu(
         if not var_bytes:
             return None, empty_clc
 
-        decoded, clc_layers = decode_icon_eu_per_point_chunked(
-            var_bytes, ctx.point_lats, ctx.point_lons,
-        )
+        with _grib_time("icon_chunked_decode"):
+            decoded, clc_layers = decode_icon_eu_per_point_chunked(
+                var_bytes, ctx.point_lats, ctx.point_lons,
+            )
         del var_bytes
-        gc.collect()
+        _grib_gc()
         return decoded, clc_layers
 
     total_enriched = 0
     for fhour in ctx.forecast_hours:
+        _grib_rss_mark("icon_fhour_pre")
         decoded_points, clc_layers = _decode_fhour(fhour)
+        _grib_rss_mark("icon_fhour_decoded")
         if not decoded_points:
             continue
 
@@ -1086,7 +1299,8 @@ def _decode_and_merge_icon_eu(
         )
         total_enriched += replaced
         del decoded_points
-        gc.collect()
+        _grib_gc()
+        _grib_rss_mark("icon_fhour_post_gc")
 
     if not total_enriched:
         logger.warning("No ICON-EU GRIB2 data retrieved for enrichment")
@@ -1153,9 +1367,10 @@ def _enrich_icon_eu_cloud_diagnostics(
         if not grib_bytes:
             continue
 
-        decoded_points = decode_icon_eu_cloud_diag_per_point(
-            grib_bytes, point_lats, point_lons,
-        )
+        with _grib_time("icon_cloud_diag_decode"):
+            decoded_points = decode_icon_eu_cloud_diag_per_point(
+                grib_bytes, point_lats, point_lons,
+            )
         del grib_bytes
         if not decoded_points:
             continue
@@ -1215,7 +1430,7 @@ def _enrich_icon_eu_cloud_diagnostics(
         del decoded_points
         del diagnostics_per_point
         del wp_diag_lookup
-        gc.collect()
+        _grib_gc()
 
     if total_enriched:
         logger.info(

--- a/src/weatherbrief/fetch/grib/cache.py
+++ b/src/weatherbrief/fetch/grib/cache.py
@@ -58,6 +58,29 @@ def cache_key(
     return f"f{forecast_hour:03d}_{variable}.grib2"
 
 
+def is_cached(
+    run_dir: Path,
+    filename: str,
+) -> bool:
+    """Check whether a cache entry exists and is not expired, without reading it.
+
+    Use this for cache-hit short-circuits where the caller will skip work
+    rather than consume the bytes — e.g. ``_prefetch_icon_eu_data`` skipping
+    already-downloaded variables. Calling :func:`get_cached` for the same
+    purpose pulls the entire file into memory just to check ``is not None``,
+    which inflates RSS on warm-cache refreshes.
+    """
+    path = run_dir / filename
+    if not path.exists():
+        return False
+    age = time.time() - path.stat().st_mtime
+    if age > CACHE_TTL_SECONDS:
+        logger.debug("Cache expired: %s (%.0fh old)", path, age / 3600)
+        path.unlink(missing_ok=True)
+        return False
+    return True
+
+
 def get_cached(
     run_dir: Path,
     filename: str,

--- a/src/weatherbrief/fetch/grib/cache.py
+++ b/src/weatherbrief/fetch/grib/cache.py
@@ -69,6 +69,9 @@ def is_cached(
     already-downloaded variables. Calling :func:`get_cached` for the same
     purpose pulls the entire file into memory just to check ``is not None``,
     which inflates RSS on warm-cache refreshes.
+
+    Side effect: if the file is past TTL, it is unlinked here, matching
+    :func:`get_cached` semantics. Returns ``False`` in that case.
     """
     path = run_dir / filename
     if not path.exists():

--- a/src/weatherbrief/fetch/grib/icon_eu_fetch.py
+++ b/src/weatherbrief/fetch/grib/icon_eu_fetch.py
@@ -27,6 +27,11 @@ DWD_BASE_URL = "https://opendata.dwd.de/weather/nwp/icon-eu/grib"
 # ICON-EU model-level horizon depends on the run cycle:
 # - Main runs (00z, 12z): model-level data published up to 120h
 # - Intermediate runs (03/06/09/15/18/21z): only up to 78h
+#
+# NOTE: empirical probing shows this is wrong — DWD actually publishes 4 main
+# runs per day (00/06/12/18) and 4 short runs (03/09/15/21z) with horizon ~48h.
+# The fix is held back until ICON memory streaming lands; see
+# designs/plans/refresh-pipeline-performance.md (Phase B/C).
 ICON_EU_MAIN_CYCLES = {0, 12}
 ICON_EU_MODEL_LEVEL_MAX_HOUR_MAIN = 120
 ICON_EU_MODEL_LEVEL_MAX_HOUR_SHORT = 78
@@ -169,7 +174,7 @@ def fetch_icon_eu_single_level(
 
         buf = bytearray()
         downloaded = 0
-        failed = 0
+        failures: dict[int | str, int] = {}
 
         with ThreadPoolExecutor(max_workers=MAX_DOWNLOAD_WORKERS) as pool:
             futures = {
@@ -177,22 +182,25 @@ def fetch_icon_eu_single_level(
                 for url in urls
             }
             for future in as_completed(futures):
-                data = future.result()
+                data, status = future.result()
                 if data is not None:
                     buf.extend(data)
                     downloaded += 1
                 else:
-                    failed += 1
+                    failures[status] = failures.get(status, 0) + 1
 
+        total_failed = sum(failures.values())
         if buf:
             result[fhour] = bytes(buf)
             logger.info(
-                "ICON-EU single-level f%03d: downloaded %d/%d files (%.1f KB)",
-                fhour, downloaded, downloaded + failed, len(buf) / 1024,
+                "ICON-EU single-level f%03d: downloaded %d/%d files (%.1f KB)%s",
+                fhour, downloaded, downloaded + total_failed, len(buf) / 1024,
+                _format_failure_summary(failures),
             )
-        else:
-            logger.debug(
-                "ICON-EU single-level f%03d: all %d files failed", fhour, failed,
+        elif total_failed:
+            logger.warning(
+                "ICON-EU single-level f%03d: all %d files failed%s",
+                fhour, total_failed, _format_failure_summary(failures),
             )
 
     return result
@@ -361,20 +369,35 @@ def compute_icon_eu_flight_window_hours(
     return sorted(fhours)
 
 
+def _format_failure_summary(failures: dict[int | str, int]) -> str:
+    """Format a per-status failure summary for log lines, e.g. '404=40'."""
+    if not failures:
+        return ""
+    parts = [f"{k}={v}" for k, v in sorted(failures.items(), key=lambda kv: str(kv[0]))]
+    return " (" + ",".join(parts) + ")"
+
+
 def _download_one_file(
     url: str,
     session: requests.Session,
-) -> bytes | None:
-    """Download and decompress a single bz2-compressed GRIB2 file."""
+) -> tuple[bytes | None, int | str]:
+    """Download and decompress a single bz2-compressed GRIB2 file.
+
+    Returns ``(bytes_or_None, status_or_error_label)`` so callers can
+    aggregate failure modes (HTTP 404 vs network errors).
+    """
     try:
         resp = session.get(url, timeout=REQUEST_TIMEOUT)
         if resp.status_code != 200:
             logger.debug("HTTP %d for %s", resp.status_code, url.split("/")[-1])
-            return None
-        return bz2.decompress(resp.content)
-    except (requests.RequestException, OSError) as e:
+            return None, resp.status_code
+        return bz2.decompress(resp.content), 200
+    except requests.RequestException as e:
         logger.debug("Download failed %s: %s", url.split("/")[-1], e)
-        return None
+        return None, "network"
+    except OSError as e:
+        logger.debug("Decompress failed %s: %s", url.split("/")[-1], e)
+        return None, "decompress"
 
 
 def fetch_icon_eu_fields(
@@ -410,7 +433,7 @@ def fetch_icon_eu_fields(
 
     result = bytearray()
     downloaded = 0
-    failed = 0
+    failures: dict[int | str, int] = {}
 
     with ThreadPoolExecutor(max_workers=MAX_DOWNLOAD_WORKERS) as pool:
         futures = {
@@ -418,16 +441,18 @@ def fetch_icon_eu_fields(
             for url in urls
         }
         for future in as_completed(futures):
-            data = future.result()
+            data, status = future.result()
             if data is not None:
                 result.extend(data)
                 downloaded += 1
             else:
-                failed += 1
+                failures[status] = failures.get(status, 0) + 1
 
+    total_failed = sum(failures.values())
     logger.info(
-        "ICON-EU f%03d: downloaded %d/%d files (%.1f KB)",
-        forecast_hour, downloaded, downloaded + failed, len(result) / 1024,
+        "ICON-EU f%03d: downloaded %d/%d files (%.1f KB)%s",
+        forecast_hour, downloaded, downloaded + total_failed, len(result) / 1024,
+        _format_failure_summary(failures),
     )
     return bytes(result)
 
@@ -459,7 +484,7 @@ def fetch_icon_eu_per_variable(
 
         buf = bytearray()
         downloaded = 0
-        failed = 0
+        failures: dict[int | str, int] = {}
 
         with ThreadPoolExecutor(max_workers=MAX_DOWNLOAD_WORKERS) as pool:
             futures = {
@@ -467,22 +492,25 @@ def fetch_icon_eu_per_variable(
                 for url in urls
             }
             for future in as_completed(futures):
-                data = future.result()
+                data, status = future.result()
                 if data is not None:
                     buf.extend(data)
                     downloaded += 1
                 else:
-                    failed += 1
+                    failures[status] = failures.get(status, 0) + 1
 
+        total_failed = sum(failures.values())
         if buf:
             result[var] = bytes(buf)
             logger.info(
-                "ICON-EU f%03d %s: downloaded %d/%d levels (%.1f KB)",
-                forecast_hour, var, downloaded, downloaded + failed, len(buf) / 1024,
+                "ICON-EU f%03d %s: downloaded %d/%d levels (%.1f KB)%s",
+                forecast_hour, var, downloaded, downloaded + total_failed,
+                len(buf) / 1024, _format_failure_summary(failures),
             )
         else:
             logger.warning(
-                "ICON-EU f%03d %s: all %d files failed", forecast_hour, var, failed,
+                "ICON-EU f%03d %s: all %d files failed%s",
+                forecast_hour, var, total_failed, _format_failure_summary(failures),
             )
 
     return result

--- a/src/weatherbrief/pipeline.py
+++ b/src/weatherbrief/pipeline.py
@@ -8,8 +8,6 @@ from __future__ import annotations
 
 import gc
 import logging
-import os
-import subprocess
 import sys
 from dataclasses import dataclass, field
 from datetime import date, datetime, timezone
@@ -38,27 +36,7 @@ from weatherbrief.tasks.outputs import run_gramet, run_skewt, run_llm_digest
 logger = logging.getLogger(__name__)
 
 
-def _current_rss_mb() -> float | None:
-    """Return current RSS in MB, or None if unavailable.
-
-    Linux: reads /proc/self/status (cheap, accurate). macOS: shells out to ps.
-    """
-    try:
-        with open("/proc/self/status") as f:
-            for line in f:
-                if line.startswith("VmRSS:"):
-                    return int(line.split()[1]) / 1024
-    except OSError:
-        pass
-    if sys.platform == "darwin":
-        try:
-            out = subprocess.check_output(
-                ["ps", "-o", "rss=", "-p", str(os.getpid())], timeout=1
-            )
-            return int(out.strip()) / 1024
-        except Exception:
-            return None
-    return None
+from weatherbrief.process_rss import current_rss_mb as _current_rss_mb
 
 
 def _peak_rss_mb() -> float | None:

--- a/src/weatherbrief/process_rss.py
+++ b/src/weatherbrief/process_rss.py
@@ -1,0 +1,30 @@
+"""Process resident-set-size helper, shared by pipeline + GRIB instrumentation."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+
+def current_rss_mb() -> float | None:
+    """Return current process RSS in MB, or None if unavailable.
+
+    Linux: reads /proc/self/status (cheap, accurate). macOS: shells out to ps.
+    """
+    try:
+        with open("/proc/self/status") as f:
+            for line in f:
+                if line.startswith("VmRSS:"):
+                    return int(line.split()[1]) / 1024
+    except OSError:
+        pass
+    if sys.platform == "darwin":
+        try:
+            out = subprocess.check_output(
+                ["ps", "-o", "rss=", "-p", str(os.getpid())], timeout=1,
+            )
+            return int(out.strip()) / 1024
+        except Exception:
+            return None
+    return None


### PR DESCRIPTION
## Summary

Phase A of a performance investigation into the briefing refresh pipeline. Adds zero-behaviour-change instrumentation to localise where the ~2 minute pipeline spends time and memory.

Full investigation, findings, and the Phase A/B/C plan are captured in [`designs/plans/refresh-pipeline-performance.md`](https://github.com/roznet/flyfun-weather/blob/perf-grib-instrumentation/designs/plans/refresh-pipeline-performance.md).

## What's in this PR

**Sub-stage timing** in `enrich_forecasts`:

```
GRIB timing: phase1_parallel=104.60s/1 icon_prefetch=104.59s/1
  icon_prefetch_var=101.69s/36 ecmwf_total=35.43s/1
  phase2_icon_decode=31.94s/1 ecmwf_a2_decode=30.18s/10
  icon_chunked_decode=28.91s/4 gfs_total=8.21s/1 …
  gc=3.47s/20
```

Thread-safe accumulation so the Phase 1 ThreadPoolExecutor's GFS/ECMWF/ICON legs each record their own time.

**Memory checkpoints** in the same call:

```
GRIB RSS: baseline=510MB after_phase1=3118MB(+2607/1)
  icon_fhour_pre=3118MB(+2607/4) icon_fhour_decoded=3063MB(+2552/4)
  icon_fhour_post_gc=3063MB(+2552/4) after_phase2=3053MB(+2542/1)
  enrich_end=3053MB(+2542/1)
```

**`_grib_gc()` wrapper** around the 5 existing `gc.collect()` call sites — tracks cumulative GC time and count without changing memory behaviour. **Calls remain in place** (load-bearing for memory).

**Improved 404 logging** in `icon_eu_fetch.py`:

```
WARNING: ICON-EU f073 qc: all 40 files failed (404=40)
```

So latent cycle/horizon mismatches surface in prod logs at INFO level without raising verbosity.

**Driver script** `scripts/profile_refresh.py` for local pyinstrument profiling, mirrors `_prepare_refresh()` so the run matches production options.

## Important — what's NOT in this PR

The two wrong constants in `icon_eu_fetch.py` (`ICON_EU_MAIN_CYCLES = {0, 12}` should be `{0, 6, 12, 18}`; `ICON_EU_MODEL_LEVEL_MAX_HOUR_SHORT = 78` should be `48`) were discovered during this investigation but are **deliberately held back**. Activating them on prod would shift more refreshes onto the heavy ICON path before we've capped the memory peak. A comment in the file points to the design doc.

The fix lands in Phase C, paired with ICON memory streaming.

## Headline numbers from this investigation

Test flight: D+3 European multi-leg, 6 waypoints, FL160, 50 route points.

| Scenario | Total | GRIB | Peak RSS |
|---|---|---|---|
| Broken-ICON (current prod most of the time) | 96s | 32s | 924 MB |
| Working-ICON (where prod can land on long-range main-cycle refreshes) | 208s | 144s | 3317 MB |

Prod log baseline today: peak 1.8–2.2 GB (Linux glibc reclaims malloc arenas more aggressively than macOS, so absolute peak is lower than our local measurement).

## Phase A → B → C plan

- **A (this PR)**: instrument, deploy, observe ~24h of prod refreshes to get real prod timing/memory numbers.
- **B**: design ICON memory streaming locally — load `var_bytes[var]` from disk one variable at a time during decode + investigate the prefetch malloc arena issue (the bigger memory win — 2.6 GB grows during Phase 1 prefetch, before decode even starts).
- **C**: ship the cycle/horizon constants fix together with B's memory work, monitored by this PR's instrumentation.

## Test plan

- [x] All 197 GRIB-related tests pass (`pytest tests/test_grib*.py tests/test_ecmwf*.py`)
- [x] Local profile run reproduces broken-ICON baseline (96s, 924 MB peak)
- [x] Local profile run reproduces working-ICON cost when 12z is freshly published (208s, 3.1 GB peak)
- [x] `GRIB timing:` and `GRIB RSS:` log lines appear cleanly in both scenarios
- [ ] Review thread-safety of the timing/RSS accumulation (acquired around dict mutations)
- [ ] Review the outer/inner function refactor of `_enrich_gfs`/`_enrich_ecmwf`/`_prefetch_icon_eu_data` (mechanical: outer wraps inner with `_grib_time(...)`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)