### PR TITLE
Phase 1: decouple METAR ingest from verification scoring

### DIFF
--- a/src/weatherbrief/api/app.py
+++ b/src/weatherbrief/api/app.py
@@ -172,6 +172,14 @@ async def lifespan(app: FastAPI):
 
         digest_task = asyncio.create_task(run_digest_loop(app.state))
 
+    metar_ingest_task = None
+    if os.environ.get("DISABLE_METAR_INGEST", "").strip() not in ("1", "true"):
+        from weatherbrief.scheduler import run_metar_ingest_loop
+
+        metar_ingest_task = asyncio.create_task(
+            run_metar_ingest_loop(app.state)
+        )
+
     forecast_fetch_task = None
     if os.environ.get("DISABLE_FORECAST_FETCH") not in ("1", "true"):
         from weatherbrief.scheduler import run_forecast_fetch_loop
@@ -219,9 +227,9 @@ async def lifespan(app: FastAPI):
     yield
 
     for task in (scheduler_task, retention_task, verification_task,
-                 digest_task, forecast_fetch_task, standalone_task,
-                 ecmwf_watcher_task, hewson_precompute_task,
-                 freshness_task):
+                 digest_task, metar_ingest_task, forecast_fetch_task,
+                 standalone_task, ecmwf_watcher_task,
+                 hewson_precompute_task, freshness_task):
         if task:
             task.cancel()
             with suppress(asyncio.CancelledError):

--- a/src/weatherbrief/scheduler.py
+++ b/src/weatherbrief/scheduler.py
@@ -39,6 +39,18 @@ _VERIF_STARTUP_DELAY_SECONDS = 60  # let auto-refresh settle first
 _DIGEST_INTERVAL_SECONDS = 86_400  # 24 hours
 _DIGEST_STARTUP_DELAY_SECONDS = 180  # let verification settle first
 _STANDALONE_STARTUP_DELAY_SECONDS = 240  # let other loops settle first
+# METAR ingest fires every 30 min on :00/:30. Most EU airports issue at HH:20
+# and HH:50, so by HH:00/HH:30 aviationweather.gov has fully absorbed the
+# previous batch — no offset needed. Decoupled from forecast fetch and scoring
+# so the observation table is populated continuously instead of only at
+# sample hours.
+_METAR_INGEST_INTERVAL_SECONDS = 1800  # 30 minutes
+_METAR_INGEST_OFFSET_SECONDS = 0  # fire at :00/:30 sharp
+_METAR_INGEST_STARTUP_DELAY_SECONDS = 200  # land before standalone (240s)
+# Verification scoring fires 15 min past each synoptic hour, giving the HH:00
+# ingest plenty of margin (METAR fetch is ~30-60s) and ensuring freshly-stored
+# METARs are scored against snapshots already in DB.
+_VERIFICATION_HOUR_OFFSET_SECONDS = 900  # 15 min
 _ECMWF_WATCHER_POLL_SECONDS = 300  # 5 minutes
 _ECMWF_WATCHER_STARTUP_DELAY_SECONDS = 15  # run early — other loops may need ready data
 _FRESHNESS_LOOP_STARTUP_DELAY_SECONDS = 20  # let ECMWF watcher run once first
@@ -467,19 +479,114 @@ def _run_retention_once() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Forecast fetch + standalone verification loops
+# METAR ingest, forecast fetch, and standalone verification loops
 #
-# Two independent loops driven by the standalone subsystem:
+# Three independent loops driven by the standalone subsystem:
 #
+#   * METAR ingest fires every 30 min (offset 5 min past :00/:30 so airports
+#     have published). Pulls METAR/TAF for the watchlist and upserts into
+#     verification_observations. Source tag: 'metar_ingest'.
 #   * Forecast fetch fires at FORECAST_FETCH_HOURS_UTC + 15 min (07:15/19:15)
 #     so Open-Meteo GFS (~+6h45m) and ECMWF direct (~+6h40m) deliveries have
 #     landed. Additionally waits up to 15 min more if a marker's next_expected
 #     is within the window. Stores fresh snapshots only.
-#   * Verification fires at VERIFICATION_HOURS_UTC (06/09/12/15/18). Pulls
-#     METAR/TAF and scores against whatever snapshots are already in DB.
+#   * Verification fires at VERIFICATION_HOURS_UTC (06/09/12/15/18). Reads
+#     observations + snapshots already in DB and scores them — does NOT call
+#     aviationweather.gov (METAR ingest owns that).
 #
