### PR TITLE
fix(verification): route ECMWF GRIB decode through pool (issue #134)

### DIFF
--- a/src/weatherbrief/fetch/grib/__init__.py
+++ b/src/weatherbrief/fetch/grib/__init__.py
@@ -239,6 +239,24 @@ def _decode_pool_workers() -> int:
         return 2
 
 
+def _decode_pool_max_tasks_per_child() -> int | None:
+    """Worker recycle threshold; ``None`` disables recycling.
+
+    cfgrib/ECCODES allocate native memory that Python GC cannot reclaim;
+    recycling caps cumulative growth across many decodes (e.g. the standalone
+    ECMWF fetch dispatches ~50 decodes per run). 0 or negative means disabled.
+    """
+    raw = os.environ.get("GRIB_DECODE_MAX_TASKS_PER_CHILD", "50").strip()
+    try:
+        v = int(raw)
+        return v if v > 0 else None
+    except ValueError:
+        logger.warning(
+            "Invalid GRIB_DECODE_MAX_TASKS_PER_CHILD=%r, defaulting to 50", raw,
+        )
+        return 50
+
+
 def _decode_timeout_s() -> float:
     raw = os.environ.get("GRIB_DECODE_TIMEOUT_S", "").strip()
     if not raw:
@@ -270,12 +288,19 @@ def _get_decode_pool() -> ProcessPoolExecutor | None:
         # its own ECCODES setup that isn't fork-safe under load.
         ctx = multiprocessing.get_context("spawn")
         from weatherbrief.fetch.grib.decode_worker import _worker_init
-        _DECODE_POOL = ProcessPoolExecutor(
-            max_workers=workers,
-            mp_context=ctx,
-            initializer=_worker_init,
+        max_tasks = _decode_pool_max_tasks_per_child()
+        kwargs: dict[str, Any] = {
+            "max_workers": workers,
+            "mp_context": ctx,
+            "initializer": _worker_init,
+        }
+        if max_tasks is not None:
+            kwargs["max_tasks_per_child"] = max_tasks
+        _DECODE_POOL = ProcessPoolExecutor(**kwargs)
+        logger.info(
+            "GRIB decode pool started (workers=%d, mp=spawn, max_tasks_per_child=%s)",
+            workers, max_tasks if max_tasks is not None else "off",
         )
-        logger.info("GRIB decode pool started (workers=%d, mp=spawn)", workers)
     return _DECODE_POOL
 
 

--- a/src/weatherbrief/fetch/grib/decode_worker.py
+++ b/src/weatherbrief/fetch/grib/decode_worker.py
@@ -165,6 +165,12 @@ def _test_crash() -> None:
     os.kill(os.getpid(), signal.SIGKILL)
 
 
+def _test_pid() -> int:
+    """Return the worker process PID — used to verify worker recycling."""
+    import os
+    return os.getpid()
+
+
 def _test_hang(seconds: float = 60.0) -> None:
     """Sleep for *seconds* — used to verify the dispatcher's timeout path.
 

--- a/src/weatherbrief/tasks/standalone_verification.py
+++ b/src/weatherbrief/tasks/standalone_verification.py
@@ -26,9 +26,22 @@ from weatherbrief.db.models import (
     VerificationObservationRow,
     VerificationScoreRow,
 )
+from weatherbrief.process_rss import current_rss_mb
 from weatherbrief.tasks.airport_watchlist import WatchlistAirport
 
 logger = logging.getLogger(__name__)
+
+
+def _rss_log(label: str) -> None:
+    """Log parent-process RSS at a cycle phase boundary.
+
+    Memory regressions in this cycle have killed the container at the 3 GiB
+    cgroup limit (issue #134). Periodic RSS logs make creep visible before
+    the next OOM rather than after.
+    """
+    rss = current_rss_mb()
+    if rss is not None:
+        logger.info("Standalone cycle RSS @ %s: %dMB", label, int(rss))
 
 # ---------------------------------------------------------------------------
 # Configuration defaults (hardcoded until config table in Step 10)
@@ -479,11 +492,10 @@ def fetch_ecmwf_grib_snapshots(
     """
     from datetime import time as dt_time
 
+    from weatherbrief.fetch.grib import _dispatch_decode
     from weatherbrief.fetch.grib.decode import (
         build_ecmwf_surface_snapshot,
         build_pressure_levels_from_grib,
-        decode_ecmwf_pressure_per_point,
-        decode_ecmwf_surface_per_point,
     )
     from weatherbrief.models.analysis import HourlyForecast
 
@@ -521,7 +533,9 @@ def fetch_ecmwf_grib_snapshots(
             a1_cache[step_h] = empty
             return empty
         try:
-            data, _ = decode_ecmwf_surface_per_point(a1_path, lats, lons)
+            data, _ = _dispatch_decode(
+                "decode_ecmwf_surface", str(a1_path), lats, lons,
+            )
         except Exception:
             logger.warning("ECMWF a1 decode failed for step %dh", step_h, exc_info=True)
             data = empty
@@ -550,7 +564,9 @@ def fetch_ecmwf_grib_snapshots(
             pl_data: list[dict[int, dict[str, float]]] | None = None
             if a2_path is not None:
                 try:
-                    pl_data, _ = decode_ecmwf_pressure_per_point(a2_path, lats, lons)
+                    pl_data, _ = _dispatch_decode(
+                        "decode_ecmwf_pressure", str(a2_path), lats, lons,
+                    )
                 except Exception:
                     logger.warning(
                         "ECMWF a2 decode failed for step %dh", step_h, exc_info=True,
@@ -1020,6 +1036,8 @@ def run_standalone_cycle(
         scores_created = 0
         pruned = 0
 
+        _rss_log(f"start ({cycle_type})")
+
         if fetch_forecasts:
             # Phase A+B: Fetch and store forecasts per model. One model at a
             # time to bound memory — each model's snapshots are stored and
@@ -1094,6 +1112,7 @@ def run_standalone_cycle(
                 logger.info("Model %s: stored %d snapshots", model, stored)
                 del snapshots
                 models_fetched += 1
+                _rss_log(f"after {model}")
         else:
             logger.info("Skipping forecast fetch (score-only cycle)")
 
@@ -1147,6 +1166,8 @@ def run_standalone_cycle(
         )
         db.add(cycle_row)
         db.commit()
+
+        _rss_log(f"end ({cycle_type})")
 
         return {
             "cycle_type": cycle_type,

--- a/tests/test_grib_pool.py
+++ b/tests/test_grib_pool.py
@@ -29,6 +29,7 @@ import pytest
 
 import weatherbrief.fetch.grib as grib_pkg
 from weatherbrief.fetch.grib import (
+    _decode_pool_max_tasks_per_child,
     _decode_pool_workers,
     _dispatch_decode,
     _get_decode_pool,
@@ -252,3 +253,49 @@ def test_concurrent_thread_dispatch(monkeypatch):
         ]
         results = sorted(f.result() for f in futures)
     assert results == list(range(n))
+
+
+def test_max_tasks_per_child_default(monkeypatch):
+    """Default of 50 keeps cfgrib/ECCODES native memory bounded across long
+    runs (issue #134) — ECMWF standalone fetch dispatches ~50 decodes per run,
+    so workers turn over roughly once per cycle."""
+    monkeypatch.delenv("GRIB_DECODE_MAX_TASKS_PER_CHILD", raising=False)
+    assert _decode_pool_max_tasks_per_child() == 50
+
+
+def test_max_tasks_per_child_override(monkeypatch):
+    monkeypatch.setenv("GRIB_DECODE_MAX_TASKS_PER_CHILD", "10")
+    assert _decode_pool_max_tasks_per_child() == 10
+
+
+def test_max_tasks_per_child_disabled_via_zero(monkeypatch):
+    """Zero (or negative) disables recycling — escape hatch for debugging
+    or for environments where worker spawn overhead matters more than
+    bounding native memory."""
+    monkeypatch.setenv("GRIB_DECODE_MAX_TASKS_PER_CHILD", "0")
+    assert _decode_pool_max_tasks_per_child() is None
+    monkeypatch.setenv("GRIB_DECODE_MAX_TASKS_PER_CHILD", "-1")
+    assert _decode_pool_max_tasks_per_child() is None
+
+
+def test_max_tasks_per_child_invalid_falls_back(monkeypatch):
+    monkeypatch.setenv("GRIB_DECODE_MAX_TASKS_PER_CHILD", "not_a_number")
+    assert _decode_pool_max_tasks_per_child() == 50
+
+
+def test_pool_recycles_workers_after_max_tasks(monkeypatch):
+    """Once a worker hits ``max_tasks_per_child`` it exits and is replaced.
+
+    Verified by counting distinct worker PIDs across N+2 dispatches with
+    ``max_tasks_per_child=N`` and ``max_workers=1``: at least 2 distinct
+    PIDs must appear, proving the worker was recycled.
+    """
+    monkeypatch.setenv("GRIB_DECODE_WORKERS", "1")
+    monkeypatch.setenv("GRIB_DECODE_MAX_TASKS_PER_CHILD", "3")
+    shutdown_decode_pool()
+
+    pids = {_dispatch_decode("_test_pid") for _ in range(6)}
+    assert len(pids) >= 2, (
+        f"max_tasks_per_child=3 with 6 dispatches should recycle the worker; "
+        f"saw only {len(pids)} distinct PIDs ({pids})"
+    )

--- a/tests/test_standalone_ecmwf_decode_pool.py
+++ b/tests/test_standalone_ecmwf_decode_pool.py
@@ -1,0 +1,177 @@
+"""Verify ECMWF GRIB decode in standalone_verification dispatches through the
+pool (issue #134).
+
+Before the fix, ``fetch_ecmwf_grib_snapshots`` called
+``decode_ecmwf_pressure_per_point`` / ``decode_ecmwf_surface_per_point``
+directly in the parent process, leaking cfgrib/ECCODES native memory into
+uvicorn until the cgroup OOM-killed it. The fix routes both decodes through
+``_dispatch_decode`` so the work runs in a recyclable worker.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+from weatherbrief.tasks.airport_watchlist import WatchlistAirport
+from weatherbrief.tasks.standalone_verification import fetch_ecmwf_grib_snapshots
+
+
+@dataclass
+class _FakeECMWFFile:
+    """Stand-in for ``ecmwf_fetch.ECMWFFileInfo`` — only the fields read by
+    ``fetch_ecmwf_grib_snapshots`` are populated."""
+
+    path: Path
+    base_time: datetime
+    step_hours: int
+    feed: str  # "a1" (surface) or "a2" (pressure)
+
+    @property
+    def is_pressure_level(self) -> bool:
+        return self.feed == "a2"
+
+    @property
+    def is_surface(self) -> bool:
+        return self.feed == "a1"
+
+
+def _airports() -> list[WatchlistAirport]:
+    return [
+        WatchlistAirport(icao="LFPG", lat=49.0097, lon=2.5479),
+        WatchlistAirport(icao="EDDF", lat=50.0379, lon=8.5622),
+    ]
+
+
+def _fake_run_files(init_time: datetime, steps: list[int]) -> list[_FakeECMWFFile]:
+    """One a1 + one a2 file per step."""
+    files: list[_FakeECMWFFile] = []
+    for s in steps:
+        files.append(
+            _FakeECMWFFile(
+                path=Path(f"/fake/a1_step{s}.grib"),
+                base_time=init_time, step_hours=s, feed="a1",
+            ),
+        )
+        files.append(
+            _FakeECMWFFile(
+                path=Path(f"/fake/a2_step{s}.grib"),
+                base_time=init_time, step_hours=s, feed="a2",
+            ),
+        )
+    return files
+
+
+def test_fetch_ecmwf_grib_snapshots_dispatches_decode_to_pool():
+    """Both surface and pressure decodes must go through ``_dispatch_decode``.
+
+    Verifying by worker-function name: the in-process path called the local
+    ``decode_ecmwf_*_per_point`` functions, which would not be visible as
+    dispatched calls.
+    """
+    init_time = datetime(2026, 5, 8, 6, 0, tzinfo=timezone.utc)
+    # Steps land on 09Z, 12Z, 15Z, 18Z within day 0 — 4 steps in SAMPLE_HOURS_UTC.
+    steps = [3, 6, 9, 12]
+    run_files = _fake_run_files(init_time, steps)
+    airports = _airports()
+    n = len(airports)
+
+    surface_payload: list[dict[str, float]] = [
+        {
+            "raw_t2m_k": 285.0, "raw_d2m_k": 280.0,
+            "raw_u10_ms": 5.0, "raw_v10_ms": 0.0,
+            "raw_tp_m": 0.0,
+        }
+        for _ in range(n)
+    ]
+    pressure_payload: list[dict[int, dict[str, float]]] = [{} for _ in range(n)]
+
+    def fake_dispatch(worker_fn_name: str, *args):
+        if worker_fn_name == "decode_ecmwf_surface":
+            return (list(surface_payload), [True] * n)
+        if worker_fn_name == "decode_ecmwf_pressure":
+            return (list(pressure_payload), [False] * n)
+        raise AssertionError(f"unexpected worker: {worker_fn_name}")
+
+    with patch(
+        "weatherbrief.fetch.grib._dispatch_decode",
+        side_effect=fake_dispatch,
+    ) as mock_dispatch:
+        snaps = fetch_ecmwf_grib_snapshots(
+            run_files, airports, sample_hours=[9, 12, 15, 18], days=0,
+        )
+
+    assert mock_dispatch.called, "decode must go through the pool dispatcher"
+
+    worker_names = {c.args[0] for c in mock_dispatch.call_args_list}
+    assert worker_names == {"decode_ecmwf_surface", "decode_ecmwf_pressure"}, (
+        f"expected both worker names dispatched, got {worker_names}"
+    )
+
+    # Verify the file path argument is a string (worker functions expect str,
+    # not Path — Path is not picklable across spawned interpreters reliably).
+    for call in mock_dispatch.call_args_list:
+        path_arg = call.args[1]
+        assert isinstance(path_arg, str), (
+            f"_dispatch_decode args must be picklable strings, got {type(path_arg)}"
+        )
+
+    assert len(snaps) > 0, "fetcher should produce snapshots from canned data"
+    icaos = {s["icao"] for s in snaps}
+    assert icaos == {"LFPG", "EDDF"}
+
+
+def test_fetch_ecmwf_grib_snapshots_caches_a1_across_steps():
+    """``_decode_a1`` caches surface decode results so step-diff reuse doesn't
+    re-dispatch the same file. Important because each dispatch is a worker
+    round-trip — caching kept the in-process path cheap; the pool path must
+    keep the same property.
+    """
+    init_time = datetime(2026, 5, 8, 6, 0, tzinfo=timezone.utc)
+    # Two consecutive steps share the previous-step lookup chain:
+    #  - Step 9 reads a1[step=9] and a1[step=8] for tp diff
+    #  - Step 12 reads a1[step=12] and a1[step=11]
+    # Step 8 and 11 don't exist in the run, so they hit the empty-fallback
+    # cache once each. We expect exactly 4 unique a1 dispatches: steps 9, 8 (miss → empty),
+    # 12, 11 (miss → empty), but the empty path doesn't dispatch at all.
+    # So the actual count is 2 (one per real step that has an a1 file).
+    steps = [9, 12]
+    run_files = _fake_run_files(init_time, steps)
+    airports = _airports()
+    n = len(airports)
+
+    a1_calls: list[str] = []
+    a2_calls: list[str] = []
+
+    def fake_dispatch(worker_fn_name: str, path: str, *args):
+        if worker_fn_name == "decode_ecmwf_surface":
+            a1_calls.append(path)
+            return ([{"raw_t2m_k": 285.0} for _ in range(n)], [True] * n)
+        if worker_fn_name == "decode_ecmwf_pressure":
+            a2_calls.append(path)
+            return ([{} for _ in range(n)], [False] * n)
+        raise AssertionError(worker_fn_name)
+
+    with patch(
+        "weatherbrief.fetch.grib._dispatch_decode",
+        side_effect=fake_dispatch,
+    ):
+        fetch_ecmwf_grib_snapshots(
+            run_files, airports, sample_hours=[15, 18], days=0,
+        )
+
+    # 15Z → step_h=9, 18Z → step_h=12. Each calls _decode_a1(step) and
+    # _decode_a1(step-1). Steps 8 and 11 have no a1 file, so they short-circuit
+    # to the empty fallback without dispatch. Real a1 dispatches: step 9 and 12.
+    assert sorted(a1_calls) == [
+        "/fake/a1_step12.grib",
+        "/fake/a1_step9.grib",
+    ], f"unexpected a1 dispatches: {a1_calls}"
+
+    # Pressure decode runs once per step — no caching.
+    assert sorted(a2_calls) == [
+        "/fake/a2_step12.grib",
+        "/fake/a2_step9.grib",
+    ], f"unexpected a2 dispatches: {a2_calls}"


### PR DESCRIPTION
## Summary

- Route standalone ECMWF GRIB decode through the existing process pool — fixes the recurring 07Z OOM
- Add `max_tasks_per_child=50` to recycle workers and cap cfgrib/ECCODES native-memory growth
- Add RSS logging at cycle boundaries so memory creep is visible in logs *before* the next OOM

Addresses #134.

## Background

The 07Z `standalone_forecast` cycle has been OOM-killed two days running. `dmesg` shows the parent uvicorn hitting the 3 GiB cgroup limit:

| Date | Time | uvicorn anon RSS |
|---|---|---|
| Thu 2026-05-07 | 07:00:52 UTC | 2,697 MB |
| Fri 2026-05-08 | 07:00:33 UTC | 2,968 MB |

Both kills happened ~30–50s into the cycle. The container auto-restarts, but the new `run_forecast_fetch_loop` schedules its next fire at 19:00 UTC, so the 07Z run is silently lost — D0 verification stats stay empty for ~12h until 19Z recovers. The same silent-skip pattern hit on 5/1 19Z.

## Root cause

`tasks/standalone_verification.py:fetch_ecmwf_grib_snapshots` decoded ECMWF a1 (surface) and a2 (pressure-level) GRIBs **in the parent process** by calling `decode_ecmwf_*_per_point` directly. cfgrib/ECCODES native allocations leak into the parent across every `(day_offset × sample_hour)` step (~50 decodes per cycle).

The briefing-side path at `fetch/grib/__init__.py:659,678` decodes the same files via `_dispatch_decode("decode_ecmwf_pressure", …)` — work runs in a `ProcessPoolExecutor` worker so leakage is isolated.

The 19Z cycle survives because `_select_ecmwf_grib_run` typically returns None at that hour (06Z/18Z runs land later than 06Z/18Z), so the cycle falls back to Open-Meteo for ECMWF — no in-process cfgrib at all.

## Changes

**1. Pool dispatch** — `fetch_ecmwf_grib_snapshots` now calls `_dispatch_decode("decode_ecmwf_surface", …)` and `_dispatch_decode("decode_ecmwf_pressure", …)`. The worker functions already existed in `decode_worker.py`. The a1 step-cache continues to dedupe the previous-step lookup so dispatch count stays bounded.

**2. `max_tasks_per_child=50`** — new `GRIB_DECODE_MAX_TASKS_PER_CHILD` env var (default 50). cfgrib native memory is unreachable from Python GC, so recycling via worker exit is the only way to release it. Workers turn over roughly once per ECMWF standalone cycle. 0/negative disables.

**3. RSS logging at cycle boundaries** — `_rss_log()` writes parent RSS at cycle start, after each model, and at end. Production logs will now show the memory trend across cycles instead of only the kill itself.

Keep the 3 GiB cgroup as a forcing function (per 2026-05-03 memory-fixes-validated note).

## Test plan

- [x] `pytest tests/test_standalone_ecmwf_decode_pool.py tests/test_grib_pool.py` — 15 tests pass
- [x] Full fast suite: `pytest --ignore=tests/test_ecmwf_sample.py` — 1641 pass, 0 fail (1 pre-existing async-mark deselect)
- [ ] Post-deploy: watch tonight's 19Z cycle log for `Standalone cycle RSS @ end` line; confirm no OOM
- [ ] Post-deploy: watch tomorrow's 07Z cycle log for the same; confirm a `standalone_forecast` row appears in `verification_cycles`
- [ ] Verify `verification_scores` D0 count for the 24h window after deploy returns to baseline (5,873–12,231 per model)

🤖 Generated with [Claude Code](https://claude.com/claude-code)