### PR TITLE
perf(grib): vectorise ECMWF pressure-level interp loop

### DIFF
--- a/src/weatherbrief/fetch/grib/decode.py
+++ b/src/weatherbrief/fetch/grib/decode.py
@@ -292,7 +292,10 @@ def _interpolate_to_points(
         return None
 
 
-def _frac_grid_indices(coord_arr, targets):
+def _frac_grid_indices(
+    coord_arr: "np.ndarray",
+    targets: "np.ndarray | list[float]",
+) -> "tuple[np.ndarray, np.ndarray]":
     """Map target coordinates to fractional indices in a 1-D coord array.
 
     Handles ascending or descending coords, uniform or non-uniform spacing.
@@ -334,14 +337,10 @@ def _decode_pressure_vars_from_datasets(
 ) -> tuple[list[dict[int, dict[str, float]]], list[bool]]:
     """Shared decode loop for pressure-level GRIB datasets.
 
-    Vectorised: for each dataset we compute fractional grid indices and
-    bilinear weights once for all route points, then for each variable
-    materialise its full ``(level, lat, lon)`` numpy array and gather all
-    four bilinear corners with advanced indexing — a single batched
-    ``(n_levels, n_points)`` interp per variable instead of an
-    ``L × N`` xarray ``.sel`` + ``.interp`` loop. The arithmetic runs in
-    numpy C code which releases the GIL, so concurrent ECMWF/GFS/ICON
-    decode threads stop spinning the interpreter against each other.
+    Vectorised: bilinear corner indices/weights are computed once per
+    dataset and the full ``(level, lat, lon)`` array is gathered with
+    numpy advanced indexing. The xarray ``.sel`` + ``.interp`` loop it
+    replaced was GIL-bound, blocking concurrent decode threads.
 
     Args:
         datasets: cfgrib-opened xarray Datasets.
@@ -420,12 +419,29 @@ def _decode_pressure_vars_from_datasets(
 
             is_frac = var_lower in frac_vars
 
-            # Determine pressure coordinate
+            # Determine pressure coordinate + the dim count we expect for this
+            # variable. Doing this *before* materialising .values avoids a full
+            # numpy allocation for ensemble/time-dim variables we'd just drop.
             pressure_coord = None
             for coord_name in ("isobaricInhPa", "level", "pressure"):
                 if coord_name in xr_var.dims:
                     pressure_coord = coord_name
                     break
+
+            if pressure_coord is None:
+                level = xr_var.attrs.get("level")
+                if level is None:
+                    continue
+                expected_ndim = 2
+            else:
+                expected_ndim = 3
+
+            if xr_var.ndim != expected_ndim:
+                logger.debug(
+                    "skip %s: expected %d-D, got %d-D %s",
+                    var_name, expected_ndim, xr_var.ndim, xr_var.dims,
+                )
+                continue
 
             try:
                 var_dims = list(xr_var.dims)
@@ -441,9 +457,6 @@ def _decode_pressure_vars_from_datasets(
             values = np.transpose(values, other_axes + [lat_axis, lon_axis])
 
             if pressure_coord is None:
-                level = xr_var.attrs.get("level")
-                if level is None or values.ndim != 2:
-                    continue
                 p_hpa = int(level)
                 interp = (
                     w00 * values[i0, j0]
@@ -464,13 +477,15 @@ def _decode_pressure_vars_from_datasets(
                     covered[pt_idx] = True
                 continue
 
-            if values.ndim != 3:
-                continue
             try:
                 pressures = np.asarray(ds.coords[pressure_coord].values)
             except Exception:
                 continue
             if pressures.shape[0] != values.shape[0]:
+                logger.debug(
+                    "skip %s: pressure coord len %d != values axis 0 len %d",
+                    var_name, pressures.shape[0], values.shape[0],
+                )
                 continue
 
             # Batched bilinear across all levels — shape (L, n_inb).

--- a/src/weatherbrief/fetch/grib/decode.py
+++ b/src/weatherbrief/fetch/grib/decode.py
@@ -383,6 +383,7 @@ def _decode_pressure_vars_from_datasets(
             lat_arr = np.asarray(ds.coords[lat_dim].values, dtype=np.float64)
             lon_arr = np.asarray(ds.coords[lon_dim].values, dtype=np.float64)
         except Exception:
+            logger.debug("skip dataset: lat/lon coord extract failed", exc_info=True)
             continue
 
         H, W = lat_arr.size, lon_arr.size
@@ -480,6 +481,10 @@ def _decode_pressure_vars_from_datasets(
             try:
                 pressures = np.asarray(ds.coords[pressure_coord].values)
             except Exception:
+                logger.debug(
+                    "skip %s: pressure coord %r extract failed",
+                    var_name, pressure_coord, exc_info=True,
+                )
                 continue
             if pressures.shape[0] != values.shape[0]:
                 logger.debug(

--- a/src/weatherbrief/fetch/grib/decode.py
+++ b/src/weatherbrief/fetch/grib/decode.py
@@ -292,6 +292,37 @@ def _interpolate_to_points(
         return None
 
 
+def _frac_grid_indices(coord_arr, targets):
+    """Map target coordinates to fractional indices in a 1-D coord array.
+
+    Handles ascending or descending coords, uniform or non-uniform spacing.
+    Out-of-range targets receive NaN — matching xarray's
+    ``.interp(method='linear')`` default which fills outside the grid with NaN.
+
+    Returns:
+        (frac, in_bounds) — both shape (n,). ``frac`` is the fractional index
+        in the original (non-reversed) coord array; ``in_bounds`` masks
+        targets strictly outside the grid extent.
+    """
+    import numpy as np
+
+    n = coord_arr.size
+    targets = np.asarray(targets, dtype=np.float64)
+    if n < 2:
+        return np.full(targets.shape, np.nan), np.zeros(targets.shape, dtype=bool)
+
+    if coord_arr[0] > coord_arr[-1]:
+        # Descending: reverse so xp ascends; remap fp to original positions.
+        xp = coord_arr[::-1]
+        fp = np.arange(n - 1, -1, -1, dtype=np.float64)
+    else:
+        xp = coord_arr
+        fp = np.arange(n, dtype=np.float64)
+
+    frac = np.interp(targets, xp, fp, left=np.nan, right=np.nan)
+    return frac, ~np.isnan(frac)
+
+
 def _decode_pressure_vars_from_datasets(
     datasets: list,
     latitudes: list[float],
@@ -303,8 +334,14 @@ def _decode_pressure_vars_from_datasets(
 ) -> tuple[list[dict[int, dict[str, float]]], list[bool]]:
     """Shared decode loop for pressure-level GRIB datasets.
 
-    Iterates datasets, maps variable names via var_map, finds the pressure
-    coordinate, interpolates per point, and stores results.
+    Vectorised: for each dataset we compute fractional grid indices and
+    bilinear weights once for all route points, then for each variable
+    materialise its full ``(level, lat, lon)`` numpy array and gather all
+    four bilinear corners with advanced indexing — a single batched
+    ``(n_levels, n_points)`` interp per variable instead of an
+    ``L × N`` xarray ``.sel`` + ``.interp`` loop. The arithmetic runs in
+    numpy C code which releases the GIL, so concurrent ECMWF/GFS/ICON
+    decode threads stop spinning the interpreter against each other.
 
     Args:
         datasets: cfgrib-opened xarray Datasets.
@@ -317,13 +354,64 @@ def _decode_pressure_vars_from_datasets(
     Returns:
         Tuple of (per-point results, coverage mask).
     """
+    import numpy as np
+
     active_map = var_map if var_map is not None else _VAR_MAP
     frac_vars = frac_vars or set()
     n_points = len(latitudes)
     results: list[dict[int, dict[str, float]]] = [{} for _ in range(n_points)]
     covered: list[bool] = [False] * n_points
 
+    if n_points == 0:
+        return results, covered
+
+    targets_lat = np.asarray(latitudes, dtype=np.float64)
+    targets_lon = np.asarray(longitudes, dtype=np.float64)
+
     for ds in datasets:
+        # Detect lat/lon dim names once per dataset
+        lat_dim = lon_dim = None
+        for dim in ds.dims:
+            dim_lower = str(dim).lower()
+            if "lat" in dim_lower:
+                lat_dim = dim
+            elif "lon" in dim_lower:
+                lon_dim = dim
+        if lat_dim is None or lon_dim is None:
+            continue
+
+        try:
+            lat_arr = np.asarray(ds.coords[lat_dim].values, dtype=np.float64)
+            lon_arr = np.asarray(ds.coords[lon_dim].values, dtype=np.float64)
+        except Exception:
+            continue
+
+        H, W = lat_arr.size, lon_arr.size
+        if H < 2 or W < 2:
+            continue
+
+        frac_lat, lat_ok = _frac_grid_indices(lat_arr, targets_lat)
+        frac_lon, lon_ok = _frac_grid_indices(lon_arr, targets_lon)
+        in_bounds = lat_ok & lon_ok
+        if not np.any(in_bounds):
+            continue
+
+        # Bilinear corner indices + weights — computed once per dataset and
+        # reused for every variable in that dataset.
+        fl = frac_lat[in_bounds]
+        fln = frac_lon[in_bounds]
+        i0 = np.clip(np.floor(fl).astype(np.intp), 0, H - 2)
+        j0 = np.clip(np.floor(fln).astype(np.intp), 0, W - 2)
+        i1 = i0 + 1
+        j1 = j0 + 1
+        ai = fl - i0
+        aj = fln - j0
+        w00 = (1.0 - ai) * (1.0 - aj)
+        w01 = (1.0 - ai) * aj
+        w10 = ai * (1.0 - aj)
+        w11 = ai * aj
+        inb_idx = np.flatnonzero(in_bounds)
+
         for var_name, xr_var in ds.data_vars.items():
             var_lower = str(var_name).lower()
             field_name = active_map.get(var_lower)
@@ -339,34 +427,71 @@ def _decode_pressure_vars_from_datasets(
                     pressure_coord = coord_name
                     break
 
-            if pressure_coord is None:
-                level = xr_var.attrs.get("level")
-                if level is not None:
-                    p_hpa = int(level)
-                    values = _interpolate_per_point(xr_var, latitudes, longitudes)
-                    for i, val in enumerate(values):
-                        if val is not None:
-                            if first_wins and field_name in results[i].get(p_hpa, {}):
-                                continue
-                            if is_frac:
-                                val *= 100.0
-                            results[i].setdefault(p_hpa, {})[field_name] = val
-                            covered[i] = True
+            try:
+                var_dims = list(xr_var.dims)
+                lat_axis = var_dims.index(lat_dim)
+                lon_axis = var_dims.index(lon_dim)
+                values = np.asarray(xr_var.values, dtype=np.float64)
+            except (ValueError, KeyError):
                 continue
 
-            pressures = ds.coords[pressure_coord].values
-            for p_val in pressures:
-                p_hpa = int(float(p_val))
-                level_data = xr_var.sel({pressure_coord: p_val})
-                values = _interpolate_per_point(level_data, latitudes, longitudes)
-                for i, val in enumerate(values):
-                    if val is not None:
-                        if first_wins and field_name in results[i].get(p_hpa, {}):
-                            continue
-                        if is_frac:
-                            val *= 100.0
-                        results[i].setdefault(p_hpa, {})[field_name] = val
-                        covered[i] = True
+            # Move lat/lon axes to the trailing positions so we can index
+            # with values[..., i, j].
+            other_axes = [a for a in range(values.ndim) if a not in (lat_axis, lon_axis)]
+            values = np.transpose(values, other_axes + [lat_axis, lon_axis])
+
+            if pressure_coord is None:
+                level = xr_var.attrs.get("level")
+                if level is None or values.ndim != 2:
+                    continue
+                p_hpa = int(level)
+                interp = (
+                    w00 * values[i0, j0]
+                    + w01 * values[i0, j1]
+                    + w10 * values[i1, j0]
+                    + w11 * values[i1, j1]
+                )
+                # interp shape: (n_inb,)
+                for k, pt_idx in enumerate(inb_idx):
+                    v = interp[k]
+                    if np.isnan(v):
+                        continue
+                    if first_wins and field_name in results[pt_idx].get(p_hpa, {}):
+                        continue
+                    if is_frac:
+                        v = v * 100.0
+                    results[pt_idx].setdefault(p_hpa, {})[field_name] = float(v)
+                    covered[pt_idx] = True
+                continue
+
+            if values.ndim != 3:
+                continue
+            try:
+                pressures = np.asarray(ds.coords[pressure_coord].values)
+            except Exception:
+                continue
+            if pressures.shape[0] != values.shape[0]:
+                continue
+
+            # Batched bilinear across all levels — shape (L, n_inb).
+            interp = (
+                w00[None, :] * values[:, i0, j0]
+                + w01[None, :] * values[:, i0, j1]
+                + w10[None, :] * values[:, i1, j0]
+                + w11[None, :] * values[:, i1, j1]
+            )
+            scale = 100.0 if is_frac else 1.0
+            for li in range(pressures.shape[0]):
+                p_hpa = int(float(pressures[li]))
+                row = interp[li]
+                for k, pt_idx in enumerate(inb_idx):
+                    v = row[k]
+                    if np.isnan(v):
+                        continue
+                    if first_wins and field_name in results[pt_idx].get(p_hpa, {}):
+                        continue
+                    results[pt_idx].setdefault(p_hpa, {})[field_name] = float(v) * scale
+                    covered[pt_idx] = True
 
     return results, covered
 

--- a/tests/test_grib.py
+++ b/tests/test_grib.py
@@ -1462,3 +1462,61 @@ class TestMergeValidHourFilter:
         assert count == 3
         for h in hourlies:
             assert h.pressure_levels[0].cloud_liquid_water_kg_kg == 0.0003
+
+
+class TestFracGridIndices:
+    """Unit tests for the bilinear-interp helper that maps target lat/lon
+    onto fractional grid indices. The descending-coord, exact-boundary, and
+    out-of-range paths are otherwise only exercised via real GRIB samples."""
+
+    def test_ascending_uniform(self):
+        import numpy as np
+        from weatherbrief.fetch.grib.decode import _frac_grid_indices
+
+        coord = np.array([0.0, 0.25, 0.5, 0.75, 1.0])
+        frac, ok = _frac_grid_indices(coord, [0.0, 0.5, 1.0, 0.625])
+        assert ok.tolist() == [True, True, True, True]
+        np.testing.assert_allclose(frac, [0.0, 2.0, 4.0, 2.5])
+
+    def test_descending_uniform(self):
+        # ECMWF lat is descending (e.g. 71.5 → 60.0 in 0.25° steps).
+        import numpy as np
+        from weatherbrief.fetch.grib.decode import _frac_grid_indices
+
+        coord = np.array([71.5, 71.25, 71.0, 70.75, 70.5])
+        frac, ok = _frac_grid_indices(coord, [71.5, 70.5, 71.0])
+        assert ok.tolist() == [True, True, True]
+        # 71.5 sits at index 0 of the original (descending) array; 70.5 at 4.
+        np.testing.assert_allclose(frac, [0.0, 4.0, 2.0])
+
+    def test_out_of_range_marks_nan(self):
+        import numpy as np
+        from weatherbrief.fetch.grib.decode import _frac_grid_indices
+
+        coord = np.array([0.0, 1.0, 2.0])
+        frac, ok = _frac_grid_indices(coord, [-0.1, 0.0, 2.0, 2.1])
+        # endpoints are in-bounds; everything strictly outside is NaN.
+        assert ok.tolist() == [False, True, True, False]
+        assert np.isnan(frac[0]) and np.isnan(frac[3])
+        np.testing.assert_allclose(frac[1:3], [0.0, 2.0])
+
+    def test_non_uniform_spacing(self):
+        # np.interp handles uneven coords — verify we don't assume a step.
+        import numpy as np
+        from weatherbrief.fetch.grib.decode import _frac_grid_indices
+
+        coord = np.array([0.0, 1.0, 4.0, 9.0])  # non-uniform spacing
+        frac, ok = _frac_grid_indices(coord, [0.0, 2.5, 9.0])
+        assert ok.tolist() == [True, True, True]
+        # 2.5 sits halfway between coord[1]=1.0 and coord[2]=4.0 in coord-space,
+        # so its fractional index is 1 + 0.5 = 1.5.
+        np.testing.assert_allclose(frac, [0.0, 1.5, 3.0])
+
+    def test_degenerate_coord_returns_all_nan(self):
+        import numpy as np
+        from weatherbrief.fetch.grib.decode import _frac_grid_indices
+
+        coord = np.array([42.0])  # n < 2 — can't interpolate
+        frac, ok = _frac_grid_indices(coord, [42.0, 43.0])
+        assert ok.tolist() == [False, False]
+        assert np.all(np.isnan(frac))


### PR DESCRIPTION
## Summary

Phase B-1' from `designs/plans/refresh-pipeline-performance.md`. The Phase B-1 ThreadPool variant didn't help because the bottleneck is the per-(level, point) Python loop in `_decode_pressure_vars_from_datasets`, not cfgrib — two threads just spin the GIL against each other. This PR vectorises that inner loop instead.

- Replace the triple loop (subgrid × variable × level) of xarray `.sel` + `.interp` calls with a single batched bilinear gather: compute fractional grid indices and weights once per dataset, then for each variable do one numpy advanced-indexing pull across all levels and all points. Same outputs, ~675× fewer xarray method calls per fhour, and the math runs in numpy C code which releases the GIL.
- Adds a small `_frac_grid_indices` helper that handles ascending/descending coords and matches xarray's NaN-out-of-bounds semantics, with parametrised unit tests.

## Scope

`_decode_pressure_vars_from_datasets` is the **shared** pressure-level decoder. Both ECMWF (via `decode_ecmwf_pressure_per_point`) and GFS (via `decode_grib_per_point`) call it, so both pick up the speedup. ICON-EU and ECMWF a1 surface use different code paths and are untouched per the brief's "ship ECMWF first" guidance — assess those after this lands. The vectorised math is model-agnostic (uses generic lat/lon coord arrays) and the parity check covers descending-coord ECMWF; ascending-coord GFS exercises the same arithmetic.

## Numbers (local, canonical test flight `lsgs→…→egtf`, D+3, FL160)

| Metric | Before | After | Δ |
|---|---|---|---|
| Inner interp loop (10 fhours) | 10.86s | 0.10s | **~113×** |
| `ecmwf_a2_decode` (10 steps) | 30.18s | 6.16s | **–80%** |
| `ecmwf_total` | 35.59s | 13.70s | –61% |
| Peak RSS during enrichment | ~2877 MB | 2877 MB | unchanged |

Brief's target was `ecmwf_a2_decode` ~halve on local (~27s → ~14s). We went to ~6s.

## Numerical equivalence

Side-by-side parity check vs the previous implementation on a 50-point Europe route across all 6 sub-grids in a real ECMWF a2 file:

```
Compared 11250 (point, level, field) combos, mismatches=0
Max abs diff: 1.455e-11, max rel diff: 1.146e-12
```

Coverage masks match exactly. Differences are float64 round-off — well inside `np.allclose(rtol=1e-6)`.

## Test plan

- [x] `pytest tests/test_grib.py tests/test_grib_fill.py tests/test_ecmwf_sample.py tests/test_ecmwf_sounding.py` — all 203 pass (added 5 unit tests for `_frac_grid_indices`)
- [x] Ad-hoc parity test on ECMWF a2 — zero mismatches (covers descending-coord + multi-grid)
- [x] Full pipeline via `scripts/profile_refresh.py` on the canonical test flight — completes successfully, no errors, RSS unchanged
- [ ] Post-deploy: confirm prod `ecmwf_a2_decode` per-step drops from ~6.9s baseline to ~1–2s on a quiet refresh; confirm GFS pressure decode also benefits (B-3 still recommended for the multi-decode contention case)

## Composes with B-3

Touches the same file (`fetch/grib/decode.py`) as the in-flight B-3 worktree but at a different layer — B-1' rewrites the inner interp; B-3 wraps the outer `decode_ecmwf_*_per_point` entry points in a process pool. Per the doc's merge-order note, this lands first so B-3's pickle/IPC ratio stays favourable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)