-# They're decoupled so verification picks up the right METARs at synoptic
-# bucket hours, while forecast fetch waits for the late ECMWF delivery.
+# Decoupled so observations accumulate continuously, scoring runs on a
+# synoptic cadence, and forecast fetch waits for the late ECMWF delivery.
+# ---------------------------------------------------------------------------
+
+
+async def run_metar_ingest_loop(app_state) -> None:
+    """Fetch METAR/TAF for the airport watchlist every 30 min.
+
+    Disableable via ``DISABLE_METAR_INGEST=1`` env var.
+    """
+    if os.environ.get("DISABLE_METAR_INGEST", "").strip() in ("1", "true"):
+        logger.info("METAR ingest disabled via env var")
+        return
+
+    logger.info(
+        "METAR ingest loop started (every %ds, offset +%ds)",
+        _METAR_INGEST_INTERVAL_SECONDS, _METAR_INGEST_OFFSET_SECONDS,
+    )
+    await asyncio.sleep(_METAR_INGEST_STARTUP_DELAY_SECONDS)
+
+    while True:
+        try:
+            sleep_secs = _seconds_until_next_30min_boundary(
+                _METAR_INGEST_OFFSET_SECONDS,
+            )
+            logger.info(
+                "METAR ingest: sleeping %ds until next ingest tick", sleep_secs,
+            )
+            await asyncio.sleep(sleep_secs)
+            await asyncio.to_thread(_run_metar_ingest_once, app_state)
+            # Advance past the current bucket so we don't re-trigger immediately
+            await asyncio.sleep(60)
+        except Exception:
+            logger.error("METAR ingest cycle failed", exc_info=True)
+            await asyncio.sleep(900)
+
+
+def _seconds_until_next_30min_boundary(offset_seconds: int) -> float:
+    """Seconds until the next ``:offset_minutes`` past either ``:00`` or ``:30``.
+
+    For ``offset_seconds=300`` (5 min), fires at ``HH:05`` and ``HH:35``.
+    """
+    now = datetime.now(timezone.utc)
+    offset_minutes = offset_seconds // 60
+    candidates = [
+        now.replace(minute=offset_minutes, second=0, microsecond=0),
+        now.replace(minute=30 + offset_minutes, second=0, microsecond=0),
+    ]
+    candidates = [c for c in candidates if c > now]
+    if candidates:
+        return (min(candidates) - now).total_seconds()
+    # Both offsets in this hour have passed — first slot of the next hour
+    next_hour = (now + timedelta(hours=1)).replace(
+        minute=offset_minutes, second=0, microsecond=0,
+    )
+    return (next_hour - now).total_seconds()
+
+
+def _run_metar_ingest_once(app_state) -> None:
+    """Execute a single METAR ingest cycle (called in a thread)."""
+    db_path = getattr(app_state, "db_path", "")
+    if not db_path:
+        logger.warning("METAR ingest: no AIRPORTS_DB configured")
+        return
+
+    from weatherbrief.tasks.airport_watchlist import (
+        get_configs_dir,
+        load_watchlist_with_coords,
+    )
+    from weatherbrief.tasks.standalone_verification import run_metar_ingest_cycle
+
+    try:
+        airports = load_watchlist_with_coords(get_configs_dir(), db_path)
+    except FileNotFoundError:
+        logger.warning(
+            "METAR ingest: airport watchlist not found. "
+            "Run: python -m weatherbrief.verify discover"
+        )
+        return
+
+    if not airports:
+        logger.warning("METAR ingest: empty watchlist")
+        return
+
+    result = run_metar_ingest_cycle(airports, db_path)
+    logger.info(
+        "METAR ingest cycle: %d airports, %d new observations (%dms)",
+        result["airports"], result["observations_stored"], result["duration_ms"],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Forecast fetch + standalone verification loops
 # ---------------------------------------------------------------------------
 
 
@@ -581,12 +688,15 @@ async def run_standalone_verification_loop(app_state) -> None:
                 sleep_secs,
             )
             await asyncio.sleep(sleep_secs)
