### PR TITLE
Phases 2 & 3: airport summary rollups

### DIFF
--- a/alembic/versions/053_airport_summary_tables.py
+++ b/alembic/versions/053_airport_summary_tables.py
@@ -1,0 +1,115 @@
+"""Add airport_monthly_summary and airport_daily_summary rollup tables.
+
+Pre-aggregated observation climatology per airport. Powers the public
+Patterns map and Spotlight leaderboards/heatmaps. Both tables are pure
+``op.create_table`` so they apply identically on SQLite (dev) and MySQL
+(prod) without batch mode.
+
+Revision ID: 053
+Revises: 052
+Create Date: 2026-05-10
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "053"
+down_revision: Union[str, None] = "052"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "airport_monthly_summary",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("month", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("icao", sa.String(4), nullable=False),
+        # Sample size
+        sa.Column("n_obs", sa.Integer(), nullable=False, server_default="0"),
+        # Flight category hour counts
+        sa.Column("n_vfr", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("n_mvfr", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("n_ifr", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("n_lifr", sa.Integer(), nullable=False, server_default="0"),
+        # Phenomena hour counts
+        sa.Column("n_obscuration", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("n_fg", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("n_br", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("n_haze", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("n_precip", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("n_ra", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("n_sn", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("n_ts", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("n_freezing", sa.Integer(), nullable=False, server_default="0"),
+        # Ceiling percentiles (ft)
+        sa.Column("ceiling_p10_ft", sa.Integer(), nullable=True),
+        sa.Column("ceiling_p25_ft", sa.Integer(), nullable=True),
+        sa.Column("ceiling_p50_ft", sa.Integer(), nullable=True),
+        sa.Column("ceiling_p75_ft", sa.Integer(), nullable=True),
+        sa.Column("ceiling_p90_ft", sa.Integer(), nullable=True),
+        # Visibility percentiles (m)
+        sa.Column("visibility_p10_m", sa.Integer(), nullable=True),
+        sa.Column("visibility_p25_m", sa.Integer(), nullable=True),
+        sa.Column("visibility_p50_m", sa.Integer(), nullable=True),
+        # Wind aggregates (kt)
+        sa.Column("wind_mean_kt", sa.Float(), nullable=True),
+        sa.Column("wind_p50_kt", sa.Float(), nullable=True),
+        sa.Column("wind_p95_kt", sa.Float(), nullable=True),
+        sa.Column("gust_max_kt", sa.Integer(), nullable=True),
+        # Hours-below-threshold convenience counts
+        sa.Column("n_ceiling_below_500", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("n_ceiling_below_1500", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("n_visibility_below_5km", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("n_wind_over_25kt", sa.Integer(), nullable=False, server_default="0"),
+        # Temperature extremes
+        sa.Column("temp_min_c", sa.Float(), nullable=True),
+        sa.Column("temp_max_c", sa.Float(), nullable=True),
+        # Volatility
+        sa.Column("category_changes", sa.Integer(), nullable=False, server_default="0"),
+        # Per-hour-of-day breakdown JSON
+        sa.Column("diurnal_json", sa.Text(), nullable=True),
+        # Constraints
+        sa.UniqueConstraint("month", "icao", name="uq_ams_key"),
+        sa.Index("ix_ams_month", "month"),
+        sa.Index("ix_ams_icao", "icao"),
+    )
+
+    op.create_table(
+        "airport_daily_summary",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("date", sa.Date(), nullable=False),
+        sa.Column("icao", sa.String(4), nullable=False),
+        sa.Column("n_obs", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("worst_category", sa.String(4), nullable=True),
+        sa.Column("n_vfr", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("n_mvfr", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("n_ifr", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("n_lifr", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("n_obscuration", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("n_fg", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("n_br", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("n_precip", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("n_ts", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("n_freezing", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("ceiling_min_ft", sa.Integer(), nullable=True),
+        sa.Column("ceiling_p10_ft", sa.Integer(), nullable=True),
+        sa.Column("ceiling_p50_ft", sa.Integer(), nullable=True),
+        sa.Column("visibility_min_m", sa.Integer(), nullable=True),
+        sa.Column("visibility_p50_m", sa.Integer(), nullable=True),
+        sa.Column("wind_max_kt", sa.Integer(), nullable=True),
+        sa.Column("gust_max_kt", sa.Integer(), nullable=True),
+        sa.Column("temp_min_c", sa.Float(), nullable=True),
+        sa.Column("temp_max_c", sa.Float(), nullable=True),
+        sa.UniqueConstraint("date", "icao", name="uq_ads_key"),
+        sa.Index("ix_ads_date", "date"),
+        sa.Index("ix_ads_icao", "icao"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("airport_daily_summary")
+    op.drop_table("airport_monthly_summary")

--- a/designs/plans/patterns-and-spotlight.md
+++ b/designs/plans/patterns-and-spotlight.md
@@ -8,7 +8,11 @@
 
 ## Status (2026-05-10)
 
-- ⏸ All phases not yet started. Planning complete.
+- ✅ **Phase 1** — METAR ingest decoupling + 30-min cadence. Shipped (PR #140) and deployed to weather.flyfun.aero.
+- 🟡 **Phase 2** — `airport_monthly_summary` rollup. In progress (this branch).
+- 🟡 **Phase 3** — `airport_daily_summary` rollup. In progress (this branch, alongside Phase 2).
+- ⏸ **Phase 4** — MySQL partitioning. **Deferred** — InnoDB rejects partitioning on tables with FKs (parent or child), and `verification_observations` has 3 inbound CASCADE FKs from score / map tables. Decided 2026-05-10 to use plain `DELETE` for retention (Option B): at current scale (~80–160k rows/month) indexed-range deletes complete in seconds; revisit only if perf becomes a real problem. ``ensure_future_partitions()`` left as a no-op stub for future pivot.
+- ⏸ Phases 5–6 not yet started.
 
 ## Why
 
@@ -80,14 +84,14 @@ are user-facing and depend on rollup tables existing (but can render
 against the live `verification_observations` table on day one if we want
 to ship them before the rollup backfill completes).
 
-- **Phase 1** — Decouple METAR ingest, run every 30 min
+- **Phase 1** — Decouple METAR ingest, run every 30 min ✅ shipped
 - **Phase 2** — `airport_monthly_summary` rollup + retention task
 - **Phase 3** — `airport_daily_summary` rollup
-- **Phase 4** — MySQL partitioning of `verification_observations`
+- **Phase 4** — ~~MySQL partitioning of `verification_observations`~~ **deferred** — see Status block. Use plain DELETE for retention.
 - **Phase 5** — Patterns tab (replaces Model Accuracy map)
 - **Phase 6** — Spotlight tab (replaces Accuracy Stats)
 
-Phases 1–4 are independent and can run in parallel. Phases 5–6 depend
+Phases 1–3 are independent and can run in parallel. Phases 5–6 depend
 on phase 2 (monthly summary) at minimum; phase 6's calendar heatmap
 depends on phase 3 (daily summary).
 

--- a/src/weatherbrief/db/models.py
+++ b/src/weatherbrief/db/models.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 
-from sqlalchemy import Boolean, DateTime, Float, ForeignKey, Index, Integer, String, Text, UniqueConstraint
+from sqlalchemy import Boolean, Date, DateTime, Float, ForeignKey, Index, Integer, String, Text, UniqueConstraint
 from sqlalchemy.dialects.mysql import MEDIUMTEXT
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -711,6 +711,141 @@ class VerificationMonthlyStatsRow(Base):
     n_convection_hit: Mapped[int | None] = mapped_column(Integer, nullable=True)
     n_convection_miss: Mapped[int | None] = mapped_column(Integer, nullable=True)
     n_convection_false_alarm: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
+
+class AirportMonthlySummaryRow(Base):
+    """Pre-aggregated monthly observation climatology per airport.
+
+    One row per (month, icao). Powers the public Patterns map and Spotlight
+    leaderboards. Rolled up nightly from ``verification_observations`` once
+    a calendar month is complete; idempotent (DELETE+INSERT per month).
+
+    Generous column set: per-phenomenon counts, multiple percentiles, and
+    hours-below-threshold derivations are stored eagerly so leaderboard
+    queries are single-table reads against ~830 rows per month.
+    """
+
+    __tablename__ = "airport_monthly_summary"
+    __table_args__ = (
+        UniqueConstraint("month", "icao", name="uq_ams_key"),
+        Index("ix_ams_month", "month"),
+        Index("ix_ams_icao", "icao"),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    month: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )  # first day of month, UTC
+    icao: Mapped[str] = mapped_column(String(4), nullable=False)
+
+    # Sample size
+    n_obs: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+
+    # Flight category hour counts (drives IR usefulness, VFR rate)
+    n_vfr: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    n_mvfr: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    n_ifr: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    n_lifr: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+
+    # Phenomena hour counts. Each counts METARs whose ``weather`` list
+    # contains the relevant code (e.g. n_ts captures TS, +TSRA, VCTS, ...).
+    n_obscuration: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    n_fg: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    n_br: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    n_haze: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    n_precip: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    n_ra: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    n_sn: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    n_ts: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    n_freezing: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+
+    # Ceiling percentiles (ft). NULL for airports with no METAR ceiling data.
+    ceiling_p10_ft: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    ceiling_p25_ft: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    ceiling_p50_ft: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    ceiling_p75_ft: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    ceiling_p90_ft: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
+    # Visibility percentiles (m).
+    visibility_p10_m: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    visibility_p25_m: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    visibility_p50_m: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
+    # Wind aggregates (kt).
+    wind_mean_kt: Mapped[float | None] = mapped_column(Float, nullable=True)
+    wind_p50_kt: Mapped[float | None] = mapped_column(Float, nullable=True)
+    wind_p95_kt: Mapped[float | None] = mapped_column(Float, nullable=True)
+    gust_max_kt: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
+    # Hours-below-threshold (handy for "approach minimums" / "low vis"
+    # rankings without re-deriving from percentiles).
+    n_ceiling_below_500: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    n_ceiling_below_1500: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    n_visibility_below_5km: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    n_wind_over_25kt: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+
+    # Temperature extremes (deg C).
+    temp_min_c: Mapped[float | None] = mapped_column(Float, nullable=True)
+    temp_max_c: Mapped[float | None] = mapped_column(Float, nullable=True)
+
+    # Volatility — count of category transitions between consecutive
+    # observations within the same UTC day, summed across the month.
+    category_changes: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+
+    # Per-hour-of-day breakdown stored as JSON. Keys are zero-padded HH
+    # strings (00..23); values are dicts {n, n_ifr, n_ts, n_fog, n_precip,
+    # ceiling_p50}. Hours with no observations are omitted.
+    diurnal_json: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+
+class AirportDailySummaryRow(Base):
+    """Daily observation climatology per airport.
+
+    One row per (date, icao). Powers Spotlight calendar heatmaps and
+    "worst day of the month" leaderboards. Rolled up nightly from
+    ``verification_observations`` for completed UTC days; idempotent.
+
+    Cannot be backfilled past raw retention — must accumulate from day 1.
+    """
+
+    __tablename__ = "airport_daily_summary"
+    __table_args__ = (
+        UniqueConstraint("date", "icao", name="uq_ads_key"),
+        Index("ix_ads_date", "date"),
+        Index("ix_ads_icao", "icao"),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    date: Mapped[datetime] = mapped_column(Date, nullable=False)  # UTC date
+    icao: Mapped[str] = mapped_column(String(4), nullable=False)
+
+    n_obs: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+
+    # Worst category seen during the day (VFR/MVFR/IFR/LIFR). Drives the
+    # calendar heatmap cell color.
+    worst_category: Mapped[str | None] = mapped_column(String(4), nullable=True)
+
+    n_vfr: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    n_mvfr: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    n_ifr: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    n_lifr: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+
+    n_obscuration: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    n_fg: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    n_br: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    n_precip: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    n_ts: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    n_freezing: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+
+    ceiling_min_ft: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    ceiling_p10_ft: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    ceiling_p50_ft: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    visibility_min_m: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    visibility_p50_m: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    wind_max_kt: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    gust_max_kt: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    temp_min_c: Mapped[float | None] = mapped_column(Float, nullable=True)
+    temp_max_c: Mapped[float | None] = mapped_column(Float, nullable=True)
 
 
 class VerificationCacheRow(Base):

--- a/src/weatherbrief/db/models.py
+++ b/src/weatherbrief/db/models.py
@@ -7,7 +7,7 @@ ForeignKey references work correctly.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import date as date_t, datetime, timezone
 
 from sqlalchemy import Boolean, Date, DateTime, Float, ForeignKey, Index, Integer, String, Text, UniqueConstraint
 from sqlalchemy.dialects.mysql import MEDIUMTEXT
@@ -816,7 +816,7 @@ class AirportDailySummaryRow(Base):
     )
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    date: Mapped[datetime] = mapped_column(Date, nullable=False)  # UTC date
+    date: Mapped[date_t] = mapped_column(Date, nullable=False)  # UTC date
     icao: Mapped[str] = mapped_column(String(4), nullable=False)
 
     n_obs: Mapped[int] = mapped_column(Integer, nullable=False, default=0)

--- a/src/weatherbrief/scheduler.py
+++ b/src/weatherbrief/scheduler.py
@@ -477,6 +477,60 @@ def _run_retention_once() -> None:
     except Exception:
         logger.error("DWD chart cache age-eviction failed", exc_info=True)
 
+    # Roll up completed months/days into the airport summary tables, then
+    # ensure future MySQL partitions exist, then prune raw obs older than
+    # retention (effectively a no-op until VERIFICATION_RAW_RETENTION_DAYS
+    # is set < 9999). Each step is wrapped independently so a single
+    # failure doesn't skip the others.
+    try:
+        from weatherbrief.tasks.airport_summary import (
+            rollup_all_complete_days,
+            rollup_all_complete_months,
+        )
+
+        db = SessionLocal()
+        try:
+            n_months = rollup_all_complete_months(db)
+            n_days = rollup_all_complete_days(db)
+            if n_months or n_days:
+                logger.info(
+                    "Airport summary rollup: %d months, %d days",
+                    n_months, n_days,
+                )
+        finally:
+            db.close()
+    except Exception:
+        logger.error("Airport summary rollup failed", exc_info=True)
+
+    try:
+        from weatherbrief.tasks.retention import ensure_future_partitions
+
+        db = SessionLocal()
+        try:
+            added = ensure_future_partitions(db, months_ahead=3)
+            if added:
+                logger.info("Created %d future verification_observations partition(s)", added)
+        finally:
+            db.close()
+    except Exception:
+        logger.error("Partition maintenance failed", exc_info=True)
+
+    try:
+        from weatherbrief.tasks.retention import prune_raw_observations
+
+        db = SessionLocal()
+        try:
+            result = prune_raw_observations(db)
+            if any(v for v in result.values()):
+                logger.info(
+                    "Raw retention: pruned obs=%d scores=%d taf=%d",
+                    result["observations"], result["scores"], result["taf_scores"],
+                )
+        finally:
+            db.close()
+    except Exception:
+        logger.error("Raw observation retention failed", exc_info=True)
+
 
 # ---------------------------------------------------------------------------
 # METAR ingest, forecast fetch, and standalone verification loops

--- a/src/weatherbrief/scheduler.py
+++ b/src/weatherbrief/scheduler.py
@@ -492,11 +492,15 @@ def _run_retention_once() -> None:
         try:
             n_months = rollup_all_complete_months(db)
             n_days = rollup_all_complete_days(db)
+            db.commit()
             if n_months or n_days:
                 logger.info(
                     "Airport summary rollup: %d months, %d days",
                     n_months, n_days,
                 )
+        except Exception:
+            db.rollback()
+            raise
         finally:
             db.close()
     except Exception:
@@ -508,8 +512,12 @@ def _run_retention_once() -> None:
         db = SessionLocal()
         try:
             added = ensure_future_partitions(db, months_ahead=3)
+            db.commit()
             if added:
                 logger.info("Created %d future verification_observations partition(s)", added)
+        except Exception:
+            db.rollback()
+            raise
         finally:
             db.close()
     except Exception:
@@ -521,11 +529,16 @@ def _run_retention_once() -> None:
         db = SessionLocal()
         try:
             result = prune_raw_observations(db)
+            db.commit()
             if any(v for v in result.values()):
                 logger.info(
-                    "Raw retention: pruned obs=%d scores=%d taf=%d",
-                    result["observations"], result["scores"], result["taf_scores"],
+                    "Raw retention: pruned obs=%d scores=%d taf=%d map=%d",
+                    result["observations"], result["scores"],
+                    result["taf_scores"], result["map_rows"],
                 )
+        except Exception:
+            db.rollback()
+            raise
         finally:
             db.close()
     except Exception:

--- a/src/weatherbrief/tasks/airport_summary.py
+++ b/src/weatherbrief/tasks/airport_summary.py
@@ -436,19 +436,21 @@ def completed_days(db: Session) -> list[date]:
 def rollup_all_complete_months(db: Session) -> int:
     """Roll up every completed month not yet in airport_monthly_summary.
 
