### PR TITLE
feat(freshness): marker-based per-source decision system (#108)

### DIFF
--- a/alembic/versions/050_pack_model_sources.py
+++ b/alembic/versions/050_pack_model_sources.py
@@ -1,0 +1,38 @@
+"""Add model_sources_json to briefing_packs (issue #108).
+
+Records which source produced each model's data in a pack (e.g.
+``{"ecmwf": "ecmwf:direct", "gfs": "gfs:openmeteo"}``).  Used by the
+new marker-based freshness check to know which freshness marker to
+compare against per model.
+
+Nullable so legacy packs created before this column work fine — the
+freshness check infers source from ``grib_init_times`` presence in
+that case.
+
+Revision ID: 050
+Revises: 049
+Create Date: 2026-05-03
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "050"
+down_revision: Union[str, None] = "049"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("briefing_packs") as batch_op:
+        batch_op.add_column(
+            sa.Column("model_sources_json", sa.Text, nullable=True),
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("briefing_packs") as batch_op:
+        batch_op.drop_column("model_sources_json")

--- a/designs/INDEX.md
+++ b/designs/INDEX.md
@@ -18,8 +18,13 @@ Key exports: `ForecastSnapshot`, `RouteConfig`, `RoutePoint`, `RouteCrossSection
 
 ### fetch
 Weather data retrieval: Open-Meteo multi-point client, route interpolation, route-aware text forecasts (NWS AFD for US, DWD for Europe), Autorouter GRAMET, SRTM elevation, model freshness, GRIB2 enrichment (GFS + ICON-EU + ECMWF IFS via ECPDS) with two-phase sequential decode for memory safety.
-Key exports: `OpenMeteoClient`, `interpolate_route`, `fetch_text_forecasts`, `AutorouterGramet`, `get_elevation_profile`, `check_freshness`, `enrich_forecasts`
+Key exports: `OpenMeteoClient`, `interpolate_route`, `fetch_text_forecasts`, `AutorouterGramet`, `get_elevation_profile`, `enrich_forecasts`
 → Full doc: fetch.md
+
+### freshness-markers
+Marker-based per-(model, source) staleness decision used by `/packs/freshness` + auto-refresh. In-memory `MarkerStore` populated by a 5-min loop; pure-compute lookup in the HTTP path. Horizon-aware comparison against pack `model_sources`. Admin endpoint surfaces observed delivery delays vs. registry expectation for ongoing calibration.
+Key exports: `SOURCE_REGISTRY`, `MarkerStore`, `get_store`, `check_source`, `run_freshness_loop`, `_build_data_status`
+→ Full doc: freshness-markers.md
 
 ### analysis
 Aviation-specific analysis: wind components, MetPy sounding analysis (thermodynamics, DD/NWP cloud methods, four icing methods — Ogimet-DD/Ogimet-NWP/SFIP-NWP/IENG-NWP, inversions, convective, vertical motion/CAT), altitude advisories, model divergence scoring. Icing gated by `is_in_cloud_layer()` consistent with cloud display layers. Icing and cloud methods selectable via user preferences.

--- a/designs/fetch.md
+++ b/designs/fetch.md
@@ -170,21 +170,24 @@ profile = get_elevation_profile(route)
 - Saved as `elevation_profile.json` in the pack directory
 - Runs early in the pipeline (before fetch) since it doesn't depend on NWP data
 
-## Model Freshness (`fetch/model_status.py`)
+## Model Freshness (`fetch/freshness/`)
 
-Checks whether NWP models have published new initialization runs since the last fetch.
+Marker-based per-(model, source) staleness decision used by `/packs/freshness` and the auto-refresh scheduler. Replaces the old per-call `meta.json` fan-out — most freshness HTTP calls are now pure compute (no I/O).
+
+A 5-min background loop populates an in-memory `MarkerStore`. The HTTP-side check is `api/packs._build_data_status(pack, flight)`, which compares each `(model, source)` recorded on the pack against the matching marker — horizon-aware, so a new run only flags stale if its forecast horizon actually covers the flight's end time.
 
 ```python
-from weatherbrief.fetch.model_status import check_freshness
-result = check_freshness(last_pack_init_times)
-# → {"fresh": False, "stale_models": ["gfs"], "model_init_times": {...}}
+# Used by /packs/freshness handler + scheduler auto-refresh:
+status = _build_data_status(pack, flight)
+if not status.fresh:
+    schedule_refresh()
 ```
 
-- Queries Open-Meteo metadata API for current model init times (GFS, ECMWF, ICON, UKMO, MeteoFrance)
-- Compares against `model_init_times` stored on the previous pack
-- DWD text forecasts checked on assumed update schedule (06:00/18:00 UTC short-range, 10:30 UTC medium-range)
-- `compute_next_update()` estimates when the next model run will be available
-- Smart refresh in the API: skips pipeline if all models are still fresh
+Eight tracked source/model pairs: ECMWF/GFS/ICON-EU direct (GRIB) + 5 Open-Meteo republishes (`gfs/ecmwf/icon/meteofrance/ukmo:openmeteo`).
+
+The legacy `fetch/model_status.py` module (`fetch_model_metadata`, `compute_next_update`) is still imported by `_finalize_refresh` to record per-model Open-Meteo init times on each pack. `check_freshness` and `compute_next_update` are no longer consumed by the freshness endpoint.
+
+→ Full doc: [freshness-markers.md](./freshness-markers.md)
 
 ## GRIB2 Enrichment (`fetch/grib/`)
 

--- a/designs/freshness-markers.md
+++ b/designs/freshness-markers.md
@@ -1,0 +1,107 @@
+# Freshness Markers
+
+> Marker-based per-(model, source) decision system for "is this pack stale?" — replaces per-call Open-Meteo `meta.json` fan-out with an in-memory marker store gated by a hardcoded schedule registry.
+
+## Intent
+
+The old freshness path (`fetch/model_status.check_freshness`) called Open-Meteo's `meta.json` for **all 5 models on every freshness check**, and never considered direct-GRIB sources at all. Three concrete problems addressed by this redesign:
+
+1. **Wasted HTTP** — N polling clients × M endpoints per freshness call.
+2. **Wasted refreshes** — auto-refresh fired before our 00Z ECMWF GRIB had landed (ready ~06:40Z, fired at 07:07Z), refreshing against stale data.
+3. **Direct ECMWF GRIB freshness was invisible** — packs recorded `grib_init_times["ecmwf"]` but `_build_data_status` only consulted `model_init_times` (Open-Meteo).
+
+What should NOT change:
+- The pure-compute property: `now < pack.next_expected_update` ⇒ fresh, no I/O. Most freshness HTTP calls are a dict lookup, not a network round-trip.
+- The marker store stays **in-memory only**. No DB persistence — bootstrap from registry on restart (~2s of inline-fallback cost). Adding persistence would widen scope; the admin endpoint covers debugging.
+- Per-(model, source) granularity. The same logical model can be sourced multiple ways (`ecmwf:direct` vs `ecmwf:openmeteo`), and which one a pack used is a per-pack property — recorded as `pack.model_sources`.
+
+## Architecture
+
+Three modules under `src/weatherbrief/fetch/freshness/`:
+
+| Module | Purpose |
+|---|---|
+| `registry.py` | `SourceConfig` dataclass, `SOURCE_REGISTRY` dict (8 source/model pairs), pure functions: `next_run_after`, `next_cycle_after`, `run_horizon`, `cycle_init_for`, `expected_delivery_for_init`, `initial_marker_for`. |
+| `markers.py` | `Marker` dataclass + `MarkerStore` (asyncio-locked, singleton via `get_store()`). Records `(cycle_init, arrival_wallclock)` observations in a maxlen=100 deque. |
+| `sources.py` | Unified `check_source(source, model)` dispatch wrapping existing helpers (`grib_fetch.find_latest_run` for GFS/NOAA, `icon_eu_fetch.find_latest_icon_eu_run` for ICON-EU/DWD, `ecmwf_watcher.get_latest_ready` for ECMWF/direct, `model_status.fetch_model_metadata` for `*:openmeteo`). |
+
+The 5-min loop lives in `scheduler.run_freshness_loop` — bootstraps the store, then on each tick: for every `(source, model)` whose `next_expected` has passed, run `check_source` (offloaded to a thread), call `store.update`. Most ticks no-op.
+
+The HTTP-side check is `api/packs._build_data_status(pack, flight)`:
+
+```
+for (model, source) in pack.model_sources or _backfill_sources(pack):
+  marker = store.get_sync(source, model_for_source(source))
+  if marker is None or marker.is_stale(loop_interval):
+    marker_health = "suspect"
+    marker = inline-fallback dynamic check
+  pack_init = grib_init_times[m] if source ends in :direct/:noaa/:dwd else model_init_times[m]
+  horizon = registry.run_horizon(source, marker.init)
+  stale iff marker.init > pack_init AND (marker.init + horizon) >= flight_end
+```
+
+Horizon-awareness matters for ICON-EU: a new 15Z intermediate run (78h) won't replace a 12Z main run (120h) for a flight needing 100h coverage.
+
+## Usage Examples
+
+```python
+# Read marker state from anywhere (sync, no lock):
+from weatherbrief.fetch.freshness.markers import get_store
+m = get_store().get_sync("ecmwf:direct", "ecmwf")
+if m.is_stale(loop_interval=timedelta(seconds=300)):
+    ...  # heartbeat suspect — fall back to inline check
+
+# Run freshness check for a pack (used by /packs/freshness + auto-refresh):
+from weatherbrief.api.packs import _build_data_status
+status = _build_data_status(pack, flight)  # DataStatus with per-model state
+if not status.fresh:
+    # at least one source has newer data covering the flight horizon
+    schedule_refresh()
+
+# Inspect calibration via admin endpoint:
+# GET /api/admin/freshness/markers
+# Returns per-marker observations (with delay_s) and per-cycle-hour
+# calibration: count / median_delay_s / p90_delay_s / configured_offset_s /
+# drift_p90_vs_config_s.
+```
+
+## Key Choices
+
+- **In-memory only.** Lost on restart, ~2s bootstrap cost. Admin endpoint provides debugging visibility; no DB persistence in scope.
+- **Source key prefix → model name.** `("icon_eu:dwd", "icon_eu")` vs `("icon:openmeteo", "icon")` — the marker store key is `(source, source.split(":", 1)[0])`. Pack-side may map the same logical pack-model name (`"icon"`) to either source; `model_for_source()` strips the suffix to find the marker.
+- **Min-rule for staleness.** If *any* source has new data covering the flight, the pack is stale. Avoids per-model weighting heuristics. If a refresh fires for a less-useful source, it just falls back to the previous source — no harm.
+- **Horizon-aware.** Without this, a 78h intermediate ICON-EU run would wrongly invalidate a 120h main-run pack for long-haul flights.
+- **Exponential slip backoff.** `slip_bump(n) = min(retry_interval × 2^(n-1), max_retry_interval)`. Default base 10min, cap 1h, 8 slips → ~6h before cycle-jump. Replaces uniform `retry_interval × 12 = 2h` cap that hammered slow-publishing OM endpoints.
+- **`(cycle_init, arrival_wallclock)` observations.** Stored as tuples in a 100-entry deque per marker. Lets the admin endpoint compute per-cycle-hour median/p90 delay vs. registry expectation, surfacing drift without needing log retention or a DB table.
+- **Pack `model_sources` recorded at enrichment time, backfilled at read time.** Legacy packs missing the column infer source from `grib_init_times` presence (a model in `grib_init_times` → direct; otherwise OM).
+
+## Patterns
+
+When adding a new (source, model) pair:
+1. Add a `SourceConfig` to `SOURCE_REGISTRY` with cycles, delivery_offset, horizon, readiness_check symbol.
+2. Add a wrapper to `sources._DISPATCH` mapping the readiness_check symbol → callable returning `datetime | None`.
+3. If the source produces a new model name not seen by `_finalize_refresh`, extend `_DIRECT_SOURCE_KEYS` in `api/packs.py` so `model_sources` records correctly.
+
+When tuning registry offsets:
+1. Wait several days, then `curl /api/admin/freshness/markers`.
+2. Read `calibration[].drift_p90_vs_config_s` for each (source, cycle_hour). Negative → registry too generous, positive → too tight.
+3. Update `delivery_offset` to `p90 + 30min` margin and redeploy. The deque auto-resets; the loop will recalibrate after a few cycles.
+
+## Gotchas
+
+- **Bootstrap is wall-clock dependent.** `initial_marker_for` picks the most-recent cycle whose expected delivery is at-or-before now, falling back one cycle if not yet due. Tests must inject `now=` explicitly to be deterministic.
+- **`marker.is_stale(loop_interval)` is heartbeat, not data freshness.** Returns True if `last_check is None` or older than `2 × loop_interval`. Used to surface `marker_health="suspect"` and trigger inline-check fallback. Not a comment on the underlying data.
+- **Open-Meteo ECMWF cycles are tracked as `(0, 12)` only.** OM publishes 06/18 as `bc-runs` with heavy lag (per issue #100); tracking them would cause the marker to bounce on bc-run shuffles.
+- **OM ICON cycles are `(0, 6, 12, 18)` not 3-hourly.** Even though DWD itself runs ICON every 3h, OM's `meta.json` reports `update_interval_seconds: 21600` — OM only republishes the 6-hourly main runs.
+- **The in-memory deque is lost on process restart.** Calibration data builds up over a few days then resets. If you need durable telemetry, add a SQL table (deferred — not in scope).
+- **Sync `get_sync()` returns a snapshot copy** so callers can't accidentally mutate the live deque. Don't pass markers across coroutines and expect mutations to land — use the async `update`/`mark_check` API.
+
+## References
+
+- Issue #108 (design + acceptance criteria)
+- Existing helpers wrapped: `fetch/model_status.py`, `fetch/grib/{grib_fetch,icon_eu_fetch,ecmwf_watcher}.py`
+- Pack-side: `api/packs.py:_build_data_status`, `_backfill_sources`, `_finalize_refresh` (records `model_sources`)
+- Loop wiring: `scheduler.py:run_freshness_loop`, `api/app.py:lifespan`
+- Admin endpoint: `api/admin.py:freshness_markers`
+- Storage: `BriefingPackMeta.model_sources`, `BriefingPackRow.model_sources_json` (Text JSON, alembic 050)
+- Tests: `tests/test_freshness_{registry,markers,sources}.py`

--- a/src/weatherbrief/api/admin.py
+++ b/src/weatherbrief/api/admin.py
@@ -106,13 +106,13 @@ def freshness_markers(
     Empty marker list if the freshness loop hasn't bootstrapped yet (e.g.
     immediately after restart).
     """
-    from datetime import timedelta
+    import math
 
+    from weatherbrief.fetch.freshness import LOOP_INTERVAL
     from weatherbrief.fetch.freshness.markers import get_store
     from weatherbrief.fetch.freshness.registry import SOURCE_REGISTRY
 
     store = get_store()
-    loop_interval = timedelta(seconds=300)
     out = []
     for (source, model), m in store.all_sync().items():
         observations = []
@@ -133,7 +133,9 @@ def freshness_markers(
                 ds = sorted(delays_by_hour[hour])
                 count = len(ds)
                 median = ds[count // 2]
-                p90_idx = max(0, int(count * 0.9) - 1) if count > 1 else 0
+                # Nearest-rank p90: ceil(count * 0.9) - 1.  ``int()`` would
+                # truncate and underestimate (e.g. count=2 → idx 0 = min, not p90).
+                p90_idx = max(0, math.ceil(count * 0.9) - 1)
                 p90 = ds[p90_idx]
                 configured = int(cfg.offset_for(hour).total_seconds())
                 calibration.append({
@@ -152,12 +154,12 @@ def freshness_markers(
             "next_expected": m.next_expected.isoformat(),
             "last_check": m.last_check.isoformat() if m.last_check else None,
             "slip_count": m.slip_count,
-            "is_stale": m.is_stale(loop_interval),
+            "is_stale": m.is_stale(LOOP_INTERVAL),
             "observations": observations,
             "calibration": calibration,
         })
     out.sort(key=lambda r: r["source"])
-    return {"loop_interval_seconds": int(loop_interval.total_seconds()), "markers": out}
+    return {"loop_interval_seconds": int(LOOP_INTERVAL.total_seconds()), "markers": out}
 
 
 @router.get("/users")

--- a/src/weatherbrief/api/admin.py
+++ b/src/weatherbrief/api/admin.py
@@ -90,6 +90,76 @@ def _user_disk_bytes(data_dir: Path, user_id: str) -> int:
     return total
 
 
+@router.get("/freshness/markers")
+def freshness_markers(
+    _admin_id: str = Depends(require_admin),
+):
+    """Dump the freshness marker store for debugging + calibration (issue #108).
+
+    For each (source, model) returns:
+    - ``init`` / ``next_expected`` / ``last_check`` / ``slip_count`` — live state.
+    - ``observations`` — recent ``(cycle_init, observed_at, delay_s)`` advances.
+    - ``calibration`` — per-cycle-hour aggregate ``count`` / ``median_delay_s``
+      / ``p90_delay_s`` plus the registry's currently-configured offset, so
+      drift between observed and configured is visible at a glance.
+
+    Empty marker list if the freshness loop hasn't bootstrapped yet (e.g.
+    immediately after restart).
+    """
+    from datetime import timedelta
+
+    from weatherbrief.fetch.freshness.markers import get_store
+    from weatherbrief.fetch.freshness.registry import SOURCE_REGISTRY
+
+    store = get_store()
+    loop_interval = timedelta(seconds=300)
+    out = []
+    for (source, model), m in store.all_sync().items():
+        observations = []
+        delays_by_hour: dict[int, list[int]] = {}
+        for cycle_init, observed_at in m.observations:
+            delay_s = int((observed_at - cycle_init).total_seconds())
+            observations.append({
+                "init": cycle_init.isoformat(),
+                "observed_at": observed_at.isoformat(),
+                "delay_s": delay_s,
+            })
+            delays_by_hour.setdefault(cycle_init.hour, []).append(delay_s)
+
+        cfg = SOURCE_REGISTRY.get(source)
+        calibration = []
+        if cfg is not None:
+            for hour in sorted(delays_by_hour):
+                ds = sorted(delays_by_hour[hour])
+                count = len(ds)
+                median = ds[count // 2]
+                p90_idx = max(0, int(count * 0.9) - 1) if count > 1 else 0
+                p90 = ds[p90_idx]
+                configured = int(cfg.offset_for(hour).total_seconds())
+                calibration.append({
+                    "cycle_hour": hour,
+                    "count": count,
+                    "median_delay_s": median,
+                    "p90_delay_s": p90,
+                    "configured_offset_s": configured,
+                    "drift_p90_vs_config_s": p90 - configured,
+                })
+
+        out.append({
+            "source": source,
+            "model": model,
+            "init": m.init.isoformat(),
+            "next_expected": m.next_expected.isoformat(),
+            "last_check": m.last_check.isoformat() if m.last_check else None,
+            "slip_count": m.slip_count,
+            "is_stale": m.is_stale(loop_interval),
+            "observations": observations,
+            "calibration": calibration,
+        })
+    out.sort(key=lambda r: r["source"])
+    return {"loop_interval_seconds": int(loop_interval.total_seconds()), "markers": out}
+
+
 @router.get("/users")
 def list_users(
     period: str = Query(default="30d", pattern="^(30d|all)$"),

--- a/src/weatherbrief/api/app.py
+++ b/src/weatherbrief/api/app.py
@@ -209,11 +209,18 @@ async def lifespan(app: FastAPI):
             run_hewson_precompute_loop(app.state)
         )
 
+    freshness_task = None
+    if os.environ.get("DISABLE_FRESHNESS_LOOP", "").strip() not in ("1", "true"):
+        from weatherbrief.scheduler import run_freshness_loop
+
+        freshness_task = asyncio.create_task(run_freshness_loop(app.state))
+
     yield
 
     for task in (scheduler_task, retention_task, verification_task,
                  digest_task, forecast_fetch_task, standalone_task,
-                 ecmwf_watcher_task, hewson_precompute_task):
+                 ecmwf_watcher_task, hewson_precompute_task,
+                 freshness_task):
         if task:
             task.cancel()
             with suppress(asyncio.CancelledError):

--- a/src/weatherbrief/api/packs.py
+++ b/src/weatherbrief/api/packs.py
@@ -45,12 +45,8 @@ def _validate_model(model: str) -> str:
     return model
 from weatherbrief.api.flights import _load_flight_or_404, _load_owned_flight
 from flyfun_common.db import current_user_id, get_db, SessionLocal
-from weatherbrief.fetch.model_status import (
-    check_freshness,
-    compute_next_update,
-    fetch_model_metadata,
-)
-from weatherbrief.models import BriefingPackMeta, DiagnosticPublic
+from weatherbrief.fetch.model_status import fetch_model_metadata
+from weatherbrief.models import BriefingPackMeta, DiagnosticPublic, Flight
 from weatherbrief.storage.flights import (
     list_packs,
     load_pack_meta,
@@ -200,14 +196,32 @@ refresh_registry = _RefreshRegistry()
 router = APIRouter(prefix="/flights/{flight_id}/packs", tags=["packs"])
 
 
-class DataStatus(BaseModel):
-    """Model freshness status."""
+class ModelStatus(BaseModel):
+    """Per-(model, source) freshness detail (issue #108)."""
 
-    fresh: bool  # True = all models up to date
+    source: str  # registry key, e.g. "ecmwf:direct"
+    pack_init: int | None = None  # Unix ts of the init the pack was built from
+    latest_available: int  # Unix ts of latest known init for this source
+    next_expected: str  # ISO datetime — wallclock when next run is expected
+    state: str  # "current" | "stale" | "awaiting" | "delayed"
+
+
+class DataStatus(BaseModel):
+    """Model freshness status.
+
+    Back-compat fields (``fresh``, ``stale_models``, ``model_init_times``,
+    ``next_expected_update``, ``next_expected_model``) are preserved so
+    existing clients keep working.  ``models`` and ``marker_health`` are
+    additive (issue #108).
+    """
+
+    fresh: bool  # True = all models up to date for the flight horizon
     stale_models: list[str] = Field(default_factory=list)
-    model_init_times: dict[str, int] = Field(default_factory=dict)  # current live init times
-    next_expected_update: str | None = None  # ISO datetime
+    model_init_times: dict[str, int] = Field(default_factory=dict)  # latest known init per model
+    next_expected_update: str | None = None  # earliest ISO datetime across sources
     next_expected_model: str | None = None  # which model updates next
+    marker_health: str = "ok"  # "ok" | "suspect"
+    models: dict[str, ModelStatus] = Field(default_factory=dict)
 
 
 class PackMetaResponse(BaseModel):
@@ -302,29 +316,154 @@ def get_freshness(
     db: Session = Depends(get_db),
 ):
     """Check whether the latest pack's data is still fresh."""
-    _load_flight_or_404(db, flight_id, viewer_id=user_id)
+    flight = _load_flight_or_404(db, flight_id, viewer_id=user_id)
     packs = list_packs(db, flight_id)
     if not packs:
         return DataStatus(fresh=False)
 
-    latest = packs[0]
-    return _build_data_status(latest.model_init_times)
+    return _build_data_status(packs[0], flight)
 
 
-def _build_data_status(stored_init_times: dict[str, int]) -> DataStatus:
-    """Fetch live metadata and compare against stored init times."""
-    models_to_check = list(stored_init_times.keys()) if stored_init_times else None
-    live = fetch_model_metadata(models_to_check)
-    is_fresh, stale = check_freshness(stored_init_times, live)
-    next_time, next_model = compute_next_update(live)
+# Source-key prefix → which pack init-time field carries the pack's init.
+# Direct sources record into ``grib_init_times``; Open-Meteo records into
+# ``model_init_times``.
+def _pack_init_for_source(pack: BriefingPackMeta, model: str, source: str) -> int | None:
+    if source.endswith(":openmeteo"):
+        return pack.model_init_times.get(model)
+    return pack.grib_init_times.get(model) or pack.model_init_times.get(model)
+
+
+def _backfill_sources(pack: BriefingPackMeta) -> dict[str, str]:
+    """Infer ``model_sources`` for legacy packs created before issue #108.
+
+    A model with a ``grib_init_times`` entry was direct-GRIB enriched; the
+    rest came from Open-Meteo.  ICON's direct path is ECMWF-style
+    ``icon_eu:dwd``; GFS's is ``gfs:noaa``.
+    """
+    if pack.model_sources:
+        return dict(pack.model_sources)
+    direct = {"ecmwf": "ecmwf:direct", "gfs": "gfs:noaa", "icon": "icon_eu:dwd"}
+    out: dict[str, str] = {}
+    all_models = set(pack.model_init_times) | set(pack.grib_init_times)
+    for model in all_models:
+        if model in pack.grib_init_times and model in direct:
+            out[model] = direct[model]
+        else:
+            out[model] = f"{model}:openmeteo"
+    return out
+
+
+def _inline_check(source: str, model: str) -> tuple[datetime, datetime] | None:
+    """Best-effort one-shot dynamic check used when the marker is suspect.
+
+    Falls back to the registry's expected delivery time if the dynamic
+    check fails — better than reporting nothing.  Returns (init, next_expected)
+    aware UTC datetimes.
+    """
+    from weatherbrief.fetch.freshness import registry
+    from weatherbrief.fetch.freshness.sources import check_source as _sync_check
+
+    observed = _sync_check(source, model)
+    if observed is None:
+        # Last-resort: synthesize from registry
+        init, nxt = registry.initial_marker_for(source)
+        return init, nxt
+    return observed, registry.next_run_after(source, observed)
+
+
+def _build_data_status(pack: BriefingPackMeta, flight: Flight) -> DataStatus:
+    """Marker-based freshness for one pack (issue #108).
+
+    Pure compute when markers are healthy: zero HTTP fan-out.  For each
+    (model, source) recorded on the pack:
+
+    1. Read the marker (or backfill via inline check if suspect/missing).
+    2. Pack is stale for this source iff:
+       - ``marker.init > pack.init`` AND
+       - the new run's horizon reaches the flight's end time.
+    """
+    from datetime import timedelta as _td
+
+    from weatherbrief.fetch.freshness import registry
+    from weatherbrief.fetch.freshness.markers import get_store
+
+    sources = _backfill_sources(pack)
+    if not sources:
+        return DataStatus(fresh=False)
+
+    flight_end = flight.departure_time + _td(hours=flight.flight_duration_hours or 0)
+    store = get_store()
+    loop_interval = _td(seconds=300)
+
+    models_out: dict[str, ModelStatus] = {}
+    next_expected_candidates: list[tuple[datetime, str]] = []
+    health = "ok"
+    any_stale = False
+    stale_models: list[str] = []
+
+    for model, source in sources.items():
+        marker = store.get_sync(source, model_for_source(source))
+        if marker is None or marker.is_stale(loop_interval):
+            health = "suspect"
+            inline = _inline_check(source, model_for_source(source))
+            if inline is None:
+                continue
+            init, nxt = inline
+        else:
+            init, nxt = marker.init, marker.next_expected
+
+        pack_init_ts = _pack_init_for_source(pack, model, source)
+        horizon = registry.run_horizon(source, init)
+        run_covers_flight = (init + horizon) >= flight_end
+
+        if pack_init_ts is None:
+            state = "current"
+        elif int(init.timestamp()) > pack_init_ts and run_covers_flight:
+            state = "stale"
+            any_stale = True
+            stale_models.append(model)
+        elif int(init.timestamp()) > pack_init_ts:
+            # Newer run exists but doesn't cover the flight → not actionable.
+            state = "current"
+        else:
+            now = datetime.now(timezone.utc)
+            state = "delayed" if now > nxt else "awaiting"
+
+        models_out[model] = ModelStatus(
+            source=source,
+            pack_init=pack_init_ts,
+            latest_available=int(init.timestamp()),
+            next_expected=nxt.isoformat(),
+            state=state,
+        )
+        next_expected_candidates.append((nxt, model))
+
+    next_time = None
+    next_model = None
+    if next_expected_candidates:
+        next_expected_candidates.sort(key=lambda c: c[0])
+        next_time, next_model = next_expected_candidates[0]
 
     return DataStatus(
-        fresh=is_fresh,
-        stale_models=stale,
-        model_init_times={m: meta.last_init_time for m, meta in live.items()},
+        fresh=not any_stale,
+        stale_models=stale_models,
+        model_init_times={m: s.latest_available for m, s in models_out.items()},
         next_expected_update=next_time.isoformat() if next_time else None,
         next_expected_model=next_model,
+        marker_health=health,
+        models=models_out,
     )
+
+
+def model_for_source(source: str) -> str:
+    """Return the model name keyed in the marker store for ``source``.
+
+    The store keys by ``(source, model_from_source_prefix)`` — e.g.
+    ``("icon_eu:dwd", "icon_eu")``.  Pack-side ``model_sources`` may map
+    pack-model ``"icon"`` to source ``"icon_eu:dwd"``; we strip the suffix
+    here to find the matching marker.
+    """
+    return source.split(":", 1)[0]
 
 
 def _can_force_refresh(request: Request, db: Session) -> bool:
@@ -592,6 +731,21 @@ def _finalize_refresh(flight_id, flight, fetch_ts, pack_path, result, db,
             if m in fetched
         }
 
+    # model_sources records which freshness source produced each model's data.
+    # Default = Open-Meteo for every fetched model; overridden to the matching
+    # direct-GRIB source where GRIB enrichment succeeded.  Used by the
+    # marker-based freshness check (issue #108).
+    model_sources: dict[str, str] = {m: f"{m}:openmeteo" for m in init_times}
+    _DIRECT_SOURCE_KEYS = {
+        "ecmwf": "ecmwf:direct",
+        "gfs": "gfs:noaa",
+        "icon": "icon_eu:dwd",
+    }
+    for m in result.grib_init_times:
+        key = _DIRECT_SOURCE_KEYS.get(m)
+        if key:
+            model_sources[m] = key
+
     # Derive alt assessment from alt advisory result if available
     alt_assessment = None
     alt_assessment_reason = None
@@ -615,6 +769,7 @@ def _finalize_refresh(flight_id, flight, fetch_ts, pack_path, result, db,
         artifact_path=str(pack_path),
         model_init_times=init_times,
         grib_init_times=result.grib_init_times,
+        model_sources=model_sources,
         models_skipped_region=result.models_skipped_region,
         diagnostics=result.diagnostics,
         alt_assessment=alt_assessment,
@@ -713,7 +868,7 @@ async def refresh_briefing(
         packs = list_packs(db, flight_id)
         if packs:
             latest = packs[0]
-            status = _build_data_status(latest.model_init_times)
+            status = _build_data_status(latest, flight)
             if status.fresh:
                 logger.info("Data is fresh for %s, skipping pipeline", flight_id)
                 return Response(
@@ -848,7 +1003,7 @@ async def refresh_briefing_stream(
             packs = list_packs(db, flight_id)
             if packs:
                 latest = packs[0]
-                status = _build_data_status(latest.model_init_times)
+                status = _build_data_status(latest, flight)
                 if status.fresh:
                     logger.info("Data is fresh for %s, skipping pipeline (stream)", flight_id)
                     pack_resp = _meta_to_response(latest, data_status=status).model_dump()

--- a/src/weatherbrief/api/packs.py
+++ b/src/weatherbrief/api/packs.py
@@ -324,7 +324,29 @@ def get_freshness(
     return _build_data_status(packs[0], flight)
 
 
-# Source-key prefix → which pack init-time field carries the pack's init.
+# Pack-model name -> freshness source key when GRIB enrichment succeeds for
+# that model.  Single source of truth: used by both ``_finalize_refresh``
+# (records ``model_sources`` on new packs) and ``_backfill_sources`` (infers
+# source for legacy packs missing the column).
+_DIRECT_SOURCE_KEYS: dict[str, str] = {
+    "ecmwf": "ecmwf:direct",
+    "gfs": "gfs:noaa",
+    "icon": "icon_eu:dwd",
+}
+
+
+def model_for_source(source: str) -> str:
+    """Return the model name keyed in the marker store for ``source``.
+
+    The store keys by ``(source, model_from_source_prefix)`` -- e.g.
+    ``("icon_eu:dwd", "icon_eu")``.  Pack-side ``model_sources`` may map
+    pack-model ``"icon"`` to source ``"icon_eu:dwd"``; we strip the suffix
+    here to find the matching marker.
+    """
+    return source.split(":", 1)[0]
+
+
+# Source-key suffix decides which pack init-time field carries the pack's init.
 # Direct sources record into ``grib_init_times``; Open-Meteo records into
 # ``model_init_times``.
 def _pack_init_for_source(pack: BriefingPackMeta, model: str, source: str) -> int | None:
@@ -337,17 +359,17 @@ def _backfill_sources(pack: BriefingPackMeta) -> dict[str, str]:
     """Infer ``model_sources`` for legacy packs created before issue #108.
 
     A model with a ``grib_init_times`` entry was direct-GRIB enriched; the
-    rest came from Open-Meteo.  ICON's direct path is ECMWF-style
-    ``icon_eu:dwd``; GFS's is ``gfs:noaa``.
+    rest came from Open-Meteo.  Direct-source mapping comes from the
+    module-level :data:`_DIRECT_SOURCE_KEYS` so it stays in sync with
+    pack-recording in :func:`_finalize_refresh`.
     """
     if pack.model_sources:
         return dict(pack.model_sources)
-    direct = {"ecmwf": "ecmwf:direct", "gfs": "gfs:noaa", "icon": "icon_eu:dwd"}
     out: dict[str, str] = {}
     all_models = set(pack.model_init_times) | set(pack.grib_init_times)
     for model in all_models:
-        if model in pack.grib_init_times and model in direct:
-            out[model] = direct[model]
+        if model in pack.grib_init_times and model in _DIRECT_SOURCE_KEYS:
+            out[model] = _DIRECT_SOURCE_KEYS[model]
         else:
             out[model] = f"{model}:openmeteo"
     return out
@@ -384,7 +406,7 @@ def _build_data_status(pack: BriefingPackMeta, flight: Flight) -> DataStatus:
     """
     from datetime import timedelta as _td
 
-    from weatherbrief.fetch.freshness import registry
+    from weatherbrief.fetch.freshness import LOOP_INTERVAL, registry
     from weatherbrief.fetch.freshness.markers import get_store
 
     sources = _backfill_sources(pack)
@@ -393,7 +415,6 @@ def _build_data_status(pack: BriefingPackMeta, flight: Flight) -> DataStatus:
 
     flight_end = flight.departure_time + _td(hours=flight.flight_duration_hours or 0)
     store = get_store()
-    loop_interval = _td(seconds=300)
 
     models_out: dict[str, ModelStatus] = {}
     next_expected_candidates: list[tuple[datetime, str]] = []
@@ -403,7 +424,7 @@ def _build_data_status(pack: BriefingPackMeta, flight: Flight) -> DataStatus:
 
     for model, source in sources.items():
         marker = store.get_sync(source, model_for_source(source))
-        if marker is None or marker.is_stale(loop_interval):
+        if marker is None or marker.is_stale(LOOP_INTERVAL):
             health = "suspect"
             inline = _inline_check(source, model_for_source(source))
             if inline is None:
@@ -455,15 +476,6 @@ def _build_data_status(pack: BriefingPackMeta, flight: Flight) -> DataStatus:
     )
 
 
-def model_for_source(source: str) -> str:
-    """Return the model name keyed in the marker store for ``source``.
-
-    The store keys by ``(source, model_from_source_prefix)`` — e.g.
-    ``("icon_eu:dwd", "icon_eu")``.  Pack-side ``model_sources`` may map
-    pack-model ``"icon"`` to source ``"icon_eu:dwd"``; we strip the suffix
-    here to find the matching marker.
-    """
-    return source.split(":", 1)[0]
 
 
 def _can_force_refresh(request: Request, db: Session) -> bool:
@@ -736,11 +748,6 @@ def _finalize_refresh(flight_id, flight, fetch_ts, pack_path, result, db,
     # direct-GRIB source where GRIB enrichment succeeded.  Used by the
     # marker-based freshness check (issue #108).
     model_sources: dict[str, str] = {m: f"{m}:openmeteo" for m in init_times}
-    _DIRECT_SOURCE_KEYS = {
-        "ecmwf": "ecmwf:direct",
-        "gfs": "gfs:noaa",
-        "icon": "icon_eu:dwd",
-    }
     for m in result.grib_init_times:
         key = _DIRECT_SOURCE_KEYS.get(m)
         if key:

--- a/src/weatherbrief/db/models.py
+++ b/src/weatherbrief/db/models.py
@@ -211,6 +211,7 @@ class BriefingPackRow(Base):
     artifact_path: Mapped[str] = mapped_column(Text, default="")
     model_init_times_json: Mapped[str] = mapped_column(Text, default="{}")
     grib_init_times_json: Mapped[str] = mapped_column(Text, default="{}")
+    model_sources_json: Mapped[str | None] = mapped_column(Text, nullable=True)
     models_skipped_region_json: Mapped[str] = mapped_column(Text, default="[]")
     diagnostics_json: Mapped[str] = mapped_column(Text, default="[]")
     alt_assessment: Mapped[str | None] = mapped_column(String(16), nullable=True)

--- a/src/weatherbrief/fetch/freshness/__init__.py
+++ b/src/weatherbrief/fetch/freshness/__init__.py
@@ -12,3 +12,11 @@ Modules:
 - :mod:`sources` — unified dynamic-check dispatch wrapping existing
   ``find_latest_*`` helpers
 """
+
+from datetime import timedelta
+
+# Single source of truth for the freshness loop's poll cadence.  Imported by
+# the scheduler (loop interval), the freshness HTTP handler (heartbeat
+# threshold for ``Marker.is_stale``), and the admin endpoint (reported as
+# ``loop_interval_seconds``).  Changing here propagates everywhere.
+LOOP_INTERVAL = timedelta(seconds=300)

--- a/src/weatherbrief/fetch/freshness/__init__.py
+++ b/src/weatherbrief/fetch/freshness/__init__.py
@@ -1,0 +1,14 @@
+"""Marker-based freshness decision system (issue #108).
+
+Replaces polling-based per-call meta.json fan-out with an in-memory marker
+store gated by a hardcoded schedule registry, populated by a 5-min
+background loop.  Most freshness checks become pure compute:
+
+    stale = (now >= pack.next_expected_update)
+
+Modules:
+- :mod:`registry` — per-(model, source) cycle/delivery/horizon config
+- :mod:`markers` — in-memory ``MarkerStore`` with asyncio lock
+- :mod:`sources` — unified dynamic-check dispatch wrapping existing
+  ``find_latest_*`` helpers
+"""

--- a/src/weatherbrief/fetch/freshness/markers.py
+++ b/src/weatherbrief/fetch/freshness/markers.py
@@ -1,0 +1,267 @@
+"""In-memory marker store for the freshness loop.
+
+Each marker tracks the latest observed init for one (source, model) pair
+along with when the next run is expected, slip-retry state, and the
+timestamp of the last dynamic check.  No persistence — markers
+re-bootstrap from :func:`registry.initial_marker_for` on startup.
+
+Concurrency: the freshness loop writes markers; the freshness HTTP
+handler reads them.  An ``asyncio.Lock`` guards mutations.  Reads via
+:meth:`MarkerStore.get` return a frozen snapshot (dataclass replace)
+so callers can inspect without holding the lock.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections import deque
+from dataclasses import dataclass, field, replace
+from datetime import datetime, timedelta, timezone
+
+from . import registry
+
+logger = logging.getLogger(__name__)
+
+
+# In-memory rolling window of recent advances per marker.  Sized to comfortably
+# cover ~3 days of observations across 4 daily cycles per source — enough to
+# spot drift without unbounded memory.  Survives advances + slip-cap jumps,
+# lost on process restart (no persistence by design — issue #108 scope).
+OBSERVATIONS_MAXLEN = 100
+
+
+@dataclass
+class Marker:
+    """Latest-known state of one (source, model) pair.
+
+    Attributes:
+        source: Registry key, e.g. ``"ecmwf:direct"``.
+        model: Logical model name, e.g. ``"ecmwf"``.
+        init: Latest observed init time (aware UTC).
+        next_expected: Wallclock time at which the next run is expected.
+        last_check: When the dynamic check last ran (None until first check).
+        slip_count: Number of consecutive slip retries since last advance.
+        observations: Recent ``(cycle_init, arrival_wallclock)`` pairs — used
+            for drift detection / calibration.  Each pair lets you compute
+            actual delivery delay vs. registry expectation.
+    """
+
+    source: str
+    model: str
+    init: datetime
+    next_expected: datetime
+    last_check: datetime | None = None
+    slip_count: int = 0
+    observations: deque[tuple[datetime, datetime]] = field(
+        default_factory=lambda: deque(maxlen=OBSERVATIONS_MAXLEN),
+    )
+
+    def is_stale(self, loop_interval: timedelta) -> bool:
+        """Return True if the loop hasn't checked this marker recently.
+
+        A marker is "stale" (suspect) when ``last_check`` is older than
+        ``2 × loop_interval`` (or never set).  Callers should fall back to
+        an inline check and surface ``marker_health="suspect"`` to the UI.
+        """
+        if self.last_check is None:
+            return True
+        return datetime.now(timezone.utc) - self.last_check > 2 * loop_interval
+
+
+class MarkerStore:
+    """Async-safe in-memory store for all (source, model) markers.
+
+    Bootstrap is lazy: :meth:`bootstrap` populates initial values from the
+    registry without doing any I/O.  The freshness loop then runs
+    :meth:`update` / :meth:`mark_slip` per dynamic check.
+    """
+
+    def __init__(self) -> None:
+        self._markers: dict[tuple[str, str], Marker] = {}
+        self._lock = asyncio.Lock()
+
+    # ------------------------------------------------------------------
+    # Bootstrap
+    # ------------------------------------------------------------------
+
+    async def bootstrap(
+        self,
+        sources: list[tuple[str, str]],
+        now: datetime | None = None,
+    ) -> None:
+        """Populate initial markers from the registry without I/O.
+
+        ``sources`` is a list of ``(source_key, model_name)`` pairs.  Each
+        gets a marker whose ``init`` is the most recent expected-delivered
+        cycle and ``next_expected`` is the next cycle's expected delivery.
+        ``last_check`` stays None so the loop will run a real check on the
+        first tick.
+        """
+        async with self._lock:
+            for source, model in sources:
+                init, nxt = registry.initial_marker_for(source, now=now)
+                self._markers[(source, model)] = Marker(
+                    source=source, model=model, init=init, next_expected=nxt,
+                )
+            logger.info(
+                "MarkerStore: bootstrapped %d (source, model) markers",
+                len(self._markers),
+            )
+
+    # ------------------------------------------------------------------
+    # Read
+    # ------------------------------------------------------------------
+
+    def get_sync(self, source: str, model: str) -> Marker | None:
+        """Lock-free read.  Returns a snapshot copy or None if not bootstrapped.
+
+        Safe because Marker dataclasses are replaced wholesale on update —
+        readers get either the old or the new immutable value.  Used from
+        sync contexts (HTTP handler) where awaiting the lock isn't ideal.
+        """
+        m = self._markers.get((source, model))
+        if m is None:
+            return None
+        return replace(m, observations=deque(m.observations, maxlen=OBSERVATIONS_MAXLEN))
+
+    async def get(self, source: str, model: str) -> Marker | None:
+        async with self._lock:
+            return self.get_sync(source, model)
+
+    def all_sync(self) -> dict[tuple[str, str], Marker]:
+        """Lock-free snapshot of every marker, intended for the admin endpoint."""
+        return {
+            k: replace(m, observations=deque(m.observations, maxlen=OBSERVATIONS_MAXLEN))
+            for k, m in self._markers.items()
+        }
+
+    def keys_sync(self) -> list[tuple[str, str]]:
+        return list(self._markers.keys())
+
+    # ------------------------------------------------------------------
+    # Mutations
+    # ------------------------------------------------------------------
+
+    async def update(
+        self,
+        source: str,
+        model: str,
+        observed_init: datetime,
+        now: datetime | None = None,
+    ) -> None:
+        """Record a fresh check.  Advances ``init`` if newer; bumps slip otherwise.
+
+        - If ``observed_init > marker.init``: advance, reset slip, append a
+          ``(cycle_init, arrival_wallclock)`` observation, and log the actual
+          delivery delay vs. the registry expectation (used for calibration).
+        - If equal and ``now >= next_expected``: slip — bump ``next_expected``
+          by ``cfg.slip_bump(slip_count)`` (exponential backoff, capped).
+          After ``max_slip_retries``, jump forward to the next cycle's
+          expected delivery and reset slip.
+        - Else: just update ``last_check`` (early/null check).
+        """
+        now = now or datetime.now(timezone.utc)
+        async with self._lock:
+            marker = self._markers.get((source, model))
+            if marker is None:
+                # Source observed before bootstrap — accept and pin from registry.
+                next_exp = registry.next_run_after(source, observed_init)
+                marker = Marker(
+                    source=source, model=model,
+                    init=observed_init, next_expected=next_exp,
+                    last_check=now,
+                )
+                marker.observations.append((observed_init, now))
+                self._markers[(source, model)] = marker
+                return
+
+            if observed_init > marker.init:
+                expected_delivery = registry.expected_delivery_for_init(source, observed_init)
+                actual_delay = now - observed_init
+                vs_expected = now - expected_delivery
+                marker.init = observed_init
+                marker.next_expected = registry.next_run_after(source, observed_init)
+                marker.slip_count = 0
+                marker.observations.append((observed_init, now))
+                marker.last_check = now
+                logger.info(
+                    "Marker advanced: %s/%s init=%s arrived_at=%s "
+                    "delivery=+%s (registry expected +%s, drift=%+ds)",
+                    source, model,
+                    observed_init.isoformat(), now.isoformat(),
+                    _fmt_td(actual_delay),
+                    _fmt_td(expected_delivery - observed_init),
+                    int(vs_expected.total_seconds()),
+                )
+                return
+
+            # No advance — only treat as slip if the expected-delivery time has passed.
+            if now >= marker.next_expected:
+                cfg = registry.SOURCE_REGISTRY[source]
+                marker.slip_count += 1
+                if marker.slip_count > cfg.max_slip_retries:
+                    # Give up on the missed cycle — jump to the cycle after it.
+                    skipped_init = registry.cycle_init_for(source, marker.next_expected)
+                    marker.next_expected = registry.next_cycle_after(source, skipped_init)
+                    marker.slip_count = 0
+                    logger.warning(
+                        "Marker slip cap hit: %s/%s — jumping to next cycle, "
+                        "next_expected=%s",
+                        source, model, marker.next_expected.isoformat(),
+                    )
+                else:
+                    bump = cfg.slip_bump(marker.slip_count)
+                    marker.next_expected = marker.next_expected + bump
+                    logger.info(
+                        "Marker slip: %s/%s slip_count=%d bump=+%s next_expected=%s",
+                        source, model, marker.slip_count,
+                        _fmt_td(bump), marker.next_expected.isoformat(),
+                    )
+            marker.last_check = now
+
+    async def mark_check(self, source: str, model: str, now: datetime | None = None) -> None:
+        """Refresh ``last_check`` without changing init/next_expected.
+
+        Used when a dynamic check returns None (couldn't determine init) so
+        the heartbeat doesn't go stale just because of a transient failure.
+        """
+        now = now or datetime.now(timezone.utc)
+        async with self._lock:
+            marker = self._markers.get((source, model))
+            if marker is not None:
+                marker.last_check = now
+
+
+# Module-level singleton, bound from the lifespan startup hook.  Importing
+# code reaches the live store via :func:`get_store` so tests can swap it.
+
+_STORE: MarkerStore | None = None
+
+
+def get_store() -> MarkerStore:
+    """Return the process-wide marker store, creating it on first access."""
+    global _STORE
+    if _STORE is None:
+        _STORE = MarkerStore()
+    return _STORE
+
+
+def reset_store_for_tests() -> None:
+    """Drop the singleton so a test can install a fresh store."""
+    global _STORE
+    _STORE = None
+
+
+def _fmt_td(td: timedelta) -> str:
+    """Compact ``Hh Mm`` (or ``Mm Ss``) format for log lines."""
+    total_s = int(td.total_seconds())
+    sign = "-" if total_s < 0 else ""
+    total_s = abs(total_s)
+    h, rem = divmod(total_s, 3600)
+    m, s = divmod(rem, 60)
+    if h:
+        return f"{sign}{h}h {m}m"
+    if m:
+        return f"{sign}{m}m {s}s"
+    return f"{sign}{s}s"

--- a/src/weatherbrief/fetch/freshness/markers.py
+++ b/src/weatherbrief/fetch/freshness/markers.py
@@ -95,14 +95,19 @@ class MarkerStore:
         ``sources`` is a list of ``(source_key, model_name)`` pairs.  Each
         gets a marker whose ``init`` is the most recent expected-delivered
         cycle and ``next_expected`` is the next cycle's expected delivery.
-        ``last_check`` stays None so the loop will run a real check on the
-        first tick.
+
+        ``last_check`` is set to ``now`` so :meth:`Marker.is_stale` doesn't
+        immediately flag every marker as suspect — the registry-derived
+        ``init`` is a good-faith estimate, and the loop will run a real
+        dynamic check the first time a marker's ``next_expected`` passes.
         """
+        bootstrap_now = now or datetime.now(timezone.utc)
         async with self._lock:
             for source, model in sources:
                 init, nxt = registry.initial_marker_for(source, now=now)
                 self._markers[(source, model)] = Marker(
                     source=source, model=model, init=init, next_expected=nxt,
+                    last_check=bootstrap_now,
                 )
             logger.info(
                 "MarkerStore: bootstrapped %d (source, model) markers",
@@ -201,14 +206,28 @@ class MarkerStore:
                 cfg = registry.SOURCE_REGISTRY[source]
                 marker.slip_count += 1
                 if marker.slip_count > cfg.max_slip_retries:
-                    # Give up on the missed cycle — jump to the cycle after it.
-                    skipped_init = registry.cycle_init_for(source, marker.next_expected)
-                    marker.next_expected = registry.next_cycle_after(source, skipped_init)
+                    # Give up on the cycle we were waiting for and target the
+                    # one *after* it.  The slipping cycle is always the one
+                    # right after ``marker.init`` (the last successfully
+                    # observed cycle) — derive it directly so accumulated
+                    # backoff bumps to ``next_expected`` don't push the jump
+                    # several cycles into the future.
+                    skipped_cycle = registry.next_cycle_init_after(
+                        source, marker.init,
+                    )
+                    target_cycle = registry.next_cycle_init_after(
+                        source, skipped_cycle,
+                    )
+                    marker.next_expected = registry.expected_delivery_for_init(
+                        source, target_cycle,
+                    )
                     marker.slip_count = 0
                     logger.warning(
-                        "Marker slip cap hit: %s/%s — jumping to next cycle, "
-                        "next_expected=%s",
-                        source, model, marker.next_expected.isoformat(),
+                        "Marker slip cap hit: %s/%s — skipping cycle %s, "
+                        "target cycle %s, next_expected=%s",
+                        source, model,
+                        skipped_cycle.isoformat(), target_cycle.isoformat(),
+                        marker.next_expected.isoformat(),
                     )
                 else:
                     bump = cfg.slip_bump(marker.slip_count)

--- a/src/weatherbrief/fetch/freshness/registry.py
+++ b/src/weatherbrief/fetch/freshness/registry.py
@@ -216,14 +216,15 @@ def next_run_after(source: str, current_init: datetime) -> datetime:
     return next_init + cfg.offset_for(next_init.hour)
 
 
-def next_cycle_after(source: str, skipped_init: datetime) -> datetime:
-    """Like :func:`next_run_after` but used after slip-cap to skip a cycle.
+def next_cycle_init_after(source: str, init: datetime) -> datetime:
+    """Return the next cycle init (without offset) strictly after ``init``.
 
-    Returns the expected delivery wallclock for the cycle *after* the one
-    that started at ``skipped_init`` — i.e. we give up on ``skipped_init``
-    and pin our hopes on the following cycle.
+    Companion to :func:`next_run_after`, exposed so callers can reason
+    about cycles separately from delivery wallclocks.  Used by the
+    marker store's slip-cap path to identify the cycle being skipped.
     """
-    return next_run_after(source, skipped_init)
+    cfg = SOURCE_REGISTRY[source]
+    return _next_cycle_init(init, cfg.cycles)
 
 
 def run_horizon(source: str, init: datetime) -> timedelta:

--- a/src/weatherbrief/fetch/freshness/registry.py
+++ b/src/weatherbrief/fetch/freshness/registry.py
@@ -1,0 +1,262 @@
+"""Per-(model, source) schedule registry.
+
+Pure config + pure functions — no I/O.  Computes when each (model, source)
+pair's next run should be expected, and how far the run's forecast horizon
+reaches.  Used by both the freshness loop (to decide when to poll) and the
+freshness check (to decide whether a newer run actually covers the flight).
+
+Each ``SourceConfig`` is keyed by ``"{model}:{source}"`` (e.g. ``"ecmwf:direct"``,
+``"gfs:openmeteo"``).  Cycles are UTC hours of day; ``delivery_offset`` is the
+expected wallclock lag from cycle init to data readiness.
+
+``run_horizon`` may differ per cycle (e.g. ECMWF 00/12 reach 168h; 06/18 are
+medium-only at ~90h; ICON-EU main cycles 120h vs intermediate 78h).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+
+
+@dataclass(frozen=True)
+class SourceConfig:
+    """Schedule + horizon config for one (model, source) pair.
+
+    Attributes:
+        key: Stable identifier ``"{model}:{source}"``.
+        cycles: UTC hours-of-day at which the source publishes runs.
+        delivery_offset: Expected lag from cycle start to data readiness.
+            May be a single ``timedelta`` (uniform) or a per-cycle dict.
+        horizon: Forecast horizon.  Uniform ``timedelta`` or per-cycle dict.
+        retry_interval: Base interval used for the *first* slip retry.
+            Subsequent retries grow exponentially (×2 per slip) up to
+            :attr:`max_retry_interval` — so we don't keep hammering a
+            slow-publishing source every 10 min for 6 h.
+        max_retry_interval: Ceiling for the exponential backoff bump.
+        max_slip_retries: After this many slip bumps, jump ``next_expected``
+            forward to the *next* scheduled cycle's expected delivery time
+            (avoids polling forever on a skipped cycle).  With the default
+            backoff schedule, 8 slips ≈ 6 h before cycle-jump.
+        readiness_check: Symbolic name of the check_source dispatch target.
+            Resolved by :mod:`sources`.
+    """
+
+    key: str
+    cycles: tuple[int, ...]
+    delivery_offset: timedelta | dict[int, timedelta]
+    horizon: timedelta | dict[int, timedelta]
+    retry_interval: timedelta = timedelta(minutes=10)
+    max_retry_interval: timedelta = timedelta(hours=1)
+    max_slip_retries: int = 8
+    readiness_check: str = ""
+
+    def slip_bump(self, slip_count: int) -> timedelta:
+        """Return the next-expected bump for the ``slip_count``-th slip.
+
+        Exponential backoff capped at :attr:`max_retry_interval`.  ``slip_count``
+        is 1-based — i.e. the first slip uses :attr:`retry_interval` exactly.
+        """
+        if slip_count <= 0:
+            return self.retry_interval
+        bump = self.retry_interval * (2 ** (slip_count - 1))
+        return min(bump, self.max_retry_interval)
+
+    def offset_for(self, cycle: int) -> timedelta:
+        if isinstance(self.delivery_offset, dict):
+            return self.delivery_offset[cycle]
+        return self.delivery_offset
+
+    def horizon_for(self, cycle: int) -> timedelta:
+        if isinstance(self.horizon, dict):
+            return self.horizon[cycle]
+        return self.horizon
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+# ECMWF: empirically +6h27m–6h37m across 14 days; +6h40m gives 3min margin
+# and works for both long (00/12 = 168h) and medium-only (06/18) cycles.
+_ECMWF_OFFSET = timedelta(hours=6, minutes=40)
+# 168h on 00/12 (with the long-tail step set), ~90h medium-only on 06/18
+# (3-hourly phase ends init+6h27m, no 168h step delivered).
+_ECMWF_HORIZON: dict[int, timedelta] = {
+    0: timedelta(hours=168),
+    6: timedelta(hours=90),
+    12: timedelta(hours=168),
+    18: timedelta(hours=90),
+}
+
+# GFS: PUBLISH_DELAY_HOURS = 5 in grib_fetch.py; horizon 384h (16 days).
+_GFS_NOAA_OFFSET = timedelta(hours=5)
+_GFS_NOAA_HORIZON = timedelta(hours=384)
+
+# ICON-EU: ICON_EU_PUBLISH_DELAY_HOURS = 3; main cycles {0,6,12,18} reach
+# 120h, intermediate {3,9,15,21} reach 78h.  See icon_eu_fetch.py:31-40.
+_ICON_EU_OFFSET = timedelta(hours=3)
+_ICON_EU_MAIN = {0, 6, 12, 18}
+_ICON_EU_HORIZON: dict[int, timedelta] = {
+    h: (timedelta(hours=120) if h in _ICON_EU_MAIN else timedelta(hours=78))
+    for h in (0, 3, 6, 9, 12, 15, 18, 21)
+}
+
+# Open-Meteo offsets — calibrated against meta.json observation 2026-05-03.
+# Open-Meteo republishes other providers' models with notable lag; the figures
+# in issue #108's table (sourced from OM docs) underestimate real delivery.
+# Bumped here with margin over observed delays so the marker doesn't slip
+# every cycle.  Drift detection (deque of last 20 observations on each marker)
+# will surface further drift if real-world publish times keep changing.
+_OM_GFS_OFFSET = timedelta(hours=6, minutes=45)      # observed 6h37m
+_OM_ECMWF_OFFSET = timedelta(hours=8)                # observed 7h30m
+_OM_ICON_OFFSET = timedelta(hours=4, minutes=30)     # observed 4h17m
+_OM_ARPEGE_OFFSET = timedelta(hours=4, minutes=30)   # observed 4h00m
+_OM_UKMO_OFFSET = timedelta(hours=8, minutes=30)     # observed 8h19m
+
+
+SOURCE_REGISTRY: dict[str, SourceConfig] = {
+    "ecmwf:direct": SourceConfig(
+        key="ecmwf:direct",
+        cycles=(0, 6, 12, 18),
+        delivery_offset=_ECMWF_OFFSET,
+        horizon=_ECMWF_HORIZON,
+        readiness_check="ecmwf_direct",
+    ),
+    "gfs:noaa": SourceConfig(
+        key="gfs:noaa",
+        cycles=(0, 6, 12, 18),
+        delivery_offset=_GFS_NOAA_OFFSET,
+        horizon=_GFS_NOAA_HORIZON,
+        readiness_check="gfs_noaa",
+    ),
+    "icon_eu:dwd": SourceConfig(
+        key="icon_eu:dwd",
+        cycles=(0, 3, 6, 9, 12, 15, 18, 21),
+        delivery_offset=_ICON_EU_OFFSET,
+        horizon=_ICON_EU_HORIZON,
+        readiness_check="icon_eu_dwd",
+    ),
+    "gfs:openmeteo": SourceConfig(
+        key="gfs:openmeteo",
+        cycles=(0, 6, 12, 18),
+        delivery_offset=_OM_GFS_OFFSET,
+        horizon=timedelta(days=16),
+        readiness_check="om_meta",
+    ),
+    # Open-Meteo only effectively publishes ECMWF 00/12 main runs in time;
+    # 06/18 are bc-runs that lag heavily — see issue #100.  We track only the
+    # main cycles so the marker doesn't bounce on bc-run shuffles.
+    "ecmwf:openmeteo": SourceConfig(
+        key="ecmwf:openmeteo",
+        cycles=(0, 12),
+        delivery_offset=_OM_ECMWF_OFFSET,
+        horizon=timedelta(days=10),
+        readiness_check="om_meta",
+    ),
+    # Open-Meteo's meta.json reports update_interval_seconds=21600 (6h) for
+    # ICON, even though DWD itself runs ICON on a 3h cycle.  OM only
+    # republishes the 6-hourly main runs (0/6/12/18Z) — tracking 3h here
+    # would slip every other cycle for no benefit.
+    "icon:openmeteo": SourceConfig(
+        key="icon:openmeteo",
+        cycles=(0, 6, 12, 18),
+        delivery_offset=_OM_ICON_OFFSET,
+        horizon=timedelta(days=7),
+        readiness_check="om_meta",
+    ),
+    "meteofrance:openmeteo": SourceConfig(
+        key="meteofrance:openmeteo",
+        cycles=(0, 6, 12, 18),
+        delivery_offset=_OM_ARPEGE_OFFSET,
+        horizon=timedelta(days=6),
+        readiness_check="om_meta",
+    ),
+    "ukmo:openmeteo": SourceConfig(
+        key="ukmo:openmeteo",
+        cycles=(0, 6, 12, 18),
+        delivery_offset=_OM_UKMO_OFFSET,
+        horizon=timedelta(days=7),
+        readiness_check="om_meta",
+    ),
+}
+
+
+# ---------------------------------------------------------------------------
+# Pure functions
+# ---------------------------------------------------------------------------
+
+
+def _floor_to_cycle(dt: datetime, cycles: tuple[int, ...]) -> datetime:
+    """Return the most recent cycle init at-or-before ``dt``."""
+    midnight = dt.replace(hour=0, minute=0, second=0, microsecond=0)
+    candidates = [midnight + timedelta(hours=h) for h in cycles]
+    candidates += [c - timedelta(days=1) for c in candidates]
+    valid = [c for c in candidates if c <= dt]
+    return max(valid)
+
+
+def _next_cycle_init(dt: datetime, cycles: tuple[int, ...]) -> datetime:
+    """Return the earliest cycle init strictly after ``dt``."""
+    midnight = dt.replace(hour=0, minute=0, second=0, microsecond=0)
+    candidates = [midnight + timedelta(hours=h) for h in cycles]
+    candidates += [c + timedelta(days=1) for c in candidates]
+    future = [c for c in candidates if c > dt]
+    return min(future)
+
+
+def next_run_after(source: str, current_init: datetime) -> datetime:
+    """Wallclock time at which the next run *after* ``current_init`` is expected.
+
+    Handles cycles within the same day and rollover to next day.  The result
+    is the next cycle's init time plus that cycle's delivery offset.
+    """
+    cfg = SOURCE_REGISTRY[source]
+    next_init = _next_cycle_init(current_init, cfg.cycles)
+    return next_init + cfg.offset_for(next_init.hour)
+
+
+def next_cycle_after(source: str, skipped_init: datetime) -> datetime:
+    """Like :func:`next_run_after` but used after slip-cap to skip a cycle.
+
+    Returns the expected delivery wallclock for the cycle *after* the one
+    that started at ``skipped_init`` — i.e. we give up on ``skipped_init``
+    and pin our hopes on the following cycle.
+    """
+    return next_run_after(source, skipped_init)
+
+
+def run_horizon(source: str, init: datetime) -> timedelta:
+    """Forecast horizon (timedelta from init) for the run started at ``init``."""
+    cfg = SOURCE_REGISTRY[source]
+    return cfg.horizon_for(init.hour)
+
+
+def cycle_init_for(source: str, dt: datetime) -> datetime:
+    """Return the latest cycle init at-or-before ``dt`` for ``source``."""
+    cfg = SOURCE_REGISTRY[source]
+    return _floor_to_cycle(dt, cfg.cycles)
+
+
+def expected_delivery_for_init(source: str, init: datetime) -> datetime:
+    """Return the wallclock time at which ``init`` is expected to be ready."""
+    cfg = SOURCE_REGISTRY[source]
+    return init + cfg.offset_for(init.hour)
+
+
+def initial_marker_for(source: str, now: datetime | None = None) -> tuple[datetime, datetime]:
+    """Bootstrap (init, next_expected) for a source at startup.
+
+    Picks the most recent cycle whose expected delivery is at-or-before
+    ``now`` (so the loop's first dynamic check has a plausible "current"
+    init to compare against).  Falls back to one cycle prior if the latest
+    cycle hasn't been delivered yet.
+    """
+    now = now or datetime.now(timezone.utc)
+    cfg = SOURCE_REGISTRY[source]
+    init = _floor_to_cycle(now, cfg.cycles)
+    if init + cfg.offset_for(init.hour) > now:
+        # current cycle not yet expected to be ready — use prior cycle
+        init = _floor_to_cycle(init - timedelta(seconds=1), cfg.cycles)
+    next_expected = next_run_after(source, init)
+    return init, next_expected

--- a/src/weatherbrief/fetch/freshness/sources.py
+++ b/src/weatherbrief/fetch/freshness/sources.py
@@ -1,0 +1,138 @@
+"""Dynamic readiness checks for the freshness loop.
+
+Each source in :data:`registry.SOURCE_REGISTRY` has a ``readiness_check``
+symbol — this module dispatches that symbol to the existing helper that
+already finds the latest available init for that (model, source).  The
+loop calls :func:`check_source` only when ``now >= marker.next_expected``
+so the cost of these I/O calls is paid at most twice per cycle per
+source (once on-time, once on slip).
+
+All wrappers must be safe to call from a thread (the loop offloads them
+via ``asyncio.to_thread``) and must return either an aware-UTC
+``datetime`` for the latest observed init or ``None`` if the check
+couldn't determine one (transient network failure, missing data).
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta, timezone
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Per-source dispatch
+# ---------------------------------------------------------------------------
+
+
+def _check_ecmwf_direct(model: str) -> datetime | None:
+    """Return latest ECMWF run with a readiness sentinel."""
+    from weatherbrief.fetch.grib.ecmwf_watcher import get_latest_ready
+    return get_latest_ready()
+
+
+def _check_gfs_noaa(model: str) -> datetime | None:
+    """Return latest GFS run that has its .idx file published on S3."""
+    from weatherbrief.fetch.grib.grib_fetch import find_latest_run
+    now = datetime.now(timezone.utc)
+    # find_latest_run uses target_time only for as-of/bracketing; passing now
+    # gets the most recently published cycle.
+    result = find_latest_run(target_time=now)
+    if result is None:
+        return None
+    init_date, init_hour = result
+    return datetime.strptime(f"{init_date}{init_hour:02d}", "%Y%m%d%H").replace(
+        tzinfo=timezone.utc,
+    )
+
+
+def _check_icon_eu_dwd(model: str) -> datetime | None:
+    """Return latest ICON-EU run whose level-74 P file responds 200 on HEAD.
+
+    For the marker we don't filter by horizon — the freshness check applies
+    horizon-awareness later.  We still rely on the existing helper, which
+    requires ``cover_until`` to verify horizon; pass ``target_time=now`` and
+    ``cover_until=now`` so any published run qualifies.
+    """
+    from weatherbrief.fetch.grib.icon_eu_fetch import find_latest_icon_eu_run
+    now = datetime.now(timezone.utc)
+    result = find_latest_icon_eu_run(target_time=now, cover_until=now)
+    if result is None:
+        return None
+    init_date, init_hour = result
+    return datetime.strptime(f"{init_date}{init_hour:02d}", "%Y%m%d%H").replace(
+        tzinfo=timezone.utc,
+    )
+
+
+def _check_om_meta(model: str) -> datetime | None:
+    """Return latest Open-Meteo init for ``model`` from its meta.json."""
+    from weatherbrief.fetch.model_status import fetch_model_metadata
+    meta = fetch_model_metadata([model])
+    if model not in meta:
+        return None
+    return datetime.fromtimestamp(meta[model].last_init_time, tz=timezone.utc)
+
+
+_DISPATCH = {
+    "ecmwf_direct": _check_ecmwf_direct,
+    "gfs_noaa": _check_gfs_noaa,
+    "icon_eu_dwd": _check_icon_eu_dwd,
+    "om_meta": _check_om_meta,
+}
+
+
+def check_source(source: str, model: str) -> datetime | None:
+    """Run the dynamic readiness check for one (source, model) pair.
+
+    Looks up the registry to find which check to dispatch, then invokes it.
+    Returns the latest observed init time (aware UTC) or None on failure.
+    Exceptions are caught and logged — the loop should never crash on a
+    transient I/O error.
+    """
+    from .registry import SOURCE_REGISTRY
+
+    cfg = SOURCE_REGISTRY.get(source)
+    if cfg is None:
+        logger.warning("check_source: unknown source %r", source)
+        return None
+    fn = _DISPATCH.get(cfg.readiness_check)
+    if fn is None:
+        logger.warning(
+            "check_source: registry has no dispatch for %r (source %r)",
+            cfg.readiness_check, source,
+        )
+        return None
+    try:
+        return fn(model)
+    except Exception:
+        logger.warning(
+            "check_source: dynamic check failed for %s/%s",
+            source, model, exc_info=True,
+        )
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Source enumeration
+# ---------------------------------------------------------------------------
+
+
+def all_tracked_sources() -> list[tuple[str, str]]:
+    """Return every (source, model) pair the marker store should track.
+
+    The model name is derived from the source key prefix (``"ecmwf:direct"``
+    → model ``"ecmwf"``).  Open-Meteo sources use the suffix-less model
+    name to match how :func:`fetch.model_status.fetch_model_metadata`
+    keys its result dict.
+    """
+    from .registry import SOURCE_REGISTRY
+
+    pairs: list[tuple[str, str]] = []
+    for key in SOURCE_REGISTRY:
+        model = key.split(":", 1)[0]
+        # icon_eu_dwd is a separate logical model from icon:openmeteo;
+        # keep the explicit mapping rather than collapsing.
+        pairs.append((key, model))
+    return pairs

--- a/src/weatherbrief/fetch/grib/ecmwf_watcher.py
+++ b/src/weatherbrief/fetch/grib/ecmwf_watcher.py
@@ -146,6 +146,45 @@ def is_run_partial(data_dir: Path | None = None, *, base_time: datetime) -> bool
     return _sentinel_path(d, base_time).with_suffix(".partial").exists()
 
 
+def _parse_sentinel_base_time(name: str) -> datetime | None:
+    """Parse the base_time from a ``.ready_YYYYMMDD_HHz[.partial]`` filename."""
+    if not name.startswith(".ready_"):
+        return None
+    # ".ready_YYYYMMDD_HHz" or ".ready_YYYYMMDD_HHz.partial"
+    body = name[len(".ready_"):]
+    if body.endswith(".partial"):
+        body = body[: -len(".partial")]
+    # Now body is "YYYYMMDD_HHz"
+    if not body.endswith("z") or len(body) != len("YYYYMMDD_HHz"):
+        return None
+    try:
+        return datetime.strptime(body, "%Y%m%d_%Hz").replace(tzinfo=timezone.utc)
+    except ValueError:
+        return None
+
+
+def get_latest_ready(data_dir: Path | None = None) -> datetime | None:
+    """Return the most recent ECMWF run with a readiness sentinel, or None.
+
+    Used by the freshness loop's dynamic check for ``ecmwf:direct``.  Reads
+    only filenames in the delivery directory — no network, no GRIB parsing.
+    Counts both ``.ready_*z`` (complete) and ``.ready_*z.partial`` (timed-out)
+    sentinels: a partial run is still useful data the briefing pipeline can
+    consume, so its arrival should also bump freshness.
+    """
+    d = data_dir or ecmwf_grib_dir()
+    if not d.exists():
+        return None
+    latest: datetime | None = None
+    for path in d.iterdir():
+        bt = _parse_sentinel_base_time(path.name)
+        if bt is None:
+            continue
+        if latest is None or bt > latest:
+            latest = bt
+    return latest
+
+
 def _expected_publish_time(
     base_time: datetime, config: DeliveryConfig,
 ) -> datetime:

--- a/src/weatherbrief/models/storage.py
+++ b/src/weatherbrief/models/storage.py
@@ -93,6 +93,12 @@ class BriefingPackMeta(BaseModel):
     artifact_path: str = ""  # path to pack directory
     model_init_times: dict[str, int] = Field(default_factory=dict)
     grib_init_times: dict[str, int] = Field(default_factory=dict)
+    # Maps logical model name → freshness source key (e.g. "ecmwf" → "ecmwf:direct"
+    # or "ecmwf:openmeteo").  Set at enrichment time so the freshness marker
+    # store knows which source to compare each pack's init against.  Empty for
+    # legacy packs created before issue #108 — the freshness check infers from
+    # ``grib_init_times`` presence in that case.
+    model_sources: dict[str, str] = Field(default_factory=dict)
     models_skipped_region: list[str] = Field(default_factory=list)
     diagnostics: list[Diagnostic] = Field(default_factory=list)
     alt_assessment: Optional[str] = None  # GREEN/AMBER/RED for alt departure

--- a/src/weatherbrief/scheduler.py
+++ b/src/weatherbrief/scheduler.py
@@ -41,7 +41,6 @@ _DIGEST_STARTUP_DELAY_SECONDS = 180  # let verification settle first
 _STANDALONE_STARTUP_DELAY_SECONDS = 240  # let other loops settle first
 _ECMWF_WATCHER_POLL_SECONDS = 300  # 5 minutes
 _ECMWF_WATCHER_STARTUP_DELAY_SECONDS = 15  # run early — other loops may need ready data
-_FRESHNESS_LOOP_POLL_SECONDS = 300  # 5 minutes
 _FRESHNESS_LOOP_STARTUP_DELAY_SECONDS = 20  # let ECMWF watcher run once first
 # Hewson precompute fires once per init cycle. 06Z and 18Z pick up the 00Z /
 # 12Z inits after ~6 h — Open-Meteo has all 3 models published by then, and
@@ -660,12 +659,12 @@ async def run_freshness_loop(app_state) -> None:
     dynamic readiness check on each (source, model) only when its marker's
     ``next_expected`` has passed.  Most ticks are no-ops and produce no I/O.
     """
+    from weatherbrief.fetch.freshness import LOOP_INTERVAL
     from weatherbrief.fetch.freshness.markers import get_store
     from weatherbrief.fetch.freshness.sources import all_tracked_sources
 
-    logger.info(
-        "Freshness loop started (poll every %ds)", _FRESHNESS_LOOP_POLL_SECONDS,
-    )
+    poll_seconds = int(LOOP_INTERVAL.total_seconds())
+    logger.info("Freshness loop started (poll every %ds)", poll_seconds)
     store = get_store()
     await store.bootstrap(all_tracked_sources())
     await asyncio.sleep(_FRESHNESS_LOOP_STARTUP_DELAY_SECONDS)
@@ -675,11 +674,21 @@ async def run_freshness_loop(app_state) -> None:
             await _run_freshness_check_once()
         except Exception:
             logger.error("Freshness loop cycle failed", exc_info=True)
-        await asyncio.sleep(_FRESHNESS_LOOP_POLL_SECONDS)
+        await asyncio.sleep(poll_seconds)
 
 
 async def _run_freshness_check_once() -> None:
-    """Check every marker whose next_expected has elapsed."""
+    """Run a single freshness-loop tick.
+
+    For every (source, model) marker:
+    - If ``next_expected`` hasn't elapsed yet, just bump ``last_check``
+      so the heartbeat stays fresh — no I/O.  Without this, sources whose
+      next-expected is hours away would have stale heartbeats and force
+      every freshness HTTP call into the inline-fallback (sync I/O on the
+      event loop) until the loop got around to checking them.
+    - Otherwise, run the dynamic ``check_source`` (offloaded to a thread)
+      and either advance the marker or record a slip.
+    """
     from weatherbrief.fetch.freshness.markers import get_store
     from weatherbrief.fetch.freshness.sources import all_tracked_sources, check_source
 
@@ -690,6 +699,7 @@ async def _run_freshness_check_once() -> None:
         if marker is None:
             continue
         if now < marker.next_expected:
+            await store.mark_check(source, model, now=now)
             continue
         observed = await asyncio.to_thread(check_source, source, model)
         if observed is None:

--- a/src/weatherbrief/scheduler.py
+++ b/src/weatherbrief/scheduler.py
@@ -41,6 +41,8 @@ _DIGEST_STARTUP_DELAY_SECONDS = 180  # let verification settle first
 _STANDALONE_STARTUP_DELAY_SECONDS = 240  # let other loops settle first
 _ECMWF_WATCHER_POLL_SECONDS = 300  # 5 minutes
 _ECMWF_WATCHER_STARTUP_DELAY_SECONDS = 15  # run early — other loops may need ready data
+_FRESHNESS_LOOP_POLL_SECONDS = 300  # 5 minutes
+_FRESHNESS_LOOP_STARTUP_DELAY_SECONDS = 20  # let ECMWF watcher run once first
 # Hewson precompute fires once per init cycle. 06Z and 18Z pick up the 00Z /
 # 12Z inits after ~6 h — Open-Meteo has all 3 models published by then, and
 # we keep ~1 h buffer before the 07Z / 19Z standalone forecast-fetch cycles.
@@ -206,11 +208,11 @@ def _auto_refresh_one(flight_row: FlightRow, app_state, user_id: str) -> None:
     try:
         flight = _row_to_flight(flight_row)
 
-        # Check freshness — skip if data hasn't changed
+        # Check freshness — skip if no source has fresher data covering the flight.
         packs = list_packs(db, flight_row.id)
         if packs:
             latest = packs[0]
-            status = _build_data_status(latest.model_init_times)
+            status = _build_data_status(latest, flight)
             if status.fresh:
                 logger.info("Auto-refresh: data is fresh for %s, skipping", flight_row.id)
                 return
@@ -644,6 +646,56 @@ def _run_ecmwf_watcher_once() -> list[datetime]:
     from weatherbrief.fetch.grib.ecmwf_watcher import check_ecmwf_completeness
 
     return check_ecmwf_completeness()
+
+
+# ---------------------------------------------------------------------------
+# Freshness marker loop (issue #108)
+# ---------------------------------------------------------------------------
+
+
+async def run_freshness_loop(app_state) -> None:
+    """Marker-based freshness loop — started as an asyncio task.
+
+    Bootstraps the in-memory ``MarkerStore`` from the registry, then runs a
+    dynamic readiness check on each (source, model) only when its marker's
+    ``next_expected`` has passed.  Most ticks are no-ops and produce no I/O.
+    """
+    from weatherbrief.fetch.freshness.markers import get_store
+    from weatherbrief.fetch.freshness.sources import all_tracked_sources
+
+    logger.info(
+        "Freshness loop started (poll every %ds)", _FRESHNESS_LOOP_POLL_SECONDS,
+    )
+    store = get_store()
+    await store.bootstrap(all_tracked_sources())
+    await asyncio.sleep(_FRESHNESS_LOOP_STARTUP_DELAY_SECONDS)
+
+    while True:
+        try:
+            await _run_freshness_check_once()
+        except Exception:
+            logger.error("Freshness loop cycle failed", exc_info=True)
+        await asyncio.sleep(_FRESHNESS_LOOP_POLL_SECONDS)
+
+
+async def _run_freshness_check_once() -> None:
+    """Check every marker whose next_expected has elapsed."""
+    from weatherbrief.fetch.freshness.markers import get_store
+    from weatherbrief.fetch.freshness.sources import all_tracked_sources, check_source
+
+    store = get_store()
+    now = datetime.now(timezone.utc)
+    for source, model in all_tracked_sources():
+        marker = store.get_sync(source, model)
+        if marker is None:
+            continue
+        if now < marker.next_expected:
+            continue
+        observed = await asyncio.to_thread(check_source, source, model)
+        if observed is None:
+            await store.mark_check(source, model, now=now)
+            continue
+        await store.update(source, model, observed, now=now)
 
 
 # ---------------------------------------------------------------------------

--- a/src/weatherbrief/storage/flights.py
+++ b/src/weatherbrief/storage/flights.py
@@ -202,6 +202,9 @@ def _meta_to_row(meta: BriefingPackMeta) -> BriefingPackRow:
         artifact_path=meta.artifact_path,
         model_init_times_json=json.dumps(meta.model_init_times),
         grib_init_times_json=json.dumps(meta.grib_init_times),
+        model_sources_json=(
+            json.dumps(meta.model_sources) if meta.model_sources else None
+        ),
         models_skipped_region_json=json.dumps(meta.models_skipped_region),
         diagnostics_json=json.dumps(
             [d.model_dump(mode="json") for d in meta.diagnostics],
@@ -290,6 +293,7 @@ def _row_to_meta(row: BriefingPackRow) -> BriefingPackMeta:
         artifact_path=_resolve_artifact_path(row.artifact_path),
         model_init_times=json.loads(row.model_init_times_json) if row.model_init_times_json else {},
         grib_init_times=json.loads(row.grib_init_times_json) if row.grib_init_times_json else {},
+        model_sources=json.loads(row.model_sources_json) if row.model_sources_json else {},
         models_skipped_region=json.loads(row.models_skipped_region_json) if row.models_skipped_region_json else [],
         diagnostics=_parse_diagnostics(row.diagnostics_json),
         alt_assessment=row.alt_assessment,

--- a/tests/test_freshness_admin.py
+++ b/tests/test_freshness_admin.py
@@ -1,0 +1,29 @@
+"""Tests for the admin freshness endpoint helpers (issue #108)."""
+
+from __future__ import annotations
+
+import math
+
+
+def _p90_index(count: int) -> int:
+    """Mirror of the formula used in admin.py for testability.
+
+    Nearest-rank p90: ceil(count * 0.9) - 1, floored at 0.
+    """
+    return max(0, math.ceil(count * 0.9) - 1)
+
+
+class TestP90Index:
+    def test_count_one_returns_zero(self):
+        assert _p90_index(1) == 0
+
+    def test_count_two_returns_one_not_zero(self):
+        # ``int(2 * 0.9) - 1 = 0`` would return the minimum sample, not p90.
+        # ``ceil(1.8) - 1 = 1`` returns the larger sample as expected.
+        assert _p90_index(2) == 1
+
+    def test_count_ten_returns_nine(self):
+        assert _p90_index(10) == 8  # ceil(9.0) - 1 = 8 (90th percentile slot)
+
+    def test_count_eleven(self):
+        assert _p90_index(11) == 9  # ceil(9.9) - 1 = 9

--- a/tests/test_freshness_markers.py
+++ b/tests/test_freshness_markers.py
@@ -1,0 +1,183 @@
+"""Unit tests for the in-memory MarkerStore (issue #108)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from weatherbrief.fetch.freshness import registry
+from weatherbrief.fetch.freshness.markers import MarkerStore
+
+
+def _utc(year: int, month: int, day: int, hour: int = 0, minute: int = 0) -> datetime:
+    return datetime(year, month, day, hour, minute, tzinfo=timezone.utc)
+
+
+@pytest.mark.asyncio
+async def test_bootstrap_populates_all_requested_sources():
+    store = MarkerStore()
+    sources = [
+        ("ecmwf:direct", "ecmwf"),
+        ("gfs:noaa", "gfs"),
+        ("icon_eu:dwd", "icon_eu"),
+    ]
+    await store.bootstrap(sources, now=_utc(2026, 5, 3, 12))
+    assert len(store.keys_sync()) == 3
+    m = store.get_sync("ecmwf:direct", "ecmwf")
+    assert m is not None
+    assert m.init <= _utc(2026, 5, 3, 12)
+    assert m.next_expected > _utc(2026, 5, 3, 12)
+    assert m.last_check is None
+
+
+@pytest.mark.asyncio
+async def test_update_advances_init_when_newer():
+    store = MarkerStore()
+    await store.bootstrap([("ecmwf:direct", "ecmwf")], now=_utc(2026, 5, 3, 12))
+    m_before = store.get_sync("ecmwf:direct", "ecmwf")
+    new_init = _utc(2026, 5, 3, 6)
+    if new_init <= m_before.init:
+        # Bootstrap may have already chosen 06Z — push forward to 12Z run.
+        new_init = _utc(2026, 5, 3, 12)
+
+    await store.update("ecmwf:direct", "ecmwf", new_init, now=_utc(2026, 5, 3, 19))
+    m = store.get_sync("ecmwf:direct", "ecmwf")
+    assert m.init == new_init
+    assert m.slip_count == 0
+    assert m.last_check == _utc(2026, 5, 3, 19)
+    # Observations are (cycle_init, arrival_wallclock) pairs.
+    obs_inits = [pair[0] for pair in m.observations]
+    obs_arrivals = [pair[1] for pair in m.observations]
+    assert new_init in obs_inits
+    assert _utc(2026, 5, 3, 19) in obs_arrivals
+
+
+@pytest.mark.asyncio
+async def test_update_no_change_before_expected_does_not_slip():
+    store = MarkerStore()
+    await store.bootstrap([("ecmwf:direct", "ecmwf")], now=_utc(2026, 5, 3, 12))
+    m_before = store.get_sync("ecmwf:direct", "ecmwf")
+
+    # Same init, before next_expected → just update last_check, no slip.
+    early = m_before.next_expected - timedelta(minutes=30)
+    await store.update("ecmwf:direct", "ecmwf", m_before.init, now=early)
+    m = store.get_sync("ecmwf:direct", "ecmwf")
+    assert m.slip_count == 0
+    assert m.next_expected == m_before.next_expected
+    assert m.last_check == early
+
+
+@pytest.mark.asyncio
+async def test_update_no_change_after_expected_increments_slip():
+    store = MarkerStore()
+    await store.bootstrap([("ecmwf:direct", "ecmwf")], now=_utc(2026, 5, 3, 12))
+    m_before = store.get_sync("ecmwf:direct", "ecmwf")
+    cfg = registry.SOURCE_REGISTRY["ecmwf:direct"]
+
+    # Same init, AT next_expected → first slip bumps by cfg.slip_bump(1) which
+    # equals the base retry_interval.
+    late = m_before.next_expected
+    await store.update("ecmwf:direct", "ecmwf", m_before.init, now=late)
+    m = store.get_sync("ecmwf:direct", "ecmwf")
+    assert m.slip_count == 1
+    assert m.next_expected == m_before.next_expected + cfg.slip_bump(1)
+    assert cfg.slip_bump(1) == cfg.retry_interval
+
+
+@pytest.mark.asyncio
+async def test_slip_backoff_grows_then_caps():
+    """Slip bumps should grow exponentially up to ``max_retry_interval``."""
+    store = MarkerStore()
+    await store.bootstrap([("ecmwf:direct", "ecmwf")], now=_utc(2026, 5, 3, 12))
+    cfg = registry.SOURCE_REGISTRY["ecmwf:direct"]
+
+    seen_bumps: list[timedelta] = []
+    prev_next = store.get_sync("ecmwf:direct", "ecmwf").next_expected
+    for slip in range(1, cfg.max_slip_retries + 1):
+        m = store.get_sync("ecmwf:direct", "ecmwf")
+        await store.update("ecmwf:direct", "ecmwf", m.init, now=m.next_expected)
+        m_after = store.get_sync("ecmwf:direct", "ecmwf")
+        seen_bumps.append(m_after.next_expected - prev_next)
+        prev_next = m_after.next_expected
+
+    # Bumps should be non-decreasing and respect the cap.
+    for i in range(1, len(seen_bumps)):
+        assert seen_bumps[i] >= seen_bumps[i - 1]
+    assert seen_bumps[-1] <= cfg.max_retry_interval
+    # And the first bump matches the base interval (1-based slip_count).
+    assert seen_bumps[0] == cfg.retry_interval
+
+
+@pytest.mark.asyncio
+async def test_slip_cap_jumps_to_next_cycle():
+    store = MarkerStore()
+    await store.bootstrap([("ecmwf:direct", "ecmwf")], now=_utc(2026, 5, 3, 12))
+    cfg = registry.SOURCE_REGISTRY["ecmwf:direct"]
+
+    # Drive slip up to and past the cap.  Each call: same observed_init,
+    # now == current next_expected → bumps.
+    for _ in range(cfg.max_slip_retries + 1):
+        m = store.get_sync("ecmwf:direct", "ecmwf")
+        await store.update("ecmwf:direct", "ecmwf", m.init, now=m.next_expected)
+
+    m_final = store.get_sync("ecmwf:direct", "ecmwf")
+    assert m_final.slip_count == 0  # reset after jump
+    # next_expected should be aligned to a registered cycle's delivery — same
+    # minute-of-hour as the registry's offset (modulo 60).
+    expected_minute = int(cfg.offset_for(0).total_seconds() / 60) % 60
+    assert m_final.next_expected.minute == expected_minute
+
+
+@pytest.mark.asyncio
+async def test_is_stale_when_never_checked():
+    store = MarkerStore()
+    await store.bootstrap([("gfs:noaa", "gfs")], now=_utc(2026, 5, 3, 12))
+    m = store.get_sync("gfs:noaa", "gfs")
+    assert m.is_stale(loop_interval=timedelta(minutes=5)) is True
+
+
+@pytest.mark.asyncio
+async def test_is_stale_after_two_loop_intervals():
+    store = MarkerStore()
+    await store.bootstrap([("gfs:noaa", "gfs")], now=_utc(2026, 5, 3, 12))
+    # Manually backdate last_check
+    m = store.get_sync("gfs:noaa", "gfs")
+    # Use an in-place mutation via internal access — fine for test
+    store._markers[("gfs:noaa", "gfs")].last_check = (
+        datetime.now(timezone.utc) - timedelta(minutes=15)
+    )
+    m = store.get_sync("gfs:noaa", "gfs")
+    assert m.is_stale(loop_interval=timedelta(minutes=5)) is True
+    # 1 × interval is not stale
+    store._markers[("gfs:noaa", "gfs")].last_check = (
+        datetime.now(timezone.utc) - timedelta(minutes=4)
+    )
+    m = store.get_sync("gfs:noaa", "gfs")
+    assert m.is_stale(loop_interval=timedelta(minutes=5)) is False
+
+
+@pytest.mark.asyncio
+async def test_get_returns_immutable_snapshot():
+    """Mutating the returned marker must not affect the store."""
+    store = MarkerStore()
+    await store.bootstrap([("gfs:noaa", "gfs")], now=_utc(2026, 5, 3, 12))
+    m1 = store.get_sync("gfs:noaa", "gfs")
+    m1.slip_count = 999
+    sentinel = (_utc(2030, 1, 1), _utc(2030, 1, 1, 5))
+    m1.observations.append(sentinel)
+    m2 = store.get_sync("gfs:noaa", "gfs")
+    assert m2.slip_count == 0
+    assert sentinel not in list(m2.observations)
+
+
+@pytest.mark.asyncio
+async def test_mark_check_refreshes_heartbeat_only():
+    store = MarkerStore()
+    await store.bootstrap([("gfs:noaa", "gfs")], now=_utc(2026, 5, 3, 12))
+    before = store.get_sync("gfs:noaa", "gfs")
+    await store.mark_check("gfs:noaa", "gfs", now=_utc(2026, 5, 3, 13))
+    after = store.get_sync("gfs:noaa", "gfs")
+    assert after.last_check == _utc(2026, 5, 3, 13)
+    assert after.init == before.init
+    assert after.next_expected == before.next_expected

--- a/tests/test_freshness_markers.py
+++ b/tests/test_freshness_markers.py
@@ -28,7 +28,11 @@ async def test_bootstrap_populates_all_requested_sources():
     assert m is not None
     assert m.init <= _utc(2026, 5, 3, 12)
     assert m.next_expected > _utc(2026, 5, 3, 12)
-    assert m.last_check is None
+    # Bootstrap sets last_check so freshly-bootstrapped markers don't
+    # immediately read as suspect (which would force every freshness HTTP
+    # call into the inline-fallback sync-I/O path).  The actual is_stale
+    # check is wall-clock-relative and tested separately.
+    assert m.last_check == _utc(2026, 5, 3, 12)
 
 
 @pytest.mark.asyncio
@@ -111,29 +115,48 @@ async def test_slip_backoff_grows_then_caps():
 
 @pytest.mark.asyncio
 async def test_slip_cap_jumps_to_next_cycle():
-    store = MarkerStore()
-    await store.bootstrap([("ecmwf:direct", "ecmwf")], now=_utc(2026, 5, 3, 12))
-    cfg = registry.SOURCE_REGISTRY["ecmwf:direct"]
+    """After slip-cap, marker should target the cycle right after the
+    one that was slipping — not several cycles later.
 
-    # Drive slip up to and past the cap.  Each call: same observed_init,
-    # now == current next_expected → bumps.
+    Regression for PR #109 review: previous code derived the skipped cycle
+    from the bumped ``next_expected`` instead of from ``marker.init``, so
+    accumulated backoff pushed the jump past intermediate cycles.
+    """
+    store = MarkerStore()
+    # Bootstrap at a time when the latest delivered ECMWF cycle is 00Z.
+    await store.bootstrap([("ecmwf:direct", "ecmwf")], now=_utc(2026, 5, 3, 8))
+    cfg = registry.SOURCE_REGISTRY["ecmwf:direct"]
+    pre_init = store.get_sync("ecmwf:direct", "ecmwf").init
+
     for _ in range(cfg.max_slip_retries + 1):
         m = store.get_sync("ecmwf:direct", "ecmwf")
         await store.update("ecmwf:direct", "ecmwf", m.init, now=m.next_expected)
 
     m_final = store.get_sync("ecmwf:direct", "ecmwf")
-    assert m_final.slip_count == 0  # reset after jump
-    # next_expected should be aligned to a registered cycle's delivery — same
-    # minute-of-hour as the registry's offset (modulo 60).
-    expected_minute = int(cfg.offset_for(0).total_seconds() / 60) % 60
-    assert m_final.next_expected.minute == expected_minute
+    assert m_final.slip_count == 0
+    # The cycle we were waiting for is the one right after pre_init.
+    # Slip-cap should target the cycle two ahead of pre_init.
+    skipped_cycle = registry.next_cycle_init_after("ecmwf:direct", pre_init)
+    target_cycle = registry.next_cycle_init_after("ecmwf:direct", skipped_cycle)
+    assert m_final.next_expected == registry.expected_delivery_for_init(
+        "ecmwf:direct", target_cycle,
+    )
 
 
 @pytest.mark.asyncio
-async def test_is_stale_when_never_checked():
-    store = MarkerStore()
-    await store.bootstrap([("gfs:noaa", "gfs")], now=_utc(2026, 5, 3, 12))
-    m = store.get_sync("gfs:noaa", "gfs")
+async def test_is_stale_when_last_check_is_none():
+    """Manually-constructed marker with last_check=None should be stale.
+
+    Bootstrap sets last_check (so this can't happen via the public API),
+    but Marker(...) is also used internally — the heartbeat logic must
+    still treat last_check=None as suspect.
+    """
+    from weatherbrief.fetch.freshness.markers import Marker
+    m = Marker(
+        source="gfs:noaa", model="gfs",
+        init=_utc(2026, 5, 3, 6), next_expected=_utc(2026, 5, 3, 12),
+        last_check=None,
+    )
     assert m.is_stale(loop_interval=timedelta(minutes=5)) is True
 
 
@@ -181,3 +204,48 @@ async def test_mark_check_refreshes_heartbeat_only():
     assert after.last_check == _utc(2026, 5, 3, 13)
     assert after.init == before.init
     assert after.next_expected == before.next_expected
+
+
+@pytest.mark.asyncio
+async def test_loop_tick_refreshes_heartbeat_for_not_yet_due_marker(monkeypatch):
+    """The freshness loop must bump last_check even for sources that aren't
+    yet due — otherwise their heartbeat goes stale during the gap between
+    next_expected boundaries, forcing freshness HTTP calls into the
+    inline-fallback (sync I/O on the event loop).
+
+    Regression for PR #109 review: previously the loop's not-due branch
+    used ``continue`` without touching last_check.
+    """
+    from weatherbrief.fetch.freshness import markers as markers_mod
+    from weatherbrief.scheduler import _run_freshness_check_once
+
+    # Inject our own store as the singleton.
+    test_store = MarkerStore()
+    await test_store.bootstrap(
+        [("gfs:noaa", "gfs")], now=_utc(2026, 5, 3, 12),
+    )
+    monkeypatch.setattr(markers_mod, "_STORE", test_store)
+
+    before = test_store.get_sync("gfs:noaa", "gfs")
+    # Simulate a tick well before next_expected (so we hit the not-due path).
+    next_exp = before.next_expected
+    assert next_exp > _utc(2026, 5, 3, 13)  # sanity
+
+    # Patch wallclock used by the loop to a moment before next_expected, but
+    # after bootstrap_now (so last_check would change visibly).
+    fake_now = _utc(2026, 5, 3, 13)
+
+    class _FakeDatetime:
+        @staticmethod
+        def now(tz):
+            return fake_now
+
+    import weatherbrief.scheduler as scheduler_mod
+    monkeypatch.setattr(scheduler_mod, "datetime", _FakeDatetime)
+
+    await _run_freshness_check_once()
+
+    after = test_store.get_sync("gfs:noaa", "gfs")
+    assert after.last_check == fake_now
+    assert after.next_expected == before.next_expected  # untouched
+    assert after.init == before.init                    # untouched

--- a/tests/test_freshness_registry.py
+++ b/tests/test_freshness_registry.py
@@ -1,0 +1,167 @@
+"""Unit tests for freshness schedule registry (issue #108)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from weatherbrief.fetch.freshness.registry import (
+    SOURCE_REGISTRY,
+    cycle_init_for,
+    expected_delivery_for_init,
+    initial_marker_for,
+    next_cycle_after,
+    next_run_after,
+    run_horizon,
+)
+
+
+def _utc(year: int, month: int, day: int, hour: int = 0, minute: int = 0) -> datetime:
+    return datetime(year, month, day, hour, minute, tzinfo=timezone.utc)
+
+
+# ---------------------------------------------------------------------------
+# next_run_after
+# ---------------------------------------------------------------------------
+
+
+class TestNextRunAfter:
+    def test_ecmwf_direct_00z_to_06z(self):
+        # 00Z init → next cycle 06Z + 6h40m offset
+        nxt = next_run_after("ecmwf:direct", _utc(2026, 5, 3, 0))
+        assert nxt == _utc(2026, 5, 3, 6) + timedelta(hours=6, minutes=40)
+
+    def test_ecmwf_direct_18z_rolls_to_next_day(self):
+        nxt = next_run_after("ecmwf:direct", _utc(2026, 5, 3, 18))
+        assert nxt == _utc(2026, 5, 4, 0) + timedelta(hours=6, minutes=40)
+
+    def test_gfs_noaa_12z_to_18z(self):
+        nxt = next_run_after("gfs:noaa", _utc(2026, 5, 3, 12))
+        assert nxt == _utc(2026, 5, 3, 18) + timedelta(hours=5)
+
+    def test_icon_eu_dwd_3h_intermediate(self):
+        # 06Z (main) → 09Z (intermediate) + 3h offset
+        nxt = next_run_after("icon_eu:dwd", _utc(2026, 5, 3, 6))
+        assert nxt == _utc(2026, 5, 3, 9) + timedelta(hours=3)
+
+    def test_ecmwf_openmeteo_skips_06_18(self):
+        # Registry only tracks ECMWF Open-Meteo 00/12 cycles.
+        nxt = next_run_after("ecmwf:openmeteo", _utc(2026, 5, 3, 0))
+        assert nxt == _utc(2026, 5, 3, 12) + timedelta(hours=8)
+
+    def test_ecmwf_openmeteo_12z_rolls_to_next_day_00z(self):
+        nxt = next_run_after("ecmwf:openmeteo", _utc(2026, 5, 3, 12))
+        assert nxt == _utc(2026, 5, 4, 0) + timedelta(hours=8)
+
+
+class TestNextCycleAfter:
+    def test_skip_one_cycle(self):
+        # If 06Z is slipping past cap, jump to expected delivery of 12Z
+        nxt = next_cycle_after("ecmwf:direct", _utc(2026, 5, 3, 6))
+        assert nxt == _utc(2026, 5, 3, 12) + timedelta(hours=6, minutes=40)
+
+
+# ---------------------------------------------------------------------------
+# run_horizon
+# ---------------------------------------------------------------------------
+
+
+class TestRunHorizon:
+    def test_ecmwf_direct_00z_is_168h(self):
+        assert run_horizon("ecmwf:direct", _utc(2026, 5, 3, 0)) == timedelta(hours=168)
+
+    def test_ecmwf_direct_06z_is_medium_only_90h(self):
+        assert run_horizon("ecmwf:direct", _utc(2026, 5, 3, 6)) == timedelta(hours=90)
+
+    def test_icon_eu_main_120h(self):
+        for h in (0, 6, 12, 18):
+            assert run_horizon("icon_eu:dwd", _utc(2026, 5, 3, h)) == timedelta(hours=120)
+
+    def test_icon_eu_intermediate_78h(self):
+        for h in (3, 9, 15, 21):
+            assert run_horizon("icon_eu:dwd", _utc(2026, 5, 3, h)) == timedelta(hours=78)
+
+    def test_gfs_noaa_uniform_384h(self):
+        assert run_horizon("gfs:noaa", _utc(2026, 5, 3, 0)) == timedelta(hours=384)
+
+
+# ---------------------------------------------------------------------------
+# cycle_init_for / expected_delivery_for_init
+# ---------------------------------------------------------------------------
+
+
+class TestCycleMath:
+    def test_cycle_init_floors_to_most_recent(self):
+        # 14:30Z → most recent ECMWF cycle is 12Z
+        assert cycle_init_for("ecmwf:direct", _utc(2026, 5, 3, 14, 30)) == _utc(2026, 5, 3, 12)
+
+    def test_cycle_init_handles_midnight_rollover(self):
+        # 00:30Z → most recent ECMWF cycle is 00Z (today, not yesterday's 18Z)
+        assert cycle_init_for("ecmwf:direct", _utc(2026, 5, 3, 0, 30)) == _utc(2026, 5, 3, 0)
+
+    def test_expected_delivery_uses_per_cycle_offset(self):
+        # ECMWF uses uniform offset, but verify the dispatch path
+        d = expected_delivery_for_init("ecmwf:direct", _utc(2026, 5, 3, 0))
+        assert d == _utc(2026, 5, 3, 6) + timedelta(minutes=40)
+
+
+# ---------------------------------------------------------------------------
+# initial_marker_for (bootstrap)
+# ---------------------------------------------------------------------------
+
+
+class TestInitialMarker:
+    def test_bootstrap_uses_latest_delivered_cycle(self):
+        # At 09:00Z, ECMWF 00Z cycle (delivered ~06:40Z) is the latest ready.
+        # Next expected is 06Z cycle's delivery at 12:40Z.
+        init, nxt = initial_marker_for("ecmwf:direct", now=_utc(2026, 5, 3, 9))
+        assert init == _utc(2026, 5, 3, 0)
+        assert nxt == _utc(2026, 5, 3, 6) + timedelta(hours=6, minutes=40)
+
+    def test_bootstrap_falls_back_when_current_cycle_not_yet_due(self):
+        # At 03:00Z, the 00Z cycle won't be ready until 06:40Z.
+        # Fall back to yesterday's 18Z cycle.
+        init, nxt = initial_marker_for("ecmwf:direct", now=_utc(2026, 5, 3, 3))
+        assert init == _utc(2026, 5, 2, 18)
+        assert nxt == _utc(2026, 5, 3, 0) + timedelta(hours=6, minutes=40)
+
+    def test_bootstrap_for_each_registered_source(self):
+        # Smoke: every registered source produces a valid (init, next_expected).
+        now = _utc(2026, 5, 3, 12)
+        for key in SOURCE_REGISTRY:
+            init, nxt = initial_marker_for(key, now=now)
+            assert init.tzinfo == timezone.utc
+            assert nxt > init
+
+
+# ---------------------------------------------------------------------------
+# Registry coverage
+# ---------------------------------------------------------------------------
+
+
+def test_all_expected_sources_registered():
+    expected = {
+        "ecmwf:direct",
+        "gfs:noaa",
+        "icon_eu:dwd",
+        "gfs:openmeteo",
+        "ecmwf:openmeteo",
+        "icon:openmeteo",
+        "meteofrance:openmeteo",
+        "ukmo:openmeteo",
+    }
+    assert set(SOURCE_REGISTRY.keys()) == expected
+
+
+@pytest.mark.parametrize("key", list(SOURCE_REGISTRY.keys()))
+def test_each_source_has_sane_offsets(key):
+    cfg = SOURCE_REGISTRY[key]
+    assert cfg.retry_interval > timedelta(0)
+    assert cfg.max_slip_retries > 0
+    # Offset should be at least 30 min and at most 12 h for any reasonable source.
+    for cycle in cfg.cycles:
+        off = cfg.offset_for(cycle)
+        assert timedelta(minutes=30) <= off <= timedelta(hours=12)
+        h = cfg.horizon_for(cycle)
+        assert h >= timedelta(hours=24)

--- a/tests/test_freshness_registry.py
+++ b/tests/test_freshness_registry.py
@@ -11,7 +11,7 @@ from weatherbrief.fetch.freshness.registry import (
     cycle_init_for,
     expected_delivery_for_init,
     initial_marker_for,
-    next_cycle_after,
+    next_cycle_init_after,
     next_run_after,
     run_horizon,
 )
@@ -55,11 +55,16 @@ class TestNextRunAfter:
         assert nxt == _utc(2026, 5, 4, 0) + timedelta(hours=8)
 
 
-class TestNextCycleAfter:
-    def test_skip_one_cycle(self):
-        # If 06Z is slipping past cap, jump to expected delivery of 12Z
-        nxt = next_cycle_after("ecmwf:direct", _utc(2026, 5, 3, 6))
-        assert nxt == _utc(2026, 5, 3, 12) + timedelta(hours=6, minutes=40)
+class TestNextCycleInitAfter:
+    def test_returns_next_cycle_init_without_offset(self):
+        # 00Z + 1 = 06Z (no offset added — caller composes with
+        # expected_delivery_for_init when delivery wallclock is needed).
+        nxt = next_cycle_init_after("ecmwf:direct", _utc(2026, 5, 3, 0))
+        assert nxt == _utc(2026, 5, 3, 6)
+
+    def test_rolls_to_next_day(self):
+        nxt = next_cycle_init_after("ecmwf:direct", _utc(2026, 5, 3, 18))
+        assert nxt == _utc(2026, 5, 4, 0)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_freshness_sources.py
+++ b/tests/test_freshness_sources.py
@@ -1,0 +1,141 @@
+"""Tests for dynamic source dispatch + the new ECMWF watcher helper."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from weatherbrief.fetch.freshness import sources
+from weatherbrief.fetch.freshness.registry import SOURCE_REGISTRY
+from weatherbrief.fetch.grib import ecmwf_watcher
+
+
+def _utc(year: int, month: int, day: int, hour: int = 0) -> datetime:
+    return datetime(year, month, day, hour, tzinfo=timezone.utc)
+
+
+# ---------------------------------------------------------------------------
+# ecmwf_watcher.get_latest_ready
+# ---------------------------------------------------------------------------
+
+
+class TestGetLatestReady:
+    def test_returns_none_for_empty_dir(self, tmp_path: Path):
+        assert ecmwf_watcher.get_latest_ready(tmp_path) is None
+
+    def test_returns_none_when_dir_missing(self, tmp_path: Path):
+        missing = tmp_path / "nope"
+        assert ecmwf_watcher.get_latest_ready(missing) is None
+
+    def test_finds_max_complete_sentinel(self, tmp_path: Path):
+        (tmp_path / ".ready_20260503_00z").write_text("complete")
+        (tmp_path / ".ready_20260502_18z").write_text("complete")
+        latest = ecmwf_watcher.get_latest_ready(tmp_path)
+        assert latest == _utc(2026, 5, 3, 0)
+
+    def test_includes_partial_sentinels(self, tmp_path: Path):
+        # Partial sentinels should also count — a timed-out partial run is
+        # still useful data.
+        (tmp_path / ".ready_20260502_18z").write_text("complete")
+        (tmp_path / ".ready_20260503_00z.partial").write_text("partial")
+        latest = ecmwf_watcher.get_latest_ready(tmp_path)
+        assert latest == _utc(2026, 5, 3, 0)
+
+    def test_ignores_non_sentinel_files(self, tmp_path: Path):
+        (tmp_path / ".ready_20260503_00z").write_text("complete")
+        (tmp_path / "delivery_config.json").write_text("{}")
+        (tmp_path / "A1S05030000050300011").write_text("grib bytes")
+        (tmp_path / ".ready_garbage").write_text("noise")
+        latest = ecmwf_watcher.get_latest_ready(tmp_path)
+        assert latest == _utc(2026, 5, 3, 0)
+
+    def test_ignores_malformed_sentinel_names(self, tmp_path: Path):
+        (tmp_path / ".ready_2026_xx_zz").write_text("noise")
+        (tmp_path / ".ready_20260503_24z").write_text("noise")  # invalid hour
+        (tmp_path / ".ready_20260503_06z").write_text("complete")
+        latest = ecmwf_watcher.get_latest_ready(tmp_path)
+        assert latest == _utc(2026, 5, 3, 6)
+
+
+# ---------------------------------------------------------------------------
+# sources.check_source dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestCheckSourceDispatch:
+    def test_unknown_source_returns_none(self, caplog):
+        assert sources.check_source("bogus:source", "ecmwf") is None
+
+    def test_ecmwf_direct_uses_watcher(self, monkeypatch, tmp_path: Path):
+        # Drop a sentinel and point the watcher at the temp dir.
+        (tmp_path / ".ready_20260503_12z").write_text("complete")
+
+        def _fake_dir():
+            return tmp_path
+        monkeypatch.setattr(
+            "weatherbrief.fetch.grib.ecmwf_watcher.ecmwf_grib_dir",
+            _fake_dir,
+        )
+        result = sources.check_source("ecmwf:direct", "ecmwf")
+        assert result == _utc(2026, 5, 3, 12)
+
+    def test_gfs_noaa_returns_aware_utc(self, monkeypatch):
+        from weatherbrief.fetch.grib import grib_fetch
+
+        def _fake(target_time, **kw):
+            return ("20260503", 6)
+        monkeypatch.setattr(grib_fetch, "find_latest_run", _fake)
+        result = sources.check_source("gfs:noaa", "gfs")
+        assert result == _utc(2026, 5, 3, 6)
+        assert result.tzinfo == timezone.utc
+
+    def test_icon_eu_dwd_returns_aware_utc(self, monkeypatch):
+        from weatherbrief.fetch.grib import icon_eu_fetch
+
+        def _fake(target_time, **kw):
+            return ("20260503", 9)
+        monkeypatch.setattr(icon_eu_fetch, "find_latest_icon_eu_run", _fake)
+        result = sources.check_source("icon_eu:dwd", "icon_eu")
+        assert result == _utc(2026, 5, 3, 9)
+
+    def test_om_meta_returns_aware_utc(self, monkeypatch):
+        from weatherbrief.fetch import model_status
+
+        ts = int(_utc(2026, 5, 3, 12).timestamp())
+
+        def _fake_meta(models, **kw):
+            return {
+                models[0]: model_status.ModelMetadata(
+                    model=models[0],
+                    last_init_time=ts,
+                    last_availability_time=ts + 60,
+                    update_interval_seconds=21600,
+                )
+            }
+        monkeypatch.setattr(model_status, "fetch_model_metadata", _fake_meta)
+        result = sources.check_source("gfs:openmeteo", "gfs")
+        assert result == _utc(2026, 5, 3, 12)
+
+    def test_dispatch_swallows_exceptions(self, monkeypatch):
+        from weatherbrief.fetch.grib import grib_fetch
+
+        def _boom(*a, **k):
+            raise RuntimeError("simulated S3 outage")
+        monkeypatch.setattr(grib_fetch, "find_latest_run", _boom)
+        result = sources.check_source("gfs:noaa", "gfs")
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# all_tracked_sources
+# ---------------------------------------------------------------------------
+
+
+def test_all_tracked_sources_matches_registry():
+    pairs = sources.all_tracked_sources()
+    assert len(pairs) == len(SOURCE_REGISTRY)
+    for src, model in pairs:
+        assert src in SOURCE_REGISTRY
+        assert src.startswith(model + ":")

--- a/web/ts/store/types.ts
+++ b/web/ts/store/types.ts
@@ -91,12 +91,22 @@ export interface CreateFlightRequest {
   raw_route?: string;
 }
 
+export interface ModelStatus {
+  source: string;
+  pack_init: number | null;
+  latest_available: number;
+  next_expected: string;
+  state: "current" | "stale" | "awaiting" | "delayed";
+}
+
 export interface DataStatus {
   fresh: boolean;
   stale_models: string[];
   model_init_times: Record<string, number>;
   next_expected_update: string | null;
   next_expected_model: string | null;
+  marker_health?: "ok" | "suspect";
+  models?: Record<string, ModelStatus>;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Replaces per-call Open-Meteo `meta.json` fan-out with an in-memory marker store gated by a hardcoded schedule registry; most freshness HTTP calls become pure compute (`now < pack.next_expected_update` ⇒ fresh, no I/O).
- Pack now records `model_sources` per model (`ecmwf:direct` vs `ecmwf:openmeteo` etc.), and `_build_data_status` is horizon-aware — a newer run only flags stale if its forecast horizon actually covers the flight's end time.
- Auto-refresh consults markers via the same path; eliminates today's "fire at 07:07Z before ECMWF 00Z is delivered" wasted-refresh issue without a wallclock shift.

## Architecture (issue #108 design)

```
background loop (5 min):
  for (model, source):
    if now < marker.next_expected: skip   # most ticks no-op
    new_init = check_source(source, model)
    if new_init > marker.init: advance (reset slip, log delay vs registry)
    elif now >= next_expected:  slip with exponential backoff
                                (cap → next-cycle jump after N slips)

freshness_check(pack, flight):              # pure compute when healthy
  for (model, source) in pack.model_sources:
    stale iff marker.init > pack.init AND registry.run_horizon ≥ flight_end
```

Eight tracked pairs: `ecmwf:direct`, `gfs:noaa`, `icon_eu:dwd` + five OM republishes (`gfs/ecmwf/icon/meteofrance/ukmo:openmeteo`).

## What's new

| Layer | Change |
|---|---|
| `fetch/freshness/registry.py` | `SourceConfig`, `SOURCE_REGISTRY`, cycle math, run horizon, exponential `slip_bump` |
| `fetch/freshness/markers.py` | `MarkerStore` (asyncio-locked), `(cycle_init, arrival_wallclock)` observations deque (maxlen 100), heartbeat `is_stale` |
| `fetch/freshness/sources.py` | Unified `check_source` dispatch wrapping existing `find_latest_run` / `find_latest_icon_eu_run` / OM `meta.json` |
| `fetch/grib/ecmwf_watcher.py` | New `get_latest_ready()` — scans existing `.ready_*z` sentinels |
| `scheduler.py` | `run_freshness_loop` (5-min cadence) + `_run_freshness_check_once`; auto-refresh (line ~213) consults markers |
| `api/packs.py` | Rewrote `_build_data_status(pack, flight)`; legacy-pack backfill via `grib_init_times`; `DataStatus` extended additively (`marker_health`, `models`) |
| `api/admin.py` | `GET /admin/freshness/markers` — full marker dump + per-cycle-hour `calibration` block (`count / median_delay_s / p90_delay_s / configured_offset_s / drift_p90_vs_config_s`) |
| `models/storage.py` + `db/models.py` | `BriefingPackMeta.model_sources` + nullable `model_sources_json` Text column |
| `alembic/050_pack_model_sources.py` | `batch_alter_table` add column (SQLite + MySQL safe per CLAUDE.md) |
| `web/ts/store/types.ts` | `ModelStatus` + extends `DataStatus` (additive — no FE behavior change) |

## Calibration during local validation

OM offsets in issue #108's table proved aggressive vs reality on 2026-05-03; observed delays were significantly longer (GFS 6h37m vs spec 3h45m, ICON 4h17m vs spec 1h30m, UKMO 8h19m vs spec 6h). Updated registry to today-observed + small margin. ICON OM cycle also corrected from 3h to 6h (matches OM's `update_interval_seconds: 21600`). The marker store's observations deque now lets the admin endpoint surface ongoing drift, so this can be retuned without further code changes.

## Backwards compatibility

- New pack column is nullable. Legacy packs missing `model_sources_json` are inferred via `_backfill_sources(pack)` — a model in `grib_init_times` → direct source; otherwise OM.
- `DataStatus` keeps `fresh`, `stale_models`, `model_init_times`, `next_expected_update`, `next_expected_model`. New fields (`marker_health`, `models`) are additive.

## Out of scope (per issue)

- Frontend adaptive polling using `next_expected_update` — separate follow-up issue.
- Persisting marker state to disk/DB.
- Auto-tuning the registry from observations (drift detection only).

Addresses #108

## Test plan

- [x] 50 new unit tests pass (registry cycle math, marker store including exponential backoff and slip-cap, source dispatch, ECMWF watcher's `get_latest_ready`).
- [x] Full suite: 1599 passed / 1 flaky pre-existing failure / 8 skipped.
- [x] Migration applies cleanly on fresh SQLite (verified locally).
- [x] App boots: bootstrap completes in <1s, `Freshness loop started (poll every 300s)`.
- [x] `/api/admin/freshness/markers` returns 8 markers; sensible `init` / `next_expected`.
- [x] End-to-end refresh records `model_sources_json` correctly: `{"ecmwf": "ecmwf:direct", "gfs": "gfs:noaa", "icon": "icon_eu:dwd"}` for a GRIB-enriched pack.
- [x] Loop observed real GFS NOAA advance 06Z→12Z at 17:11Z (calibration data captured in deque).
- [x] Slip handling exercised by real OM cadence drift before registry was retuned (slip=12 reached, behavior verified before backoff change).
- [ ] Reviewer: hit `/api/admin/freshness/markers` after a few cycles to spot-check `calibration.drift_p90_vs_config_s` — should converge near zero with the tuned offsets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)