+            # Offset by 15 min so the HH:00 METAR ingest (~30-60s fetch) has
+            # fully landed before scoring picks the nearest obs.
+            await asyncio.sleep(_VERIFICATION_HOUR_OFFSET_SECONDS)
             await asyncio.to_thread(
                 _run_standalone_once, app_state,
                 False,  # fetch_forecasts
                 True,   # score_observations
             )
-            await asyncio.sleep(60)  # advance past the current hour
+            await asyncio.sleep(60)  # advance past the current offset
         except Exception:
             logger.error("Standalone verification cycle failed", exc_info=True)
             await asyncio.sleep(900)

--- a/src/weatherbrief/tasks/standalone_verification.py
+++ b/src/weatherbrief/tasks/standalone_verification.py
@@ -1129,10 +1129,13 @@ def run_standalone_cycle(
         fetch + store snapshots only. Used by the forecast-fetch loop, which
         fires after ECMWF deliveries land.
       * ``fetch_forecasts=False, score_observations=True`` → ``"light"``:
-        METAR/TAF fetch + scoring only. Used by the verification loop, which
-        scores observations against whatever snapshots are already in DB.
+        Score-only. Reads observations already stored in the DB (populated
+        by :func:`run_metar_ingest_cycle`) — does NOT call aviationweather.gov.
 
     The remaining ``(False, False)`` combination is rejected.
+
+    Note: METAR fetch is owned by :func:`run_metar_ingest_cycle`, which fires
+    every 30 min on its own loop. Scoring cycles only read from DB.
 
     Returns a summary dict with counts and timing.
     """
@@ -1253,12 +1256,10 @@ def run_standalone_cycle(
         t_fetch_done = time.monotonic()
 
         if score_observations:
-            # Phase C: Fetch METAR/TAF
-            obs_stored = _fetch_and_store_observations(airports, airports_db_path, db)
+            # Phase D: Score against snapshots + observations already in DB.
+            # METAR fetch is owned by run_metar_ingest_cycle on its own loop —
+            # this cycle is a pure-DB operation now.
             t_obs_done = time.monotonic()
-            logger.info("Stored %d new observations", obs_stored)
-
-            # Phase D: Score against snapshots already in DB.
             scores_created = _score_cycle(now, airports, airports_db_path, db)
             t_score_done = time.monotonic()
             logger.info("Created %d scores", scores_created)
@@ -1354,6 +1355,69 @@ def run_standalone_cycle(
         db.close()
 
 
+# ---------------------------------------------------------------------------
+# METAR ingest cycle — fires every 30 min, decoupled from scoring
+# ---------------------------------------------------------------------------
+
+
+def run_metar_ingest_cycle(
+    airports: list[WatchlistAirport],
+    airports_db_path: str,
+) -> dict:
+    """Fetch METAR/TAF for the watchlist and upsert into verification_observations.
+
+    Called from the 30-min METAR ingest loop. Does no forecast fetch and no
+    scoring — those are owned by the forecast-fetch and verification loops
+    respectively. The 30-min bucket dedup in :func:`store_observations`
+    means cycles firing at HH:05 and HH:35 each insert at most one row per
+    airper-bucket, so SPECIs land alongside regular reports.
+
+    Returns a summary dict; persists a row in ``verification_cycles`` with
+    ``source='metar_ingest'``.
+    """
+    from flyfun_common.db import SessionLocal
+
+    t_start = time.monotonic()
+    started_at = datetime.now(timezone.utc)
+
+    db = SessionLocal()
+    try:
+        try:
+            obs_stored = _fetch_and_store_observations(
+                airports, airports_db_path, db,
+            )
+            db.commit()
+        except Exception:
+            db.rollback()
+            _record_failed_cycle(
+                started_at, t_start, "metar_ingest", len(airports),
+            )
+            raise
+
+        duration_ms = int((time.monotonic() - t_start) * 1000)
+
+        cycle_row = VerificationCycleRow(
+            started_at=started_at,
+            duration_ms=duration_ms,
+            source="metar_ingest",
+            phase_fetch_ms=duration_ms,
+            airports=len(airports),
+            observations_stored=obs_stored,
+            scored=0,
+        )
+        db.add(cycle_row)
+        db.commit()
+
+        return {
+            "cycle_type": "metar_ingest",
+            "airports": len(airports),
+            "observations_stored": obs_stored,
+            "duration_ms": duration_ms,
+        }
+    finally:
+        db.close()
+
+
 def _record_failed_cycle(
     started_at: datetime,
     t_start: float,
@@ -1368,12 +1432,16 @@ def _record_failed_cycle(
     duration_ms = int((time.monotonic() - t_start) * 1000)
     error_msg = traceback.format_exc()[-500:]  # last 500 chars
 
+    # New metar_ingest cycle keeps its bare source name; the legacy
+    # standalone cycles prefix it for backward-compat with existing queries.
+    source = cycle_type if cycle_type == "metar_ingest" else f"standalone_{cycle_type}"
+
     try:
         err_db = SessionLocal()
         cycle_row = VerificationCycleRow(
             started_at=started_at,
             duration_ms=duration_ms,
-            source=f"standalone_{cycle_type}",
+            source=source,
             phase_fetch_ms=0,
             phase_find_ms=0,
             phase_gather_ms=0,

--- a/src/weatherbrief/tasks/verification.py
+++ b/src/weatherbrief/tasks/verification.py
@@ -269,23 +269,29 @@ def fetch_observations_batch(
 # ---------------------------------------------------------------------------
 
 
-def _should_skip_for_hourly_dedup(
+def _should_skip_for_bucket_dedup(
     db: Session, icao: str, obs_time: datetime,
 ) -> bool:
-    """One-per-hour filter: keep at most one observation per airport per clock hour.
+    """30-min bucket filter: keep at most one observation per airport per
+    30-minute bucket (``[HH:00, HH:30)`` and ``[HH:30, HH+1:00)``).
 
-    Returns True if an observation already exists for this (icao, hour) —
+    Returns True if an observation already exists for this (icao, bucket) —
     the caller should skip this observation. Once an observation is stored
     it is never replaced, since scores or FK references may already point
     to it.
+
+    METARs are normally issued every 30 minutes; SPECIs land at off-cycle
+    times. The 30-min bucket lets the new ingest loop (firing every 30 min)
+    capture both regular reports and SPECIs without inflating the table.
     """
-    hour_start = obs_time.replace(minute=0, second=0, microsecond=0)
-    hour_end = hour_start + timedelta(hours=1)
+    bucket_minute = 0 if obs_time.minute < 30 else 30
+    bucket_start = obs_time.replace(minute=bucket_minute, second=0, microsecond=0)
+    bucket_end = bucket_start + timedelta(minutes=30)
     existing = db.execute(
         select(VerificationObservationRow.id)
         .where(VerificationObservationRow.icao == icao)
-        .where(VerificationObservationRow.observation_time >= hour_start)
-        .where(VerificationObservationRow.observation_time < hour_end)
+        .where(VerificationObservationRow.observation_time >= bucket_start)
+        .where(VerificationObservationRow.observation_time < bucket_end)
         .limit(1)
     ).scalar_one_or_none()
 
@@ -299,8 +305,9 @@ def store_observations(
 ) -> int:
     """Store observations and create flight linkages.
 
-    Deduplicates on (icao, observation_time). Applies one-per-hour filter.
-    Returns count of newly inserted observations.
+    Deduplicates on (icao, observation_time). Applies one-per-30-min-bucket
+    filter so HH:00 and HH:30 METARs both land while SPECIs at HH:15 are
+    absorbed. Returns count of newly inserted observations.
     """
     inserted = 0
 
@@ -315,8 +322,8 @@ def store_observations(
         if existing is not None:
             obs_row_id = existing.id
         else:
-            # One-per-hour filter: keep whichever observation is closer to :00
-            if _should_skip_for_hourly_dedup(db, obs.icao, obs.observation_time):
+            # One-per-30-min-bucket filter: keep first arrival per bucket.
+            if _should_skip_for_bucket_dedup(db, obs.icao, obs.observation_time):
                 continue
 
             row = VerificationObservationRow(

--- a/tests/test_standalone_verification.py
+++ b/tests/test_standalone_verification.py
@@ -591,7 +591,6 @@ class TestRunStandaloneCycle:
 
     @patch("weatherbrief.tasks.standalone_verification._prune_old_snapshots", return_value=0)
     @patch("weatherbrief.tasks.standalone_verification._score_cycle", return_value=5)
-    @patch("weatherbrief.tasks.standalone_verification._fetch_and_store_observations", return_value=3)
     @patch("weatherbrief.tasks.standalone_verification._store_snapshots", return_value=100)
     @patch("weatherbrief.tasks.standalone_verification._enrich_with_grib")
     @patch("weatherbrief.tasks.standalone_verification._fetch_forecasts_for_model", return_value=([{"dummy": True}], 1))
@@ -599,7 +598,7 @@ class TestRunStandaloneCycle:
     @patch("flyfun_common.db.SessionLocal")
     def test_full_cycle_orchestration(
         self, mock_session_local, mock_meta, mock_fetch, mock_enrich,
-        mock_store_snap, mock_store_obs, mock_score, mock_prune,
+        mock_store_snap, mock_score, mock_prune,
     ):
         from weatherbrief.tasks.standalone_verification import run_standalone_cycle
 
@@ -618,7 +617,8 @@ class TestRunStandaloneCycle:
 
         assert result["models_fetched"] == 1
         assert result["snapshots_stored"] == 100
-        assert result["observations_stored"] == 3
+        # METAR fetch is no longer the cycle's job — owned by metar_ingest loop
+        assert result["observations_stored"] == 0
         assert result["scores_created"] == 5
         assert result["duration_ms"] >= 0
         assert mock_db.commit.call_count >= 1
@@ -637,8 +637,7 @@ class TestRunStandaloneCycle:
             "gfs": SimpleNamespace(last_init_time=int(GFS_INIT.timestamp())),
         }
 
-        with patch("weatherbrief.tasks.standalone_verification._fetch_and_store_observations", return_value=0), \
-             patch("weatherbrief.tasks.standalone_verification._score_cycle", return_value=0), \
+        with patch("weatherbrief.tasks.standalone_verification._score_cycle", return_value=0), \
              patch("weatherbrief.tasks.standalone_verification._prune_old_snapshots", return_value=0), \
              patch("weatherbrief.tasks.standalone_verification._store_snapshots", return_value=0):
             result = run_standalone_cycle(
@@ -650,12 +649,11 @@ class TestRunStandaloneCycle:
 
     @patch("weatherbrief.tasks.standalone_verification._prune_old_snapshots", return_value=0)
     @patch("weatherbrief.tasks.standalone_verification._score_cycle", return_value=7)
-    @patch("weatherbrief.tasks.standalone_verification._fetch_and_store_observations", return_value=5)
     @patch("flyfun_common.db.SessionLocal")
     def test_light_cycle_skips_fetch(
-        self, mock_session_local, mock_store_obs, mock_score, mock_prune,
+        self, mock_session_local, mock_score, mock_prune,
     ):
-        """Light cycle (fetch_forecasts=False) skips Phase A+B entirely."""
+        """Light cycle (fetch_forecasts=False) skips Phase A+B and reads obs from DB."""
         from weatherbrief.tasks.standalone_verification import run_standalone_cycle
 
         mock_db = MagicMock()
@@ -667,13 +665,13 @@ class TestRunStandaloneCycle:
         assert result["cycle_type"] == "light"
         assert result["models_fetched"] == 0
         assert result["snapshots_stored"] == 0
-        assert result["observations_stored"] == 5
+        # Light cycle no longer fetches METARs — that's the metar_ingest loop's job.
+        assert result["observations_stored"] == 0
         assert result["scores_created"] == 7
         assert result["duration_ms"] >= 0
 
     @patch("weatherbrief.tasks.standalone_verification._prune_old_snapshots", return_value=0)
     @patch("weatherbrief.tasks.standalone_verification._score_cycle", return_value=5)
-    @patch("weatherbrief.tasks.standalone_verification._fetch_and_store_observations", return_value=3)
     @patch("weatherbrief.tasks.standalone_verification._store_snapshots", return_value=100)
     @patch("weatherbrief.tasks.standalone_verification._enrich_with_grib")
     @patch("weatherbrief.tasks.standalone_verification._fetch_forecasts_for_model", return_value=([{"dummy": True}], 1))
@@ -681,7 +679,7 @@ class TestRunStandaloneCycle:
     @patch("flyfun_common.db.SessionLocal")
     def test_full_cycle_returns_cycle_type(
         self, mock_session_local, mock_meta, mock_fetch, mock_enrich,
-        mock_store_snap, mock_store_obs, mock_score, mock_prune,
+        mock_store_snap, mock_score, mock_prune,
     ):
         """Full cycle sets cycle_type='full' in result."""
         from weatherbrief.tasks.standalone_verification import run_standalone_cycle
@@ -698,6 +696,38 @@ class TestRunStandaloneCycle:
         result = run_standalone_cycle(airports, "/fake/db")
 
         assert result["cycle_type"] == "full"
+
+
+class TestRunMetarIngestCycle:
+
+    @patch("weatherbrief.tasks.standalone_verification._fetch_and_store_observations", return_value=7)
+    @patch("flyfun_common.db.SessionLocal")
+    def test_records_cycle_row_with_metar_ingest_source(
+        self, mock_session_local, mock_fetch_obs,
+    ):
+        """run_metar_ingest_cycle commits a cycle row tagged source='metar_ingest'."""
+        from weatherbrief.tasks.standalone_verification import run_metar_ingest_cycle
+
+        mock_db = MagicMock()
+        mock_session_local.return_value = mock_db
+
+        airports = [
+            WatchlistAirport(icao="LFPG", lat=49.01, lon=2.55),
+            WatchlistAirport(icao="EGLL", lat=51.47, lon=-0.46),
+        ]
+        result = run_metar_ingest_cycle(airports, "/fake/db")
+
+        assert result["cycle_type"] == "metar_ingest"
+        assert result["airports"] == 2
+        assert result["observations_stored"] == 7
+        assert result["duration_ms"] >= 0
+        # _fetch_and_store_observations was called with the watchlist
+        mock_fetch_obs.assert_called_once()
+        # A cycle row was added (along with whatever the fetch helper added)
+        assert mock_db.add.called
+        added_rows = [c.args[0] for c in mock_db.add.call_args_list]
+        cycle_rows = [r for r in added_rows if getattr(r, "source", None) == "metar_ingest"]
+        assert len(cycle_rows) == 1
 
 
 class TestEnrichWithSounding:

--- a/tests/test_verification.py
+++ b/tests/test_verification.py
@@ -35,7 +35,7 @@ from weatherbrief.db.models import (
 )
 from weatherbrief.models.verification import VerificationObservation
 from weatherbrief.tasks.verification import (
-    _should_skip_for_hourly_dedup,
+    _should_skip_for_bucket_dedup,
     collect_and_store,
     fetch_observations_batch,
     finalize_completed_flights,
@@ -287,19 +287,33 @@ class TestGatherAirports:
 
 
 # ---------------------------------------------------------------------------
-# Hourly dedup
+# 30-min bucket dedup
 # ---------------------------------------------------------------------------
 
 
-class TestHourlyDedup:
+class TestBucketDedup:
 
     def test_empty_db_no_skip(self, db_session):
-        assert not _should_skip_for_hourly_dedup(
+        assert not _should_skip_for_bucket_dedup(
             db_session, "EGTK", NOW,
         )
 
-    def test_existing_observation_skips(self, db_session):
-        # Observation at 12:20 — same clock hour as 12:30
+    def test_same_bucket_skips(self, db_session):
+        # 12:05 and 12:25 both fall in the [12:00, 12:30) bucket
+        db_session.add(VerificationObservationRow(
+            icao="EGTK",
+            observation_time=_utc(2026, 4, 1, 12, 5),
+            collected_at=NOW,
+        ))
+        db_session.flush()
+
+        assert _should_skip_for_bucket_dedup(
+            db_session, "EGTK", _utc(2026, 4, 1, 12, 25),
+        )
+
+    def test_different_bucket_within_hour_no_skip(self, db_session):
+        # 12:20 is in [12:00, 12:30); 12:35 is in [12:30, 13:00) — different
+        # buckets, both should be storable.
         db_session.add(VerificationObservationRow(
             icao="EGTK",
             observation_time=_utc(2026, 4, 1, 12, 20),
@@ -307,8 +321,8 @@ class TestHourlyDedup:
         ))
         db_session.flush()
 
-        assert _should_skip_for_hourly_dedup(
-            db_session, "EGTK", _utc(2026, 4, 1, 12, 30),
+        assert not _should_skip_for_bucket_dedup(
+            db_session, "EGTK", _utc(2026, 4, 1, 12, 35),
         )
 
     def test_different_hour_no_skip(self, db_session):
@@ -319,7 +333,7 @@ class TestHourlyDedup:
         ))
         db_session.flush()
 
-        assert not _should_skip_for_hourly_dedup(db_session, "EGTK", NOW)
+        assert not _should_skip_for_bucket_dedup(db_session, "EGTK", NOW)
 
     def test_different_airport_no_skip(self, db_session):
         db_session.add(VerificationObservationRow(
@@ -329,7 +343,7 @@ class TestHourlyDedup:
         ))
         db_session.flush()
 
-        assert not _should_skip_for_hourly_dedup(db_session, "EGTK", NOW)
+        assert not _should_skip_for_bucket_dedup(db_session, "EGTK", NOW)
 
 
 # ---------------------------------------------------------------------------
@@ -373,7 +387,20 @@ class TestStoreObservations:
         ).scalars().all()
         assert len(rows) == 1
 
-    def test_hourly_dedup_skips_second_obs(self, db_session, dev_user):
+    def test_bucket_dedup_skips_second_obs_same_bucket(self, db_session, dev_user):
+        # Both fall in the [12:00, 12:30) bucket — only one stored.
+        flight = _make_flight(db_session, dev_user, verification_status="collecting")
+        obs1 = _make_observation(observation_time=_utc(2026, 4, 1, 12, 5))
+        obs2 = _make_observation(observation_time=_utc(2026, 4, 1, 12, 25))
+        icao_map = {"EGTK": {flight.id}}
+
+        count = store_observations([obs1, obs2], icao_map, db_session)
+        db_session.flush()
+
+        assert count == 1
+
+    def test_bucket_dedup_keeps_obs_in_different_buckets(self, db_session, dev_user):
+        # 12:05 in [12:00, 12:30); 12:35 in [12:30, 13:00) — both stored.
         flight = _make_flight(db_session, dev_user, verification_status="collecting")
         obs1 = _make_observation(observation_time=_utc(2026, 4, 1, 12, 5))
         obs2 = _make_observation(observation_time=_utc(2026, 4, 1, 12, 35))
@@ -382,7 +409,7 @@ class TestStoreObservations:
         count = store_observations([obs1, obs2], icao_map, db_session)
         db_session.flush()
 
-        assert count == 1
+        assert count == 2
 
     def test_creates_flight_linkage(self, db_session, dev_user):
         flight = _make_flight(db_session, dev_user, verification_status="collecting")


### PR DESCRIPTION
## Summary

First infrastructure phase of the Patterns + Spotlight rework
([plan](designs/plans/patterns-and-spotlight.md)). Splits the standalone
pipeline into three independent loops so observations accumulate
continuously rather than only at the five synoptic sample hours.

- **METAR ingest** every 30 min at HH:00 / HH:30, just stores observations.
  Most EU airports issue at HH:20 / HH:50, so by HH:00 aviationweather has
  fully absorbed the previous batch — no offset needed. Disable via
  `DISABLE_METAR_INGEST=1`.
- **Verification scoring** shifts to HH:15 at synoptic hours (15-min offset,
  same pattern the forecast-fetch loop already uses). Reads stored obs
  from the DB; no longer calls aviationweather.gov.
- **Dedup** relaxes from "one per clock hour" to "one per 30-min bucket"
  so HH:00 and HH:30 METARs both land while SPECIs at HH:15 are absorbed.
- New `run_metar_ingest_cycle()` records `verification_cycles` rows tagged
  `source='metar_ingest'` for visibility alongside the existing
  `standalone_full` / `standalone_light` cycle types.

Behaviorally neutral for scoring quality at deploy time: the HH:00 ingest
+ HH:15 score combination picks fresher METARs than the old HH:00
fetch-then-score (which often only saw HH:50 issuances). The bigger win
is everywhere downstream — SPECI capture, climatology granularity,
foggiest/stormiest leaderboards in the upcoming Spotlight tab.

## Test plan

- [x] `pytest tests/test_verification.py tests/test_standalone_verification.py tests/test_scheduler.py` (86 tests green)
- [x] App imports cleanly with all DISABLE_* env vars set
- [x] Manually verified `_seconds_until_next_30min_boundary(0)` fires correctly at :00/:30 boundaries
- [ ] Deploy to weather.flyfun.aero and confirm:
  - [ ] `verification_cycles` accumulates `source='metar_ingest'` rows every 30 min
  - [ ] `verification_observations` row count grows ~2× prior rate
  - [ ] `standalone_light` cycles' `phase_gather_ms` drops to near zero (no METAR fetch)
  - [ ] No regression in scoring quality vs prior cycles

🤖 Generated with [Claude Code](https://claude.com/claude-code)