### PR TITLE
feat(briefing): progressive render via briefing_ready SSE event (server + web)

### DIFF
--- a/src/weatherbrief/api/packs.py
+++ b/src/weatherbrief/api/packs.py
@@ -46,7 +46,14 @@ def _validate_model(model: str) -> str:
 from weatherbrief.api.flights import _load_flight_or_404, _load_owned_flight
 from flyfun_common.db import current_user_id, get_db, SessionLocal
 from weatherbrief.fetch.model_status import fetch_model_metadata
-from weatherbrief.models import BriefingPackMeta, DiagnosticPublic, Flight
+from weatherbrief.models import (
+    BriefingPackMeta,
+    DiagnosticPublic,
+    Flight,
+    # Imported eagerly so an ImportError surfaces at module load rather than
+    # being silently swallowed by the broad except in _assessment_from_advisories.
+    RouteAdvisoriesManifest as _RouteAdvisoriesManifest,
+)
 from weatherbrief.storage.flights import (
     list_packs,
     load_pack_meta,
@@ -829,11 +836,6 @@ def _build_pack_meta(
     )
 
 
-# Module-level imports so an ImportError surfaces at module load instead of
-# being silently swallowed by the broad ``except`` in ``_assessment_from_advisories``.
-from weatherbrief.models import RouteAdvisoriesManifest as _RouteAdvisoriesManifest
-
-
 def _assessment_from_advisories(
     manifest: "RouteAdvisoriesManifest | None",
     pack_path: Path,
@@ -853,6 +855,13 @@ def _assessment_from_advisories(
         try:
             return derive_assessment_from_advisories(manifest)
         except Exception:
+            # Broad catch is intentional: derive_assessment_from_advisories
+            # iterates over advisory entries and could raise anything an
+            # individual evaluator surfaces (AttributeError on a malformed
+            # status enum, KeyError on a missing field, etc.). Provisional
+            # persist must never abort the pipeline — fall back to NULL.
+            # Don't narrow this to (ValueError, AttributeError); a future
+            # change to the manifest format would silently bubble through.
             logger.warning(
                 "Could not derive assessment from in-memory manifest — falling back to NULL",
                 exc_info=True,
@@ -927,6 +936,13 @@ def _persist_pack_finalize(
         provisional=False,
     )
     if not update_pack_meta(db, meta):
+        # Sync /refresh, scheduler, or a provisional persist that failed
+        # silently — log so we can correlate with any earlier "Provisional
+        # pack persist failed" warning.
+        logger.info(
+            "No provisional row for %s @ %s — inserting directly",
+            flight_id, fetch_ts,
+        )
         save_pack_meta(db, meta)
 
     # Log usage and charge credits

--- a/src/weatherbrief/api/packs.py
+++ b/src/weatherbrief/api/packs.py
@@ -52,6 +52,7 @@ from weatherbrief.storage.flights import (
     load_pack_meta,
     pack_dir_for,
     save_pack_meta,
+    update_pack_meta,
 )
 
 logger = logging.getLogger(__name__)
@@ -505,6 +506,7 @@ _STAGE_LABELS: dict[str, str] = {
     "save_snapshot": "Saving snapshot",
     "fetch_gramet": "Fetching GRAMET",
     "generate_skewt": "Generating Skew-T",
+    "briefing_ready": "Briefing ready",
     "llm_digest": "Generating AI digest",
 }
 
@@ -521,6 +523,7 @@ _STAGE_PROGRESS: dict[str, float] = {
     "save_snapshot": 0.65,
     "fetch_gramet": 0.75,
     "generate_skewt": 0.85,
+    "briefing_ready": 0.88,
     "llm_digest": 0.95,
 }
 
@@ -720,9 +723,31 @@ def _charge_briefing_cost(
         logger.warning("Failed to charge briefing cost for %s", user_id, exc_info=True)
 
 
-def _finalize_refresh(flight_id, flight, fetch_ts, pack_path, result, db,
-                      user_id=None, model_metadata=None, as_of_time=None):
-    """Shared finalization: build and save pack metadata, log usage, return response."""
+def _build_pack_meta(
+    flight_id,
+    flight,
+    fetch_ts,
+    pack_path,
+    result,
+    *,
+    model_metadata=None,
+    as_of_time=None,
+    provisional: bool = False,
+) -> BriefingPackMeta:
+    """Build a ``BriefingPackMeta`` from a (possibly partial) ``BriefingResult``.
+
+    Pure: builds the model object only — does not touch the DB.
+
+    When ``provisional=True`` (called between phase 6 and phase 7), the LLM
+    digest hasn't run yet, so ``has_digest`` is forced to False and the
+    assessment is derived from the route advisories on disk rather than the
+    digest.
+
+    When ``provisional=False`` (called after phase 7), ``has_digest`` reflects
+    whether the digest succeeded and the assessment prefers the digest's
+    output (falling back to the advisories-derived value when the digest
+    failed).
+    """
     if as_of_time:
         days_out = (flight.departure_time.date() - as_of_time.date()).days
     else:
@@ -764,27 +789,117 @@ def _finalize_refresh(flight_id, flight, fetch_ts, pack_path, result, db,
             result.alt_advisory_result.manifest,
         )
 
-    meta = BriefingPackMeta(
+    # Assessment: prefer the digest's, fall back to advisories on disk.
+    assessment: str | None = None
+    assessment_reason: str | None = None
+    if not provisional and result.digest:
+        assessment = result.digest.assessment
+        assessment_reason = result.digest.assessment_reason
+    if assessment is None:
+        assessment, assessment_reason = _assessment_from_disk(pack_path)
+
+    has_digest = False if provisional else (result.digest_path is not None)
+
+    return BriefingPackMeta(
         flight_id=flight_id,
         fetch_timestamp=fetch_ts,
         days_out=days_out,
         has_gramet=result.gramet_path is not None,
         has_skewt=len(result.skewt_paths) > 0,
-        has_digest=result.digest_path is not None,
-        assessment=result.digest.assessment if result.digest else None,
-        assessment_reason=result.digest.assessment_reason if result.digest else None,
+        has_digest=has_digest,
+        assessment=assessment,
+        assessment_reason=assessment_reason,
         artifact_path=str(pack_path),
         model_init_times=init_times,
         grib_init_times=result.grib_init_times,
         model_sources=model_sources,
         models_skipped_region=result.models_skipped_region,
-        diagnostics=result.diagnostics,
+        diagnostics=list(result.diagnostics),
         alt_assessment=alt_assessment,
         alt_assessment_reason=alt_assessment_reason,
         has_alt_advisories=has_alt_advisories,
     )
 
+
+def _assessment_from_disk(pack_path: Path) -> tuple[str | None, str | None]:
+    """Read ``route_advisories.json`` and derive (assessment, reason).
+
+    Returns ``(None, None)`` if the file is missing or unparseable so the
+    pack row falls back to NULL — the briefing UI handles missing
+    assessments gracefully.
+    """
+    adv_path = Path(pack_path) / "route_advisories.json"
+    if not adv_path.exists():
+        return (None, None)
+    try:
+        from weatherbrief.models import RouteAdvisoriesManifest
+        from weatherbrief.tasks.advise import derive_assessment_from_advisories
+
+        manifest = RouteAdvisoriesManifest.model_validate_json(adv_path.read_text())
+        return derive_assessment_from_advisories(manifest)
+    except Exception:
+        logger.warning(
+            "Could not derive assessment from %s — falling back to NULL",
+            adv_path, exc_info=True,
+        )
+        return (None, None)
+
+
+def _persist_pack_provisional(
+    flight_id,
+    flight,
+    fetch_ts,
+    pack_path,
+    result,
+    db,
+    *,
+    model_metadata=None,
+    as_of_time=None,
+) -> BriefingPackMeta:
+    """Insert a provisional pack row at the briefing_ready milestone.
+
+    The LLM digest hasn't run yet — ``has_digest=False`` and the assessment
+    comes from advisories. ``_persist_pack_finalize`` will update this row
+    once the digest completes (or update with ``has_digest=False`` if it
+    fails). The row is inserted unconditionally; if a row with the same
+    ``(flight_id, fetch_timestamp)`` already exists (which shouldn't happen
+    in practice — each refresh allocates a fresh timestamp), the SQL layer
+    will surface the conflict.
+    """
+    meta = _build_pack_meta(
+        flight_id, flight, fetch_ts, pack_path, result,
+        model_metadata=model_metadata,
+        as_of_time=as_of_time,
+        provisional=True,
+    )
     save_pack_meta(db, meta)
+    logger.info("Provisional pack persisted for %s: %s", flight_id, fetch_ts)
+    return meta
+
+
+def _persist_pack_finalize(
+    flight_id,
+    flight,
+    fetch_ts,
+    pack_path,
+    result,
+    db,
+    *,
+    user_id=None,
+    model_metadata=None,
+    as_of_time=None,
+) -> BriefingPackMeta:
+    """Finalize the pack row after phase 7 — update if a provisional row
+    exists, otherwise insert. Logs usage and charges credits.
+    """
+    meta = _build_pack_meta(
+        flight_id, flight, fetch_ts, pack_path, result,
+        model_metadata=model_metadata,
+        as_of_time=as_of_time,
+        provisional=False,
+    )
+    if not update_pack_meta(db, meta):
+        save_pack_meta(db, meta)
 
     # Log usage and charge credits
     from weatherbrief.api.usage import log_api_usage, log_briefing_usage
@@ -806,6 +921,22 @@ def _finalize_refresh(flight_id, flight, fetch_ts, pack_path, result, db,
 
     logger.info("Briefing refreshed for %s: %s", flight_id, fetch_ts)
     return meta
+
+
+def _finalize_refresh(flight_id, flight, fetch_ts, pack_path, result, db,
+                      user_id=None, model_metadata=None, as_of_time=None):
+    """Backwards-compatible single-shot persist (no provisional row).
+
+    Used by the synchronous ``/refresh`` endpoint that doesn't speak SSE and
+    therefore can't render a partial briefing — there's no benefit to a
+    provisional row in that path.
+    """
+    return _persist_pack_finalize(
+        flight_id, flight, fetch_ts, pack_path, result, db,
+        user_id=user_id,
+        model_metadata=model_metadata,
+        as_of_time=as_of_time,
+    )
 
 
 class RefreshAccepted(BaseModel):
@@ -1076,6 +1207,13 @@ async def refresh_briefing_stream(
     loop = asyncio.get_event_loop()
 
     def progress_callback(stage: str, detail: str | None = None) -> None:
+        refresh_registry.update_progress(flight_id, stage, detail)
+        # briefing_ready emits a dedicated SSE event with the provisional pack
+        # metadata (handled by briefing_ready_callback below). Skip the generic
+        # progress event so clients don't see two notifications for the same
+        # milestone.
+        if stage == "briefing_ready":
+            return
         label = _STAGE_LABELS.get(stage, stage)
         progress = _STAGE_PROGRESS.get(stage, 0.0)
         event = {
@@ -1085,7 +1223,37 @@ async def refresh_briefing_stream(
             "label": label,
             "progress": progress,
         }
-        refresh_registry.update_progress(flight_id, stage, detail)
+        asyncio.run_coroutine_threadsafe(queue.put(event), loop)
+
+    def briefing_ready_callback(result) -> None:
+        """Persist the provisional pack row and emit the briefing_ready SSE event.
+
+        Runs in the pipeline worker thread, between phase 6 and phase 7.
+        Failures here are logged but never bubble back into the pipeline —
+        the digest still runs and ``_persist_pack_finalize`` will insert
+        the row at the end if the provisional persist failed.
+        """
+        try:
+            thread_db = SessionLocal()
+            try:
+                meta = _persist_pack_provisional(
+                    flight_id, flight, fetch_ts, pack_path, result, thread_db,
+                    model_metadata=model_metadata,
+                    as_of_time=as_of_time,
+                )
+                thread_db.commit()
+            finally:
+                thread_db.close()
+        except Exception:
+            logger.warning(
+                "Provisional pack persist failed for %s — digest will still run",
+                flight_id, exc_info=True,
+            )
+            return
+        event = {
+            "type": "briefing_ready",
+            "pack": _meta_to_response(meta).model_dump(mode="json"),
+        }
         asyncio.run_coroutine_threadsafe(queue.put(event), loop)
 
     def run_pipeline() -> None:
@@ -1098,6 +1266,7 @@ async def refresh_briefing_stream(
                 departure_time=flight.departure_time,
                 options=options,
                 progress_callback=progress_callback,
+                briefing_ready_callback=briefing_ready_callback,
             )
             # Capture timing before unregister
             queue_wait, total_elapsed = refresh_registry.get_timing(flight_id)
@@ -1108,9 +1277,11 @@ async def refresh_briefing_stream(
             # Use a dedicated DB session — the request-scoped one isn't thread-safe
             thread_db = SessionLocal()
             try:
-                meta = _finalize_refresh(flight_id, flight, fetch_ts, pack_path, result, thread_db,
-                                         user_id=user_id, model_metadata=model_metadata,
-                                         as_of_time=as_of_time)
+                meta = _persist_pack_finalize(
+                    flight_id, flight, fetch_ts, pack_path, result, thread_db,
+                    user_id=user_id, model_metadata=model_metadata,
+                    as_of_time=as_of_time,
+                )
                 thread_db.commit()
             finally:
                 thread_db.close()

--- a/src/weatherbrief/api/packs.py
+++ b/src/weatherbrief/api/packs.py
@@ -874,10 +874,14 @@ def _assessment_from_advisories(
     try:
         loaded = _RouteAdvisoriesManifest.model_validate_json(adv_path.read_text())
         return derive_assessment_from_advisories(loaded)
-    except (OSError, ValueError) as exc:
+    except Exception:
+        # Same broad catch as the in-memory path above: I/O can raise OSError,
+        # validation can raise ValueError, and derive_assessment_from_advisories
+        # can raise AttributeError/KeyError on malformed entries. Persisting
+        # the pack must never abort because of an assessment-derivation hiccup.
         logger.warning(
-            "Could not derive assessment from %s (%s) — falling back to NULL",
-            adv_path, exc,
+            "Could not derive assessment from %s — falling back to NULL",
+            adv_path, exc_info=True,
         )
         return (None, None)
 

--- a/src/weatherbrief/api/packs.py
+++ b/src/weatherbrief/api/packs.py
@@ -523,6 +523,10 @@ _STAGE_PROGRESS: dict[str, float] = {
     "save_snapshot": 0.65,
     "fetch_gramet": 0.75,
     "generate_skewt": 0.85,
+    # The SSE handler emits a dedicated `briefing_ready` event instead of a
+    # generic `progress` event for this stage (see refresh_briefing_stream),
+    # so this entry is only consumed by the polling /refresh/status endpoint
+    # to surface the stage label between provisional persist and digest.
     "briefing_ready": 0.88,
     "llm_digest": 0.95,
 }
@@ -724,14 +728,14 @@ def _charge_briefing_cost(
 
 
 def _build_pack_meta(
-    flight_id,
-    flight,
-    fetch_ts,
-    pack_path,
-    result,
+    flight_id: str,
+    flight: Flight,
+    fetch_ts: datetime,
+    pack_path: Path,
+    result: "BriefingResult",
     *,
-    model_metadata=None,
-    as_of_time=None,
+    model_metadata: dict | None = None,
+    as_of_time: datetime | None = None,
     provisional: bool = False,
 ) -> BriefingPackMeta:
     """Build a ``BriefingPackMeta`` from a (possibly partial) ``BriefingResult``.
@@ -740,8 +744,7 @@ def _build_pack_meta(
 
     When ``provisional=True`` (called between phase 6 and phase 7), the LLM
     digest hasn't run yet, so ``has_digest`` is forced to False and the
-    assessment is derived from the route advisories on disk rather than the
-    digest.
+    assessment is derived from the route advisories rather than the digest.
 
     When ``provisional=False`` (called after phase 7), ``has_digest`` reflects
     whether the digest succeeded and the assessment prefers the digest's
@@ -789,14 +792,19 @@ def _build_pack_meta(
             result.alt_advisory_result.manifest,
         )
 
-    # Assessment: prefer the digest's, fall back to advisories on disk.
+    # Assessment: prefer the digest's, fall back to the advisories manifest.
+    # The manifest is in-memory on the BriefingResult after phase 3; only
+    # fall through to the on-disk read when callers (e.g. legacy unit tests)
+    # provide a result that doesn't carry the manifest.
     assessment: str | None = None
     assessment_reason: str | None = None
     if not provisional and result.digest:
         assessment = result.digest.assessment
         assessment_reason = result.digest.assessment_reason
     if assessment is None:
-        assessment, assessment_reason = _assessment_from_disk(pack_path)
+        assessment, assessment_reason = _assessment_from_advisories(
+            result.route_advisories_manifest, pack_path,
+        )
 
     has_digest = False if provisional else (result.digest_path is not None)
 
@@ -821,40 +829,60 @@ def _build_pack_meta(
     )
 
 
-def _assessment_from_disk(pack_path: Path) -> tuple[str | None, str | None]:
-    """Read ``route_advisories.json`` and derive (assessment, reason).
+# Module-level imports so an ImportError surfaces at module load instead of
+# being silently swallowed by the broad ``except`` in ``_assessment_from_advisories``.
+from weatherbrief.models import RouteAdvisoriesManifest as _RouteAdvisoriesManifest
 
-    Returns ``(None, None)`` if the file is missing or unparseable so the
-    pack row falls back to NULL — the briefing UI handles missing
-    assessments gracefully.
+
+def _assessment_from_advisories(
+    manifest: "RouteAdvisoriesManifest | None",
+    pack_path: Path,
+) -> tuple[str | None, str | None]:
+    """Derive (assessment, reason) from advisories.
+
+    Prefers the in-memory manifest; falls back to reading
+    ``route_advisories.json`` from disk only when the caller didn't supply
+    one (legacy callers / tests that hand-build a partial BriefingResult).
+    Returns ``(None, None)`` if no manifest is available so the pack row
+    falls back to NULL — the briefing UI handles missing assessments
+    gracefully.
     """
+    from weatherbrief.tasks.advise import derive_assessment_from_advisories
+
+    if manifest is not None:
+        try:
+            return derive_assessment_from_advisories(manifest)
+        except Exception:
+            logger.warning(
+                "Could not derive assessment from in-memory manifest — falling back to NULL",
+                exc_info=True,
+            )
+            return (None, None)
+
     adv_path = Path(pack_path) / "route_advisories.json"
     if not adv_path.exists():
         return (None, None)
     try:
-        from weatherbrief.models import RouteAdvisoriesManifest
-        from weatherbrief.tasks.advise import derive_assessment_from_advisories
-
-        manifest = RouteAdvisoriesManifest.model_validate_json(adv_path.read_text())
-        return derive_assessment_from_advisories(manifest)
-    except Exception:
+        loaded = _RouteAdvisoriesManifest.model_validate_json(adv_path.read_text())
+        return derive_assessment_from_advisories(loaded)
+    except (OSError, ValueError) as exc:
         logger.warning(
-            "Could not derive assessment from %s — falling back to NULL",
-            adv_path, exc_info=True,
+            "Could not derive assessment from %s (%s) — falling back to NULL",
+            adv_path, exc,
         )
         return (None, None)
 
 
 def _persist_pack_provisional(
-    flight_id,
-    flight,
-    fetch_ts,
-    pack_path,
-    result,
-    db,
+    flight_id: str,
+    flight: Flight,
+    fetch_ts: datetime,
+    pack_path: Path,
+    result: "BriefingResult",
+    db: Session,
     *,
-    model_metadata=None,
-    as_of_time=None,
+    model_metadata: dict | None = None,
+    as_of_time: datetime | None = None,
 ) -> BriefingPackMeta:
     """Insert a provisional pack row at the briefing_ready milestone.
 
@@ -878,16 +906,16 @@ def _persist_pack_provisional(
 
 
 def _persist_pack_finalize(
-    flight_id,
-    flight,
-    fetch_ts,
-    pack_path,
-    result,
-    db,
+    flight_id: str,
+    flight: Flight,
+    fetch_ts: datetime,
+    pack_path: Path,
+    result: "BriefingResult",
+    db: Session,
     *,
-    user_id=None,
-    model_metadata=None,
-    as_of_time=None,
+    user_id: str | None = None,
+    model_metadata: dict | None = None,
+    as_of_time: datetime | None = None,
 ) -> BriefingPackMeta:
     """Finalize the pack row after phase 7 — update if a provisional row
     exists, otherwise insert. Logs usage and charges credits.
@@ -923,13 +951,22 @@ def _persist_pack_finalize(
     return meta
 
 
-def _finalize_refresh(flight_id, flight, fetch_ts, pack_path, result, db,
-                      user_id=None, model_metadata=None, as_of_time=None):
+def _finalize_refresh(
+    flight_id: str,
+    flight: Flight,
+    fetch_ts: datetime,
+    pack_path: Path,
+    result: "BriefingResult",
+    db: Session,
+    user_id: str | None = None,
+    model_metadata: dict | None = None,
+    as_of_time: datetime | None = None,
+) -> BriefingPackMeta:
     """Backwards-compatible single-shot persist (no provisional row).
 
-    Used by the synchronous ``/refresh`` endpoint that doesn't speak SSE and
-    therefore can't render a partial briefing — there's no benefit to a
-    provisional row in that path.
+    Used by the synchronous ``/refresh`` endpoint and the auto-refresh
+    scheduler — paths that don't speak SSE and so can't render a partial
+    briefing. There's no benefit to a provisional row in those paths.
     """
     return _persist_pack_finalize(
         flight_id, flight, fetch_ts, pack_path, result, db,
@@ -1225,7 +1262,7 @@ async def refresh_briefing_stream(
         }
         asyncio.run_coroutine_threadsafe(queue.put(event), loop)
 
-    def briefing_ready_callback(result) -> None:
+    def briefing_ready_callback(result: "BriefingResult") -> None:
         """Persist the provisional pack row and emit the briefing_ready SSE event.
 
         Runs in the pipeline worker thread, between phase 6 and phase 7.
@@ -1233,8 +1270,8 @@ async def refresh_briefing_stream(
         the digest still runs and ``_persist_pack_finalize`` will insert
         the row at the end if the provisional persist failed.
         """
+        thread_db = SessionLocal()
         try:
-            thread_db = SessionLocal()
             try:
                 meta = _persist_pack_provisional(
                     flight_id, flight, fetch_ts, pack_path, result, thread_db,
@@ -1242,14 +1279,17 @@ async def refresh_briefing_stream(
                     as_of_time=as_of_time,
                 )
                 thread_db.commit()
-            finally:
-                thread_db.close()
-        except Exception:
-            logger.warning(
-                "Provisional pack persist failed for %s — digest will still run",
-                flight_id, exc_info=True,
-            )
-            return
+            except Exception:
+                # Explicit rollback before close so a failed flush/commit
+                # leaves no half-written state lingering in the session.
+                thread_db.rollback()
+                logger.warning(
+                    "Provisional pack persist failed for %s — digest will still run",
+                    flight_id, exc_info=True,
+                )
+                return
+        finally:
+            thread_db.close()
         event = {
             "type": "briefing_ready",
             "pack": _meta_to_response(meta).model_dump(mode="json"),

--- a/src/weatherbrief/pipeline.py
+++ b/src/weatherbrief/pipeline.py
@@ -22,6 +22,7 @@ from weatherbrief.models import (
     Diagnostic,
     ForecastSnapshot,
     ModelSource,
+    RouteAdvisoriesManifest,
     RouteConfig,
     WaypointAnalysis,
 )
@@ -122,6 +123,10 @@ class BriefingResult:
     snapshot_path: Path
     elevation_profile_path: Path | None = None
     route_advisories_path: Path | None = None
+    # In-memory manifest produced by phase 3 advisories. Allows the
+    # briefing_ready callback to derive the provisional assessment without
+    # re-reading route_advisories.json from disk (the file was just written).
+    route_advisories_manifest: RouteAdvisoriesManifest | None = None
     gramet_path: Path | None = None
     skewt_paths: list[Path] = field(default_factory=list)
     digest_path: Path | None = None
@@ -491,6 +496,8 @@ def execute_briefing(
         result.elevation_profile_path = pack_dir / "elevation_profile.json"
     if route_advisories_manifest and pack_dir:
         result.route_advisories_path = pack_dir / "route_advisories.json"
+    if route_advisories_manifest is not None:
+        result.route_advisories_manifest = route_advisories_manifest
     if alt_advisory_result is not None:
         result.alt_advisory_result = alt_advisory_result
 
@@ -534,18 +541,24 @@ def execute_briefing(
         stage_timings["generate_skewt"] = perf_counter() - _t0
 
     # === 6.5 Briefing ready milestone ===
-    # Visible briefing artifacts (snapshot + advisories + GRAMET + Skew-T) are
-    # all on disk by this point. Notify callers so they can render the briefing
+    # Visible briefing artifacts (snapshot + advisories + optional GRAMET) are
+    # on disk by this point. Notify callers so they can render the briefing
     # and persist a provisional pack row while the LLM digest still runs.
-    _notify("briefing_ready", str(snapshot_path))
-    if briefing_ready_callback is not None:
-        try:
-            briefing_ready_callback(result)
-        except Exception:
-            logger.warning(
-                "briefing_ready_callback raised — continuing with digest",
-                exc_info=True,
-            )
+    #
+    # When the digest phase is disabled there's nothing to wait for: the
+    # provisional row would be inserted and immediately overwritten by
+    # finalize, with no user-visible benefit. Skip both the progress event
+    # and the callback in that case.
+    if options.generate_llm_digest:
+        _notify("briefing_ready", str(snapshot_path))
+        if briefing_ready_callback is not None:
+            try:
+                briefing_ready_callback(result)
+            except Exception:
+                logger.warning(
+                    "briefing_ready_callback raised — continuing with digest",
+                    exc_info=True,
+                )
 
     # === 7. Optional: LLM digest ===
     if options.generate_llm_digest:

--- a/src/weatherbrief/pipeline.py
+++ b/src/weatherbrief/pipeline.py
@@ -192,6 +192,7 @@ def execute_briefing(
     departure_time: datetime,
     options: BriefingOptions | None = None,
     progress_callback: Callable[[str, str | None], None] | None = None,
+    briefing_ready_callback: Callable[["BriefingResult"], None] | None = None,
 ) -> BriefingResult:
     """Run the full briefing pipeline.
 
@@ -200,6 +201,12 @@ def execute_briefing(
 
     Args:
         departure_time: Aware UTC datetime for the flight departure.
+        briefing_ready_callback: Optional callback invoked after the visible
+            briefing artifacts (snapshot, advisories, GRAMET, Skew-T) have
+            been produced and before the LLM digest phase. Receives the
+            partially-populated ``BriefingResult`` so callers can persist a
+            provisional pack row and notify clients while the digest still
+            runs in the background.
 
     Raises:
         ValueError: If target_date is in the past.
@@ -525,6 +532,20 @@ def execute_briefing(
         if skewt_result.diagnostic:
             result.diagnostics.append(skewt_result.diagnostic)
         stage_timings["generate_skewt"] = perf_counter() - _t0
+
+    # === 6.5 Briefing ready milestone ===
+    # Visible briefing artifacts (snapshot + advisories + GRAMET + Skew-T) are
+    # all on disk by this point. Notify callers so they can render the briefing
+    # and persist a provisional pack row while the LLM digest still runs.
+    _notify("briefing_ready", str(snapshot_path))
+    if briefing_ready_callback is not None:
+        try:
+            briefing_ready_callback(result)
+        except Exception:
+            logger.warning(
+                "briefing_ready_callback raised — continuing with digest",
+                exc_info=True,
+            )
 
     # === 7. Optional: LLM digest ===
     if options.generate_llm_digest:

--- a/src/weatherbrief/storage/flights.py
+++ b/src/weatherbrief/storage/flights.py
@@ -189,30 +189,42 @@ def _verify_pack_hmac(row: BriefingPackRow) -> bool:
     return hmac.compare_digest(row.integrity_hmac, _compute_pack_hmac_legacy(row))
 
 
-def _meta_to_row(meta: BriefingPackMeta) -> BriefingPackRow:
-    return BriefingPackRow(
-        flight_id=meta.flight_id,
-        fetch_timestamp=meta.fetch_timestamp,
-        days_out=meta.days_out,
-        has_gramet=meta.has_gramet,
-        has_skewt=meta.has_skewt,
-        has_digest=meta.has_digest,
-        assessment=meta.assessment,
-        assessment_reason=meta.assessment_reason,
-        artifact_path=meta.artifact_path,
-        model_init_times_json=json.dumps(meta.model_init_times),
-        grib_init_times_json=json.dumps(meta.grib_init_times),
-        model_sources_json=(
-            json.dumps(meta.model_sources) if meta.model_sources else None
-        ),
-        models_skipped_region_json=json.dumps(meta.models_skipped_region),
-        diagnostics_json=json.dumps(
-            [d.model_dump(mode="json") for d in meta.diagnostics],
-        ),
-        alt_assessment=meta.alt_assessment,
-        alt_assessment_reason=meta.alt_assessment_reason,
-        has_alt_advisories=meta.has_alt_advisories,
+def _apply_meta_to_row(row: BriefingPackRow, meta: BriefingPackMeta) -> None:
+    """Copy every BriefingPackMeta field onto a BriefingPackRow.
+
+    Single source of truth for the meta→row mapping, used by both
+    ``_meta_to_row`` (insert path) and ``update_pack_meta`` (update path)
+    so they can't drift when a new field is added to ``BriefingPackMeta``.
+    Does NOT touch ``id`` or ``integrity_hmac`` — those are managed by
+    SQLAlchemy and ``_compute_pack_hmac`` respectively.
+    """
+    row.flight_id = meta.flight_id
+    row.fetch_timestamp = meta.fetch_timestamp
+    row.days_out = meta.days_out
+    row.has_gramet = meta.has_gramet
+    row.has_skewt = meta.has_skewt
+    row.has_digest = meta.has_digest
+    row.assessment = meta.assessment
+    row.assessment_reason = meta.assessment_reason
+    row.artifact_path = meta.artifact_path
+    row.model_init_times_json = json.dumps(meta.model_init_times)
+    row.grib_init_times_json = json.dumps(meta.grib_init_times)
+    row.model_sources_json = (
+        json.dumps(meta.model_sources) if meta.model_sources else None
     )
+    row.models_skipped_region_json = json.dumps(meta.models_skipped_region)
+    row.diagnostics_json = json.dumps(
+        [d.model_dump(mode="json") for d in meta.diagnostics],
+    )
+    row.alt_assessment = meta.alt_assessment
+    row.alt_assessment_reason = meta.alt_assessment_reason
+    row.has_alt_advisories = meta.has_alt_advisories
+
+
+def _meta_to_row(meta: BriefingPackMeta) -> BriefingPackRow:
+    row = BriefingPackRow()
+    _apply_meta_to_row(row, meta)
+    return row
 
 
 def _resolve_artifact_path(raw: str) -> str:
@@ -571,26 +583,7 @@ def update_pack_meta(session: Session, meta: BriefingPackMeta) -> bool:
     row = session.execute(stmt).scalar_one_or_none()
     if row is None:
         return False
-
-    row.days_out = meta.days_out
-    row.has_gramet = meta.has_gramet
-    row.has_skewt = meta.has_skewt
-    row.has_digest = meta.has_digest
-    row.assessment = meta.assessment
-    row.assessment_reason = meta.assessment_reason
-    row.artifact_path = meta.artifact_path
-    row.model_init_times_json = json.dumps(meta.model_init_times)
-    row.grib_init_times_json = json.dumps(meta.grib_init_times)
-    row.model_sources_json = (
-        json.dumps(meta.model_sources) if meta.model_sources else None
-    )
-    row.models_skipped_region_json = json.dumps(meta.models_skipped_region)
-    row.diagnostics_json = json.dumps(
-        [d.model_dump(mode="json") for d in meta.diagnostics],
-    )
-    row.alt_assessment = meta.alt_assessment
-    row.alt_assessment_reason = meta.alt_assessment_reason
-    row.has_alt_advisories = meta.has_alt_advisories
+    _apply_meta_to_row(row, meta)
     row.integrity_hmac = _compute_pack_hmac(row)
     session.flush()
     return True

--- a/src/weatherbrief/storage/flights.py
+++ b/src/weatherbrief/storage/flights.py
@@ -557,6 +557,45 @@ def save_pack_meta(session: Session, meta: BriefingPackMeta) -> None:
     session.flush()
 
 
+def update_pack_meta(session: Session, meta: BriefingPackMeta) -> bool:
+    """Update an existing pack row (matched by flight_id + fetch_timestamp).
+
+    Returns True when an existing row was updated, False when no row existed
+    (caller should fall back to ``save_pack_meta``).
+    """
+    naive_ts = meta.fetch_timestamp.replace(tzinfo=None)
+    stmt = select(BriefingPackRow).where(
+        BriefingPackRow.flight_id == meta.flight_id,
+        BriefingPackRow.fetch_timestamp == naive_ts,
+    )
+    row = session.execute(stmt).scalar_one_or_none()
+    if row is None:
+        return False
+
+    row.days_out = meta.days_out
+    row.has_gramet = meta.has_gramet
+    row.has_skewt = meta.has_skewt
+    row.has_digest = meta.has_digest
+    row.assessment = meta.assessment
+    row.assessment_reason = meta.assessment_reason
+    row.artifact_path = meta.artifact_path
+    row.model_init_times_json = json.dumps(meta.model_init_times)
+    row.grib_init_times_json = json.dumps(meta.grib_init_times)
+    row.model_sources_json = (
+        json.dumps(meta.model_sources) if meta.model_sources else None
+    )
+    row.models_skipped_region_json = json.dumps(meta.models_skipped_region)
+    row.diagnostics_json = json.dumps(
+        [d.model_dump(mode="json") for d in meta.diagnostics],
+    )
+    row.alt_assessment = meta.alt_assessment
+    row.alt_assessment_reason = meta.alt_assessment_reason
+    row.has_alt_advisories = meta.has_alt_advisories
+    row.integrity_hmac = _compute_pack_hmac(row)
+    session.flush()
+    return True
+
+
 def load_pack_meta(
     session: Session, flight_id: str, fetch_timestamp: str | datetime
 ) -> BriefingPackMeta:

--- a/tests/test_briefing_ready.py
+++ b/tests/test_briefing_ready.py
@@ -91,8 +91,10 @@ def _write_advisories(
     *,
     aggregate_status: AdvisoryStatus = AdvisoryStatus.AMBER,
     advisory_id: str = "icing.fiki",
-) -> None:
-    """Write a minimal ``route_advisories.json`` so assessment derivation works."""
+) -> RouteAdvisoriesManifest:
+    """Write a minimal ``route_advisories.json`` so assessment derivation works.
+    Returns the manifest so tests can also exercise the in-memory branch.
+    """
     pack_path.mkdir(parents=True, exist_ok=True)
     manifest = RouteAdvisoriesManifest(
         advisories=[
@@ -106,6 +108,7 @@ def _write_advisories(
     (pack_path / "route_advisories.json").write_text(
         manifest.model_dump_json(indent=2),
     )
+    return manifest
 
 
 # --- Persistence layer ---
@@ -143,6 +146,44 @@ class TestPersistProvisional:
         assert packs[0].assessment == "AMBER"
         assert packs[0].has_gramet is True
         assert packs[0].has_skewt is True
+
+    def test_uses_in_memory_manifest_without_disk_read(
+        self, db_session, dev_user, tmp_path, monkeypatch,
+    ):
+        """Hot production path: the manifest set on BriefingResult is used
+        directly; route_advisories.json on disk is NOT re-read.
+        """
+        from weatherbrief.api import packs as packs_mod
+        from weatherbrief.api.packs import _persist_pack_provisional
+
+        flight = _make_flight()
+        save_flight(db_session, flight, dev_user)
+
+        pack_path = tmp_path / "pack"
+        manifest = _write_advisories(pack_path, aggregate_status=AdvisoryStatus.RED)
+
+        # Trip-wire: if the code falls back to disk, model_validate_json
+        # gets called and the test fails.
+        def _fail_if_called(*_a, **_kw):
+            raise AssertionError(
+                "_assessment_from_advisories re-read disk despite an in-memory manifest",
+            )
+        monkeypatch.setattr(
+            packs_mod._RouteAdvisoriesManifest,
+            "model_validate_json",
+            _fail_if_called,
+        )
+
+        result = _make_partial_result(pack_path)
+        result.route_advisories_manifest = manifest
+        fetch_ts = datetime.now(timezone.utc).replace(microsecond=0)
+
+        meta = _persist_pack_provisional(
+            flight.id, flight, fetch_ts, pack_path, result, db_session,
+        )
+
+        assert meta.assessment == "RED"
+        assert meta.has_digest is False
 
     def test_no_advisories_leaves_assessment_null(
         self, db_session, dev_user, tmp_path,

--- a/tests/test_briefing_ready.py
+++ b/tests/test_briefing_ready.py
@@ -1,0 +1,421 @@
+"""Tests for the briefing_ready milestone (issue #113).
+
+Covers three layers:
+- Pipeline: ``execute_briefing`` calls the progress + briefing_ready callbacks
+  between phase 6 (Skew-T) and phase 7 (LLM digest).
+- Persistence: ``_persist_pack_provisional`` / ``_persist_pack_finalize``
+  write/update the ``BriefingPackRow`` correctly.
+- SSE handler: ``briefing_ready_callback`` emits a ``briefing_ready`` event
+  with provisional pack metadata.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from flyfun_common.db import DEV_USER_ID
+from weatherbrief.models import (
+    AdvisoryStatus,
+    BriefingPackMeta,
+    Flight,
+    ForecastSnapshot,
+    RouteAdvisoriesManifest,
+    RouteAdvisoryResult,
+    RouteConfig,
+    Waypoint,
+)
+from weatherbrief.pipeline import BriefingResult
+from weatherbrief.storage.flights import (
+    list_packs,
+    save_flight,
+)
+
+
+# --- Helpers ---
+
+
+def _make_route() -> RouteConfig:
+    return RouteConfig(
+        name="test",
+        waypoints=[
+            Waypoint(icao="EGTK", name="Oxford", lat=51.8, lon=-1.3),
+            Waypoint(icao="LSGS", name="Sion", lat=46.2, lon=7.3),
+        ],
+        cruise_altitude_ft=8000,
+        flight_duration_hours=4.0,
+    )
+
+
+def _make_flight(flight_id: str = "test-flight") -> Flight:
+    return Flight(
+        id=flight_id,
+        user_id=DEV_USER_ID,
+        route_name="test",
+        waypoints=["EGTK", "LSGS"],
+        departure_time=datetime.now(timezone.utc) + timedelta(days=2),
+        cruise_altitude_ft=8000,
+        flight_ceiling_ft=18000,
+        flight_duration_hours=4.0,
+        created_at=datetime.now(timezone.utc),
+    )
+
+
+def _make_partial_result(pack_path: Path) -> BriefingResult:
+    """A BriefingResult as it would look at the briefing_ready milestone:
+    snapshot/advisories/GRAMET/Skew-T present, no digest.
+    """
+    snapshot = ForecastSnapshot(
+        route=_make_route(),
+        target_date=(datetime.now(timezone.utc).date() + timedelta(days=2)).isoformat(),
+        fetch_date=datetime.now(timezone.utc).date().isoformat(),
+        days_out=2,
+    )
+    result = BriefingResult(
+        snapshot=snapshot,
+        snapshot_path=pack_path / "briefing.json",
+    )
+    result.gramet_path = pack_path / "gramet.pdf"
+    result.skewt_paths = [pack_path / "skewt" / "EGTK_gfs.png"]
+    result.route_advisories_path = pack_path / "route_advisories.json"
+    result.models_fetched = ["ecmwf", "gfs"]
+    result.grib_init_times = {}
+    return result
+
+
+def _write_advisories(
+    pack_path: Path,
+    *,
+    aggregate_status: AdvisoryStatus = AdvisoryStatus.AMBER,
+    advisory_id: str = "icing.fiki",
+) -> None:
+    """Write a minimal ``route_advisories.json`` so assessment derivation works."""
+    pack_path.mkdir(parents=True, exist_ok=True)
+    manifest = RouteAdvisoriesManifest(
+        advisories=[
+            RouteAdvisoryResult(
+                advisory_id=advisory_id,
+                aggregate_status=aggregate_status,
+                per_model=[],
+            ),
+        ],
+    )
+    (pack_path / "route_advisories.json").write_text(
+        manifest.model_dump_json(indent=2),
+    )
+
+
+# --- Persistence layer ---
+
+
+class TestPersistProvisional:
+    def test_writes_row_with_has_digest_false(
+        self, db_session, dev_user, tmp_path,
+    ):
+        """_persist_pack_provisional inserts a pack row with has_digest=False
+        and an assessment derived from advisories on disk.
+        """
+        from weatherbrief.api.packs import _persist_pack_provisional
+
+        flight = _make_flight()
+        save_flight(db_session, flight, dev_user)
+
+        pack_path = tmp_path / "pack"
+        _write_advisories(pack_path, aggregate_status=AdvisoryStatus.AMBER)
+
+        result = _make_partial_result(pack_path)
+        fetch_ts = datetime.now(timezone.utc).replace(microsecond=0)
+
+        meta = _persist_pack_provisional(
+            flight.id, flight, fetch_ts, pack_path, result, db_session,
+        )
+
+        assert meta.has_digest is False
+        # Advisories with aggregate_status='amber' → assessment AMBER
+        assert meta.assessment == "AMBER"
+
+        packs = list_packs(db_session, flight.id)
+        assert len(packs) == 1
+        assert packs[0].has_digest is False
+        assert packs[0].assessment == "AMBER"
+        assert packs[0].has_gramet is True
+        assert packs[0].has_skewt is True
+
+    def test_no_advisories_leaves_assessment_null(
+        self, db_session, dev_user, tmp_path,
+    ):
+        """When route_advisories.json doesn't exist, assessment is NULL."""
+        from weatherbrief.api.packs import _persist_pack_provisional
+
+        flight = _make_flight()
+        save_flight(db_session, flight, dev_user)
+
+        pack_path = tmp_path / "pack"
+        pack_path.mkdir()  # no route_advisories.json
+
+        result = _make_partial_result(pack_path)
+        result.route_advisories_path = None
+        fetch_ts = datetime.now(timezone.utc).replace(microsecond=0)
+
+        meta = _persist_pack_provisional(
+            flight.id, flight, fetch_ts, pack_path, result, db_session,
+        )
+
+        assert meta.has_digest is False
+        assert meta.assessment is None
+        assert meta.assessment_reason is None
+
+
+class TestPersistFinalize:
+    def test_updates_existing_provisional_row(
+        self, db_session, dev_user, tmp_path,
+    ):
+        """_persist_pack_finalize updates the row from provisional rather
+        than inserting a duplicate.
+        """
+        from weatherbrief.api.packs import (
+            _persist_pack_finalize,
+            _persist_pack_provisional,
+        )
+
+        flight = _make_flight()
+        save_flight(db_session, flight, dev_user)
+
+        pack_path = tmp_path / "pack"
+        _write_advisories(pack_path, aggregate_status=AdvisoryStatus.AMBER)
+
+        result = _make_partial_result(pack_path)
+        fetch_ts = datetime.now(timezone.utc).replace(microsecond=0)
+
+        _persist_pack_provisional(
+            flight.id, flight, fetch_ts, pack_path, result, db_session,
+        )
+        assert len(list_packs(db_session, flight.id)) == 1
+
+        # Phase 7 completes: digest produces a different assessment.
+        class FakeDigest:
+            assessment = "GREEN"
+            assessment_reason = "Conditions improved"
+
+        result.digest = FakeDigest()
+        result.digest_path = pack_path / "digest.json"
+
+        meta = _persist_pack_finalize(
+            flight.id, flight, fetch_ts, pack_path, result, db_session,
+            user_id=dev_user,
+        )
+
+        packs = list_packs(db_session, flight.id)
+        assert len(packs) == 1, "row count must not increase on finalize"
+        assert packs[0].has_digest is True
+        assert packs[0].assessment == "GREEN"
+        assert packs[0].assessment_reason == "Conditions improved"
+        assert meta.has_digest is True
+
+    def test_digest_failure_keeps_has_digest_false(
+        self, db_session, dev_user, tmp_path,
+    ):
+        """If the digest fails (no digest_path), finalize updates with
+        has_digest=False but the assessment from advisories survives.
+        """
+        from weatherbrief.api.packs import (
+            _persist_pack_finalize,
+            _persist_pack_provisional,
+        )
+
+        flight = _make_flight()
+        save_flight(db_session, flight, dev_user)
+
+        pack_path = tmp_path / "pack"
+        _write_advisories(pack_path, aggregate_status=AdvisoryStatus.AMBER)
+
+        result = _make_partial_result(pack_path)
+        fetch_ts = datetime.now(timezone.utc).replace(microsecond=0)
+
+        _persist_pack_provisional(
+            flight.id, flight, fetch_ts, pack_path, result, db_session,
+        )
+
+        # Digest fails → result.digest is None and digest_path is None.
+        meta = _persist_pack_finalize(
+            flight.id, flight, fetch_ts, pack_path, result, db_session,
+            user_id=dev_user,
+        )
+
+        packs = list_packs(db_session, flight.id)
+        assert len(packs) == 1
+        assert packs[0].has_digest is False
+        assert packs[0].assessment == "AMBER"
+        assert meta.has_digest is False
+
+    def test_finalize_inserts_when_no_provisional(
+        self, db_session, dev_user, tmp_path,
+    ):
+        """The synchronous /refresh path skips the provisional step; finalize
+        must insert a fresh row instead of failing silently.
+        """
+        from weatherbrief.api.packs import _persist_pack_finalize
+
+        flight = _make_flight()
+        save_flight(db_session, flight, dev_user)
+
+        pack_path = tmp_path / "pack"
+        _write_advisories(pack_path, aggregate_status=AdvisoryStatus.GREEN)
+
+        result = _make_partial_result(pack_path)
+        result.digest_path = pack_path / "digest.json"
+
+        class FakeDigest:
+            assessment = "GREEN"
+            assessment_reason = "All clear"
+
+        result.digest = FakeDigest()
+        fetch_ts = datetime.now(timezone.utc).replace(microsecond=0)
+
+        meta = _persist_pack_finalize(
+            flight.id, flight, fetch_ts, pack_path, result, db_session,
+            user_id=dev_user,
+        )
+
+        packs = list_packs(db_session, flight.id)
+        assert len(packs) == 1
+        assert packs[0].has_digest is True
+        assert meta.has_digest is True
+
+
+# --- Pipeline emission ---
+
+
+class TestPipelineEmitsBriefingReady:
+    """Verify execute_briefing fires the briefing_ready callbacks between
+    phase 6 (Skew-T) and phase 7 (LLM digest).
+    """
+
+    def _patch_pipeline_phases(self, monkeypatch):
+        """Stub out heavy pipeline stages so the orchestrator can run end-to-end
+        in a test without network or real GRIB data.
+        """
+        from weatherbrief.tasks.advise import AdvisoryResult
+        from weatherbrief.tasks.analyze import AnalysisResult
+        from weatherbrief.tasks.fetch import FetchResult
+        from weatherbrief.tasks.outputs import DigestResult, GrametResult, SkewtResult
+        import weatherbrief.pipeline as pipeline_mod
+
+        def fake_run_fetch(**_kwargs):
+            return FetchResult(
+                route_points=[],
+                all_forecasts=[],
+                cross_sections=[],
+                elevation_profile=None,
+                models_fetched=["ecmwf", "gfs"],
+            )
+
+        def fake_run_analysis(**_kwargs):
+            return AnalysisResult(
+                waypoint_analyses=[],
+                route_analyses=[],
+                route_analyses_manifest=None,
+                model_names=["ecmwf", "gfs"],
+            )
+
+        def fake_run_advisories(**_kwargs):
+            return AdvisoryResult(manifest=None)
+
+        def fake_run_gramet(**_kwargs):
+            return GrametResult()
+
+        def fake_run_skewt(**_kwargs):
+            return SkewtResult()
+
+        def fake_run_llm_digest(**_kwargs):
+            return DigestResult()
+
+        # Stub at the import sites used inside pipeline.py (re-exported from tasks).
+        monkeypatch.setattr(pipeline_mod, "run_fetch", fake_run_fetch)
+        monkeypatch.setattr(pipeline_mod, "run_analysis", fake_run_analysis)
+        monkeypatch.setattr(pipeline_mod, "run_advisories", fake_run_advisories)
+        monkeypatch.setattr(pipeline_mod, "run_gramet", fake_run_gramet)
+        monkeypatch.setattr(pipeline_mod, "run_skewt", fake_run_skewt)
+        monkeypatch.setattr(pipeline_mod, "run_llm_digest", fake_run_llm_digest)
+
+    def test_briefing_ready_fires_before_llm_digest(self, monkeypatch, tmp_path):
+        """Pipeline emits 'briefing_ready' before the 'llm_digest' progress stage."""
+        from weatherbrief.pipeline import BriefingOptions, execute_briefing
+
+        self._patch_pipeline_phases(monkeypatch)
+
+        progress_stages: list[str] = []
+        ready_called: list[BriefingResult] = []
+
+        def progress_cb(stage: str, _detail: str | None = None) -> None:
+            progress_stages.append(stage)
+
+        def ready_cb(result: BriefingResult) -> None:
+            ready_called.append(result)
+
+        options = BriefingOptions(
+            output_dir=tmp_path / "pack",
+            fetch_gramet=True,
+            generate_skewt=True,
+            generate_llm_digest=True,
+        )
+
+        execute_briefing(
+            route=_make_route(),
+            departure_time=datetime.now(timezone.utc) + timedelta(days=2),
+            options=options,
+            progress_callback=progress_cb,
+            briefing_ready_callback=ready_cb,
+        )
+
+        assert "briefing_ready" in progress_stages, progress_stages
+        assert "llm_digest" in progress_stages, progress_stages
+        # Ordering matters: briefing_ready must fire BEFORE llm_digest.
+        assert progress_stages.index("briefing_ready") < progress_stages.index("llm_digest")
+        # generate_skewt is part of the visible briefing — it must run before
+        # the briefing_ready milestone.
+        assert progress_stages.index("generate_skewt") < progress_stages.index("briefing_ready")
+
+        # The briefing_ready_callback receives the partially-populated result
+        # (digest still empty at this point).
+        assert len(ready_called) == 1
+        assert ready_called[0].digest is None
+        assert ready_called[0].digest_path is None
+
+    def test_briefing_ready_callback_failure_does_not_abort_pipeline(
+        self, monkeypatch, tmp_path,
+    ):
+        """A throwing briefing_ready_callback must not block the digest phase."""
+        from weatherbrief.pipeline import BriefingOptions, execute_briefing
+
+        self._patch_pipeline_phases(monkeypatch)
+
+        progress_stages: list[str] = []
+
+        def progress_cb(stage: str, _detail: str | None = None) -> None:
+            progress_stages.append(stage)
+
+        def ready_cb(_result: BriefingResult) -> None:
+            raise RuntimeError("simulated provisional persist failure")
+
+        options = BriefingOptions(
+            output_dir=tmp_path / "pack",
+            fetch_gramet=False,
+            generate_skewt=False,
+            generate_llm_digest=True,
+        )
+
+        # Pipeline must still complete (digest stage runs after briefing_ready).
+        execute_briefing(
+            route=_make_route(),
+            departure_time=datetime.now(timezone.utc) + timedelta(days=2),
+            options=options,
+            progress_callback=progress_cb,
+            briefing_ready_callback=ready_cb,
+        )
+
+        assert "briefing_ready" in progress_stages
+        assert "llm_digest" in progress_stages

--- a/tests/test_briefing_ready.py
+++ b/tests/test_briefing_ready.py
@@ -385,6 +385,43 @@ class TestPipelineEmitsBriefingReady:
         assert ready_called[0].digest is None
         assert ready_called[0].digest_path is None
 
+    def test_briefing_ready_skipped_when_no_digest(self, monkeypatch, tmp_path):
+        """When generate_llm_digest=False, the provisional persist would be
+        immediately overwritten by finalize — skip both the progress event
+        and the callback to avoid the redundant DB roundtrip.
+        """
+        from weatherbrief.pipeline import BriefingOptions, execute_briefing
+
+        self._patch_pipeline_phases(monkeypatch)
+
+        progress_stages: list[str] = []
+        ready_called: list[BriefingResult] = []
+
+        def progress_cb(stage: str, _detail: str | None = None) -> None:
+            progress_stages.append(stage)
+
+        def ready_cb(result: BriefingResult) -> None:
+            ready_called.append(result)
+
+        options = BriefingOptions(
+            output_dir=tmp_path / "pack",
+            fetch_gramet=False,
+            generate_skewt=False,
+            generate_llm_digest=False,
+        )
+
+        execute_briefing(
+            route=_make_route(),
+            departure_time=datetime.now(timezone.utc) + timedelta(days=2),
+            options=options,
+            progress_callback=progress_cb,
+            briefing_ready_callback=ready_cb,
+        )
+
+        assert "briefing_ready" not in progress_stages
+        assert "llm_digest" not in progress_stages
+        assert ready_called == []
+
     def test_briefing_ready_callback_failure_does_not_abort_pipeline(
         self, monkeypatch, tmp_path,
     ):

--- a/tests/test_flights_storage.py
+++ b/tests/test_flights_storage.py
@@ -17,6 +17,7 @@ from weatherbrief.storage.flights import (
     pack_dir_for,
     save_flight,
     save_pack_meta,
+    update_pack_meta,
 )
 
 
@@ -162,6 +163,43 @@ class TestBriefingPacks:
         pack_dir = pack_dir_for("user-123", "flight-abc", "2026-02-19T18:00:00Z")
         assert "user-123" in str(pack_dir)
         assert "flight-abc" in str(pack_dir)
+
+    def test_update_pack_meta_updates_existing(
+        self, db_session, dev_user, sample_flight, sample_pack_meta,
+    ):
+        """update_pack_meta updates an existing row in place (no new row)."""
+        save_flight(db_session, sample_flight, dev_user)
+        # Insert provisional row with has_digest=False
+        provisional = sample_pack_meta.model_copy(update={
+            "has_digest": False,
+            "assessment": "AMBER",
+            "assessment_reason": "advisories: icing=AMBER",
+        })
+        save_pack_meta(db_session, provisional)
+
+        # Finalize: same timestamp, has_digest=True, assessment overridden
+        finalized = sample_pack_meta.model_copy(update={
+            "has_digest": True,
+            "assessment": "GREEN",
+            "assessment_reason": "Digest concluded all clear",
+        })
+        updated = update_pack_meta(db_session, finalized)
+
+        assert updated is True
+        packs = list_packs(db_session, sample_flight.id)
+        assert len(packs) == 1  # row count must not increase
+        assert packs[0].has_digest is True
+        assert packs[0].assessment == "GREEN"
+        assert packs[0].assessment_reason == "Digest concluded all clear"
+
+    def test_update_pack_meta_returns_false_when_missing(
+        self, db_session, dev_user, sample_flight, sample_pack_meta,
+    ):
+        """update_pack_meta returns False if no matching row exists."""
+        save_flight(db_session, sample_flight, dev_user)
+        # No provisional row inserted — update should report not-found.
+        assert update_pack_meta(db_session, sample_pack_meta) is False
+        assert list_packs(db_session, sample_flight.id) == []
 
 
 # --- Model tests ---

--- a/web/ts/adapters/api-adapter.ts
+++ b/web/ts/adapters/api-adapter.ts
@@ -264,9 +264,20 @@ export async function fetchFreshness(flightId: string): Promise<DataStatus> {
   );
 }
 
-/** SSE event from the streaming refresh endpoint. */
+/** SSE event from the streaming refresh endpoint.
+ *
+ * Event types in stream order (best case):
+ *   progress* → briefing_ready → progress(llm_digest) → complete
+ *
+ * `briefing_ready` carries a provisional `pack` with `has_digest=false`;
+ * the visible briefing artifacts (snapshot, advisories, GRAMET) are on
+ * disk and ready to render. `complete` carries the final `pack` with
+ * `has_digest=true` (or false if the digest stage failed). Older servers
+ * that don't emit `briefing_ready` still work — clients just see the
+ * existing `progress* → complete` flow.
+ */
 export interface RefreshStreamEvent {
-  type: 'progress' | 'complete' | 'error';
+  type: 'progress' | 'briefing_ready' | 'complete' | 'error';
   stage?: string;
   detail?: string | null;
   label?: string;

--- a/web/ts/briefing-main.ts
+++ b/web/ts/briefing-main.ts
@@ -887,6 +887,7 @@ async function init(): Promise<void> {
       state.currentPack !== prev.currentPack ||
       state.snapshot !== prev.snapshot ||
       state.digest !== prev.digest ||
+      state.digestPending !== prev.digestPending ||
       state.routeAnalyses !== prev.routeAnalyses ||
       state.routeAdvisories !== prev.routeAdvisories ||
       state.altAdvisories !== prev.altAdvisories ||
@@ -897,7 +898,7 @@ async function init(): Promise<void> {
       ui.renderAssessment(state.currentPack, state.flight, state.routeAdvisories, state.altAdvisories);
       renderAdvisories(getEffectiveAdvisories(state), () => store.getState().recalculateAdvisories(), state.displayMode, getAltitudeOverrideConfig(state), handleAltitudeTable, getAltTimeToggleConfig(state), getProfileSelectorConfig(state));
       ui.renderRouteObservations(state.snapshot, () => store.getState().refreshObservations());
-      ui.renderSynopsis(state.flight, state.currentPack, state.digest, state.displayMode);
+      ui.renderSynopsis(state.flight, state.currentPack, state.digest, state.displayMode, state.digestPending);
       ui.renderDWDOverview(state.flight, state.currentPack);
       ui.renderGramet(state.flight, state.currentPack);
       renderPointSections(state);
@@ -943,7 +944,7 @@ async function init(): Promise<void> {
       renderPointSections(state);
       if (state.displayMode !== prev.displayMode) {
         renderAdvisories(getEffectiveAdvisories(state), () => store.getState().recalculateAdvisories(), state.displayMode, getAltitudeOverrideConfig(state), handleAltitudeTable, getAltTimeToggleConfig(state), getProfileSelectorConfig(state));
-        ui.renderSynopsis(state.flight, state.currentPack, state.digest, state.displayMode);
+        ui.renderSynopsis(state.flight, state.currentPack, state.digest, state.displayMode, state.digestPending);
         // Entering compact: enforce preferred-only layers for clouds/icing
         // (triggers vizSettings change → renderVisualization runs via that subscriber)
         if (state.displayMode === 'compact' && Object.keys(preferredMethods).length > 0) {
@@ -1263,7 +1264,7 @@ async function init(): Promise<void> {
     ui.renderAssessment(s.currentPack, s.flight, s.routeAdvisories, s.altAdvisories);
     renderAdvisories(getEffectiveAdvisories(s), () => store.getState().recalculateAdvisories(), s.displayMode, getAltitudeOverrideConfig(s), handleAltitudeTable, getAltTimeToggleConfig(s), getProfileSelectorConfig(s));
     ui.renderRouteObservations(s.snapshot, () => store.getState().refreshObservations());
-    ui.renderSynopsis(s.flight, s.currentPack, s.digest, s.displayMode);
+    ui.renderSynopsis(s.flight, s.currentPack, s.digest, s.displayMode, s.digestPending);
     ui.renderDWDOverview(s.flight, s.currentPack);
     ui.renderGramet(s.flight, s.currentPack);
     renderPointSections(s);

--- a/web/ts/i18n/locales/de.json
+++ b/web/ts/i18n/locales/de.json
@@ -121,6 +121,7 @@
   "digest.watchItems": "Beobachtungspunkte",
   "digest.noBriefing": "Kein Briefing geladen.",
   "digest.loading": "Zusammenfassung wird geladen...",
+  "digest.generating": "Zusammenfassung wird erstellt…",
   "digest.notAvailable": "Synoptische Übersicht nicht verfügbar. Führen Sie eine Aktualisierung durch, um sie zu generieren.",
   "digest.failed": "Zusammenfassung konnte nicht geladen werden.",
   "digest.profileMismatch": "Diese Zusammenfassung wurde mit Profil \"{name}\" erstellt. Das aktuelle Profil ist anders — neu berechnen, um zu aktualisieren.",

--- a/web/ts/i18n/locales/en.json
+++ b/web/ts/i18n/locales/en.json
@@ -131,6 +131,7 @@
   "digest.watchItems": "Watch Items",
   "digest.noBriefing": "No briefing loaded.",
   "digest.loading": "Loading digest...",
+  "digest.generating": "Generating summary…",
   "digest.notAvailable": "Synopsis not available. Trigger a refresh to generate.",
   "digest.failed": "Failed to load digest.",
   "digest.profileMismatch": "This summary was generated with profile \"{name}\". The current profile is different \u2014 recalculate to update.",

--- a/web/ts/i18n/locales/es.json
+++ b/web/ts/i18n/locales/es.json
@@ -121,6 +121,7 @@
   "digest.watchItems": "Elementos a vigilar",
   "digest.noBriefing": "No se ha cargado ningún briefing.",
   "digest.loading": "Cargando resumen...",
+  "digest.generating": "Generando resumen…",
   "digest.notAvailable": "Sinopsis no disponible. Ejecute una actualización para generarla.",
   "digest.failed": "Error al cargar el resumen.",
   "digest.profileMismatch": "Este resumen fue generado con el perfil \"{name}\". El perfil actual es diferente — recalcule para actualizar.",

--- a/web/ts/i18n/locales/fr.json
+++ b/web/ts/i18n/locales/fr.json
@@ -121,6 +121,7 @@
   "digest.watchItems": "Points de vigilance",
   "digest.noBriefing": "Aucun briefing chargé.",
   "digest.loading": "Chargement du résumé...",
+  "digest.generating": "Génération du résumé…",
   "digest.notAvailable": "Résumé synoptique non disponible. Lancez une actualisation pour le générer.",
   "digest.failed": "Échec du chargement du résumé.",
   "digest.profileMismatch": "Ce résumé a été généré avec le profil \"{name}\". Le profil actuel est différent — recalculez pour mettre à jour.",

--- a/web/ts/managers/briefing-ui.ts
+++ b/web/ts/managers/briefing-ui.ts
@@ -875,6 +875,7 @@ export function renderSynopsis(
   pack: PackMeta | null,
   digest: WeatherDigest | null,
   displayMode: DisplayMode = 'full',
+  digestPending: boolean = false,
 ): void {
   const el = $('synopsis-section');
   if (!el) return;
@@ -894,6 +895,14 @@ export function renderSynopsis(
   if (pack.has_digest) {
     el.innerHTML = `<p class="muted">${t('digest.loading')}</p>`;
     fetchAndRenderDigestJson(flight.id, pack.fetch_timestamp, el, displayMode, flight.profile_id);
+    return;
+  }
+
+  // `digestPending` is set while the SSE refresh stream is between its
+  // briefing_ready and complete events — the visible briefing is rendered
+  // but the digest is still being generated in the background.
+  if (digestPending) {
+    el.innerHTML = `<p class="muted">${t('digest.generating')}</p>`;
     return;
   }
 

--- a/web/ts/store/briefing-store.ts
+++ b/web/ts/store/briefing-store.ts
@@ -186,10 +186,12 @@ function makeRefreshEventHandler(
     } else if (event.type === 'briefing_ready' && event.pack) {
       const ts = event.pack.fetch_timestamp;
       set({ digestPending: true });
-      // Render the visible briefing while the digest stage continues. The
-      // post-stream code path (after `complete`) will reload+reselect so any
-      // assessment update from the digest is reflected.
-      get().loadPacks().then(() => get().selectPack(ts)).catch(() => {
+      // Render the visible briefing while the digest stage continues.
+      // selectPack fetches the pack + snapshot + advisories directly via its
+      // timestamp, so we don't need a fresh /packs list here — the
+      // post-stream code path runs `loadPacks()` once `complete` arrives,
+      // which is when the dropdown actually needs the new entry.
+      get().selectPack(ts).catch(() => {
         /* non-critical — final reload after `complete` will recover */
       });
     } else if (event.type === 'complete' && event.elapsed_seconds) {

--- a/web/ts/store/briefing-store.ts
+++ b/web/ts/store/briefing-store.ts
@@ -101,6 +101,11 @@ export interface BriefingState {
   refreshProgress: number;
   refreshElapsed: number | null;
   avgRefreshSeconds: number | null;
+  /** True between the SSE `briefing_ready` and `complete` events: the visible
+   * briefing is rendered but the LLM digest is still being generated. The UI
+   * uses this to show a "Generating summary…" placeholder in the digest panel
+   * instead of the default "Summary not available" copy. */
+  digestPending: boolean;
   notifyEmail: boolean;
   advisoryAltitudeOverride: number | null;
   altitudeTable: AltitudeTableResult | null;
@@ -151,6 +156,48 @@ export interface BriefingState {
   setVizPreset: (presetId: string | null) => void;
 }
 
+/** Build the SSE event handler shared by `refresh` and `forceRefresh`.
+ *
+ * Three event types:
+ * - `progress`: update stage label / detail / fraction.
+ * - `briefing_ready`: provisional pack with `has_digest=false` is in the DB and
+ *   the visible artifacts are on disk. Reload the pack list and select the new
+ *   pack so the UI renders the briefing immediately, while the digest stage
+ *   continues in the background. `digestPending=true` tells the synopsis
+ *   renderer to show "Generating summary…" instead of "not available".
+ * - `complete`: capture elapsed time. The post-stream code paths reload+reselect
+ *   to pick up the final assessment + digest. Backward-compatible: if the
+ *   server doesn't emit `briefing_ready` (older deploy), the store sees only
+ *   `progress` + `complete` and behaves exactly as before.
+ */
+function makeRefreshEventHandler(
+  set: (partial: Partial<BriefingState>) => void,
+  get: () => BriefingState,
+  tracker: { elapsed: number | null },
+): (event: import('../adapters/api-adapter').RefreshStreamEvent) => void {
+  return (event) => {
+    if (event.type === 'progress') {
+      set({
+        refreshStatus: 'refreshing',
+        refreshStage: event.label || event.stage || null,
+        refreshDetail: event.detail || null,
+        refreshProgress: event.progress || 0,
+      });
+    } else if (event.type === 'briefing_ready' && event.pack) {
+      const ts = event.pack.fetch_timestamp;
+      set({ digestPending: true });
+      // Render the visible briefing while the digest stage continues. The
+      // post-stream code path (after `complete`) will reload+reselect so any
+      // assessment update from the digest is reflected.
+      get().loadPacks().then(() => get().selectPack(ts)).catch(() => {
+        /* non-critical — final reload after `complete` will recover */
+      });
+    } else if (event.type === 'complete' && event.elapsed_seconds) {
+      tracker.elapsed = event.elapsed_seconds;
+    }
+  };
+}
+
 export const briefingStore = createStore<BriefingState>((set, get) => ({
   flight: null,
   packs: [],
@@ -177,6 +224,7 @@ export const briefingStore = createStore<BriefingState>((set, get) => ({
   refreshProgress: 0,
   refreshElapsed: null,
   avgRefreshSeconds: null,
+  digestPending: false,
   notifyEmail: false,
   advisoryAltitudeOverride: null,
   altitudeTable: null,
@@ -273,39 +321,31 @@ export const briefingStore = createStore<BriefingState>((set, get) => ({
   refresh: async (asOfDate?: string) => {
     const flight = get().flight;
     if (!flight) return;
-    set({ refreshing: true, refreshStatus: 'refreshing', refreshStage: null, refreshDetail: null, refreshProgress: 0, refreshElapsed: null, error: null });
+    set({ refreshing: true, refreshStatus: 'refreshing', refreshStage: null, refreshDetail: null, refreshProgress: 0, refreshElapsed: null, digestPending: false, error: null });
     // Fetch average refresh time for the progress hint (best-effort, non-blocking)
     api.fetchRefreshStats().then(stats => {
       if (stats.avg_elapsed_seconds) set({ avgRefreshSeconds: stats.avg_elapsed_seconds });
     }).catch(() => { /* ignore */ });
     try {
-      let elapsed: number | null = null;
+      const tracker: { elapsed: number | null } = { elapsed: null };
+      const handleEvent = makeRefreshEventHandler(set, get, tracker);
       const notifyEmail = get().notifyEmail;
-      const newPack = await api.refreshBriefingStream(flight.id, (event) => {
-        if (event.type === 'progress') {
-          set({
-            refreshStatus: 'refreshing',
-            refreshStage: event.label || event.stage || null,
-            refreshDetail: event.detail || null,
-            refreshProgress: event.progress || 0,
-          });
-        } else if (event.type === 'complete' && event.elapsed_seconds) {
-          elapsed = event.elapsed_seconds;
-        }
-      }, false, asOfDate, notifyEmail);
+      const newPack = await api.refreshBriefingStream(
+        flight.id, handleEvent, false, asOfDate, notifyEmail,
+      );
       // If the server returned a data_status (fresh skip), update freshness
       if (newPack.data_status) {
         set({ freshness: newPack.data_status });
       }
       await get().loadPacks();
       await get().selectPack(newPack.fetch_timestamp);
-      set({ refreshing: false, refreshStatus: null, refreshStage: null, refreshDetail: null, refreshProgress: 0, refreshElapsed: elapsed });
+      set({ refreshing: false, refreshStatus: null, refreshStage: null, refreshDetail: null, refreshProgress: 0, refreshElapsed: tracker.elapsed, digestPending: false });
       // Re-check freshness after a real refresh
       if (!newPack.data_status) {
         get().checkFreshness();
       }
       // Clear elapsed message after 15 seconds
-      if (elapsed) setTimeout(() => set({ refreshElapsed: null }), 15_000);
+      if (tracker.elapsed) setTimeout(() => set({ refreshElapsed: null }), 15_000);
     } catch (err) {
       // If another refresh is already in progress, poll for its completion
       if (err instanceof RefreshStreamError && /already in progress/i.test(err.message)) {
@@ -313,40 +353,30 @@ export const briefingStore = createStore<BriefingState>((set, get) => ({
         return;
       }
       const msg = err instanceof Error ? err.message : String(err);
-      set({ refreshing: false, refreshStatus: null, refreshStage: null, refreshDetail: null, refreshProgress: 0, refreshElapsed: null, error: msg });
+      set({ refreshing: false, refreshStatus: null, refreshStage: null, refreshDetail: null, refreshProgress: 0, refreshElapsed: null, digestPending: false, error: msg });
     }
   },
 
   forceRefresh: async () => {
     const flight = get().flight;
     if (!flight) return;
-    set({ refreshing: true, refreshStatus: 'refreshing', refreshStage: null, refreshDetail: null, refreshProgress: 0, refreshElapsed: null, error: null });
+    set({ refreshing: true, refreshStatus: 'refreshing', refreshStage: null, refreshDetail: null, refreshProgress: 0, refreshElapsed: null, digestPending: false, error: null });
     try {
-      let elapsed: number | null = null;
-      const newPack = await api.refreshBriefingStream(flight.id, (event) => {
-        if (event.type === 'progress') {
-          set({
-            refreshStatus: 'refreshing',
-            refreshStage: event.label || event.stage || null,
-            refreshDetail: event.detail || null,
-            refreshProgress: event.progress || 0,
-          });
-        } else if (event.type === 'complete' && event.elapsed_seconds) {
-          elapsed = event.elapsed_seconds;
-        }
-      }, true);
+      const tracker: { elapsed: number | null } = { elapsed: null };
+      const handleEvent = makeRefreshEventHandler(set, get, tracker);
+      const newPack = await api.refreshBriefingStream(flight.id, handleEvent, true);
       await get().loadPacks();
       await get().selectPack(newPack.fetch_timestamp);
-      set({ refreshing: false, refreshStatus: null, refreshStage: null, refreshDetail: null, refreshProgress: 0, refreshElapsed: elapsed });
+      set({ refreshing: false, refreshStatus: null, refreshStage: null, refreshDetail: null, refreshProgress: 0, refreshElapsed: tracker.elapsed, digestPending: false });
       get().checkFreshness();
-      if (elapsed) setTimeout(() => set({ refreshElapsed: null }), 15_000);
+      if (tracker.elapsed) setTimeout(() => set({ refreshElapsed: null }), 15_000);
     } catch (err) {
       if (err instanceof RefreshStreamError && /already in progress/i.test(err.message)) {
         get().checkActiveRefresh();
         return;
       }
       const msg = err instanceof Error ? err.message : String(err);
-      set({ refreshing: false, refreshStatus: null, refreshStage: null, refreshDetail: null, refreshProgress: 0, refreshElapsed: null, error: msg });
+      set({ refreshing: false, refreshStatus: null, refreshStage: null, refreshDetail: null, refreshProgress: 0, refreshElapsed: null, digestPending: false, error: msg });
     }
   },
 

--- a/web/ts/store/briefing-store.ts
+++ b/web/ts/store/briefing-store.ts
@@ -400,14 +400,14 @@ export const briefingStore = createStore<BriefingState>((set, get) => ({
       const MAX_POLL_ATTEMPTS = 100; // ~5 minutes at 3s intervals
       const poll = async (attempt = 0): Promise<void> => {
         if (attempt >= MAX_POLL_ATTEMPTS) {
-          set({ refreshing: false, refreshStatus: null, refreshStage: null, refreshDetail: null, refreshProgress: 0, error: 'Refresh timed out' });
+          set({ refreshing: false, refreshStatus: null, refreshStage: null, refreshDetail: null, refreshProgress: 0, digestPending: false, error: 'Refresh timed out' });
           return;
         }
         await new Promise(r => setTimeout(r, 3000));
         const s = await api.fetchRefreshStatus(flight.id);
         if (!s.active) {
           // Done — reload packs and select latest
-          set({ refreshing: false, refreshStatus: null, refreshStage: null, refreshDetail: null, refreshProgress: 0 });
+          set({ refreshing: false, refreshStatus: null, refreshStage: null, refreshDetail: null, refreshProgress: 0, digestPending: false });
           await get().loadPacks();
           await get().selectLatest();
           get().checkFreshness();


### PR DESCRIPTION
Combines Parts B (#113, server) and C (#114, web client) of the progressive-render epic so the user-visible win lands in one shippable change. iOS (#115) stays separate.

## What changes

### Server (#113)
The pipeline now signals `briefing_ready` between phase 6 (Skew-T) and phase 7 (LLM digest). The streaming refresh handler inserts a provisional `BriefingPackRow` with `has_digest=False` and assessment derived from advisories, then updates that same row to `has_digest=True` after the digest finishes (or leaves it false on digest failure).

Old clients that don't understand `briefing_ready` simply skip the new event and keep waiting for `complete` — fully forward-compatible.

### Web (#114)
- `RefreshStreamEvent` union now includes `'briefing_ready'`.
- New `digestPending` flag in `briefingStore`, set true between `briefing_ready` and `complete`.
- On `briefing_ready`: reload the pack list, select the new pack — the visible briefing renders while the digest stage continues running.
- `renderSynopsis` shows a "Generating summary…" placeholder when `digestPending` and the digest hasn't arrived (i18n: en/fr/de/es).
- On `complete`: existing post-stream `selectPack` reloads the final pack — assessment/digest update naturally.

### Backend review fixes from PR #118 first round
- Shared `_apply_meta_to_row` helper so `save_pack_meta` and `update_pack_meta` can't drift when fields are added.
- Explicit `thread_db.rollback()` before close on provisional persist failure.
- New `BriefingResult.route_advisories_manifest` so `_build_pack_meta` derives the provisional assessment from the in-memory manifest instead of re-reading `route_advisories.json`.
- Skip `briefing_ready` emission when `generate_llm_digest=False` (avoids redundant insert + immediate update).
- Type annotations on new helpers; module-level `RouteAdvisoriesManifest` import so `ImportError` surfaces loudly instead of being silently caught.
- Clarifying comment on `_STAGE_PROGRESS["briefing_ready"]` documenting that the SSE path emits a dedicated event instead.

## Failure handling

- **Digest fails**: row is updated with `has_digest=False` + digest diagnostic. Web shows "Summary not available". Briefing still rendered.
- **Stream disconnects between briefing_ready and complete**: provisional row sits at `has_digest=False`. Pipeline keeps running in the executor; finalize updates the same row to `has_digest=True`. Reconnects via `/packs/latest` see the final state.
- **Provisional persist fails**: digest still runs; finalize inserts the row at the end (the `update_pack_meta`-then-`save_pack_meta` fallback handles the missing-row case).

## Backward compatibility

- `BriefingPackRow` schema unchanged — no migration.
- Sync `/refresh` endpoint and the auto-refresh scheduler still go through `_finalize_refresh` (now a thin wrapper around `_persist_pack_finalize`) — single insert, same end state as before.
- Old web clients ignore the new event; old packs load via `_row_to_meta` exactly as before.

## Test plan

- [x] Backend tests pass (145 in pipeline + packs + flights_storage + briefing_ready + scheduler + api)
- [x] New tests: pipeline emits briefing_ready before llm_digest; skips it when `generate_llm_digest=False`; provisional/finalize persist correctly; failing callback doesn't abort pipeline
- [x] `tsc --noEmit` clean for all `web/ts/`
- [x] esbuild bundle for `briefing-main.ts` builds clean
- [ ] Manual: trigger a refresh in the UI, confirm briefing view appears at ~40-60s with "Generating summary…" placeholder, then digest content appears at ~60-90s
- [ ] Manual: simulate a digest failure and verify the briefing still renders with "Summary not available"
- [ ] Manual: kill the network tab between briefing_ready and complete, reload the page, verify the pack is there and the digest fills in once available

Closes #113, closes #114.