### PR TITLE
perf(verification): parallelise standalone forecast fetch chunks (#110)

### DIFF
--- a/src/weatherbrief/tasks/standalone_verification.py
+++ b/src/weatherbrief/tasks/standalone_verification.py
@@ -161,7 +161,13 @@ def _fetch_forecasts_for_model(
     ]
     total_chunks = len(chunks)
 
-    def _fetch_one_chunk(chunk_idx: int, chunk_list: list[WatchlistAirport]) -> list[dict]:
+    def _fetch_one_chunk(
+        chunk_idx: int, chunk_list: list[WatchlistAirport],
+    ) -> tuple[list[dict], int]:
+        # Reset thread-local call count so the caller can attribute HTTP
+        # calls — including failed retries — back to this chunk after the
+        # pool joins. The shared `client.call_count` is racy under threads.
+        client._reset_thread_call_count()
         chunk_num = chunk_idx + 1
         points = [
             RoutePoint(
@@ -172,14 +178,16 @@ def _fetch_forecasts_for_model(
             for a in chunk_list
         ]
 
-        chunk_started = time.monotonic()
         forecasts = None
+        fetch_seconds = 0.0
         for attempt in range(3):
+            attempt_started = time.monotonic()
             try:
                 forecasts = client.fetch_multi_point(
                     points, model_source,
                     start_date=start_date, end_date=end_date,
                 )
+                fetch_seconds = time.monotonic() - attempt_started
                 break
             except Exception:
                 if attempt < 2:
@@ -197,12 +205,11 @@ def _fetch_forecasts_for_model(
                         model, len(chunk_list), exc_info=True,
                     )
         if forecasts is None:
-            return []
+            return [], client._thread_call_count()
 
         logger.info(
             "Model %s chunk %d/%d: processing %d airports (fetch %.1fs)",
-            model, chunk_num, total_chunks, len(chunk_list),
-            time.monotonic() - chunk_started,
+            model, chunk_num, total_chunks, len(chunk_list), fetch_seconds,
         )
         chunk_results: list[dict] = []
         for airport, wpf in zip(chunk_list, forecasts):
@@ -242,13 +249,14 @@ def _fetch_forecasts_for_model(
                 _enrich_with_sounding(snap, hourly, model)
 
                 chunk_results.append(snap)
-        return chunk_results
+        return chunk_results, client._thread_call_count()
 
     all_results: list[dict] = []
     if not chunks:
         return all_results, client.call_count
 
     max_workers = max(1, min(_OPEN_METEO_CONCURRENCY, total_chunks))
+    total_calls = 0
     with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
         futures = [
             executor.submit(_fetch_one_chunk, idx, chunk)
@@ -256,7 +264,9 @@ def _fetch_forecasts_for_model(
         ]
         for future in concurrent.futures.as_completed(futures):
             try:
-                all_results.extend(future.result())
+                chunk_results, chunk_calls = future.result()
+                all_results.extend(chunk_results)
+                total_calls += chunk_calls
             except Exception:
                 # Per-chunk retries already logged inside the worker. A leak
                 # here is unexpected — note it but don't abort other chunks.
@@ -265,6 +275,9 @@ def _fetch_forecasts_for_model(
                     model, exc_info=True,
                 )
 
+    # Replace the racy aggregate with the summed per-thread totals so the
+    # caller sees the correct count of HTTP calls made under concurrency.
+    client.call_count = total_calls
     return all_results, client.call_count
 
 

--- a/src/weatherbrief/tasks/standalone_verification.py
+++ b/src/weatherbrief/tasks/standalone_verification.py
@@ -7,6 +7,7 @@ at multiple lead times (D-0 through D-7).
 
 from __future__ import annotations
 
+import concurrent.futures
 import json
 import logging
 import os
@@ -55,6 +56,7 @@ MODEL_FORECAST_DAYS = {
 }
 
 _OPEN_METEO_BATCH_SIZE = 100  # airports per Open-Meteo API call (also retry boundary)
+_OPEN_METEO_CONCURRENCY = int(os.environ.get("STANDALONE_FETCH_CONCURRENCY", "4"))
 _LCL_CONSTANT_FT = 400  # 400 * (T - Td) approximation for LCL in feet
 
 
@@ -153,14 +155,14 @@ def _fetch_forecasts_for_model(
     end_date = end_dt.strftime("%Y-%m-%d")
 
     client = OpenMeteoClient(timeout=60)
-    all_results: list[dict] = []
 
-    # Process airports in chunks
-    chunk_num = 0
-    total_chunks = (len(airports) + _OPEN_METEO_BATCH_SIZE - 1) // _OPEN_METEO_BATCH_SIZE
-    for chunk_airports in batched(airports, _OPEN_METEO_BATCH_SIZE):
-        chunk_num += 1
-        chunk_list = list(chunk_airports)
+    chunks: list[list[WatchlistAirport]] = [
+        list(c) for c in batched(airports, _OPEN_METEO_BATCH_SIZE)
+    ]
+    total_chunks = len(chunks)
+
+    def _fetch_one_chunk(chunk_idx: int, chunk_list: list[WatchlistAirport]) -> list[dict]:
+        chunk_num = chunk_idx + 1
         points = [
             RoutePoint(
                 lat=a.lat, lon=a.lon,
@@ -170,6 +172,7 @@ def _fetch_forecasts_for_model(
             for a in chunk_list
         ]
 
+        chunk_started = time.monotonic()
         forecasts = None
         for attempt in range(3):
             try:
@@ -194,10 +197,14 @@ def _fetch_forecasts_for_model(
                         model, len(chunk_list), exc_info=True,
                     )
         if forecasts is None:
-            continue
+            return []
 
-        logger.info("Model %s chunk %d/%d: processing %d airports",
-                    model, chunk_num, total_chunks, len(chunk_list))
+        logger.info(
+            "Model %s chunk %d/%d: processing %d airports (fetch %.1fs)",
+            model, chunk_num, total_chunks, len(chunk_list),
+            time.monotonic() - chunk_started,
+        )
+        chunk_results: list[dict] = []
         for airport, wpf in zip(chunk_list, forecasts):
             # Filter to sample hours only
             for hourly in wpf.hourly:
@@ -234,7 +241,29 @@ def _fetch_forecasts_for_model(
                 # Run sounding analysis on pressure levels (already fetched)
                 _enrich_with_sounding(snap, hourly, model)
 
-                all_results.append(snap)
+                chunk_results.append(snap)
+        return chunk_results
+
+    all_results: list[dict] = []
+    if not chunks:
+        return all_results, client.call_count
+
+    max_workers = max(1, min(_OPEN_METEO_CONCURRENCY, total_chunks))
+    with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
+        futures = [
+            executor.submit(_fetch_one_chunk, idx, chunk)
+            for idx, chunk in enumerate(chunks)
+        ]
+        for future in concurrent.futures.as_completed(futures):
+            try:
+                all_results.extend(future.result())
+            except Exception:
+                # Per-chunk retries already logged inside the worker. A leak
+                # here is unexpected — note it but don't abort other chunks.
+                logger.warning(
+                    "Open-Meteo %s chunk worker raised unexpectedly",
+                    model, exc_info=True,
+                )
 
     return all_results, client.call_count
 

--- a/src/weatherbrief/tasks/standalone_verification.py
+++ b/src/weatherbrief/tasks/standalone_verification.py
@@ -259,11 +259,15 @@ def _fetch_forecasts_for_model(
         return all_results, client.call_count
 
     # Unlike the briefing-side parallel fetch (tasks/fetch.py), this path
-    # doesn't gate on `client.has_api_key`. Standalone runs the per-model
-    # loop sequentially, so at most _OPEN_METEO_CONCURRENCY (default 4)
-    # chunks are in flight at once — and each chunk takes ~100s, putting
-    # peak load at well under 1 RPS. Free-tier (600/min) is in no danger,
-    # and `_get_with_retry` would absorb a stray 429 anyway.
+    # doesn't gate on `client.has_api_key`. The briefing gate exists
+    # because briefings fire per-user-action on any deployment — including
+    # local dev without a key — so the gate keeps free-tier dev runs from
+    # tripping rate limits. Standalone is different: it's a scheduled
+    # server-side cycle (twice daily), and a deployment that runs it at
+    # all is expected to have the paid key set. Without the key the cycle
+    # would still complete (peak ~4 in-flight requests, well under
+    # 600/min), but the daily call budget for verification at full
+    # watchlist scale belongs in a paid plan regardless of parallelism.
     max_workers = max(1, min(_OPEN_METEO_CONCURRENCY, total_chunks))
     total_calls = 0
     with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:

--- a/src/weatherbrief/tasks/standalone_verification.py
+++ b/src/weatherbrief/tasks/standalone_verification.py
@@ -178,16 +178,18 @@ def _fetch_forecasts_for_model(
             for a in chunk_list
         ]
 
+        # Time the whole retry ladder, not just the successful attempt: a
+        # chunk that needed retries took that long to deliver useful data,
+        # and that's the signal we want surfaced when scanning logs for
+        # slow chunks.
+        chunk_started = time.monotonic()
         forecasts = None
-        fetch_seconds = 0.0
         for attempt in range(3):
-            attempt_started = time.monotonic()
             try:
                 forecasts = client.fetch_multi_point(
                     points, model_source,
                     start_date=start_date, end_date=end_date,
                 )
-                fetch_seconds = time.monotonic() - attempt_started
                 break
             except Exception:
                 if attempt < 2:
@@ -209,7 +211,8 @@ def _fetch_forecasts_for_model(
 
         logger.info(
             "Model %s chunk %d/%d: processing %d airports (fetch %.1fs)",
-            model, chunk_num, total_chunks, len(chunk_list), fetch_seconds,
+            model, chunk_num, total_chunks, len(chunk_list),
+            time.monotonic() - chunk_started,
         )
         chunk_results: list[dict] = []
         for airport, wpf in zip(chunk_list, forecasts):
@@ -255,6 +258,12 @@ def _fetch_forecasts_for_model(
     if not chunks:
         return all_results, client.call_count
 
+    # Unlike the briefing-side parallel fetch (tasks/fetch.py), this path
+    # doesn't gate on `client.has_api_key`. Standalone runs the per-model
+    # loop sequentially, so at most _OPEN_METEO_CONCURRENCY (default 4)
+    # chunks are in flight at once — and each chunk takes ~100s, putting
+    # peak load at well under 1 RPS. Free-tier (600/min) is in no danger,
+    # and `_get_with_retry` would absorb a stray 429 anyway.
     max_workers = max(1, min(_OPEN_METEO_CONCURRENCY, total_chunks))
     total_calls = 0
     with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:

--- a/tests/test_standalone_fetch_parallel.py
+++ b/tests/test_standalone_fetch_parallel.py
@@ -1,0 +1,213 @@
+"""Tests for parallel chunk fetch in standalone_verification (issue #110).
+
+Mirrors the briefing-side test_fetch_parallel.py pattern: verify chunks run
+concurrently (via threading.Barrier), survive partial failures, and cap
+worker count to chunk count.
+"""
+
+from __future__ import annotations
+
+import threading
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+import pytest
+
+from weatherbrief.models import HourlyForecast, ModelSource, Waypoint, WaypointForecast
+from weatherbrief.tasks import standalone_verification as sv
+from weatherbrief.tasks.airport_watchlist import WatchlistAirport
+
+
+def _airport(icao: str) -> WatchlistAirport:
+    return WatchlistAirport(icao=icao, lat=50.0, lon=2.0)
+
+
+def _airports(n: int) -> list[WatchlistAirport]:
+    return [_airport(f"EG{i:02d}") for i in range(n)]
+
+
+def _empty_forecast(icao: str) -> WaypointForecast:
+    """A WaypointForecast with no hourly samples — keeps tests focused on
+    chunk-level concurrency rather than per-snapshot parsing."""
+    return WaypointForecast(
+        waypoint=Waypoint(icao=icao, name=icao, lat=50.0, lon=2.0),
+        model=ModelSource.GFS,
+        fetched_at=datetime.now(timezone.utc),
+        hourly=[],
+    )
+
+
+def _forecast_with_one_sample(icao: str) -> WaypointForecast:
+    """One hourly sample at a SAMPLE_HOURS_UTC hour so it survives the filter
+    and produces exactly one snapshot dict per airport."""
+    return WaypointForecast(
+        waypoint=Waypoint(icao=icao, name=icao, lat=50.0, lon=2.0),
+        model=ModelSource.GFS,
+        fetched_at=datetime.now(timezone.utc),
+        hourly=[
+            HourlyForecast(
+                time=datetime(2026, 5, 5, 12, 0, tzinfo=timezone.utc),
+                temperature_2m_c=10.0,
+                cloud_cover_pct=30.0,
+                precipitation_mm=0.0,
+                pressure_levels=[],
+            ),
+        ],
+    )
+
+
+@pytest.fixture
+def small_chunk_size(monkeypatch):
+    """Force 4 airports → 4 single-airport chunks so we can drive concurrency
+    behaviour without 100s of fixture rows."""
+    monkeypatch.setattr(sv, "_OPEN_METEO_BATCH_SIZE", 1)
+
+
+def test_chunks_dispatch_concurrently(small_chunk_size, monkeypatch):
+    """Chunks must run in parallel — verified via threading.Barrier.
+
+    A barrier of N parties only releases when N threads arrive. If the loop
+    were sequential only one worker would ever be inside `fetch_multi_point`
+    at a time and the barrier would time out.
+    """
+    airports = _airports(4)
+    monkeypatch.setattr(sv, "_OPEN_METEO_CONCURRENCY", 4)
+    barrier = threading.Barrier(len(airports), timeout=15.0)
+
+    def fake_fetch_multi_point(self, points, model, *, start_date=None, end_date=None, chunk_size=None):
+        barrier.wait()  # raises BrokenBarrierError on timeout
+        self._record_call()
+        return [_empty_forecast(p.waypoint_icao) for p in points]
+
+    with patch(
+        "weatherbrief.fetch.open_meteo.OpenMeteoClient.fetch_multi_point",
+        new=fake_fetch_multi_point,
+    ):
+        snaps, calls = sv._fetch_forecasts_for_model(
+            "gfs",
+            datetime(2026, 5, 5, 0, 0, tzinfo=timezone.utc),
+            airports,
+            session=None,
+        )
+
+    # 4 chunks × 1 airport, but no hourly samples → 0 snapshots; we still
+    # verify that all chunks completed by checking the call count.
+    assert snaps == []
+    assert calls == 4
+
+
+def test_aggregated_snapshot_count_matches_sequential(small_chunk_size, monkeypatch):
+    """Output count under parallel dispatch matches what the sequential code
+    would produce — no chunk dropped, no duplicates."""
+    airports = _airports(4)
+    monkeypatch.setattr(sv, "_OPEN_METEO_CONCURRENCY", 4)
+
+    def fake_fetch_multi_point(self, points, model, *, start_date=None, end_date=None, chunk_size=None):
+        self._record_call()
+        return [_forecast_with_one_sample(p.waypoint_icao) for p in points]
+
+    with patch(
+        "weatherbrief.fetch.open_meteo.OpenMeteoClient.fetch_multi_point",
+        new=fake_fetch_multi_point,
+    ):
+        snaps, calls = sv._fetch_forecasts_for_model(
+            "gfs",
+            datetime(2026, 5, 5, 0, 0, tzinfo=timezone.utc),
+            airports,
+            session=None,
+        )
+
+    icaos = sorted(s["icao"] for s in snaps)
+    assert icaos == ["EG00", "EG01", "EG02", "EG03"]
+    assert calls == 4
+
+
+def test_partial_chunk_failure_does_not_abort_others(small_chunk_size, monkeypatch):
+    """One chunk's retry-exhausted failure must not stop the others from
+    completing — partial success beats total failure."""
+    airports = _airports(4)
+    monkeypatch.setattr(sv, "_OPEN_METEO_CONCURRENCY", 4)
+
+    # Don't actually wait between retries.
+    monkeypatch.setattr(sv.time, "sleep", lambda _: None)
+
+    def fake_fetch_multi_point(self, points, model, *, start_date=None, end_date=None, chunk_size=None):
+        if any(p.waypoint_icao == "EG02" for p in points):
+            self._record_call()
+            raise RuntimeError("simulated 500")
+        self._record_call()
+        return [_forecast_with_one_sample(p.waypoint_icao) for p in points]
+
+    with patch(
+        "weatherbrief.fetch.open_meteo.OpenMeteoClient.fetch_multi_point",
+        new=fake_fetch_multi_point,
+    ):
+        snaps, calls = sv._fetch_forecasts_for_model(
+            "gfs",
+            datetime(2026, 5, 5, 0, 0, tzinfo=timezone.utc),
+            airports,
+            session=None,
+        )
+
+    icaos = sorted(s["icao"] for s in snaps)
+    assert icaos == ["EG00", "EG01", "EG03"]
+    # 3 successful chunks + 3 retry attempts on the failing chunk = 6
+    assert calls == 6
+
+
+def test_concurrency_capped_to_chunk_count(small_chunk_size, monkeypatch):
+    """Worker count never exceeds the actual number of chunks."""
+    airports = _airports(2)
+    monkeypatch.setattr(sv, "_OPEN_METEO_CONCURRENCY", 8)
+
+    seen_max_workers: list[int] = []
+    real_executor = sv.concurrent.futures.ThreadPoolExecutor
+
+    class CapturingExecutor(real_executor):
+        def __init__(self, max_workers=None, **kw):
+            seen_max_workers.append(max_workers)
+            super().__init__(max_workers=max_workers, **kw)
+
+    monkeypatch.setattr(
+        sv.concurrent.futures, "ThreadPoolExecutor", CapturingExecutor,
+    )
+
+    def fake_fetch_multi_point(self, points, model, *, start_date=None, end_date=None, chunk_size=None):
+        return [_empty_forecast(p.waypoint_icao) for p in points]
+
+    with patch(
+        "weatherbrief.fetch.open_meteo.OpenMeteoClient.fetch_multi_point",
+        new=fake_fetch_multi_point,
+    ):
+        sv._fetch_forecasts_for_model(
+            "gfs",
+            datetime(2026, 5, 5, 0, 0, tzinfo=timezone.utc),
+            airports,
+            session=None,
+        )
+
+    assert seen_max_workers == [2], (
+        f"Expected max_workers capped to 2 (chunk count), got {seen_max_workers}"
+    )
+
+
+def test_empty_airport_list_returns_no_snapshots(monkeypatch):
+    """Empty input must short-circuit cleanly without spinning up an executor."""
+    monkeypatch.setattr(sv, "_OPEN_METEO_CONCURRENCY", 4)
+
+    def fake_fetch_multi_point(self, points, model, *, start_date=None, end_date=None, chunk_size=None):
+        raise AssertionError("fetch_multi_point must not be called for empty input")
+
+    with patch(
+        "weatherbrief.fetch.open_meteo.OpenMeteoClient.fetch_multi_point",
+        new=fake_fetch_multi_point,
+    ):
+        snaps, calls = sv._fetch_forecasts_for_model(
+            "gfs",
+            datetime(2026, 5, 5, 0, 0, tzinfo=timezone.utc),
+            airports=[],
+            session=None,
+        )
+
+    assert snaps == []
+    assert calls == 0


### PR DESCRIPTION
## Summary

Replace the sequential per-chunk loop in `_fetch_forecasts_for_model` with a `ThreadPoolExecutor` so the chunk-level Open-Meteo HTTP calls in the heavy 07Z/19Z standalone cycles run in parallel. Outer per-model loop in `run_standalone_cycle` stays sequential — parallelising across models would multiply peak memory.

- Worker count via `STANDALONE_FETCH_CONCURRENCY` env var (default 4), capped to actual chunk count.
- Each worker keeps the existing 3-attempt retry block; chunks fail independently.
- Per-chunk wall time added to the existing `Model %s chunk %d/%d` log line so the diagnostic that helped find the May 2 ECMWF win stays intact.
- Shared `OpenMeteoClient` / `requests.Session` (thread-safe per the requests docs); racy `call_count` increment is benign — used only for log aggregates.

Mirrors the briefing-side pattern from PR #116 (closed issue #112). With standalone heavy cycles currently ~25 min / 99% in `phase_fetch_ms`, expected drop to ~5–7 min on the next 07Z/19Z fire post-deploy.

Closes #110

## Test plan

- [x] `tests/test_standalone_fetch_parallel.py` — 5 new tests:
  - `test_chunks_dispatch_concurrently` — `threading.Barrier(N)` would deadlock if sequential
  - `test_aggregated_snapshot_count_matches_sequential` — no chunk dropped, no duplicates
  - `test_partial_chunk_failure_does_not_abort_others` — one chunk's retry exhaustion doesn't stop others
  - `test_concurrency_capped_to_chunk_count` — `max_workers` never exceeds chunk count
  - `test_empty_airport_list_returns_no_snapshots` — empty input short-circuits cleanly
- [x] Existing standalone tests still pass (`tests/test_standalone_verification.py` — 34 tests)
- [x] Briefing-side parallel tests still pass (`tests/test_fetch_parallel.py` — 6 tests)
- [ ] Post-deploy: watch `verification_cycles.duration_ms` for `source='standalone_full'` over the next two days. Expect ~25 min → ~5–7 min for 07/19Z runs. No 429s in logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)