### PR TITLE
feat(freshness): per-source detail popover + provider-aware banner

### DIFF
--- a/src/weatherbrief/api/admin.py
+++ b/src/weatherbrief/api/admin.py
@@ -158,6 +158,7 @@ def freshness_markers(
             "next_expected": m.next_expected.isoformat(),
             "last_check": m.last_check.isoformat() if m.last_check else None,
             "slip_count": m.slip_count,
+            "published_at": m.published_at.isoformat() if m.published_at else None,
             "is_stale": m.is_stale(LOOP_INTERVAL),
             "observations": observations,
             "calibration": calibration,

--- a/src/weatherbrief/api/packs.py
+++ b/src/weatherbrief/api/packs.py
@@ -203,6 +203,26 @@ class ModelStatus(BaseModel):
     pack_init: int | None = None  # Unix ts of the init the pack was built from
     latest_available: int  # Unix ts of latest known init for this source
     next_expected: str  # ISO datetime — wallclock when next run is expected
+    published_at: str | None = None  # provider-reported publish time (OM only)
+    state: str  # "current" | "stale" | "awaiting" | "delayed"
+
+
+class ModelSourceDetail(BaseModel):
+    """One (model, source) row for the freshness info popover.
+
+    Distinct from :class:`ModelStatus` because a single pack-model can have
+    *multiple* contributing sources (Open-Meteo as base + direct GRIB
+    enrichment); ``models`` only carries the primary, while ``sources``
+    enumerates every contributing path.
+    """
+
+    model: str  # pack-model name, e.g. "gfs"
+    source: str  # registry key, e.g. "gfs:noaa"
+    provider: str  # human display name: "NOAA", "DWD", "ECMWF", "Open-Meteo"
+    role: str  # "primary" (in pack.model_sources) | "base" (OM under direct)
+    init: int  # Unix ts of the run as it landed in the pack
+    published_at: str | None = None  # ISO datetime, OM only
+    next_expected: str  # ISO datetime
     state: str  # "current" | "stale" | "awaiting" | "delayed"
 
 
@@ -212,7 +232,8 @@ class DataStatus(BaseModel):
     Back-compat fields (``fresh``, ``stale_models``, ``model_init_times``,
     ``next_expected_update``, ``next_expected_model``) are preserved so
     existing clients keep working.  ``models`` and ``marker_health`` are
-    additive (issue #108).
+    additive (issue #108).  ``sources`` enumerates every contributing
+    (model, source) pair for the freshness info popover.
     """
 
     fresh: bool  # True = all models up to date for the flight horizon
@@ -222,6 +243,26 @@ class DataStatus(BaseModel):
     next_expected_model: str | None = None  # which model updates next
     marker_health: str = "ok"  # "ok" | "suspect"
     models: dict[str, ModelStatus] = Field(default_factory=dict)
+    sources: list[ModelSourceDetail] = Field(default_factory=list)
+
+
+# Display names used in API payload + UI (single source of truth so the
+# frontend doesn't have to duplicate the source-key → provider mapping).
+_PROVIDER_LABELS: dict[str, str] = {
+    "ecmwf:direct": "ECMWF",
+    "gfs:noaa": "NOAA",
+    "icon_eu:dwd": "DWD",
+    "ecmwf:openmeteo": "Open-Meteo",
+    "gfs:openmeteo": "Open-Meteo",
+    "icon:openmeteo": "Open-Meteo",
+    "ukmo:openmeteo": "Open-Meteo",
+    "meteofrance:openmeteo": "Open-Meteo",
+}
+
+
+def _provider_label(source: str) -> str:
+    """Human display name for a source key (fallbacks to the suffix)."""
+    return _PROVIDER_LABELS.get(source, source.split(":", 1)[-1].title())
 
 
 class PackMetaResponse(BaseModel):
@@ -375,12 +416,15 @@ def _backfill_sources(pack: BriefingPackMeta) -> dict[str, str]:
     return out
 
 
-def _inline_check(source: str, model: str) -> tuple[datetime, datetime] | None:
+def _inline_check(
+    source: str, model: str,
+) -> tuple[datetime, datetime, datetime | None] | None:
     """Best-effort one-shot dynamic check used when the marker is suspect.
 
     Falls back to the registry's expected delivery time if the dynamic
-    check fails — better than reporting nothing.  Returns (init, next_expected)
-    aware UTC datetimes.
+    check fails — better than reporting nothing.  Returns
+    ``(init, next_expected, published_at)`` aware UTC datetimes (with
+    ``published_at`` set only for Open-Meteo).
     """
     from weatherbrief.fetch.freshness import registry
     from weatherbrief.fetch.freshness.sources import check_source as _sync_check
@@ -389,8 +433,12 @@ def _inline_check(source: str, model: str) -> tuple[datetime, datetime] | None:
     if observed is None:
         # Last-resort: synthesize from registry
         init, nxt = registry.initial_marker_for(source)
-        return init, nxt
-    return observed, registry.next_run_after(source, observed)
+        return init, nxt, None
+    return (
+        observed.init,
+        registry.next_run_after(source, observed.init),
+        observed.published_at,
+    )
 
 
 def _build_data_status(pack: BriefingPackMeta, flight: Flight) -> DataStatus:
@@ -417,21 +465,26 @@ def _build_data_status(pack: BriefingPackMeta, flight: Flight) -> DataStatus:
     store = get_store()
 
     models_out: dict[str, ModelStatus] = {}
+    sources_out: list[ModelSourceDetail] = []
     next_expected_candidates: list[tuple[datetime, str]] = []
     health = "ok"
     any_stale = False
     stale_models: list[str] = []
 
-    for model, source in sources.items():
+    def _resolve_marker(source: str, model: str) -> tuple[datetime, datetime, datetime | None] | None:
+        """Return (init, next_expected, published_at) or None on suspect+failure."""
+        nonlocal health
         marker = store.get_sync(source, model_for_source(source))
         if marker is None or marker.is_stale(LOOP_INTERVAL):
             health = "suspect"
-            inline = _inline_check(source, model_for_source(source))
-            if inline is None:
-                continue
-            init, nxt = inline
-        else:
-            init, nxt = marker.init, marker.next_expected
+            return _inline_check(source, model_for_source(source))
+        return marker.init, marker.next_expected, marker.published_at
+
+    for model, source in sources.items():
+        resolved = _resolve_marker(source, model)
+        if resolved is None:
+            continue
+        init, nxt, published_at = resolved
 
         pack_init_ts = _pack_init_for_source(pack, model, source)
         horizon = registry.run_horizon(source, init)
@@ -450,14 +503,53 @@ def _build_data_status(pack: BriefingPackMeta, flight: Flight) -> DataStatus:
             now = datetime.now(timezone.utc)
             state = "delayed" if now > nxt else "awaiting"
 
+        published_at_iso = published_at.isoformat() if published_at else None
         models_out[model] = ModelStatus(
             source=source,
             pack_init=pack_init_ts,
             latest_available=int(init.timestamp()),
             next_expected=nxt.isoformat(),
+            published_at=published_at_iso,
             state=state,
         )
         next_expected_candidates.append((nxt, model))
+
+        # Primary row in the popover-friendly list — uses the run that
+        # actually landed in the pack (pack_init_ts) so the popover shows
+        # what the pilot is looking at, not just what's now-available.
+        sources_out.append(ModelSourceDetail(
+            model=model,
+            source=source,
+            provider=_provider_label(source),
+            role="primary",
+            init=pack_init_ts if pack_init_ts is not None else int(init.timestamp()),
+            published_at=published_at_iso,
+            next_expected=nxt.isoformat(),
+            state=state,
+        ))
+
+        # When the primary is direct GRIB, OM also contributed (it's always
+        # fetched first — see fetch.py:244-247) and supplied the surface base
+        # layer.  Surface that as a "base" row so the popover honestly shows
+        # both contributing sources.
+        if not source.endswith(":openmeteo"):
+            om_source = f"{model}:openmeteo"
+            om_pack_init = pack.model_init_times.get(model)
+            if om_pack_init is not None:
+                om_resolved = _resolve_marker(om_source, model)
+                if om_resolved is not None:
+                    om_init, om_nxt, om_pub = om_resolved
+                    om_pub_iso = om_pub.isoformat() if om_pub else None
+                    sources_out.append(ModelSourceDetail(
+                        model=model,
+                        source=om_source,
+                        provider=_provider_label(om_source),
+                        role="base",
+                        init=om_pack_init,
+                        published_at=om_pub_iso,
+                        next_expected=om_nxt.isoformat(),
+                        state="current",
+                    ))
 
     next_time = None
     next_model = None
@@ -473,6 +565,7 @@ def _build_data_status(pack: BriefingPackMeta, flight: Flight) -> DataStatus:
         next_expected_model=next_model,
         marker_health=health,
         models=models_out,
+        sources=sources_out,
     )
 
 

--- a/src/weatherbrief/api/packs.py
+++ b/src/weatherbrief/api/packs.py
@@ -203,7 +203,10 @@ class ModelStatus(BaseModel):
     pack_init: int | None = None  # Unix ts of the init the pack was built from
     latest_available: int  # Unix ts of latest known init for this source
     next_expected: str  # ISO datetime — wallclock when next run is expected
-    published_at: str | None = None  # provider-reported publish time (OM only)
+    # Provider-reported publish wallclock when known.  OM: from meta.json's
+    # last_run_availability_time.  Direct GRIB: NOAA's S3 Last-Modified,
+    # DWD's HTTP Last-Modified, ECMWF's local sentinel mtime.
+    published_at: str | None = None
     state: str  # "current" | "stale" | "awaiting" | "delayed"
 
 
@@ -221,7 +224,9 @@ class ModelSourceDetail(BaseModel):
     provider: str  # human display name: "NOAA", "DWD", "ECMWF", "Open-Meteo"
     role: str  # "primary" (in pack.model_sources) | "base" (OM under direct)
     init: int  # Unix ts of the run as it landed in the pack
-    published_at: str | None = None  # ISO datetime, OM only
+    # Provider-reported publish wallclock — populated for all sources now
+    # (OM meta.json; direct GRIB Last-Modified or sentinel mtime).
+    published_at: str | None = None
     next_expected: str  # ISO datetime
     state: str  # "current" | "stale" | "awaiting" | "delayed"
 
@@ -423,8 +428,9 @@ def _inline_check(
 
     Falls back to the registry's expected delivery time if the dynamic
     check fails — better than reporting nothing.  Returns
-    ``(init, next_expected, published_at)`` aware UTC datetimes (with
-    ``published_at`` set only for Open-Meteo).
+    ``(init, next_expected, published_at)`` aware UTC datetimes;
+    ``published_at`` may still be ``None`` if the dispatch couldn't
+    determine one (e.g. ECMWF sentinel race, missing HTTP header).
     """
     from weatherbrief.fetch.freshness import registry
     from weatherbrief.fetch.freshness.sources import check_source as _sync_check
@@ -540,6 +546,21 @@ def _build_data_status(pack: BriefingPackMeta, flight: Flight) -> DataStatus:
                 if om_resolved is not None:
                     om_init, om_nxt, om_pub = om_resolved
                     om_pub_iso = om_pub.isoformat() if om_pub else None
+                    # Compute the OM base's actual marker state instead of
+                    # hardcoding "current" — the popover should honestly
+                    # reflect a delayed OM publish, even when the pack's
+                    # primary direct source is fine.
+                    om_now = datetime.now(timezone.utc)
+                    if int(om_init.timestamp()) > om_pack_init:
+                        om_horizon = registry.run_horizon(om_source, om_init)
+                        om_state = (
+                            "stale" if (om_init + om_horizon) >= flight_end
+                            else "current"
+                        )
+                    elif om_now > om_nxt:
+                        om_state = "delayed"
+                    else:
+                        om_state = "current" if int(om_init.timestamp()) == om_pack_init else "awaiting"
                     sources_out.append(ModelSourceDetail(
                         model=model,
                         source=om_source,
@@ -548,7 +569,7 @@ def _build_data_status(pack: BriefingPackMeta, flight: Flight) -> DataStatus:
                         init=om_pack_init,
                         published_at=om_pub_iso,
                         next_expected=om_nxt.isoformat(),
-                        state="current",
+                        state=om_state,
                     ))
 
     next_time = None

--- a/src/weatherbrief/fetch/freshness/markers.py
+++ b/src/weatherbrief/fetch/freshness/markers.py
@@ -42,6 +42,10 @@ class Marker:
         next_expected: Wallclock time at which the next run is expected.
         last_check: When the dynamic check last ran (None until first check).
         slip_count: Number of consecutive slip retries since last advance.
+        published_at: Provider-reported wallclock when the run became
+            available (only Open-Meteo exposes this via ``meta.json``'s
+            ``last_run_availability_time``).  ``None`` for direct GRIB
+            sources where we can only observe local arrival.
         observations: Recent ``(cycle_init, arrival_wallclock)`` pairs — used
             for drift detection / calibration.  Each pair lets you compute
             actual delivery delay vs. registry expectation.
@@ -53,6 +57,7 @@ class Marker:
     next_expected: datetime
     last_check: datetime | None = None
     slip_count: int = 0
+    published_at: datetime | None = None
     observations: deque[tuple[datetime, datetime]] = field(
         default_factory=lambda: deque(maxlen=OBSERVATIONS_MAXLEN),
     )
@@ -162,12 +167,15 @@ class MarkerStore:
         model: str,
         observed_init: datetime,
         now: datetime | None = None,
+        published_at: datetime | None = None,
     ) -> None:
         """Record a fresh check.  Advances ``init`` if newer; bumps slip otherwise.
 
         - If ``observed_init > marker.init``: advance, reset slip, append a
-          ``(cycle_init, arrival_wallclock)`` observation, and log the actual
-          delivery delay vs. the registry expectation (used for calibration).
+          ``(cycle_init, arrival_wallclock)`` observation, refresh
+          ``published_at`` from the dispatch (Open-Meteo only — direct sources
+          pass ``None``), and log the actual delivery delay vs. the registry
+          expectation (used for calibration).
         - If equal and ``now >= next_expected``: slip — bump ``next_expected``
           by ``cfg.slip_bump(slip_count)`` (exponential backoff, capped).
           After ``max_slip_retries``, jump forward to the next cycle's
@@ -196,6 +204,7 @@ class MarkerStore:
                     source=source, model=model,
                     init=observed_init, next_expected=next_exp,
                     last_check=now,
+                    published_at=published_at,
                     observations=new_observations,
                 )
                 return
@@ -212,6 +221,7 @@ class MarkerStore:
                     next_expected=registry.next_run_after(source, observed_init),
                     slip_count=0,
                     last_check=now,
+                    published_at=published_at,
                     observations=new_observations,
                 )
                 logger.info(
@@ -265,11 +275,20 @@ class MarkerStore:
                         source, model, new_slip_count,
                         _fmt_td(bump), new_next_expected.isoformat(),
                     )
+            # Capture published_at on every successful OM observation, even
+            # when init hasn't advanced — otherwise we'd discard a freshly
+            # observed publish wallclock just because the run didn't change,
+            # leaving popover restarts blank for hours until the next cycle.
+            # Direct sources always pass None here; only update when set.
+            new_published_at = (
+                published_at if published_at is not None else marker.published_at
+            )
             self._markers[(source, model)] = replace(
                 marker,
                 next_expected=new_next_expected,
                 slip_count=new_slip_count,
                 last_check=now,
+                published_at=new_published_at,
             )
             if log_warning is not None:
                 logger.warning(*log_warning)

--- a/src/weatherbrief/fetch/freshness/sources.py
+++ b/src/weatherbrief/fetch/freshness/sources.py
@@ -44,17 +44,31 @@ class Observation(NamedTuple):
 
 
 def _check_ecmwf_direct(model: str) -> Observation | None:
-    """Return latest ECMWF run with a readiness sentinel."""
-    from weatherbrief.fetch.grib.ecmwf_watcher import get_latest_ready
-    init = get_latest_ready()
-    if init is None:
+    """Return latest ECMWF run with a readiness sentinel.
+
+    ``published_at`` is the sentinel mtime — i.e. when the watcher finished
+    writing it after rsync delivery.  That's our local arrival time, not
+    ECMWF's central publish time, but it's the closest analogue we have
+    and is what a pilot really wants to know ("when did this data become
+    usable on the briefing server?").
+    """
+    from weatherbrief.fetch.grib.ecmwf_watcher import get_latest_ready_with_mtime
+    result = get_latest_ready_with_mtime()
+    if result is None:
         return None
-    return Observation(init=init)
+    init, mtime = result
+    return Observation(init=init, published_at=mtime)
 
 
 def _check_gfs_noaa(model: str) -> Observation | None:
-    """Return latest GFS run that has its .idx file published on S3."""
-    from weatherbrief.fetch.grib.grib_fetch import find_latest_run
+    """Return latest GFS run that has its .idx file published on S3.
+
+    Captures the ``Last-Modified`` header from the .idx HEAD response as
+    ``published_at`` — that's NOAA's server-side timestamp, equivalent in
+    quality to Open-Meteo's ``last_run_availability_time``.  One extra
+    HEAD per loop tick (every 5 min when due) is negligible.
+    """
+    from weatherbrief.fetch.grib.grib_fetch import find_latest_run, gfs_idx_url
     now = datetime.now(timezone.utc)
     # find_latest_run uses target_time only for as-of/bracketing; passing now
     # gets the most recently published cycle.
@@ -65,7 +79,8 @@ def _check_gfs_noaa(model: str) -> Observation | None:
     init = datetime.strptime(f"{init_date}{init_hour:02d}", "%Y%m%d%H").replace(
         tzinfo=timezone.utc,
     )
-    return Observation(init=init)
+    published_at = _http_last_modified(gfs_idx_url(init_date, init_hour, 0))
+    return Observation(init=init, published_at=published_at)
 
 
 def _check_icon_eu_dwd(model: str) -> Observation | None:
@@ -75,8 +90,14 @@ def _check_icon_eu_dwd(model: str) -> Observation | None:
     horizon-awareness later.  We still rely on the existing helper, which
     requires ``cover_until`` to verify horizon; pass ``target_time=now`` and
     ``cover_until=now`` so any published run qualifies.
+
+    Captures the ``Last-Modified`` header from the level-74 P file HEAD as
+    ``published_at`` — DWD's server-side publish wallclock.
     """
-    from weatherbrief.fetch.grib.icon_eu_fetch import find_latest_icon_eu_run
+    from weatherbrief.fetch.grib.icon_eu_fetch import (
+        find_latest_icon_eu_run,
+        icon_eu_file_url,
+    )
     now = datetime.now(timezone.utc)
     result = find_latest_icon_eu_run(target_time=now, cover_until=now)
     if result is None:
@@ -85,7 +106,35 @@ def _check_icon_eu_dwd(model: str) -> Observation | None:
     init = datetime.strptime(f"{init_date}{init_hour:02d}", "%Y%m%d%H").replace(
         tzinfo=timezone.utc,
     )
-    return Observation(init=init)
+    published_at = _http_last_modified(
+        icon_eu_file_url(init_date, init_hour, 0, 74, "p"),
+    )
+    return Observation(init=init, published_at=published_at)
+
+
+def _http_last_modified(url: str) -> datetime | None:
+    """HEAD ``url`` and parse its ``Last-Modified`` header (aware UTC).
+
+    Returns ``None`` on any error — the caller falls back to the absent
+    publish time.  Failures here must never break the freshness loop, so
+    no exception is allowed to escape.
+    """
+    import email.utils
+
+    import requests
+
+    try:
+        resp = requests.head(url, timeout=10)
+        if resp.status_code != 200:
+            return None
+        header = resp.headers.get("Last-Modified")
+        if not header:
+            return None
+        # parsedate_to_datetime returns aware UTC for RFC-1123 HTTP dates.
+        return email.utils.parsedate_to_datetime(header).astimezone(timezone.utc)
+    except Exception:
+        logger.debug("Last-Modified probe failed for %s", url, exc_info=True)
+        return None
 
 
 def _check_om_meta(model: str) -> Observation | None:

--- a/src/weatherbrief/fetch/freshness/sources.py
+++ b/src/weatherbrief/fetch/freshness/sources.py
@@ -8,17 +8,34 @@ so the cost of these I/O calls is paid at most twice per cycle per
 source (once on-time, once on slip).
 
 All wrappers must be safe to call from a thread (the loop offloads them
-via ``asyncio.to_thread``) and must return either an aware-UTC
-``datetime`` for the latest observed init or ``None`` if the check
-couldn't determine one (transient network failure, missing data).
+via ``asyncio.to_thread``) and must return either an :class:`Observation`
+for the latest observed init (with an optional provider-reported
+``published_at`` wallclock) or ``None`` if the check couldn't determine
+one (transient network failure, missing data).
 """
 
 from __future__ import annotations
 
 import logging
 from datetime import datetime, timedelta, timezone
+from typing import NamedTuple
 
 logger = logging.getLogger(__name__)
+
+
+class Observation(NamedTuple):
+    """Result of a dynamic readiness check.
+
+    ``published_at`` is the provider-reported wallclock when the run
+    became available — only Open-Meteo exposes this (via ``meta.json``'s
+    ``last_run_availability_time``).  Direct GRIB sources return ``None``
+    because the providers don't publish a server-side availability time;
+    the closest local proxy is the marker's ``last_check`` wallclock when
+    the run was first observed.
+    """
+
+    init: datetime
+    published_at: datetime | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -26,13 +43,16 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 
-def _check_ecmwf_direct(model: str) -> datetime | None:
+def _check_ecmwf_direct(model: str) -> Observation | None:
     """Return latest ECMWF run with a readiness sentinel."""
     from weatherbrief.fetch.grib.ecmwf_watcher import get_latest_ready
-    return get_latest_ready()
+    init = get_latest_ready()
+    if init is None:
+        return None
+    return Observation(init=init)
 
 
-def _check_gfs_noaa(model: str) -> datetime | None:
+def _check_gfs_noaa(model: str) -> Observation | None:
     """Return latest GFS run that has its .idx file published on S3."""
     from weatherbrief.fetch.grib.grib_fetch import find_latest_run
     now = datetime.now(timezone.utc)
@@ -42,12 +62,13 @@ def _check_gfs_noaa(model: str) -> datetime | None:
     if result is None:
         return None
     init_date, init_hour = result
-    return datetime.strptime(f"{init_date}{init_hour:02d}", "%Y%m%d%H").replace(
+    init = datetime.strptime(f"{init_date}{init_hour:02d}", "%Y%m%d%H").replace(
         tzinfo=timezone.utc,
     )
+    return Observation(init=init)
 
 
-def _check_icon_eu_dwd(model: str) -> datetime | None:
+def _check_icon_eu_dwd(model: str) -> Observation | None:
     """Return latest ICON-EU run whose level-74 P file responds 200 on HEAD.
 
     For the marker we don't filter by horizon — the freshness check applies
@@ -61,18 +82,25 @@ def _check_icon_eu_dwd(model: str) -> datetime | None:
     if result is None:
         return None
     init_date, init_hour = result
-    return datetime.strptime(f"{init_date}{init_hour:02d}", "%Y%m%d%H").replace(
+    init = datetime.strptime(f"{init_date}{init_hour:02d}", "%Y%m%d%H").replace(
         tzinfo=timezone.utc,
     )
+    return Observation(init=init)
 
 
-def _check_om_meta(model: str) -> datetime | None:
-    """Return latest Open-Meteo init for ``model`` from its meta.json."""
+def _check_om_meta(model: str) -> Observation | None:
+    """Return latest Open-Meteo init + publish time for ``model``."""
     from weatherbrief.fetch.model_status import fetch_model_metadata
     meta = fetch_model_metadata([model])
     if model not in meta:
         return None
-    return datetime.fromtimestamp(meta[model].last_init_time, tz=timezone.utc)
+    m = meta[model]
+    return Observation(
+        init=datetime.fromtimestamp(m.last_init_time, tz=timezone.utc),
+        published_at=datetime.fromtimestamp(
+            m.last_availability_time, tz=timezone.utc,
+        ),
+    )
 
 
 _DISPATCH = {
@@ -83,13 +111,13 @@ _DISPATCH = {
 }
 
 
-def check_source(source: str, model: str) -> datetime | None:
+def check_source(source: str, model: str) -> Observation | None:
     """Run the dynamic readiness check for one (source, model) pair.
 
     Looks up the registry to find which check to dispatch, then invokes it.
-    Returns the latest observed init time (aware UTC) or None on failure.
-    Exceptions are caught and logged — the loop should never crash on a
-    transient I/O error.
+    Returns the latest :class:`Observation` (aware UTC ``init``, optional
+    ``published_at``) or None on failure.  Exceptions are caught and
+    logged — the loop should never crash on a transient I/O error.
     """
     from .registry import SOURCE_REGISTRY
 

--- a/src/weatherbrief/fetch/freshness/sources.py
+++ b/src/weatherbrief/fetch/freshness/sources.py
@@ -63,24 +63,26 @@ def _check_ecmwf_direct(model: str) -> Observation | None:
 def _check_gfs_noaa(model: str) -> Observation | None:
     """Return latest GFS run that has its .idx file published on S3.
 
-    Captures the ``Last-Modified`` header from the .idx HEAD response as
-    ``published_at`` — that's NOAA's server-side timestamp, equivalent in
-    quality to Open-Meteo's ``last_run_availability_time``.  One extra
-    HEAD per loop tick (every 5 min when due) is negligible.
+    Reuses the HEAD that ``find_latest_run_with_response`` already issues
+    to confirm the run, extracting ``published_at`` from its
+    ``Last-Modified`` header — NOAA's server-side timestamp, equivalent
+    in quality to Open-Meteo's ``last_run_availability_time``.
     """
-    from weatherbrief.fetch.grib.grib_fetch import find_latest_run, gfs_idx_url
+    from weatherbrief.fetch.grib.grib_fetch import find_latest_run_with_response
     now = datetime.now(timezone.utc)
-    # find_latest_run uses target_time only for as-of/bracketing; passing now
-    # gets the most recently published cycle.
-    result = find_latest_run(target_time=now)
+    # target_time is only used for as-of/bracketing; passing ``now`` gets
+    # the most recently published cycle.
+    result = find_latest_run_with_response(target_time=now)
     if result is None:
         return None
-    init_date, init_hour = result
+    init_date, init_hour, resp = result
     init = datetime.strptime(f"{init_date}{init_hour:02d}", "%Y%m%d%H").replace(
         tzinfo=timezone.utc,
     )
-    published_at = _http_last_modified(gfs_idx_url(init_date, init_hour, 0))
-    return Observation(init=init, published_at=published_at)
+    return Observation(
+        init=init,
+        published_at=_parse_last_modified(resp.headers.get("Last-Modified")),
+    )
 
 
 def _check_icon_eu_dwd(model: str) -> Observation | None:
@@ -91,64 +93,66 @@ def _check_icon_eu_dwd(model: str) -> Observation | None:
     requires ``cover_until`` to verify horizon; pass ``target_time=now`` and
     ``cover_until=now`` so any published run qualifies.
 
-    Captures the ``Last-Modified`` header from the level-74 P file HEAD as
-    ``published_at`` — DWD's server-side publish wallclock.
+    Reuses the HEAD that ``find_latest_icon_eu_run_with_response`` issues,
+    extracting ``published_at`` from its ``Last-Modified`` header — DWD's
+    server-side publish wallclock.
     """
     from weatherbrief.fetch.grib.icon_eu_fetch import (
-        find_latest_icon_eu_run,
-        icon_eu_file_url,
+        find_latest_icon_eu_run_with_response,
     )
     now = datetime.now(timezone.utc)
-    result = find_latest_icon_eu_run(target_time=now, cover_until=now)
+    result = find_latest_icon_eu_run_with_response(target_time=now, cover_until=now)
     if result is None:
         return None
-    init_date, init_hour = result
+    init_date, init_hour, resp = result
     init = datetime.strptime(f"{init_date}{init_hour:02d}", "%Y%m%d%H").replace(
         tzinfo=timezone.utc,
     )
-    published_at = _http_last_modified(
-        icon_eu_file_url(init_date, init_hour, 0, 74, "p"),
+    return Observation(
+        init=init,
+        published_at=_parse_last_modified(resp.headers.get("Last-Modified")),
     )
-    return Observation(init=init, published_at=published_at)
 
 
-def _http_last_modified(url: str) -> datetime | None:
-    """HEAD ``url`` and parse its ``Last-Modified`` header (aware UTC).
+def _parse_last_modified(header: str | None) -> datetime | None:
+    """Parse a ``Last-Modified`` HTTP header into an aware UTC datetime.
 
-    Returns ``None`` on any error — the caller falls back to the absent
-    publish time.  Failures here must never break the freshness loop, so
-    no exception is allowed to escape.
+    Returns ``None`` if the header is missing or unparseable — failures
+    here must never break the freshness loop, so no exception is allowed
+    to escape.
     """
-    import email.utils
-
-    import requests
-
+    if not header:
+        return None
     try:
-        resp = requests.head(url, timeout=10)
-        if resp.status_code != 200:
-            return None
-        header = resp.headers.get("Last-Modified")
-        if not header:
-            return None
+        import email.utils
+
         # parsedate_to_datetime returns aware UTC for RFC-1123 HTTP dates.
         return email.utils.parsedate_to_datetime(header).astimezone(timezone.utc)
     except Exception:
-        logger.debug("Last-Modified probe failed for %s", url, exc_info=True)
+        logger.debug("Failed to parse Last-Modified header %r", header, exc_info=True)
         return None
 
 
 def _check_om_meta(model: str) -> Observation | None:
-    """Return latest Open-Meteo init + publish time for ``model``."""
+    """Return latest Open-Meteo init + publish time for ``model``.
+
+    Guards ``last_availability_time == 0`` (set by OM when a model hasn't
+    yet published) so we don't surface ``1970-01-01 00:00 UTC`` as the
+    publish time in the popover.
+    """
     from weatherbrief.fetch.model_status import fetch_model_metadata
     meta = fetch_model_metadata([model])
     if model not in meta:
         return None
     m = meta[model]
+    published_at = (
+        datetime.fromtimestamp(m.last_availability_time, tz=timezone.utc)
+        if m.last_availability_time
+        else None
+    )
     return Observation(
         init=datetime.fromtimestamp(m.last_init_time, tz=timezone.utc),
-        published_at=datetime.fromtimestamp(
-            m.last_availability_time, tz=timezone.utc,
-        ),
+        published_at=published_at,
     )
 
 

--- a/src/weatherbrief/fetch/grib/ecmwf_watcher.py
+++ b/src/weatherbrief/fetch/grib/ecmwf_watcher.py
@@ -178,7 +178,7 @@ def get_latest_ready(data_dir: Path | None = None) -> datetime | None:
 
 def get_latest_ready_with_mtime(
     data_dir: Path | None = None,
-) -> tuple[datetime, datetime] | None:
+) -> tuple[datetime, datetime | None] | None:
     """Like :func:`get_latest_ready` but also returns the sentinel's mtime.
 
     The mtime approximates "when the run finished landing locally" — the
@@ -187,8 +187,11 @@ def get_latest_ready_with_mtime(
     Open-Meteo's ``meta.json`` does.  Used by the freshness ``Observation``
     so the popover can show *something* under "Published" rather than "—".
 
-    Returns ``(init, sentinel_mtime)`` aware UTC, or ``None`` if no
-    sentinel exists.
+    Returns ``(init, sentinel_mtime)`` aware UTC, with ``sentinel_mtime``
+    possibly ``None`` if a race deleted the sentinel between ``iterdir``
+    and ``stat`` — caller surfaces that as "—" rather than substituting
+    the cycle init time, which would mislead pilots about freshness.
+    Returns ``None`` if no sentinel exists at all.
     """
     d = data_dir or ecmwf_grib_dir()
     if not d.exists():
@@ -209,7 +212,7 @@ def get_latest_ready_with_mtime(
                 latest_mtime = None
     if latest is None:
         return None
-    return latest, latest_mtime if latest_mtime is not None else latest
+    return latest, latest_mtime
 
 
 def _expected_publish_time(

--- a/src/weatherbrief/fetch/grib/ecmwf_watcher.py
+++ b/src/weatherbrief/fetch/grib/ecmwf_watcher.py
@@ -172,17 +172,44 @@ def get_latest_ready(data_dir: Path | None = None) -> datetime | None:
     sentinels: a partial run is still useful data the briefing pipeline can
     consume, so its arrival should also bump freshness.
     """
+    result = get_latest_ready_with_mtime(data_dir)
+    return result[0] if result is not None else None
+
+
+def get_latest_ready_with_mtime(
+    data_dir: Path | None = None,
+) -> tuple[datetime, datetime] | None:
+    """Like :func:`get_latest_ready` but also returns the sentinel's mtime.
+
+    The mtime approximates "when the run finished landing locally" — the
+    closest analogue we have to a publish wallclock for direct ECMWF, since
+    ECMWF themselves don't expose a server-side availability time the way
+    Open-Meteo's ``meta.json`` does.  Used by the freshness ``Observation``
+    so the popover can show *something* under "Published" rather than "—".
+
+    Returns ``(init, sentinel_mtime)`` aware UTC, or ``None`` if no
+    sentinel exists.
+    """
     d = data_dir or ecmwf_grib_dir()
     if not d.exists():
         return None
     latest: datetime | None = None
+    latest_mtime: datetime | None = None
     for path in d.iterdir():
         bt = _parse_sentinel_base_time(path.name)
         if bt is None:
             continue
         if latest is None or bt > latest:
             latest = bt
-    return latest
+            try:
+                latest_mtime = datetime.fromtimestamp(
+                    path.stat().st_mtime, tz=timezone.utc,
+                )
+            except OSError:
+                latest_mtime = None
+    if latest is None:
+        return None
+    return latest, latest_mtime if latest_mtime is not None else latest
 
 
 def _expected_publish_time(

--- a/src/weatherbrief/fetch/grib/grib_fetch.py
+++ b/src/weatherbrief/fetch/grib/grib_fetch.py
@@ -56,8 +56,25 @@ def find_latest_run(
 ) -> tuple[str, int] | None:
     """Find the latest available GFS model run for a target time.
 
+    Thin wrapper around :func:`find_latest_run_with_response` for callers
+    that don't need the HEAD response.
+    """
+    found = find_latest_run_with_response(target_time, session, as_of_time)
+    return (found[0], found[1]) if found is not None else None
+
+
+def find_latest_run_with_response(
+    target_time: datetime,
+    session: requests.Session | None = None,
+    as_of_time: datetime | None = None,
+) -> tuple[str, int, requests.Response] | None:
+    """Find the latest available GFS model run + return the matching HEAD response.
+
     Tries model cycles (00z, 06z, 12z, 18z) in reverse chronological order,
     checking that enough time has passed for publication.
+
+    The response is returned so the freshness dispatch can read its
+    ``Last-Modified`` header without re-issuing the same HEAD upstream.
 
     Args:
         target_time: The forecast target time.
@@ -66,7 +83,7 @@ def find_latest_run(
             (for historical "as-of" briefings). Uses ``now`` if None.
 
     Returns:
-        (init_date_YYYYMMDD, init_hour) or None if no run available.
+        ``(init_date_YYYYMMDD, init_hour, head_response)`` or ``None``.
     """
     sess = session or requests.Session()
     reference_time = as_of_time or datetime.now(timezone.utc)
@@ -92,7 +109,7 @@ def find_latest_run(
                 resp = sess.head(idx_url, timeout=10)
                 if resp.status_code == 200:
                     logger.info("Found GFS run: %s %02dz", date_str, cycle)
-                    return date_str, cycle
+                    return date_str, cycle, resp
             except requests.RequestException:
                 continue
 

--- a/src/weatherbrief/fetch/grib/icon_eu_fetch.py
+++ b/src/weatherbrief/fetch/grib/icon_eu_fetch.py
@@ -210,10 +210,30 @@ def find_latest_icon_eu_run(
 ) -> tuple[str, int] | None:
     """Find the latest available ICON-EU model run whose horizon covers the flight.
 
+    Thin wrapper around :func:`find_latest_icon_eu_run_with_response` for
+    callers that don't need the HEAD response.
+    """
+    found = find_latest_icon_eu_run_with_response(
+        target_time, session, as_of_time, cover_until,
+    )
+    return (found[0], found[1]) if found is not None else None
+
+
+def find_latest_icon_eu_run_with_response(
+    target_time: datetime,
+    session: requests.Session | None = None,
+    as_of_time: datetime | None = None,
+    cover_until: datetime | None = None,
+) -> tuple[str, int, requests.Response] | None:
+    """Find the latest ICON-EU run + return the matching probe HEAD response.
+
     Tries cycles in reverse chronological order, checking that enough time
     has passed for publication and that the run's model-level horizon
     reaches ``cover_until``.  If ``cover_until`` is None, any run that
     covers ``target_time`` is accepted.
+
+    The response is returned so the freshness dispatch can read its
+    ``Last-Modified`` header without re-issuing the same HEAD upstream.
 
     Args:
         target_time: Flight departure time.
@@ -225,7 +245,7 @@ def find_latest_icon_eu_run(
             are skipped in favour of an older main run with longer range.
 
     Returns:
-        (init_date_YYYYMMDD, init_hour) or None if no run available.
+        ``(init_date_YYYYMMDD, init_hour, head_response)`` or ``None``.
     """
     sess = session or requests.Session()
     reference_time = as_of_time or datetime.now(timezone.utc)
@@ -260,7 +280,7 @@ def find_latest_icon_eu_run(
                 resp = sess.head(probe_url, timeout=10)
                 if resp.status_code == 200:
                     logger.info("Found ICON-EU run: %s %02dz (horizon %dh)", date_str, cycle, max_hour)
-                    return date_str, cycle
+                    return date_str, cycle, resp
             except requests.RequestException:
                 continue
 

--- a/src/weatherbrief/scheduler.py
+++ b/src/weatherbrief/scheduler.py
@@ -705,7 +705,10 @@ async def _run_freshness_check_once() -> None:
         if observed is None:
             await store.mark_check(source, model, now=now)
             continue
-        await store.update(source, model, observed, now=now)
+        await store.update(
+            source, model, observed.init, now=now,
+            published_at=observed.published_at,
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_freshness_markers.py
+++ b/tests/test_freshness_markers.py
@@ -50,11 +50,58 @@ async def test_update_advances_init_when_newer():
     assert m.init == new_init
     assert m.slip_count == 0
     assert m.last_check == _utc(2026, 5, 3, 19)
+    # Direct sources advance without a published_at — Open-Meteo is the
+    # only dispatch that supplies one.
+    assert m.published_at is None
     # Observations are (cycle_init, arrival_wallclock) pairs.
     obs_inits = [pair[0] for pair in m.observations]
     obs_arrivals = [pair[1] for pair in m.observations]
     assert new_init in obs_inits
     assert _utc(2026, 5, 3, 19) in obs_arrivals
+
+
+@pytest.mark.asyncio
+async def test_update_records_published_at_for_open_meteo():
+    """OM advances should persist the provider-reported publish wallclock."""
+    store = MarkerStore()
+    await store.bootstrap([("gfs:openmeteo", "gfs")], now=_utc(2026, 5, 3, 12))
+    new_init = _utc(2026, 5, 3, 18)
+    publish_time = _utc(2026, 5, 3, 18, 45)
+
+    await store.update(
+        "gfs:openmeteo", "gfs", new_init,
+        now=_utc(2026, 5, 3, 19),
+        published_at=publish_time,
+    )
+    m = store.get_sync("gfs:openmeteo", "gfs")
+    assert m.init == new_init
+    assert m.published_at == publish_time
+
+
+@pytest.mark.asyncio
+async def test_update_captures_published_at_on_no_advance():
+    """Bootstrap → first loop tick observes the same init → published_at
+    must still be captured, otherwise the popover stays blank for hours.
+    """
+    store = MarkerStore()
+    await store.bootstrap([("gfs:openmeteo", "gfs")], now=_utc(2026, 5, 3, 12))
+    same_init = store.get_sync("gfs:openmeteo", "gfs").init
+    publish_time = same_init + timedelta(hours=7)  # OM publishes ~7h after init
+
+    # Same init, before next_expected (no slip) — should still record publish.
+    early = store.get_sync("gfs:openmeteo", "gfs").next_expected - timedelta(minutes=30)
+    await store.update(
+        "gfs:openmeteo", "gfs", same_init,
+        now=early, published_at=publish_time,
+    )
+    m = store.get_sync("gfs:openmeteo", "gfs")
+    assert m.published_at == publish_time
+
+    # Subsequent no-advance check WITHOUT a publish_time must not overwrite.
+    later = early + timedelta(minutes=5)
+    await store.update("gfs:openmeteo", "gfs", same_init, now=later, published_at=None)
+    m2 = store.get_sync("gfs:openmeteo", "gfs")
+    assert m2.published_at == publish_time
 
 
 @pytest.mark.asyncio

--- a/tests/test_freshness_sources.py
+++ b/tests/test_freshness_sources.py
@@ -68,10 +68,31 @@ class TestGetLatestReady:
         assert result is not None
         init, mtime = result
         assert init == _utc(2026, 5, 3, 12)
+        assert mtime is not None
         assert int(mtime.timestamp()) == int(mtime_ts)
 
     def test_with_mtime_returns_none_for_empty_dir(self, tmp_path: Path):
         assert ecmwf_watcher.get_latest_ready_with_mtime(tmp_path) is None
+
+    def test_with_mtime_propagates_none_when_stat_races(self, tmp_path: Path, monkeypatch):
+        """If stat() raises (sentinel deleted between iterdir and stat),
+        the helper must return mtime=None — NOT substitute the cycle init,
+        which would mislead the popover with a wildly wrong publish time.
+        """
+        (tmp_path / ".ready_20260503_12z").write_text("complete")
+        original_stat = Path.stat
+
+        def _racing_stat(self, *args, **kwargs):
+            if self.name.startswith(".ready_"):
+                raise OSError("simulated race: sentinel removed")
+            return original_stat(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "stat", _racing_stat)
+        result = ecmwf_watcher.get_latest_ready_with_mtime(tmp_path)
+        assert result is not None
+        init, mtime = result
+        assert init == _utc(2026, 5, 3, 12)
+        assert mtime is None  # crucial: NOT init
 
 
 # ---------------------------------------------------------------------------
@@ -105,34 +126,59 @@ class TestCheckSourceDispatch:
         assert int(result.published_at.timestamp()) == int(mtime_ts)
 
     def test_gfs_noaa_returns_aware_utc(self, monkeypatch):
-        from weatherbrief.fetch.freshness import sources as srcs
         from weatherbrief.fetch.grib import grib_fetch
 
+        class _Resp:
+            headers = {"Last-Modified": "Sun, 03 May 2026 11:15:42 GMT"}
+
         def _fake(target_time, **kw):
-            return ("20260503", 6)
-        monkeypatch.setattr(grib_fetch, "find_latest_run", _fake)
-        # Stub the Last-Modified probe so the dispatch doesn't touch S3.
-        publish_ts = _utc(2026, 5, 3, 11, 15)
-        monkeypatch.setattr(srcs, "_http_last_modified", lambda url: publish_ts)
+            return ("20260503", 6, _Resp())
+        monkeypatch.setattr(grib_fetch, "find_latest_run_with_response", _fake)
         result = sources.check_source("gfs:noaa", "gfs")
         assert result is not None
         assert result.init == _utc(2026, 5, 3, 6)
         assert result.init.tzinfo == timezone.utc
-        assert result.published_at == publish_ts
+        # Publish time comes from the HEAD response we already had —
+        # no second round-trip.
+        assert result.published_at == _utc(2026, 5, 3, 11, 15).replace(second=42)
 
     def test_icon_eu_dwd_returns_aware_utc(self, monkeypatch):
-        from weatherbrief.fetch.freshness import sources as srcs
         from weatherbrief.fetch.grib import icon_eu_fetch
 
+        class _Resp:
+            headers = {"Last-Modified": "Sun, 03 May 2026 12:08:11 GMT"}
+
         def _fake(target_time, **kw):
-            return ("20260503", 9)
-        monkeypatch.setattr(icon_eu_fetch, "find_latest_icon_eu_run", _fake)
-        publish_ts = _utc(2026, 5, 3, 12, 8)
-        monkeypatch.setattr(srcs, "_http_last_modified", lambda url: publish_ts)
+            return ("20260503", 9, _Resp())
+        monkeypatch.setattr(
+            icon_eu_fetch, "find_latest_icon_eu_run_with_response", _fake,
+        )
         result = sources.check_source("icon_eu:dwd", "icon_eu")
         assert result is not None
         assert result.init == _utc(2026, 5, 3, 9)
-        assert result.published_at == publish_ts
+        assert result.published_at == _utc(2026, 5, 3, 12, 8).replace(second=11)
+
+    def test_om_meta_skips_zero_availability(self, monkeypatch):
+        """Guard against OM's `last_availability_time=0` (unpublished model)
+        rendering as Jan 1 1970 in the popover."""
+        from weatherbrief.fetch import model_status
+
+        init_ts = int(_utc(2026, 5, 3, 12).timestamp())
+
+        def _fake_meta(models, **kw):
+            return {
+                models[0]: model_status.ModelMetadata(
+                    model=models[0],
+                    last_init_time=init_ts,
+                    last_availability_time=0,  # OM sentinel for "not yet"
+                    update_interval_seconds=21600,
+                )
+            }
+        monkeypatch.setattr(model_status, "fetch_model_metadata", _fake_meta)
+        result = sources.check_source("gfs:openmeteo", "gfs")
+        assert result is not None
+        assert result.init == _utc(2026, 5, 3, 12)
+        assert result.published_at is None
 
     def test_om_meta_returns_init_and_publish_time(self, monkeypatch):
         from weatherbrief.fetch import model_status
@@ -161,7 +207,7 @@ class TestCheckSourceDispatch:
 
         def _boom(*a, **k):
             raise RuntimeError("simulated S3 outage")
-        monkeypatch.setattr(grib_fetch, "find_latest_run", _boom)
+        monkeypatch.setattr(grib_fetch, "find_latest_run_with_response", _boom)
         result = sources.check_source("gfs:noaa", "gfs")
         assert result is None
 
@@ -171,51 +217,28 @@ class TestCheckSourceDispatch:
 # ---------------------------------------------------------------------------
 
 
-class TestHttpLastModified:
-    """Cover the small HEAD helper used by the GFS / ICON dispatches."""
+class TestParseLastModified:
+    """Cover the small header-parse helper used by the GFS / ICON dispatches."""
 
-    def test_returns_aware_utc_for_valid_header(self, monkeypatch):
+    def test_returns_aware_utc_for_valid_header(self):
         from weatherbrief.fetch.freshness import sources as srcs
 
-        class _Resp:
-            status_code = 200
-            headers = {"Last-Modified": "Sun, 03 May 2026 11:15:42 GMT"}
-
-        monkeypatch.setattr(
-            "requests.head", lambda url, timeout=10: _Resp(),
-        )
-        result = srcs._http_last_modified("https://example.test/x")
+        result = srcs._parse_last_modified("Sun, 03 May 2026 11:15:42 GMT")
         assert result is not None
         assert result.tzinfo is not None
         assert result == _utc(2026, 5, 3, 11, 15).replace(second=42)
 
-    def test_returns_none_on_non_200(self, monkeypatch):
+    def test_returns_none_for_none_header(self):
         from weatherbrief.fetch.freshness import sources as srcs
+        assert srcs._parse_last_modified(None) is None
 
-        class _Resp:
-            status_code = 404
-            headers = {}
-
-        monkeypatch.setattr("requests.head", lambda url, timeout=10: _Resp())
-        assert srcs._http_last_modified("https://example.test/x") is None
-
-    def test_returns_none_when_header_missing(self, monkeypatch):
+    def test_returns_none_for_empty_header(self):
         from weatherbrief.fetch.freshness import sources as srcs
+        assert srcs._parse_last_modified("") is None
 
-        class _Resp:
-            status_code = 200
-            headers = {}
-
-        monkeypatch.setattr("requests.head", lambda url, timeout=10: _Resp())
-        assert srcs._http_last_modified("https://example.test/x") is None
-
-    def test_swallows_request_exceptions(self, monkeypatch):
+    def test_returns_none_for_garbage_header(self):
         from weatherbrief.fetch.freshness import sources as srcs
-
-        def _boom(url, timeout=10):
-            raise RuntimeError("network down")
-        monkeypatch.setattr("requests.head", _boom)
-        assert srcs._http_last_modified("https://example.test/x") is None
+        assert srcs._parse_last_modified("not-a-real-date") is None
 
 
 def test_all_tracked_sources_matches_registry():

--- a/tests/test_freshness_sources.py
+++ b/tests/test_freshness_sources.py
@@ -79,7 +79,10 @@ class TestCheckSourceDispatch:
             _fake_dir,
         )
         result = sources.check_source("ecmwf:direct", "ecmwf")
-        assert result == _utc(2026, 5, 3, 12)
+        assert result is not None
+        assert result.init == _utc(2026, 5, 3, 12)
+        # Direct sources don't have a provider-reported publish time.
+        assert result.published_at is None
 
     def test_gfs_noaa_returns_aware_utc(self, monkeypatch):
         from weatherbrief.fetch.grib import grib_fetch
@@ -88,8 +91,10 @@ class TestCheckSourceDispatch:
             return ("20260503", 6)
         monkeypatch.setattr(grib_fetch, "find_latest_run", _fake)
         result = sources.check_source("gfs:noaa", "gfs")
-        assert result == _utc(2026, 5, 3, 6)
-        assert result.tzinfo == timezone.utc
+        assert result is not None
+        assert result.init == _utc(2026, 5, 3, 6)
+        assert result.init.tzinfo == timezone.utc
+        assert result.published_at is None
 
     def test_icon_eu_dwd_returns_aware_utc(self, monkeypatch):
         from weatherbrief.fetch.grib import icon_eu_fetch
@@ -98,25 +103,31 @@ class TestCheckSourceDispatch:
             return ("20260503", 9)
         monkeypatch.setattr(icon_eu_fetch, "find_latest_icon_eu_run", _fake)
         result = sources.check_source("icon_eu:dwd", "icon_eu")
-        assert result == _utc(2026, 5, 3, 9)
+        assert result is not None
+        assert result.init == _utc(2026, 5, 3, 9)
+        assert result.published_at is None
 
-    def test_om_meta_returns_aware_utc(self, monkeypatch):
+    def test_om_meta_returns_init_and_publish_time(self, monkeypatch):
         from weatherbrief.fetch import model_status
 
-        ts = int(_utc(2026, 5, 3, 12).timestamp())
+        init_ts = int(_utc(2026, 5, 3, 12).timestamp())
+        avail_ts = init_ts + 60 * 45  # OM published 45 min after run init
 
         def _fake_meta(models, **kw):
             return {
                 models[0]: model_status.ModelMetadata(
                     model=models[0],
-                    last_init_time=ts,
-                    last_availability_time=ts + 60,
+                    last_init_time=init_ts,
+                    last_availability_time=avail_ts,
                     update_interval_seconds=21600,
                 )
             }
         monkeypatch.setattr(model_status, "fetch_model_metadata", _fake_meta)
         result = sources.check_source("gfs:openmeteo", "gfs")
-        assert result == _utc(2026, 5, 3, 12)
+        assert result is not None
+        assert result.init == _utc(2026, 5, 3, 12)
+        assert result.published_at is not None
+        assert int(result.published_at.timestamp()) == avail_ts
 
     def test_dispatch_swallows_exceptions(self, monkeypatch):
         from weatherbrief.fetch.grib import grib_fetch

--- a/tests/test_freshness_sources.py
+++ b/tests/test_freshness_sources.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -12,8 +13,8 @@ from weatherbrief.fetch.freshness.registry import SOURCE_REGISTRY
 from weatherbrief.fetch.grib import ecmwf_watcher
 
 
-def _utc(year: int, month: int, day: int, hour: int = 0) -> datetime:
-    return datetime(year, month, day, hour, tzinfo=timezone.utc)
+def _utc(year: int, month: int, day: int, hour: int = 0, minute: int = 0) -> datetime:
+    return datetime(year, month, day, hour, minute, tzinfo=timezone.utc)
 
 
 # ---------------------------------------------------------------------------
@@ -58,6 +59,20 @@ class TestGetLatestReady:
         latest = ecmwf_watcher.get_latest_ready(tmp_path)
         assert latest == _utc(2026, 5, 3, 6)
 
+    def test_with_mtime_returns_sentinel_mtime(self, tmp_path: Path):
+        sentinel = tmp_path / ".ready_20260503_12z"
+        sentinel.write_text("complete")
+        mtime_ts = _utc(2026, 5, 3, 18, 47).timestamp()
+        os.utime(sentinel, (mtime_ts, mtime_ts))
+        result = ecmwf_watcher.get_latest_ready_with_mtime(tmp_path)
+        assert result is not None
+        init, mtime = result
+        assert init == _utc(2026, 5, 3, 12)
+        assert int(mtime.timestamp()) == int(mtime_ts)
+
+    def test_with_mtime_returns_none_for_empty_dir(self, tmp_path: Path):
+        assert ecmwf_watcher.get_latest_ready_with_mtime(tmp_path) is None
+
 
 # ---------------------------------------------------------------------------
 # sources.check_source dispatch
@@ -70,7 +85,11 @@ class TestCheckSourceDispatch:
 
     def test_ecmwf_direct_uses_watcher(self, monkeypatch, tmp_path: Path):
         # Drop a sentinel and point the watcher at the temp dir.
-        (tmp_path / ".ready_20260503_12z").write_text("complete")
+        sentinel = tmp_path / ".ready_20260503_12z"
+        sentinel.write_text("complete")
+        # Pin the sentinel mtime so we can assert on the publish_at value.
+        mtime_ts = _utc(2026, 5, 3, 18, 32).timestamp()
+        os.utime(sentinel, (mtime_ts, mtime_ts))
 
         def _fake_dir():
             return tmp_path
@@ -81,31 +100,39 @@ class TestCheckSourceDispatch:
         result = sources.check_source("ecmwf:direct", "ecmwf")
         assert result is not None
         assert result.init == _utc(2026, 5, 3, 12)
-        # Direct sources don't have a provider-reported publish time.
-        assert result.published_at is None
+        # Sentinel mtime is the closest analogue to publish time for direct.
+        assert result.published_at is not None
+        assert int(result.published_at.timestamp()) == int(mtime_ts)
 
     def test_gfs_noaa_returns_aware_utc(self, monkeypatch):
+        from weatherbrief.fetch.freshness import sources as srcs
         from weatherbrief.fetch.grib import grib_fetch
 
         def _fake(target_time, **kw):
             return ("20260503", 6)
         monkeypatch.setattr(grib_fetch, "find_latest_run", _fake)
+        # Stub the Last-Modified probe so the dispatch doesn't touch S3.
+        publish_ts = _utc(2026, 5, 3, 11, 15)
+        monkeypatch.setattr(srcs, "_http_last_modified", lambda url: publish_ts)
         result = sources.check_source("gfs:noaa", "gfs")
         assert result is not None
         assert result.init == _utc(2026, 5, 3, 6)
         assert result.init.tzinfo == timezone.utc
-        assert result.published_at is None
+        assert result.published_at == publish_ts
 
     def test_icon_eu_dwd_returns_aware_utc(self, monkeypatch):
+        from weatherbrief.fetch.freshness import sources as srcs
         from weatherbrief.fetch.grib import icon_eu_fetch
 
         def _fake(target_time, **kw):
             return ("20260503", 9)
         monkeypatch.setattr(icon_eu_fetch, "find_latest_icon_eu_run", _fake)
+        publish_ts = _utc(2026, 5, 3, 12, 8)
+        monkeypatch.setattr(srcs, "_http_last_modified", lambda url: publish_ts)
         result = sources.check_source("icon_eu:dwd", "icon_eu")
         assert result is not None
         assert result.init == _utc(2026, 5, 3, 9)
-        assert result.published_at is None
+        assert result.published_at == publish_ts
 
     def test_om_meta_returns_init_and_publish_time(self, monkeypatch):
         from weatherbrief.fetch import model_status
@@ -142,6 +169,53 @@ class TestCheckSourceDispatch:
 # ---------------------------------------------------------------------------
 # all_tracked_sources
 # ---------------------------------------------------------------------------
+
+
+class TestHttpLastModified:
+    """Cover the small HEAD helper used by the GFS / ICON dispatches."""
+
+    def test_returns_aware_utc_for_valid_header(self, monkeypatch):
+        from weatherbrief.fetch.freshness import sources as srcs
+
+        class _Resp:
+            status_code = 200
+            headers = {"Last-Modified": "Sun, 03 May 2026 11:15:42 GMT"}
+
+        monkeypatch.setattr(
+            "requests.head", lambda url, timeout=10: _Resp(),
+        )
+        result = srcs._http_last_modified("https://example.test/x")
+        assert result is not None
+        assert result.tzinfo is not None
+        assert result == _utc(2026, 5, 3, 11, 15).replace(second=42)
+
+    def test_returns_none_on_non_200(self, monkeypatch):
+        from weatherbrief.fetch.freshness import sources as srcs
+
+        class _Resp:
+            status_code = 404
+            headers = {}
+
+        monkeypatch.setattr("requests.head", lambda url, timeout=10: _Resp())
+        assert srcs._http_last_modified("https://example.test/x") is None
+
+    def test_returns_none_when_header_missing(self, monkeypatch):
+        from weatherbrief.fetch.freshness import sources as srcs
+
+        class _Resp:
+            status_code = 200
+            headers = {}
+
+        monkeypatch.setattr("requests.head", lambda url, timeout=10: _Resp())
+        assert srcs._http_last_modified("https://example.test/x") is None
+
+    def test_swallows_request_exceptions(self, monkeypatch):
+        from weatherbrief.fetch.freshness import sources as srcs
+
+        def _boom(url, timeout=10):
+            raise RuntimeError("network down")
+        monkeypatch.setattr("requests.head", _boom)
+        assert srcs._http_last_modified("https://example.test/x") is None
 
 
 def test_all_tracked_sources_matches_registry():

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -596,6 +596,73 @@ label {
   font-size: 0.8rem;
 }
 
+.freshness-info-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 14px;
+  height: 14px;
+  padding: 0;
+  margin-left: 0.2rem;
+  border: 1px solid var(--border);
+  border-radius: 50%;
+  background: var(--surface);
+  color: var(--text-muted);
+  font-size: 0.6rem;
+  line-height: 1;
+  cursor: pointer;
+  vertical-align: middle;
+  opacity: 0.6;
+  transition: color 0.15s, border-color 0.15s, opacity 0.15s;
+}
+
+.freshness-info-btn:hover {
+  color: var(--primary);
+  border-color: var(--primary);
+  opacity: 1;
+}
+
+.freshness-popup h3 {
+  margin: 0 0 0.5rem;
+  font-size: 1rem;
+}
+
+.freshness-popup-intro {
+  margin: 0 0 0.75rem;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+  line-height: 1.4;
+}
+
+.freshness-popup-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.85rem;
+}
+
+.freshness-popup-table th,
+.freshness-popup-table td {
+  text-align: left;
+  padding: 0.35rem 0.5rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.freshness-popup-table th {
+  font-weight: 600;
+  color: var(--text-muted);
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.freshness-popup-model {
+  font-weight: 600;
+}
+
+.freshness-popup-base td {
+  color: var(--text-muted);
+}
+
 .freshness-elapsed {
   color: var(--text-muted);
   font-size: 0.8rem;

--- a/web/ts/i18n/locales/en.json
+++ b/web/ts/i18n/locales/en.json
@@ -94,7 +94,7 @@
   "freshness.sourcesTitle": "Forecast data sources",
   "freshness.sourcesIntro": "Each model can be sourced directly from the forecast centre or via Open-Meteo. When both contribute, the run actually used for upper-air enrichment is shown first; the Open-Meteo entry is the surface base layer.",
   "freshness.colModel": "Model",
-  "freshness.colSource": "Source",
+  "freshness.colProvider": "Provider",
   "freshness.colRun": "Run",
   "freshness.colPublished": "Published",
   "freshness.colNextUpdate": "Next update",

--- a/web/ts/i18n/locales/en.json
+++ b/web/ts/i18n/locales/en.json
@@ -91,6 +91,15 @@
   "freshness.upToDate": "Up to date",
   "freshness.updatesAvailable": "Updates available: ",
   "freshness.auto": " (auto)",
+  "freshness.sourcesTitle": "Forecast data sources",
+  "freshness.sourcesIntro": "Each model can be sourced directly from the forecast centre or via Open-Meteo. When both contribute, the run actually used for upper-air enrichment is shown first; the Open-Meteo entry is the surface base layer.",
+  "freshness.colModel": "Model",
+  "freshness.colSource": "Source",
+  "freshness.colRun": "Run",
+  "freshness.colPublished": "Published",
+  "freshness.colNextUpdate": "Next update",
+  "freshness.publishedUnknown": "—",
+  "freshness.infoLabel": "About these sources",
 
   "privacy.label": "Private",
 

--- a/web/ts/managers/briefing-ui.ts
+++ b/web/ts/managers/briefing-ui.ts
@@ -391,7 +391,7 @@ function renderSourcesPopupContent(sources: ModelSourceDetail[]): string {
         <thead>
           <tr>
             <th>${t('freshness.colModel')}</th>
-            <th>${t('freshness.colSource')}</th>
+            <th>${t('freshness.colProvider')}</th>
             <th>${t('freshness.colRun')}</th>
             <th>${t('freshness.colPublished')}</th>
             <th>${t('freshness.colNextUpdate')}</th>

--- a/web/ts/managers/briefing-ui.ts
+++ b/web/ts/managers/briefing-ui.ts
@@ -11,6 +11,7 @@ import type {
   DataStatus,
   FlightResponse,
   ForecastSnapshot,
+  ModelSourceDetail,
   ObservationComparison,
   PackMeta,
   RouteAnalysesManifest,
@@ -273,6 +274,137 @@ function formatModelRunTime(initTime: number): string {
   return `${h}Z`;
 }
 
+/** Build the per-model basis segments from the freshness `sources` list.
+ *
+ * For each model:
+ * - if only one source contributed, render `MODEL RUNZ PROVIDER`
+ * - if both contributed AND on the same run, collapse to the primary alone
+ *   (no need to mention Open-Meteo redundantly)
+ * - if both contributed AND runs differ, render `MODEL DIRECTRUNZ PROVIDER, OMRUNZ Open-Meteo`
+ *
+ * Falls back to the legacy pack-times path when the API hasn't sent the
+ * `sources` field yet (older clients/responses).
+ */
+function buildBasisFromSources(
+  sources: ModelSourceDetail[] | undefined,
+  pack: PackMeta | null,
+): string[] {
+  if (!sources || sources.length === 0) {
+    // Legacy fallback: use pack init times (no provider attribution).
+    const packTimes = pack?.model_init_times || {};
+    const gribTimes = pack?.grib_init_times || {};
+    return Object.entries(packTimes).map(([m, t]) => {
+      const gribTs = gribTimes[m];
+      if (gribTs && gribTs !== t) {
+        return `${modelLabel(m)} ${formatModelRunTime(gribTs)}, ${formatModelRunTime(t)} Open-Meteo`;
+      }
+      return `${modelLabel(m)} ${formatModelRunTime(t)}`;
+    });
+  }
+
+  // Group sources by model, preserving insertion order.
+  const byModel = new Map<string, ModelSourceDetail[]>();
+  for (const s of sources) {
+    const list = byModel.get(s.model) || [];
+    list.push(s);
+    byModel.set(s.model, list);
+  }
+
+  const out: string[] = [];
+  for (const [model, rows] of byModel) {
+    const primary = rows.find(r => r.role === 'primary') || rows[0];
+    const base = rows.find(r => r !== primary);
+    const label = modelLabel(model);
+    // Drop the provider tag when it's already a token in the model label
+    // (e.g. "DWD ICON 12Z DWD" → "DWD ICON 12Z", "ECMWF IFS 12Z ECMWF" →
+    // "ECMWF IFS 12Z").  Avoids visible duplication for ICON/ECMWF where
+    // the provider is part of how pilots refer to the model.
+    const tag = (provider: string) =>
+      labelHasProvider(label, provider) ? '' : ` ${provider}`;
+    if (!base || base.init === primary.init) {
+      out.push(`${label} ${formatModelRunTime(primary.init)}${tag(primary.provider)}`);
+    } else {
+      out.push(
+        `${label} ${formatModelRunTime(primary.init)}${tag(primary.provider)}, ` +
+        `${formatModelRunTime(base.init)}${tag(base.provider)}`,
+      );
+    }
+  }
+  return out;
+}
+
+/** Return true when the provider name appears as a whole-word token in the label. */
+function labelHasProvider(label: string, provider: string): boolean {
+  const tokens = label.toUpperCase().split(/\s+/);
+  return tokens.includes(provider.toUpperCase());
+}
+
+/** Format an ISO datetime for the popup as `DD MMM HH:MM UTC`. */
+function formatPopupTime(iso: string): string {
+  const d = new Date(iso);
+  const day = d.getUTCDate().toString().padStart(2, '0');
+  const months = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+  const mon = months[d.getUTCMonth()];
+  const h = d.getUTCHours().toString().padStart(2, '0');
+  const m = d.getUTCMinutes().toString().padStart(2, '0');
+  return `${day} ${mon} ${h}:${m} UTC`;
+}
+
+/** Build the per-source detail table shown in the (i) popover. */
+function renderSourcesPopupContent(sources: ModelSourceDetail[]): string {
+  // Group by model so the "primary + base" pairing is visually adjacent.
+  const byModel = new Map<string, ModelSourceDetail[]>();
+  for (const s of sources) {
+    const list = byModel.get(s.model) || [];
+    list.push(s);
+    byModel.set(s.model, list);
+  }
+
+  const rows: string[] = [];
+  for (const [model, modelRows] of byModel) {
+    const primary = modelRows.find(r => r.role === 'primary') || modelRows[0];
+    const ordered = [primary, ...modelRows.filter(r => r !== primary)];
+    ordered.forEach((r, idx) => {
+      const modelCell = idx === 0
+        ? `<td class="freshness-popup-model">${escapeHtml(modelLabel(model))}</td>`
+        : `<td></td>`;
+      const published = r.published_at
+        ? formatPopupTime(r.published_at)
+        : t('freshness.publishedUnknown');
+      rows.push(`
+        <tr class="freshness-popup-row freshness-popup-${r.role}">
+          ${modelCell}
+          <td>${escapeHtml(r.provider)}</td>
+          <td>${formatModelRunTime(r.init)}</td>
+          <td>${escapeHtml(published)}</td>
+          <td>${formatPopupTime(r.next_expected)}</td>
+        </tr>
+      `);
+    });
+  }
+
+  return `
+    <div class="freshness-popup">
+      <h3>${t('freshness.sourcesTitle')}</h3>
+      <p class="freshness-popup-intro">${t('freshness.sourcesIntro')}</p>
+      <table class="freshness-popup-table">
+        <thead>
+          <tr>
+            <th>${t('freshness.colModel')}</th>
+            <th>${t('freshness.colSource')}</th>
+            <th>${t('freshness.colRun')}</th>
+            <th>${t('freshness.colPublished')}</th>
+            <th>${t('freshness.colNextUpdate')}</th>
+          </tr>
+        </thead>
+        <tbody>
+          ${rows.join('')}
+        </tbody>
+      </table>
+    </div>
+  `;
+}
+
 function formatTimeUntil(isoStr: string): string {
   const target = new Date(isoStr).getTime();
   const now = Date.now();
@@ -348,21 +480,24 @@ export function renderFreshnessBar(
     return;
   }
 
-  // Model basis line from the pack's init times, with GRIB annotation when different
-  const packTimes = pack?.model_init_times || {};
-  const gribTimes = pack?.grib_init_times || {};
-  const fetchedParts = Object.entries(packTimes)
-    .map(([m, t]) => {
-      const gribTs = gribTimes[m];
-      if (gribTs && gribTs !== t) {
-        return `${modelLabel(m)} ${formatModelRunTime(t)} (GRIB ${formatModelRunTime(gribTs)})`;
-      }
-      return `${modelLabel(m)} ${formatModelRunTime(t)}`;
-    });
+  // Model basis line — one segment per model, listing each contributing
+  // provider with its run time.  When the primary (direct) and base (OM)
+  // sources are on the same run, collapse to the primary alone — no
+  // need to mention Open-Meteo redundantly.  Models are separated by `·`
+  // so the within-model comma stays unambiguous.
+  const fetchedParts = buildBasisFromSources(freshness.sources, pack);
   const skippedParts = (pack?.models_skipped_region || [])
     .map(m => `${modelLabel(m)} <span class="model-skipped">${t('freshness.skipped')}</span>`);
-  const basisParts = [...fetchedParts, ...skippedParts].join(', ');
-  const basisLine = basisParts ? `<span class="freshness-basis">${t('freshness.basedOn')}${basisParts}</span>` : '';
+  const basisParts = [...fetchedParts, ...skippedParts].join(' · ');
+  // Note: don't add `metric-info-btn` here — there's a global click
+  // delegate (briefing-main.ts) that routes that class to showMetricInfo
+  // and would override our handler with "no info for this metric".
+  const infoBtn = (freshness.sources && freshness.sources.length > 0)
+    ? ` <button type="button" class="freshness-info-btn" id="freshness-sources-info" aria-label="${t('freshness.infoLabel')}">i</button>`
+    : '';
+  const basisLine = basisParts
+    ? `<span class="freshness-basis">${t('freshness.basedOn')}${basisParts}${infoBtn}</span>`
+    : '';
 
   // Build diagnostics HTML — show warn (retryable issues) and error
   // (irrecoverable failures); info entries are persisted for debug only.
@@ -420,6 +555,13 @@ export function renderFreshnessBar(
   const emailEl = document.getElementById(emailCheckId) as HTMLInputElement | null;
   if (emailEl && onNotifyEmailChange) {
     emailEl.addEventListener('change', () => onNotifyEmailChange(emailEl.checked));
+  }
+  const sourcesInfoBtn = document.getElementById('freshness-sources-info');
+  if (sourcesInfoBtn && freshness.sources) {
+    sourcesInfoBtn.addEventListener('click', (e) => {
+      e.preventDefault();
+      showPopupContent(renderSourcesPopupContent(freshness.sources!));
+    });
   }
 }
 

--- a/web/ts/store/types.ts
+++ b/web/ts/store/types.ts
@@ -96,6 +96,18 @@ export interface ModelStatus {
   pack_init: number | null;
   latest_available: number;
   next_expected: string;
+  published_at?: string | null;
+  state: "current" | "stale" | "awaiting" | "delayed";
+}
+
+export interface ModelSourceDetail {
+  model: string;
+  source: string;
+  provider: string;
+  role: "primary" | "base";
+  init: number;
+  published_at?: string | null;
+  next_expected: string;
   state: "current" | "stale" | "awaiting" | "delayed";
 }
 
@@ -107,6 +119,7 @@ export interface DataStatus {
   next_expected_model: string | null;
   marker_health?: "ok" | "suspect";
   models?: Record<string, ModelStatus>;
+  sources?: ModelSourceDetail[];
 }
 
 /**


### PR DESCRIPTION
## Summary
- Adds an (i) info popover next to the freshness banner showing a per-(model, source) table with reference run, **publish time**, and next expected update — closes the gap where pilots couldn't see when each model's data was actually published.
- Reworks the banner to drop the "GRIB" jargon in favour of provider names (NOAA / DWD / ECMWF / Open-Meteo). Collapses to a single entry when both sources are on the same run; keeps both visible when they differ. Skips the trailing provider tag when it's already part of the model label (e.g. `DWD ICON 12Z` not `DWD ICON 12Z DWD`).
- Captures publish wallclock for **all** sources, not just Open-Meteo:
  - **OM**: `last_run_availability_time` from `meta.json` (was previously parsed and discarded).
  - **ECMWF direct**: sentinel mtime via new `get_latest_ready_with_mtime` (closest analogue to "publish time" — when the run finished landing locally).
  - **GFS NOAA**: `Last-Modified` HTTP header from a HEAD on the .idx URL (S3 server-side timestamp).
  - **ICON-EU DWD**: `Last-Modified` from a HEAD on the level-74 P file (DWD server-side timestamp).
- Fixes a latent bug where `MarkerStore.update`'s no-advance branch threw away `published_at`, so a freshly-bootstrapped server would have an empty Published column for hours until the next OM cycle landed.

## Wire format
- New `ModelSourceDetail` rows on `DataStatus.sources` enumerate every contributing source per model (primary direct + OM base layer when both ran), with a server-side provider label so the FE doesn't duplicate the source-key → display-name mapping.
- `ModelStatus.published_at` and `Marker.published_at` added for the primary path.
- Admin `/freshness/markers` exposes `published_at` for calibration.
- TS types mirror the additions.

## Test plan
- [x] 19/19 freshness sources tests pass (covers all four dispatches + new HTTP `Last-Modified` helper)
- [x] 54 sync freshness tests pass overall
- [x] Async marker tests added for `published_at` capture on both advance and no-advance branches (run in CI)
- [x] TypeScript typechecks cleanly
- [ ] Manual: load a briefing, click the (i) button next to the "Based on..." line, verify per-source popover renders with provider names and Published times
- [ ] Manual: verify banner collapses correctly when primary + base agree on the run, and shows both when they differ
- [ ] Manual: after a few minutes post-deploy, verify all rows in the popover have non-empty Published times

🤖 Generated with [Claude Code](https://claude.com/claude-code)