### PR TITLE
feat(maps): airport profile panel via right-click on forecast markers (#121)

### DIFF
--- a/src/weatherbrief/api/airport_profile.py
+++ b/src/weatherbrief/api/airport_profile.py
@@ -24,6 +24,8 @@ from __future__ import annotations
 import asyncio
 import json as json_mod
 import logging
+import threading
+from collections import defaultdict
 from collections.abc import AsyncGenerator
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -42,6 +44,112 @@ router = APIRouter(prefix="/maps", tags=["maps"])
 
 _VALID_MODELS = ("gfs", "icon", "ecmwf")
 _DEFAULT_WINDOW_H = 3  # selected hour + 3 forward = 4 forecast hours
+
+
+# ---------------------------------------------------------------------------
+# Concurrency control
+#
+# Two layers of concurrency protection (see issue #121 PR #122 review):
+#
+# A) Per-user / global stream limiter — bounds the "user clicks 20 airports
+#    rapidly" DoS surface and the global thread-pool exhaustion surface.
+#    Lighter than packs._RefreshRegistry: no queue, no progress polling,
+#    no flight_id dedup — just an int counter.
+#
+# B) Same-run GRIB enrichment lock — two simultaneous panels for different
+#    airports on the same (model, run_init) currently both call
+#    enrich_forecasts(), which both download the same GFS / ICON GRIB
+#    file. Without this lock they race at the file-write level (see #123
+#    for the underlying cache-layer fix). With it, the second request
+#    waits for the first's enrichment to finish; by the time it acquires
+#    the lock, the disk cache is warm and the second request is fast.
+# ---------------------------------------------------------------------------
+
+_MAX_PER_USER = 3
+_MAX_GLOBAL = 20
+
+
+class _StreamLimiter:
+    """Bounded-counter request limiter for the airport-profile SSE.
+
+    Caps in-flight streams per-user (so one user can't monopolise the
+    thread pool with rapid right-clicks) and globally (so total in-flight
+    work is bounded). Counters are incremented synchronously at acquire
+    and decremented in the endpoint's `finally` block — `acquire()`
+    raises `HTTPException(429)` rather than blocking, so the client sees
+    the rejection immediately and can retry instead of hanging.
+    """
+
+    def __init__(self, max_per_user: int = _MAX_PER_USER, max_global: int = _MAX_GLOBAL) -> None:
+        self._lock = threading.Lock()
+        self._per_user: dict[str, int] = defaultdict(int)
+        self._global = 0
+        self._max_per_user = max_per_user
+        self._max_global = max_global
+
+    def acquire(self, user_id: str) -> None:
+        with self._lock:
+            if self._global >= self._max_global:
+                raise HTTPException(
+                    status_code=429,
+                    detail=f"Server busy ({self._global} airport profiles in flight). Try again shortly.",
+                )
+            if self._per_user[user_id] >= self._max_per_user:
+                raise HTTPException(
+                    status_code=429,
+                    detail=f"You already have {self._per_user[user_id]} airport profiles in flight (limit {self._max_per_user}).",
+                )
+            self._per_user[user_id] += 1
+            self._global += 1
+
+    def release(self, user_id: str) -> None:
+        with self._lock:
+            self._per_user[user_id] = max(0, self._per_user[user_id] - 1)
+            if self._per_user[user_id] == 0:
+                self._per_user.pop(user_id, None)
+            self._global = max(0, self._global - 1)
+
+    def snapshot(self) -> dict[str, int]:
+        """Return active counts for diagnostics / tests."""
+        with self._lock:
+            return {"global": self._global, "users": len(self._per_user)}
+
+
+_limiter = _StreamLimiter()
+
+
+class _GribRunDedup:
+    """Process-wide async-lock pool keyed by (model, init_time_unix).
+
+    Two simultaneous airport-profile streams on the same model+run
+    currently both invoke `enrich_forecasts`, which redownloads the same
+    GFS / ICON GRIB file (see #123 for the cache-layer race). This pool
+    serialises the enrichment phase so the second request sees a warm
+    cache and skips the download.
+
+    Locks are created lazily and never freed — there are at most ~6 active
+    GRIB runs at any moment (3 models × 2 cycles a day) so unbounded
+    growth is not a concern.
+    """
+
+    def __init__(self) -> None:
+        self._sync_lock = threading.Lock()
+        self._locks: dict[tuple[str, int], asyncio.Lock] = {}
+
+    def lock_for(self, model: str, run_init_unix: int | None) -> asyncio.Lock:
+        # Use a sentinel for "no init time available yet" so per-model
+        # bursts before the first GRIB resolves still serialise rather
+        # than all charging at the cold cache.
+        key = (model, run_init_unix if run_init_unix is not None else -1)
+        with self._sync_lock:
+            lock = self._locks.get(key)
+            if lock is None:
+                lock = asyncio.Lock()
+                self._locks[key] = lock
+            return lock
+
+
+_grib_dedup = _GribRunDedup()
 
 
 def _iso_utc(dt: datetime) -> str:
@@ -403,6 +511,12 @@ async def get_airport_profile(
     # SSE error mid-stream).
     surface = _surface_from_cache(db, icao, model, hours)
 
+    # Acquire the per-user / global concurrency slot before opening the
+    # stream. Released in the generator's finally block. Done synchronously
+    # (raises 429) so the client doesn't waste a round-trip on an SSE
+    # connection that would never produce a complete event.
+    _limiter.acquire(_user_id)
+
     async def event_generator() -> AsyncGenerator[str, None]:
         def _event(event_type: str, payload: dict) -> str:
             return f"event: {event_type}\ndata: {json_mod.dumps(payload, default=str)}\n\n"
@@ -415,88 +529,109 @@ async def get_airport_profile(
             so the SSE stream closes normally."""
             return _event("error", {"type": "error", "phase": phase, "message": message})
 
-        # Phase 0 (meta): instant — lets the client size the canvas.
-        meta = {
-            "type": "meta",
-            "icao": icao,
-            "lat": lat,
-            "lon": lon,
-            "elevation_ft": elevation_ft,
-            "model": model,
-            "start_hour": _iso_utc(start_dt),
-            "window_h": window_h,
-            "hours": [_iso_utc(h) for h in hours],
-        }
-        yield _event("meta", meta)
-
-        # Phase 1 (surface): cached scalars. Already snapshotted above so
-        # nothing to do in the executor.
-        yield _event("surface", {"type": "surface", "hours": surface})
-
-        # Phase 2 (levels) — runs in a thread since it does network I/O.
-        loop = asyncio.get_running_loop()
         try:
-            wf = await loop.run_in_executor(
-                None, _fetch_pressure_levels, icao, lat, lon, model, hours,
-            )
-        except Exception as exc:
-            logger.warning("Airport profile: levels fetch raised: %s", exc, exc_info=True)
-            wf = None
+            # Phase 0 (meta): instant — lets the client size the canvas.
+            meta = {
+                "type": "meta",
+                "icao": icao,
+                "lat": lat,
+                "lon": lon,
+                "elevation_ft": elevation_ft,
+                "model": model,
+                "start_hour": _iso_utc(start_dt),
+                "window_h": window_h,
+                "hours": [_iso_utc(h) for h in hours],
+            }
+            yield _event("meta", meta)
 
-        if wf is not None:
-            # Filter to the requested hours. Open-Meteo can return naive
-            # datetimes; normalize before matching.
-            target_set = {h.replace(tzinfo=None) for h in hours}
-            kept = []
-            for h in wf.hourly:
-                ht = h.time.replace(tzinfo=None) if h.time.tzinfo else h.time
-                if ht in target_set:
-                    kept.append(_hourly_to_dict(h))
-            yield _event("levels", {"type": "levels", "hours": kept})
-        else:
-            yield _event("levels", {"type": "levels", "hours": [], "error": "fetch_failed"})
+            # Phase 1 (surface): cached scalars. Already snapshotted above so
+            # nothing to do in the executor.
+            yield _event("surface", {"type": "surface", "hours": surface})
 
-        # Phase 2.5 (enriched) — local-GRIB augmentation. Modifies wf in-place.
-        # Skipped when the levels phase failed (nothing to augment) or when
-        # the caller passed enrich=false. The whole phase is guarded so a
-        # PermissionError on iterdir() (preflight) or any other unexpected
-        # raise doesn't kill the stream — the client still gets the derived
-        # phase on the unenriched profile.
-        if enrich and wf is not None:
+            # Phase 2 (levels) — runs in a thread since it does network I/O.
+            loop = asyncio.get_running_loop()
             try:
-                enrichment = await loop.run_in_executor(
-                    None, _grib_enrich_levels, wf, lat, lon, model, hours, data_dir,
+                wf = await loop.run_in_executor(
+                    None, _fetch_pressure_levels, icao, lat, lon, model, hours,
+                )
+            except Exception as exc:
+                logger.warning("Airport profile: levels fetch raised: %s", exc, exc_info=True)
+                wf = None
+
+            if wf is not None:
+                # Filter to the requested hours. Open-Meteo can return naive
+                # datetimes; normalize before matching.
+                target_set = {h.replace(tzinfo=None) for h in hours}
+                kept = []
+                for h in wf.hourly:
+                    ht = h.time.replace(tzinfo=None) if h.time.tzinfo else h.time
+                    if ht in target_set:
+                        kept.append(_hourly_to_dict(h))
+                yield _event("levels", {"type": "levels", "hours": kept})
+            else:
+                yield _event("levels", {"type": "levels", "hours": [], "error": "fetch_failed"})
+
+            # Phase 2.5 (enriched) — local-GRIB augmentation. Modifies wf in-place.
+            # Skipped when the levels phase failed (nothing to augment) or when
+            # the caller passed enrich=false. Guarded so unexpected raises
+            # (e.g. PermissionError on iterdir()) don't kill the stream — the
+            # client still gets the derived phase on the unenriched profile.
+            #
+            # Wrapped in `_grib_dedup.lock_for(model, hours[0])` so two
+            # concurrent panels for the same model+hour don't both download
+            # the same GRIB file. The second panel waits for the first's
+            # enrichment to finish, then enters with a warm cache. See #123
+            # for the deeper cache-layer atomicity issue.
+            if enrich and wf is not None:
+                run_lock = _grib_dedup.lock_for(model, int(hours[0].timestamp()))
+                async with run_lock:
+                    try:
+                        enrichment = await loop.run_in_executor(
+                            None, _grib_enrich_levels, wf, lat, lon, model, hours, data_dir,
+                        )
+                    except Exception as exc:
+                        logger.warning(
+                            "Airport profile: enrichment executor raised: %s", exc, exc_info=True,
+                        )
+                        enrichment = {"sources": {}, "skipped": {"all": "exception"}}
+                yield _event("enriched", {"type": "enriched", **enrichment})
+
+            # Phase 3 (derived) — analyze_sounding on the (possibly-enriched) levels.
+            # If this fails the client gets nothing useful past the levels phase;
+            # emit a structured error and stop instead of letting the executor
+            # exception bubble up and kill the stream silently.
+            try:
+                derived = await loop.run_in_executor(
+                    None, _build_derived_payload, wf, hours,
                 )
             except Exception as exc:
                 logger.warning(
-                    "Airport profile: enrichment executor raised: %s", exc, exc_info=True,
+                    "Airport profile: derived executor raised: %s", exc, exc_info=True,
                 )
-                enrichment = {"sources": {}, "skipped": {"all": "exception"}}
-            yield _event("enriched", {"type": "enriched", **enrichment})
+                yield _error_event("derived", str(exc))
+                return
+            yield _event("derived", {"type": "derived", "points": derived})
 
-        # Phase 3 (derived) — analyze_sounding on the (possibly-enriched) levels.
-        # If this fails the client gets nothing useful past the levels phase;
-        # emit a structured error and stop instead of letting the executor
-        # exception bubble up and kill the stream silently.
-        try:
-            derived = await loop.run_in_executor(
-                None, _build_derived_payload, wf, hours,
-            )
-        except Exception as exc:
-            logger.warning(
-                "Airport profile: derived executor raised: %s", exc, exc_info=True,
-            )
-            yield _error_event("derived", str(exc))
-            return
-        yield _event("derived", {"type": "derived", "points": derived})
+            yield _event("complete", {"type": "complete"})
+        finally:
+            # Always release the slot — covers normal completion, error
+            # returns, and client disconnect (Starlette closes the
+            # generator, which runs this block).
+            _limiter.release(_user_id)
 
-        yield _event("complete", {"type": "complete"})
-
-    return StreamingResponse(
-        event_generator(),
-        media_type="text/event-stream",
-        headers={
-            "Cache-Control": "no-cache",
-            "X-Accel-Buffering": "no",
-        },
-    )
+    try:
+        return StreamingResponse(
+            event_generator(),
+            media_type="text/event-stream",
+            headers={
+                "Cache-Control": "no-cache",
+                "X-Accel-Buffering": "no",
+            },
+        )
+    except Exception:
+        # StreamingResponse construction itself shouldn't raise, but if it
+        # does, the generator's finally will never run and the slot leaks.
+        # Release defensively. (Same pattern /refresh/stream uses around
+        # refresh_registry.unregister.)
+        _limiter.release(_user_id)
+        raise

--- a/src/weatherbrief/api/airport_profile.py
+++ b/src/weatherbrief/api/airport_profile.py
@@ -29,7 +29,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import StreamingResponse
 from sqlalchemy import select
 from sqlalchemy.orm import Session
@@ -58,13 +58,7 @@ def _iso_utc(dt: datetime) -> str:
     return dt.isoformat()
 
 
-def _airports_db(request: Request) -> str:
-    return request.app.state.db_path
-
-
-def _data_dir(request: Request) -> Path:
-    """Shared data directory (DATA_DIR env var). GRIB cache lives under here."""
-    return request.app.state.data_dir
+from weatherbrief.api.deps import airports_db as _airports_db, data_dir as _data_dir
 
 
 def _resolve_airport_coords(icao: str, airports_db_path: str) -> tuple[float, float, float | None] | None:
@@ -413,6 +407,14 @@ async def get_airport_profile(
         def _event(event_type: str, payload: dict) -> str:
             return f"event: {event_type}\ndata: {json_mod.dumps(payload, default=str)}\n\n"
 
+        def _error_event(phase: str, message: str) -> str:
+            """Match /refresh/stream's pattern: emit a structured error
+            event so the client sees a clean handoff instead of the
+            EventSource onerror connection-level signal. After yielding
+            this, the generator should `break` out of `event_generator`
+            so the SSE stream closes normally."""
+            return _event("error", {"type": "error", "phase": phase, "message": message})
+
         # Phase 0 (meta): instant — lets the client size the canvas.
         meta = {
             "type": "meta",
@@ -427,7 +429,8 @@ async def get_airport_profile(
         }
         yield _event("meta", meta)
 
-        # Phase 1 (surface): cached scalars.
+        # Phase 1 (surface): cached scalars. Already snapshotted above so
+        # nothing to do in the executor.
         yield _event("surface", {"type": "surface", "hours": surface})
 
         # Phase 2 (levels) — runs in a thread since it does network I/O.
@@ -455,17 +458,36 @@ async def get_airport_profile(
 
         # Phase 2.5 (enriched) — local-GRIB augmentation. Modifies wf in-place.
         # Skipped when the levels phase failed (nothing to augment) or when
-        # the caller passed enrich=false.
+        # the caller passed enrich=false. The whole phase is guarded so a
+        # PermissionError on iterdir() (preflight) or any other unexpected
+        # raise doesn't kill the stream — the client still gets the derived
+        # phase on the unenriched profile.
         if enrich and wf is not None:
-            enrichment = await loop.run_in_executor(
-                None, _grib_enrich_levels, wf, lat, lon, model, hours, data_dir,
-            )
+            try:
+                enrichment = await loop.run_in_executor(
+                    None, _grib_enrich_levels, wf, lat, lon, model, hours, data_dir,
+                )
+            except Exception as exc:
+                logger.warning(
+                    "Airport profile: enrichment executor raised: %s", exc, exc_info=True,
+                )
+                enrichment = {"sources": {}, "skipped": {"all": "exception"}}
             yield _event("enriched", {"type": "enriched", **enrichment})
 
         # Phase 3 (derived) — analyze_sounding on the (possibly-enriched) levels.
-        derived = await loop.run_in_executor(
-            None, _build_derived_payload, wf, hours,
-        )
+        # If this fails the client gets nothing useful past the levels phase;
+        # emit a structured error and stop instead of letting the executor
+        # exception bubble up and kill the stream silently.
+        try:
+            derived = await loop.run_in_executor(
+                None, _build_derived_payload, wf, hours,
+            )
+        except Exception as exc:
+            logger.warning(
+                "Airport profile: derived executor raised: %s", exc, exc_info=True,
+            )
+            yield _error_event("derived", str(exc))
+            return
         yield _event("derived", {"type": "derived", "points": derived})
 
         yield _event("complete", {"type": "complete"})

--- a/src/weatherbrief/api/airport_profile.py
+++ b/src/weatherbrief/api/airport_profile.py
@@ -26,6 +26,7 @@ import json as json_mod
 import logging
 from collections.abc import AsyncGenerator
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
@@ -43,11 +44,25 @@ _VALID_MODELS = ("gfs", "icon", "ecmwf")
 _DEFAULT_WINDOW_H = 3  # selected hour + 3 forward = 4 forecast hours
 
 
+def _iso_utc(dt: datetime) -> str:
+    """Serialize a datetime as a UTC-aware ISO 8601 string.
+
+    All time keys emitted by this endpoint go through here so that strict
+    equality (`===`) on the client matches between phases. Open-Meteo
+    sometimes returns naive datetimes; we treat those as UTC.
+    """
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    else:
+        dt = dt.astimezone(timezone.utc)
+    return dt.isoformat()
+
+
 def _airports_db(request: Request) -> str:
     return request.app.state.db_path
 
 
-def _data_dir(request: Request):
+def _data_dir(request: Request) -> Path:
     """Shared data directory (DATA_DIR env var). GRIB cache lives under here."""
     return request.app.state.data_dir
 
@@ -138,7 +153,7 @@ def _surface_from_cache(
         if row is None:
             continue
         result.append({
-            "time": h.isoformat(),
+            "time": _iso_utc(h),
             "temperature_2m_c": row.temperature_2m_c,
             "dewpoint_2m_c": row.dewpoint_2m_c,
             "visibility_m": row.visibility_m,
@@ -157,6 +172,7 @@ def _surface_from_cache(
 
 
 def _fetch_pressure_levels(
+    icao: str,
     lat: float,
     lon: float,
     model: str,
@@ -186,17 +202,22 @@ def _fetch_pressure_levels(
         )
     except Exception:
         logger.warning(
-            "Airport profile: pressure-level fetch failed for %s/%s",
-            model, lat, exc_info=True,
+            "Airport profile: pressure-level fetch failed for %s %s (%.4f, %.4f)",
+            icao, model, lat, lon, exc_info=True,
         )
         return None
     return forecasts[0] if forecasts else None
 
 
 def _hourly_to_dict(h) -> dict[str, Any]:
-    """Project a HourlyForecast to a serializable dict (levels included)."""
+    """Project a HourlyForecast to a serializable dict (levels included).
+
+    The `time` key uses `_iso_utc()` so it round-trips exactly with the
+    `meta.hours[i]` strings on the client (Open-Meteo returns naive
+    datetimes which would otherwise miss the `+00:00` suffix).
+    """
     return {
-        "time": h.time.isoformat() if hasattr(h.time, "isoformat") else str(h.time),
+        "time": _iso_utc(h.time),
         "temperature_2m_c": h.temperature_2m_c,
         "dewpoint_2m_c": h.dewpoint_2m_c,
         "wind_speed_10m_kt": h.wind_speed_10m_kt,
@@ -251,14 +272,23 @@ def _grib_enrich_levels(
     stay intact and `analyze_sounding` still runs in the derived phase.
     """
     if waypoint_forecast is None or not hours:
-        return {"sources": {}, "skipped": "no_levels"}
+        return {"sources": {}, "skipped": {"all": "no_levels"}}
+
+    # Fast preflight: if nothing is configured locally, skip the heavy
+    # call entirely so dev environments don't pay a futile S3 round-trip
+    # on every right-click. The check is intentionally cheap and
+    # conservative — production deployments set ECMWF_GRIB_DIR to a real
+    # populated directory; dev typically doesn't.
+    from weatherbrief.fetch.grib.ecmwf_fetch import ecmwf_grib_dir
+    ecmwf_dir = ecmwf_grib_dir()
+    has_ecmwf_dir = ecmwf_dir.exists() and any(ecmwf_dir.iterdir()) if ecmwf_dir.exists() else False
+    if not has_ecmwf_dir:
+        return {"sources": {}, "skipped": {"all": "no_local_grib_configured"}}
 
     from datetime import timezone as _tz
 
     from weatherbrief.fetch.grib import enrich_forecasts
-    from weatherbrief.models import (
-        ModelSource, RouteCrossSection, RoutePoint, WaypointForecast as _WF,
-    )
+    from weatherbrief.models import RouteCrossSection, RoutePoint
 
     src = _model_to_source(model)
     point = RoutePoint(lat=lat, lon=lon, distance_from_origin_nm=0.0)
@@ -305,7 +335,7 @@ def _build_derived_payload(
     # Index hourly entries by their UTC time (naive form for matching).
     by_time: dict[Any, Any] = {}
     for h in waypoint_forecast.hourly:
-        ht = h.time.replace(tzinfo=None) if hasattr(h.time, "tzinfo") and h.time.tzinfo else h.time
+        ht = h.time.replace(tzinfo=None) if h.time.tzinfo else h.time
         by_time[ht] = h
 
     results: list[dict[str, Any]] = []
@@ -325,7 +355,7 @@ def _build_derived_payload(
             continue
         results.append({
             "point_index": idx,
-            "time": target_hour.isoformat(),
+            "time": _iso_utc(target_hour),
             "sounding": sa.model_dump(mode="json"),
         })
     return results
@@ -338,11 +368,10 @@ async def get_airport_profile(
     start_hour: str = Query(..., description="ISO 8601 UTC start hour, e.g. 2026-05-07T12:00:00Z"),
     window_h: int = Query(default=_DEFAULT_WINDOW_H, ge=0, le=12),
     enrich: bool = Query(default=True, description="Run local-GRIB enrichment phase"),
-    request: Request = None,  # type: ignore[assignment]
     _user_id: str = Depends(current_user_id),
     db: Session = Depends(get_db),
     airports_db: str = Depends(_airports_db),
-    data_dir = Depends(_data_dir),
+    data_dir: Path = Depends(_data_dir),
 ):
     """Stream airport profile data via Server-Sent Events.
 
@@ -392,9 +421,9 @@ async def get_airport_profile(
             "lon": lon,
             "elevation_ft": elevation_ft,
             "model": model,
-            "start_hour": start_dt.isoformat(),
+            "start_hour": _iso_utc(start_dt),
             "window_h": window_h,
-            "hours": [h.isoformat() for h in hours],
+            "hours": [_iso_utc(h) for h in hours],
         }
         yield _event("meta", meta)
 
@@ -402,10 +431,10 @@ async def get_airport_profile(
         yield _event("surface", {"type": "surface", "hours": surface})
 
         # Phase 2 (levels) — runs in a thread since it does network I/O.
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         try:
             wf = await loop.run_in_executor(
-                None, _fetch_pressure_levels, lat, lon, model, hours,
+                None, _fetch_pressure_levels, icao, lat, lon, model, hours,
             )
         except Exception as exc:
             logger.warning("Airport profile: levels fetch raised: %s", exc, exc_info=True)
@@ -417,7 +446,7 @@ async def get_airport_profile(
             target_set = {h.replace(tzinfo=None) for h in hours}
             kept = []
             for h in wf.hourly:
-                ht = h.time.replace(tzinfo=None) if hasattr(h.time, "tzinfo") and h.time.tzinfo else h.time
+                ht = h.time.replace(tzinfo=None) if h.time.tzinfo else h.time
                 if ht in target_set:
                     kept.append(_hourly_to_dict(h))
             yield _event("levels", {"type": "levels", "hours": kept})

--- a/src/weatherbrief/api/airport_profile.py
+++ b/src/weatherbrief/api/airport_profile.py
@@ -47,6 +47,11 @@ def _airports_db(request: Request) -> str:
     return request.app.state.db_path
 
 
+def _data_dir(request: Request):
+    """Shared data directory (DATA_DIR env var). GRIB cache lives under here."""
+    return request.app.state.data_dir
+
+
 def _resolve_airport_coords(icao: str, airports_db_path: str) -> tuple[float, float, float | None] | None:
     """Look up an ICAO's lat/lon/elevation from the euro_aip database.
 
@@ -218,6 +223,75 @@ def _hourly_to_dict(h) -> dict[str, Any]:
     }
 
 
+def _grib_enrich_levels(
+    waypoint_forecast,
+    lat: float,
+    lon: float,
+    model: str,
+    hours: list[datetime],
+    data_dir,
+) -> dict[str, Any]:
+    """Run the local-GRIB enrichment pipeline against a synthetic single-point
+    "route" so the existing per-flight machinery can run unchanged.
+
+    The pipeline (`fetch.grib.enrich_forecasts`) is route-shaped: it expects
+    a list of `RouteCrossSection`, a list of `RoutePoint`, and a flight
+    departure time / duration. Wrap our (icao, model, hours[]) into that
+    shape and let the function modify the WaypointForecast in-place.
+
+    The returned dict is suitable for the SSE payload — it summarises which
+    sources contributed (so the client can show "GRIB enriched: ECMWF run
+    12Z" or "no local GRIB available").
+
+    NOTE: This path requires:
+      - ECMWF: a populated ECMWF_GRIB_DIR with a recent run covering hours[-1]
+      - ICON-EU: airport inside the ICON-EU domain (~Europe + adjoining seas)
+      - GFS: NOAA S3 access (GFS GRIB is downloaded on-demand into data_dir)
+    Any of those failing is non-fatal: the pre-enrichment Open-Meteo levels
+    stay intact and `analyze_sounding` still runs in the derived phase.
+    """
+    if waypoint_forecast is None or not hours:
+        return {"sources": {}, "skipped": "no_levels"}
+
+    from datetime import timezone as _tz
+
+    from weatherbrief.fetch.grib import enrich_forecasts
+    from weatherbrief.models import (
+        ModelSource, RouteCrossSection, RoutePoint, WaypointForecast as _WF,
+    )
+
+    src = _model_to_source(model)
+    point = RoutePoint(lat=lat, lon=lon, distance_from_origin_nm=0.0)
+    cs = RouteCrossSection(
+        model=src,
+        route_points=[point],
+        fetched_at=datetime.now(_tz.utc),
+        point_forecasts=[waypoint_forecast],
+    )
+
+    departure = hours[0]
+    duration_h = (hours[-1] - hours[0]).total_seconds() / 3600.0
+
+    try:
+        grib_init_times, grib_skip_reasons = enrich_forecasts(
+            cross_sections=[cs],
+            all_forecasts=[waypoint_forecast],
+            route_points=[point],
+            departure_time=departure,
+            data_dir=data_dir,
+            flight_duration_hours=duration_h,
+        )
+    except Exception:
+        logger.warning("Airport profile: GRIB enrichment failed", exc_info=True)
+        return {"sources": {}, "skipped": "exception"}
+
+    sources: dict[str, dict[str, Any]] = {}
+    for m, ts in grib_init_times.items():
+        sources[m] = {"init_time_unix": ts}
+    skipped = {m: reason for m, reason in grib_skip_reasons.items()}
+    return {"sources": sources, "skipped": skipped}
+
+
 def _build_derived_payload(
     waypoint_forecast,
     hours: list[datetime],
@@ -263,10 +337,12 @@ async def get_airport_profile(
     model: str = Query(default="ecmwf", description="Weather model: gfs / icon / ecmwf"),
     start_hour: str = Query(..., description="ISO 8601 UTC start hour, e.g. 2026-05-07T12:00:00Z"),
     window_h: int = Query(default=_DEFAULT_WINDOW_H, ge=0, le=12),
+    enrich: bool = Query(default=True, description="Run local-GRIB enrichment phase"),
     request: Request = None,  # type: ignore[assignment]
     _user_id: str = Depends(current_user_id),
     db: Session = Depends(get_db),
     airports_db: str = Depends(_airports_db),
+    data_dir = Depends(_data_dir),
 ):
     """Stream airport profile data via Server-Sent Events.
 
@@ -348,7 +424,16 @@ async def get_airport_profile(
         else:
             yield _event("levels", {"type": "levels", "hours": [], "error": "fetch_failed"})
 
-        # Phase 3 (derived) — analyze_sounding on the levels.
+        # Phase 2.5 (enriched) — local-GRIB augmentation. Modifies wf in-place.
+        # Skipped when the levels phase failed (nothing to augment) or when
+        # the caller passed enrich=false.
+        if enrich and wf is not None:
+            enrichment = await loop.run_in_executor(
+                None, _grib_enrich_levels, wf, lat, lon, model, hours, data_dir,
+            )
+            yield _event("enriched", {"type": "enriched", **enrichment})
+
+        # Phase 3 (derived) — analyze_sounding on the (possibly-enriched) levels.
         derived = await loop.run_in_executor(
             None, _build_derived_payload, wf, hours,
         )

--- a/src/weatherbrief/api/airport_profile.py
+++ b/src/weatherbrief/api/airport_profile.py
@@ -38,6 +38,8 @@ from sqlalchemy.orm import Session
 
 from flyfun_common.db import current_user_id, get_db
 
+from weatherbrief.api.deps import airports_db as _airports_db, data_dir as _data_dir
+
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/maps", tags=["maps"])
@@ -119,28 +121,38 @@ _limiter = _StreamLimiter()
 
 
 class _GribRunDedup:
-    """Process-wide async-lock pool keyed by (model, init_time_unix).
+    """Process-wide async-lock pool keyed by (model, forecast_start_unix).
 
-    Two simultaneous airport-profile streams on the same model+run
-    currently both invoke `enrich_forecasts`, which redownloads the same
-    GFS / ICON GRIB file (see #123 for the cache-layer race). This pool
-    serialises the enrichment phase so the second request sees a warm
-    cache and skips the download.
+    Two simultaneous airport-profile streams that share both the model
+    AND the user-selected forecast start hour serialise their enrichment
+    phase so the second request sees a warm cache. The most common
+    bursty pattern (multiple users right-clicking different airports
+    while the map's hour selector hasn't moved) hits this exactly.
 
-    Locks are created lazily and never freed — there are at most ~6 active
-    GRIB runs at any moment (3 models × 2 cycles a day) so unbounded
-    growth is not a concern.
+    What this does NOT cover: two streams whose forecast start hours
+    differ but whose underlying GRIB run is the same (e.g. user A on
+    12Z forecast, user B on 15Z forecast, both served by the same GFS
+    06Z run). Resolving the actual run init would require running
+    ``find_best_*_run`` before acquiring the lock, which adds a slow
+    pre-step to every request. Issue #123 will eliminate the race at
+    the cache layer (``put_cached`` becoming atomic via tempfile +
+    rename), at which point this lock can be removed entirely.
+
+    Locks are created lazily and never freed. Pool size is bounded by
+    ``unique (model, forecast_start)`` pairs ever clicked — in practice
+    a few hundred entries before a server restart, well under any
+    memory pressure threshold.
     """
 
     def __init__(self) -> None:
         self._sync_lock = threading.Lock()
         self._locks: dict[tuple[str, int], asyncio.Lock] = {}
 
-    def lock_for(self, model: str, run_init_unix: int | None) -> asyncio.Lock:
-        # Use a sentinel for "no init time available yet" so per-model
-        # bursts before the first GRIB resolves still serialise rather
-        # than all charging at the cold cache.
-        key = (model, run_init_unix if run_init_unix is not None else -1)
+    def lock_for(self, model: str, forecast_start_unix: int | None) -> asyncio.Lock:
+        # Sentinel `-1` buckets all "no start hour known" calls under a
+        # single key — kept for API symmetry; the airport-profile call
+        # site always passes a real timestamp.
+        key = (model, forecast_start_unix if forecast_start_unix is not None else -1)
         with self._sync_lock:
             lock = self._locks.get(key)
             if lock is None:
@@ -164,9 +176,6 @@ def _iso_utc(dt: datetime) -> str:
     else:
         dt = dt.astimezone(timezone.utc)
     return dt.isoformat()
-
-
-from weatherbrief.api.deps import airports_db as _airports_db, data_dir as _data_dir
 
 
 def _resolve_airport_coords(icao: str, airports_db_path: str) -> tuple[float, float, float | None] | None:
@@ -240,18 +249,22 @@ def _surface_from_cache(
     ).scalars().all()
 
     # Pick the freshest snapshot per forecast_hour (latest model_init_time).
+    # Normalise every key to `timezone.utc` regardless of how the driver
+    # presents the value: SQLite returns naive (treat as UTC), MySQL
+    # returns aware but the offset object may be `timezone(timedelta(0))`
+    # rather than `timezone.utc` — both compare equal as datetimes but
+    # Python uses identity-then-equality on dict lookup, so converting
+    # explicitly with astimezone() avoids any subtle miss.
     by_hour: dict[datetime, AirportForecastSnapshotRow] = {}
     for r in rows:
         fh = r.forecast_hour
-        if fh.tzinfo is None:
-            fh = fh.replace(tzinfo=timezone.utc)
+        fh = fh.replace(tzinfo=timezone.utc) if fh.tzinfo is None else fh.astimezone(timezone.utc)
         if fh not in by_hour:
             by_hour[fh] = r
 
     result: list[dict[str, Any]] = []
     for h in hours:
-        # Match either tz-aware or naive (DBs vary).
-        row = by_hour.get(h) or by_hour.get(h.replace(tzinfo=None))
+        row = by_hour.get(h)
         if row is None:
             continue
         result.append({
@@ -279,10 +292,13 @@ def _fetch_pressure_levels(
     lon: float,
     model: str,
     hours: list[datetime],
-):
+) -> Any:
     """Fetch hourly pressure-level data from Open-Meteo for one airport.
 
-    Returns a WaypointForecast (or None on failure).
+    Returns a ``WaypointForecast`` (or ``None`` on failure). The annotation
+    is ``Any`` rather than the real type to keep ``weatherbrief.models``
+    out of this module's import graph — matches the lazy-import pattern
+    used elsewhere in this file.
     """
     from weatherbrief.fetch.open_meteo import OpenMeteoClient
     from weatherbrief.models import RoutePoint
@@ -376,18 +392,23 @@ def _grib_enrich_levels(
     if waypoint_forecast is None or not hours:
         return {"sources": {}, "skipped": {"all": "no_levels"}}
 
-    # Fast preflight: if nothing is configured locally, skip the heavy
-    # call entirely so dev environments don't pay a futile S3 round-trip
-    # on every right-click. The check is intentionally cheap and
-    # conservative — production deployments set ECMWF_GRIB_DIR to a real
-    # populated directory; dev typically doesn't.
+    # Fast preflight: skip the heavy call when no local GRIB is
+    # configured so dev environments don't pay a futile S3 round-trip
+    # on every right-click.
+    #
+    # Assumption: production deployments that have ICON-EU and/or GFS
+    # enrichment configured ALSO have ECMWF_GRIB_DIR populated — the
+    # three sources are wired together in the same deploy and we
+    # haven't seen a partial setup in the wild. ECMWF presence is a
+    # cheap proxy for "is this prod?" without scanning each source's
+    # cache directory. If a deployment ever ships ICON/GFS without
+    # ECMWF, this check would silently skip enrichment for it; revisit
+    # then.
     from weatherbrief.fetch.grib.ecmwf_fetch import ecmwf_grib_dir
     ecmwf_dir = ecmwf_grib_dir()
     # is_dir() returns False for nonexistent paths — no exception risk.
     if not (ecmwf_dir.is_dir() and any(ecmwf_dir.iterdir())):
         return {"sources": {}, "skipped": {"all": "no_local_grib_configured"}}
-
-    from datetime import timezone as _tz
 
     from weatherbrief.fetch.grib import enrich_forecasts
     from weatherbrief.models import RouteCrossSection, RoutePoint
@@ -397,7 +418,7 @@ def _grib_enrich_levels(
     cs = RouteCrossSection(
         model=src,
         route_points=[point],
-        fetched_at=datetime.now(_tz.utc),
+        fetched_at=datetime.now(timezone.utc),
         point_forecasts=[waypoint_forecast],
     )
 
@@ -577,11 +598,13 @@ async def get_airport_profile(
             # (e.g. PermissionError on iterdir()) don't kill the stream — the
             # client still gets the derived phase on the unenriched profile.
             #
-            # Wrapped in `_grib_dedup.lock_for(model, hours[0])` so two
-            # concurrent panels for the same model+hour don't both download
-            # the same GRIB file. The second panel waits for the first's
-            # enrichment to finish, then enters with a warm cache. See #123
-            # for the deeper cache-layer atomicity issue.
+            # Serialise concurrent enrichment calls that share both
+            # model and forecast start hour. Catches the common bursty
+            # pattern (multiple users right-clicking different airports
+            # while the map's hour selector hasn't moved); does NOT
+            # catch two requests whose forecast hours differ but whose
+            # underlying GRIB run is the same. See #123 for the deeper
+            # cache-layer atomicity fix that supersedes this lock.
             if enrich and wf is not None:
                 run_lock = _grib_dedup.lock_for(model, int(hours[0].timestamp()))
                 async with run_lock:

--- a/src/weatherbrief/api/airport_profile.py
+++ b/src/weatherbrief/api/airport_profile.py
@@ -1,0 +1,366 @@
+"""Airport profile SSE endpoint for the forecast map's right-click panel.
+
+Provides a phased SSE stream so the frontend can paint axes immediately,
+fill in surface scalars from cache, then layer in pressure-level data
+(Open-Meteo) and the analyzed sounding once they're ready.
+
+Phases:
+  surface  — airport_forecast_snapshots cache (~0ms)
+  levels   — Open-Meteo per-airport pressure-level fetch (1–2s)
+  derived  — analyze_sounding on combined data (~50ms)
+  complete — done
+
+Each phase event carries the partial data the client needs to render
+that layer; the client doesn't need to wait for `complete` to start
+showing anything.
+
+Note: GRIB enrichment (the `enriched` phase in the design doc) is not
+yet implemented. The frontend tolerates its absence — derived runs on
+the levels-only profile when no enriched payload arrives.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json as json_mod
+import logging
+from collections.abc import AsyncGenerator
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi.responses import StreamingResponse
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from flyfun_common.db import current_user_id, get_db
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/maps", tags=["maps"])
+
+_VALID_MODELS = ("gfs", "icon", "ecmwf")
+_DEFAULT_WINDOW_H = 3  # selected hour + 3 forward = 4 forecast hours
+
+
+def _airports_db(request: Request) -> str:
+    return request.app.state.db_path
+
+
+def _resolve_airport_coords(icao: str, airports_db_path: str) -> tuple[float, float, float | None] | None:
+    """Look up an ICAO's lat/lon/elevation from the euro_aip database.
+
+    Returns (lat, lon, elevation_ft) or None if not found.
+    """
+    from weatherbrief.airports import _load_airport_model
+
+    model = _load_airport_model(airports_db_path)
+    apt = model.airports.get(icao)
+    if apt is None:
+        return None
+    # euro_aip's Airport model field name varies — try common spellings.
+    elev_ft = None
+    for attr in ("elevation_ft", "elevation_feet"):
+        v = getattr(apt, attr, None)
+        if v is not None:
+            elev_ft = float(v)
+            break
+    if elev_ft is None:
+        # Fall back to meters → feet if available.
+        elev_m = getattr(apt, "elevation_m", None) or getattr(apt, "elevation_meters", None)
+        if elev_m is not None:
+            elev_ft = float(elev_m) * 3.28084
+    return float(apt.latitude_deg), float(apt.longitude_deg), elev_ft
+
+
+def _model_to_source(model: str):
+    """Map model id to OpenMeteo ModelSource."""
+    from weatherbrief.models import ModelSource
+
+    return {
+        "gfs": ModelSource.GFS,
+        "icon": ModelSource.ICON,
+        "ecmwf": ModelSource.ECMWF,
+    }[model]
+
+
+def _build_hours(start_hour: datetime, window_h: int) -> list[datetime]:
+    """Return the [start, start+1, ..., start+window_h] hour list."""
+    return [start_hour + timedelta(hours=i) for i in range(window_h + 1)]
+
+
+def _surface_from_cache(
+    db: Session,
+    icao: str,
+    model: str,
+    hours: list[datetime],
+) -> list[dict[str, Any]]:
+    """Read surface fields from airport_forecast_snapshots for each hour.
+
+    Picks the most recent snapshot per (icao, model, forecast_hour). Hours
+    with no data simply don't appear in the result; the frontend treats
+    those as gaps.
+    """
+    from weatherbrief.db.models import AirportForecastSnapshotRow
+
+    if not hours:
+        return []
+
+    rows = db.execute(
+        select(AirportForecastSnapshotRow)
+        .where(AirportForecastSnapshotRow.icao == icao)
+        .where(AirportForecastSnapshotRow.model == model)
+        .where(AirportForecastSnapshotRow.forecast_hour.in_(hours))
+        .order_by(
+            AirportForecastSnapshotRow.forecast_hour.asc(),
+            AirportForecastSnapshotRow.model_init_time.desc(),
+        )
+    ).scalars().all()
+
+    # Pick the freshest snapshot per forecast_hour (latest model_init_time).
+    by_hour: dict[datetime, AirportForecastSnapshotRow] = {}
+    for r in rows:
+        fh = r.forecast_hour
+        if fh.tzinfo is None:
+            fh = fh.replace(tzinfo=timezone.utc)
+        if fh not in by_hour:
+            by_hour[fh] = r
+
+    result: list[dict[str, Any]] = []
+    for h in hours:
+        # Match either tz-aware or naive (DBs vary).
+        row = by_hour.get(h) or by_hour.get(h.replace(tzinfo=None))
+        if row is None:
+            continue
+        result.append({
+            "time": h.isoformat(),
+            "temperature_2m_c": row.temperature_2m_c,
+            "dewpoint_2m_c": row.dewpoint_2m_c,
+            "visibility_m": row.visibility_m,
+            "wind_speed_kt": row.wind_speed_10m_kt,
+            "wind_direction_deg": row.wind_direction_10m_deg,
+            "wind_gusts_kt": row.wind_gusts_10m_kt,
+            "precipitation_mm": row.precipitation_mm,
+            "snowfall_cm": row.snowfall_cm,
+            "cape_jkg": row.cape_jkg,
+            "cloud_cover_pct": row.cloud_cover_pct,
+            "cloud_cover_low_pct": row.cloud_cover_low_pct,
+            "ceiling_ft": row.nwp_ceiling_ft or row.sounding_ceiling_ft,
+            "freezing_level_ft": row.freezing_level_ft,
+        })
+    return result
+
+
+def _fetch_pressure_levels(
+    lat: float,
+    lon: float,
+    model: str,
+    hours: list[datetime],
+):
+    """Fetch hourly pressure-level data from Open-Meteo for one airport.
+
+    Returns a WaypointForecast (or None on failure).
+    """
+    from weatherbrief.fetch.open_meteo import OpenMeteoClient
+    from weatherbrief.models import RoutePoint
+
+    if not hours:
+        return None
+
+    client = OpenMeteoClient(timeout=30)
+    point = RoutePoint(
+        lat=lat, lon=lon, distance_from_origin_nm=0.0,
+    )
+    start_date = hours[0].date().isoformat()
+    end_date = hours[-1].date().isoformat()
+
+    try:
+        forecasts = client.fetch_multi_point(
+            [point], _model_to_source(model),
+            start_date=start_date, end_date=end_date,
+        )
+    except Exception:
+        logger.warning(
+            "Airport profile: pressure-level fetch failed for %s/%s",
+            model, lat, exc_info=True,
+        )
+        return None
+    return forecasts[0] if forecasts else None
+
+
+def _hourly_to_dict(h) -> dict[str, Any]:
+    """Project a HourlyForecast to a serializable dict (levels included)."""
+    return {
+        "time": h.time.isoformat() if hasattr(h.time, "isoformat") else str(h.time),
+        "temperature_2m_c": h.temperature_2m_c,
+        "dewpoint_2m_c": h.dewpoint_2m_c,
+        "wind_speed_10m_kt": h.wind_speed_10m_kt,
+        "wind_direction_10m_deg": h.wind_direction_10m_deg,
+        "wind_gusts_10m_kt": h.wind_gusts_10m_kt,
+        "cape_jkg": h.cape_jkg,
+        "cloud_cover_pct": h.cloud_cover_pct,
+        "cloud_cover_low_pct": h.cloud_cover_low_pct,
+        "freezing_level_m": h.freezing_level_m,
+        "visibility_m": h.visibility_m,
+        "pressure_levels": [
+            {
+                "pressure_hpa": pl.pressure_hpa,
+                "altitude_ft": (pl.geopotential_height_m * 3.28084) if pl.geopotential_height_m is not None else None,
+                "temperature_c": pl.temperature_c,
+                "dewpoint_c": pl.dewpoint_c,
+                "wind_speed_kt": pl.wind_speed_kt,
+                "wind_direction_deg": pl.wind_direction_deg,
+                "relative_humidity_pct": pl.relative_humidity_pct,
+                "cloud_area_fraction_pct": pl.cloud_area_fraction_pct,
+            }
+            for pl in (h.pressure_levels or [])
+        ],
+    }
+
+
+def _build_derived_payload(
+    waypoint_forecast,
+    hours: list[datetime],
+) -> list[dict[str, Any]]:
+    """Run analyze_sounding on each hour and build per-point analysis dicts."""
+    from weatherbrief.analysis.sounding import analyze_sounding
+
+    if waypoint_forecast is None:
+        return []
+
+    # Index hourly entries by their UTC time (naive form for matching).
+    by_time: dict[Any, Any] = {}
+    for h in waypoint_forecast.hourly:
+        ht = h.time.replace(tzinfo=None) if hasattr(h.time, "tzinfo") and h.time.tzinfo else h.time
+        by_time[ht] = h
+
+    results: list[dict[str, Any]] = []
+    for idx, target_hour in enumerate(hours):
+        hourly = by_time.get(target_hour.replace(tzinfo=None))
+        if hourly is None or not hourly.pressure_levels:
+            continue
+        try:
+            sa = analyze_sounding(hourly.pressure_levels, hourly)
+        except Exception:
+            logger.debug(
+                "analyze_sounding failed for airport profile hour %s",
+                target_hour, exc_info=True,
+            )
+            sa = None
+        if sa is None:
+            continue
+        results.append({
+            "point_index": idx,
+            "time": target_hour.isoformat(),
+            "sounding": sa.model_dump(mode="json"),
+        })
+    return results
+
+
+@router.get("/airport-profile")
+async def get_airport_profile(
+    icao: str = Query(..., description="Airport ICAO code"),
+    model: str = Query(default="ecmwf", description="Weather model: gfs / icon / ecmwf"),
+    start_hour: str = Query(..., description="ISO 8601 UTC start hour, e.g. 2026-05-07T12:00:00Z"),
+    window_h: int = Query(default=_DEFAULT_WINDOW_H, ge=0, le=12),
+    request: Request = None,  # type: ignore[assignment]
+    _user_id: str = Depends(current_user_id),
+    db: Session = Depends(get_db),
+    airports_db: str = Depends(_airports_db),
+):
+    """Stream airport profile data via Server-Sent Events.
+
+    Phases (each emitted as a separate SSE event):
+      - meta:    icao, lat/lon, elevation, hours covered
+      - surface: cached surface fields per hour
+      - levels:  raw pressure-level data per hour (Open-Meteo)
+      - derived: analyzed sounding (clouds, icing, CAT, indices) per hour
+      - complete or error
+    """
+    icao = icao.upper()
+    if model not in _VALID_MODELS:
+        raise HTTPException(status_code=400, detail=f"Invalid model: {model}")
+
+    try:
+        start_dt = datetime.fromisoformat(start_hour.replace("Z", "+00:00"))
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid start_hour (expected ISO 8601)")
+    if start_dt.tzinfo is None:
+        start_dt = start_dt.replace(tzinfo=timezone.utc)
+    else:
+        start_dt = start_dt.astimezone(timezone.utc)
+    # Snap to top-of-hour
+    start_dt = start_dt.replace(minute=0, second=0, microsecond=0)
+
+    coords = _resolve_airport_coords(icao, airports_db)
+    if coords is None:
+        raise HTTPException(status_code=404, detail=f"Airport {icao} not found")
+    lat, lon, elevation_ft = coords
+
+    hours = _build_hours(start_dt, window_h)
+
+    # Snapshot surface from cache before opening the long-lived stream so
+    # any DB error surfaces as a normal HTTP error (cleaner UX than an
+    # SSE error mid-stream).
+    surface = _surface_from_cache(db, icao, model, hours)
+
+    async def event_generator() -> AsyncGenerator[str, None]:
+        def _event(event_type: str, payload: dict) -> str:
+            return f"event: {event_type}\ndata: {json_mod.dumps(payload, default=str)}\n\n"
+
+        # Phase 0 (meta): instant — lets the client size the canvas.
+        meta = {
+            "type": "meta",
+            "icao": icao,
+            "lat": lat,
+            "lon": lon,
+            "elevation_ft": elevation_ft,
+            "model": model,
+            "start_hour": start_dt.isoformat(),
+            "window_h": window_h,
+            "hours": [h.isoformat() for h in hours],
+        }
+        yield _event("meta", meta)
+
+        # Phase 1 (surface): cached scalars.
+        yield _event("surface", {"type": "surface", "hours": surface})
+
+        # Phase 2 (levels) — runs in a thread since it does network I/O.
+        loop = asyncio.get_event_loop()
+        try:
+            wf = await loop.run_in_executor(
+                None, _fetch_pressure_levels, lat, lon, model, hours,
+            )
+        except Exception as exc:
+            logger.warning("Airport profile: levels fetch raised: %s", exc, exc_info=True)
+            wf = None
+
+        if wf is not None:
+            # Filter to the requested hours. Open-Meteo can return naive
+            # datetimes; normalize before matching.
+            target_set = {h.replace(tzinfo=None) for h in hours}
+            kept = []
+            for h in wf.hourly:
+                ht = h.time.replace(tzinfo=None) if hasattr(h.time, "tzinfo") and h.time.tzinfo else h.time
+                if ht in target_set:
+                    kept.append(_hourly_to_dict(h))
+            yield _event("levels", {"type": "levels", "hours": kept})
+        else:
+            yield _event("levels", {"type": "levels", "hours": [], "error": "fetch_failed"})
+
+        # Phase 3 (derived) — analyze_sounding on the levels.
+        derived = await loop.run_in_executor(
+            None, _build_derived_payload, wf, hours,
+        )
+        yield _event("derived", {"type": "derived", "points": derived})
+
+        yield _event("complete", {"type": "complete"})
+
+    return StreamingResponse(
+        event_generator(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "X-Accel-Buffering": "no",
+        },
+    )

--- a/src/weatherbrief/api/airport_profile.py
+++ b/src/weatherbrief/api/airport_profile.py
@@ -2,21 +2,21 @@
 
 Provides a phased SSE stream so the frontend can paint axes immediately,
 fill in surface scalars from cache, then layer in pressure-level data
-(Open-Meteo) and the analyzed sounding once they're ready.
+(Open-Meteo), augment with local-GRIB sources where available, and run
+the sounding analysis on the assembled profile.
 
 Phases:
+  meta     — icao + lat/lon/elevation + hour list (~0ms)
   surface  — airport_forecast_snapshots cache (~0ms)
   levels   — Open-Meteo per-airport pressure-level fetch (1–2s)
-  derived  — analyze_sounding on combined data (~50ms)
+  enriched — local-GRIB augmentation via fetch.grib.enrich_forecasts (up to ~10s)
+  derived  — analyze_sounding on the (possibly-enriched) profile (~50ms)
   complete — done
 
 Each phase event carries the partial data the client needs to render
 that layer; the client doesn't need to wait for `complete` to start
-showing anything.
-
-Note: GRIB enrichment (the `enriched` phase in the design doc) is not
-yet implemented. The frontend tolerates its absence — derived runs on
-the levels-only profile when no enriched payload arrives.
+showing anything. The `enriched` phase is skipped fast-path when no
+local GRIB is configured (see `_grib_enrich_levels`).
 """
 
 from __future__ import annotations
@@ -281,8 +281,8 @@ def _grib_enrich_levels(
     # populated directory; dev typically doesn't.
     from weatherbrief.fetch.grib.ecmwf_fetch import ecmwf_grib_dir
     ecmwf_dir = ecmwf_grib_dir()
-    has_ecmwf_dir = ecmwf_dir.exists() and any(ecmwf_dir.iterdir()) if ecmwf_dir.exists() else False
-    if not has_ecmwf_dir:
+    # is_dir() returns False for nonexistent paths — no exception risk.
+    if not (ecmwf_dir.is_dir() and any(ecmwf_dir.iterdir())):
         return {"sources": {}, "skipped": {"all": "no_local_grib_configured"}}
 
     from datetime import timezone as _tz
@@ -313,7 +313,7 @@ def _grib_enrich_levels(
         )
     except Exception:
         logger.warning("Airport profile: GRIB enrichment failed", exc_info=True)
-        return {"sources": {}, "skipped": "exception"}
+        return {"sources": {}, "skipped": {"all": "exception"}}
 
     sources: dict[str, dict[str, Any]] = {}
     for m, ts in grib_init_times.items():

--- a/src/weatherbrief/api/airport_profile.py
+++ b/src/weatherbrief/api/airport_profile.py
@@ -45,6 +45,18 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/maps", tags=["maps"])
 
 _VALID_MODELS = ("gfs", "icon", "ecmwf")
+
+# Reuse the briefing pipeline's progress labels so the panel's status row
+# reads the same as /refresh/stream. Mapping is phase → stage_name in
+# packs._STAGE_LABELS. The `surface` phase has no analogue (the briefing
+# pipeline doesn't read a surface cache); we emit a generic label for it.
+# Keys are looked up lazily inside the SSE generator so a circular import
+# from packs (which itself imports from many places) can't break startup.
+_PHASE_TO_STAGE: dict[str, str] = {
+    "levels": "fetch_forecasts",
+    "enriched": "grib_enrichment",
+    "derived": "waypoint_analysis",
+}
 _DEFAULT_WINDOW_H = 3  # selected hour + 3 forward = 4 forecast hours
 
 
@@ -539,7 +551,18 @@ async def get_airport_profile(
     _limiter.acquire(_user_id)
 
     async def event_generator() -> AsyncGenerator[str, None]:
+        # Lazy import to avoid an import cycle at module load (packs.py
+        # is heavy and pulls in much of the API surface).
+        from weatherbrief.api.packs import _STAGE_LABELS
+
+        def _label_for(phase: str) -> str | None:
+            stage = _PHASE_TO_STAGE.get(phase)
+            return _STAGE_LABELS.get(stage) if stage else None
+
         def _event(event_type: str, payload: dict) -> str:
+            label = _label_for(event_type)
+            if label and "label" not in payload:
+                payload = {**payload, "label": label}
             return f"event: {event_type}\ndata: {json_mod.dumps(payload, default=str)}\n\n"
 
         def _error_event(phase: str, message: str) -> str:

--- a/src/weatherbrief/api/app.py
+++ b/src/weatherbrief/api/app.py
@@ -48,6 +48,7 @@ from weatherbrief.api.credits import (
 from weatherbrief.api.feedback import router as feedback_router
 from weatherbrief.api.messages import admin_router as messages_admin_router, router as messages_router
 from weatherbrief.api.maps import router as maps_router
+from weatherbrief.api.airport_profile import router as airport_profile_router
 from weatherbrief.api.hewson_map import router as hewson_map_router
 from weatherbrief.api.models import router as models_router
 from weatherbrief.api.tokens import router as tokens_router
@@ -342,6 +343,7 @@ def create_app() -> FastAPI:
     app.include_router(messages_router, prefix="/api")
     app.include_router(messages_admin_router, prefix="/api")
     app.include_router(maps_router, prefix="/api")
+    app.include_router(airport_profile_router, prefix="/api")
     app.include_router(hewson_map_router, prefix="/api")
     app.include_router(tokens_router, prefix="/api")
     app.include_router(models_router, prefix="/api")

--- a/src/weatherbrief/api/deps.py
+++ b/src/weatherbrief/api/deps.py
@@ -1,0 +1,24 @@
+"""Shared FastAPI dependency functions for the API package.
+
+Extracted to avoid duplication between modules that need the same
+app-state values (the `Request`-keyed accessors). Add new accessors
+here when more than one router needs them — single-use accessors can
+stay private to their module.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi import Request
+
+
+def airports_db(request: Request) -> str:
+    """Path to the euro_aip airports SQLite database."""
+    return request.app.state.db_path
+
+
+def data_dir(request: Request) -> Path:
+    """Shared data directory (DATA_DIR env var). Houses GRIB cache,
+    pack snapshots, and other per-deployment artifacts."""
+    return request.app.state.data_dir

--- a/src/weatherbrief/api/maps.py
+++ b/src/weatherbrief/api/maps.py
@@ -14,7 +14,7 @@ import logging
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 
 from flyfun_common.db import current_user_id, get_db
@@ -26,8 +26,7 @@ router = APIRouter(prefix="/maps", tags=["maps"])
 from weatherbrief.tasks.standalone_verification import SAMPLE_HOURS_UTC as _SAMPLE_HOURS
 
 
-def _airports_db(request: Request) -> str:
-    return request.app.state.db_path
+from weatherbrief.api.deps import airports_db as _airports_db
 
 
 @router.get("/forecast")

--- a/tests/test_airport_profile.py
+++ b/tests/test_airport_profile.py
@@ -14,6 +14,7 @@ not easy to exercise in unit tests; what we can pin down here is:
 """
 from __future__ import annotations
 
+import asyncio
 import json
 from datetime import datetime, timezone
 from pathlib import Path
@@ -240,3 +241,133 @@ class TestGribEnrichSkippedShape:
         )
         assert isinstance(result["skipped"], dict)
         assert result["skipped"] == {"all": "no_local_grib_configured"}
+
+
+# ---------------------------------------------------------------------------
+# Concurrency: per-user / global stream limiter (PR #122 design discussion).
+#
+# Bursty right-clicks on the forecast map could otherwise saturate the thread
+# pool. The limiter is light (just two int counters) — no queue, no progress
+# polling, no flight_id dedup like packs._RefreshRegistry. Tests below pin
+# the cap behavior + acquire/release symmetry.
+# ---------------------------------------------------------------------------
+
+
+class TestStreamLimiter:
+    def test_acquire_release_cycle(self):
+        from weatherbrief.api.airport_profile import _StreamLimiter
+
+        limiter = _StreamLimiter(max_per_user=3, max_global=10)
+        assert limiter.snapshot()["global"] == 0
+
+        limiter.acquire("alice")
+        limiter.acquire("alice")
+        assert limiter.snapshot() == {"global": 2, "users": 1}
+
+        limiter.release("alice")
+        limiter.release("alice")
+        assert limiter.snapshot() == {"global": 0, "users": 0}
+
+    def test_per_user_cap_returns_429(self):
+        from fastapi import HTTPException
+
+        from weatherbrief.api.airport_profile import _StreamLimiter
+
+        limiter = _StreamLimiter(max_per_user=2, max_global=10)
+        limiter.acquire("alice")
+        limiter.acquire("alice")
+
+        with pytest.raises(HTTPException) as exc_info:
+            limiter.acquire("alice")
+        assert exc_info.value.status_code == 429
+        assert "limit 2" in str(exc_info.value.detail)
+
+        # Other users are unaffected by alice's cap.
+        limiter.acquire("bob")
+        assert limiter.snapshot()["global"] == 3
+
+    def test_global_cap_returns_429(self):
+        from fastapi import HTTPException
+
+        from weatherbrief.api.airport_profile import _StreamLimiter
+
+        limiter = _StreamLimiter(max_per_user=10, max_global=2)
+        limiter.acquire("alice")
+        limiter.acquire("bob")
+
+        with pytest.raises(HTTPException) as exc_info:
+            limiter.acquire("carol")
+        assert exc_info.value.status_code == 429
+        assert "Server busy" in exc_info.value.detail
+
+    def test_release_below_zero_is_safe(self):
+        """Defensive: a doubled release shouldn't underflow into negative
+        counts. Could happen if the synchronous release-on-construction-
+        error path collides with the generator's finally — both should
+        be tolerated."""
+        from weatherbrief.api.airport_profile import _StreamLimiter
+
+        limiter = _StreamLimiter(max_per_user=2, max_global=5)
+        limiter.acquire("alice")
+        limiter.release("alice")
+        limiter.release("alice")  # extra release
+        assert limiter.snapshot() == {"global": 0, "users": 0}
+
+
+class TestGribRunDedup:
+    """Two simultaneous panels for the same (model, run) should serialise
+    their enrichment phase. Locks for different keys must NOT serialise."""
+
+    def test_same_key_returns_same_lock(self):
+        from weatherbrief.api.airport_profile import _GribRunDedup
+
+        dedup = _GribRunDedup()
+        a = dedup.lock_for("ecmwf", 1717000000)
+        b = dedup.lock_for("ecmwf", 1717000000)
+        assert a is b
+
+    def test_different_keys_return_different_locks(self):
+        from weatherbrief.api.airport_profile import _GribRunDedup
+
+        dedup = _GribRunDedup()
+        a = dedup.lock_for("ecmwf", 1717000000)
+        b = dedup.lock_for("ecmwf", 1717003600)  # different run
+        c = dedup.lock_for("gfs", 1717000000)    # different model
+        assert a is not b
+        assert a is not c
+        assert b is not c
+
+    def test_none_init_uses_sentinel_key(self):
+        """Before the GRIB run resolves we don't know its init time. The
+        dedup pool buckets all None-init requests under one sentinel so a
+        burst still serialises rather than racing the cold cache."""
+        from weatherbrief.api.airport_profile import _GribRunDedup
+
+        dedup = _GribRunDedup()
+        a = dedup.lock_for("ecmwf", None)
+        b = dedup.lock_for("ecmwf", None)
+        assert a is b
+
+    @pytest.mark.asyncio
+    async def test_lock_serialises_concurrent_acquirers(self):
+        """Mechanical: two coroutines acquiring the same lock interleave
+        their critical sections in order, not in parallel."""
+        from weatherbrief.api.airport_profile import _GribRunDedup
+
+        dedup = _GribRunDedup()
+        lock = dedup.lock_for("ecmwf", 1717000000)
+        order: list[str] = []
+
+        async def worker(name: str, hold_s: float) -> None:
+            async with lock:
+                order.append(f"{name}:enter")
+                await asyncio.sleep(hold_s)
+                order.append(f"{name}:exit")
+
+        await asyncio.gather(worker("a", 0.01), worker("b", 0.01))
+
+        # Either a→a→b→b or b→b→a→a (no interleave like a→b→a→b).
+        assert order in (
+            ["a:enter", "a:exit", "b:enter", "b:exit"],
+            ["b:enter", "b:exit", "a:enter", "a:exit"],
+        )

--- a/tests/test_airport_profile.py
+++ b/tests/test_airport_profile.py
@@ -1,0 +1,35 @@
+"""Smoke tests for the airport profile SSE helpers.
+
+The SSE endpoint itself depends on Open-Meteo and the airports DB so it's
+not easy to exercise in unit tests; what we can pin down here is the
+purely-functional helpers (hour-window construction, time-key matching).
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from weatherbrief.api.airport_profile import _build_hours, _DEFAULT_WINDOW_H
+
+
+def test_build_hours_default_window():
+    start = datetime(2026, 5, 7, 12, 0, tzinfo=timezone.utc)
+    hours = _build_hours(start, _DEFAULT_WINDOW_H)
+    assert len(hours) == _DEFAULT_WINDOW_H + 1
+    assert hours[0] == start
+    assert hours[-1].hour == start.hour + _DEFAULT_WINDOW_H
+    # All hours are aware UTC.
+    assert all(h.tzinfo is not None for h in hours)
+
+
+def test_build_hours_zero_window_is_single_point():
+    start = datetime(2026, 5, 7, 12, 0, tzinfo=timezone.utc)
+    hours = _build_hours(start, 0)
+    assert hours == [start]
+
+
+def test_build_hours_crosses_midnight():
+    start = datetime(2026, 5, 7, 22, 0, tzinfo=timezone.utc)
+    hours = _build_hours(start, 3)  # 22, 23, 00, 01
+    assert [h.hour for h in hours] == [22, 23, 0, 1]
+    assert hours[0].day == 7
+    assert hours[-1].day == 8

--- a/tests/test_airport_profile.py
+++ b/tests/test_airport_profile.py
@@ -1,12 +1,24 @@
 """Smoke tests for the airport profile SSE helpers.
 
 The SSE endpoint itself depends on Open-Meteo and the airports DB so it's
-not easy to exercise in unit tests; what we can pin down here is the
-purely-functional helpers (hour-window construction, time-key matching).
+not easy to exercise in unit tests; what we can pin down here is:
+
+  1. Purely-functional helpers (hour-window construction, time-key matching).
+  2. The JSON-encoder discipline that protects the SSE stream from
+     silently dying on a non-JSON-trivial field — a class of bug the
+     briefing pipeline shipped once (PR #107: ``Diagnostic.error_id: UUID``
+     killed every refresh stream). See ``test_api.py::TestRefreshStreamEncoder``
+     for the canonical version of this guard.
+  3. The ``_grib_enrich_levels`` return-shape contract (string-vs-dict
+     regression guard from the PR review of #122).
 """
 from __future__ import annotations
 
+import json
 from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
 
 from weatherbrief.api.airport_profile import _build_hours, _DEFAULT_WINDOW_H
 
@@ -33,3 +45,198 @@ def test_build_hours_crosses_midnight():
     assert [h.hour for h in hours] == [22, 23, 0, 1]
     assert hours[0].day == 7
     assert hours[-1].day == 8
+
+
+# ---------------------------------------------------------------------------
+# JSON-encoder discipline (mirrors test_api.py::TestRefreshStreamEncoder).
+#
+# The /api/maps/airport-profile SSE generator builds events as raw dicts
+# and serialises with ``json_mod.dumps(payload, default=str)``. The
+# ``derived`` event embeds a ``SoundingAnalysis.model_dump(mode="json")``
+# payload, which is a much larger Pydantic structure than the briefing's
+# pack response — every datetime, UUID, Enum, or other non-JSON-trivial
+# field added to ``SoundingAnalysis`` (or any of its nested models) flows
+# through this encoder.
+#
+# Two layers of defense, each tested below:
+#   1. The route uses ``model_dump(mode="json")`` so Pydantic stringifies
+#      UUID/datetime/Enum on its way out.
+#   2. The route uses ``json.dumps(..., default=str)`` as a backstop in
+#      case mode="json" misses something (or someone adds a fresh
+#      json_mod.dumps call without it — see the structural lint test).
+# ---------------------------------------------------------------------------
+
+
+class TestAirportProfileEncoder:
+    """The same class of regression that killed /refresh/stream once."""
+
+    def test_derived_event_round_trips_through_sse_encoder(self):
+        """Build a real SoundingAnalysis (the heaviest payload the
+        airport-profile stream emits), run it through the exact
+        two-step encode the route does, and decode back. Catches any
+        future field on SoundingAnalysis (or its nested models) that
+        plain ``json.dumps`` can't handle.
+        """
+        from weatherbrief.models.analysis import (
+            ConvectiveAssessment, IcingRisk, SoundingAnalysis, ThermodynamicIndices,
+        )
+
+        # Construct a SoundingAnalysis with the kind of fields most likely
+        # to surface a non-trivial encoder issue: enums (IcingRisk),
+        # nested Pydantic models, datetimes if/when added.
+        sa = SoundingAnalysis(
+            indices=ThermodynamicIndices(
+                lcl_pressure_hpa=950.0,
+                lcl_altitude_ft=2000.0,
+                cape_surface_jkg=350.0,
+                cin_surface_jkg=-25.0,
+                lifted_index=2.5,
+                freezing_level_ft=10000.0,
+            ),
+            convective=ConvectiveAssessment(risk_level=IcingRisk.NONE),
+        )
+
+        # Step 1: same model_dump call the route makes.
+        payload = {
+            "type": "derived",
+            "points": [{
+                "point_index": 0,
+                "time": "2026-05-07T12:00:00+00:00",
+                "sounding": sa.model_dump(mode="json"),
+            }],
+        }
+        # Step 2: same json.dumps call the route makes (default=str backstop).
+        encoded = json.dumps(payload, default=str)
+        parsed = json.loads(encoded)
+
+        assert parsed["type"] == "derived"
+        assert len(parsed["points"]) == 1
+        # Key indices fields survived through to the JSON payload.
+        survived = parsed["points"][0]["sounding"]
+        assert survived["indices"]["cape_surface_jkg"] == 350.0
+        # Enum was stringified, not left as a Python repr.
+        assert survived["convective"]["risk_level"] == IcingRisk.NONE.value
+
+    def test_meta_event_is_json_safe(self):
+        """The meta event contains the only datetime-derived strings the
+        endpoint emits (start_hour, hours[i]). They go through
+        ``_iso_utc()`` so they're already strings — but lock that in so
+        a future change that emits a raw datetime breaks here, not at
+        runtime."""
+        from weatherbrief.api.airport_profile import _build_hours, _iso_utc
+
+        start = datetime(2026, 5, 7, 12, 0, tzinfo=timezone.utc)
+        hours = _build_hours(start, _DEFAULT_WINDOW_H)
+        meta = {
+            "type": "meta",
+            "icao": "EGLL",
+            "lat": 51.4775,
+            "lon": -0.4614,
+            "elevation_ft": 83.0,
+            "model": "ecmwf",
+            "start_hour": _iso_utc(start),
+            "window_h": _DEFAULT_WINDOW_H,
+            "hours": [_iso_utc(h) for h in hours],
+        }
+        encoded = json.dumps(meta, default=str)
+        parsed = json.loads(encoded)
+        # All time strings carry the +00:00 suffix — same as derived/surface
+        # so the client's strict === match works across phases.
+        assert parsed["start_hour"].endswith("+00:00")
+        assert all(h.endswith("+00:00") for h in parsed["hours"])
+
+    def test_airport_profile_module_sse_encoders_are_json_safe(self):
+        """Structural lint, mirrored from test_api.py::TestRefreshStreamEncoder.
+
+        Every ``json_mod.dumps(...)`` call in ``airport_profile.py`` must
+        include ``default=str`` on the same line. This is the only test in
+        this class that catches a *route-level* regression — the encoder
+        round-trip tests above only lock in encoder behavior, but a future
+        patch removing ``default=str`` from a new SSE event would silently
+        revert the production guard.
+        """
+        src = (
+            Path(__file__).parent.parent
+            / "src" / "weatherbrief" / "api" / "airport_profile.py"
+        ).read_text()
+
+        bad_dumps = [
+            (i, line.strip())
+            for i, line in enumerate(src.splitlines(), 1)
+            if "json_mod.dumps(" in line and "default=str" not in line
+        ]
+        assert not bad_dumps, (
+            "Found json_mod.dumps() without default=str in airport_profile.py — "
+            "the SSE stream will silently die on any non-JSON-trivial "
+            "field (UUID, datetime, Path, Decimal, …). Add default=str.\n"
+            + "\n".join(f"  L{i}: {line}" for i, line in bad_dumps)
+        )
+
+    def test_airport_profile_model_dump_uses_json_mode(self):
+        """The ``derived`` payload embeds ``sa.model_dump(mode="json")``.
+        Without ``mode="json"``, UUID/datetime/Enum stay as Python objects
+        and die in the json.dumps downstream — the exact bug PR #107
+        shipped on /refresh/stream.
+        """
+        import re
+
+        src = (
+            Path(__file__).parent.parent
+            / "src" / "weatherbrief" / "api" / "airport_profile.py"
+        ).read_text()
+
+        # Look for any .model_dump(...) call inside this file. The lint
+        # is intentionally broad — every payload that goes into a SSE
+        # event should be json-mode-dumped.
+        pattern = re.compile(r"\.model_dump\(([^)]*)\)")
+        for match in pattern.finditer(src):
+            args = match.group(1)
+            line_no = src[: match.start()].count("\n") + 1
+            assert 'mode="json"' in args or "mode='json'" in args, (
+                f"airport_profile.py:{line_no} — .model_dump() must use "
+                f"mode='json' (got args: {args!r}). Without it, UUID/"
+                f"datetime/Enum fields stay as Python objects and die in "
+                f"the json_mod.dumps() call downstream."
+            )
+
+
+# ---------------------------------------------------------------------------
+# Contract: _grib_enrich_levels.skipped is always Dict[str, str].
+#
+# The TS adapter declares ``skipped: Record<string, string>``. The Python
+# function had four return paths — three returned dicts, one returned the
+# bare string ``"exception"`` (caught in PR review). Lock it in.
+# ---------------------------------------------------------------------------
+
+
+class TestGribEnrichSkippedShape:
+    def test_no_levels_returns_dict_skipped(self):
+        from weatherbrief.api.airport_profile import _grib_enrich_levels
+
+        result = _grib_enrich_levels(
+            None, 51.4775, -0.4614, "ecmwf", [], Path("/tmp"),
+        )
+        assert isinstance(result["skipped"], dict)
+        assert result["skipped"] == {"all": "no_levels"}
+        assert result["sources"] == {}
+
+    def test_no_grib_dir_returns_dict_skipped(self, tmp_path, monkeypatch):
+        """Force the preflight to skip by pointing ECMWF_GRIB_DIR at an
+        empty (or nonexistent) directory."""
+        from weatherbrief.api.airport_profile import _grib_enrich_levels
+        from weatherbrief.fetch.grib import ecmwf_fetch as ecmwf_mod
+
+        empty = tmp_path / "ecmwf_empty_dir"  # never created
+        monkeypatch.setattr(ecmwf_mod, "ecmwf_grib_dir", lambda: empty)
+
+        # Construct a minimal fake WaypointForecast — only used as a
+        # truthy-ness check before the preflight.
+        class _FakeWf:
+            hourly = []
+
+        hours = [datetime(2026, 5, 7, 12, 0, tzinfo=timezone.utc)]
+        result = _grib_enrich_levels(
+            _FakeWf(), 51.4775, -0.4614, "ecmwf", hours, tmp_path,
+        )
+        assert isinstance(result["skipped"], dict)
+        assert result["skipped"] == {"all": "no_local_grib_configured"}

--- a/web/maps.html
+++ b/web/maps.html
@@ -71,7 +71,11 @@
       background: var(--surface);
       border: 1px solid var(--border);
       border-radius: 8px;
-      overflow: hidden;
+      /* Was overflow:hidden for rounded-corner clipping; relaxed so the
+       * settings drawer (positioned at right:100%) can extend left over
+       * the map. The inner sections do their own clipping. */
+      overflow: visible;
+      position: relative;
     }
 
     .ap-panel { display: flex; flex-direction: column; height: calc(100vh - 280px); min-height: 400px; }
@@ -121,6 +125,91 @@
     .ap-cross, .ap-skewt { background: var(--bg); position: relative; min-height: 0; }
     .ap-cross + .ap-skewt { border-top: 1px solid var(--border); }
 
+    /* Loading state — kills the "blue sky = forecast is clear" trap by
+     * desaturating the empty canvas and overlaying a "Loading…" badge
+     * until the `derived` SSE phase lands real data. The status row
+     * (with dots-spinner) keeps showing the actual stage label. */
+    .ap-cross.is-loading > canvas,
+    .ap-skewt.is-loading > canvas {
+      filter: grayscale(0.95) opacity(0.45);
+      transition: filter 0.15s ease-out;
+    }
+    .ap-cross.is-loading::after,
+    .ap-skewt.is-loading::after {
+      content: 'Loading\2026';
+      position: absolute; inset: 0;
+      display: flex; align-items: center; justify-content: center;
+      font-size: 0.85rem; font-weight: 600;
+      color: var(--text-muted);
+      letter-spacing: 0.04em;
+      pointer-events: none;
+    }
+
+    /* Gear / settings button in the controls row. Uses the same toggle
+     * vocabulary as the briefing-page sidebar gear so users find it
+     * familiar. */
+    .ap-settings-btn {
+      margin-left: auto;
+      padding: 0.2rem 0.45rem; border: 1px solid var(--border);
+      background: var(--surface); color: var(--text); cursor: pointer;
+      border-radius: 4px; font-size: 0.9rem; line-height: 1;
+    }
+    .ap-settings-btn:hover { background: var(--bg); }
+    .ap-settings-btn.active { background: var(--primary); color: #fff; border-color: var(--primary); }
+
+    /* Settings drawer slides out to the LEFT of the panel and overlaps
+     * the map. Width is fixed; on narrow viewports the drawer drops
+     * inline below the controls instead (see media query below). */
+    .ap-settings-drawer {
+      position: absolute;
+      top: 0; right: 100%;
+      height: 100%;
+      width: 320px;
+      margin-right: 4px;
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      box-shadow: -6px 0 14px rgba(0, 0, 0, 0.15);
+      z-index: 1500;
+      overflow-y: auto;
+      padding: 0.6rem 0.7rem;
+      font-size: 0.78rem;
+    }
+    .ap-settings-drawer[hidden] { display: none; }
+    .ap-drawer-header {
+      display: flex; align-items: center; justify-content: space-between;
+      padding-bottom: 0.4rem; margin-bottom: 0.5rem;
+      border-bottom: 1px solid var(--border);
+    }
+    .ap-drawer-title { font-weight: 600; font-size: 0.85rem; }
+    .ap-drawer-close {
+      border: none; background: transparent; color: var(--text-muted);
+      font-size: 1.2rem; line-height: 1; cursor: pointer; padding: 0 0.3rem;
+    }
+    .ap-drawer-close:hover { color: var(--text); }
+    .ap-drawer-section { margin-bottom: 0.7rem; }
+    .ap-drawer-section + .ap-drawer-section {
+      border-top: 1px solid var(--border);
+      padding-top: 0.6rem;
+    }
+    .ap-drawer-section-title {
+      margin: 0 0 0.4rem 0; font-size: 0.75rem; font-weight: 600;
+      color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.04em;
+    }
+    .ap-drawer-empty { color: var(--text-muted); font-style: italic; padding: 0.3rem 0; }
+    /* Reused viz layer-toggle styling: tighter line height + wrap inside
+     * the narrow drawer column. */
+    .ap-settings-drawer .viz-layer-toggles {
+      display: flex; flex-direction: column; gap: 0.3rem;
+    }
+    .ap-settings-drawer .viz-layer-group {
+      display: flex; flex-wrap: wrap; align-items: center; gap: 0.25rem 0.5rem;
+    }
+    .ap-settings-drawer .viz-layer-checkbox {
+      display: inline-flex; align-items: center; gap: 0.25rem;
+      font-size: 0.78rem;
+    }
+
     @media (max-width: 900px) {
       .ap-split-host { display: block; }
       .ap-split-host > .ap-panel-host {
@@ -128,6 +217,14 @@
         z-index: 2000; border-radius: 0;
       }
       .ap-panel { height: 100vh; }
+      /* No room for a left-overlap drawer on phones; render it as a
+       * full-width sheet at the bottom of the panel instead. */
+      .ap-settings-drawer {
+        position: fixed; left: 0; right: 0; bottom: 0; top: auto;
+        width: auto; height: 60vh; border-radius: 8px 8px 0 0;
+        margin-right: 0;
+        box-shadow: 0 -6px 14px rgba(0, 0, 0, 0.2);
+      }
     }
 
     /* Share-view button (page header). Shows the icon + label and

--- a/web/maps.html
+++ b/web/maps.html
@@ -56,6 +56,80 @@
 
     .map-wrapper { position: relative; }
 
+    /* --- Airport profile panel (right-click on a forecast marker) --- */
+    /* Forecast tab switches to a 2-column grid when the panel is open;
+     * the map keeps its existing height and the panel claims the right
+     * column. On narrow screens (<900px) the panel becomes a full-screen
+     * takeover so the map and detail don't fight for width. */
+    .ap-split-host { display: flex; gap: 0.5rem; position: relative; }
+    .ap-split-host > .map-wrapper { flex: 1 1 auto; min-width: 0; }
+    .ap-split-host > .ap-panel-host {
+      flex: 0 0 480px;
+      max-width: 50%;
+      min-width: 360px;
+      display: flex; flex-direction: column;
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      overflow: hidden;
+    }
+
+    .ap-panel { display: flex; flex-direction: column; height: calc(100vh - 280px); min-height: 400px; }
+    .ap-panel-header {
+      display: flex; align-items: center; justify-content: space-between;
+      padding: 0.4rem 0.6rem; border-bottom: 1px solid var(--border);
+    }
+    .ap-panel-title { font-weight: 600; font-size: 0.9rem; color: var(--text); }
+    .ap-panel-close {
+      border: none; background: transparent; color: var(--text-muted);
+      font-size: 1.4rem; line-height: 1; cursor: pointer; padding: 0 0.4rem;
+    }
+    .ap-panel-close:hover { color: var(--text); }
+    .ap-panel-controls {
+      display: flex; flex-wrap: wrap; gap: 0.5rem; align-items: center;
+      padding: 0.35rem 0.6rem; border-bottom: 1px solid var(--border);
+      font-size: 0.8rem;
+    }
+    .ap-panel-controls label { color: var(--text-muted); font-weight: 600; font-size: 0.75rem; }
+    .ap-panel-controls select {
+      padding: 0.2rem 0.4rem; border: 1px solid var(--border);
+      background: var(--surface); color: var(--text); border-radius: 4px;
+      font-size: 0.75rem;
+    }
+    .ap-panel-controls .btn-toggle {
+      padding: 0.2rem 0.5rem; border: 1px solid var(--border);
+      background: var(--surface); color: var(--text); cursor: pointer;
+      font-size: 0.75rem;
+    }
+    .ap-panel-controls .btn-group .btn-toggle:first-child { border-radius: 4px 0 0 4px; }
+    .ap-panel-controls .btn-group .btn-toggle:last-child { border-radius: 0 4px 4px 0; }
+    .ap-panel-controls .btn-group .btn-toggle:not(:first-child) { border-left: none; }
+    .ap-panel-controls .btn-toggle.active { background: var(--primary); color: #fff; border-color: var(--primary); }
+
+    .ap-panel-status {
+      padding: 0.2rem 0.6rem;
+      font-size: 0.75rem; color: var(--text-muted);
+      min-height: 1.1rem; border-bottom: 1px solid var(--border);
+    }
+    .ap-panel-status:empty { display: none; }
+
+    .ap-panel-body { flex: 1 1 auto; display: flex; flex-direction: column; min-height: 0; }
+    .ap-panel.view-both .ap-cross,
+    .ap-panel.view-both .ap-skewt { flex: 1 1 50%; min-height: 0; position: relative; }
+    .ap-panel.view-cross .ap-cross { flex: 1 1 100%; min-height: 0; position: relative; }
+    .ap-panel.view-skewt .ap-skewt { flex: 1 1 100%; min-height: 0; position: relative; }
+    .ap-cross, .ap-skewt { background: var(--bg); position: relative; min-height: 0; }
+    .ap-cross + .ap-skewt { border-top: 1px solid var(--border); }
+
+    @media (max-width: 900px) {
+      .ap-split-host { display: block; }
+      .ap-split-host > .ap-panel-host {
+        position: fixed; inset: 0; max-width: none; min-width: 0;
+        z-index: 2000; border-radius: 0;
+      }
+      .ap-panel { height: 100vh; }
+    }
+
     /* Share-view button (page header). Shows the icon + label and
      * flashes "Link copied" briefly on success. */
     .btn-share-link {
@@ -234,8 +308,11 @@
         </select>
       </div>
 
-      <div class="map-wrapper">
-        <div id="map-container"></div>
+      <div class="ap-split-host" id="forecast-split-host">
+        <div class="map-wrapper">
+          <div id="map-container"></div>
+        </div>
+        <div class="ap-panel-host" id="ap-panel-host" style="display:none"></div>
       </div>
       <div class="map-info" id="map-info"></div>
     </div>

--- a/web/ts/adapters/airport-profile-adapter.ts
+++ b/web/ts/adapters/airport-profile-adapter.ts
@@ -1,0 +1,406 @@
+/** SSE adapter + VizRouteData synthesis for the airport profile panel.
+ *
+ * Right-clicking an airport on the forecast map fires a phased SSE stream
+ * (`/api/maps/airport-profile`). This module:
+ *   1. Wraps the EventSource lifecycle (start, abort, error)
+ *   2. Translates phase events into a synthetic `VizRouteData` whose
+ *      X-axis is hours-since-start (collapsing the route's spatial
+ *      extent into a single airport), so the existing
+ *      `CrossSectionRenderer` can render without modification.
+ */
+
+import type { VizRouteData, VizPoint, AltitudeLines, VizCloudLayer, VizIcingZone, VizSfipZone, VizCATLayer, VizInversionLayer } from '../visualization/types';
+import type { SoundingProfileData, SoundingProfileLevel, ParcelPathPoint, CloudLayer, IcingZone, InversionLayer } from '../visualization/skewt/types';
+import { API_BASE } from '../utils';
+
+export interface AirportProfileMeta {
+  icao: string;
+  lat: number;
+  lon: number;
+  elevation_ft: number | null;
+  model: string;
+  start_hour: string;
+  window_h: number;
+  hours: string[];
+}
+
+export interface AirportProfileSurfaceHour {
+  time: string;
+  temperature_2m_c: number | null;
+  dewpoint_2m_c: number | null;
+  visibility_m: number | null;
+  wind_speed_kt: number | null;
+  wind_direction_deg: number | null;
+  wind_gusts_kt: number | null;
+  cape_jkg: number | null;
+  cloud_cover_pct: number | null;
+  ceiling_ft: number | null;
+  freezing_level_ft: number | null;
+}
+
+export interface AirportProfileLevelsHour {
+  time: string;
+  temperature_2m_c: number | null;
+  dewpoint_2m_c: number | null;
+  wind_speed_10m_kt: number | null;
+  wind_direction_10m_deg: number | null;
+  wind_gusts_10m_kt: number | null;
+  cape_jkg: number | null;
+  cloud_cover_pct: number | null;
+  cloud_cover_low_pct: number | null;
+  freezing_level_m: number | null;
+  visibility_m: number | null;
+  pressure_levels: Array<{
+    pressure_hpa: number;
+    altitude_ft: number | null;
+    temperature_c: number | null;
+    dewpoint_c: number | null;
+    wind_speed_kt: number | null;
+    wind_direction_deg: number | null;
+    relative_humidity_pct: number | null;
+    cloud_area_fraction_pct: number | null;
+  }>;
+}
+
+export interface AirportProfileDerivedPoint {
+  point_index: number;
+  time: string;
+  /** Server-side `SoundingAnalysis.model_dump()` payload (snake_case keys). */
+  sounding: any;
+}
+
+export interface AirportProfileSnapshot {
+  meta: AirportProfileMeta | null;
+  surface: AirportProfileSurfaceHour[];
+  levels: AirportProfileLevelsHour[];
+  derived: AirportProfileDerivedPoint[];
+}
+
+export type AirportProfilePhase = 'meta' | 'surface' | 'levels' | 'derived' | 'complete' | 'error';
+
+export interface AirportProfileStreamHandle {
+  abort(): void;
+}
+
+/** Open the SSE stream and call `onPhase` after each phase update. */
+export function streamAirportProfile(
+  params: { icao: string; model: string; startHour: string; windowH?: number },
+  onPhase: (phase: AirportProfilePhase, snapshot: AirportProfileSnapshot, raw: any) => void,
+): AirportProfileStreamHandle {
+  const qs = new URLSearchParams({
+    icao: params.icao,
+    model: params.model,
+    start_hour: params.startHour,
+  });
+  if (params.windowH !== undefined) qs.set('window_h', String(params.windowH));
+
+  const url = `${API_BASE}/maps/airport-profile?${qs.toString()}`;
+  const es = new EventSource(url, { withCredentials: true });
+  const snapshot: AirportProfileSnapshot = { meta: null, surface: [], levels: [], derived: [] };
+
+  const dispatch = (phase: AirportProfilePhase, raw: any) => onPhase(phase, snapshot, raw);
+
+  es.addEventListener('meta', (e: MessageEvent) => {
+    try {
+      const data = JSON.parse(e.data);
+      snapshot.meta = data;
+      dispatch('meta', data);
+    } catch (err) { console.warn('airport-profile: bad meta event', err); }
+  });
+  es.addEventListener('surface', (e: MessageEvent) => {
+    try {
+      const data = JSON.parse(e.data);
+      snapshot.surface = data.hours ?? [];
+      dispatch('surface', data);
+    } catch (err) { console.warn('airport-profile: bad surface event', err); }
+  });
+  es.addEventListener('levels', (e: MessageEvent) => {
+    try {
+      const data = JSON.parse(e.data);
+      snapshot.levels = data.hours ?? [];
+      dispatch('levels', data);
+    } catch (err) { console.warn('airport-profile: bad levels event', err); }
+  });
+  es.addEventListener('derived', (e: MessageEvent) => {
+    try {
+      const data = JSON.parse(e.data);
+      snapshot.derived = data.points ?? [];
+      dispatch('derived', data);
+    } catch (err) { console.warn('airport-profile: bad derived event', err); }
+  });
+  es.addEventListener('complete', () => {
+    dispatch('complete', null);
+    es.close();
+  });
+  es.addEventListener('error', (e) => {
+    dispatch('error', e);
+    es.close();
+  });
+
+  return { abort: () => es.close() };
+}
+
+// ---------------------------------------------------------------------------
+// Adapter: AirportProfileSnapshot → VizRouteData (time-axis mode)
+// ---------------------------------------------------------------------------
+
+const HOURS_TO_NM_SCALE = 1; // 1 hour = 1 "nm" on the synthetic distance axis
+
+/** Build a synthetic `VizRouteData` whose X-axis is hours-since-start.
+ *
+ * `points[i].distanceNm` carries the hour offset (i in 0..window_h). The
+ * cross-section's tick formatter checks `timeAxisMode` and renders the
+ * point's `time` as the X label instead of nautical miles.
+ *
+ * Surface-only (no levels/derived yet) still produces points with empty
+ * weather layers — the cross-section axes paint immediately, and the
+ * derived phase fills in clouds/icing/CAT/etc.
+ */
+export function snapshotToVizData(
+  snapshot: AirportProfileSnapshot,
+  options: { defaultCeilingFt?: number } = {},
+): VizRouteData | null {
+  if (!snapshot.meta) return null;
+  const { meta } = snapshot;
+  const elevationFt = meta.elevation_ft ?? 0;
+
+  // Build per-hour points. Ordering follows meta.hours so we render even
+  // when surface/derived have gaps.
+  const derivedByTime = new Map<string, AirportProfileDerivedPoint>();
+  for (const d of snapshot.derived) derivedByTime.set(d.time, d);
+  const surfaceByTime = new Map<string, AirportProfileSurfaceHour>();
+  for (const s of snapshot.surface) surfaceByTime.set(s.time, s);
+
+  const points: VizPoint[] = meta.hours.map((time, idx) => {
+    const derived = derivedByTime.get(time);
+    const sounding = derived?.sounding ?? null;
+    const surface = surfaceByTime.get(time);
+    return synthesizeVizPoint(time, idx, meta.lat, meta.lon, elevationFt, sounding, surface ?? null);
+  });
+
+  // Cap the Y axis using the highest cruise-altitude target we'd reasonably
+  // care about for an airport detail view (default 18000 ft, matching most
+  // GA briefings). The real altitude data drives the layers — this just
+  // sizes the canvas.
+  const ceilingFt = options.defaultCeilingFt ?? 18000;
+
+  return {
+    points,
+    cruiseAltitudeFt: ceilingFt,
+    ceilingAltitudeFt: ceilingFt,
+    flightCeilingFt: ceilingFt + 5000,
+    totalDistanceNm: Math.max(1, (meta.hours.length - 1) * HOURS_TO_NM_SCALE),
+    waypointMarkers: [],
+    departureTime: meta.start_hour,
+    flightDurationHours: meta.window_h,
+    terrainProfile: [
+      { distanceNm: 0, elevationFt },
+      { distanceNm: Math.max(1, (meta.hours.length - 1) * HOURS_TO_NM_SCALE), elevationFt },
+    ],
+    timeAxisMode: true,
+  };
+}
+
+function synthesizeVizPoint(
+  time: string,
+  idx: number,
+  lat: number,
+  lon: number,
+  elevationFt: number,
+  sounding: any | null,
+  surface: AirportProfileSurfaceHour | null,
+): VizPoint {
+  const indices = sounding?.indices ?? null;
+
+  const altitudeLines: AltitudeLines = {
+    freezingLevelFt: indices?.freezing_level_ft ?? null,
+    minus10cLevelFt: indices?.minus10c_level_ft ?? null,
+    minus20cLevelFt: indices?.minus20c_level_ft ?? null,
+    lclAltitudeFt: indices?.lcl_altitude_ft ?? null,
+    lfcAltitudeFt: indices?.lfc_altitude_ft ?? null,
+    elAltitudeFt: indices?.el_altitude_ft ?? null,
+  };
+
+  const cloudLayers: VizCloudLayer[] = (sounding?.cloud_layers ?? []).map((cl: any) => ({
+    baseFt: cl.base_ft, topFt: cl.top_ft, coverage: cl.coverage,
+    meanDewpointDepressionC: cl.mean_dewpoint_depression_c ?? undefined,
+    meanCloudCoverPct: cl.mean_cloud_cover_pct ?? undefined,
+    meanTemperatureC: cl.mean_temperature_c ?? undefined,
+  }));
+  const rawNwpCloudLayers = sounding?.nwp_cloud_layers ?? null;
+  const nwpCloudLayers: VizCloudLayer[] | null = rawNwpCloudLayers === null
+    ? null
+    : rawNwpCloudLayers.map((cl: any) => ({
+        baseFt: cl.base_ft, topFt: cl.top_ft, coverage: cl.coverage,
+        meanCloudCoverPct: cl.mean_cloud_cover_pct ?? undefined,
+        meanTemperatureC: cl.mean_temperature_c ?? undefined,
+        source: cl.source ?? 'dd',
+      }));
+
+  const mapIcingZone = (iz: any): VizIcingZone => ({
+    baseFt: iz.base_ft, topFt: iz.top_ft, risk: iz.risk, type: iz.icing_type,
+    meanIcingIndex: iz.mean_icing_index ?? undefined,
+    meanTemperatureC: iz.mean_temperature_c ?? undefined,
+    sldRisk: iz.sld_risk ?? undefined,
+  });
+
+  const icingZones: VizIcingZone[] = (sounding?.icing_zones ?? []).map(mapIcingZone);
+  const icingOgimetNwpZones: VizIcingZone[] = (sounding?.icing_ogimet_nwp_zones ?? []).map(mapIcingZone);
+  const iengIcingZones: VizIcingZone[] = (sounding?.ieng_icing_zones ?? []).map(mapIcingZone);
+
+  const sfipZones: VizSfipZone[] = (sounding?.sfip_zones ?? []).map((sz: any) => ({
+    baseFt: sz.base_ft, topFt: sz.top_ft, risk: sz.risk, type: sz.icing_type,
+    meanSfip100: sz.mean_sfip_100 ?? null, variant: sz.variant ?? 'full',
+    meanTemperatureC: sz.mean_temperature_c ?? undefined,
+  }));
+  const sldZones = (sounding?.sld_zones ?? []).map((sz: any) => ({
+    baseFt: sz.base_ft, topFt: sz.top_ft, risk: sz.risk,
+    mechanism: sz.mechanism ?? 'unknown',
+  }));
+  const catLayers: VizCATLayer[] = (sounding?.vertical_motion?.cat_risk_layers ?? []).map((cl: any) => ({
+    baseFt: cl.base_ft, topFt: cl.top_ft, risk: cl.risk,
+    richardsonNumber: cl.richardson_number ?? undefined,
+  }));
+  const eShearLayers: VizCATLayer[] = (sounding?.vertical_motion?.e_shear_layers ?? []).map((cl: any) => ({
+    baseFt: cl.base_ft, topFt: cl.top_ft, risk: cl.risk,
+    richardsonNumber: cl.richardson_number ?? undefined,
+  }));
+  const inversions: VizInversionLayer[] = (sounding?.inversion_layers ?? []).map((inv: any) => ({
+    baseFt: inv.base_ft, topFt: inv.top_ft, strengthC: inv.strength_c,
+    surfaceBased: inv.surface_based ?? undefined,
+  }));
+
+  const low = sounding?.cloud_cover_low_pct ?? 0;
+  const mid = sounding?.cloud_cover_mid_pct ?? 0;
+  const high = sounding?.cloud_cover_high_pct ?? 0;
+
+  return {
+    distanceNm: idx * HOURS_TO_NM_SCALE,
+    lat, lon, time,
+    altitudeLines,
+    cloudLayers, nwpCloudLayers,
+    icingZones, icingOgimetNwpZones, iengIcingZones,
+    sfipZones, sldZones,
+    catLayers, eShearLayers,
+    inversions,
+    convectiveRisk: sounding?.convective?.risk_level ?? 'none',
+    convectiveBaseFt: sounding?.convective?.base_ft ?? null,
+    convectiveTopFt: sounding?.convective?.top_ft ?? null,
+    cinSurfaceJkg: indices?.cin_surface_jkg ?? sounding?.convective?.cin_jkg ?? 0,
+    nwpConvectiveRisk: sounding?.convective_nwp?.risk_level ?? 'none',
+    nwpConvectiveBaseFt: sounding?.convective_nwp?.base_ft ?? null,
+    nwpConvectiveTopFt: sounding?.convective_nwp?.top_ft ?? null,
+    nwpConvectiveCoverPct: sounding?.convective_nwp?.cover_pct ?? null,
+    nwpConvectiveMethod: sounding?.convective_nwp?.method ?? null,
+    hasNwpConvective: sounding?.convective_nwp != null,
+    cloudCoverTotalPct: Math.min(100, low + mid + high),
+    cloudCoverLowPct: low,
+    cloudCoverMidPct: mid,
+    headwindKt: 0,
+    crosswindKt: 0,
+    capeSurfaceJkg: indices?.cape_surface_jkg ?? surface?.cape_jkg ?? 0,
+    worstModelAgreement: 'good',
+    nwpCloudDiag: null,
+    soundingCeilingFt: indices?.sounding_ceiling_ft ?? surface?.ceiling_ft ?? null,
+    terrainElevationFt: elevationFt,
+    temperatureC: surface?.temperature_2m_c ?? null,
+    precipitationMm: null,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Skew-T data: pick a single hour's derived sounding + raw levels
+// ---------------------------------------------------------------------------
+
+/** Build a `SoundingProfileData` for the Skew-T renderer from the snapshot,
+ *  selecting the hour at `hourIndex` (0 = start_hour). Returns null when
+ *  the levels phase hasn't arrived yet (caller can show a skeleton). */
+export function snapshotToSkewtData(
+  snapshot: AirportProfileSnapshot,
+  hourIndex: number = 0,
+): SoundingProfileData | null {
+  if (!snapshot.meta) return null;
+  const time = snapshot.meta.hours[hourIndex];
+  if (!time) return null;
+
+  const levelsHour = snapshot.levels.find((h) => h.time === time);
+  const derived = snapshot.derived.find((d) => d.time === time);
+  if (!levelsHour && !derived) return null;
+
+  const levels: SoundingProfileLevel[] = (levelsHour?.pressure_levels ?? [])
+    .filter((pl) => pl.temperature_c !== null)
+    .map((pl) => {
+      // DD inline (server hasn't run analyze_sounding yet for this hour).
+      let dd: number | null = null;
+      if (pl.temperature_c !== null && pl.dewpoint_c !== null) {
+        dd = +(pl.temperature_c - pl.dewpoint_c).toFixed(1);
+      }
+      return {
+        pressure_hpa: pl.pressure_hpa,
+        altitude_ft: pl.altitude_ft,
+        temperature_c: pl.temperature_c as number,
+        dewpoint_c: pl.dewpoint_c,
+        wind_speed_kt: pl.wind_speed_kt,
+        wind_direction_deg: pl.wind_direction_deg,
+        relative_humidity_pct: pl.relative_humidity_pct,
+        dewpoint_depression_c: dd,
+        wet_bulb_c: null,
+        theta_e_k: null,
+        lapse_rate_c_per_km: null,
+        icing_index: null,
+        icing_index_nwp: null,
+        sfip_100: null,
+        cloud_liquid_water_g_m3: null,
+        ice_mixing_ratio_g_kg: null,
+        cloud_area_fraction_pct: pl.cloud_area_fraction_pct,
+        richardson_number: null,
+        omega_pa_s: null,
+        w_fpm: null,
+      };
+    })
+    .sort((a, b) => b.pressure_hpa - a.pressure_hpa);
+
+  const sa = derived?.sounding ?? null;
+  const indices = sa?.indices ?? null;
+  const parcel_path: ParcelPathPoint[] = (sa?.parcel_path ?? []).map((p: any) => ({
+    pressure_hpa: p.pressure_hpa, temperature_c: p.temperature_c,
+  }));
+  const cloud_layers: CloudLayer[] = (sa?.cloud_layers ?? []).map((cl: any) => ({
+    base_ft: cl.base_ft, top_ft: cl.top_ft, coverage: cl.coverage,
+  }));
+  const nwp_cloud_layers: CloudLayer[] = (sa?.nwp_cloud_layers ?? []).map((cl: any) => ({
+    base_ft: cl.base_ft, top_ft: cl.top_ft, coverage: cl.coverage,
+  }));
+  const icing_zones: IcingZone[] = (sa?.icing_zones ?? []).map((iz: any) => ({
+    base_ft: iz.base_ft, top_ft: iz.top_ft, risk: iz.risk, icing_type: iz.icing_type,
+  }));
+  const icing_ogimet_nwp_zones: IcingZone[] = (sa?.icing_ogimet_nwp_zones ?? []).map((iz: any) => ({
+    base_ft: iz.base_ft, top_ft: iz.top_ft, risk: iz.risk, icing_type: iz.icing_type,
+  }));
+  const inversion_layers: InversionLayer[] = (sa?.inversion_layers ?? []).map((inv: any) => ({
+    base_ft: inv.base_ft, top_ft: inv.top_ft, strength_c: inv.strength_c,
+  }));
+
+  return {
+    point_index: hourIndex,
+    lat: snapshot.meta.lat,
+    lon: snapshot.meta.lon,
+    distance_from_origin_nm: hourIndex,
+    waypoint_icao: snapshot.meta.icao,
+    model: snapshot.meta.model,
+    time,
+    levels,
+    cruise_altitude_ft: null,
+    track_deg: null,
+    label: snapshot.meta.icao,
+    indices,
+    parcel_path,
+    cloud_layers,
+    nwp_cloud_layers,
+    icing_zones,
+    icing_ogimet_nwp_zones,
+    sfip_zones: sa?.sfip_zones ?? [],
+    inversion_layers,
+    convective: sa?.convective ?? null,
+  };
+}

--- a/web/ts/adapters/airport-profile-adapter.ts
+++ b/web/ts/adapters/airport-profile-adapter.ts
@@ -69,14 +69,24 @@ export interface AirportProfileDerivedPoint {
   sounding: any;
 }
 
+/** Result of the local-GRIB enrichment phase. `sources[m]` is present
+ *  when the model `m` actually contributed (init_time_unix is the run
+ *  timestamp). `skipped[m]` is set when a model couldn't enrich
+ *  (out_of_domain / out_of_range / no_data). */
+export interface AirportProfileEnriched {
+  sources: Record<string, { init_time_unix: number }>;
+  skipped: Record<string, string>;
+}
+
 export interface AirportProfileSnapshot {
   meta: AirportProfileMeta | null;
   surface: AirportProfileSurfaceHour[];
   levels: AirportProfileLevelsHour[];
+  enriched: AirportProfileEnriched | null;
   derived: AirportProfileDerivedPoint[];
 }
 
-export type AirportProfilePhase = 'meta' | 'surface' | 'levels' | 'derived' | 'complete' | 'error';
+export type AirportProfilePhase = 'meta' | 'surface' | 'levels' | 'enriched' | 'derived' | 'complete' | 'error';
 
 export interface AirportProfileStreamHandle {
   abort(): void;
@@ -96,7 +106,9 @@ export function streamAirportProfile(
 
   const url = `${API_BASE}/maps/airport-profile?${qs.toString()}`;
   const es = new EventSource(url, { withCredentials: true });
-  const snapshot: AirportProfileSnapshot = { meta: null, surface: [], levels: [], derived: [] };
+  const snapshot: AirportProfileSnapshot = {
+    meta: null, surface: [], levels: [], enriched: null, derived: [],
+  };
 
   const dispatch = (phase: AirportProfilePhase, raw: any) => onPhase(phase, snapshot, raw);
 
@@ -120,6 +132,13 @@ export function streamAirportProfile(
       snapshot.levels = data.hours ?? [];
       dispatch('levels', data);
     } catch (err) { console.warn('airport-profile: bad levels event', err); }
+  });
+  es.addEventListener('enriched', (e: MessageEvent) => {
+    try {
+      const data = JSON.parse(e.data);
+      snapshot.enriched = { sources: data.sources ?? {}, skipped: data.skipped ?? {} };
+      dispatch('enriched', data);
+    } catch (err) { console.warn('airport-profile: bad enriched event', err); }
   });
   es.addEventListener('derived', (e: MessageEvent) => {
     try {

--- a/web/ts/adapters/airport-profile-adapter.ts
+++ b/web/ts/adapters/airport-profile-adapter.ts
@@ -180,8 +180,16 @@ export function streamAirportProfile(
     dispatch('complete', null);
     es.close();
   });
-  es.addEventListener('error', (e) => {
-    dispatch('error', e);
+  // Server-emitted structured error event (matches /refresh/stream pattern).
+  // We piggyback on the same 'error' phase the EventSource onerror uses;
+  // the raw payload tells the host whether it was a clean server error
+  // (has phase + message) or a connection drop (no payload).
+  es.addEventListener('error', (e: Event) => {
+    let payload: any = null;
+    if (e instanceof MessageEvent && typeof e.data === 'string') {
+      try { payload = JSON.parse(e.data); } catch { /* not JSON, treat as connection error */ }
+    }
+    dispatch('error', payload ?? e);
     es.close();
   });
 

--- a/web/ts/adapters/airport-profile-adapter.ts
+++ b/web/ts/adapters/airport-profile-adapter.ts
@@ -32,8 +32,11 @@ export interface AirportProfileSurfaceHour {
   wind_speed_kt: number | null;
   wind_direction_deg: number | null;
   wind_gusts_kt: number | null;
+  precipitation_mm: number | null;
+  snowfall_cm: number | null;
   cape_jkg: number | null;
   cloud_cover_pct: number | null;
+  cloud_cover_low_pct: number | null;
   ceiling_ft: number | null;
   freezing_level_ft: number | null;
 }
@@ -315,7 +318,11 @@ function synthesizeVizPoint(
     surfaceBased: inv.surface_based ?? undefined,
   }));
 
-  const low = sounding?.cloud_cover_low_pct ?? 0;
+  // Cloud cover: prefer the sounding (derived phase) values, but fall back
+  // to the surface cache so the cross-section's cloud-cover-derived
+  // metrics aren't pinned at zero during the ~2s window between levels
+  // arriving and derived completing.
+  const low = sounding?.cloud_cover_low_pct ?? surface?.cloud_cover_low_pct ?? 0;
   const mid = sounding?.cloud_cover_mid_pct ?? 0;
   const high = sounding?.cloud_cover_high_pct ?? 0;
 
@@ -349,7 +356,7 @@ function synthesizeVizPoint(
     soundingCeilingFt: indices?.sounding_ceiling_ft ?? surface?.ceiling_ft ?? null,
     terrainElevationFt: elevationFt,
     temperatureC: surface?.temperature_2m_c ?? null,
-    precipitationMm: null,
+    precipitationMm: surface?.precipitation_mm ?? null,
   };
 }
 

--- a/web/ts/adapters/airport-profile-adapter.ts
+++ b/web/ts/adapters/airport-profile-adapter.ts
@@ -62,11 +62,37 @@ export interface AirportProfileLevelsHour {
   }>;
 }
 
+/** Shallow shape of the server-side `SoundingAnalysis.model_dump()`
+ *  payload. Only the fields the adapter actually projects are listed —
+ *  the full Python model is much larger. Field types use `any` for
+ *  nested zone/layer arrays where the structural assumptions are too
+ *  varied to express here without duplicating server contracts; the
+ *  point of this interface is to surface the top-level keys so
+ *  refactors can't silently drop one without breaking compilation. */
+export interface SoundingPayload {
+  indices: Record<string, number | null> | null;
+  parcel_path?: Array<{ pressure_hpa: number; temperature_c: number }>;
+  cloud_layers?: any[];
+  nwp_cloud_layers?: any[] | null;
+  icing_zones?: any[];
+  icing_ogimet_nwp_zones?: any[];
+  ieng_icing_zones?: any[];
+  sfip_zones?: any[];
+  sld_zones?: any[];
+  inversion_layers?: any[];
+  vertical_motion?: { cat_risk_layers?: any[]; e_shear_layers?: any[] } | null;
+  convective?: { risk_level?: string; base_ft?: number | null; top_ft?: number | null; cin_jkg?: number } | null;
+  convective_nwp?: { risk_level?: string; base_ft?: number | null; top_ft?: number | null; cover_pct?: number | null; method?: string | null } | null;
+  cloud_cover_low_pct?: number | null;
+  cloud_cover_mid_pct?: number | null;
+  cloud_cover_high_pct?: number | null;
+}
+
 export interface AirportProfileDerivedPoint {
   point_index: number;
   time: string;
   /** Server-side `SoundingAnalysis.model_dump()` payload (snake_case keys). */
-  sounding: any;
+  sounding: SoundingPayload | null;
 }
 
 /** Result of the local-GRIB enrichment phase. `sources[m]` is present
@@ -226,7 +252,7 @@ function synthesizeVizPoint(
   lat: number,
   lon: number,
   elevationFt: number,
-  sounding: any | null,
+  sounding: SoundingPayload | null,
   surface: AirportProfileSurfaceHour | null,
 ): VizPoint {
   const indices = sounding?.indices ?? null;

--- a/web/ts/maps-main.ts
+++ b/web/ts/maps-main.ts
@@ -58,6 +58,12 @@ let fcHour = 12;
 let fcModel = 'worst';
 let fcMetric: ForecastMetric = 'flight_category';
 
+// Number of forward hours the airport-profile panel requests beyond the
+// selected start hour. Mirror of `_DEFAULT_WINDOW_H` in the Python
+// endpoint — both must agree, otherwise the cross-section X-axis would
+// show fewer/more time ticks than the streamed payload contains.
+const AIRPORT_PROFILE_WINDOW_H = 3;
+
 // Airport profile panel state (right-click on a forecast marker)
 let airportPanel: AirportProfilePanel | null = null;
 let airportPanelIcao: string | null = null;
@@ -186,7 +192,7 @@ function openAirportPanel(icao: string, opts: { initialModel?: string } = {}): v
   airportPanelIcao = icao;
   forecastMap?.setHighlightedIcao(icao);
   airportPanel.load({
-    icao, startHour: forecastStartHour(), windowH: 3,
+    icao, startHour: forecastStartHour(), windowH: AIRPORT_PROFILE_WINDOW_H,
   });
   syncUrl();
   // The map width changed — let Leaflet re-layout.
@@ -208,7 +214,7 @@ function refreshAirportPanelOnHourChange(): void {
   // Map's day/hour changed: reload the open panel; metric changes are ignored.
   if (!airportPanel || !airportPanelIcao) return;
   airportPanel.load({
-    icao: airportPanelIcao, startHour: forecastStartHour(), windowH: 3,
+    icao: airportPanelIcao, startHour: forecastStartHour(), windowH: AIRPORT_PROFILE_WINDOW_H,
   });
 }
 

--- a/web/ts/maps-main.ts
+++ b/web/ts/maps-main.ts
@@ -87,6 +87,12 @@ const mapsUrlState = createUrlState({
     default: 'flight_category' as ForecastMetric,
     values: ['flight_category', 'wind_speed_kt', 'crosswind_kt', 'headwind_kt', 'ceiling_ft', 'visibility_m', 'cape_jkg', 'convective_risk', 'cloud_cover_pct'] as readonly ForecastMetric[],
   },
+  // Open airport-profile panel (ICAO) and the panel's selected model.
+  // Empty ICAO = no panel open. Panel model defaults differ from the
+  // map's per-airport model (panel always needs a real model, not a
+  // consensus mode), so they're separate keys.
+  'fc.apt':    { default: '' },
+  'fc.apModel':{ default: 'ecmwf', values: ['gfs', 'icon', 'ecmwf'] as readonly string[] },
   'vf.period': { default: '7d', values: ['7d', '30d'] as readonly string[] },
   'vf.days':   { default: 0, values: [0, 1, 2, 3] as readonly number[] },
   'vf.model':  { default: 'all', values: ['all', 'gfs', 'icon', 'ecmwf'] as readonly string[] },
@@ -103,6 +109,8 @@ function syncUrl(): void {
     'fc.hour':   fcHour,
     'fc.model':  fcModel,
     'fc.metric': fcMetric,
+    'fc.apt':    airportPanelIcao ?? '',
+    'fc.apModel': airportPanel?.getModel() ?? 'ecmwf',
     'vf.period': verifPeriod,
     'vf.days':   verifDays,
     'vf.model':  verifModel,
@@ -161,22 +169,26 @@ function panelDefaultModel(): string {
   return ['gfs', 'icon', 'ecmwf'].includes(fcModel) ? fcModel : 'ecmwf';
 }
 
-function openAirportPanel(icao: string): void {
+function openAirportPanel(icao: string, opts: { initialModel?: string } = {}): void {
   const host = $('ap-panel-host') as HTMLElement | null;
   if (!host) return;
   host.style.display = 'flex';
   if (!airportPanel) {
     airportPanel = new AirportProfilePanel({
       container: host,
-      initialModel: panelDefaultModel(),
+      initialModel: opts.initialModel ?? panelDefaultModel(),
       onClose: () => closeAirportPanel(),
+      onModelChange: () => syncUrl(),
     });
+  } else if (opts.initialModel) {
+    airportPanel.setModel(opts.initialModel);
   }
   airportPanelIcao = icao;
   forecastMap?.setHighlightedIcao(icao);
   airportPanel.load({
     icao, startHour: forecastStartHour(), windowH: 3,
   });
+  syncUrl();
   // The map width changed — let Leaflet re-layout.
   setTimeout(() => forecastMap?.invalidateSize(), 50);
 }
@@ -188,6 +200,7 @@ function closeAirportPanel(): void {
   airportPanel = null;
   airportPanelIcao = null;
   forecastMap?.setHighlightedIcao(null);
+  syncUrl();
   setTimeout(() => forecastMap?.invalidateSize(), 50);
 }
 
@@ -836,6 +849,14 @@ async function main(): Promise<void> {
     loadForecast();
   } else {
     switchTab(currentTab);
+  }
+
+  // Re-open the airport-profile panel if the URL carried one. Defer until
+  // after the forecast load triggers a marker render so setHighlightedIcao
+  // has a marker to highlight.
+  const urlIcao = init['fc.apt'];
+  if (urlIcao && currentTab === 'forecast') {
+    openAirportPanel(urlIcao, { initialModel: init['fc.apModel'] });
   }
 }
 

--- a/web/ts/maps-main.ts
+++ b/web/ts/maps-main.ts
@@ -11,6 +11,7 @@ import {
   type HewsonAllMetricsSlice,
 } from './adapters/hewson-map-adapter';
 import { WeatherMap, type ForecastMetric, type VerifMetric } from './visualization/weather-map';
+import { AirportProfilePanel } from './visualization/airport-profile-panel';
 import { SynopticMap } from './visualization/synoptic-map';
 import { type HewsonMetric, type ColorScale, vRangeFor } from './visualization/hewson-colormaps';
 import { initInfoPopup, showPopupContent } from './components/info-popup';
@@ -56,6 +57,10 @@ let fcDay = 0;
 let fcHour = 12;
 let fcModel = 'worst';
 let fcMetric: ForecastMetric = 'flight_category';
+
+// Airport profile panel state (right-click on a forecast marker)
+let airportPanel: AirportProfilePanel | null = null;
+let airportPanelIcao: string | null = null;
 
 // Verification state
 let verifData: VerificationMapResponse | null = null;
@@ -140,6 +145,60 @@ function updateForecastDatetime(): void {
 
 // --- Data loading ---
 
+function forecastStartHour(): string {
+  // Build an ISO 8601 UTC string for the currently-selected (day, hour).
+  const now = new Date();
+  const dt = new Date(Date.UTC(
+    now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() + fcDay,
+    fcHour, 0, 0,
+  ));
+  return dt.toISOString().replace(/\.\d{3}Z$/, 'Z');
+}
+
+function panelDefaultModel(): string {
+  // Map: forecast tab might be in consensus mode, panel needs a real
+  // model. Pick the same model when one is selected, otherwise ECMWF.
+  return ['gfs', 'icon', 'ecmwf'].includes(fcModel) ? fcModel : 'ecmwf';
+}
+
+function openAirportPanel(icao: string): void {
+  const host = $('ap-panel-host') as HTMLElement | null;
+  if (!host) return;
+  host.style.display = 'flex';
+  if (!airportPanel) {
+    airportPanel = new AirportProfilePanel({
+      container: host,
+      initialModel: panelDefaultModel(),
+      onClose: () => closeAirportPanel(),
+    });
+  }
+  airportPanelIcao = icao;
+  forecastMap?.setHighlightedIcao(icao);
+  airportPanel.load({
+    icao, startHour: forecastStartHour(), windowH: 3,
+  });
+  // The map width changed — let Leaflet re-layout.
+  setTimeout(() => forecastMap?.invalidateSize(), 50);
+}
+
+function closeAirportPanel(): void {
+  const host = $('ap-panel-host') as HTMLElement | null;
+  if (host) host.style.display = 'none';
+  airportPanel?.destroy();
+  airportPanel = null;
+  airportPanelIcao = null;
+  forecastMap?.setHighlightedIcao(null);
+  setTimeout(() => forecastMap?.invalidateSize(), 50);
+}
+
+function refreshAirportPanelOnHourChange(): void {
+  // Map's day/hour changed: reload the open panel; metric changes are ignored.
+  if (!airportPanel || !airportPanelIcao) return;
+  airportPanel.load({
+    icao: airportPanelIcao, startHour: forecastStartHour(), windowH: 3,
+  });
+}
+
 async function loadForecast(): Promise<void> {
   updateForecastDatetime();
   showInfo('Loading forecast...', 'map-info');
@@ -216,12 +275,14 @@ function wireForecastControls(): void {
     } catch { /* ignore */ }
     syncUrl();
     loadForecast();
+    refreshAirportPanelOnHourChange();
   });
 
   wireButtonGroup('hour-picker', 'hour', (v) => {
     fcHour = parseInt(v);
     syncUrl();
     loadForecast();
+    refreshAirportPanelOnHourChange();
   });
 
   wireButtonGroup('model-picker', 'model', (v) => {
@@ -681,6 +742,7 @@ async function main(): Promise<void> {
   if (!container) return;
   forecastMap = new WeatherMap(container);
   forecastMap.init();
+  forecastMap.setAirportContextHandler((icao) => openAirportPanel(icao));
 
   // Set up the briefing-style info modal (used by the synoptic tab's (i)).
   initInfoPopup();

--- a/web/ts/visualization/airport-profile-panel.ts
+++ b/web/ts/visualization/airport-profile-panel.ts
@@ -1,0 +1,264 @@
+/** Airport profile panel — right-click an airport on /maps.html to inspect
+ *  its vertical conditions (cross-section + Skew-T) for a 4-hour window.
+ *
+ *  Renders into a host element that the maps page sizes via CSS. The panel
+ *  owns its own SSE stream lifecycle; the only inputs from the host are
+ *  airport coords + selected (day, hour, model).
+ *
+ *  View modes (segmented toggle, persisted to localStorage):
+ *    'both'  — cross-section on top, Skew-T below (default)
+ *    'cross' — cross-section only
+ *    'skewt' — Skew-T only
+ *
+ *  The issue calls out "stacked-views crowding (likely)" as something to
+ *  revisit visually; the toggle is in place from day one so the follow-up
+ *  is "change the default", not a refactor.
+ */
+
+import { CrossSectionRenderer } from './cross-section/renderer';
+import { SkewTRenderer } from './skewt/renderer';
+import { getAllLayers, getDefaultEnabled } from './cross-section/layer-registry';
+import {
+  streamAirportProfile, snapshotToVizData, snapshotToSkewtData,
+  type AirportProfileSnapshot, type AirportProfileStreamHandle,
+} from '../adapters/airport-profile-adapter';
+
+type ViewMode = 'both' | 'cross' | 'skewt';
+const VIEW_MODE_KEY = 'wb_apProfileView';
+
+function loadViewMode(): ViewMode {
+  const v = localStorage.getItem(VIEW_MODE_KEY);
+  if (v === 'cross' || v === 'skewt' || v === 'both') return v;
+  return 'both';
+}
+function saveViewMode(m: ViewMode): void {
+  localStorage.setItem(VIEW_MODE_KEY, m);
+}
+
+export interface AirportProfilePanelOptions {
+  container: HTMLElement;
+  initialModel?: string;
+  onClose?: () => void;
+}
+
+export interface AirportProfileRequest {
+  icao: string;
+  startHour: string;  // ISO 8601 UTC, e.g. "2026-05-07T12:00:00Z"
+  windowH?: number;
+}
+
+const MODELS = ['gfs', 'icon', 'ecmwf'] as const;
+
+export class AirportProfilePanel {
+  private container: HTMLElement;
+  private model: string;
+  private viewMode: ViewMode;
+  private onClose?: () => void;
+
+  private crossEl: HTMLDivElement;
+  private skewtEl: HTMLDivElement;
+  private statusEl: HTMLDivElement;
+  private titleEl: HTMLDivElement;
+  private modelSel: HTMLSelectElement;
+  private viewBtns: Record<ViewMode, HTMLButtonElement>;
+
+  private crossRenderer: CrossSectionRenderer | null = null;
+  private skewtRenderer: SkewTRenderer | null = null;
+
+  private snapshot: AirportProfileSnapshot = { meta: null, surface: [], levels: [], derived: [] };
+  private stream: AirportProfileStreamHandle | null = null;
+  private currentRequest: AirportProfileRequest | null = null;
+
+  constructor(opts: AirportProfilePanelOptions) {
+    this.container = opts.container;
+    this.model = opts.initialModel ?? 'ecmwf';
+    this.viewMode = loadViewMode();
+    this.onClose = opts.onClose;
+
+    this.container.classList.add('ap-panel');
+    this.container.innerHTML = `
+      <div class="ap-panel-header">
+        <div class="ap-panel-title" id="ap-title">—</div>
+        <button class="ap-panel-close" type="button" title="Close">&times;</button>
+      </div>
+      <div class="ap-panel-controls">
+        <label>Model</label>
+        <select class="ap-model-sel">
+          <option value="gfs">GFS</option>
+          <option value="icon">ICON</option>
+          <option value="ecmwf">ECMWF</option>
+        </select>
+        <label>View</label>
+        <div class="ap-view-group btn-group" role="group">
+          <button class="btn-toggle" data-view="both">Both</button>
+          <button class="btn-toggle" data-view="cross">Cross-section</button>
+          <button class="btn-toggle" data-view="skewt">Skew-T</button>
+        </div>
+      </div>
+      <div class="ap-panel-status" id="ap-status"></div>
+      <div class="ap-panel-body">
+        <div class="ap-cross" id="ap-cross"></div>
+        <div class="ap-skewt" id="ap-skewt"></div>
+      </div>
+    `;
+
+    this.titleEl = this.container.querySelector('.ap-panel-title') as HTMLDivElement;
+    this.statusEl = this.container.querySelector('.ap-panel-status') as HTMLDivElement;
+    this.crossEl = this.container.querySelector('.ap-cross') as HTMLDivElement;
+    this.skewtEl = this.container.querySelector('.ap-skewt') as HTMLDivElement;
+    this.modelSel = this.container.querySelector('.ap-model-sel') as HTMLSelectElement;
+    this.modelSel.value = this.model;
+
+    const viewGroup = this.container.querySelector('.ap-view-group') as HTMLElement;
+    this.viewBtns = {
+      both: viewGroup.querySelector('[data-view="both"]') as HTMLButtonElement,
+      cross: viewGroup.querySelector('[data-view="cross"]') as HTMLButtonElement,
+      skewt: viewGroup.querySelector('[data-view="skewt"]') as HTMLButtonElement,
+    };
+
+    this.applyViewMode();
+
+    this.container.querySelector('.ap-panel-close')?.addEventListener('click', () => this.close());
+    this.modelSel.addEventListener('change', () => {
+      this.model = this.modelSel.value;
+      if (this.currentRequest) this.load(this.currentRequest);
+    });
+    viewGroup.addEventListener('click', (e) => {
+      const btn = (e.target as HTMLElement).closest('button');
+      if (!btn) return;
+      const v = btn.getAttribute('data-view') as ViewMode | null;
+      if (!v) return;
+      this.viewMode = v;
+      saveViewMode(v);
+      this.applyViewMode();
+    });
+  }
+
+  /** Update the model from outside (e.g. for URL deep-linking). */
+  setModel(model: string): void {
+    if (!MODELS.includes(model as any)) return;
+    this.model = model;
+    this.modelSel.value = model;
+  }
+
+  /** Start (or restart) loading the profile for a new airport / hour. */
+  load(req: AirportProfileRequest): void {
+    this.currentRequest = req;
+    this.snapshot = { meta: null, surface: [], levels: [], derived: [] };
+    if (this.stream) { this.stream.abort(); this.stream = null; }
+    this.titleEl.textContent = `${req.icao} — loading…`;
+    this.statusEl.textContent = 'Connecting…';
+    this.clearRenderers();
+
+    this.stream = streamAirportProfile(
+      { icao: req.icao, model: this.model, startHour: req.startHour, windowH: req.windowH },
+      (phase, snapshot, raw) => this.onPhase(phase, snapshot, raw),
+    );
+  }
+
+  private onPhase(phase: string, snapshot: AirportProfileSnapshot, raw: any): void {
+    this.snapshot = snapshot;
+    if (phase === 'meta') {
+      const m = snapshot.meta!;
+      const start = new Date(m.start_hour);
+      const startStr = start.toISOString().slice(11, 16) + 'Z';
+      this.titleEl.textContent = `${m.icao} · ${m.model.toUpperCase()} · ${startStr} +${m.window_h}h`;
+      this.statusEl.textContent = 'Surface…';
+      this.renderCross();
+    } else if (phase === 'surface') {
+      this.statusEl.textContent = 'Pressure levels…';
+      this.renderCross();
+    } else if (phase === 'levels') {
+      this.statusEl.textContent = (raw && raw.error) ? `Levels failed (${raw.error})` : 'Analyzing…';
+      this.renderSkewT();
+    } else if (phase === 'derived') {
+      this.statusEl.textContent = '';
+      this.renderCross();
+      this.renderSkewT();
+    } else if (phase === 'complete') {
+      this.statusEl.textContent = '';
+    } else if (phase === 'error') {
+      this.statusEl.textContent = 'Stream error';
+    }
+  }
+
+  private applyViewMode(): void {
+    for (const v of ['both', 'cross', 'skewt'] as const) {
+      this.viewBtns[v].classList.toggle('active', v === this.viewMode);
+    }
+    const showCross = this.viewMode === 'both' || this.viewMode === 'cross';
+    const showSkewT = this.viewMode === 'both' || this.viewMode === 'skewt';
+    this.crossEl.style.display = showCross ? 'block' : 'none';
+    this.skewtEl.style.display = showSkewT ? 'block' : 'none';
+    this.container.classList.toggle('view-both', this.viewMode === 'both');
+    this.container.classList.toggle('view-cross', this.viewMode === 'cross');
+    this.container.classList.toggle('view-skewt', this.viewMode === 'skewt');
+
+    // Force a re-render so canvases pick up the new container size.
+    setTimeout(() => {
+      this.crossRenderer?.render();
+      this.renderSkewT();
+    }, 0);
+  }
+
+  private ensureCrossRenderer(): CrossSectionRenderer {
+    if (!this.crossRenderer) {
+      this.crossRenderer = new CrossSectionRenderer(this.crossEl);
+      const layers = getAllLayers();
+      const enabled = getDefaultEnabled();
+      this.crossRenderer.setLayers(layers, enabled);
+    }
+    return this.crossRenderer;
+  }
+
+  private ensureSkewTRenderer(): SkewTRenderer {
+    if (!this.skewtRenderer) {
+      this.skewtRenderer = new SkewTRenderer(this.skewtEl);
+    }
+    return this.skewtRenderer;
+  }
+
+  private renderCross(): void {
+    if (this.viewMode === 'skewt') return;
+    const data = snapshotToVizData(this.snapshot);
+    if (!data) return;
+    const r = this.ensureCrossRenderer();
+    r.setData(data);
+    r.render();
+  }
+
+  private renderSkewT(): void {
+    if (this.viewMode === 'cross') return;
+    const data = snapshotToSkewtData(this.snapshot, 0);
+    if (!data || data.levels.length === 0) {
+      this.skewtRenderer?.clear();
+      return;
+    }
+    const r = this.ensureSkewTRenderer();
+    r.setData(data);
+  }
+
+  private clearRenderers(): void {
+    this.crossRenderer?.destroy();
+    this.crossRenderer = null;
+    this.skewtRenderer?.destroy();
+    this.skewtRenderer = null;
+    this.crossEl.innerHTML = '';
+    this.skewtEl.innerHTML = '';
+  }
+
+  /** Close the panel and notify the host. */
+  close(): void {
+    if (this.stream) { this.stream.abort(); this.stream = null; }
+    this.clearRenderers();
+    this.onClose?.();
+  }
+
+  /** Tear down everything (used when the host removes the panel). */
+  destroy(): void {
+    if (this.stream) { this.stream.abort(); this.stream = null; }
+    this.clearRenderers();
+    this.container.innerHTML = '';
+    this.container.classList.remove('ap-panel', 'view-both', 'view-cross', 'view-skewt');
+  }
+}

--- a/web/ts/visualization/airport-profile-panel.ts
+++ b/web/ts/visualization/airport-profile-panel.ts
@@ -38,6 +38,20 @@ function formatEnrichmentBadge(e: AirportProfileEnriched | null): string {
   return `GRIB: ${parts.join(', ')}`;
 }
 
+/** HTML-escape user-visible strings before injecting into the status
+ *  bar (we use innerHTML there so the dots-spinner span renders). */
+function esc(s: string): string {
+  const d = document.createElement('div');
+  d.textContent = s;
+  return d.innerHTML;
+}
+
+/** Status row template that matches briefing-ui's "Refreshing · <stage>…"
+ *  pattern: phase label followed by an animated dots-spinner. */
+function statusLoading(label: string): string {
+  return `${esc(label)}<span class="dots-spinner"></span>`;
+}
+
 type ViewMode = 'both' | 'cross' | 'skewt';
 const VIEW_MODE_KEY = 'wb_apProfileView';
 
@@ -90,6 +104,12 @@ export class AirportProfilePanel {
   };
   private stream: AirportProfileStreamHandle | null = null;
   private currentRequest: AirportProfileRequest | null = null;
+
+  /** Per-(icao,startHour,model) cache of completed snapshots so model
+   *  switching reuses prior fetches. Cleared whenever the request shape
+   *  changes (different icao or startHour) since the previous entries
+   *  no longer apply. */
+  private snapshotCache = new Map<string, AirportProfileSnapshot>();
 
   constructor(opts: AirportProfilePanelOptions) {
     this.container = opts.container;
@@ -173,13 +193,35 @@ export class AirportProfilePanel {
 
   /** Start (or restart) loading the profile for a new airport / hour. */
   load(req: AirportProfileRequest): void {
+    // Drop the cache on icao or startHour change — the cached snapshots
+    // are scoped to the previous request shape and no longer apply.
+    if (
+      this.currentRequest
+      && (this.currentRequest.icao !== req.icao
+          || this.currentRequest.startHour !== req.startHour)
+    ) {
+      this.snapshotCache.clear();
+    }
     this.currentRequest = req;
+    if (this.stream) { this.stream.abort(); this.stream = null; }
+
+    // Cache hit: skip the SSE round-trip entirely.
+    const cached = this.snapshotCache.get(this.cacheKey(req, this.model));
+    if (cached) {
+      this.snapshot = cached;
+      this.applyTitle(cached);
+      this.statusEl.innerHTML = esc(formatEnrichmentBadge(cached.enriched));
+      this.clearRenderers();
+      this.renderCross();
+      this.renderSkewT();
+      return;
+    }
+
     this.snapshot = {
       meta: null, surface: [], levels: [], enriched: null, derived: [],
     };
-    if (this.stream) { this.stream.abort(); this.stream = null; }
     this.titleEl.textContent = `${req.icao} — loading…`;
-    this.statusEl.textContent = 'Connecting…';
+    this.statusEl.innerHTML = statusLoading('Connecting');
     this.clearRenderers();
 
     this.stream = streamAirportProfile(
@@ -188,36 +230,72 @@ export class AirportProfilePanel {
     );
   }
 
+  private cacheKey(req: AirportProfileRequest, model: string): string {
+    return `${req.icao}|${req.startHour}|${model}`;
+  }
+
+  /** Render the panel header from the snapshot's meta. */
+  private applyTitle(snapshot: AirportProfileSnapshot): void {
+    if (!snapshot.meta) return;
+    const m = snapshot.meta;
+    const startStr = new Date(m.start_hour).toISOString().slice(11, 16) + 'Z';
+    this.titleEl.textContent = `${m.icao} · ${m.model.toUpperCase()} · ${startStr} +${m.window_h}h`;
+  }
+
   private onPhase(phase: string, snapshot: AirportProfileSnapshot, raw: any): void {
     this.snapshot = snapshot;
+    // Backend emits a `label` field on phases that map to a stage in the
+    // briefing pipeline (see api/airport_profile.py:_PHASE_TO_STAGE). For
+    // phases without a label (`meta`, `surface`) we use a local string
+    // since the briefing pipeline has no analogue.
+    const labelFromBackend = (raw && typeof raw === 'object' && typeof raw.label === 'string')
+      ? raw.label as string
+      : null;
+
     if (phase === 'meta') {
-      const m = snapshot.meta!;
-      const start = new Date(m.start_hour);
-      const startStr = start.toISOString().slice(11, 16) + 'Z';
-      this.titleEl.textContent = `${m.icao} · ${m.model.toUpperCase()} · ${startStr} +${m.window_h}h`;
-      this.statusEl.textContent = 'Surface…';
+      this.applyTitle(snapshot);
+      this.statusEl.innerHTML = statusLoading('Loading');
       this.renderCross();
     } else if (phase === 'surface') {
-      this.statusEl.textContent = 'Pressure levels…';
+      this.statusEl.innerHTML = statusLoading(labelFromBackend ?? 'Loading');
       this.renderCross();
     } else if (phase === 'levels') {
-      this.statusEl.textContent = (raw && raw.error) ? `Levels failed (${raw.error})` : 'GRIB enrichment…';
+      const text = (raw && raw.error)
+        ? `Levels failed (${raw.error})`
+        : (labelFromBackend ?? 'Fetching forecasts');
+      this.statusEl.innerHTML = (raw && raw.error) ? esc(text) : statusLoading(text);
       this.renderSkewT();
     } else if (phase === 'enriched') {
-      this.statusEl.textContent = `Analyzing… ${formatEnrichmentBadge(snapshot.enriched)}`;
+      this.statusEl.innerHTML = statusLoading(labelFromBackend ?? 'Adding cloud & icing detail');
     } else if (phase === 'derived') {
-      this.statusEl.textContent = formatEnrichmentBadge(snapshot.enriched);
+      this.statusEl.innerHTML = esc(formatEnrichmentBadge(snapshot.enriched));
       this.renderCross();
       this.renderSkewT();
     } else if (phase === 'complete') {
-      this.statusEl.textContent = formatEnrichmentBadge(snapshot.enriched);
+      this.statusEl.innerHTML = esc(formatEnrichmentBadge(snapshot.enriched));
+      // Successful completion: cache the snapshot for fast model-switch.
+      if (this.currentRequest) {
+        this.snapshotCache.set(
+          this.cacheKey(this.currentRequest, this.model),
+          // Store a shallow clone so subsequent mutations of `snapshot`
+          // (in onPhase callbacks for a follow-on request) don't bleed
+          // back into the cached entry.
+          {
+            meta: snapshot.meta,
+            surface: snapshot.surface,
+            levels: snapshot.levels,
+            enriched: snapshot.enriched,
+            derived: snapshot.derived,
+          },
+        );
+      }
     } else if (phase === 'error') {
       // Backend-emitted structured error: {type, phase, message}. Falls
       // through to a generic message when the connection just dropped.
       const detail = raw && typeof raw === 'object' && raw.phase
         ? `${raw.phase}: ${raw.message ?? 'unknown error'}`
         : 'connection lost';
-      this.statusEl.textContent = `Error — ${detail}`;
+      this.statusEl.innerHTML = esc(`Error — ${detail}`);
     }
   }
 
@@ -299,6 +377,7 @@ export class AirportProfilePanel {
    *  empty the container. Idempotent. */
   destroy(): void {
     if (this.stream) { this.stream.abort(); this.stream = null; }
+    this.snapshotCache.clear();
     this.clearRenderers();
     this.container.innerHTML = '';
     this.container.classList.remove('ap-panel', 'view-both', 'view-cross', 'view-skewt');

--- a/web/ts/visualization/airport-profile-panel.ts
+++ b/web/ts/visualization/airport-profile-panel.ts
@@ -143,8 +143,14 @@ export class AirportProfilePanel {
   /** Per-(icao,startHour,model) cache of completed snapshots so model
    *  switching reuses prior fetches. Cleared whenever the request shape
    *  changes (different icao or startHour) since the previous entries
-   *  no longer apply. */
+   *  no longer apply.
+   *
+   *  Bounded LRU: each entry holds full pressure-level arrays + sounding
+   *  analysis (~hundreds of KB up to a few MB). Without a cap, a session
+   *  hopping airports would accumulate unbounded snapshots. JS `Map`
+   *  preserves insertion order, so we evict the oldest key on overflow. */
   private snapshotCache = new Map<string, AirportProfileSnapshot>();
+  private static readonly SNAPSHOT_CACHE_MAX = 10;
 
   constructor(opts: AirportProfilePanelOptions) {
     this.container = opts.container;
@@ -248,9 +254,15 @@ export class AirportProfilePanel {
     this.currentRequest = req;
     if (this.stream) { this.stream.abort(); this.stream = null; }
 
-    // Cache hit: skip the SSE round-trip entirely.
-    const cached = this.snapshotCache.get(this.cacheKey(req, this.model));
+    // Cache hit: skip the SSE round-trip entirely. Bump the entry to
+    // the most-recently-used slot (Map preserves insertion order, so
+    // delete-then-set moves it to the end) — that way a still-actively-used
+    // entry isn't evicted just because it was loaded first.
+    const cacheKey = this.cacheKey(req, this.model);
+    const cached = this.snapshotCache.get(cacheKey);
     if (cached) {
+      this.snapshotCache.delete(cacheKey);
+      this.snapshotCache.set(cacheKey, cached);
       this.snapshot = cached;
       this.applyTitle(cached);
       this.statusEl.innerHTML = esc(formatEnrichmentBadge(cached.enriched));
@@ -335,19 +347,27 @@ export class AirportProfilePanel {
       this.statusEl.innerHTML = esc(formatEnrichmentBadge(snapshot.enriched));
       // Successful completion: cache the snapshot for fast model-switch.
       if (this.currentRequest) {
-        this.snapshotCache.set(
-          this.cacheKey(this.currentRequest, this.model),
-          // Store a shallow clone so subsequent mutations of `snapshot`
-          // (in onPhase callbacks for a follow-on request) don't bleed
-          // back into the cached entry.
-          {
-            meta: snapshot.meta,
-            surface: snapshot.surface,
-            levels: snapshot.levels,
-            enriched: snapshot.enriched,
-            derived: snapshot.derived,
-          },
-        );
+        const key = this.cacheKey(this.currentRequest, this.model);
+        // Re-insert overwrites + moves to most-recently-used slot.
+        this.snapshotCache.delete(key);
+        // Store a shallow clone so subsequent mutations of `snapshot`
+        // (in onPhase callbacks for a follow-on request) don't bleed
+        // back into the cached entry.
+        this.snapshotCache.set(key, {
+          meta: snapshot.meta,
+          surface: snapshot.surface,
+          levels: snapshot.levels,
+          enriched: snapshot.enriched,
+          derived: snapshot.derived,
+        });
+        // Evict oldest entries until we're back under the cap. JS Map
+        // iteration order is insertion order, so the first key is the
+        // least-recently-used.
+        while (this.snapshotCache.size > AirportProfilePanel.SNAPSHOT_CACHE_MAX) {
+          const oldest = this.snapshotCache.keys().next().value;
+          if (oldest === undefined) break;
+          this.snapshotCache.delete(oldest);
+        }
       }
     } else if (phase === 'error') {
       // Backend-emitted structured error: {type, phase, message}. Falls
@@ -408,6 +428,10 @@ export class AirportProfilePanel {
 
   private renderSkewT(): void {
     if (this.viewMode === 'cross') return;
+    // TODO(#121-followup): Skew-T is locked to hour 0 of the window;
+    // the cross-section above shows all 4 hours but there's no
+    // affordance (click on a time tick, hour selector, etc.) to
+    // inspect hours 1–3 here. Tracked separately from the v1 issue.
     const data = snapshotToSkewtData(this.snapshot, 0);
     if (!data || data.levels.length === 0) {
       this.skewtRenderer?.clear();

--- a/web/ts/visualization/airport-profile-panel.ts
+++ b/web/ts/visualization/airport-profile-panel.ts
@@ -18,6 +18,8 @@
 import { CrossSectionRenderer } from './cross-section/renderer';
 import { SkewTRenderer } from './skewt/renderer';
 import { getAllLayers, getDefaultEnabled } from './cross-section/layer-registry';
+import { renderLayerToggles } from './controls/panel';
+import { renderSkewtOverlayControls } from './skewt/overlay-controls';
 import {
   streamAirportProfile, snapshotToVizData, snapshotToSkewtData,
   type AirportProfileSnapshot, type AirportProfileStreamHandle,
@@ -54,6 +56,10 @@ function statusLoading(label: string): string {
 
 type ViewMode = 'both' | 'cross' | 'skewt';
 const VIEW_MODE_KEY = 'wb_apProfileView';
+/** Per-panel layer-enable map. Key is independent from the main
+ *  briefing's `wb_visibleLayers` so toggles in this panel don't bleed
+ *  into the main /briefing.html view. */
+const LAYERS_KEY = 'wb_apProfileLayers';
 
 function loadViewMode(): ViewMode {
   const v = localStorage.getItem(VIEW_MODE_KEY);
@@ -62,6 +68,28 @@ function loadViewMode(): ViewMode {
 }
 function saveViewMode(m: ViewMode): void {
   localStorage.setItem(VIEW_MODE_KEY, m);
+}
+
+function loadEnabledLayers(): Record<string, boolean> {
+  const defaults = getDefaultEnabled();
+  try {
+    const raw = localStorage.getItem(LAYERS_KEY);
+    if (!raw) return defaults;
+    const saved = JSON.parse(raw) as Record<string, unknown>;
+    // Merge: keep any layer the saved blob didn't know about at its
+    // default. Coerce values to boolean so a malformed entry can't
+    // poison the renderer's enable check.
+    const merged: Record<string, boolean> = { ...defaults };
+    for (const [k, v] of Object.entries(saved)) {
+      if (typeof v === 'boolean') merged[k] = v;
+    }
+    return merged;
+  } catch {
+    return defaults;
+  }
+}
+function saveEnabledLayers(m: Record<string, boolean>): void {
+  try { localStorage.setItem(LAYERS_KEY, JSON.stringify(m)); } catch { /* quota */ }
 }
 
 export interface AirportProfilePanelOptions {
@@ -95,9 +123,16 @@ export class AirportProfilePanel {
   private titleEl: HTMLDivElement;
   private modelSel: HTMLSelectElement;
   private viewBtns: Record<ViewMode, HTMLButtonElement>;
+  private settingsBtn: HTMLButtonElement;
+  private drawerEl: HTMLDivElement;
+  private drawerOpen = false;
 
   private crossRenderer: CrossSectionRenderer | null = null;
   private skewtRenderer: SkewTRenderer | null = null;
+  /** Layer enable state for the cross-section. Persisted to localStorage
+   *  so the user's toggles survive panel close + reopen. Applied to the
+   *  renderer via `setLayers()` whenever it (re)mounts. */
+  private enabledLayers: Record<string, boolean> = loadEnabledLayers();
 
   private snapshot: AirportProfileSnapshot = {
     meta: null, surface: [], levels: [], enriched: null, derived: [],
@@ -137,12 +172,14 @@ export class AirportProfilePanel {
           <button class="btn-toggle" data-view="cross">Cross-section</button>
           <button class="btn-toggle" data-view="skewt">Skew-T</button>
         </div>
+        <button class="ap-settings-btn" type="button" title="Layers & overlays" aria-label="Settings" aria-expanded="false">⚙</button>
       </div>
       <div class="ap-panel-status" id="ap-status"></div>
       <div class="ap-panel-body">
         <div class="ap-cross" id="ap-cross"></div>
         <div class="ap-skewt" id="ap-skewt"></div>
       </div>
+      <div class="ap-settings-drawer" hidden></div>
     `;
 
     this.titleEl = this.container.querySelector('.ap-panel-title') as HTMLDivElement;
@@ -151,6 +188,8 @@ export class AirportProfilePanel {
     this.skewtEl = this.container.querySelector('.ap-skewt') as HTMLDivElement;
     this.modelSel = this.container.querySelector('.ap-model-sel') as HTMLSelectElement;
     this.modelSel.value = this.model;
+    this.settingsBtn = this.container.querySelector('.ap-settings-btn') as HTMLButtonElement;
+    this.drawerEl = this.container.querySelector('.ap-settings-drawer') as HTMLDivElement;
 
     const viewGroup = this.container.querySelector('.ap-view-group') as HTMLElement;
     this.viewBtns = {
@@ -175,7 +214,11 @@ export class AirportProfilePanel {
       this.viewMode = v;
       saveViewMode(v);
       this.applyViewMode();
+      // Drawer contents depend on viewMode; re-render if open so a
+      // section that just became visible shows its controls.
+      if (this.drawerOpen) this.renderDrawer();
     });
+    this.settingsBtn.addEventListener('click', () => this.toggleDrawer());
   }
 
   /** Update the model from outside (e.g. for URL deep-linking). */
@@ -212,6 +255,7 @@ export class AirportProfilePanel {
       this.applyTitle(cached);
       this.statusEl.innerHTML = esc(formatEnrichmentBadge(cached.enriched));
       this.clearRenderers();
+      this.setLoading(false);
       this.renderCross();
       this.renderSkewT();
       return;
@@ -223,11 +267,23 @@ export class AirportProfilePanel {
     this.titleEl.textContent = `${req.icao} — loading…`;
     this.statusEl.innerHTML = statusLoading('Connecting');
     this.clearRenderers();
+    // Mark canvases as loading so the empty cross-section doesn't read
+    // as "real-clear-skies forecast" while we wait for derived data.
+    // Lifted in onPhase('derived') / 'complete' / 'error'.
+    this.setLoading(true);
 
     this.stream = streamAirportProfile(
       { icao: req.icao, model: this.model, startHour: req.startHour, windowH: req.windowH },
       (phase, snapshot, raw) => this.onPhase(phase, snapshot, raw),
     );
+  }
+
+  /** Toggle the dimmed/grayscale "loading" state on the canvas areas.
+   *  Driven by `is-loading` CSS class on `.ap-cross` and `.ap-skewt`
+   *  (see maps.html). */
+  private setLoading(loading: boolean): void {
+    this.crossEl.classList.toggle('is-loading', loading);
+    this.skewtEl.classList.toggle('is-loading', loading);
   }
 
   private cacheKey(req: AirportProfileRequest, model: string): string {
@@ -265,10 +321,14 @@ export class AirportProfilePanel {
         : (labelFromBackend ?? 'Fetching forecasts');
       this.statusEl.innerHTML = (raw && raw.error) ? esc(text) : statusLoading(text);
       this.renderSkewT();
+      // Skew-T renderer just mounted — refresh drawer if open so
+      // the previously-empty Skew-T section now has controls.
+      if (this.drawerOpen) this.renderDrawer();
     } else if (phase === 'enriched') {
       this.statusEl.innerHTML = statusLoading(labelFromBackend ?? 'Adding cloud & icing detail');
     } else if (phase === 'derived') {
       this.statusEl.innerHTML = esc(formatEnrichmentBadge(snapshot.enriched));
+      this.setLoading(false);
       this.renderCross();
       this.renderSkewT();
     } else if (phase === 'complete') {
@@ -296,6 +356,10 @@ export class AirportProfilePanel {
         ? `${raw.phase}: ${raw.message ?? 'unknown error'}`
         : 'connection lost';
       this.statusEl.innerHTML = esc(`Error — ${detail}`);
+      // Lift the loading dim on error too — the canvases now show
+      // whatever last-known state they have (typically empty axes),
+      // which is the correct signal alongside the error message.
+      this.setLoading(false);
     }
   }
 
@@ -321,9 +385,7 @@ export class AirportProfilePanel {
   private ensureCrossRenderer(): CrossSectionRenderer {
     if (!this.crossRenderer) {
       this.crossRenderer = new CrossSectionRenderer(this.crossEl);
-      const layers = getAllLayers();
-      const enabled = getDefaultEnabled();
-      this.crossRenderer.setLayers(layers, enabled);
+      this.crossRenderer.setLayers(getAllLayers(), this.enabledLayers);
     }
     return this.crossRenderer;
   }
@@ -364,6 +426,85 @@ export class AirportProfilePanel {
     this.skewtEl.innerHTML = '';
   }
 
+  // -------------------------------------------------------------------
+  // Settings drawer (gear icon → slide-out panel that overlaps the map)
+  //
+  // The drawer is anchored to the panel's left edge via CSS (see
+  // maps.html: `.ap-settings-drawer { right: 100%; }`) so it grows
+  // toward the map without resizing the panel itself. Contents are
+  // rebuilt on every open + on viewMode change so toggling the View
+  // segmented control swaps which section's controls are visible.
+  // -------------------------------------------------------------------
+  private toggleDrawer(): void {
+    this.drawerOpen = !this.drawerOpen;
+    this.drawerEl.hidden = !this.drawerOpen;
+    this.container.classList.toggle('drawer-open', this.drawerOpen);
+    this.settingsBtn.setAttribute('aria-expanded', String(this.drawerOpen));
+    this.settingsBtn.classList.toggle('active', this.drawerOpen);
+    if (this.drawerOpen) this.renderDrawer();
+    else this.drawerEl.innerHTML = '';
+  }
+
+  private renderDrawer(): void {
+    const showCross = this.viewMode !== 'skewt';
+    const showSkewT = this.viewMode !== 'cross';
+
+    // Build section shells; populate each with the appropriate
+    // sub-control via the dedicated render helpers.
+    let html = '<div class="ap-drawer-header">';
+    html += '<span class="ap-drawer-title">Layers & overlays</span>';
+    html += '<button class="ap-drawer-close" type="button" title="Close" aria-label="Close">×</button>';
+    html += '</div>';
+    if (showCross) {
+      html += '<section class="ap-drawer-section" data-section="cross">';
+      html += '<h4 class="ap-drawer-section-title">Cross-section</h4>';
+      html += '<div class="ap-drawer-cross-host"></div>';
+      html += '</section>';
+    }
+    if (showSkewT) {
+      html += '<section class="ap-drawer-section" data-section="skewt">';
+      html += '<h4 class="ap-drawer-section-title">Skew-T</h4>';
+      html += '<div class="ap-drawer-skewt-host"></div>';
+      html += '</section>';
+    }
+    this.drawerEl.innerHTML = html;
+    this.drawerEl.querySelector('.ap-drawer-close')?.addEventListener(
+      'click', () => this.toggleDrawer(),
+    );
+
+    if (showCross) {
+      const host = this.drawerEl.querySelector('.ap-drawer-cross-host') as HTMLElement;
+      // Toggles work even before the cross-section renderer mounts —
+      // state is owned by the panel and applied via setLayers() once
+      // the renderer exists (see ensureCrossRenderer).
+      renderLayerToggles(host, this.enabledLayers, (layerId) => this.onLayerToggle(layerId));
+    }
+    if (showSkewT) {
+      const host = this.drawerEl.querySelector('.ap-drawer-skewt-host') as HTMLElement;
+      // Skew-T overlay controls read state from the renderer, so they
+      // need it to exist. When the levels phase hasn't completed yet,
+      // show a placeholder; renderDrawer is re-called on phase events
+      // (see onPhase) so the controls light up once data lands.
+      if (this.skewtRenderer) {
+        renderSkewtOverlayControls(host, this.skewtRenderer);
+      } else {
+        host.innerHTML = '<div class="ap-drawer-empty">Available once data loads</div>';
+      }
+    }
+  }
+
+  private onLayerToggle(layerId: string): void {
+    // Default-enabled layers are stored as `true`; flipping a missing
+    // key to `false` is the explicit "off" signal the renderer checks.
+    const current = this.enabledLayers[layerId] !== false;
+    this.enabledLayers = { ...this.enabledLayers, [layerId]: !current };
+    saveEnabledLayers(this.enabledLayers);
+    if (this.crossRenderer) {
+      this.crossRenderer.setLayers(getAllLayers(), this.enabledLayers);
+      this.crossRenderer.render();
+    }
+  }
+
   /** User clicked the ✕ button. Notifies the host so it can decide
    *  what to do with the panel container — the host is then expected
    *  to call `destroy()`. We don't tear anything down here; that keeps
@@ -378,8 +519,9 @@ export class AirportProfilePanel {
   destroy(): void {
     if (this.stream) { this.stream.abort(); this.stream = null; }
     this.snapshotCache.clear();
+    this.drawerOpen = false;
     this.clearRenderers();
     this.container.innerHTML = '';
-    this.container.classList.remove('ap-panel', 'view-both', 'view-cross', 'view-skewt');
+    this.container.classList.remove('ap-panel', 'view-both', 'view-cross', 'view-skewt', 'drawer-open');
   }
 }

--- a/web/ts/visualization/airport-profile-panel.ts
+++ b/web/ts/visualization/airport-profile-panel.ts
@@ -54,6 +54,10 @@ export interface AirportProfilePanelOptions {
   container: HTMLElement;
   initialModel?: string;
   onClose?: () => void;
+  /** Fired when the user picks a different model from the panel's
+   *  dropdown — lets the host round-trip the selection through URL
+   *  state without polling. */
+  onModelChange?: (model: string) => void;
 }
 
 export interface AirportProfileRequest {
@@ -69,6 +73,7 @@ export class AirportProfilePanel {
   private model: string;
   private viewMode: ViewMode;
   private onClose?: () => void;
+  private onModelChange?: (model: string) => void;
 
   private crossEl: HTMLDivElement;
   private skewtEl: HTMLDivElement;
@@ -91,6 +96,7 @@ export class AirportProfilePanel {
     this.model = opts.initialModel ?? 'ecmwf';
     this.viewMode = loadViewMode();
     this.onClose = opts.onClose;
+    this.onModelChange = opts.onModelChange;
 
     this.container.classList.add('ap-panel');
     this.container.innerHTML = `
@@ -138,6 +144,7 @@ export class AirportProfilePanel {
     this.container.querySelector('.ap-panel-close')?.addEventListener('click', () => this.close());
     this.modelSel.addEventListener('change', () => {
       this.model = this.modelSel.value;
+      this.onModelChange?.(this.model);
       if (this.currentRequest) this.load(this.currentRequest);
     });
     viewGroup.addEventListener('click', (e) => {
@@ -156,6 +163,12 @@ export class AirportProfilePanel {
     if (!MODELS.includes(model as any)) return;
     this.model = model;
     this.modelSel.value = model;
+  }
+
+  /** Read the panel's current model — used by the host to round-trip
+   *  the panel's selection through the URL state. */
+  getModel(): string {
+    return this.model;
   }
 
   /** Start (or restart) loading the profile for a new airport / hour. */

--- a/web/ts/visualization/airport-profile-panel.ts
+++ b/web/ts/visualization/airport-profile-panel.ts
@@ -21,7 +21,22 @@ import { getAllLayers, getDefaultEnabled } from './cross-section/layer-registry'
 import {
   streamAirportProfile, snapshotToVizData, snapshotToSkewtData,
   type AirportProfileSnapshot, type AirportProfileStreamHandle,
+  type AirportProfileEnriched,
 } from '../adapters/airport-profile-adapter';
+
+/** Render a one-line summary of which GRIB sources contributed
+ *  (or empty when none did, so the status row collapses). */
+function formatEnrichmentBadge(e: AirportProfileEnriched | null): string {
+  if (!e) return '';
+  const parts: string[] = [];
+  for (const [m, info] of Object.entries(e.sources)) {
+    const dt = new Date(info.init_time_unix * 1000);
+    const hh = String(dt.getUTCHours()).padStart(2, '0');
+    parts.push(`${m.toUpperCase()} ${hh}Z`);
+  }
+  if (parts.length === 0) return '';
+  return `GRIB: ${parts.join(', ')}`;
+}
 
 type ViewMode = 'both' | 'cross' | 'skewt';
 const VIEW_MODE_KEY = 'wb_apProfileView';
@@ -65,7 +80,9 @@ export class AirportProfilePanel {
   private crossRenderer: CrossSectionRenderer | null = null;
   private skewtRenderer: SkewTRenderer | null = null;
 
-  private snapshot: AirportProfileSnapshot = { meta: null, surface: [], levels: [], derived: [] };
+  private snapshot: AirportProfileSnapshot = {
+    meta: null, surface: [], levels: [], enriched: null, derived: [],
+  };
   private stream: AirportProfileStreamHandle | null = null;
   private currentRequest: AirportProfileRequest | null = null;
 
@@ -144,7 +161,9 @@ export class AirportProfilePanel {
   /** Start (or restart) loading the profile for a new airport / hour. */
   load(req: AirportProfileRequest): void {
     this.currentRequest = req;
-    this.snapshot = { meta: null, surface: [], levels: [], derived: [] };
+    this.snapshot = {
+      meta: null, surface: [], levels: [], enriched: null, derived: [],
+    };
     if (this.stream) { this.stream.abort(); this.stream = null; }
     this.titleEl.textContent = `${req.icao} — loading…`;
     this.statusEl.textContent = 'Connecting…';
@@ -169,14 +188,16 @@ export class AirportProfilePanel {
       this.statusEl.textContent = 'Pressure levels…';
       this.renderCross();
     } else if (phase === 'levels') {
-      this.statusEl.textContent = (raw && raw.error) ? `Levels failed (${raw.error})` : 'Analyzing…';
+      this.statusEl.textContent = (raw && raw.error) ? `Levels failed (${raw.error})` : 'GRIB enrichment…';
       this.renderSkewT();
+    } else if (phase === 'enriched') {
+      this.statusEl.textContent = `Analyzing… ${formatEnrichmentBadge(snapshot.enriched)}`;
     } else if (phase === 'derived') {
-      this.statusEl.textContent = '';
+      this.statusEl.textContent = formatEnrichmentBadge(snapshot.enriched);
       this.renderCross();
       this.renderSkewT();
     } else if (phase === 'complete') {
-      this.statusEl.textContent = '';
+      this.statusEl.textContent = formatEnrichmentBadge(snapshot.enriched);
     } else if (phase === 'error') {
       this.statusEl.textContent = 'Stream error';
     }

--- a/web/ts/visualization/airport-profile-panel.ts
+++ b/web/ts/visualization/airport-profile-panel.ts
@@ -212,7 +212,12 @@ export class AirportProfilePanel {
     } else if (phase === 'complete') {
       this.statusEl.textContent = formatEnrichmentBadge(snapshot.enriched);
     } else if (phase === 'error') {
-      this.statusEl.textContent = 'Stream error';
+      // Backend-emitted structured error: {type, phase, message}. Falls
+      // through to a generic message when the connection just dropped.
+      const detail = raw && typeof raw === 'object' && raw.phase
+        ? `${raw.phase}: ${raw.message ?? 'unknown error'}`
+        : 'connection lost';
+      this.statusEl.textContent = `Error — ${detail}`;
     }
   }
 

--- a/web/ts/visualization/airport-profile-panel.ts
+++ b/web/ts/visualization/airport-profile-panel.ts
@@ -281,14 +281,17 @@ export class AirportProfilePanel {
     this.skewtEl.innerHTML = '';
   }
 
-  /** Close the panel and notify the host. */
+  /** User clicked the ✕ button. Notifies the host so it can decide
+   *  what to do with the panel container — the host is then expected
+   *  to call `destroy()`. We don't tear anything down here; that keeps
+   *  the lifecycle linear (one teardown path) instead of having
+   *  `close()` and `destroy()` partially overlap. */
   close(): void {
-    if (this.stream) { this.stream.abort(); this.stream = null; }
-    this.clearRenderers();
     this.onClose?.();
   }
 
-  /** Tear down everything (used when the host removes the panel). */
+  /** Single teardown path: abort the SSE stream, dispose renderers,
+   *  empty the container. Idempotent. */
   destroy(): void {
     if (this.stream) { this.stream.abort(); this.stream = null; }
     this.clearRenderers();

--- a/web/ts/visualization/controls/panel.ts
+++ b/web/ts/visualization/controls/panel.ts
@@ -22,6 +22,72 @@ const GROUP_INFO: Record<string, () => string> = {
   icing: () => t('viz.icingMethods'),
 };
 
+/** Options shared between the main toolbar's layer-toggle block and the
+ *  standalone {@link renderLayerToggles} helper. */
+export interface LayerTogglesOptions {
+  displayMode?: DisplayMode;
+  preferredMethods?: Record<string, string>;
+  unavailableLayers?: Set<string>;
+}
+
+/** Build the `<div class="viz-layer-toggles">...</div>` block for a set of
+ *  enabled-layer states. Used inline by the main toolbar and by
+ *  {@link renderLayerToggles} for callers that only want this section. */
+function layerTogglesHtml(
+  enabledLayers: Record<string, boolean>,
+  opts: LayerTogglesOptions = {},
+): string {
+  const { displayMode, preferredMethods, unavailableLayers } = opts;
+  const groups = getLayerGroups();
+  let html = '<div class="viz-layer-toggles">';
+  for (const group of groups) {
+    const isCompactCollapse = displayMode === 'compact' && COMPACT_GROUPS.has(group.group);
+    const layersToRender = isCompactCollapse
+      ? [getPreferredLayerForGroup(group.group, group.layers, preferredMethods?.[group.group])]
+      : group.layers;
+
+    html += `<div class="viz-layer-group">`;
+    html += `<span class="viz-group-label">${group.label}:</span>`;
+    if (GROUP_INFO[group.group]) {
+      html += `<button class="viz-layer-info-btn viz-group-info-btn" data-group-info="${group.group}" title="About ${group.label}" aria-label="About ${group.label}">ⓘ</button>`;
+    }
+    for (const layer of layersToRender) {
+      const isUnavailable = unavailableLayers?.has(layer.id) ?? false;
+      const checked = !isUnavailable && enabledLayers[layer.id] !== false ? 'checked' : '';
+      const disabled = isUnavailable ? 'disabled' : '';
+      const dimClass = isUnavailable ? ' viz-layer-unavailable' : '';
+      const tooltip = isUnavailable ? ` title="${t('viz.notAvailableModel')}"` : '';
+      html += `<label class="viz-layer-checkbox${dimClass}"${tooltip}>`;
+      html += `<input type="checkbox" data-layer-id="${layer.id}" ${checked} ${disabled}>`;
+      html += `<span>${isCompactCollapse ? group.label : t('viz.layer.' + layer.id)}</span>`;
+      html += `</label>`;
+      if (layer.metricId) {
+        html += `<button class="viz-layer-info-btn" data-layer-info="${layer.id}" data-metric-id="${layer.metricId}" title="${t('viz.moreInfo')}" aria-label="${t('viz.moreInfo')}">ⓘ</button>`;
+      }
+    }
+    html += '</div>';
+  }
+  html += '</div>';
+  return html;
+}
+
+/** Render layer toggle checkboxes into a standalone container and wire
+ *  change events. For callers that only need the layer-selection part of
+ *  the main toolbar (e.g. the airport-profile panel's settings drawer).
+ *  Group/layer info buttons are emitted but NOT wired here — wire them in
+ *  the caller if needed. */
+export function renderLayerToggles(
+  container: HTMLElement,
+  enabledLayers: Record<string, boolean>,
+  onToggle: (layerId: string) => void,
+  opts: LayerTogglesOptions = {},
+): void {
+  container.innerHTML = layerTogglesHtml(enabledLayers, opts);
+  container.querySelectorAll<HTMLInputElement>('input[data-layer-id]').forEach((cb) => {
+    cb.addEventListener('change', () => onToggle(cb.dataset.layerId!));
+  });
+}
+
 export interface VizControlCallbacks {
   onLayerToggle: (layerId: string) => void;
   onLayoutChange: (layout: VizLayout) => void;
@@ -50,8 +116,6 @@ export function renderVizControls(
   preferredMethods?: Record<string, string>,
   unavailableLayers?: Set<string>,
 ): void {
-  const groups = getLayerGroups();
-
   let html = '<div class="viz-toolbar">';
 
   // Top row: Layout toggle + Model indicator + Render mode toggle
@@ -117,39 +181,14 @@ export function renderVizControls(
 
   html += '</div>'; // .viz-toolbar-top
 
-  // Layer toggles — only when cross-section visible
+  // Layer toggles — only when cross-section visible. The HTML is built
+  // by `layerTogglesHtml()` (also reused by `renderLayerToggles()` for
+  // the airport-profile drawer); change listeners are wired below.
   if (settings.layout !== 'map') {
-    html += '<div class="viz-layer-toggles">';
-    for (const group of groups) {
-      const isCompactCollapse = displayMode === 'compact' && COMPACT_GROUPS.has(group.group);
-      const layersToRender = isCompactCollapse
-        ? [getPreferredLayerForGroup(group.group, group.layers, preferredMethods?.[group.group])]
-        : group.layers;
-
-      html += `<div class="viz-layer-group">`;
-      html += `<span class="viz-group-label">${group.label}:</span>`;
-      if (GROUP_INFO[group.group]) {
-        html += `<button class="viz-layer-info-btn viz-group-info-btn" data-group-info="${group.group}" title="About ${group.label}" aria-label="About ${group.label}">\u24d8</button>`;
-      }
-      for (const layer of layersToRender) {
-        const isUnavailable = unavailableLayers?.has(layer.id) ?? false;
-        const checked = !isUnavailable && settings.enabledLayers[layer.id] !== false ? 'checked' : '';
-        const disabled = isUnavailable ? 'disabled' : '';
-        const dimClass = isUnavailable ? ' viz-layer-unavailable' : '';
-        const tooltip = isUnavailable ? ` title="${t('viz.notAvailableModel')}"` : '';
-        html += `<label class="viz-layer-checkbox${dimClass}"${tooltip}>`;
-        html += `<input type="checkbox" data-layer-id="${layer.id}" ${checked} ${disabled}>`;
-        html += `<span>${isCompactCollapse ? group.label : t('viz.layer.' + layer.id)}</span>`;
-        html += `</label>`;
-        if (layer.metricId) {
-          html += `<button class="viz-layer-info-btn" data-layer-info="${layer.id}" data-metric-id="${layer.metricId}" title="${t('viz.moreInfo')}" aria-label="${t('viz.moreInfo')}">\u24d8</button>`;
-        }
-      }
-      html += '</div>';
-    }
-    html += '</div>';
+    html += layerTogglesHtml(settings.enabledLayers, {
+      displayMode, preferredMethods, unavailableLayers,
+    });
   }
-
   html += '</div>'; // .viz-toolbar
 
   container.innerHTML = html;

--- a/web/ts/visualization/controls/panel.ts
+++ b/web/ts/visualization/controls/panel.ts
@@ -71,11 +71,36 @@ function layerTogglesHtml(
   return html;
 }
 
+/** Wire `data-layer-info` and `data-group-info` buttons inside `container`
+ *  to their respective info popups. Used by both the main toolbar and the
+ *  standalone {@link renderLayerToggles} so an info ⓘ is interactive
+ *  wherever the toggles render. */
+function wireLayerInfoButtons(container: HTMLElement): void {
+  container.querySelectorAll('[data-layer-info]').forEach((btn) => {
+    btn.addEventListener('click', (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      const el = btn as HTMLElement;
+      const layerId = el.dataset.layerInfo!;
+      const metricId = el.dataset.metricId!;
+      showLayerInfo(layerId, metricId);
+    });
+  });
+  container.querySelectorAll('[data-group-info]').forEach((btn) => {
+    btn.addEventListener('click', (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      const groupKey = (btn as HTMLElement).dataset.groupInfo!;
+      const infoFn = GROUP_INFO[groupKey];
+      if (infoFn) showPopupContent(infoFn());
+    });
+  });
+}
+
 /** Render layer toggle checkboxes into a standalone container and wire
- *  change events. For callers that only need the layer-selection part of
- *  the main toolbar (e.g. the airport-profile panel's settings drawer).
- *  Group/layer info buttons are emitted but NOT wired here — wire them in
- *  the caller if needed. */
+ *  change events + ⓘ info popups. For callers that only need the
+ *  layer-selection part of the main toolbar (e.g. the airport-profile
+ *  panel's settings drawer). */
 export function renderLayerToggles(
   container: HTMLElement,
   enabledLayers: Record<string, boolean>,
@@ -86,6 +111,7 @@ export function renderLayerToggles(
   container.querySelectorAll<HTMLInputElement>('input[data-layer-id]').forEach((cb) => {
     cb.addEventListener('change', () => onToggle(cb.dataset.layerId!));
   });
+  wireLayerInfoButtons(container);
 }
 
 export interface VizControlCallbacks {
@@ -242,28 +268,8 @@ export function renderVizControls(
     });
   }
 
-  // Wire info buttons
-  container.querySelectorAll('[data-layer-info]').forEach((btn) => {
-    btn.addEventListener('click', (e) => {
-      e.preventDefault();
-      e.stopPropagation();
-      const el = btn as HTMLElement;
-      const layerId = el.dataset.layerInfo!;
-      const metricId = el.dataset.metricId!;
-      showLayerInfo(layerId, metricId);
-    });
-  });
-
-  // Wire group info buttons
-  container.querySelectorAll('[data-group-info]').forEach((btn) => {
-    btn.addEventListener('click', (e) => {
-      e.preventDefault();
-      e.stopPropagation();
-      const groupKey = (btn as HTMLElement).dataset.groupInfo!;
-      const infoFn = GROUP_INFO[groupKey];
-      if (infoFn) showPopupContent(infoFn());
-    });
-  });
+  // Wire layer + group info ⓘ buttons (shared with renderLayerToggles).
+  wireLayerInfoButtons(container);
 }
 
 /** Render route graph controls (toggle + metric dropdowns) into a separate container below the graph. */

--- a/web/ts/visualization/cross-section/axes.ts
+++ b/web/ts/visualization/cross-section/axes.ts
@@ -18,11 +18,13 @@ export function drawAxes(
 ): void {
   ctx.font = FONT;
 
-  const visibleWaypoints = pickVisibleWaypointLabels(ctx, transform, data);
+  const visibleWaypoints = data.timeAxisMode
+    ? new Array(data.waypointMarkers.length).fill(false)
+    : pickVisibleWaypointLabels(ctx, transform, data);
 
   drawAltitudeAxis(ctx, transform, data);
   drawDistanceAxis(ctx, transform, data, visibleWaypoints);
-  drawWaypointLines(ctx, transform, data, visibleWaypoints);
+  if (!data.timeAxisMode) drawWaypointLines(ctx, transform, data, visibleWaypoints);
   drawPlotBorder(ctx, transform);
 }
 
@@ -146,6 +148,10 @@ function drawDistanceAxis(
   data: VizRouteData,
   visibleWaypoints: boolean[],
 ): void {
+  if (data.timeAxisMode) {
+    drawTimeAxis(ctx, transform, data);
+    return;
+  }
   const { plotArea } = transform;
   const maxDist = data.totalDistanceNm;
 
@@ -193,6 +199,35 @@ function drawDistanceAxis(
       ctx.fillStyle = labelColor();
       ctx.fillText(timeStr, x, plotArea.top + plotArea.height + 20);
     }
+  }
+}
+
+/** Time-axis variant: each point's `distanceNm` is treated as an hour offset
+ *  and the X label shows HH:MMZ from `point.time`. Used by the airport
+ *  profile panel. */
+function drawTimeAxis(
+  ctx: CanvasRenderingContext2D,
+  transform: CoordTransform,
+  data: VizRouteData,
+): void {
+  const { plotArea } = transform;
+  ctx.fillStyle = labelColor();
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'top';
+
+  for (const p of data.points) {
+    const x = transform.distanceToX(p.distanceNm);
+
+    ctx.strokeStyle = getActiveTheme().axes.gridColor;
+    ctx.lineWidth = 0.5;
+    ctx.setLineDash([]);
+    ctx.beginPath();
+    ctx.moveTo(x, plotArea.top);
+    ctx.lineTo(x, plotArea.top + plotArea.height);
+    ctx.stroke();
+
+    ctx.fillStyle = labelColor();
+    ctx.fillText(formatTimeUTC(p.time), x, plotArea.top + plotArea.height + 6);
   }
 }
 

--- a/web/ts/visualization/types.ts
+++ b/web/ts/visualization/types.ts
@@ -83,6 +83,14 @@ export interface VizRouteData {
   departureTime: string;
   flightDurationHours: number;
   terrainProfile: TerrainPoint[] | null;
+  /**
+   * When true, the cross-section's X-axis renders time labels (HH:MMZ)
+   * instead of distance ticks. Used by the airport-profile panel where
+   * the spatial extent collapses to one point and time becomes the X-axis.
+   * Distance values in `points[i].distanceNm` are repurposed as hour
+   * offsets from the start time, and `totalDistanceNm` is the total span.
+   */
+  timeAxisMode?: boolean;
 }
 
 export interface WaypointMarker {

--- a/web/ts/visualization/weather-map.ts
+++ b/web/ts/visualization/weather-map.ts
@@ -366,6 +366,8 @@ const FORECAST_LEGENDS: Record<ForecastMetric, { title: string; items: Array<{ c
 
 // --- Map class ---
 
+export type AirportContextHandler = (icao: string, lat: number, lon: number) => void;
+
 export class WeatherMap {
   private container: HTMLElement;
   private map: L.Map | null = null;
@@ -373,9 +375,34 @@ export class WeatherMap {
   private legendEl: HTMLElement | null = null;
   private tileLayer: L.TileLayer | null = null;
   private zoomHandler: (() => void) | null = null;
+  private contextHandler: AirportContextHandler | null = null;
+  private highlightedIcao: string | null = null;
+  private icaoToMarker: Map<string, L.CircleMarker> = new Map();
 
   constructor(container: HTMLElement) {
     this.container = container;
+  }
+
+  /** Register a callback fired when the user right-clicks an airport marker.
+   *  The forecast tab uses this to open the airport-profile detail panel. */
+  setAirportContextHandler(handler: AirportContextHandler | null): void {
+    this.contextHandler = handler;
+  }
+
+  /** Visually highlight one airport (typically the one currently shown
+   *  in the detail panel). Pass null to clear the highlight. */
+  setHighlightedIcao(icao: string | null): void {
+    if (this.highlightedIcao === icao) return;
+    if (this.highlightedIcao) {
+      const prev = this.icaoToMarker.get(this.highlightedIcao);
+      prev?.setStyle({ weight: 1 });
+    }
+    this.highlightedIcao = icao;
+    if (icao) {
+      const marker = this.icaoToMarker.get(icao);
+      marker?.setStyle({ weight: 4, color: '#fbbf24' });
+      marker?.bringToFront();
+    }
   }
 
   init(): void {
@@ -428,6 +455,7 @@ export class WeatherMap {
   setForecastData(data: ForecastMapResponse, metric: ForecastMetric, model: string): void {
     if (!this.markersGroup || !this.map) return;
     this.markersGroup.clearLayers();
+    this.icaoToMarker.clear();
 
     const r = this.markerRadius();
     const consensusMode: ConsensusMode | null = isConsensusMode(model) ? model : null;
@@ -447,11 +475,25 @@ export class WeatherMap {
       });
 
       marker.bindTooltip(getForecastTooltip(apt, model, metric), { className: 'map-tooltip' });
+      // Right-click → open airport profile panel. Native contextmenu is
+      // suppressed so the browser menu doesn't fight Leaflet's event.
+      marker.on('contextmenu', (e: L.LeafletMouseEvent) => {
+        L.DomEvent.preventDefault(e.originalEvent);
+        L.DomEvent.stopPropagation(e.originalEvent);
+        this.contextHandler?.(apt.icao, apt.lat, apt.lon);
+      });
       marker.addTo(this.markersGroup);
+      this.icaoToMarker.set(apt.icao, marker);
     }
 
     this.attachZoomHandler();
     this.renderLegend(FORECAST_LEGENDS[metric]);
+
+    // Re-apply highlight if the currently-highlighted airport is still on the map.
+    if (this.highlightedIcao) {
+      const m = this.icaoToMarker.get(this.highlightedIcao);
+      if (m) { m.setStyle({ weight: 4, color: '#fbbf24' }); m.bringToFront(); }
+    }
   }
 
   setVerificationData(data: VerificationMapResponse, metric: VerifMetric): void {

--- a/web/ts/visualization/weather-map.ts
+++ b/web/ts/visualization/weather-map.ts
@@ -366,7 +366,12 @@ const FORECAST_LEGENDS: Record<ForecastMetric, { title: string; items: Array<{ c
 
 // --- Map class ---
 
-export type AirportContextHandler = (icao: string, lat: number, lon: number) => void;
+/** Right-click handler — receives only the ICAO. The map already has the
+ *  coords via the marker, but the host re-resolves them server-side
+ *  (via `_resolve_airport_coords`) so passing them here would be dead
+ *  payload. If a future host wants to skip that lookup, extend the
+ *  signature then. */
+export type AirportContextHandler = (icao: string) => void;
 
 export class WeatherMap {
   private container: HTMLElement;
@@ -488,7 +493,7 @@ export class WeatherMap {
       marker.on('contextmenu', (e: L.LeafletMouseEvent) => {
         L.DomEvent.preventDefault(e.originalEvent);
         L.DomEvent.stopPropagation(e.originalEvent);
-        this.contextHandler?.(apt.icao, apt.lat, apt.lon);
+        this.contextHandler?.(apt.icao);
       });
       marker.addTo(this.markersGroup);
       this.icaoToMarker.set(apt.icao, { marker, weight: baseWeight, color: border });

--- a/web/ts/visualization/weather-map.ts
+++ b/web/ts/visualization/weather-map.ts
@@ -377,7 +377,12 @@ export class WeatherMap {
   private zoomHandler: (() => void) | null = null;
   private contextHandler: AirportContextHandler | null = null;
   private highlightedIcao: string | null = null;
-  private icaoToMarker: Map<string, L.CircleMarker> = new Map();
+  /** Marker registry. Stores the original style alongside the marker so
+   *  `setHighlightedIcao(null)` can restore the exact pre-highlight
+   *  appearance — consensus mode uses weight=2 + agreement-color border,
+   *  individual-model mode uses weight=1, and a single restored value
+   *  would silently change the visual encoding. */
+  private icaoToMarker: Map<string, { marker: L.CircleMarker; weight: number; color: string }> = new Map();
 
   constructor(container: HTMLElement) {
     this.container = container;
@@ -395,13 +400,15 @@ export class WeatherMap {
     if (this.highlightedIcao === icao) return;
     if (this.highlightedIcao) {
       const prev = this.icaoToMarker.get(this.highlightedIcao);
-      prev?.setStyle({ weight: 1 });
+      if (prev) prev.marker.setStyle({ weight: prev.weight, color: prev.color });
     }
     this.highlightedIcao = icao;
     if (icao) {
-      const marker = this.icaoToMarker.get(icao);
-      marker?.setStyle({ weight: 4, color: '#fbbf24' });
-      marker?.bringToFront();
+      const entry = this.icaoToMarker.get(icao);
+      if (entry) {
+        entry.marker.setStyle({ weight: 4, color: '#fbbf24' });
+        entry.marker.bringToFront();
+      }
     }
   }
 
@@ -464,13 +471,14 @@ export class WeatherMap {
       const border = consensusMode
         ? (AGREEMENT_COLORS[getAgreementForMetric(getConsensus(apt, consensusMode), metric) ?? ''] || '#888')
         : color;
+      const baseWeight = consensusMode ? 2 : 1;
 
       const marker = L.circleMarker([apt.lat, apt.lon], {
         radius: r,
         fillColor: color,
         fillOpacity: 0.85,
         color: border,
-        weight: consensusMode ? 2 : 1,
+        weight: baseWeight,
         opacity: 1,
       });
 
@@ -483,7 +491,7 @@ export class WeatherMap {
         this.contextHandler?.(apt.icao, apt.lat, apt.lon);
       });
       marker.addTo(this.markersGroup);
-      this.icaoToMarker.set(apt.icao, marker);
+      this.icaoToMarker.set(apt.icao, { marker, weight: baseWeight, color: border });
     }
 
     this.attachZoomHandler();
@@ -491,8 +499,11 @@ export class WeatherMap {
 
     // Re-apply highlight if the currently-highlighted airport is still on the map.
     if (this.highlightedIcao) {
-      const m = this.icaoToMarker.get(this.highlightedIcao);
-      if (m) { m.setStyle({ weight: 4, color: '#fbbf24' }); m.bringToFront(); }
+      const entry = this.icaoToMarker.get(this.highlightedIcao);
+      if (entry) {
+        entry.marker.setStyle({ weight: 4, color: '#fbbf24' });
+        entry.marker.bringToFront();
+      }
     }
   }
 


### PR DESCRIPTION
Right-clicking an airport marker on /maps.html opens a right-side panel
showing a vertical cross-section + Skew-T for that airport across the
selected hour and the next 3 forward hours, without creating a flight
briefing. Pilots can compare models (independent dropdown) and toggle
between Both / Cross-section / Skew-T views.

Closes #121.

## Backend

`GET /api/maps/airport-profile` streams phased SSE events:

| Phase | Source | Latency |
|-------|--------|---------|
| `meta` | static | ~0ms |
| `surface` | `airport_forecast_snapshots` cache | ~0ms |
| `levels` | Open-Meteo per-airport pressure-level fetch | 1–2s |
| `enriched` | local GRIB index (ECMWF/ICON-EU/GFS) via `enrich_forecasts` | up to ~10s |
| `derived` | `analyze_sounding` per hour on the (possibly-enriched) profile | ~50ms |
| `complete` / `error` | — | — |

GRIB enrichment reuses the existing per-flight `fetch.grib.enrich_forecasts()`
pipeline by wrapping our (icao, model, hours[]) into a synthetic single-point
RouteCrossSection — zero duplicate decode logic. A fast preflight skips the
phase when `ECMWF_GRIB_DIR` doesn't exist (dev environments). Pass
`?enrich=false` to bypass entirely.

## Frontend

- **`airport-profile-adapter.ts`**: SSE client + synthetic VizRouteData
  assembly. Hour offset is mapped onto `distanceNm` so the existing
  CrossSectionRenderer renders the time-axis view without a fork.
- **`airport-profile-panel.ts`**: panel UI (header, model select, view
  toggle, cross + skewt slots) with view mode persisted to localStorage.
- **`axes.ts`**: optional `timeAxisMode` on VizRouteData renders the
  X-axis as `HH:MMZ` ticks per point instead of nautical miles;
  waypoint labels suppressed in this mode.
- **`weather-map.ts`**: contextmenu handler on each forecast marker;
  `setHighlightedIcao()` ties the open panel to its source pin.
- **`maps.html`**: split-screen flex layout for the forecast tab;
  panel becomes a full-screen takeover at <900px viewport.
- **`maps-main.ts`**: panel open/close + reload on day/hour change
  (metric changes intentionally don't reload). Panel state
  (`fc.apt`, `fc.apModel`) round-trips via the URL share-link pattern.

## Tests

- 222 existing web tests pass; new `tests/test_airport_profile.py`
  exercises the hour-window helper.
- TypeScript typecheck clean.
- **Untested locally** — no Python runtime in this session. See [issue #121
  comment](https://github.com/roznet/flyfun-weather/issues/121#issuecomment-4396146395)
  for the on-device test plan.