### PR TITLE
perf(briefing): parallelise per-model Open-Meteo fetch (#112)

### DIFF
--- a/designs/future/us-expansion-plan.md
+++ b/designs/future/us-expansion-plan.md
@@ -52,7 +52,7 @@ Score table growth is the storage concern. Activate the existing `verification_m
 
 ## Implementation order
 
-1. **Pre-req**: EU parallelisation PR (issue #110) merged and validated in prod
+1. **Pre-req**: standalone-verification parallelisation (issue #110 — chunk-level parallelism inside `_fetch_forecasts_for_model`) merged and validated in prod. Distinct from issue #112, which parallelises the per-model loop in the *briefing* pipeline; that's already shipped and unrelated to standalone capacity headroom.
 2. Add `region` column to watchlist JSON and `AirportForecastSnapshotRow` (alembic migration)
 3. Extend `STANDALONE_MODELS` to be region-aware: `{"eu": ["gfs", "icon", "ecmwf"], "us": ["gfs", "ecmwf"]}`
 4. Add 13Z and 01Z to `FORECAST_FETCH_HOURS_UTC` for the US region (or split the loop)

--- a/designs/future/us-expansion-plan.md
+++ b/designs/future/us-expansion-plan.md
@@ -1,0 +1,69 @@
+# US Watchlist Expansion
+
+> Add CONUS airports to the standalone verification pipeline as a second region alongside the existing European watchlist. Goal: attract US users without compromising the EU pipeline.
+
+## Context
+
+The standalone verification pipeline currently monitors ~619 European airports across `LF/ED/EG/EH/EB/LS/...` ICAO prefixes (see `configs/airport_watchlist.json`). With the EU heavy-cycle parallelisation landed (issue #110), spare droplet capacity is available — duty cycle drops to ~3%. Expanding to US adds users without infrastructure cost, and the ECMWF GRIB order already includes CONUS (`project_ecmwf_order.md`: "Coverage: Europe AND US ... grid coverage is global for the order"), so the ECMWF leg is purely compute.
+
+## Key Decisions
+
+- **2 models for US**: GFS (Open-Meteo) + ECMWF (GRIB-direct). No ICON (DWD model is European-domain only). No NBM/HRRR initially — see "Models considered and rejected" below.
+- **Airport set**: TAF-issuing US airports only (~720 CONUS + ~60 AK/HI/PR ≈ ~780). This keeps cycle volume comparable to EU (619 × 3 models = 1857 model-airport calls; US 780 × 2 = 1560 — actually slightly less). METAR-only stations not included in v1.
+- **Schedule offset by 6h from EU**: heavy fetch at 13Z and 01Z. Aligns with US pilot use windows (8–9 AM ET / 8–9 PM ET) and zero overlap with EU 07Z/19Z heavy cycles or EU 06/09/12/15/18Z light cycles.
+- **Region tagging**: add a `region` column to `airport_forecast_snapshots` (`eu` / `us`) so cache rebuilds can split by region. Alternative — derive region from ICAO prefix at query time — works but loses an index opportunity.
+- **Watchlist file structure**: extend `configs/airport_watchlist.json` with a region-keyed top-level: `{"airports_eu": {...}, "airports_us": {...}}`. Or split into two files. Either is fine; pick what makes the discover/refresh tooling simpler.
+- **Cache split**: `forecast_map` cache entries keyed per-region (`forecast_map:eu:{day}:{hour}`, `forecast_map:us:{day}:{hour}`). Doubles entry count from 20 → 40 but keeps each blob under 1.5 MB. Verification map and stats caches similar.
+- **Forecast horizon**: keep at 4 days for US (same as EU). Long-range fixed-airport verification is too noisy to be useful; per-flight briefing is the right tool for D+5+.
+- **LLM digest cost**: scales linearly with airports — US adds ~125% to current digest spend. Real cost driver, watch closely. Consider gating US digest behind a feature flag at first.
+
+## Models considered and rejected
+
+| Model | Why rejected |
+|---|---|
+| **NBM CONUS** (`ncep_nbm_conus`) | Probed 2026-05-04 at KJFK. Despite 11-day horizon and 2.5 km resolution, only populates 8/17 of our standard surface variables. Critical missing: `dewpoint_2m`, `cloud_cover_low/mid/high`, `pressure_msl`, `freezing_level_height`, `lifted_index`, `convective_inhibition`. The cloud-layer breakdown gap is the blocker — ceiling derivation needs low/mid/high split, and NBM only outputs total. Visibility partial (drops out ~D-3.8). |
+| **HRRR CONUS** (`ncep_hrrr_conus`) | 18-hour horizon (48h on 00/06/12/18Z runs) — only contributes to D-0 verification bucket, leaves D-1..D-4 empty. Useful as a future "+1" model for D-0 high-res accuracy boost, not a primary model. |
+| **GEM (Canada)** | Open-Meteo `region=NORTH_AMERICA`, 10-day horizon. Less optimised for CONUS than US-domestic alternatives, no clear differentiation vs GFS over the US. Skip. |
+
+## Open-Meteo model name convention
+
+US models on Open-Meteo use the `ncep_` prefix:
+- `ncep_gfs025` (0.25°), `ncep_gfs013` (0.11°)
+- `ncep_hrrr_conus`, `ncep_nam_conus`, `ncep_nbm_conus`
+- `ncep_gfs_graphcast025`
+
+Bare names (`gfs`, `hrrr`, `nbm`) are rejected by the API. Add explicit `model_param` entries when registering in `MODEL_ENDPOINTS` (see `fetch/variables.py:129`).
+
+## Storage growth
+
+Linear in airport count for the snapshot table (10-day retention bounds it). `verification_scores` is unbounded and grows roughly proportional to (airports × models × days_out × time). Estimated steady-state with US added:
+
+| Layer | EU only | EU + US |
+|---|---|---|
+| Snapshot rows/cycle | ~37k | ~84k |
+| Snapshot table | 236 MB | ~540 MB |
+| Score table /year | ~10 GB | ~17 GB |
+
+Score table growth is the storage concern. Activate the existing `verification_monthly_stats` rollup (table schema already in place, currently empty in prod) and prune raw scores after rollup at ~12 months. Defer until score table exceeds 5 GB.
+
+## Cache rebuild scaling
+
+`tasks/cache_builder.py` rebuilds all three cache categories (stats / verif_map / forecast_map) after each cycle. Currently 42 entries. With per-region split for forecast_map and verif_map: ~62 entries. Each entry runs aggregation queries against snapshots/scores. Watch the `Cache rebuild: ... (%dms)` log line — should stay under 30s.
+
+## Implementation order
+
+1. **Pre-req**: EU parallelisation PR (issue #110) merged and validated in prod
+2. Add `region` column to watchlist JSON and `AirportForecastSnapshotRow` (alembic migration)
+3. Extend `STANDALONE_MODELS` to be region-aware: `{"eu": ["gfs", "icon", "ecmwf"], "us": ["gfs", "ecmwf"]}`
+4. Add 13Z and 01Z to `FORECAST_FETCH_HOURS_UTC` for the US region (or split the loop)
+5. Update cache builder to emit per-region keys; update API endpoints to accept `region` query param
+6. Discover and seed US TAF watchlist via `python -m weatherbrief.verify discover --region us` (extend the discover command)
+7. Validate: 2 days of clean US 13Z/01Z cycles in `verification_cycles`, no EU regression
+
+## Out of scope
+
+- NBM, HRRR, GEM additions
+- Forecast horizon extension (4 days stays)
+- Pre-rendering Skew-T or cross-section tiles for the watchlist
+- US text-forecast integration (NWS AFD) — already exists for flight pipeline; revisit if standalone needs it
+- Multi-language digest variants for US users

--- a/src/weatherbrief/api/packs.py
+++ b/src/weatherbrief/api/packs.py
@@ -496,7 +496,7 @@ _STAGE_LABELS: dict[str, str] = {
     "route_interpolation": "Interpolating route",
     "elevation_profile": "Fetching terrain data",
     "fetch_forecasts": "Fetching forecasts",
-    "grib_enrichment": "Enriching with GRIB2 data",
+    "grib_enrichment": "Adding cloud & icing detail",
     "waypoint_analysis": "Analyzing waypoints",
     "route_analysis": "Analyzing route points",
     "route_advisories": "Evaluating route advisories",

--- a/src/weatherbrief/fetch/grib/__init__.py
+++ b/src/weatherbrief/fetch/grib/__init__.py
@@ -458,7 +458,7 @@ def _enrich_forecasts_inner(
     # variable; overlapping with GFS decode caused OOM.
     # ECMWF GRIB is local disk I/O — runs in parallel with network fetches.
     if progress_callback is not None:
-        progress_callback("grib_enrichment", "GFS + ICON-EU + ECMWF GRIB")
+        progress_callback("grib_enrichment", None)
 
     gfs_ts: int | None = None
     icon_ts: int | None = None

--- a/src/weatherbrief/fetch/open_meteo.py
+++ b/src/weatherbrief/fetch/open_meteo.py
@@ -86,18 +86,26 @@ class OpenMeteoClient:
 
     def _record_call(self) -> None:
         """Bump both the global aggregate and the thread-local counter."""
-        # Global is racy under threading but fine for non-concurrent paths.
+        # `self.call_count` is a plain int and the increment is racy under
+        # threading. That's fine because concurrent callers (tasks/fetch.py)
+        # ignore the value during the run and overwrite it with the summed
+        # per-thread total after the pool joins. Single-threaded callers
+        # see no race and read it directly.
         self.call_count += 1
         self._tls.count = getattr(self._tls, "count", 0) + 1
 
-    def reset_thread_call_count(self) -> None:
+    def _reset_thread_call_count(self) -> None:
         """Zero this thread's call counter — call before a unit of work whose
-        cost the caller wants to attribute back to itself."""
+        cost the caller wants to attribute back to itself.
+
+        Internal hook for the concurrent orchestrator in tasks/fetch.py;
+        not part of the public client API.
+        """
         self._tls.count = 0
 
-    def thread_call_count(self) -> int:
+    def _thread_call_count(self) -> int:
         """Return the number of HTTP calls this thread has issued since its
-        last `reset_thread_call_count()`."""
+        last `_reset_thread_call_count()`. Internal — see above."""
         return getattr(self._tls, "count", 0)
 
     def _prepare_request(self, url: str, params: dict) -> tuple[str, dict]:

--- a/src/weatherbrief/fetch/open_meteo.py
+++ b/src/weatherbrief/fetch/open_meteo.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import math
+import threading
 import time
 from datetime import datetime, timezone
 
@@ -71,13 +72,33 @@ class OpenMeteoClient:
         self._historical = historical
         self.timeout = 60 if historical else timeout  # historical API is slower
         self.session = requests.Session()
+        # `call_count` is read by single-threaded callers (CLI, single-point
+        # fetch_forecast); for concurrent paths the per-thread counter below
+        # is the source of truth and the caller aggregates after join.
         self.call_count = 0
+        self._tls = threading.local()
         self._api_key = os.environ.get("OPENMETEO_API_KEY")
         self.has_api_key = bool(self._api_key)
         if self._api_key:
             logger.info("Using Open-Meteo customer API (paid plan)")
         if historical:
             logger.info("Using Open-Meteo historical forecast API (free tier)")
+
+    def _record_call(self) -> None:
+        """Bump both the global aggregate and the thread-local counter."""
+        # Global is racy under threading but fine for non-concurrent paths.
+        self.call_count += 1
+        self._tls.count = getattr(self._tls, "count", 0) + 1
+
+    def reset_thread_call_count(self) -> None:
+        """Zero this thread's call counter — call before a unit of work whose
+        cost the caller wants to attribute back to itself."""
+        self._tls.count = 0
+
+    def thread_call_count(self) -> int:
+        """Return the number of HTTP calls this thread has issued since its
+        last `reset_thread_call_count()`."""
+        return getattr(self._tls, "count", 0)
 
     def _prepare_request(self, url: str, params: dict) -> tuple[str, dict]:
         """Swap to historical or customer API host as needed.
@@ -107,7 +128,7 @@ class OpenMeteoClient:
         """GET with retry on 429 rate-limit and 5xx server error responses."""
         url, params = self._prepare_request(url, params)
         for attempt in range(_MAX_RETRIES):
-            self.call_count += 1
+            self._record_call()
             resp = self.session.get(url, params=params, timeout=self.timeout)
             if resp.status_code not in self._RETRYABLE_STATUS_CODES:
                 resp.raise_for_status()
@@ -122,7 +143,7 @@ class OpenMeteoClient:
             )
             time.sleep(wait)
         # Final attempt — let it raise on any error
-        self.call_count += 1
+        self._record_call()
         resp = self.session.get(url, params=params, timeout=self.timeout)
         resp.raise_for_status()
         return resp

--- a/src/weatherbrief/tasks/fetch.py
+++ b/src/weatherbrief/tasks/fetch.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import concurrent.futures
 import logging
 import os
+import time
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Callable
@@ -21,14 +22,6 @@ from weatherbrief.fetch.variables import (
     detect_model_region,
     route_covers_prefixes,
 )
-
-# Delay between Open-Meteo API calls to avoid rate limiting.
-# Paid API key has generous limits; free tier allows 600/min but be polite.
-# Retained for the legacy sequential path; parallel fetch ignores them.
-_INTER_MODEL_DELAY_PAID = 0.0
-_INTER_MODEL_DELAY_FREE = 1.0
-
-_BRIEFING_FETCH_CONCURRENCY = int(os.environ.get("BRIEFING_FETCH_CONCURRENCY", "4"))
 from weatherbrief.models import (
     Diagnostic,
     ElevationProfile,
@@ -39,6 +32,13 @@ from weatherbrief.models import (
     RoutePoint,
     WaypointForecast,
 )
+
+# Free-tier rate limit (600/min) means we can't blast all models at once
+# without occasional 429s; the paid tier has generous limits and parallelises
+# safely. Free tier therefore keeps the sequential path with a small delay
+# between models; paid tier dispatches to a thread pool.
+_INTER_MODEL_DELAY_FREE = 1.0  # seconds between models on free tier
+_BRIEFING_FETCH_CONCURRENCY = int(os.environ.get("BRIEFING_FETCH_CONCURRENCY", "4"))
 
 logger = logging.getLogger(__name__)
 
@@ -241,43 +241,73 @@ def run_fetch(
             continue
         models_to_fetch.append(model)
 
-    def _fetch_one_model(model: ModelSource) -> tuple[ModelSource, list[WaypointForecast]]:
-        point_forecasts = client.fetch_multi_point(
-            route_points, model,
-            start_date=target_date, end_date=end_date,
-        )
-        return model, point_forecasts
+    def _record_success(model: ModelSource, point_forecasts: list[WaypointForecast]) -> None:
+        for rp, fc in zip(route_points, point_forecasts):
+            if rp.waypoint_icao:
+                all_forecasts.append(fc)
+        cross_sections.append(RouteCrossSection(
+            model=model,
+            route_points=route_points,
+            fetched_at=point_forecasts[0].fetched_at,
+            point_forecasts=point_forecasts,
+        ))
+        logger.info("Fetched %s: %d points", model.value, len(point_forecasts))
+        models_fetched_names.append(model.value)
 
     if models_to_fetch:
-        # Single notify before parallel dispatch — per-model detail would
-        # flicker across concurrent workers and isn't useful to the user.
+        # Single notify before dispatch — per-model detail would flicker
+        # between concurrent workers and isn't useful to the user.
         _notify("fetch_forecasts")
-        max_workers = max(1, min(_BRIEFING_FETCH_CONCURRENCY, len(models_to_fetch)))
-        with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
-            future_to_model = {
-                executor.submit(_fetch_one_model, model): model
-                for model in models_to_fetch
-            }
-            for future in concurrent.futures.as_completed(future_to_model):
-                model = future_to_model[future]
+
+        if client.has_api_key:
+            # Paid tier: parallel dispatch. Workers share the OpenMeteoClient
+            # (and its requests.Session) — safe here because we only issue
+            # unauthenticated GETs with no redirects, where urllib3's
+            # connection pool handles concurrency. Each worker resets its
+            # thread-local call counter, then returns it so we can aggregate
+            # an accurate `open_meteo_api_calls` count without racing on the
+            # shared `client.call_count` integer.
+            def _fetch_one_model(model: ModelSource) -> tuple[ModelSource, list[WaypointForecast], int]:
+                client.reset_thread_call_count()
+                point_forecasts = client.fetch_multi_point(
+                    route_points, model,
+                    start_date=target_date, end_date=end_date,
+                )
+                return model, point_forecasts, client.thread_call_count()
+
+            max_workers = max(1, min(_BRIEFING_FETCH_CONCURRENCY, len(models_to_fetch)))
+            total_calls = 0
+            with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
+                future_to_model = {
+                    executor.submit(_fetch_one_model, model): model
+                    for model in models_to_fetch
+                }
+                for future in concurrent.futures.as_completed(future_to_model):
+                    model = future_to_model[future]
+                    try:
+                        _, point_forecasts, calls = future.result()
+                    except Exception:
+                        logger.warning("Failed to fetch %s", model.value, exc_info=True)
+                        continue
+                    total_calls += calls
+                    _record_success(model, point_forecasts)
+            # Replace the racy aggregate with the summed per-thread totals.
+            client.call_count = total_calls
+        else:
+            # Free tier: sequential with a small inter-model delay to stay
+            # under the 600/min rate limit.
+            for i, model in enumerate(models_to_fetch):
+                if i > 0 and _INTER_MODEL_DELAY_FREE > 0:
+                    time.sleep(_INTER_MODEL_DELAY_FREE)
                 try:
-                    _, point_forecasts = future.result()
+                    point_forecasts = client.fetch_multi_point(
+                        route_points, model,
+                        start_date=target_date, end_date=end_date,
+                    )
                 except Exception:
                     logger.warning("Failed to fetch %s", model.value, exc_info=True)
                     continue
-                # Extract waypoint-only forecasts for analysis
-                for rp, fc in zip(route_points, point_forecasts):
-                    if rp.waypoint_icao:
-                        all_forecasts.append(fc)
-                # Store the full cross-section
-                cross_sections.append(RouteCrossSection(
-                    model=model,
-                    route_points=route_points,
-                    fetched_at=point_forecasts[0].fetched_at,
-                    point_forecasts=point_forecasts,
-                ))
-                logger.info("Fetched %s: %d points", model.value, len(point_forecasts))
-                models_fetched_names.append(model.value)
+                _record_success(model, point_forecasts)
 
     # --- GRIB2 enrichment (optional) ---
     grib_enriched = False

--- a/src/weatherbrief/tasks/fetch.py
+++ b/src/weatherbrief/tasks/fetch.py
@@ -6,8 +6,9 @@ and persist its artifacts to a pack directory.
 
 from __future__ import annotations
 
+import concurrent.futures
 import logging
-import time
+import os
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Callable
@@ -23,8 +24,11 @@ from weatherbrief.fetch.variables import (
 
 # Delay between Open-Meteo API calls to avoid rate limiting.
 # Paid API key has generous limits; free tier allows 600/min but be polite.
+# Retained for the legacy sequential path; parallel fetch ignores them.
 _INTER_MODEL_DELAY_PAID = 0.0
 _INTER_MODEL_DELAY_FREE = 1.0
+
+_BRIEFING_FETCH_CONCURRENCY = int(os.environ.get("BRIEFING_FETCH_CONCURRENCY", "4"))
 from weatherbrief.models import (
     Diagnostic,
     ElevationProfile,
@@ -208,10 +212,15 @@ def run_fetch(
     models_fetched_names: list[str] = []
     models_skipped_region: list[str] = []
     models_skipped_range: list[tuple[str, int, int]] = []
-    models_fetched_count = 0
 
     route_region = detect_model_region(route)
+    end_date = (
+        departure_time
+        + timedelta(hours=math.ceil(route.flight_duration_hours or 0))
+    ).strftime("%Y-%m-%d")
 
+    # Filter models up-front so we don't waste worker threads on skipped models.
+    models_to_fetch: list[ModelSource] = []
     for model in models:
         endpoint = MODEL_ENDPOINTS[model.value]
         if days_out_for_range is not None and days_out_for_range >= endpoint.max_days:
@@ -230,37 +239,45 @@ def run_fetch(
             )
             models_skipped_region.append(model.value)
             continue
-        # Delay between model fetches to avoid Open-Meteo rate limiting
-        if models_fetched_count > 0:
-            delay = _INTER_MODEL_DELAY_PAID if client.has_api_key else _INTER_MODEL_DELAY_FREE
-            if delay > 0:
-                time.sleep(delay)
-        _notify("fetch_forecasts", model.value)
-        try:
-            end_date = (
-                departure_time
-                + timedelta(hours=math.ceil(route.flight_duration_hours or 0))
-            ).strftime("%Y-%m-%d")
-            point_forecasts = client.fetch_multi_point(
-                route_points, model,
-                start_date=target_date, end_date=end_date,
-            )
-            # Extract waypoint-only forecasts for analysis
-            for rp, fc in zip(route_points, point_forecasts):
-                if rp.waypoint_icao:
-                    all_forecasts.append(fc)
-            # Store the full cross-section
-            cross_sections.append(RouteCrossSection(
-                model=model,
-                route_points=route_points,
-                fetched_at=point_forecasts[0].fetched_at,
-                point_forecasts=point_forecasts,
-            ))
-            logger.info("Fetched %s: %d points", model.value, len(point_forecasts))
-            models_fetched_count += 1
-            models_fetched_names.append(model.value)
-        except Exception:
-            logger.warning("Failed to fetch %s", model.value, exc_info=True)
+        models_to_fetch.append(model)
+
+    def _fetch_one_model(model: ModelSource) -> tuple[ModelSource, list[WaypointForecast]]:
+        point_forecasts = client.fetch_multi_point(
+            route_points, model,
+            start_date=target_date, end_date=end_date,
+        )
+        return model, point_forecasts
+
+    if models_to_fetch:
+        # Single notify before parallel dispatch — per-model detail would
+        # flicker across concurrent workers and isn't useful to the user.
+        _notify("fetch_forecasts")
+        max_workers = max(1, min(_BRIEFING_FETCH_CONCURRENCY, len(models_to_fetch)))
+        with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
+            future_to_model = {
+                executor.submit(_fetch_one_model, model): model
+                for model in models_to_fetch
+            }
+            for future in concurrent.futures.as_completed(future_to_model):
+                model = future_to_model[future]
+                try:
+                    _, point_forecasts = future.result()
+                except Exception:
+                    logger.warning("Failed to fetch %s", model.value, exc_info=True)
+                    continue
+                # Extract waypoint-only forecasts for analysis
+                for rp, fc in zip(route_points, point_forecasts):
+                    if rp.waypoint_icao:
+                        all_forecasts.append(fc)
+                # Store the full cross-section
+                cross_sections.append(RouteCrossSection(
+                    model=model,
+                    route_points=route_points,
+                    fetched_at=point_forecasts[0].fetched_at,
+                    point_forecasts=point_forecasts,
+                ))
+                logger.info("Fetched %s: %d points", model.value, len(point_forecasts))
+                models_fetched_names.append(model.value)
 
     # --- GRIB2 enrichment (optional) ---
     grib_enriched = False

--- a/src/weatherbrief/tasks/fetch.py
+++ b/src/weatherbrief/tasks/fetch.py
@@ -260,20 +260,27 @@ def run_fetch(
         _notify("fetch_forecasts")
 
         if client.has_api_key:
-            # Paid tier: parallel dispatch. Workers share the OpenMeteoClient
-            # (and its requests.Session) — safe here because we only issue
-            # unauthenticated GETs with no redirects, where urllib3's
-            # connection pool handles concurrency. Each worker resets its
-            # thread-local call counter, then returns it so we can aggregate
-            # an accurate `open_meteo_api_calls` count without racing on the
-            # shared `client.call_count` integer.
-            def _fetch_one_model(model: ModelSource) -> tuple[ModelSource, list[WaypointForecast], int]:
-                client.reset_thread_call_count()
-                point_forecasts = client.fetch_multi_point(
-                    route_points, model,
-                    start_date=target_date, end_date=end_date,
-                )
-                return model, point_forecasts, client.thread_call_count()
+            # Paid tier: parallel dispatch. Workers share one OpenMeteoClient
+            # (and one requests.Session). This is safe under the current
+            # invariants — unauthenticated GETs only, no cookies set, no
+            # session-level state mutated post-init, redirects not followed
+            # — because urllib3's PoolManager (the actual transport layer)
+            # is itself thread-safe. If any of those invariants change
+            # (cookies, auth headers, redirect following), revisit.
+            #
+            # Each worker resets its thread-local call counter, runs its
+            # fetch, captures the count, and returns it — even on failure —
+            # so retries that 429'd before raising still get counted.
+            def _fetch_one_model(model: ModelSource) -> tuple[ModelSource, list[WaypointForecast] | None, int, BaseException | None]:
+                client._reset_thread_call_count()
+                try:
+                    point_forecasts = client.fetch_multi_point(
+                        route_points, model,
+                        start_date=target_date, end_date=end_date,
+                    )
+                    return model, point_forecasts, client._thread_call_count(), None
+                except BaseException as exc:
+                    return model, None, client._thread_call_count(), exc
 
             max_workers = max(1, min(_BRIEFING_FETCH_CONCURRENCY, len(models_to_fetch)))
             total_calls = 0
@@ -284,12 +291,14 @@ def run_fetch(
                 }
                 for future in concurrent.futures.as_completed(future_to_model):
                     model = future_to_model[future]
-                    try:
-                        _, point_forecasts, calls = future.result()
-                    except Exception:
-                        logger.warning("Failed to fetch %s", model.value, exc_info=True)
-                        continue
+                    _, point_forecasts, calls, exc = future.result()
                     total_calls += calls
+                    if exc is not None:
+                        logger.warning(
+                            "Failed to fetch %s", model.value,
+                            exc_info=(type(exc), exc, exc.__traceback__),
+                        )
+                        continue
                     _record_success(model, point_forecasts)
             # Replace the racy aggregate with the summed per-thread totals.
             client.call_count = total_calls

--- a/tests/test_fetch_parallel.py
+++ b/tests/test_fetch_parallel.py
@@ -137,6 +137,41 @@ def test_paid_path_partial_failure(paid_api_key):
     assert result.open_meteo_api_calls == 2
 
 
+def test_paid_path_failed_worker_calls_still_counted(paid_api_key):
+    """A worker that records HTTP calls (e.g. 429 retries) and then raises
+    must still contribute those calls to the aggregate. Otherwise we
+    under-count traffic against the paid quota."""
+    models = [ModelSource.GFS, ModelSource.ECMWF]
+
+    def fake_fetch_multi_point(self, points, model, *, start_date=None, end_date=None, chunk_size=None):
+        if model == ModelSource.ECMWF:
+            # Simulate 4 retry attempts that all 429'd before the worker
+            # gives up — exactly the scenario that would silently drop
+            # calls from the count if we didn't capture pre-raise.
+            self._record_call()
+            self._record_call()
+            self._record_call()
+            self._record_call()
+            raise RuntimeError("rate limited")
+        self._record_call()
+        return [_make_forecast(p, model) for p in points]
+
+    with _disable_elevation(), patch(
+        "weatherbrief.fetch.open_meteo.OpenMeteoClient.fetch_multi_point",
+        new=fake_fetch_multi_point,
+    ):
+        result = fetch_module.run_fetch(
+            route=_route(),
+            departure_time=datetime(2026, 5, 4, 9, 0, tzinfo=timezone.utc),
+            models=models,
+            enrich_grib=False,
+        )
+
+    assert result.models_fetched == ["gfs"]
+    # 1 (gfs success) + 4 (ecmwf failed retries) = 5
+    assert result.open_meteo_api_calls == 5
+
+
 def test_paid_path_concurrency_capped_to_model_count(paid_api_key, monkeypatch):
     """Worker count never exceeds the number of models actually being fetched."""
     seen_max_workers: list[int] = []

--- a/tests/test_fetch_parallel.py
+++ b/tests/test_fetch_parallel.py
@@ -1,8 +1,9 @@
-"""Tests for parallel per-model fetch in run_fetch (issue #112)."""
+"""Tests for parallel/sequential per-model fetch in run_fetch (issue #112)."""
 
 from __future__ import annotations
 
 import threading
+import time
 from datetime import datetime, timezone
 from unittest.mock import patch
 
@@ -17,6 +18,18 @@ from weatherbrief.models import (
     WaypointForecast,
 )
 from weatherbrief.tasks import fetch as fetch_module
+
+
+@pytest.fixture
+def paid_api_key(monkeypatch):
+    """Force the paid (parallel) path by setting OPENMETEO_API_KEY."""
+    monkeypatch.setenv("OPENMETEO_API_KEY", "test-key")
+
+
+@pytest.fixture
+def free_tier(monkeypatch):
+    """Force the free-tier (sequential + delay) path."""
+    monkeypatch.delenv("OPENMETEO_API_KEY", raising=False)
 
 
 def _route() -> RouteConfig:
@@ -63,18 +76,19 @@ def _disable_elevation():
     )
 
 
-def test_models_fetched_concurrently():
+def test_paid_path_runs_models_concurrently(paid_api_key):
     """All non-skipped models run in parallel — verified via threading.Barrier.
 
-    A barrier of N parties only releases when N threads arrive. If the loop were
-    sequential, only one worker would ever be in `fetch_multi_point` at a time
-    and the barrier would time out.
+    A barrier of N parties only releases when N threads arrive. If the loop
+    were sequential only one worker would ever be inside `fetch_multi_point`
+    at a time and the barrier would time out.
     """
     models = [ModelSource.GFS, ModelSource.ECMWF, ModelSource.ICON]
-    barrier = threading.Barrier(len(models), timeout=5.0)
+    barrier = threading.Barrier(len(models), timeout=15.0)
 
     def fake_fetch_multi_point(self, points, model, *, start_date=None, end_date=None, chunk_size=None):
         barrier.wait()  # raises BrokenBarrierError on timeout
+        self._record_call()  # simulate one HTTP call per model
         return [_make_forecast(p, model) for p in points]
 
     with _disable_elevation(), patch(
@@ -90,15 +104,18 @@ def test_models_fetched_concurrently():
 
     assert sorted(result.models_fetched) == ["ecmwf", "gfs", "icon"]
     assert len(result.cross_sections) == 3
+    # Each worker recorded one call; aggregate via thread-local sum.
+    assert result.open_meteo_api_calls == 3
 
 
-def test_partial_failure_does_not_abort_other_models():
+def test_paid_path_partial_failure(paid_api_key):
     """One model raising must not stop others from completing."""
     models = [ModelSource.GFS, ModelSource.ECMWF, ModelSource.ICON]
 
     def fake_fetch_multi_point(self, points, model, *, start_date=None, end_date=None, chunk_size=None):
         if model == ModelSource.ECMWF:
             raise RuntimeError("simulated failure")
+        self._record_call()
         return [_make_forecast(p, model) for p in points]
 
     with _disable_elevation(), patch(
@@ -116,9 +133,11 @@ def test_partial_failure_does_not_abort_other_models():
     assert "ecmwf" not in result.models_fetched
     fetched_models = {cs.model for cs in result.cross_sections}
     assert fetched_models == {ModelSource.GFS, ModelSource.ICON}
+    # Two successful workers, each recorded one call; failed worker recorded none.
+    assert result.open_meteo_api_calls == 2
 
 
-def test_concurrency_capped_to_number_of_models(monkeypatch):
+def test_paid_path_concurrency_capped_to_model_count(paid_api_key, monkeypatch):
     """Worker count never exceeds the number of models actually being fetched."""
     seen_max_workers: list[int] = []
 
@@ -151,3 +170,68 @@ def test_concurrency_capped_to_number_of_models(monkeypatch):
     assert seen_max_workers == [2], (
         f"Expected max_workers capped to 2 (model count), got {seen_max_workers}"
     )
+
+
+def test_free_tier_runs_sequentially_with_delay(free_tier, monkeypatch):
+    """Free tier uses the sequential path with an inter-model delay so we
+    don't blow through the 600/min rate limit."""
+    monkeypatch.setattr(fetch_module, "_INTER_MODEL_DELAY_FREE", 0.05)
+    sleep_calls: list[float] = []
+    real_sleep = time.sleep
+
+    def fake_sleep(seconds: float) -> None:
+        sleep_calls.append(seconds)
+        real_sleep(0)  # don't actually delay the test
+
+    monkeypatch.setattr(fetch_module.time, "sleep", fake_sleep)
+
+    # Track the order workers are dispatched in — sequential should match
+    # input order strictly.
+    dispatched: list[str] = []
+
+    def fake_fetch_multi_point(self, points, model, *, start_date=None, end_date=None, chunk_size=None):
+        dispatched.append(model.value)
+        return [_make_forecast(p, model) for p in points]
+
+    models = [ModelSource.GFS, ModelSource.ECMWF, ModelSource.ICON]
+    with _disable_elevation(), patch(
+        "weatherbrief.fetch.open_meteo.OpenMeteoClient.fetch_multi_point",
+        new=fake_fetch_multi_point,
+    ):
+        result = fetch_module.run_fetch(
+            route=_route(),
+            departure_time=datetime(2026, 5, 4, 9, 0, tzinfo=timezone.utc),
+            models=models,
+            enrich_grib=False,
+        )
+
+    # Sequential: dispatch order matches input order.
+    assert dispatched == ["gfs", "ecmwf", "icon"]
+    # And so does the resulting models_fetched list (parallel path would be
+    # completion order, which is non-deterministic).
+    assert result.models_fetched == ["gfs", "ecmwf", "icon"]
+    # 3 models → 2 inter-model delays.
+    assert sleep_calls == [0.05, 0.05]
+
+
+def test_free_tier_partial_failure(free_tier, monkeypatch):
+    """One model failing in the free-tier path must not abort others."""
+    monkeypatch.setattr(fetch_module, "_INTER_MODEL_DELAY_FREE", 0.0)
+
+    def fake_fetch_multi_point(self, points, model, *, start_date=None, end_date=None, chunk_size=None):
+        if model == ModelSource.ECMWF:
+            raise RuntimeError("simulated failure")
+        return [_make_forecast(p, model) for p in points]
+
+    with _disable_elevation(), patch(
+        "weatherbrief.fetch.open_meteo.OpenMeteoClient.fetch_multi_point",
+        new=fake_fetch_multi_point,
+    ):
+        result = fetch_module.run_fetch(
+            route=_route(),
+            departure_time=datetime(2026, 5, 4, 9, 0, tzinfo=timezone.utc),
+            models=[ModelSource.GFS, ModelSource.ECMWF, ModelSource.ICON],
+            enrich_grib=False,
+        )
+
+    assert result.models_fetched == ["gfs", "icon"]

--- a/tests/test_fetch_parallel.py
+++ b/tests/test_fetch_parallel.py
@@ -1,0 +1,153 @@
+"""Tests for parallel per-model fetch in run_fetch (issue #112)."""
+
+from __future__ import annotations
+
+import threading
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+import pytest
+
+from weatherbrief.models import (
+    HourlyForecast,
+    ModelSource,
+    RouteConfig,
+    RoutePoint,
+    Waypoint,
+    WaypointForecast,
+)
+from weatherbrief.tasks import fetch as fetch_module
+
+
+def _route() -> RouteConfig:
+    return RouteConfig(
+        name="EGTK-LFPB",
+        waypoints=[
+            Waypoint(icao="EGTK", name="Oxford", lat=51.8361, lon=-1.32),
+            Waypoint(icao="LFPB", name="Paris Le Bourget", lat=48.9694, lon=2.4414),
+        ],
+        cruise_altitude_ft=8000,
+        flight_duration_hours=2.0,
+    )
+
+
+def _make_forecast(point: RoutePoint, model: ModelSource) -> WaypointForecast:
+    wp = Waypoint(
+        icao=point.waypoint_icao or f"RP{int(point.distance_from_origin_nm):03d}",
+        name=point.waypoint_name or "interp",
+        lat=point.lat,
+        lon=point.lon,
+    )
+    return WaypointForecast(
+        waypoint=wp,
+        model=model,
+        fetched_at=datetime.now(timezone.utc),
+        hourly=[
+            HourlyForecast(
+                time=datetime(2026, 5, 4, 9, 0, tzinfo=timezone.utc),
+                temperature_2m_c=10.0,
+                cloud_cover_pct=30.0,
+                precipitation_mm=0.0,
+                freezing_level_m=2000.0,
+                pressure_levels=[],
+            ),
+        ],
+    )
+
+
+def _disable_elevation():
+    """Stop SRTM downloads in the test environment."""
+    return patch(
+        "weatherbrief.fetch.elevation.get_elevation_profile",
+        side_effect=Exception("disabled in test"),
+    )
+
+
+def test_models_fetched_concurrently():
+    """All non-skipped models run in parallel — verified via threading.Barrier.
+
+    A barrier of N parties only releases when N threads arrive. If the loop were
+    sequential, only one worker would ever be in `fetch_multi_point` at a time
+    and the barrier would time out.
+    """
+    models = [ModelSource.GFS, ModelSource.ECMWF, ModelSource.ICON]
+    barrier = threading.Barrier(len(models), timeout=5.0)
+
+    def fake_fetch_multi_point(self, points, model, *, start_date=None, end_date=None, chunk_size=None):
+        barrier.wait()  # raises BrokenBarrierError on timeout
+        return [_make_forecast(p, model) for p in points]
+
+    with _disable_elevation(), patch(
+        "weatherbrief.fetch.open_meteo.OpenMeteoClient.fetch_multi_point",
+        new=fake_fetch_multi_point,
+    ):
+        result = fetch_module.run_fetch(
+            route=_route(),
+            departure_time=datetime(2026, 5, 4, 9, 0, tzinfo=timezone.utc),
+            models=models,
+            enrich_grib=False,
+        )
+
+    assert sorted(result.models_fetched) == ["ecmwf", "gfs", "icon"]
+    assert len(result.cross_sections) == 3
+
+
+def test_partial_failure_does_not_abort_other_models():
+    """One model raising must not stop others from completing."""
+    models = [ModelSource.GFS, ModelSource.ECMWF, ModelSource.ICON]
+
+    def fake_fetch_multi_point(self, points, model, *, start_date=None, end_date=None, chunk_size=None):
+        if model == ModelSource.ECMWF:
+            raise RuntimeError("simulated failure")
+        return [_make_forecast(p, model) for p in points]
+
+    with _disable_elevation(), patch(
+        "weatherbrief.fetch.open_meteo.OpenMeteoClient.fetch_multi_point",
+        new=fake_fetch_multi_point,
+    ):
+        result = fetch_module.run_fetch(
+            route=_route(),
+            departure_time=datetime(2026, 5, 4, 9, 0, tzinfo=timezone.utc),
+            models=models,
+            enrich_grib=False,
+        )
+
+    assert sorted(result.models_fetched) == ["gfs", "icon"]
+    assert "ecmwf" not in result.models_fetched
+    fetched_models = {cs.model for cs in result.cross_sections}
+    assert fetched_models == {ModelSource.GFS, ModelSource.ICON}
+
+
+def test_concurrency_capped_to_number_of_models(monkeypatch):
+    """Worker count never exceeds the number of models actually being fetched."""
+    seen_max_workers: list[int] = []
+
+    real_executor = fetch_module.concurrent.futures.ThreadPoolExecutor
+
+    class CapturingExecutor(real_executor):
+        def __init__(self, max_workers=None, **kw):
+            seen_max_workers.append(max_workers)
+            super().__init__(max_workers=max_workers, **kw)
+
+    monkeypatch.setattr(
+        fetch_module.concurrent.futures, "ThreadPoolExecutor", CapturingExecutor,
+    )
+    monkeypatch.setattr(fetch_module, "_BRIEFING_FETCH_CONCURRENCY", 8)
+
+    def fake_fetch_multi_point(self, points, model, *, start_date=None, end_date=None, chunk_size=None):
+        return [_make_forecast(p, model) for p in points]
+
+    with _disable_elevation(), patch(
+        "weatherbrief.fetch.open_meteo.OpenMeteoClient.fetch_multi_point",
+        new=fake_fetch_multi_point,
+    ):
+        fetch_module.run_fetch(
+            route=_route(),
+            departure_time=datetime(2026, 5, 4, 9, 0, tzinfo=timezone.utc),
+            models=[ModelSource.GFS, ModelSource.ECMWF],
+            enrich_grib=False,
+        )
+
+    assert seen_max_workers == [2], (
+        f"Expected max_workers capped to 2 (model count), got {seen_max_workers}"
+    )


### PR DESCRIPTION
## Summary

- Replace the sequential per-model loop in `run_fetch` with a `ThreadPoolExecutor`. The 3-5 Open-Meteo HTTP calls now run concurrently, dropping the `fetch` phase from ~25-50s to ~7-13s on a typical briefing. Worker count via `BRIEFING_FETCH_CONCURRENCY` env var (default 4).
- Skip checks (range, region) run up-front so worker threads aren't spent on models we wouldn't fetch. Per-model failures still don't abort other models — same semantics as the sequential loop, just faster.
- Drive-by progress-banner fixes: renamed `grib_enrichment` label from the jargon-heavy "Enriching with GRIB2 data" → "Adding cloud & icing detail", and dropped the per-model detail on `fetch_forecasts` (would flicker between concurrent workers) plus the `"GFS + ICON-EU + ECMWF GRIB"` detail on `grib_enrichment`.

Closes #112

## Test plan

- [x] `tests/test_fetch_parallel.py` — 3 new tests: concurrent dispatch via `threading.Barrier` (would deadlock if sequential), partial-failure tolerance, worker cap to model count.
- [x] Full pytest suite: 1638 passed (`test_freshness_markers.py::test_bootstrap_populates_all_requested_sources` is a pre-existing async/SQLAlchemy fixture failure on `main`, unrelated).
- [x] Manual: live-tested on dev server with a 5-day-out flight refresh — backend logs show all 3 models' "Fetching X" lines fire before any "Fetched X" line, and ECMWF returned first even though GFS was submitted first (i.e., order is completion-driven, confirming concurrency).
- [ ] Post-deploy: watch `Pipeline timing:` log lines for 24h. Expect `fetch` phase to drop from ~18-63s typical to ~7-15s; median total briefing latency in `briefing_usage` should drop ~20-40s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)