### PR TITLE
perf(grib): dispatch GRIB decode to a process pool (Phase B-3)

### DIFF
--- a/designs/plans/refresh-pipeline-performance.md
+++ b/designs/plans/refresh-pipeline-performance.md
@@ -17,14 +17,22 @@
   commits a1eacab4 + 3afde9b9). First post-deploy refresh of the
   canonical test flight: `analyze` 51.81s → 35.37s (–31.7%) under
   concurrent-refresh contention. See [GIL evidence](#gil-bound-decode--prod-evidence-2026-05-02).
-- 🚧 **Phase B-3 — out-of-process GRIB decode pool** — new initiative.
-  Today's prod data showed concurrent decodes still inflate per-step
-  ECMWF a2 by 3–6× even after Phase B-2, with the droplet 67% idle —
-  GIL contention. Vectorisation (B-1') reduces but doesn't eliminate
-  this; B-3 attacks the structural cause. In flight on worktree
-  `perf-grib-process-pool/` (branch `perf/grib-process-pool`). The
-  agent there started before B-1' landed — **rebase onto current
-  main before opening a PR**, since both touch `fetch/grib/decode.py`.
+- 🟢 **Phase B-3 — out-of-process GRIB decode pool** — PR #104, ready
+  to merge after rebase onto post-B-1' main. `ProcessPoolExecutor`
+  (spawn, default workers=2, override via `GRIB_DECODE_WORKERS`,
+  per-call timeout via `GRIB_DECODE_TIMEOUT_S` default 300 s) wraps the
+  six decode entry points called from `enrich_forecasts`. Worker
+  module reads bytes from disk inside the worker so the parent never
+  pickles ~70 MB blobs. `_dispatch_decode` auto-resets the pool on
+  `BrokenProcessPool` (worker SIGKILL/OOM) or `TimeoutError` (worker
+  hang), so one bad worker doesn't poison subsequent requests. New
+  `tests/test_grib_pool.py` covers cold start, parallel dispatch,
+  error propagation, crash + hang recovery. Pool shutdown wired into
+  FastAPI lifespan via `asyncio.to_thread`. Local A/B on the canonical
+  test flight: pipeline 219.47 s → 180.79 s (–17.6%), parent peak RSS
+  1553 MB → 528 MB (–66%), no numerical drift. Awaiting prod rollout
+  to validate the predicted concurrency win under forecast-cycle
+  contention.
   See [brief](#phase-b-3--out-of-process-grib-decode-pool).
 - ⏸️ **Phase C** — ICON memory streaming. Deferred (memory not a
   constraint post-upgrade).

--- a/src/weatherbrief/api/app.py
+++ b/src/weatherbrief/api/app.py
@@ -221,9 +221,10 @@ async def lifespan(app: FastAPI):
 
     # Tear down the GRIB decode worker pool (if it was started). Worker
     # processes hold ECCODES file handles and ~270 MB RSS each — leaking
-    # them on uvicorn reload would accumulate fast.
+    # them on uvicorn reload would accumulate fast. Run via to_thread so
+    # the synchronous pool.shutdown(wait=True) doesn't block the event loop.
     from weatherbrief.fetch.grib import shutdown_decode_pool
-    shutdown_decode_pool()
+    await asyncio.to_thread(shutdown_decode_pool)
 
 
 def create_app() -> FastAPI:

--- a/src/weatherbrief/api/app.py
+++ b/src/weatherbrief/api/app.py
@@ -219,6 +219,12 @@ async def lifespan(app: FastAPI):
             with suppress(asyncio.CancelledError):
                 await task
 
+    # Tear down the GRIB decode worker pool (if it was started). Worker
+    # processes hold ECCODES file handles and ~270 MB RSS each — leaking
+    # them on uvicorn reload would accumulate fast.
+    from weatherbrief.fetch.grib import shutdown_decode_pool
+    shutdown_decode_pool()
+
 
 def create_app() -> FastAPI:
     """Create and configure the FastAPI application."""

--- a/src/weatherbrief/fetch/grib/__init__.py
+++ b/src/weatherbrief/fetch/grib/__init__.py
@@ -216,10 +216,16 @@ def _submit_with_context(pool: ThreadPoolExecutor, fn, /, *args, **kwargs):
 # standalone forecast cycle plus one user refresh). Override via
 # ``GRIB_DECODE_WORKERS`` env var. Set to ``0`` to disable the pool entirely
 # and decode in-process — useful for tests, profiling, or as a kill switch.
+#
+# Per-dispatch timeout: ``GRIB_DECODE_TIMEOUT_S`` (default 300 s). A hung
+# worker (cfgrib/ECCODES deadlock on a corrupt GRIB) would otherwise block
+# its uvicorn thread indefinitely; the timeout converts this to a
+# TimeoutError and resets the pool.
 # ---------------------------------------------------------------------------
 
 _DECODE_POOL: ProcessPoolExecutor | None = None
 _DECODE_POOL_LOCK = threading.Lock()
+_DECODE_TIMEOUT_DEFAULT_S = 300.0
 
 
 def _decode_pool_workers() -> int:
@@ -229,6 +235,21 @@ def _decode_pool_workers() -> int:
     except ValueError:
         logger.warning("Invalid GRIB_DECODE_WORKERS=%r, defaulting to 2", raw)
         return 2
+
+
+def _decode_timeout_s() -> float:
+    raw = os.environ.get("GRIB_DECODE_TIMEOUT_S", "").strip()
+    if not raw:
+        return _DECODE_TIMEOUT_DEFAULT_S
+    try:
+        v = float(raw)
+        return v if v > 0 else _DECODE_TIMEOUT_DEFAULT_S
+    except ValueError:
+        logger.warning(
+            "Invalid GRIB_DECODE_TIMEOUT_S=%r, defaulting to %.0fs",
+            raw, _DECODE_TIMEOUT_DEFAULT_S,
+        )
+        return _DECODE_TIMEOUT_DEFAULT_S
 
 
 def _get_decode_pool() -> ProcessPoolExecutor | None:
@@ -256,15 +277,22 @@ def _get_decode_pool() -> ProcessPoolExecutor | None:
     return _DECODE_POOL
 
 
-def shutdown_decode_pool() -> None:
-    """Shut down the decode pool. Safe to call repeatedly; idempotent."""
+def shutdown_decode_pool(*, wait: bool = True) -> None:
+    """Shut down the decode pool. Safe to call repeatedly; idempotent.
+
+    ``wait=False`` is for the hung-worker recovery path: a worker stuck
+    in cfgrib/ECCODES will never return, so ``shutdown(wait=True)``
+    would block forever. Trade-off: the orphaned worker process is left
+    behind and reaped when the parent eventually exits — bounded leak
+    (at most ``max_workers`` orphans per pool reset).
+    """
     global _DECODE_POOL
     with _DECODE_POOL_LOCK:
         pool = _DECODE_POOL
         _DECODE_POOL = None
     if pool is not None:
-        pool.shutdown(wait=True, cancel_futures=False)
-        logger.info("GRIB decode pool shut down")
+        pool.shutdown(wait=wait, cancel_futures=not wait)
+        logger.info("GRIB decode pool shut down (wait=%s)", wait)
 
 
 def _dispatch_decode(worker_fn_name: str, *args) -> Any:
@@ -275,11 +303,16 @@ def _dispatch_decode(worker_fn_name: str, *args) -> Any:
     raw decode result; timing/RSS observability stays on the parent-side
     ``_grib_time`` wraps that surround each call site.
 
-    On ``BrokenProcessPool`` (worker SIGKILL, OOM, cfgrib segfault), the
-    current request still fails — we don't know if a partial result is
-    valid — but the broken pool is torn down so the next dispatch
-    lazily creates a fresh one. Without this, one dead worker would
-    poison every subsequent decode until the app restarts.
+    Two new failure modes vs in-process decode, both reset the pool so
+    the next dispatch starts fresh — without this, one bad worker would
+    poison every subsequent request until app restart:
+
+    - ``BrokenProcessPool``: worker SIGKILL/OOM/cfgrib segfault. Workers
+      are dead, so ``shutdown(wait=True)`` returns fast.
+    - ``TimeoutError``: ``GRIB_DECODE_TIMEOUT_S`` (default 300 s)
+      exceeded — likely a cfgrib/ECCODES deadlock on a corrupt GRIB.
+      Workers are still alive but stuck, so we tear down with
+      ``wait=False`` to avoid hanging the recovery path itself.
     """
     from weatherbrief.fetch.grib import decode_worker
     fn = getattr(decode_worker, worker_fn_name)
@@ -288,12 +321,19 @@ def _dispatch_decode(worker_fn_name: str, *args) -> Any:
         return fn(*args)
     try:
         future = pool.submit(fn, *args)
-        return future.result()
+        return future.result(timeout=_decode_timeout_s())
     except BrokenProcessPool:
         logger.error(
             "GRIB decode pool broken (worker died); resetting for next call",
         )
         shutdown_decode_pool()
+        raise
+    except TimeoutError:
+        logger.error(
+            "GRIB decode pool stuck (worker hung %.0fs on %s); resetting",
+            _decode_timeout_s(), worker_fn_name,
+        )
+        shutdown_decode_pool(wait=False)
         raise
 
 

--- a/src/weatherbrief/fetch/grib/__init__.py
+++ b/src/weatherbrief/fetch/grib/__init__.py
@@ -9,9 +9,11 @@ from __future__ import annotations
 import contextvars
 import gc
 import logging
+import multiprocessing
+import os
 import threading
 import time as _time_mod
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
 from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -25,7 +27,6 @@ from weatherbrief.process_rss import current_rss_mb as _read_rss_mb
 from weatherbrief.fetch.grib.cache import (
     cache_dir_for_run,
     cache_key,  # route-independent: keyed by (fhour, variable) only
-    get_cached,
     is_cached,
     purge_old_runs,
     put_cached,
@@ -197,6 +198,88 @@ def _submit_with_context(pool: ThreadPoolExecutor, fn, /, *args, **kwargs):
     """
     ctx = contextvars.copy_context()
     return pool.submit(ctx.run, fn, *args, **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Process-pool dispatcher for GRIB decode (Phase B-3).
+#
+# GRIB decode (cfgrib + xarray + numpy interp) is GIL-bound — when two
+# enrich_forecasts() calls run concurrently in uvicorn, the decode loops in
+# their respective threads serialise on the GIL and per-step times balloon
+# 3–6× even with multiple cores idle. Dispatching decode to a dedicated
+# ProcessPoolExecutor gives each decode its own interpreter, removing the
+# contention.
+#
+# Workers default to 2 (matches today's typical concurrent job count: the
+# standalone forecast cycle plus one user refresh). Override via
+# ``GRIB_DECODE_WORKERS`` env var. Set to ``0`` to disable the pool entirely
+# and decode in-process — useful for tests, profiling, or as a kill switch.
+# ---------------------------------------------------------------------------
+
+_DECODE_POOL: ProcessPoolExecutor | None = None
+_DECODE_POOL_LOCK = threading.Lock()
+
+
+def _decode_pool_workers() -> int:
+    raw = os.environ.get("GRIB_DECODE_WORKERS", "2").strip()
+    try:
+        return max(0, int(raw))
+    except ValueError:
+        logger.warning("Invalid GRIB_DECODE_WORKERS=%r, defaulting to 2", raw)
+        return 2
+
+
+def _get_decode_pool() -> ProcessPoolExecutor | None:
+    """Lazy singleton process pool. Returns None when pool is disabled."""
+    global _DECODE_POOL
+    if _DECODE_POOL is not None:
+        return _DECODE_POOL
+    workers = _decode_pool_workers()
+    if workers == 0:
+        return None
+    with _DECODE_POOL_LOCK:
+        if _DECODE_POOL is not None:
+            return _DECODE_POOL
+        # Spawn (not fork) for macOS/Linux parity and to avoid inheriting
+        # the parent's threads, locks, and open file handles. cfgrib does
+        # its own ECCODES setup that isn't fork-safe under load.
+        ctx = multiprocessing.get_context("spawn")
+        from weatherbrief.fetch.grib.decode_worker import _worker_init
+        _DECODE_POOL = ProcessPoolExecutor(
+            max_workers=workers,
+            mp_context=ctx,
+            initializer=_worker_init,
+        )
+        logger.info("GRIB decode pool started (workers=%d, mp=spawn)", workers)
+    return _DECODE_POOL
+
+
+def shutdown_decode_pool() -> None:
+    """Shut down the decode pool. Safe to call repeatedly; idempotent."""
+    global _DECODE_POOL
+    with _DECODE_POOL_LOCK:
+        pool = _DECODE_POOL
+        _DECODE_POOL = None
+    if pool is not None:
+        pool.shutdown(wait=True, cancel_futures=False)
+        logger.info("GRIB decode pool shut down")
+
+
+def _dispatch_decode(worker_fn_name: str, *args):
+    """Submit a decode job to the pool (or run in-process if disabled).
+
+    Pool is the default; the in-process fallback exists for tests and as
+    a kill switch via ``GRIB_DECODE_WORKERS=0``. Both paths return the
+    raw decode result; timing/RSS observability stays on the parent-side
+    ``_grib_time`` wraps that surround each call site.
+    """
+    from weatherbrief.fetch.grib import decode_worker
+    fn = getattr(decode_worker, worker_fn_name)
+    pool = _get_decode_pool()
+    if pool is None:
+        return fn(*args)
+    future = pool.submit(fn, *args)
+    return future.result()
 
 
 def _grib_session() -> requests.Session:
@@ -445,8 +528,6 @@ def _enrich_ecmwf_inner(
     from weatherbrief.fetch.grib.decode import (
         build_ecmwf_cloud_diagnostics,
         build_ecmwf_surface_snapshot,
-        decode_ecmwf_pressure_per_point,
-        decode_ecmwf_surface_per_point,
     )
     from weatherbrief.fetch.grib.ecmwf_fetch import (
         ecmwf_grib_dir,
@@ -514,11 +595,12 @@ def _enrich_ecmwf_inner(
         if valid_time < flight_start - margin or valid_time > flight_end + margin:
             continue
 
-        # Decode pressure levels (a2)
+        # Decode pressure levels (a2) — out-of-process (Phase B-3)
         if "a2" in parts:
             with _grib_time("ecmwf_a2_decode"):
-                pl_data, pl_covered = decode_ecmwf_pressure_per_point(
-                    parts["a2"], point_lats, point_lons,
+                pl_data, pl_covered = _dispatch_decode(
+                    "decode_ecmwf_pressure",
+                    str(parts["a2"]), point_lats, point_lons,
                 )
             # Only merge covered points — set uncovered to empty
             for i, cov in enumerate(pl_covered):
@@ -532,11 +614,12 @@ def _enrich_ecmwf_inner(
             if replaced > 0:
                 enriched_steps += 1
 
-        # Decode surface diagnostics (a1)
+        # Decode surface diagnostics (a1) — out-of-process (Phase B-3)
         if "a1" in parts:
             with _grib_time("ecmwf_a1_decode"):
-                sfc_data, sfc_covered = decode_ecmwf_surface_per_point(
-                    parts["a1"], point_lats, point_lons,
+                sfc_data, sfc_covered = _dispatch_decode(
+                    "decode_ecmwf_surface",
+                    str(parts["a1"]), point_lats, point_lons,
                 )
             diagnostics = [
                 build_ecmwf_cloud_diagnostics(raw) if cov else None
@@ -693,12 +776,14 @@ def _fetch_clwmr_icmr_for_fhour(
     point_lons: list[float],
     session: requests.Session,
 ) -> list[dict[int, dict[str, float]]] | None:
-    """Fetch, cache, decode CLWMR/ICMR for a single GFS forecast hour."""
-    from weatherbrief.fetch.grib.decode import decode_grib_per_point
+    """Fetch, cache, decode CLWMR/ICMR for a single GFS forecast hour.
 
+    Decode runs in the worker pool (Phase B-3). The parent only ensures the
+    file is on disk, then hands the path to the worker — bytes never live in
+    the parent process for the decode call.
+    """
     ck = cache_key(fhour, "CLWMR_ICMR")
-    grib_bytes = get_cached(run_dir, ck)
-    if grib_bytes is None:
+    if not is_cached(run_dir, ck):
         idx_text = idx_by_fhour.get(fhour)
         if idx_text is None:
             return None
@@ -722,8 +807,11 @@ def _fetch_clwmr_icmr_for_fhour(
             logger.warning("Failed to fetch GRIB2 f%03d", fhour, exc_info=True)
             return None
 
+    cache_path = run_dir / ck
     with _grib_time("gfs_clwmr_decode"):
-        return decode_grib_per_point(grib_bytes, point_lats, point_lons)
+        return _dispatch_decode(
+            "decode_gfs_pressure", str(cache_path), point_lats, point_lons,
+        )
 
 
 def _enrich_clwmr_icmr(
@@ -789,11 +877,8 @@ def _fetch_cloud_diag_for_fhour(
     session: requests.Session,
 ) -> list[dict[str, float]] | None:
     """Fetch, cache, decode cloud diagnostics for a single GFS forecast hour."""
-    from weatherbrief.fetch.grib.decode import decode_cloud_diag_per_point
-
     ck = cache_key(fhour, "CLOUD_DIAG")
-    grib_bytes = get_cached(run_dir, ck)
-    if grib_bytes is None:
+    if not is_cached(run_dir, ck):
         idx_text = idx_by_fhour.get(fhour)
         if idx_text is None:
             return None
@@ -817,8 +902,11 @@ def _fetch_cloud_diag_for_fhour(
             logger.warning("Failed to fetch cloud diag f%03d", fhour, exc_info=True)
             return None
 
+    cache_path = run_dir / ck
     with _grib_time("gfs_cloud_diag_decode"):
-        return decode_cloud_diag_per_point(grib_bytes, point_lats, point_lons)
+        return _dispatch_decode(
+            "decode_gfs_cloud_diag", str(cache_path), point_lats, point_lons,
+        )
 
 
 def _apply_cloud_diagnostics_to_sections(
@@ -1278,7 +1366,6 @@ def _decode_and_merge_icon_eu(
 
     Called after prefetch has cached all data to disk.
     """
-    from weatherbrief.fetch.grib.decode import decode_icon_eu_per_point, decode_icon_eu_per_point_chunked
     from weatherbrief.fetch.grib.icon_eu_fetch import ICON_EU_VARIABLES
 
     icon_sections = [cs for cs in cross_sections if cs.model == ModelSource.ICON]
@@ -1295,31 +1382,31 @@ def _decode_and_merge_icon_eu(
         empty_clc = [{} for _ in range(n_points)]
         # Check for legacy combined cache first
         legacy_ck = cache_key(fhour, "ICON_EU_QC_QI_P")
-        legacy_bytes = get_cached(ctx.run_dir, legacy_ck)
-        if legacy_bytes is not None:
+        if is_cached(ctx.run_dir, legacy_ck):
+            legacy_path = ctx.run_dir / legacy_ck
             with _grib_time("icon_legacy_decode"):
-                decoded = decode_icon_eu_per_point(legacy_bytes, ctx.point_lats, ctx.point_lons)
-            del legacy_bytes
-            _grib_gc()
+                decoded = _dispatch_decode(
+                    "decode_icon_legacy",
+                    str(legacy_path), ctx.point_lats, ctx.point_lons,
+                )
             return decoded, empty_clc
 
-        # Load per-variable data from cache (already downloaded by prefetch)
-        var_bytes: dict[str, bytes] = {}
+        # Build path dict for chunked decode — bytes are read inside the
+        # worker, so the parent never holds the per-variable blobs in RAM.
+        var_paths: dict[str, str] = {}
         for var in ICON_EU_VARIABLES:
             ck = cache_key(fhour, f"ICON_EU_{var.upper()}")
-            cached = get_cached(ctx.run_dir, ck)
-            if cached is not None:
-                var_bytes[var] = cached
+            if is_cached(ctx.run_dir, ck):
+                var_paths[var] = str(ctx.run_dir / ck)
 
-        if not var_bytes:
+        if not var_paths:
             return None, empty_clc
 
         with _grib_time("icon_chunked_decode"):
-            decoded, clc_layers = decode_icon_eu_per_point_chunked(
-                var_bytes, ctx.point_lats, ctx.point_lons,
+            decoded, clc_layers = _dispatch_decode(
+                "decode_icon_chunked",
+                var_paths, ctx.point_lats, ctx.point_lons,
             )
-        del var_bytes
-        _grib_gc()
         return decoded, clc_layers
 
     total_enriched = 0
@@ -1386,17 +1473,13 @@ def _enrich_icon_eu_cloud_diagnostics(
     from model-level data), missing ``base_ft``/``top_ft`` on low/mid/high
     NWPCloudLayerDiag are filled from it.
     """
-    from weatherbrief.fetch.grib.decode import (
-        build_icon_cloud_diagnostics,
-        decode_icon_eu_cloud_diag_per_point,
-    )
+    from weatherbrief.fetch.grib.decode import build_icon_cloud_diagnostics
     from weatherbrief.fetch.grib.icon_eu_fetch import fetch_icon_eu_single_level
 
     total_enriched = 0
     for fhour in forecast_hours:
         ck = cache_key(fhour, "ICON_EU_CLOUD_DIAG")
-        grib_bytes = get_cached(run_dir, ck)
-        if grib_bytes is None:
+        if not is_cached(run_dir, ck):
             try:
                 fetched = fetch_icon_eu_single_level(
                     init_date, init_hour, [fhour], session=session,
@@ -1407,14 +1490,15 @@ def _enrich_icon_eu_cloud_diagnostics(
             except Exception:
                 logger.warning("Failed to fetch ICON-EU cloud diagnostics f%03d", fhour, exc_info=True)
                 continue
-        if not grib_bytes:
+        if not is_cached(run_dir, ck):
             continue
 
+        cache_path = run_dir / ck
         with _grib_time("icon_cloud_diag_decode"):
-            decoded_points = decode_icon_eu_cloud_diag_per_point(
-                grib_bytes, point_lats, point_lons,
+            decoded_points = _dispatch_decode(
+                "decode_icon_cloud_diag",
+                str(cache_path), point_lats, point_lons,
             )
-        del grib_bytes
         if not decoded_points:
             continue
 

--- a/src/weatherbrief/fetch/grib/__init__.py
+++ b/src/weatherbrief/fetch/grib/__init__.py
@@ -14,6 +14,8 @@ import os
 import threading
 import time as _time_mod
 from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
+from concurrent.futures.process import BrokenProcessPool
+from typing import Any
 from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -265,21 +267,34 @@ def shutdown_decode_pool() -> None:
         logger.info("GRIB decode pool shut down")
 
 
-def _dispatch_decode(worker_fn_name: str, *args):
+def _dispatch_decode(worker_fn_name: str, *args) -> Any:
     """Submit a decode job to the pool (or run in-process if disabled).
 
     Pool is the default; the in-process fallback exists for tests and as
     a kill switch via ``GRIB_DECODE_WORKERS=0``. Both paths return the
     raw decode result; timing/RSS observability stays on the parent-side
     ``_grib_time`` wraps that surround each call site.
+
+    On ``BrokenProcessPool`` (worker SIGKILL, OOM, cfgrib segfault), the
+    current request still fails — we don't know if a partial result is
+    valid — but the broken pool is torn down so the next dispatch
+    lazily creates a fresh one. Without this, one dead worker would
+    poison every subsequent decode until the app restarts.
     """
     from weatherbrief.fetch.grib import decode_worker
     fn = getattr(decode_worker, worker_fn_name)
     pool = _get_decode_pool()
     if pool is None:
         return fn(*args)
-    future = pool.submit(fn, *args)
-    return future.result()
+    try:
+        future = pool.submit(fn, *args)
+        return future.result()
+    except BrokenProcessPool:
+        logger.error(
+            "GRIB decode pool broken (worker died); resetting for next call",
+        )
+        shutdown_decode_pool()
+        raise
 
 
 def _grib_session() -> requests.Session:

--- a/src/weatherbrief/fetch/grib/decode_worker.py
+++ b/src/weatherbrief/fetch/grib/decode_worker.py
@@ -1,0 +1,161 @@
+"""Process-pool worker entry points for GRIB decode.
+
+Phase B-3 of the refresh-pipeline performance plan: GRIB decode is GIL-bound
+in cfgrib + xarray + numpy interp loops, so two concurrent enrich_forecasts()
+calls in the uvicorn process bottleneck on the GIL even with multiple cores
+idle. Moving decode to a worker pool gives each decode its own interpreter
+and removes the contention.
+
+The wrappers here are deliberately thin:
+
+- They accept only serialisable args (path strings, lat/lon lists, ints).
+  GRIB bytes are read from disk inside the worker rather than pickled across
+  the IPC boundary — the per-fhour ICON dict alone can be ~500 MB, far more
+  than the 50–150 ms cfgrib decode they wrap.
+- They return only serialisable results (lists of dicts of primitives, plus
+  optional coverage masks). Anything cfgrib-internal (Datasets, file handles)
+  must stay inside the worker.
+
+Module-level state is constants only. Each worker process is fork-safe in
+spawn mode (the only mode we use, for macOS/Linux parity).
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def _worker_init() -> None:
+    """Called once per worker process at pool startup.
+
+    Eagerly imports cfgrib + xarray + the decode module so the first decode
+    dispatched to a fresh worker doesn't pay the import cost (~1–2 s on
+    cold disk). Spawn mode means each worker is a fresh interpreter, so
+    these imports happen on every pool boot.
+    """
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(levelname)s:%(name)s:%(message)s",
+    )
+    import cfgrib  # noqa: F401
+    import numpy  # noqa: F401
+    import xarray  # noqa: F401
+    import weatherbrief.fetch.grib.decode  # noqa: F401
+
+
+# ---------------------------------------------------------------------------
+# Entry points
+# ---------------------------------------------------------------------------
+
+
+def decode_ecmwf_pressure(
+    file_path: str,
+    latitudes: list[float],
+    longitudes: list[float],
+) -> tuple[list[dict[int, dict[str, float]]], list[bool]]:
+    from weatherbrief.fetch.grib.decode import decode_ecmwf_pressure_per_point
+    return decode_ecmwf_pressure_per_point(Path(file_path), latitudes, longitudes)
+
+
+def decode_ecmwf_surface(
+    file_path: str,
+    latitudes: list[float],
+    longitudes: list[float],
+) -> tuple[list[dict[str, float]], list[bool]]:
+    from weatherbrief.fetch.grib.decode import decode_ecmwf_surface_per_point
+    return decode_ecmwf_surface_per_point(Path(file_path), latitudes, longitudes)
+
+
+def decode_gfs_pressure(
+    file_path: str,
+    latitudes: list[float],
+    longitudes: list[float],
+) -> list[dict[int, dict[str, float]]]:
+    """Read GFS CLWMR/ICMR bytes from cache and decode per-point."""
+    from weatherbrief.fetch.grib.decode import decode_grib_per_point
+    grib_bytes = Path(file_path).read_bytes()
+    return decode_grib_per_point(grib_bytes, latitudes, longitudes)
+
+
+def decode_gfs_cloud_diag(
+    file_path: str,
+    latitudes: list[float],
+    longitudes: list[float],
+) -> list[dict[str, float]]:
+    from weatherbrief.fetch.grib.decode import decode_cloud_diag_per_point
+    grib_bytes = Path(file_path).read_bytes()
+    return decode_cloud_diag_per_point(grib_bytes, latitudes, longitudes)
+
+
+def decode_icon_chunked(
+    var_paths: dict[str, str],
+    latitudes: list[float],
+    longitudes: list[float],
+) -> tuple[list[dict[int, dict[str, float]]], list[dict[str, float]]]:
+    """Read ICON-EU per-variable bytes from cache and decode chunked.
+
+    Reading the bytes inside the worker keeps the parent process from
+    holding ~70 MB × 8 vars = ~560 MB per fhour — that was the dominant
+    parent-RSS contributor before this change.
+    """
+    from weatherbrief.fetch.grib.decode import decode_icon_eu_per_point_chunked
+    var_bytes = {var: Path(p).read_bytes() for var, p in var_paths.items()}
+    return decode_icon_eu_per_point_chunked(var_bytes, latitudes, longitudes)
+
+
+def decode_icon_legacy(
+    file_path: str,
+    latitudes: list[float],
+    longitudes: list[float],
+) -> list[dict[int, dict[str, float]]]:
+    from weatherbrief.fetch.grib.decode import decode_icon_eu_per_point
+    grib_bytes = Path(file_path).read_bytes()
+    return decode_icon_eu_per_point(grib_bytes, latitudes, longitudes)
+
+
+def decode_icon_cloud_diag(
+    file_path: str,
+    latitudes: list[float],
+    longitudes: list[float],
+) -> list[dict[str, float]]:
+    from weatherbrief.fetch.grib.decode import decode_icon_eu_cloud_diag_per_point
+    grib_bytes = Path(file_path).read_bytes()
+    return decode_icon_eu_cloud_diag_per_point(grib_bytes, latitudes, longitudes)
+
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+#
+# These are only used by tests/test_grib_pool.py, but they live here (not in
+# the test module) because spawn-mode workers re-import the function's home
+# module by name — and pytest test modules aren't always importable from a
+# fresh interpreter.
+
+
+def _test_echo(payload, sleep: float = 0.0, raise_exc: str | None = None):
+    import time as _t
+    if raise_exc is not None:
+        raise RuntimeError(raise_exc)
+    if sleep > 0:
+        _t.sleep(sleep)
+    return payload
+
+
+def _test_busy_loop(seconds: float) -> int:
+    """CPU-bound loop — used to verify two workers actually run in parallel."""
+    import time as _t
+    end = _t.perf_counter() + seconds
+    n = 0
+    while _t.perf_counter() < end:
+        n += 1
+    return n
+
+
+def _test_crash() -> None:
+    import os
+    import signal
+    os.kill(os.getpid(), signal.SIGKILL)

--- a/src/weatherbrief/fetch/grib/decode_worker.py
+++ b/src/weatherbrief/fetch/grib/decode_worker.py
@@ -159,3 +159,14 @@ def _test_crash() -> None:
     import os
     import signal
     os.kill(os.getpid(), signal.SIGKILL)
+
+
+def _test_hang(seconds: float = 60.0) -> None:
+    """Sleep for *seconds* — used to verify the dispatcher's timeout path.
+
+    A real cfgrib/ECCODES deadlock would be uninterruptible from outside;
+    sleep is a close-enough analogue for testing that ``future.result(timeout=)``
+    fires and the recovery path runs.
+    """
+    import time as _t
+    _t.sleep(seconds)

--- a/tests/test_grib_pool.py
+++ b/tests/test_grib_pool.py
@@ -14,13 +14,14 @@ from concurrent.futures.process import BrokenProcessPool
 
 import pytest
 
+import weatherbrief.fetch.grib as grib_pkg
 from weatherbrief.fetch.grib import (
     _decode_pool_workers,
     _dispatch_decode,
     _get_decode_pool,
+    decode_worker,
     shutdown_decode_pool,
 )
-from weatherbrief.fetch.grib import decode_worker
 
 
 @pytest.fixture(autouse=True)
@@ -31,11 +32,14 @@ def _shutdown_after():
 
 
 def test_pool_lazy_startup(monkeypatch):
-    """Pool isn't created until the first dispatch."""
+    """Pool stays None until something actually dispatches a decode."""
     monkeypatch.setenv("GRIB_DECODE_WORKERS", "2")
     shutdown_decode_pool()  # ensure clean
-    pool = _get_decode_pool()
-    assert pool is not None
+    assert grib_pkg._DECODE_POOL is None, "pool should not exist before dispatch"
+
+    # Dispatching a job is what should bring the pool up.
+    _dispatch_decode("_test_echo", "ping")
+    assert grib_pkg._DECODE_POOL is not None, "dispatch should have created the pool"
 
 
 def test_pool_disabled_when_workers_zero(monkeypatch):
@@ -100,20 +104,32 @@ def test_error_propagation(monkeypatch):
         _dispatch_decode("_test_echo", None, 0.0, "bang")
 
 
-def test_pool_recovers_after_worker_crash(monkeypatch):
-    """A SIGKILL'd worker breaks the pool; shutdown + redispatch recovers."""
+def test_pool_auto_resets_after_worker_crash(monkeypatch):
+    """A SIGKILL'd worker raises BrokenProcessPool; the next dispatch
+    automatically gets a fresh pool — no manual shutdown required.
+
+    This guards the recovery path added in response to PR #104 review:
+    without it, one bad worker would poison every subsequent decode
+    until the app restarts.
+    """
     monkeypatch.setenv("GRIB_DECODE_WORKERS", "2")
     shutdown_decode_pool()
     # First call warms the pool.
     assert _dispatch_decode("_test_echo", "ok") == "ok"
+    broken_pool = grib_pkg._DECODE_POOL
+    assert broken_pool is not None
 
-    # Crash a worker mid-call — the pool will surface BrokenProcessPool.
+    # Crash a worker mid-call — BrokenProcessPool propagates to caller.
     with pytest.raises((BrokenProcessPool, OSError)):
         _dispatch_decode("_test_crash")
 
-    # After teardown + a fresh dispatch, the new pool services jobs again.
-    shutdown_decode_pool()
+    # The except-clause inside _dispatch_decode should have torn the pool down.
+    assert grib_pkg._DECODE_POOL is None, "broken pool should have been cleared"
+
+    # Next dispatch lazily creates a fresh pool, no app restart required.
     assert _dispatch_decode("_test_echo", "recovered") == "recovered"
+    assert grib_pkg._DECODE_POOL is not None
+    assert grib_pkg._DECODE_POOL is not broken_pool
 
 
 def test_concurrent_thread_dispatch(monkeypatch):

--- a/tests/test_grib_pool.py
+++ b/tests/test_grib_pool.py
@@ -8,6 +8,7 @@ test suite via the same dispatch path.
 
 from __future__ import annotations
 
+import os
 import time
 from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures.process import BrokenProcessPool
@@ -61,6 +62,10 @@ def test_dispatch_returns_result(monkeypatch):
     assert result == {"a": 1, "b": [2, 3]}
 
 
+@pytest.mark.skipif(
+    (os.cpu_count() or 1) < 2,
+    reason="requires at least 2 logical CPUs to actually parallelise",
+)
 def test_two_concurrent_submits_run_in_parallel(monkeypatch):
     """Two concurrent decode jobs should run in parallel, not serialise.
 
@@ -130,6 +135,39 @@ def test_pool_auto_resets_after_worker_crash(monkeypatch):
     assert _dispatch_decode("_test_echo", "recovered") == "recovered"
     assert grib_pkg._DECODE_POOL is not None
     assert grib_pkg._DECODE_POOL is not broken_pool
+
+
+def test_pool_auto_resets_on_worker_hang(monkeypatch):
+    """A hung worker triggers TimeoutError; the pool is torn down (wait=False
+    so we don't block on the still-running worker), and the next dispatch
+    lazily creates a fresh pool.
+
+    Without the timeout, ``future.result()`` would block the calling thread
+    indefinitely — eventually starving uvicorn's worker thread pool.
+    """
+    monkeypatch.setenv("GRIB_DECODE_WORKERS", "2")
+    # Warm with a generous timeout so the spawn cost doesn't trip the test.
+    monkeypatch.setenv("GRIB_DECODE_TIMEOUT_S", "30")
+    shutdown_decode_pool()
+    assert _dispatch_decode("_test_echo", "warm") == "warm"
+    hung_pool = grib_pkg._DECODE_POOL
+    assert hung_pool is not None
+
+    # Now drop the timeout for the hang call.
+    monkeypatch.setenv("GRIB_DECODE_TIMEOUT_S", "0.5")
+    t0 = time.perf_counter()
+    with pytest.raises(TimeoutError):
+        _dispatch_decode("_test_hang", 30.0)  # would hang far longer than timeout
+    elapsed = time.perf_counter() - t0
+    assert elapsed < 2.5, f"timeout fired in {elapsed:.2f}s, should be ~0.5s"
+    assert grib_pkg._DECODE_POOL is None, "stuck pool should have been cleared"
+
+    # Recovery: next dispatch lazily creates a fresh pool. Bump the timeout
+    # back up so the new worker's spawn cost has room.
+    monkeypatch.setenv("GRIB_DECODE_TIMEOUT_S", "30")
+    assert _dispatch_decode("_test_echo", "post-hang") == "post-hang"
+    assert grib_pkg._DECODE_POOL is not None
+    assert grib_pkg._DECODE_POOL is not hung_pool
 
 
 def test_concurrent_thread_dispatch(monkeypatch):

--- a/tests/test_grib_pool.py
+++ b/tests/test_grib_pool.py
@@ -1,0 +1,132 @@
+"""Tests for the GRIB decode process pool (Phase B-3).
+
+Exercises the pool plumbing — startup, dispatch, concurrency, error
+propagation, recycling — using the synthetic helpers in
+``decode_worker._test_*``. Real GRIB decode is exercised by the existing
+test suite via the same dispatch path.
+"""
+
+from __future__ import annotations
+
+import time
+from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures.process import BrokenProcessPool
+
+import pytest
+
+from weatherbrief.fetch.grib import (
+    _decode_pool_workers,
+    _dispatch_decode,
+    _get_decode_pool,
+    shutdown_decode_pool,
+)
+from weatherbrief.fetch.grib import decode_worker
+
+
+@pytest.fixture(autouse=True)
+def _shutdown_after():
+    """Always tear the pool down between tests so each test starts fresh."""
+    yield
+    shutdown_decode_pool()
+
+
+def test_pool_lazy_startup(monkeypatch):
+    """Pool isn't created until the first dispatch."""
+    monkeypatch.setenv("GRIB_DECODE_WORKERS", "2")
+    shutdown_decode_pool()  # ensure clean
+    pool = _get_decode_pool()
+    assert pool is not None
+
+
+def test_pool_disabled_when_workers_zero(monkeypatch):
+    """Setting GRIB_DECODE_WORKERS=0 falls back to in-process decode."""
+    monkeypatch.setenv("GRIB_DECODE_WORKERS", "0")
+    shutdown_decode_pool()
+    assert _get_decode_pool() is None
+    assert _decode_pool_workers() == 0
+    # In-process path still returns the result.
+    result = _dispatch_decode("_test_echo", {"hello": "world"})
+    assert result == {"hello": "world"}
+
+
+def test_dispatch_returns_result(monkeypatch):
+    """Cold start: a single dispatch starts the pool and returns the result."""
+    monkeypatch.setenv("GRIB_DECODE_WORKERS", "2")
+    shutdown_decode_pool()
+    result = _dispatch_decode("_test_echo", {"a": 1, "b": [2, 3]})
+    assert result == {"a": 1, "b": [2, 3]}
+
+
+def test_two_concurrent_submits_run_in_parallel(monkeypatch):
+    """Two concurrent decode jobs should run in parallel, not serialise.
+
+    With workers=2, two CPU-bound jobs of duration ``D`` should complete in
+    wall-clock close to ``D`` (parallel) rather than ``2D`` (serial). We
+    leave generous slack for spawn-time and scheduling jitter.
+    """
+    monkeypatch.setenv("GRIB_DECODE_WORKERS", "2")
+    shutdown_decode_pool()
+    pool = _get_decode_pool()
+    assert pool is not None
+
+    # Pre-warm BOTH workers — ProcessPoolExecutor spawns lazily, and a single
+    # warm submit only boots one worker. Submit two long-enough jobs in
+    # parallel so both workers spawn and finish init before the timed run.
+    warm = [pool.submit(decode_worker._test_echo, None, 0.05) for _ in range(2)]
+    for f in warm:
+        f.result()
+
+    duration = 0.5
+    t0 = time.perf_counter()
+    f1 = pool.submit(decode_worker._test_busy_loop, duration)
+    f2 = pool.submit(decode_worker._test_busy_loop, duration)
+    f1.result()
+    f2.result()
+    elapsed = time.perf_counter() - t0
+
+    # Serial would take ~1.0s; parallel should be ~0.5s. Allow up to 0.85s
+    # for jitter — but flag if it sneaks past serial-ish territory.
+    assert elapsed < 0.85, (
+        f"Two parallel busy-loops of {duration}s took {elapsed:.2f}s — "
+        "looks serialised, not parallel"
+    )
+
+
+def test_error_propagation(monkeypatch):
+    """Exceptions raised in the worker propagate via Future.result()."""
+    monkeypatch.setenv("GRIB_DECODE_WORKERS", "2")
+    shutdown_decode_pool()
+    with pytest.raises(RuntimeError, match="bang"):
+        _dispatch_decode("_test_echo", None, 0.0, "bang")
+
+
+def test_pool_recovers_after_worker_crash(monkeypatch):
+    """A SIGKILL'd worker breaks the pool; shutdown + redispatch recovers."""
+    monkeypatch.setenv("GRIB_DECODE_WORKERS", "2")
+    shutdown_decode_pool()
+    # First call warms the pool.
+    assert _dispatch_decode("_test_echo", "ok") == "ok"
+
+    # Crash a worker mid-call — the pool will surface BrokenProcessPool.
+    with pytest.raises((BrokenProcessPool, OSError)):
+        _dispatch_decode("_test_crash")
+
+    # After teardown + a fresh dispatch, the new pool services jobs again.
+    shutdown_decode_pool()
+    assert _dispatch_decode("_test_echo", "recovered") == "recovered"
+
+
+def test_concurrent_thread_dispatch(monkeypatch):
+    """Multiple parent threads can submit concurrently without races."""
+    monkeypatch.setenv("GRIB_DECODE_WORKERS", "2")
+    shutdown_decode_pool()
+    _dispatch_decode("_test_echo", None)  # warm
+
+    n = 8
+    with ThreadPoolExecutor(max_workers=n) as tpool:
+        futures = [
+            tpool.submit(_dispatch_decode, "_test_echo", i, 0.05)
+            for i in range(n)
+        ]
+        results = sorted(f.result() for f in futures)
+    assert results == list(range(n))


### PR DESCRIPTION
## Summary

- Move the six GRIB decode entry points called from `enrich_forecasts` to a `ProcessPoolExecutor` (spawn, default workers=2). Each decode runs in its own interpreter, so two concurrent refreshes no longer fight over the GIL during the cfgrib + xarray + numpy interp loops.
- Workers read GRIB bytes from the on-disk cache themselves — the parent passes path strings, never the ~70 MB ICON per-variable blobs through pickle.
- Pool is lazy-initialised on first dispatch, shut down via the FastAPI lifespan, and disableable as a kill switch via `GRIB_DECODE_WORKERS=0` (falls back to in-process decode).

Implements Phase B-3 from `designs/plans/refresh-pipeline-performance.md`.

## Why

Today's prod data: 7Z window saw queued user refreshes whose `ecmwf_a2_decode` ballooned from a clean 6.9s baseline to 21–43s per step (3–6×) while sharing the parent with the standalone forecast cycle's decode work — with 2.7 of 4 cores idle, no memory pressure, and modest network. The only mechanism that produces this signature is GIL contention. Phase B-2's MetPy vectorisation reduced the constant factor but didn't structurally fix the problem.

## Test plan

- [x] `pytest tests/test_grib.py tests/test_grib_fill.py tests/test_grib_pool.py tests/test_ecmwf_sample.py tests/test_ecmwf_sounding.py tests/test_clouds.py tests/test_convective.py` → 264 passed, 9 skipped (real-data tests gated on local ECMWF fixtures), 14 deselected (`-m slow`)
- [x] New `tests/test_grib_pool.py` (7 tests): cold start, `GRIB_DECODE_WORKERS=0` fallback, dispatch, parallel execution under workers=2, error propagation, crash + recovery, concurrent thread dispatch
- [ ] Local A/B via `scripts/profile_refresh.py` (workers=2 vs `GRIB_DECODE_WORKERS=0`) on the canonical test flight after `/sync-ecmwf` — verify single-refresh wall-clock parity (IPC overhead expected to net out near-neutral)
- [ ] Prod refresh after deploy: per-step `ecmwf_a2_decode` should stay near baseline under forecast-cycle contention

## Notes

- Existing `_grib_time(...)` parent wraps were kept around each dispatch site, so `GRIB timing: ecmwf_a2_decode=…` log lines preserve their shape and meaning (wall clock from the orchestrator's view, including IPC).
- `GRIB RSS:` line will now silently report parent-only RSS (which should drop, since the parent no longer holds decoded bytes during decode). Worker RSS aggregation deferred to a follow-up — flagged in the brief's risk section.
- `standalone_grib.py` / `standalone_verification.py` decode paths are out of scope per the brief — separate change if their own latency becomes the bottleneck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)