+    Caller commits — matches the convention used by verification_rollup.
     Returns total rows inserted across all months.
     """
     total = 0
     for month_start in completed_months(db):
         total += rollup_month(db, month_start)
-    db.commit()
     return total
 
 
 def rollup_all_complete_days(db: Session) -> int:
-    """Roll up every completed UTC day not yet in airport_daily_summary."""
+    """Roll up every completed UTC day not yet in airport_daily_summary.
+
+    Caller commits.
+    """
     total = 0
     for d in completed_days(db):
         total += rollup_day(db, d)
-    db.commit()
     return total

--- a/src/weatherbrief/tasks/airport_summary.py
+++ b/src/weatherbrief/tasks/airport_summary.py
@@ -1,0 +1,454 @@
+"""Rollup of raw observations into airport_monthly_summary + airport_daily_summary.
+
+These tables power the public Patterns map (climatology metrics per airport)
+and Spotlight leaderboards/heatmaps. Aggregation runs nightly at 02:00 UTC
+once a calendar period (month/day) is complete; idempotent DELETE+INSERT.
+
+Volatility convention: count of category transitions between consecutive
+observations within the same UTC day, summed across the period. A flap of
+VFR→MVFR→VFR within a day counts as 2 transitions.
+
+Diurnal JSON convention (monthly only): keys are zero-padded HH strings
+(00..23), values are dicts {n, n_ifr, n_ts, n_fog, n_precip, ceiling_p50}.
+Hours with zero observations are omitted to keep the blob compact.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections import defaultdict
+from datetime import date, datetime, timedelta, timezone
+
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
+
+from weatherbrief.db.models import (
+    AirportDailySummaryRow,
+    AirportMonthlySummaryRow,
+    VerificationObservationRow,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# Phenomenon detection: a weather list (e.g. ["+TSRA", "BR"]) matches a
+# phenomenon if any code contains the marker substring. "TSRA" matches both
+# TS and RA — intentional, since the obs has both. FG matches FG, BCFG,
+# MIFG, PRFG, VCFG, FZFG. FZ matches FZRA, FZDZ, FZFG, FZUP.
+_PHENOMENA = {
+    "ts": ("TS",),
+    "fg": ("FG",),
+    "br": ("BR",),
+    "haze": ("HZ",),
+    "ra": ("RA",),
+    "sn": ("SN",),
+    "freezing": ("FZ",),
+}
+# Anything that reduces visibility on its own
+_OBSCURATION_MARKERS = ("FG", "BR", "HZ", "FU", "SA", "DU", "VA")
+# Any precipitation
+_PRECIP_MARKERS = ("RA", "DZ", "SN", "SG", "IC", "PL", "GR", "GS", "UP")
+
+_CAT_SEVERITY = {"VFR": 0, "MVFR": 1, "IFR": 2, "LIFR": 3}
+
+
+def _ensure_utc(dt: datetime | None) -> datetime | None:
+    if dt is None:
+        return None
+    return dt.replace(tzinfo=timezone.utc) if dt.tzinfo is None else dt
+
+
+def _has_marker(weather: list[str], markers: tuple[str, ...]) -> bool:
+    """True if any code in *weather* contains any of *markers* as substring."""
+    return any(any(m in code for m in markers) for code in weather)
+
+
+def _percentile(values: list[float], pct: float) -> float | None:
+    """Linear-interpolated percentile. ``pct`` is 0–100. Returns None for empty."""
+    if not values:
+        return None
+    if len(values) == 1:
+        return values[0]
+    s = sorted(values)
+    # Position in [0, n-1]
+    pos = (len(s) - 1) * (pct / 100.0)
+    lo = int(pos)
+    hi = min(lo + 1, len(s) - 1)
+    frac = pos - lo
+    return s[lo] + (s[hi] - s[lo]) * frac
+
+
+def _worst_category(cats: list[str]) -> str | None:
+    """Return the severity-max non-null category, or None if none present."""
+    valid = [c for c in cats if c in _CAT_SEVERITY]
+    if not valid:
+        return None
+    return max(valid, key=lambda c: _CAT_SEVERITY[c])
+
+
+def _category_changes_within_day(obs_list: list[VerificationObservationRow]) -> int:
+    """Count category transitions between consecutive obs within each UTC day.
+
+    Sorts by observation_time; counts pairs where both have a category and
+    the categories differ. Cross-day pairs are not counted (we segment by
+    UTC date first).
+    """
+    by_day: dict[date, list[VerificationObservationRow]] = defaultdict(list)
+    for obs in obs_list:
+        t = _ensure_utc(obs.observation_time)
+        if t is None:
+            continue
+        by_day[t.date()].append(obs)
+
+    total = 0
+    for day_obs in by_day.values():
+        day_obs.sort(key=lambda o: _ensure_utc(o.observation_time))
+        prev: str | None = None
+        for obs in day_obs:
+            cat = obs.flight_category
+            if cat is None:
+                # Treat unknown as a hole — don't count adjacency over it.
+                prev = None
+                continue
+            if prev is not None and prev != cat:
+                total += 1
+            prev = cat
+    return total
+
+
+def _build_diurnal_json(obs_list: list[VerificationObservationRow]) -> str | None:
+    """Per-hour-of-day breakdown JSON, or None if obs_list empty.
+
+    Only hours with at least one observation are emitted, keeping the blob
+    compact for airports that only report at sample hours.
+    """
+    if not obs_list:
+        return None
+    by_hour: dict[int, list[VerificationObservationRow]] = defaultdict(list)
+    for obs in obs_list:
+        t = _ensure_utc(obs.observation_time)
+        if t is None:
+            continue
+        by_hour[t.hour].append(obs)
+
+    out: dict[str, dict[str, int | None]] = {}
+    for h in sorted(by_hour):
+        rows = by_hour[h]
+        weathers = [json.loads(r.weather) if r.weather else [] for r in rows]
+        ceilings = [r.ceiling_ft for r in rows if r.ceiling_ft is not None]
+        out[f"{h:02d}"] = {
+            "n": len(rows),
+            "n_ifr": sum(1 for r in rows if r.flight_category in ("IFR", "LIFR")),
+            "n_ts": sum(1 for w in weathers if _has_marker(w, _PHENOMENA["ts"])),
+            "n_fog": sum(1 for w in weathers if _has_marker(w, _PHENOMENA["fg"])),
+            "n_precip": sum(1 for w in weathers if _has_marker(w, _PRECIP_MARKERS)),
+            "ceiling_p50": (
+                int(_percentile([float(c) for c in ceilings], 50))
+                if ceilings else None
+            ),
+        }
+    return json.dumps(out, separators=(",", ":"))
+
+
+# ---------------------------------------------------------------------------
+# Monthly rollup
+# ---------------------------------------------------------------------------
+
+
+def rollup_month(db: Session, month_start: datetime) -> int:
+    """Aggregate raw observations for one month into airport_monthly_summary.
+
+    ``month_start`` is the first instant of the month, UTC. Idempotent —
+    rows for this month are deleted and re-inserted. Returns row count.
+    """
+    if month_start.tzinfo is None:
+        month_start = month_start.replace(tzinfo=timezone.utc)
+
+    if month_start.month == 12:
+        month_end = datetime(month_start.year + 1, 1, 1, tzinfo=timezone.utc)
+    else:
+        month_end = datetime(
+            month_start.year, month_start.month + 1, 1, tzinfo=timezone.utc,
+        )
+
+    # Wipe existing rows for this month (idempotency). Expire the session
+    # afterwards so any cached AirportMonthlySummaryRow identity-map entries
+    # don't fight with the new rows we're about to insert.
+    db.execute(
+        AirportMonthlySummaryRow.__table__.delete().where(
+            AirportMonthlySummaryRow.month == month_start
+        )
+    )
+    db.expunge_all()
+
+    # Stream obs for this month grouped by ICAO. ~830 airports × ~150 obs ≈
+    # 125k rows worst case — fits easily in memory.
+    rows = db.execute(
+        select(VerificationObservationRow)
+        .where(VerificationObservationRow.observation_time >= month_start)
+        .where(VerificationObservationRow.observation_time < month_end)
+    ).scalars().all()
+
+    by_icao: dict[str, list[VerificationObservationRow]] = defaultdict(list)
+    for obs in rows:
+        by_icao[obs.icao].append(obs)
+
+    inserted = 0
+    for icao, obs_list in by_icao.items():
+        summary = _build_monthly_summary(month_start, icao, obs_list)
+        db.add(summary)
+        inserted += 1
+
+    db.flush()
+    logger.info(
+        "airport_monthly_summary: rolled up %d airports for %s",
+        inserted, month_start.strftime("%Y-%m"),
+    )
+    return inserted
+
+
+def _build_monthly_summary(
+    month_start: datetime,
+    icao: str,
+    obs_list: list[VerificationObservationRow],
+) -> AirportMonthlySummaryRow:
+    """Compute one summary row from a month's worth of observations for one airport."""
+    weathers = [json.loads(o.weather) if o.weather else [] for o in obs_list]
+    ceilings = [float(o.ceiling_ft) for o in obs_list if o.ceiling_ft is not None]
+    visibilities = [float(o.visibility_m) for o in obs_list if o.visibility_m is not None]
+    winds = [float(o.wind_speed_kt) for o in obs_list if o.wind_speed_kt is not None]
+    gusts = [o.wind_gust_kt for o in obs_list if o.wind_gust_kt is not None]
+    temps = [o.temperature_c for o in obs_list if o.temperature_c is not None]
+
+    return AirportMonthlySummaryRow(
+        month=month_start,
+        icao=icao,
+        n_obs=len(obs_list),
+        # Category counts
+        n_vfr=sum(1 for o in obs_list if o.flight_category == "VFR"),
+        n_mvfr=sum(1 for o in obs_list if o.flight_category == "MVFR"),
+        n_ifr=sum(1 for o in obs_list if o.flight_category == "IFR"),
+        n_lifr=sum(1 for o in obs_list if o.flight_category == "LIFR"),
+        # Phenomena
+        n_obscuration=sum(1 for w in weathers if _has_marker(w, _OBSCURATION_MARKERS)),
+        n_fg=sum(1 for w in weathers if _has_marker(w, _PHENOMENA["fg"])),
+        n_br=sum(1 for w in weathers if _has_marker(w, _PHENOMENA["br"])),
+        n_haze=sum(1 for w in weathers if _has_marker(w, _PHENOMENA["haze"])),
+        n_precip=sum(1 for w in weathers if _has_marker(w, _PRECIP_MARKERS)),
+        n_ra=sum(1 for w in weathers if _has_marker(w, _PHENOMENA["ra"])),
+        n_sn=sum(1 for w in weathers if _has_marker(w, _PHENOMENA["sn"])),
+        n_ts=sum(1 for w in weathers if _has_marker(w, _PHENOMENA["ts"])),
+        n_freezing=sum(1 for w in weathers if _has_marker(w, _PHENOMENA["freezing"])),
+        # Ceiling percentiles
+        ceiling_p10_ft=int(_percentile(ceilings, 10)) if ceilings else None,
+        ceiling_p25_ft=int(_percentile(ceilings, 25)) if ceilings else None,
+        ceiling_p50_ft=int(_percentile(ceilings, 50)) if ceilings else None,
+        ceiling_p75_ft=int(_percentile(ceilings, 75)) if ceilings else None,
+        ceiling_p90_ft=int(_percentile(ceilings, 90)) if ceilings else None,
+        # Visibility percentiles
+        visibility_p10_m=int(_percentile(visibilities, 10)) if visibilities else None,
+        visibility_p25_m=int(_percentile(visibilities, 25)) if visibilities else None,
+        visibility_p50_m=int(_percentile(visibilities, 50)) if visibilities else None,
+        # Wind aggregates
+        wind_mean_kt=(sum(winds) / len(winds)) if winds else None,
+        wind_p50_kt=_percentile(winds, 50) if winds else None,
+        wind_p95_kt=_percentile(winds, 95) if winds else None,
+        gust_max_kt=max(gusts) if gusts else None,
+        # Hours-below-threshold
+        n_ceiling_below_500=sum(
+            1 for o in obs_list if o.ceiling_ft is not None and o.ceiling_ft < 500
+        ),
+        n_ceiling_below_1500=sum(
+            1 for o in obs_list if o.ceiling_ft is not None and o.ceiling_ft < 1500
+        ),
+        n_visibility_below_5km=sum(
+            1 for o in obs_list if o.visibility_m is not None and o.visibility_m < 5000
+        ),
+        n_wind_over_25kt=sum(
+            1 for o in obs_list if o.wind_speed_kt is not None and o.wind_speed_kt > 25
+        ),
+        # Temperature
+        temp_min_c=min(temps) if temps else None,
+        temp_max_c=max(temps) if temps else None,
+        # Volatility
+        category_changes=_category_changes_within_day(obs_list),
+        # Diurnal
+        diurnal_json=_build_diurnal_json(obs_list),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Daily rollup
+# ---------------------------------------------------------------------------
+
+
+def rollup_day(db: Session, day: date) -> int:
+    """Aggregate raw observations for one UTC date into airport_daily_summary.
+
+    Idempotent — rows for this date are deleted and re-inserted. Returns
+    row count.
+    """
+    day_start = datetime(day.year, day.month, day.day, tzinfo=timezone.utc)
+    day_end = day_start + timedelta(days=1)
+
+    db.execute(
+        AirportDailySummaryRow.__table__.delete().where(
+            AirportDailySummaryRow.date == day
+        )
+    )
+    db.expunge_all()
+
+    rows = db.execute(
+        select(VerificationObservationRow)
+        .where(VerificationObservationRow.observation_time >= day_start)
+        .where(VerificationObservationRow.observation_time < day_end)
+    ).scalars().all()
+
+    by_icao: dict[str, list[VerificationObservationRow]] = defaultdict(list)
+    for obs in rows:
+        by_icao[obs.icao].append(obs)
+
+    inserted = 0
+    for icao, obs_list in by_icao.items():
+        summary = _build_daily_summary(day, icao, obs_list)
+        db.add(summary)
+        inserted += 1
+
+    db.flush()
+    logger.info(
+        "airport_daily_summary: rolled up %d airports for %s",
+        inserted, day.isoformat(),
+    )
+    return inserted
+
+
+def _build_daily_summary(
+    day: date,
+    icao: str,
+    obs_list: list[VerificationObservationRow],
+) -> AirportDailySummaryRow:
+    weathers = [json.loads(o.weather) if o.weather else [] for o in obs_list]
+    ceilings = [float(o.ceiling_ft) for o in obs_list if o.ceiling_ft is not None]
+    visibilities = [float(o.visibility_m) for o in obs_list if o.visibility_m is not None]
+    winds = [o.wind_speed_kt for o in obs_list if o.wind_speed_kt is not None]
+    gusts = [o.wind_gust_kt for o in obs_list if o.wind_gust_kt is not None]
+    temps = [o.temperature_c for o in obs_list if o.temperature_c is not None]
+    cats = [o.flight_category for o in obs_list]
+
+    return AirportDailySummaryRow(
+        date=day,
+        icao=icao,
+        n_obs=len(obs_list),
+        worst_category=_worst_category(cats),
+        n_vfr=sum(1 for c in cats if c == "VFR"),
+        n_mvfr=sum(1 for c in cats if c == "MVFR"),
+        n_ifr=sum(1 for c in cats if c == "IFR"),
+        n_lifr=sum(1 for c in cats if c == "LIFR"),
+        n_obscuration=sum(1 for w in weathers if _has_marker(w, _OBSCURATION_MARKERS)),
+        n_fg=sum(1 for w in weathers if _has_marker(w, _PHENOMENA["fg"])),
+        n_br=sum(1 for w in weathers if _has_marker(w, _PHENOMENA["br"])),
+        n_precip=sum(1 for w in weathers if _has_marker(w, _PRECIP_MARKERS)),
+        n_ts=sum(1 for w in weathers if _has_marker(w, _PHENOMENA["ts"])),
+        n_freezing=sum(1 for w in weathers if _has_marker(w, _PHENOMENA["freezing"])),
+        ceiling_min_ft=int(min(ceilings)) if ceilings else None,
+        ceiling_p10_ft=int(_percentile(ceilings, 10)) if ceilings else None,
+        ceiling_p50_ft=int(_percentile(ceilings, 50)) if ceilings else None,
+        visibility_min_m=int(min(visibilities)) if visibilities else None,
+        visibility_p50_m=int(_percentile(visibilities, 50)) if visibilities else None,
+        wind_max_kt=max(winds) if winds else None,
+        gust_max_kt=max(gusts) if gusts else None,
+        temp_min_c=min(temps) if temps else None,
+        temp_max_c=max(temps) if temps else None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Orchestrators — walk forward through completed periods
+# ---------------------------------------------------------------------------
+
+
+def completed_months(db: Session) -> list[datetime]:
+    """First-of-month datetimes (UTC) for fully-elapsed months that still
+    need rolling up. A month is "complete" once the current UTC time is
+    past its end. Already-rolled-up months are excluded.
+    """
+    now = datetime.now(timezone.utc)
+    earliest = db.execute(
+        select(func.min(VerificationObservationRow.observation_time))
+    ).scalar()
+    if earliest is None:
+        return []
+    earliest = _ensure_utc(earliest)
+
+    existing = {
+        (dt.year, dt.month)
+        for dt in db.execute(
+            select(AirportMonthlySummaryRow.month).distinct()
+        ).scalars().all()
+        if dt is not None
+    }
+
+    months: list[datetime] = []
+    y, m = earliest.year, earliest.month
+    while True:
+        month_start = datetime(y, m, 1, tzinfo=timezone.utc)
+        next_start = (
+            datetime(y + 1, 1, 1, tzinfo=timezone.utc)
+            if m == 12
+            else datetime(y, m + 1, 1, tzinfo=timezone.utc)
+        )
+        if next_start <= now and (y, m) not in existing:
+            months.append(month_start)
+        if next_start > now:
+            break
+        y, m = next_start.year, next_start.month
+    return months
+
+
+def completed_days(db: Session) -> list[date]:
+    """UTC dates for fully-elapsed days that still need rolling up.
+
+    Excludes the current UTC day (incomplete) and dates already summarised.
+    """
+    now = datetime.now(timezone.utc)
+    today = now.date()
+    earliest = db.execute(
+        select(func.min(VerificationObservationRow.observation_time))
+    ).scalar()
+    if earliest is None:
+        return []
+    earliest = _ensure_utc(earliest)
+
+    existing = set(
+        db.execute(select(AirportDailySummaryRow.date).distinct()).scalars().all()
+    )
+
+    out: list[date] = []
+    d = earliest.date()
+    while d < today:
+        if d not in existing:
+            out.append(d)
+        d += timedelta(days=1)
+    return out
+
+
+def rollup_all_complete_months(db: Session) -> int:
+    """Roll up every completed month not yet in airport_monthly_summary.
+
+    Returns total rows inserted across all months.
+    """
+    total = 0
+    for month_start in completed_months(db):
+        total += rollup_month(db, month_start)
+    db.commit()
+    return total
+
+
+def rollup_all_complete_days(db: Session) -> int:
+    """Roll up every completed UTC day not yet in airport_daily_summary."""
+    total = 0
+    for d in completed_days(db):
+        total += rollup_day(db, d)
+    db.commit()
+    return total

--- a/src/weatherbrief/tasks/retention.py
+++ b/src/weatherbrief/tasks/retention.py
@@ -21,7 +21,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
-from sqlalchemy import func, select
+from sqlalchemy import func, select, text
 from sqlalchemy.orm import Session
 
 from weatherbrief.db.models import BriefingPackRow, BriefingUsageRow, FlightRow, PirepRow, UserRow
@@ -269,3 +269,189 @@ def _dir_size(path: Path) -> int:
             except OSError:
                 pass
     return total
+
+
+# ---------------------------------------------------------------------------
+# Verification observation retention
+#
+# Independent of the briefing-pack tiered retention above. Once raw obs are
+# rolled up into airport_monthly/daily_summary, we can drop the originals.
+# Default retention is intentionally very high (9999 days = effectively
+# disabled) until the Patterns/Spotlight UI has been live long enough to
+# validate the rollup column set covers everything we query. Once that's
+# confirmed, switch to ~180 days via VERIFICATION_RAW_RETENTION_DAYS.
+# ---------------------------------------------------------------------------
+
+
+_DEFAULT_RAW_RETENTION_DAYS = 9999  # disabled by default — see comment above
+
+
+def prune_raw_observations(
+    db: Session,
+    retain_days: int | None = None,
+) -> dict:
+    """Delete verification_observations / scores older than retain_days.
+
+    Only deletes data older than the cutoff *AND* whose containing month
+    has at least one row in airport_monthly_summary — never delete obs that
+    haven't been summarised yet, even if the cutoff has passed (e.g. if
+    rollup has been failing). This is a safety belt; in normal operation
+    rollup runs nightly and is well ahead of the cutoff.
+
+    Returns a dict with deletion counts per table.
+    """
+    from weatherbrief.db.models import (
+        AirportMonthlySummaryRow,
+        TafVerificationScoreRow,
+        VerificationObservationRow,
+        VerificationScoreRow,
+    )
+
+    if retain_days is None:
+        retain_days = int(
+            os.environ.get(
+                "VERIFICATION_RAW_RETENTION_DAYS",
+                str(_DEFAULT_RAW_RETENTION_DAYS),
+            )
+        )
+
+    if retain_days >= _DEFAULT_RAW_RETENTION_DAYS:
+        # Effectively disabled. Don't even scan.
+        logger.debug("Raw observation retention disabled (retain_days=%d)", retain_days)
+        return {"observations": 0, "scores": 0, "taf_scores": 0}
+
+    cutoff = datetime.now(timezone.utc) - timedelta(days=retain_days)
+
+    # Months that have been summarised (any airport row implies the month
+    # was rolled up — rollup is all-or-nothing per month).
+    summarised_months: set[tuple[int, int]] = set()
+    for dt in db.execute(
+        select(AirportMonthlySummaryRow.month).distinct()
+    ).scalars().all():
+        if dt is not None:
+            summarised_months.add((dt.year, dt.month))
+
+    if not summarised_months:
+        logger.warning(
+            "Raw retention: no months summarised yet — refusing to delete"
+        )
+        return {"observations": 0, "scores": 0, "taf_scores": 0}
+
+    # Build list of (month_start, month_end) ranges fully inside the cutoff
+    # AND in summarised_months.
+    safe_ranges: list[tuple[datetime, datetime]] = []
+    for (y, m) in sorted(summarised_months):
+        month_start = datetime(y, m, 1, tzinfo=timezone.utc)
+        month_end = (
+            datetime(y + 1, 1, 1, tzinfo=timezone.utc)
+            if m == 12
+            else datetime(y, m + 1, 1, tzinfo=timezone.utc)
+        )
+        if month_end <= cutoff:
+            safe_ranges.append((month_start, month_end))
+
+    if not safe_ranges:
+        return {"observations": 0, "scores": 0, "taf_scores": 0}
+
+    obs_deleted = 0
+    score_deleted = 0
+    taf_deleted = 0
+    for start, end in safe_ranges:
+        r = db.execute(
+            VerificationObservationRow.__table__.delete()
+            .where(VerificationObservationRow.observation_time >= start)
+            .where(VerificationObservationRow.observation_time < end)
+        )
+        obs_deleted += r.rowcount or 0
+        r = db.execute(
+            VerificationScoreRow.__table__.delete()
+            .where(VerificationScoreRow.observation_time >= start)
+            .where(VerificationScoreRow.observation_time < end)
+        )
+        score_deleted += r.rowcount or 0
+        r = db.execute(
+            TafVerificationScoreRow.__table__.delete()
+            .where(TafVerificationScoreRow.observation_time >= start)
+            .where(TafVerificationScoreRow.observation_time < end)
+        )
+        taf_deleted += r.rowcount or 0
+
+    db.commit()
+    logger.info(
+        "Raw retention: pruned %d observations, %d scores, %d TAF scores "
+        "(retain_days=%d, cutoff=%s)",
+        obs_deleted, score_deleted, taf_deleted, retain_days, cutoff.isoformat(),
+    )
+    return {
+        "observations": obs_deleted,
+        "scores": score_deleted,
+        "taf_scores": taf_deleted,
+    }
+
+
+# ---------------------------------------------------------------------------
+# MySQL partition maintenance — Phase 4
+# ---------------------------------------------------------------------------
+
+
+def ensure_future_partitions(db: Session, months_ahead: int = 3) -> int:
+    """Pre-create monthly partitions for verification_observations on MySQL.
+
+    Without this, an INSERT for a date past the highest existing partition
+    would fail. SQLite is a no-op (no partitioning).
+
+    Returns the number of partitions added.
+    """
+    bind = db.get_bind()
+    if bind.dialect.name != "mysql":
+        return 0
+
+    # Discover existing partitions
+    rows = db.execute(text(
+        "SELECT partition_name, partition_description "
+        "FROM information_schema.PARTITIONS "
+        "WHERE table_schema = DATABASE() "
+        "AND table_name = 'verification_observations' "
+        "AND partition_name IS NOT NULL"
+    )).all()
+
+    existing_names = {r[0] for r in rows}
+    if not existing_names:
+        # Table isn't partitioned yet (migration 054 hasn't run). Nothing to do.
+        logger.debug(
+            "ensure_future_partitions: verification_observations not partitioned"
+        )
+        return 0
+
+    # Compute target month names for the next N months.
+    now = datetime.now(timezone.utc)
+    targets: list[tuple[int, int]] = []
+    y, m = now.year, now.month
+    for _ in range(months_ahead + 1):
+        m += 1
+        if m > 12:
+            m = 1
+            y += 1
+        targets.append((y, m))
+
+    added = 0
+    for (y, m) in targets:
+        name = f"p_{y:04d}{m:02d}"
+        if name in existing_names:
+            continue
+        # TO_DAYS upper bound = first day of the *following* month
+        next_y, next_m = (y + 1, 1) if m == 12 else (y, m + 1)
+        upper = f"{next_y:04d}-{next_m:02d}-01"
+        # REORGANIZE the catch-all p_future partition to add the new range.
+        db.execute(text(
+            f"ALTER TABLE verification_observations "
+            f"REORGANIZE PARTITION p_future INTO ("
+            f"PARTITION {name} VALUES LESS THAN (TO_DAYS('{upper}')), "
+            f"PARTITION p_future VALUES LESS THAN MAXVALUE)"
+        ))
+        added += 1
+        logger.info("Added partition %s (upper=%s)", name, upper)
+
+    if added:
+        db.commit()
+    return added

--- a/src/weatherbrief/tasks/retention.py
+++ b/src/weatherbrief/tasks/retention.py
@@ -302,6 +302,7 @@ def prune_raw_observations(
     """
     from weatherbrief.db.models import (
         AirportMonthlySummaryRow,
+        FlightVerificationMapRow,
         TafVerificationScoreRow,
         VerificationObservationRow,
         VerificationScoreRow,
@@ -318,7 +319,7 @@ def prune_raw_observations(
     if retain_days >= _DEFAULT_RAW_RETENTION_DAYS:
         # Effectively disabled. Don't even scan.
         logger.debug("Raw observation retention disabled (retain_days=%d)", retain_days)
-        return {"observations": 0, "scores": 0, "taf_scores": 0}
+        return {"observations": 0, "scores": 0, "taf_scores": 0, "map_rows": 0}
 
     cutoff = datetime.now(timezone.utc) - timedelta(days=retain_days)
 
@@ -335,7 +336,7 @@ def prune_raw_observations(
         logger.warning(
             "Raw retention: no months summarised yet — refusing to delete"
         )
-        return {"observations": 0, "scores": 0, "taf_scores": 0}
+        return {"observations": 0, "scores": 0, "taf_scores": 0, "map_rows": 0}
 
     # Build list of (month_start, month_end) ranges fully inside the cutoff
     # AND in summarised_months.
@@ -351,18 +352,31 @@ def prune_raw_observations(
             safe_ranges.append((month_start, month_end))
 
     if not safe_ranges:
-        return {"observations": 0, "scores": 0, "taf_scores": 0}
+        return {"observations": 0, "scores": 0, "taf_scores": 0, "map_rows": 0}
 
+    # All three child FKs to verification_observations.id use ON DELETE
+    # CASCADE, so a parent-first delete would also work — but the child
+    # rows would already be gone by the time we ran the child deletes,
+    # making our score/taf counters useless for monitoring. Deleting
+    # children first gives us accurate per-table metrics.
     obs_deleted = 0
     score_deleted = 0
     taf_deleted = 0
+    map_deleted = 0
     for start, end in safe_ranges:
-        r = db.execute(
-            VerificationObservationRow.__table__.delete()
+        # FlightVerificationMapRow has no observation_time of its own —
+        # find linked map rows by joining through observation_id.
+        obs_id_subquery = (
+            select(VerificationObservationRow.id)
             .where(VerificationObservationRow.observation_time >= start)
             .where(VerificationObservationRow.observation_time < end)
+            .scalar_subquery()
         )
-        obs_deleted += r.rowcount or 0
+        r = db.execute(
+            FlightVerificationMapRow.__table__.delete()
+            .where(FlightVerificationMapRow.observation_id.in_(obs_id_subquery))
+        )
+        map_deleted += r.rowcount or 0
         r = db.execute(
             VerificationScoreRow.__table__.delete()
             .where(VerificationScoreRow.observation_time >= start)
@@ -375,17 +389,28 @@ def prune_raw_observations(
             .where(TafVerificationScoreRow.observation_time < end)
         )
         taf_deleted += r.rowcount or 0
+        r = db.execute(
+            VerificationObservationRow.__table__.delete()
+            .where(VerificationObservationRow.observation_time >= start)
+            .where(VerificationObservationRow.observation_time < end)
+        )
+        obs_deleted += r.rowcount or 0
 
-    db.commit()
+    # Caller commits — matches the rollup convention. expire_all so any
+    # cached ORM objects representing the deleted rows reflect their absence.
+    db.flush()
+    db.expire_all()
     logger.info(
-        "Raw retention: pruned %d observations, %d scores, %d TAF scores "
-        "(retain_days=%d, cutoff=%s)",
-        obs_deleted, score_deleted, taf_deleted, retain_days, cutoff.isoformat(),
+        "Raw retention: pruned %d observations, %d scores, %d TAF scores, "
+        "%d map rows (retain_days=%d, cutoff=%s)",
+        obs_deleted, score_deleted, taf_deleted, map_deleted,
+        retain_days, cutoff.isoformat(),
     )
     return {
         "observations": obs_deleted,
         "scores": score_deleted,
         "taf_scores": taf_deleted,
+        "map_rows": map_deleted,
     }
 
 
@@ -427,7 +452,7 @@ def ensure_future_partitions(db: Session, months_ahead: int = 3) -> int:
     now = datetime.now(timezone.utc)
     targets: list[tuple[int, int]] = []
     y, m = now.year, now.month
-    for _ in range(months_ahead + 1):
+    for _ in range(months_ahead):
         m += 1
         if m > 12:
             m = 1
@@ -452,6 +477,4 @@ def ensure_future_partitions(db: Session, months_ahead: int = 3) -> int:
         added += 1
         logger.info("Added partition %s (upper=%s)", name, upper)
 
-    if added:
-        db.commit()
     return added

--- a/src/weatherbrief/verify/__main__.py
+++ b/src/weatherbrief/verify/__main__.py
@@ -352,6 +352,56 @@ def cmd_rebuild_cache(args):
         db.close()
 
 
+def cmd_rollup_summary(args):
+    """Roll up raw observations into airport_monthly_summary / airport_daily_summary."""
+    from datetime import date as date_cls, datetime as dt, timezone
+
+    from flyfun_common.db import SessionLocal
+
+    from weatherbrief.tasks.airport_summary import (
+        rollup_all_complete_days,
+        rollup_all_complete_months,
+        rollup_day,
+        rollup_month,
+    )
+
+    _init_db()
+    load_dotenv()
+
+    db = SessionLocal()
+    try:
+        if args.all or (not args.month and not args.day):
+            n_months = rollup_all_complete_months(db)
+            n_days = rollup_all_complete_days(db)
+            print(f"Rolled up {n_months} airport-months and {n_days} airport-days.")
+            return
+
+        if args.month:
+            try:
+                year, month = args.month.split("-")
+                month_start = dt(int(year), int(month), 1, tzinfo=timezone.utc)
+            except (ValueError, AttributeError):
+                print(f"ERROR: invalid --month {args.month!r} (expect YYYY-MM)",
+                      file=sys.stderr)
+                sys.exit(1)
+            n = rollup_month(db, month_start)
+            db.commit()
+            print(f"Rolled up {n} airport-months for {args.month}.")
+
+        if args.day:
+            try:
+                d = date_cls.fromisoformat(args.day)
+            except ValueError:
+                print(f"ERROR: invalid --day {args.day!r} (expect YYYY-MM-DD)",
+                      file=sys.stderr)
+                sys.exit(1)
+            n = rollup_day(db, d)
+            db.commit()
+            print(f"Rolled up {n} airport-days for {args.day}.")
+    finally:
+        db.close()
+
+
 def cmd_digest(args):
     """Preview or send the admin digest."""
     from datetime import timedelta
@@ -465,6 +515,24 @@ def main():
         help="Rebuild verification/forecast map cache",
     )
 
+    # rollup-summary
+    p_rollup_summary = subparsers.add_parser(
+        "rollup-summary",
+        help="Roll up obs into airport_monthly/daily_summary tables",
+    )
+    p_rollup_summary.add_argument(
+        "--month",
+        help="Roll up a specific month (YYYY-MM). Default: every completed month.",
+    )
+    p_rollup_summary.add_argument(
+        "--day",
+        help="Roll up a specific UTC date (YYYY-MM-DD). Default: every completed day.",
+    )
+    p_rollup_summary.add_argument(
+        "--all", action="store_true",
+        help="Roll up every completed period for both monthly and daily tables.",
+    )
+
     # digest
     p_digest = subparsers.add_parser(
         "digest",
@@ -501,6 +569,8 @@ def main():
         cmd_standalone(args)
     elif args.command == "rebuild-cache":
         cmd_rebuild_cache(args)
+    elif args.command == "rollup-summary":
+        cmd_rollup_summary(args)
     elif args.command == "digest":
         cmd_digest(args)
 

--- a/src/weatherbrief/verify/__main__.py
+++ b/src/weatherbrief/verify/__main__.py
@@ -373,6 +373,7 @@ def cmd_rollup_summary(args):
         if args.all or (not args.month and not args.day):
             n_months = rollup_all_complete_months(db)
             n_days = rollup_all_complete_days(db)
+            db.commit()
             print(f"Rolled up {n_months} airport-months and {n_days} airport-days.")
             return
 

--- a/tests/test_airport_summary.py
+++ b/tests/test_airport_summary.py
@@ -1,0 +1,392 @@
+"""Tests for airport_monthly_summary and airport_daily_summary rollups."""
+
+from __future__ import annotations
+
+import json
+from datetime import date, datetime, timezone
+
+from sqlalchemy import select
+
+from weatherbrief.db.models import (
+    AirportDailySummaryRow,
+    AirportMonthlySummaryRow,
+    VerificationObservationRow,
+)
+from weatherbrief.tasks.airport_summary import (
+    _build_diurnal_json,
+    _category_changes_within_day,
+    _has_marker,
+    _percentile,
+    _worst_category,
+    _OBSCURATION_MARKERS,
+    _PHENOMENA,
+    _PRECIP_MARKERS,
+    completed_days,
+    completed_months,
+    rollup_all_complete_days,
+    rollup_all_complete_months,
+    rollup_day,
+    rollup_month,
+)
+
+
+def _utc(*args) -> datetime:
+    return datetime(*args, tzinfo=timezone.utc)
+
+
+def _obs(
+    icao: str,
+    when: datetime,
+    *,
+    category: str | None = "VFR",
+    ceiling: int | None = 5000,
+    visibility: int | None = 9999,
+    wind_kt: int | None = 5,
+    gust_kt: int | None = None,
+    temp: float | None = 12.0,
+    weather: list[str] | None = None,
+) -> VerificationObservationRow:
+    return VerificationObservationRow(
+        icao=icao,
+        observation_time=when,
+        collected_at=when,
+        flight_category=category,
+        ceiling_ft=ceiling,
+        visibility_m=visibility,
+        wind_speed_kt=wind_kt,
+        wind_gust_kt=gust_kt,
+        temperature_c=temp,
+        weather=json.dumps(weather or []),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Pure helper unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestPercentile:
+    def test_empty(self):
+        assert _percentile([], 50) is None
+
+    def test_single_value(self):
+        assert _percentile([42], 50) == 42
+
+    def test_median_odd(self):
+        assert _percentile([1, 2, 3, 4, 5], 50) == 3
+
+    def test_p10(self):
+        # Position = (10-1) * 0.1 = 0.9 → between values[0]=1 and values[1]=2
+        assert _percentile([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 10) == 1.9
+
+    def test_p90(self):
+        assert _percentile([1, 2, 3, 4, 5], 90) == 4.6
+
+    def test_unsorted_input(self):
+        # Function must sort internally
+        assert _percentile([5, 2, 4, 1, 3], 50) == 3
+
+
+class TestHasMarker:
+    def test_thunderstorm_variants(self):
+        assert _has_marker(["TS"], _PHENOMENA["ts"])
+        assert _has_marker(["+TSRA"], _PHENOMENA["ts"])
+        assert _has_marker(["VCTS"], _PHENOMENA["ts"])
+        assert _has_marker(["TSGR"], _PHENOMENA["ts"])
+        assert not _has_marker(["RA"], _PHENOMENA["ts"])
+
+    def test_fog_variants(self):
+        # FG, BCFG, MIFG, PRFG, VCFG, FZFG all contain "FG"
+        for code in ("FG", "BCFG", "MIFG", "VCFG", "FZFG"):
+            assert _has_marker([code], _PHENOMENA["fg"]), code
+
+    def test_freezing_marker_catches_all_fz_codes(self):
+        for code in ("FZRA", "FZDZ", "FZFG", "FZUP"):
+            assert _has_marker([code], _PHENOMENA["freezing"]), code
+
+    def test_obscuration_total(self):
+        assert _has_marker(["FG"], _OBSCURATION_MARKERS)
+        assert _has_marker(["BR"], _OBSCURATION_MARKERS)
+        assert _has_marker(["HZ"], _OBSCURATION_MARKERS)
+        assert not _has_marker(["RA"], _OBSCURATION_MARKERS)
+
+    def test_precip_total(self):
+        assert _has_marker(["RA"], _PRECIP_MARKERS)
+        assert _has_marker(["+SHRA"], _PRECIP_MARKERS)
+        assert _has_marker(["FZDZ"], _PRECIP_MARKERS)  # FZDZ contains DZ
+        assert not _has_marker(["FG"], _PRECIP_MARKERS)
+
+    def test_empty_list(self):
+        assert not _has_marker([], _PHENOMENA["ts"])
+
+
+class TestWorstCategory:
+    def test_returns_max_severity(self):
+        assert _worst_category(["VFR", "IFR", "MVFR"]) == "IFR"
+
+    def test_lifr_wins(self):
+        assert _worst_category(["VFR", "MVFR", "IFR", "LIFR"]) == "LIFR"
+
+    def test_ignores_unknown(self):
+        # Unknown values are filtered before max() so they don't crash
+        assert _worst_category(["VFR", "UNKNOWN", None]) == "VFR"
+
+    def test_empty(self):
+        assert _worst_category([]) is None
+        assert _worst_category([None, None]) is None
+
+
+class TestCategoryChangesWithinDay:
+    def test_no_changes(self):
+        # All VFR → 0 transitions
+        obs = [
+            _obs("LFPG", _utc(2026, 4, 1, 6, 0)),
+            _obs("LFPG", _utc(2026, 4, 1, 9, 0)),
+            _obs("LFPG", _utc(2026, 4, 1, 12, 0)),
+        ]
+        assert _category_changes_within_day(obs) == 0
+
+    def test_one_transition(self):
+        obs = [
+            _obs("LFPG", _utc(2026, 4, 1, 6, 0), category="VFR"),
+            _obs("LFPG", _utc(2026, 4, 1, 12, 0), category="IFR"),
+        ]
+        assert _category_changes_within_day(obs) == 1
+
+    def test_flap_counts_twice(self):
+        # VFR → IFR → VFR = 2 transitions
+        obs = [
+            _obs("LFPG", _utc(2026, 4, 1, 6, 0), category="VFR"),
+            _obs("LFPG", _utc(2026, 4, 1, 9, 0), category="IFR"),
+            _obs("LFPG", _utc(2026, 4, 1, 12, 0), category="VFR"),
+        ]
+        assert _category_changes_within_day(obs) == 2
+
+    def test_segments_by_utc_day(self):
+        # Day 1 has 1 transition; day 2 has 0; cross-day pair NOT counted
+        obs = [
+            _obs("LFPG", _utc(2026, 4, 1, 12, 0), category="VFR"),
+            _obs("LFPG", _utc(2026, 4, 1, 18, 0), category="IFR"),
+            # Cross day with same final state — counted? No, day boundary resets.
+            _obs("LFPG", _utc(2026, 4, 2, 6, 0), category="VFR"),
+            _obs("LFPG", _utc(2026, 4, 2, 12, 0), category="VFR"),
+        ]
+        assert _category_changes_within_day(obs) == 1
+
+    def test_unknown_category_breaks_chain(self):
+        # VFR → None → IFR: no transition counted across the gap
+        obs = [
+            _obs("LFPG", _utc(2026, 4, 1, 6, 0), category="VFR"),
+            _obs("LFPG", _utc(2026, 4, 1, 9, 0), category=None),
+            _obs("LFPG", _utc(2026, 4, 1, 12, 0), category="IFR"),
+        ]
+        assert _category_changes_within_day(obs) == 0
+
+
+class TestBuildDiurnalJson:
+    def test_empty_input(self):
+        assert _build_diurnal_json([]) is None
+
+    def test_omits_empty_hours(self):
+        # Only one observation at 06Z — only "06" should appear in the output
+        obs = [_obs("LFPG", _utc(2026, 4, 1, 6, 30))]
+        out = json.loads(_build_diurnal_json(obs))
+        assert list(out.keys()) == ["06"]
+        assert out["06"]["n"] == 1
+
+    def test_groups_by_hour_of_day(self):
+        # Two obs at 06Z (different days), one at 09Z
+        obs = [
+            _obs("LFPG", _utc(2026, 4, 1, 6, 0), category="IFR", weather=["FG"]),
+            _obs("LFPG", _utc(2026, 4, 2, 6, 30), category="VFR"),
+            _obs("LFPG", _utc(2026, 4, 1, 9, 0), category="VFR", weather=["TSRA"]),
+        ]
+        out = json.loads(_build_diurnal_json(obs))
+        assert out["06"]["n"] == 2
+        assert out["06"]["n_ifr"] == 1
+        assert out["06"]["n_fog"] == 1
+        assert out["09"]["n"] == 1
+        assert out["09"]["n_ts"] == 1
+        assert out["09"]["n_precip"] == 1
+
+
+# ---------------------------------------------------------------------------
+# rollup_month — integration against in-memory DB
+# ---------------------------------------------------------------------------
+
+
+class TestRollupMonth:
+    def test_empty_month_produces_no_rows(self, db_session):
+        rollup_month(db_session, _utc(2026, 4, 1))
+        rows = db_session.execute(select(AirportMonthlySummaryRow)).scalars().all()
+        assert rows == []
+
+    def test_single_airport_basic_counts(self, db_session):
+        # 4 obs in April for LFPG: 2 VFR, 1 MVFR, 1 IFR. One has TS+RA weather.
+        for o in [
+            _obs("LFPG", _utc(2026, 4, 5, 6, 0), category="VFR"),
+            _obs("LFPG", _utc(2026, 4, 10, 9, 0), category="VFR"),
+            _obs("LFPG", _utc(2026, 4, 15, 12, 0), category="MVFR", weather=["BR"]),
+            _obs(
+                "LFPG", _utc(2026, 4, 20, 15, 0), category="IFR",
+                ceiling=400, visibility=2000, weather=["+TSRA"],
+            ),
+        ]:
+            db_session.add(o)
+        db_session.flush()
+
+        rollup_month(db_session, _utc(2026, 4, 1))
+
+        rows = db_session.execute(select(AirportMonthlySummaryRow)).scalars().all()
+        assert len(rows) == 1
+        r = rows[0]
+        assert r.icao == "LFPG"
+        assert r.n_obs == 4
+        assert r.n_vfr == 2
+        assert r.n_mvfr == 1
+        assert r.n_ifr == 1
+        assert r.n_lifr == 0
+        # Phenomena
+        assert r.n_ts == 1
+        assert r.n_ra == 1  # +TSRA contains RA
+        assert r.n_br == 1
+        assert r.n_obscuration == 1  # the BR obs
+        assert r.n_precip == 1  # +TSRA
+        # Hours below threshold
+        assert r.n_ceiling_below_500 == 1
+        assert r.n_ceiling_below_1500 == 1  # only the 400ft one is < 1500 (others 5000)
+        assert r.n_visibility_below_5km == 1
+
+    def test_idempotent_rerun_replaces_rows(self, db_session):
+        db_session.add(_obs("LFPG", _utc(2026, 4, 5, 6, 0), category="VFR"))
+        db_session.flush()
+
+        rollup_month(db_session, _utc(2026, 4, 1))
+        first = db_session.execute(select(AirportMonthlySummaryRow)).scalars().all()
+        assert len(first) == 1
+
+        # Add another obs and re-run; previous row should be replaced, not duplicated
+        db_session.add(_obs("LFPG", _utc(2026, 4, 6, 6, 0), category="IFR"))
+        db_session.flush()
+
+        rollup_month(db_session, _utc(2026, 4, 1))
+        second = db_session.execute(select(AirportMonthlySummaryRow)).scalars().all()
+        assert len(second) == 1
+        assert second[0].n_obs == 2
+        assert second[0].n_ifr == 1
+
+    def test_separate_rows_per_airport(self, db_session):
+        db_session.add(_obs("LFPG", _utc(2026, 4, 5, 6, 0)))
+        db_session.add(_obs("EGLL", _utc(2026, 4, 5, 6, 0)))
+        db_session.flush()
+
+        rollup_month(db_session, _utc(2026, 4, 1))
+        rows = db_session.execute(select(AirportMonthlySummaryRow)).scalars().all()
+        icaos = {r.icao for r in rows}
+        assert icaos == {"LFPG", "EGLL"}
+
+    def test_obs_outside_month_excluded(self, db_session):
+        # March obs ignored when rolling up April
+        db_session.add(_obs("LFPG", _utc(2026, 3, 31, 23, 30)))
+        db_session.add(_obs("LFPG", _utc(2026, 4, 1, 0, 30)))
+        db_session.flush()
+
+        rollup_month(db_session, _utc(2026, 4, 1))
+        rows = db_session.execute(select(AirportMonthlySummaryRow)).scalars().all()
+        assert rows[0].n_obs == 1  # only the April obs
+
+    def test_ceiling_percentiles_when_data_present(self, db_session):
+        for ceiling in (1000, 2000, 3000, 4000, 5000):
+            db_session.add(_obs(
+                "LFPG", _utc(2026, 4, 1, 6, ceiling // 1000),
+                ceiling=ceiling, category="VFR",
+            ))
+        db_session.flush()
+
+        rollup_month(db_session, _utc(2026, 4, 1))
+        r = db_session.execute(select(AirportMonthlySummaryRow)).scalar_one()
+        assert r.ceiling_p50_ft == 3000
+        # p10 ≈ 1000 + 0.4*(2000-1000) = 1400
+        assert r.ceiling_p10_ft == 1400
+        assert r.ceiling_p90_ft == 4600
+
+    def test_no_ceiling_data_yields_null_percentiles(self, db_session):
+        db_session.add(_obs("LFPG", _utc(2026, 4, 5, 6, 0), ceiling=None))
+        db_session.flush()
+
+        rollup_month(db_session, _utc(2026, 4, 1))
+        r = db_session.execute(select(AirportMonthlySummaryRow)).scalar_one()
+        assert r.ceiling_p50_ft is None
+        assert r.ceiling_p10_ft is None
+
+
+class TestRollupDay:
+    def test_worst_category_recorded(self, db_session):
+        # IFR → MVFR → VFR over a single day; worst should be IFR
+        for cat, h in [("VFR", 6), ("IFR", 9), ("MVFR", 12), ("VFR", 15)]:
+            db_session.add(_obs("LFPG", _utc(2026, 4, 5, h, 0), category=cat))
+        db_session.flush()
+
+        rollup_day(db_session, date(2026, 4, 5))
+        r = db_session.execute(select(AirportDailySummaryRow)).scalar_one()
+        assert r.worst_category == "IFR"
+        assert r.n_obs == 4
+        assert r.n_vfr == 2
+        assert r.n_ifr == 1
+        assert r.n_mvfr == 1
+
+    def test_idempotent(self, db_session):
+        db_session.add(_obs("LFPG", _utc(2026, 4, 5, 6, 0)))
+        db_session.flush()
+
+        rollup_day(db_session, date(2026, 4, 5))
+        rollup_day(db_session, date(2026, 4, 5))
+        rows = db_session.execute(select(AirportDailySummaryRow)).scalars().all()
+        assert len(rows) == 1
+
+    def test_only_obs_in_target_date(self, db_session):
+        db_session.add(_obs("LFPG", _utc(2026, 4, 4, 23, 30)))
+        db_session.add(_obs("LFPG", _utc(2026, 4, 5, 12, 0)))
+        db_session.add(_obs("LFPG", _utc(2026, 4, 6, 0, 30)))
+        db_session.flush()
+
+        rollup_day(db_session, date(2026, 4, 5))
+        r = db_session.execute(select(AirportDailySummaryRow)).scalar_one()
+        assert r.n_obs == 1
+
+
+class TestOrchestrators:
+    def test_completed_months_excludes_current_and_summarised(self, db_session):
+        from datetime import datetime as dt
+
+        # Drop one obs in February 2026 (definitely completed by 2026-05-10)
+        db_session.add(_obs("LFPG", _utc(2026, 2, 15, 6, 0)))
+        db_session.add(_obs("LFPG", _utc(2026, 3, 15, 6, 0)))
+        db_session.flush()
+
+        months = completed_months(db_session)
+        # Should include February + March, not the current month
+        labels = {m.strftime("%Y-%m") for m in months}
+        assert "2026-02" in labels
+        assert "2026-03" in labels
+
+        # After rolling up Feb, it shouldn't be a candidate again
+        rollup_month(db_session, _utc(2026, 2, 1))
+        labels_after = {m.strftime("%Y-%m") for m in completed_months(db_session)}
+        assert "2026-02" not in labels_after
+        assert "2026-03" in labels_after
+
+    def test_rollup_all_processes_each_month_once(self, db_session):
+        db_session.add(_obs("LFPG", _utc(2026, 2, 15, 6, 0)))
+        db_session.add(_obs("LFPG", _utc(2026, 3, 15, 6, 0)))
+        db_session.flush()
+
+        rollup_all_complete_months(db_session)
+        rows = db_session.execute(select(AirportMonthlySummaryRow)).scalars().all()
+        assert len({r.month for r in rows}) >= 2
+
+        # Re-running shouldn't add any new rows (all months already done)
+        before = len(rows)
+        rollup_all_complete_months(db_session)
+        rows = db_session.execute(select(AirportMonthlySummaryRow)).scalars().all()
+        assert len(rows) == before

--- a/tests/test_retention.py
+++ b/tests/test_retention.py
@@ -16,6 +16,7 @@ from weatherbrief.tasks.retention import (
     _inactive_user_ids,
     _purge_full_pack,
     _purge_heavy_artifacts,
+    prune_raw_observations,
     run_retention,
 )
 
@@ -513,3 +514,123 @@ class TestDebriefExemption:
         db_session.expire_all()
         assert db_session.get(BriefingPackRow, p1_id) is not None
         assert db_session.get(BriefingPackRow, p2_id) is not None
+
+
+# ---------------------------------------------------------------------------
+# prune_raw_observations
+# ---------------------------------------------------------------------------
+
+
+class TestPruneRawObservations:
+    """Verify the raw-obs retention pruner — disabled-by-default, safety
+    belts, and accurate per-table counters when actually pruning."""
+
+    def test_disabled_default_does_nothing(self, db_session):
+        from weatherbrief.db.models import VerificationObservationRow
+
+        # Insert one obs from years ago — would absolutely be pruned if
+        # retention were active.
+        old = VerificationObservationRow(
+            icao="LFPG",
+            observation_time=_utc(2020, 1, 1, 0, 0),
+            collected_at=_utc(2020, 1, 1, 0, 0),
+        )
+        db_session.add(old)
+        db_session.flush()
+
+        result = prune_raw_observations(db_session)
+        assert result == {
+            "observations": 0, "scores": 0, "taf_scores": 0, "map_rows": 0,
+        }
+
+    def test_no_summarised_months_refuses_to_delete(self, db_session):
+        """Safety belt: even if retain_days is short, refuse to delete when
+        no months have been rolled up — could indicate a broken rollup loop."""
+        from weatherbrief.db.models import VerificationObservationRow
+
+        old = VerificationObservationRow(
+            icao="LFPG",
+            observation_time=_utc(2020, 1, 1, 0, 0),
+            collected_at=_utc(2020, 1, 1, 0, 0),
+        )
+        db_session.add(old)
+        db_session.flush()
+
+        # Force an aggressive retention but no AirportMonthlySummary rows exist
+        result = prune_raw_observations(db_session, retain_days=1)
+        assert result["observations"] == 0
+        assert db_session.get(VerificationObservationRow, old.id) is not None
+
+    def test_deletes_children_before_parent_with_accurate_counters(self, db_session):
+        """Children must be deleted before parent so per-table counters
+        reflect what was actually removed (with CASCADE FKs the parent-first
+        order would silently zero the child counters)."""
+        from weatherbrief.db.models import (
+            AirportMonthlySummaryRow,
+            VerificationObservationRow,
+            VerificationScoreRow,
+        )
+
+        # One obs in Feb 2026 with a score row pointing at it
+        feb_obs = VerificationObservationRow(
+            icao="LFPG",
+            observation_time=_utc(2026, 2, 15, 12, 0),
+            collected_at=_utc(2026, 2, 15, 12, 0),
+        )
+        db_session.add(feb_obs)
+        db_session.flush()
+        feb_id = feb_obs.id  # capture before prune (which expires the session)
+        score = VerificationScoreRow(
+            icao="LFPG",
+            observation_id=feb_id,
+            observation_time=feb_obs.observation_time,
+            model="gfs",
+            model_init_time=_utc(2026, 2, 15, 0, 0),
+            lead_hours=12,
+            days_out=0,
+            source="standalone",
+        )
+        db_session.add(score)
+        # Mark Feb 2026 as summarised so retention will prune it.
+        db_session.add(AirportMonthlySummaryRow(
+            month=_utc(2026, 2, 1), icao="LFPG", n_obs=1,
+        ))
+        db_session.flush()
+
+        # retain_days=1 with cutoff way in the future from Feb 2026 → prune
+        result = prune_raw_observations(db_session, retain_days=1)
+        assert result["observations"] == 1
+        assert result["scores"] == 1  # would be 0 if parent-first w/ CASCADE
+        assert db_session.get(VerificationObservationRow, feb_id) is None
+
+    def test_unsummarised_month_left_alone(self, db_session):
+        """Obs from a month that's never been rolled up stays put even when
+        the cutoff has passed — protects against a broken rollup loop."""
+        from weatherbrief.db.models import (
+            AirportMonthlySummaryRow,
+            VerificationObservationRow,
+        )
+
+        # Mar 2026 is summarised; Feb 2026 is NOT summarised.
+        feb_obs = VerificationObservationRow(
+            icao="LFPG",
+            observation_time=_utc(2026, 2, 15, 12, 0),
+            collected_at=_utc(2026, 2, 15, 12, 0),
+        )
+        mar_obs = VerificationObservationRow(
+            icao="LFPG",
+            observation_time=_utc(2026, 3, 15, 12, 0),
+            collected_at=_utc(2026, 3, 15, 12, 0),
+        )
+        db_session.add_all([feb_obs, mar_obs])
+        db_session.add(AirportMonthlySummaryRow(
+            month=_utc(2026, 3, 1), icao="LFPG", n_obs=1,
+        ))
+        db_session.flush()
+        feb_id, mar_id = feb_obs.id, mar_obs.id  # capture before prune
+
+        result = prune_raw_observations(db_session, retain_days=1)
+        # Only March (the summarised month past cutoff) gets pruned
+        assert result["observations"] == 1
+        assert db_session.get(VerificationObservationRow, feb_id) is not None
+        assert db_session.get(VerificationObservationRow, mar_id) is None


### PR DESCRIPTION
## Summary

Builds on top of Phase 1 (PR #140, deployed). Adds two pre-aggregated rollup tables that power the upcoming Patterns map and Spotlight leaderboards:

- **`airport_monthly_summary`** — one row per `(month, icao)`. Generous column set: category hour counts, per-phenomenon counts (FG, BR, HZ, RA, SN, TS, FZ, obscuration total, precip total), ceiling p10/p25/p50/p75/p90, visibility percentiles, wind mean/p50/p95/gust_max, hours-below-threshold, temp extremes, volatility (category transitions within UTC day, summed), and a rich `diurnal_json` blob (per-hour {n, n_ifr, n_ts, n_fog, n_precip, ceiling_p50}).
- **`airport_daily_summary`** — one row per `(date, icao)` with lighter aggregates including `worst_category` for the calendar heatmap. Can't be backfilled past raw retention so it must accumulate from day 1 — added now even though no UI consumes it yet.

New `tasks/airport_summary.py` with idempotent `rollup_month` / `rollup_day` and `rollup_all_complete_*` orchestrators, wired into the existing daily 02:00 UTC retention loop. CLI: `python -m weatherbrief.verify rollup-summary [--month YYYY-MM | --day YYYY-MM-DD | --all]`.

`prune_raw_observations()` scaffold added in `tasks/retention.py` with default `retain_days=9999` (effectively disabled). Will switch to ~180 days after Patterns + Spotlight UI is live and we've confirmed the rollup column set covers everything we query.

### Phase 4 deferred

InnoDB rejects partitioning on tables with FKs (parent or child) and `verification_observations` has 3 inbound CASCADE FKs from score / map tables. Decided to use **plain DELETE** for retention (Option B): at our scale (~80–160k rows/month) indexed-range deletes complete in seconds. `ensure_future_partitions()` kept as a no-op stub for a future pivot if perf becomes a real problem. See the plan doc for the analysis.

### Decided design choices (locked in this PR)

- **Volatility** = count of category transitions between consecutive observations *within the same UTC day*, summed across the period. A flap of VFR→IFR→VFR within a day counts as 2.
- **Diurnal JSON** = rich per-hour content `{n, n_ifr, n_ts, n_fog, n_precip, ceiling_p50}`. Hours with no observations are omitted to keep the blob compact.
- **Generous column set** — separate `n_fg` / `n_br` / `n_haze`, multiple ceiling percentiles, hours-below-threshold convenience counts. Storage is trivial (~5 MB/year for 830 airports × 12 months) and retention can't be undone, so paying for optionality up-front.

## Test plan

- [x] 36 new tests in `test_airport_summary.py` cover percentile math, phenomena marker detection (TS variants, FG variants, FZ catches all freezing precip), volatility counting (no changes / one transition / flap / cross-day segmentation / unknown-category gap), diurnal JSON shape, idempotent re-runs, orchestrator behavior.
- [x] Full pytest suite: 1807 passed.
- [x] Migration 053 applies cleanly on a fresh SQLite DB.
- [x] Pure `op.create_table` works identically on MySQL — no batch mode needed.
- [ ] Deploy to weather.flyfun.aero and confirm:
  - [ ] Migration 053 applies cleanly on prod MySQL
  - [ ] Nightly 02:00 UTC tick logs `Airport summary rollup: N months, M days`
  - [ ] First completed-month rollup populates ~830 rows in `airport_monthly_summary`
  - [ ] Daily summary accumulates from deploy day forward
  - [ ] No regression in existing retention loop behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)