### PR TITLE
fix(icing): zones must respect cloud-band gaps from gating

### DIFF
--- a/designs/icing-models-analysis.md
+++ b/designs/icing-models-analysis.md
@@ -118,9 +118,15 @@ Wet-bulb temperature with dry-bulb fallback. Thresholds shifted ~1°C colder tha
 
 Used by all three methods (previously SFIP used dry-bulb only with different thresholds).
 
-### `group_icing_levels(icing_levels, build_zone_fn)`
+### `group_icing_levels(icing_levels, build_zone_fn, *, all_levels=None)`
 
-Shared adjacency grouping: pressure gap ≤ 100 hPa → same zone. Used by Ogimet-DD, Ogimet-NWP, and SFIP.
+Shared adjacency grouping. Two icing entries merge into the same zone iff **both**:
+1. They are directly consecutive in *all_levels* (the pre-gated input the caller iterated over) — guarantees the grouper never bridges a level filtered out by the caller's gate (e.g. an NWP cloud-band gap).
+2. Their pressure gap is ≤ `ZONE_MAX_PRESSURE_GAP_HPA` (100 hPa) — guarantees sparse inputs (e.g. only two levels far apart) still split.
+
+When *all_levels* is omitted the function falls back to the legacy pressure-only check; this path is preserved for backward compatibility but should not be used by new callers (it's vulnerable to bug #7 below).
+
+Used by all four zone builders: Ogimet-DD, Ogimet-NWP, IENG, and SFIP.
 
 ---
 
@@ -161,6 +167,12 @@ Shared adjacency grouping: pressure gap ≤ 100 hPa → same zone. Used by Ogime
 **Problem:** `_is_near_cloud`, `_classify_icing_type`, `_nwp_cloud_for_altitude`/`_cloud_cover_for_level`, and zone grouping logic were duplicated between `icing.py` and `sfip.py` with subtle differences.
 
 **Fix:** Extracted to `icing_common.py`. Both modules delegate to shared implementations. Original private functions preserved as thin wrappers for backward compatibility.
+
+### 7. Icing zones bridging cloud-band gaps (PR #106)
+
+**Problem:** `group_icing_levels` merged adjacent surviving icing levels using a pressure-gap heuristic alone (`abs(p1 - p2) ≤ 100 hPa`). At typical 25 hPa input spacing, a 3-level NWP cloud-band gap (e.g. GFS lcc top FL114 → mcc base FL157) collapses to exactly 100 hPa between the surviving icing levels on either side — the heuristic let two cloud-gated zones bridge the "no cloud" stretch. Visible on prod flight `kpao_kgcn-2026-05-05-dc1b` GFS pt13: NWP cloud bands `[4088-11477]` and `[15679-20851]` ft, but `icing_ogimet_nwp_zones` produced a single `7257-18442` ft zone bridging the FL114-FL157 gap — rendering as icing over apparent blue sky on the cross-section.
+
+**Fix:** `group_icing_levels` now optionally takes the pre-gated input list (`all_levels=`). When provided, two icing entries merge iff **both** they were directly consecutive in `all_levels` (no level filtered between them) and the pressure gap stays under the legacy threshold. All four zone builders updated. The dual-check guarantees zones never bridge a gating-induced gap regardless of how the underlying pressure spacing aligns with the gap width.
 
 ---
 

--- a/src/weatherbrief/analysis/sounding/icing.py
+++ b/src/weatherbrief/analysis/sounding/icing.py
@@ -353,9 +353,15 @@ def _build_zone_simple(
 
 def _group_into_zones(
     icing_levels: list[tuple[DerivedLevel, IcingType, IcingRisk, float]],
+    all_levels: list[DerivedLevel] | None = None,
 ) -> list[IcingZone]:
-    """Group adjacent icing levels into zones (no severity enhancement)."""
-    return group_icing_levels(icing_levels, _build_zone_simple)
+    """Group adjacent icing levels into zones (no severity enhancement).
+
+    Pass *all_levels* (the pre-gated full input the caller iterated over)
+    so the grouper splits zones at gating-induced gaps — see
+    :func:`group_icing_levels` for details.
+    """
+    return group_icing_levels(icing_levels, _build_zone_simple, all_levels=all_levels)
 
 
 def assess_icing_zones_ogimet_dd(
@@ -408,7 +414,7 @@ def assess_icing_zones_ogimet_dd(
         lv.icing_index = round(effective, 1)
         icing_levels.append((lv, icing_type, risk, effective))
 
-    return _group_into_zones(icing_levels)
+    return _group_into_zones(icing_levels, all_levels=levels)
 
 
 def assess_icing_zones_ogimet_nwp(
@@ -490,7 +496,7 @@ def assess_icing_zones_ogimet_nwp(
         lv.icing_index_nwp = round(effective, 1)
         icing_levels.append((lv, icing_type, risk, effective))
 
-    return _group_into_zones(icing_levels)
+    return _group_into_zones(icing_levels, all_levels=levels)
 
 
 def assess_icing_zones_ieng(
@@ -560,4 +566,4 @@ def assess_icing_zones_ieng(
         risk = _index_to_risk(effective)
         icing_levels.append((lv, icing_type, risk, effective))
 
-    return _group_into_zones(icing_levels)
+    return _group_into_zones(icing_levels, all_levels=levels)

--- a/src/weatherbrief/analysis/sounding/icing.py
+++ b/src/weatherbrief/analysis/sounding/icing.py
@@ -355,12 +355,7 @@ def _group_into_zones(
     icing_levels: list[tuple[DerivedLevel, IcingType, IcingRisk, float]],
     all_levels: list[DerivedLevel] | None = None,
 ) -> list[IcingZone]:
-    """Group adjacent icing levels into zones (no severity enhancement).
-
-    Pass *all_levels* (the pre-gated full input the caller iterated over)
-    so the grouper splits zones at gating-induced gaps — see
-    :func:`group_icing_levels` for details.
-    """
+    """Group adjacent icing levels into zones — see :func:`group_icing_levels` for ``all_levels`` semantics."""
     return group_icing_levels(icing_levels, _build_zone_simple, all_levels=all_levels)
 
 

--- a/src/weatherbrief/analysis/sounding/icing_common.py
+++ b/src/weatherbrief/analysis/sounding/icing_common.py
@@ -228,15 +228,39 @@ MIN_ZONE_HALF_THICKNESS_FT = 500
 def group_icing_levels(
     icing_levels: list[tuple[DerivedLevel, IcingType, IcingRisk, float]],
     build_zone_fn: Callable,
+    *,
+    all_levels: list[DerivedLevel] | None = None,
 ) -> list:
     """Group adjacent icing levels into zones using shared adjacency logic.
 
-    Adjacent levels (pressure gap <= 100 hPa) are grouped together.
-    Each group is passed to *build_zone_fn* to construct the zone object.
+    When *all_levels* is provided (the full pre-gated input list, in
+    the iteration order the caller used), two icing entries merge into
+    the same zone iff **both**: they were directly consecutive in
+    *all_levels* (so nothing was filtered out between them by the
+    caller's gate), **and** their pressure gap is ≤
+    ``ZONE_MAX_PRESSURE_GAP_HPA`` (so a sparse input doesn't merge
+    levels that are physically far apart).
+
+    The index check fixes the cloud-gap bridging bug — see the
+    fix/icing-zones-respect-cloud-gaps regression in test_icing.py.
+    The pressure check preserves the legacy split for sparse inputs
+    where two surviving levels happen to be the only entries either
+    side of a wide gap.
+
+    Without *all_levels* we fall back to the legacy pressure-gap
+    heuristic alone. That heuristic is fragile: at typical 25 hPa
+    spacing the threshold of 100 hPa exactly matches the spacing
+    across a 3-level NWP cloud-band gap, so two cloud-gated icing
+    zones get merged across a "no cloud" stretch.
 
     Args:
-        icing_levels: Tuples of (level, icing_type, risk, index_value).
-        build_zone_fn: Callable that takes a list of tuples and returns a zone.
+        icing_levels: Tuples of (level, icing_type, risk, index_value),
+            in the same order as the caller iterated *all_levels*.
+        build_zone_fn: Callable that takes a list of tuples and returns
+            a zone.
+        all_levels: Optional pre-gated input. When provided, enables
+            index-based adjacency (the principled behaviour). When
+            None, uses the legacy pressure-gap heuristic.
 
     Returns:
         List of zone objects, ordered by ascending altitude.
@@ -244,13 +268,34 @@ def group_icing_levels(
     if not icing_levels:
         return []
 
+    def _pressure_close(prev_lv: DerivedLevel, this_lv: DerivedLevel) -> bool:
+        return abs(prev_lv.pressure_hpa - this_lv.pressure_hpa) <= ZONE_MAX_PRESSURE_GAP_HPA
+
+    if all_levels is not None:
+        # Map level identity → its position in the pre-gated input.
+        # Identity comparison is correct here: derived levels are not
+        # re-instantiated between pipeline stages.
+        pos: dict[int, int] = {id(lv): i for i, lv in enumerate(all_levels)}
+
+        def _adjacent(prev_lv: DerivedLevel, this_lv: DerivedLevel) -> bool:
+            # Merge requires BOTH: directly consecutive in the pre-gated
+            # input (so we don't bridge a filtered-out gap), AND close in
+            # pressure (so we don't merge across a sparse-input jump).
+            ip = pos.get(id(prev_lv), -2)
+            it = pos.get(id(this_lv), -1)
+            if ip < 0 or it < 0 or (it - ip) != 1:
+                return False
+            return _pressure_close(prev_lv, this_lv)
+    else:
+        _adjacent = _pressure_close
+
     zones: list = []
     current: list[tuple[DerivedLevel, IcingType, IcingRisk, float]] = [icing_levels[0]]
 
     for item in icing_levels[1:]:
         prev_lv = current[-1][0]
         this_lv = item[0]
-        if abs(prev_lv.pressure_hpa - this_lv.pressure_hpa) <= ZONE_MAX_PRESSURE_GAP_HPA:
+        if _adjacent(prev_lv, this_lv):
             current.append(item)
         else:
             zones.append(build_zone_fn(current))

--- a/src/weatherbrief/analysis/sounding/icing_common.py
+++ b/src/weatherbrief/analysis/sounding/icing_common.py
@@ -233,25 +233,12 @@ def group_icing_levels(
 ) -> list:
     """Group adjacent icing levels into zones using shared adjacency logic.
 
-    When *all_levels* is provided (the full pre-gated input list, in
-    the iteration order the caller used), two icing entries merge into
-    the same zone iff **both**: they were directly consecutive in
-    *all_levels* (so nothing was filtered out between them by the
-    caller's gate), **and** their pressure gap is ≤
-    ``ZONE_MAX_PRESSURE_GAP_HPA`` (so a sparse input doesn't merge
-    levels that are physically far apart).
-
-    The index check fixes the cloud-gap bridging bug — see the
-    fix/icing-zones-respect-cloud-gaps regression in test_icing.py.
-    The pressure check preserves the legacy split for sparse inputs
-    where two surviving levels happen to be the only entries either
-    side of a wide gap.
-
-    Without *all_levels* we fall back to the legacy pressure-gap
-    heuristic alone. That heuristic is fragile: at typical 25 hPa
-    spacing the threshold of 100 hPa exactly matches the spacing
-    across a 3-level NWP cloud-band gap, so two cloud-gated icing
-    zones get merged across a "no cloud" stretch.
+    With *all_levels* (the pre-gated input the caller iterated), two
+    icing entries merge iff (a) directly consecutive in *all_levels*
+    so no level was filtered between them, AND (b) pressure gap ≤
+    ``ZONE_MAX_PRESSURE_GAP_HPA``. Without *all_levels*, falls back to
+    pressure-only (legacy, vulnerable to cloud-gap bridging — see
+    bug #7 in designs/icing-models-analysis.md).
 
     Args:
         icing_levels: Tuples of (level, icing_type, risk, index_value),

--- a/src/weatherbrief/analysis/sounding/sfip.py
+++ b/src/weatherbrief/analysis/sounding/sfip.py
@@ -388,10 +388,6 @@ def assess_sfip_zones(
     if not sfip_levels:
         return []
 
-    # Group adjacent levels into zones (shared adjacency logic).
-    # Pass *levels* so the grouper splits zones at gating-induced gaps —
-    # SFIP gates per-level on either NWP or DD cloud layers, and either
-    # method can produce gaps that the grouper must respect.
     return group_icing_levels(sfip_levels, _build_sfip_zone, all_levels=levels)
 
 

--- a/src/weatherbrief/analysis/sounding/sfip.py
+++ b/src/weatherbrief/analysis/sounding/sfip.py
@@ -388,8 +388,11 @@ def assess_sfip_zones(
     if not sfip_levels:
         return []
 
-    # Group adjacent levels into zones (shared adjacency logic)
-    return group_icing_levels(sfip_levels, _build_sfip_zone)
+    # Group adjacent levels into zones (shared adjacency logic).
+    # Pass *levels* so the grouper splits zones at gating-induced gaps —
+    # SFIP gates per-level on either NWP or DD cloud layers, and either
+    # method can produce gaps that the grouper must respect.
+    return group_icing_levels(sfip_levels, _build_sfip_zone, all_levels=levels)
 
 
 def _build_sfip_zone(

--- a/tests/test_icing.py
+++ b/tests/test_icing.py
@@ -398,18 +398,7 @@ def test_ieng_none_clouds_returns_empty():
     assert assess_icing_zones_ieng(levels, [], nwp_cloud_mid_pct=80.0) == []
 
 
-# --- Cloud-gap respect: zones must split at cloud-band gaps ---
-#
-# Regression: GFS produces three discrete NWP cloud bands (low/mid/high)
-# with real altitude gaps between them. When icing-prone levels exist on
-# both sides of a gap, the legacy pressure-gap heuristic in
-# ``group_icing_levels`` (≤ 100 hPa) bridges across the gap because at
-# typical 25 hPa spacing a 3-level cloud-band gap collapses to exactly
-# 100 hPa between surviving icing levels. The result was one big icing
-# zone displayed across "blue sky" in the cross-section — see
-# investigation 2026-05-02 on flight kpao_kgcn-2026-05-05-dc1b pt13.
-# The fix is index-based grouping: surviving icing levels only merge
-# when they are *directly consecutive* in the pre-gated input.
+# --- Zones must split at gating-induced cloud-band gaps (PR #106) ---
 
 
 def test_ogimet_nwp_does_not_bridge_cloud_band_gap():
@@ -477,12 +466,32 @@ def test_ogimet_nwp_single_band_still_one_zone():
     assert len(zones) == 1
 
 
-def test_ogimet_dd_does_not_bridge_dd_cloud_gap():
-    """Same fix applies to Ogimet-DD when DD clouds happen to have gaps.
+def test_ieng_does_not_bridge_cloud_band_gap():
+    """IENG uses the same NWP gating as Ogimet-NWP — must also split at gaps."""
+    from weatherbrief.analysis.sounding.icing import assess_icing_zones_ieng
 
-    DD clouds are usually continuous (RH-derived) so this case is rare,
-    but the fix in the shared grouper must cover it consistently.
-    """
+    icing_T = -7.0
+    levels = [
+        DerivedLevel(pressure_hpa=700, altitude_ft=9900, temperature_c=icing_T,
+                     dewpoint_c=icing_T - 0.5, dewpoint_depression_c=0.5),
+        DerivedLevel(pressure_hpa=675, altitude_ft=10840, temperature_c=icing_T,
+                     dewpoint_c=icing_T - 0.5, dewpoint_depression_c=0.5),
+        DerivedLevel(pressure_hpa=625, altitude_ft=12810, temperature_c=icing_T,
+                     dewpoint_c=icing_T - 0.5, dewpoint_depression_c=0.5),
+        DerivedLevel(pressure_hpa=600, altitude_ft=13840, temperature_c=icing_T,
+                     dewpoint_c=icing_T - 0.5, dewpoint_depression_c=0.5),
+        DerivedLevel(pressure_hpa=550, altitude_ft=16020, temperature_c=icing_T,
+                     dewpoint_c=icing_T - 0.5, dewpoint_depression_c=0.5),
+        DerivedLevel(pressure_hpa=525, altitude_ft=17170, temperature_c=icing_T,
+                     dewpoint_c=icing_T - 0.5, dewpoint_depression_c=0.5),
+    ]
+    bands = [_cloud(4088, 11477), _cloud(15679, 20851)]
+    zones = assess_icing_zones_ieng(levels, bands, nwp_cloud_mid_pct=80.0)
+    assert len(zones) == 2, f"IENG: expected 2 zones split at cloud gap, got {len(zones)}"
+
+
+def test_ogimet_dd_does_not_bridge_dd_cloud_gap():
+    """Same fix applies to Ogimet-DD when DD clouds happen to have gaps."""
     icing_T = -7.0
     icing_TD = -7.5
     levels = [

--- a/tests/test_icing.py
+++ b/tests/test_icing.py
@@ -491,23 +491,69 @@ def test_ieng_does_not_bridge_cloud_band_gap():
 
 
 def test_ogimet_dd_does_not_bridge_dd_cloud_gap():
-    """Same fix applies to Ogimet-DD when DD clouds happen to have gaps."""
+    """DD-gated Ogimet must split at cloud-band gaps even when surviving levels
+    are within ≤100 hPa pressure (the case the legacy heuristic would merge).
+
+    Setup: surviving icing levels at 675 hPa (in band 1) and 600 hPa (in band 2)
+    are 75 hPa apart — old code merges, new code splits because indices 1 and 4
+    in `levels` are not consecutive (650 and 625 were filtered out).
+    """
     icing_T = -7.0
     icing_TD = -7.5
     levels = [
         DerivedLevel(pressure_hpa=700, altitude_ft=9900, temperature_c=icing_T,
                      dewpoint_c=icing_TD, dewpoint_depression_c=0.5),
-        DerivedLevel(pressure_hpa=650, altitude_ft=11810, temperature_c=icing_T,
-                     dewpoint_c=icing_TD, dewpoint_depression_c=5.0),  # DD too high → gated out
-        DerivedLevel(pressure_hpa=600, altitude_ft=13840, temperature_c=icing_T,
-                     dewpoint_c=icing_TD, dewpoint_depression_c=5.0),  # gated out
-        DerivedLevel(pressure_hpa=550, altitude_ft=16020, temperature_c=icing_T,
+        DerivedLevel(pressure_hpa=675, altitude_ft=10800, temperature_c=icing_T,
+                     dewpoint_c=icing_TD, dewpoint_depression_c=0.5),
+        DerivedLevel(pressure_hpa=650, altitude_ft=11800, temperature_c=icing_T,
+                     dewpoint_c=icing_TD, dewpoint_depression_c=0.5),  # outside band → gated
+        DerivedLevel(pressure_hpa=625, altitude_ft=12800, temperature_c=icing_T,
+                     dewpoint_c=icing_TD, dewpoint_depression_c=0.5),  # outside band → gated
+        DerivedLevel(pressure_hpa=600, altitude_ft=13800, temperature_c=icing_T,
                      dewpoint_c=icing_TD, dewpoint_depression_c=0.5),
     ]
-    # Two DD cloud bands with a gap, mirroring NWP shape
-    bands = [_cloud(8000, 12000), _cloud(15500, 17000)]
+    # Two DD cloud bands with a 13000-ft gap. ±500 ft margin ⇒ band 1 covers
+    # 7500-11500, band 2 covers 13000-15500. 11800 and 12800 land in the gap.
+    bands = [_cloud(8000, 11000), _cloud(13500, 15000)]
     zones = assess_icing_zones_ogimet_dd(levels, bands)
-    assert len(zones) == 2, f"expected 2 DD zones split at cloud gap, got {len(zones)}"
+    assert len(zones) == 2, f"expected 2 DD zones split at cloud gap, got {len(zones)}: {[(int(z.base_ft), int(z.top_ft)) for z in zones]}"
+
+
+def test_sfip_does_not_bridge_cloud_band_gap():
+    """SFIP (full variant, NWP-gated) must split at cloud-band gaps.
+
+    Mirrors the Ogimet-NWP regression for the SFIP code path. With CLW
+    set on every level, SFIP uses NWP cloud gating; the levels in the
+    band gap are filtered out and the surviving levels on either side
+    must form separate zones.
+    """
+    from weatherbrief.analysis.sounding.sfip import assess_sfip_zones
+
+    def _l(p, alt, t):
+        return DerivedLevel(
+            pressure_hpa=p, altitude_ft=alt, temperature_c=t,
+            dewpoint_c=t - 0.5, relative_humidity_pct=96.0,
+            dewpoint_depression_c=0.5, cloud_liquid_water_g_kg=0.15,
+        )
+
+    levels = [
+        _l(750, 8100, -6.0),    # band 1
+        _l(725, 9000, -7.0),    # band 1
+        _l(700, 9900, -8.0),    # band 1
+        _l(675, 10800, -9.0),   # gap — gated out (10800 > 10500 + 500)
+        _l(650, 11800, -10.0),  # gap — gated out
+        _l(600, 13800, -12.0),  # band 2
+        _l(575, 14900, -13.0),  # band 2
+    ]
+    bands = [
+        EnhancedCloudLayer(base_ft=4000, top_ft=10500, source="grib", coverage=CloudCoverage.BKN),
+        EnhancedCloudLayer(base_ft=13000, top_ft=16000, source="grib", coverage=CloudCoverage.OVC),
+    ]
+    zones = assess_sfip_zones(
+        levels, nwp_cloud_layers=bands,
+        nwp_cloud_low_pct=80.0, nwp_cloud_mid_pct=99.0,
+    )
+    assert len(zones) == 2, f"SFIP: expected 2 zones split at cloud gap, got {len(zones)}: {[(int(z.base_ft), int(z.top_ft)) for z in zones]}"
 
 
 def test_ogimet_nwp_zero_cloud_pct_no_icing():

--- a/tests/test_icing.py
+++ b/tests/test_icing.py
@@ -398,6 +398,109 @@ def test_ieng_none_clouds_returns_empty():
     assert assess_icing_zones_ieng(levels, [], nwp_cloud_mid_pct=80.0) == []
 
 
+# --- Cloud-gap respect: zones must split at cloud-band gaps ---
+#
+# Regression: GFS produces three discrete NWP cloud bands (low/mid/high)
+# with real altitude gaps between them. When icing-prone levels exist on
+# both sides of a gap, the legacy pressure-gap heuristic in
+# ``group_icing_levels`` (≤ 100 hPa) bridges across the gap because at
+# typical 25 hPa spacing a 3-level cloud-band gap collapses to exactly
+# 100 hPa between surviving icing levels. The result was one big icing
+# zone displayed across "blue sky" in the cross-section — see
+# investigation 2026-05-02 on flight kpao_kgcn-2026-05-05-dc1b pt13.
+# The fix is index-based grouping: surviving icing levels only merge
+# when they are *directly consecutive* in the pre-gated input.
+
+
+def test_ogimet_nwp_does_not_bridge_cloud_band_gap():
+    """Two NWP cloud bands with a gap → two icing zones, not one merged."""
+    # Mimic GFS pt13 shape: lower band 4088-11477, mid band 15679-20851.
+    # Levels at 700/675 hPa are inside lower; 650/625/600/575 are in the
+    # gap (filtered by gating); 550/525/500 are inside mid.
+    icing_T = -7.0  # peak Ogimet index temperature
+    icing_TD = -7.5  # tight DD → nonzero index
+    levels = [
+        DerivedLevel(pressure_hpa=700, altitude_ft=9900, temperature_c=icing_T,
+                     dewpoint_c=icing_TD, dewpoint_depression_c=0.5),
+        DerivedLevel(pressure_hpa=675, altitude_ft=10840, temperature_c=icing_T,
+                     dewpoint_c=icing_TD, dewpoint_depression_c=0.5),
+        # Gap levels — same icing-prone profile but should be gated out
+        DerivedLevel(pressure_hpa=650, altitude_ft=11810, temperature_c=icing_T,
+                     dewpoint_c=icing_TD, dewpoint_depression_c=0.5),
+        DerivedLevel(pressure_hpa=625, altitude_ft=12810, temperature_c=icing_T,
+                     dewpoint_c=icing_TD, dewpoint_depression_c=0.5),
+        DerivedLevel(pressure_hpa=600, altitude_ft=13840, temperature_c=icing_T,
+                     dewpoint_c=icing_TD, dewpoint_depression_c=0.5),
+        DerivedLevel(pressure_hpa=575, altitude_ft=14910, temperature_c=icing_T,
+                     dewpoint_c=icing_TD, dewpoint_depression_c=0.5),
+        # Levels inside the mid cloud band
+        DerivedLevel(pressure_hpa=550, altitude_ft=16020, temperature_c=icing_T,
+                     dewpoint_c=icing_TD, dewpoint_depression_c=0.5),
+        DerivedLevel(pressure_hpa=525, altitude_ft=17170, temperature_c=icing_T,
+                     dewpoint_c=icing_TD, dewpoint_depression_c=0.5),
+    ]
+    bands = [
+        _cloud(4088, 11477),  # lower
+        _cloud(15679, 20851),  # mid
+    ]
+    zones = assess_icing_zones_ogimet_nwp(levels, bands, nwp_cloud_mid_pct=80.0)
+
+    # Expect TWO zones, one per cloud band.
+    assert len(zones) == 2, f"expected 2 zones split at cloud gap, got {len(zones)}: {[(z.base_ft, z.top_ft) for z in zones]}"
+
+    # Lower zone sits inside the lower cloud band.
+    assert zones[0].base_ft >= 4088 - 500  # within ±CLOUD_MARGIN_FT
+    assert zones[0].top_ft <= 11477 + 500
+    # Upper zone sits inside the mid cloud band.
+    assert zones[1].base_ft >= 15679 - 500
+    assert zones[1].top_ft <= 20851 + 500
+
+
+def test_ogimet_nwp_single_band_still_one_zone():
+    """Sanity: a single cloud band with continuous icing → still ONE zone.
+
+    The cloud-gap fix must not over-split: when all icing levels are
+    directly consecutive in the input, the grouper should still merge
+    them into one zone exactly like before.
+    """
+    levels = [
+        DerivedLevel(pressure_hpa=750, altitude_ft=8100, temperature_c=-5.0,
+                     dewpoint_c=-5.5, dewpoint_depression_c=0.5),
+        DerivedLevel(pressure_hpa=725, altitude_ft=8990, temperature_c=-6.0,
+                     dewpoint_c=-6.5, dewpoint_depression_c=0.5),
+        DerivedLevel(pressure_hpa=700, altitude_ft=9900, temperature_c=-7.0,
+                     dewpoint_c=-7.5, dewpoint_depression_c=0.5),
+    ]
+    zones = assess_icing_zones_ogimet_nwp(
+        levels, [_cloud(7000, 11000)], nwp_cloud_mid_pct=80.0,
+    )
+    assert len(zones) == 1
+
+
+def test_ogimet_dd_does_not_bridge_dd_cloud_gap():
+    """Same fix applies to Ogimet-DD when DD clouds happen to have gaps.
+
+    DD clouds are usually continuous (RH-derived) so this case is rare,
+    but the fix in the shared grouper must cover it consistently.
+    """
+    icing_T = -7.0
+    icing_TD = -7.5
+    levels = [
+        DerivedLevel(pressure_hpa=700, altitude_ft=9900, temperature_c=icing_T,
+                     dewpoint_c=icing_TD, dewpoint_depression_c=0.5),
+        DerivedLevel(pressure_hpa=650, altitude_ft=11810, temperature_c=icing_T,
+                     dewpoint_c=icing_TD, dewpoint_depression_c=5.0),  # DD too high → gated out
+        DerivedLevel(pressure_hpa=600, altitude_ft=13840, temperature_c=icing_T,
+                     dewpoint_c=icing_TD, dewpoint_depression_c=5.0),  # gated out
+        DerivedLevel(pressure_hpa=550, altitude_ft=16020, temperature_c=icing_T,
+                     dewpoint_c=icing_TD, dewpoint_depression_c=0.5),
+    ]
+    # Two DD cloud bands with a gap, mirroring NWP shape
+    bands = [_cloud(8000, 12000), _cloud(15500, 17000)]
+    zones = assess_icing_zones_ogimet_dd(levels, bands)
+    assert len(zones) == 2, f"expected 2 DD zones split at cloud gap, got {len(zones)}"
+
+
 def test_ogimet_nwp_zero_cloud_pct_no_icing():
     """0% NWP cloud cover in matching band → no icing despite cloud layer."""
     levels = [

--- a/tests/test_icing.py
+++ b/tests/test_icing.py
@@ -467,27 +467,33 @@ def test_ogimet_nwp_single_band_still_one_zone():
 
 
 def test_ieng_does_not_bridge_cloud_band_gap():
-    """IENG uses the same NWP gating as Ogimet-NWP — must also split at gaps."""
+    """IENG uses the same NWP gating as Ogimet-NWP — must also split at gaps.
+
+    Surviving icing levels at 675 hPa (band 1) and 600 hPa (band 2) are
+    75 hPa apart — within the 100 hPa legacy threshold — so the old
+    pressure-only path would merge them. The new dual-check splits
+    because index 1 and index 4 in `levels` are not consecutive.
+    """
     from weatherbrief.analysis.sounding.icing import assess_icing_zones_ieng
 
     icing_T = -7.0
     levels = [
         DerivedLevel(pressure_hpa=700, altitude_ft=9900, temperature_c=icing_T,
                      dewpoint_c=icing_T - 0.5, dewpoint_depression_c=0.5),
-        DerivedLevel(pressure_hpa=675, altitude_ft=10840, temperature_c=icing_T,
+        DerivedLevel(pressure_hpa=675, altitude_ft=10800, temperature_c=icing_T,
                      dewpoint_c=icing_T - 0.5, dewpoint_depression_c=0.5),
-        DerivedLevel(pressure_hpa=625, altitude_ft=12810, temperature_c=icing_T,
-                     dewpoint_c=icing_T - 0.5, dewpoint_depression_c=0.5),
-        DerivedLevel(pressure_hpa=600, altitude_ft=13840, temperature_c=icing_T,
-                     dewpoint_c=icing_T - 0.5, dewpoint_depression_c=0.5),
-        DerivedLevel(pressure_hpa=550, altitude_ft=16020, temperature_c=icing_T,
-                     dewpoint_c=icing_T - 0.5, dewpoint_depression_c=0.5),
-        DerivedLevel(pressure_hpa=525, altitude_ft=17170, temperature_c=icing_T,
+        DerivedLevel(pressure_hpa=650, altitude_ft=11800, temperature_c=icing_T,
+                     dewpoint_c=icing_T - 0.5, dewpoint_depression_c=0.5),  # outside bands → gated
+        DerivedLevel(pressure_hpa=625, altitude_ft=12800, temperature_c=icing_T,
+                     dewpoint_c=icing_T - 0.5, dewpoint_depression_c=0.5),  # outside bands → gated
+        DerivedLevel(pressure_hpa=600, altitude_ft=13800, temperature_c=icing_T,
                      dewpoint_c=icing_T - 0.5, dewpoint_depression_c=0.5),
     ]
-    bands = [_cloud(4088, 11477), _cloud(15679, 20851)]
+    # ±500 ft margin ⇒ band 1 covers 7500-11500, band 2 covers 13000-15500.
+    # 11800 and 12800 land in the gap.
+    bands = [_cloud(8000, 11000), _cloud(13500, 15000)]
     zones = assess_icing_zones_ieng(levels, bands, nwp_cloud_mid_pct=80.0)
-    assert len(zones) == 2, f"IENG: expected 2 zones split at cloud gap, got {len(zones)}"
+    assert len(zones) == 2, f"IENG: expected 2 zones split at cloud gap, got {len(zones)}: {[(int(z.base_ft), int(z.top_ft)) for z in zones]}"
 
 
 def test_ogimet_dd_does_not_bridge_dd_cloud_gap():
@@ -536,12 +542,15 @@ def test_sfip_does_not_bridge_cloud_band_gap():
             dewpoint_depression_c=0.5, cloud_liquid_water_g_kg=0.15,
         )
 
+    # ±500 ft margin ⇒ band 1 covers 3500-11000, band 2 covers 12500-16500.
+    # 650 hPa at 11800 ft lands in the gap and is the only filtered level;
+    # 675 hPa at 10800 ft is still inside band 1 via the margin.
     levels = [
         _l(750, 8100, -6.0),    # band 1
         _l(725, 9000, -7.0),    # band 1
         _l(700, 9900, -8.0),    # band 1
-        _l(675, 10800, -9.0),   # gap — gated out (10800 > 10500 + 500)
-        _l(650, 11800, -10.0),  # gap — gated out
+        _l(675, 10800, -9.0),   # band 1 (10800 < 11000 with margin)
+        _l(650, 11800, -10.0),  # gap — gated out (11800 > 11000 and < 12500)
         _l(600, 13800, -12.0),  # band 2
         _l(575, 14900, -13.0),  # band 2
     ]


### PR DESCRIPTION
## Summary

- Icing zones (Ogimet-DD/NWP, IENG, SFIP) were bridging cloud-band gaps because the shared `group_icing_levels` heuristic merged surviving icing levels whose pressure gap was ≤ 100 hPa — exactly the spacing produced by a 3-level NWP cloud-band gap at 25 hPa input resolution.
- Reproduced on prod flight `kpao_kgcn-2026-05-05-dc1b` GFS pt13: NWP cloud bands at `4088-11477` and `15679-20851` ft (real gap FL114-FL157), but `icing_ogimet_nwp_zones` produced a single `7257-18442` ft zone bridging it. Visible to the user as "icing over blue sky" in the cross-section.
- Fix: `group_icing_levels` now optionally takes the pre-gated input list. Surviving icing levels merge iff (a) directly consecutive in that list — no level filtered between them — AND (b) pressure gap ≤ legacy threshold. All four icing zone-builders updated to pass `all_levels`.

## Why both checks

The index check fixes the gating-bridge bug. The pressure check preserves the legacy split for sparse inputs (e.g. `test_zones_split_by_gap` constructs a two-level input with a wide pressure gap and expects them to split — index-only would have merged them since they're "consecutive" in a 2-element list).

## Scope of impact

| Method | Gating | Bug-prone before |
|---|---|---|
| Ogimet-DD | DD cloud layers | rare (DD usually continuous) |
| **Ogimet-NWP** | NWP cloud layers | **YES** — main symptom |
| **IENG** | NWP cloud layers | **YES** — same gating |
| **SFIP** | NWP or DD per-level | **YES** when CLW present |

`e_shear.py` has its own grouping (different domain — turbulence shear, not icing) — out of scope.

## Test plan

- [x] `pytest tests/test_icing.py tests/test_sfip.py tests/test_clouds.py -q` → 133 passed
- [x] Full suite (`pytest tests/ --ignore=tests/test_llm_digest.py`) → 1542 passed (one unrelated `test_grib_pool` flake from pool-state pollution; passes in isolation)
- [x] Synthetic reproduction of GFS pt13 case: 1 merged zone → 2 split zones, gap respected
- [ ] Post-deploy spot-check: refresh `kpao_kgcn-2026-05-05-dc1b` and confirm cross-section no longer shows icing in the FL114-FL157 gap

🤖 Generated with [Claude Code](https://claude.com/claude-code)