### PR TITLE
fix(clouds): make Skew-T render same decks as cross-section + cleaner AI-pending banner

### DIFF
--- a/designs/cloud-layers-analysis.md
+++ b/designs/cloud-layers-analysis.md
@@ -140,6 +140,23 @@ Four-tier approach, tried in this preference order:
 - Stratiform → −20°C level (glaciation limit)
 - Only set when exceeding sounding-derived cloud top
 
+### Stage 6: Active `cloud_layers` slot
+
+`SoundingAnalysis` exposes three cloud-layer fields:
+- `dd_cloud_layers` — immutable DD-derived layers (Method 1).
+- `nwp_cloud_layers` — immutable NWP-derived layers (Method 2), or `None` if the model has no native NWP source.
+- `cloud_layers` — the **active slot** consumed by Skew-T, cross-section, ceiling computation, and downstream icing/IFR feasibility. Today it is set to `list(dd_cloud_layers)` verbatim.
+
+#### ICAO band overlay (disabled)
+
+Historically the active slot was `apply_nwp_coverage(dd_cloud_layers, …)` — an overlay that splits DD decks at ICAO band boundaries (6500 / 20000 ft) and re-classifies each segment's coverage from the model's bulk band % (`cloud_cover_low/mid/high_pct`). The function and its tests are kept callable but the call site is gated by `_APPLY_NWP_COVERAGE_OVERLAY` in `analysis/sounding/__init__.py`, hard-coded to `False`.
+
+**Why disabled:** the category-split DD detector (PR #142) already produces good per-deck OVC/BKN/SCT classes with moisture-defined edges. The overlay degrades that signal in two ways:
+1. Splitting at 6500 / 20000 ft turns a single moisture-defined deck (e.g. 4351–10892 ft OVC) into two band-bounded segments with different coverages.
+2. Split segments inherit `base_pressure_hpa=None` or `top_pressure_hpa=None` from the band-cut edges, which causes the Skew-T (a pressure-axis view) to skip them entirely.
+
+**To re-enable** (e.g. if NWP bulk bands later re-prove useful for ceiling adjustment), flip `_APPLY_NWP_COVERAGE_OVERLAY = True` and run `tests/test_clouds.py` — existing tests for the overlay still cover its semantics. Consider exposing as a per-user preference rather than re-enabling globally.
+
 ---
 
 ## Cloud Data in Icing Assessment

--- a/src/weatherbrief/analysis/sounding/__init__.py
+++ b/src/weatherbrief/analysis/sounding/__init__.py
@@ -18,6 +18,15 @@ logger = logging.getLogger(__name__)
 # Dry air gas constant (J/(kg·K))
 _RD = 287.05
 
+# Hardcoded off — see designs/cloud-layers-analysis.md "ICAO band overlay (disabled)".
+# When True, the active ``cloud_layers`` slot is built by
+# ``apply_nwp_coverage(dd_cloud_layers, …)``, which splits decks at ICAO
+# band boundaries (6500/20000 ft) and re-codes coverage from NWP bulk
+# band %. Now that the category-split DD detector produces good per-deck
+# OVC/BKN/SCT classes with moisture-defined edges, that overlay degrades
+# rather than improves the result. Kept callable so we can A/B it later.
+_APPLY_NWP_COVERAGE_OVERLAY = False
+
 
 def _enrich_lwc(
     derived_levels: list[DerivedLevel],
@@ -210,19 +219,23 @@ def analyze_sounding_lite(
         lcl_altitude_ft=indices.lcl_altitude_ft,
     )
 
-    # Apply NWP coverage to DD layers so ceiling reflects model cloud amount.
-    # TODO: With the category-split DD detector, dd_cloud_layers already
-    # carries moisture-defined edges and per-deck OVC/BKN/SCT classes. The
-    # ICAO band overlay below can override those classes with band averages
-    # — re-evaluate whether the overlay still adds value or should be
-    # toggleable / removed.
-    cloud_layers = apply_nwp_coverage(
-        dd_cloud_layers,
-        nwp_cloud_low_pct=hourly.cloud_cover_low_pct if hourly else None,
-        nwp_cloud_mid_pct=hourly.cloud_cover_mid_pct if hourly else None,
-        nwp_cloud_high_pct=hourly.cloud_cover_high_pct if hourly else None,
-        nwp_cloud_diagnostics=hourly.nwp_cloud_diagnostics if hourly else None,
-    )
+    # Active cloud_layers slot. With _APPLY_NWP_COVERAGE_OVERLAY off (the
+    # current default) we publish dd_cloud_layers verbatim — they already
+    # carry moisture-defined edges and per-deck OVC/BKN/SCT classes from
+    # the category-split detector. The ICAO band overlay (when enabled)
+    # would split decks at 6500/20000 ft and re-classify each segment by
+    # NWP bulk band %, which destroys the per-deck edges and produces
+    # zero-pressure-span segments that disappear from the Skew-T view.
+    if _APPLY_NWP_COVERAGE_OVERLAY:
+        cloud_layers = apply_nwp_coverage(
+            dd_cloud_layers,
+            nwp_cloud_low_pct=hourly.cloud_cover_low_pct if hourly else None,
+            nwp_cloud_mid_pct=hourly.cloud_cover_mid_pct if hourly else None,
+            nwp_cloud_high_pct=hourly.cloud_cover_high_pct if hourly else None,
+            nwp_cloud_diagnostics=hourly.nwp_cloud_diagnostics if hourly else None,
+        )
+    else:
+        cloud_layers = list(dd_cloud_layers)
 
     # Inversions (cheap — single linear scan, ~2 µs)
     inversion_layers = detect_inversions(derived_levels)
@@ -340,19 +353,18 @@ def _analyze_sounding_heavy(
     eff_cape = effective_cape(indices)
     enrich_cloud_top_uncertainty(dd_cloud_layers, indices, eff_cape)
 
-    # Apply NWP coverage percentages to DD layers.
-    # TODO: With the category-split DD detector, dd_cloud_layers already
-    # carries moisture-defined edges and per-deck OVC/BKN/SCT classes. The
-    # ICAO band overlay below can override those classes with band averages
-    # — re-evaluate whether the overlay still adds value or should be
-    # toggleable / removed.
-    cloud_layers = apply_nwp_coverage(
-        dd_cloud_layers,
-        nwp_cloud_low_pct=hourly.cloud_cover_low_pct if hourly else None,
-        nwp_cloud_mid_pct=hourly.cloud_cover_mid_pct if hourly else None,
-        nwp_cloud_high_pct=hourly.cloud_cover_high_pct if hourly else None,
-        nwp_cloud_diagnostics=hourly.nwp_cloud_diagnostics if hourly else None,
-    )
+    # Active cloud_layers slot. See _APPLY_NWP_COVERAGE_OVERLAY note above
+    # — overlay disabled by default, so we publish dd_cloud_layers verbatim.
+    if _APPLY_NWP_COVERAGE_OVERLAY:
+        cloud_layers = apply_nwp_coverage(
+            dd_cloud_layers,
+            nwp_cloud_low_pct=hourly.cloud_cover_low_pct if hourly else None,
+            nwp_cloud_mid_pct=hourly.cloud_cover_mid_pct if hourly else None,
+            nwp_cloud_high_pct=hourly.cloud_cover_high_pct if hourly else None,
+            nwp_cloud_diagnostics=hourly.nwp_cloud_diagnostics if hourly else None,
+        )
+    else:
+        cloud_layers = list(dd_cloud_layers)
 
     # Temperature inversion detection
     inversion_layers = detect_inversions(derived_levels)

--- a/src/weatherbrief/analysis/sounding/clouds.py
+++ b/src/weatherbrief/analysis/sounding/clouds.py
@@ -63,20 +63,26 @@ def _dd_category(
     return _classify_coverage(dd)
 
 
-def _dd_crossing_altitude(
+def _dd_crossing_edge(
     a: DerivedLevel,
     b: DerivedLevel,
     a_cat: CloudCoverage,
     b_cat: CloudCoverage | None,
-) -> float | None:
-    """Altitude (ft) where ``dewpoint_depression_c`` linearly crosses the
-    boundary DD separating a's and b's coverage categories.
+) -> tuple[float, float] | None:
+    """``(altitude_ft, pressure_hpa)`` where ``dewpoint_depression_c``
+    linearly crosses the boundary DD separating a's and b's coverage
+    categories.
 
-    Mirrors ``_crossing_altitude`` for the NWP-3D path but on DD: ``a`` is
+    Mirrors ``_crossing_edge`` for the NWP-3D path but on DD: ``a`` is
     always a level inside a deck (so ``a_cat`` non-None and
     ``a_dd < dd_threshold``); ``b`` is the adjacent neighbor — possibly
     clear (``b_cat=None`` and ``b_dd >= dd_threshold``). The denser
     endpoint is the one with the lower DD.
+
+    Both altitude and pressure are interpolated at the same fraction of
+    the [a, b] segment, so the returned edge represents one consistent
+    point in the sounding — needed by Skew-T (pressure axis) and the
+    cross-section (altitude axis) views to render the same deck.
 
     Returns ``None`` if either endpoint lacks data, the two levels share
     the same DD (no crossing possible), the boundary DD lies outside
@@ -106,26 +112,30 @@ def _dd_crossing_altitude(
     frac = (target - a_dd) / (b_dd - a_dd)
     if not 0.0 <= frac <= 1.0:
         return None
-    return a.altitude_ft + frac * (b.altitude_ft - a.altitude_ft)
+    altitude_ft = a.altitude_ft + frac * (b.altitude_ft - a.altitude_ft)
+    pressure_hpa = a.pressure_hpa + frac * (b.pressure_hpa - a.pressure_hpa)
+    return (altitude_ft, pressure_hpa)
 
 
-def _dd_midpoint_altitude_ft(
+def _dd_midpoint_edge(
     inner: DerivedLevel,
     outer: DerivedLevel | None,
-) -> float | None:
-    """Edge altitude when threshold-crossing isn't usable.
+) -> tuple[float, float] | None:
+    """Edge ``(altitude_ft, pressure_hpa)`` when threshold-crossing isn't usable.
 
     Two behaviours, both intentional:
-      - ``outer`` present → altitude midway between the deck-edge level
-        and its neighbor.
+      - ``outer`` present → midpoint between the deck-edge level and its
+        neighbor (altitude AND pressure both averaged at frac=0.5).
       - ``outer is None`` (column floor / TOA) → the deck-edge level's
-        own altitude, since there's no neighbor to interpolate against.
+        own altitude/pressure, since there's no neighbor to interpolate.
     """
     if inner.altitude_ft is None:
         return None
     if outer is None or outer.altitude_ft is None:
-        return inner.altitude_ft
-    return (inner.altitude_ft + outer.altitude_ft) / 2.0
+        return (inner.altitude_ft, float(inner.pressure_hpa))
+    altitude_ft = (inner.altitude_ft + outer.altitude_ft) / 2.0
+    pressure_hpa = (inner.pressure_hpa + outer.pressure_hpa) / 2.0
+    return (altitude_ft, pressure_hpa)
 
 
 def _dd_layer_edge_below(
@@ -133,13 +143,14 @@ def _dd_layer_edge_below(
     cats: list[CloudCoverage | None],
     i: int,
     cat: CloudCoverage,
-) -> float | None:
-    """Altitude of the lower edge of the run starting at index i."""
+) -> tuple[float, float] | None:
+    """``(altitude_ft, pressure_hpa)`` of the lower edge of the run starting
+    at index i."""
     if i > 0:
-        ft = _dd_crossing_altitude(levels[i], levels[i - 1], cat, cats[i - 1])
-        if ft is not None:
-            return ft
-    return _dd_midpoint_altitude_ft(levels[i], levels[i - 1] if i > 0 else None)
+        edge = _dd_crossing_edge(levels[i], levels[i - 1], cat, cats[i - 1])
+        if edge is not None:
+            return edge
+    return _dd_midpoint_edge(levels[i], levels[i - 1] if i > 0 else None)
 
 
 def _dd_layer_edge_above(
@@ -147,14 +158,15 @@ def _dd_layer_edge_above(
     cats: list[CloudCoverage | None],
     j: int,
     cat: CloudCoverage,
-) -> float | None:
-    """Altitude of the upper edge of the run ending at index j."""
+) -> tuple[float, float] | None:
+    """``(altitude_ft, pressure_hpa)`` of the upper edge of the run ending
+    at index j."""
     n = len(levels)
     if j + 1 < n:
-        ft = _dd_crossing_altitude(levels[j], levels[j + 1], cat, cats[j + 1])
-        if ft is not None:
-            return ft
-    return _dd_midpoint_altitude_ft(levels[j], levels[j + 1] if j + 1 < n else None)
+        edge = _dd_crossing_edge(levels[j], levels[j + 1], cat, cats[j + 1])
+        if edge is not None:
+            return edge
+    return _dd_midpoint_edge(levels[j], levels[j + 1] if j + 1 < n else None)
 
 
 def detect_cloud_layers(
@@ -215,16 +227,19 @@ def detect_cloud_layers(
         while j + 1 < n and cats[j + 1] == cat:
             j += 1
 
-        base_ft = _dd_layer_edge_below(sorted_levels, cats, i, cat)
-        top_ft = _dd_layer_edge_above(sorted_levels, cats, j, cat)
-        if base_ft is None or top_ft is None or top_ft <= base_ft:
+        base_edge = _dd_layer_edge_below(sorted_levels, cats, i, cat)
+        top_edge = _dd_layer_edge_above(sorted_levels, cats, j, cat)
+        if base_edge is None or top_edge is None or top_edge[0] <= base_edge[0]:
             logger.warning(
                 "Dropping DD cloud deck at run [%d..%d] (cat=%s): "
-                "base_ft=%s top_ft=%s — degenerate layer geometry",
-                i, j, cat, base_ft, top_ft,
+                "base_edge=%s top_edge=%s — degenerate layer geometry",
+                i, j, cat, base_edge, top_edge,
             )
             i = j + 1
             continue
+
+        base_ft, base_pressure_hpa = base_edge
+        top_ft, top_pressure_hpa = top_edge
 
         run = sorted_levels[i:j + 1]
         # Every level in the run has DD + altitude (cats[k] non-None requires
@@ -238,8 +253,8 @@ def detect_cloud_layers(
         cloud_layers.append(EnhancedCloudLayer(
             base_ft=round(base_ft),
             top_ft=round(top_ft),
-            base_pressure_hpa=run[0].pressure_hpa,
-            top_pressure_hpa=run[-1].pressure_hpa,
+            base_pressure_hpa=round(base_pressure_hpa),
+            top_pressure_hpa=round(top_pressure_hpa),
             thickness_ft=round(top_ft - base_ft),
             mean_temperature_c=mean_t,
             coverage=cat,
@@ -280,20 +295,26 @@ _NWP_CATEGORY_LOWER_BOUNDS: dict[CloudCoverage, float] = {
 }
 
 
-def _crossing_altitude(
+def _crossing_edge(
     a: PressureLevelData,
     b: PressureLevelData,
     a_cat: CloudCoverage,
     b_cat: CloudCoverage | None,
-) -> float | None:
-    """Altitude (ft) where ``cloud_area_fraction_pct`` linearly crosses the
-    boundary CAF separating a's and b's coverage categories.
+) -> tuple[float, float] | None:
+    """``(altitude_ft, pressure_hpa)`` where ``cloud_area_fraction_pct``
+    linearly crosses the boundary CAF separating a's and b's coverage
+    categories.
 
     ``a`` is always a level inside a deck (so ``a_cat`` is non-None and
     ``a_caf >= 12.5 %``); ``b`` is the adjacent neighbor — possibly clear
     (``b_cat=None`` and ``b_caf < 12.5 %``). Used to anchor a deck's
     base/top to the model's own cloud field instead of pinning to a level
     altitude.
+
+    Both altitude and pressure are interpolated at the same fraction of
+    the [a, b] segment, so the returned edge represents one consistent
+    point in the sounding — needed by Skew-T (pressure axis) and the
+    cross-section (altitude axis) views to render the same deck.
 
     Returns ``None`` if either endpoint lacks data, the two levels share
     the same CAF (no crossing possible), the boundary CAF lies outside
@@ -326,27 +347,31 @@ def _crossing_altitude(
         return None
     a_ft = a.geopotential_height_m * _M_TO_FT
     b_ft = b.geopotential_height_m * _M_TO_FT
-    return a_ft + frac * (b_ft - a_ft)
+    altitude_ft = a_ft + frac * (b_ft - a_ft)
+    pressure_hpa = a.pressure_hpa + frac * (b.pressure_hpa - a.pressure_hpa)
+    return (altitude_ft, pressure_hpa)
 
 
-def _midpoint_altitude_ft(
+def _midpoint_edge(
     inner: PressureLevelData,
     outer: PressureLevelData | None,
-) -> float | None:
-    """Edge altitude when threshold-crossing isn't usable.
+) -> tuple[float, float] | None:
+    """Edge ``(altitude_ft, pressure_hpa)`` when threshold-crossing isn't usable.
 
     Two behaviours, both intentional:
-      - ``outer`` present → altitude midway between the deck-edge level
-        and its neighbor.
+      - ``outer`` present → midpoint between the deck-edge level and its
+        neighbor (altitude AND pressure both averaged at frac=0.5).
       - ``outer is None`` (column floor / TOA) → the deck-edge level's
-        own altitude, since there's no neighbor to interpolate against.
+        own altitude/pressure, since there's no neighbor to interpolate.
     """
     if inner.geopotential_height_m is None:
         return None
     inner_ft = inner.geopotential_height_m * _M_TO_FT
     if outer is None or outer.geopotential_height_m is None:
-        return inner_ft
-    return (inner_ft + outer.geopotential_height_m * _M_TO_FT) / 2.0
+        return (inner_ft, float(inner.pressure_hpa))
+    altitude_ft = (inner_ft + outer.geopotential_height_m * _M_TO_FT) / 2.0
+    pressure_hpa = (inner.pressure_hpa + outer.pressure_hpa) / 2.0
+    return (altitude_ft, pressure_hpa)
 
 
 def _layer_edge_below(
@@ -354,13 +379,14 @@ def _layer_edge_below(
     cats: list[CloudCoverage | None],
     i: int,
     cat: CloudCoverage,
-) -> float | None:
-    """Altitude of the lower edge of the run starting at index i."""
+) -> tuple[float, float] | None:
+    """``(altitude_ft, pressure_hpa)`` of the lower edge of the run starting
+    at index i."""
     if i > 0:
-        ft = _crossing_altitude(levels[i], levels[i - 1], cat, cats[i - 1])
-        if ft is not None:
-            return ft
-    return _midpoint_altitude_ft(levels[i], levels[i - 1] if i > 0 else None)
+        edge = _crossing_edge(levels[i], levels[i - 1], cat, cats[i - 1])
+        if edge is not None:
+            return edge
+    return _midpoint_edge(levels[i], levels[i - 1] if i > 0 else None)
 
 
 def _layer_edge_above(
@@ -368,14 +394,15 @@ def _layer_edge_above(
     cats: list[CloudCoverage | None],
     j: int,
     cat: CloudCoverage,
-) -> float | None:
-    """Altitude of the upper edge of the run ending at index j."""
+) -> tuple[float, float] | None:
+    """``(altitude_ft, pressure_hpa)`` of the upper edge of the run ending
+    at index j."""
     n = len(levels)
     if j + 1 < n:
-        ft = _crossing_altitude(levels[j], levels[j + 1], cat, cats[j + 1])
-        if ft is not None:
-            return ft
-    return _midpoint_altitude_ft(levels[j], levels[j + 1] if j + 1 < n else None)
+        edge = _crossing_edge(levels[j], levels[j + 1], cat, cats[j + 1])
+        if edge is not None:
+            return edge
+    return _midpoint_edge(levels[j], levels[j + 1] if j + 1 < n else None)
 
 
 def build_nwp_cloud_layers_from_fraction(
@@ -431,9 +458,9 @@ def build_nwp_cloud_layers_from_fraction(
         while j + 1 < n and cats[j + 1] == cat:
             j += 1
 
-        base_ft = _layer_edge_below(levels, cats, i, cat)
-        top_ft = _layer_edge_above(levels, cats, j, cat)
-        if base_ft is None or top_ft is None or top_ft <= base_ft:
+        base_edge = _layer_edge_below(levels, cats, i, cat)
+        top_edge = _layer_edge_above(levels, cats, j, cat)
+        if base_edge is None or top_edge is None or top_edge[0] <= base_edge[0]:
             # Should not happen with well-formed sounding data: a category run
             # always has at least one level with valid CAF + geopotential, and
             # well-ordered geopotential should give top > base. Logged so a
@@ -441,11 +468,14 @@ def build_nwp_cloud_layers_from_fraction(
             # disappear from the cross-section.
             logger.warning(
                 "Dropping NWP-3D cloud deck at run [%d..%d] (cat=%s): "
-                "base_ft=%s top_ft=%s — degenerate layer geometry",
-                i, j, cat, base_ft, top_ft,
+                "base_edge=%s top_edge=%s — degenerate layer geometry",
+                i, j, cat, base_edge, top_edge,
             )
             i = j + 1
             continue
+
+        base_ft, base_pressure_hpa = base_edge
+        top_ft, top_pressure_hpa = top_edge
 
         run = levels[i:j + 1]
         # Every level in the run is guaranteed to carry CAF + geopotential
@@ -460,8 +490,8 @@ def build_nwp_cloud_layers_from_fraction(
         layers.append(EnhancedCloudLayer(
             base_ft=round(base_ft),
             top_ft=round(top_ft),
-            base_pressure_hpa=levels[i].pressure_hpa,
-            top_pressure_hpa=levels[j].pressure_hpa,
+            base_pressure_hpa=round(base_pressure_hpa),
+            top_pressure_hpa=round(top_pressure_hpa),
             thickness_ft=round(top_ft - base_ft),
             mean_temperature_c=mean_t,
             coverage=cat,

--- a/tests/test_clouds.py
+++ b/tests/test_clouds.py
@@ -186,6 +186,38 @@ def test_empty_levels():
     assert detect_cloud_layers([]) == []
 
 
+def test_single_level_deck_has_non_collapsed_pressures():
+    """A deck consisting of one pressure level must still span a non-zero
+    pressure range — interpolated between neighbors so the Skew-T view
+    (which plots in pressure coords) renders the deck instead of drawing
+    a zero-height band.
+
+    Regression for the OBIMO/ICON case where a BKN run at a single level
+    (600 hPa) reported base_pressure_hpa == top_pressure_hpa, making the
+    deck invisible on the Skew-T while the cross-section (altitude axis)
+    correctly drew it.
+    """
+    levels = [
+        DerivedLevel(pressure_hpa=850, altitude_ft=4760, dewpoint_depression_c=0.3),  # OVC
+        DerivedLevel(pressure_hpa=700, altitude_ft=9880, dewpoint_depression_c=0.3),  # OVC
+        DerivedLevel(pressure_hpa=600, altitude_ft=13800, dewpoint_depression_c=1.8),  # BKN
+        DerivedLevel(pressure_hpa=500, altitude_ft=18300, dewpoint_depression_c=2.3),  # SCT
+    ]
+    layers = detect_cloud_layers(levels)
+    # Three runs: OVC[850,700], BKN[600], SCT[500] → 3 layers.
+    assert len(layers) == 3, [(c.base_ft, c.top_ft, c.coverage.value) for c in layers]
+    bkn = next(c for c in layers if c.coverage == CloudCoverage.BKN)
+    assert bkn.base_pressure_hpa is not None and bkn.top_pressure_hpa is not None
+    assert bkn.base_pressure_hpa > bkn.top_pressure_hpa, (
+        f"Single-level BKN deck collapsed: base={bkn.base_pressure_hpa} "
+        f"top={bkn.top_pressure_hpa} hPa"
+    )
+    # Interpolated edges — base sits between 700 (denser) and 600 (in deck),
+    # top sits between 600 (in deck) and 500 (clear/lighter).
+    assert 600 < bkn.base_pressure_hpa < 700
+    assert 500 < bkn.top_pressure_hpa < 600
+
+
 # --- NWP cloud layer tests ---
 
 

--- a/tests/test_nwp_cloud_layers_from_cc.py
+++ b/tests/test_nwp_cloud_layers_from_cc.py
@@ -86,6 +86,36 @@ def test_clear_gap_produces_two_separate_decks():
     assert layers[1].base_ft > layers[0].top_ft
 
 
+def test_single_level_deck_has_non_collapsed_pressures():
+    """A deck consisting of one pressure level must still span a non-zero
+    pressure range — interpolated between neighbors so the Skew-T view
+    (which plots in pressure coords) renders the deck instead of drawing
+    a zero-height band.
+
+    Mirror of the DD-path regression test: ECMWF/ICON 3D-cloud paths
+    have the same single-level-collapse failure mode.
+    """
+    # OVC[850,700], BKN at single level 600, SCT at single level 500.
+    levels = [
+        _lv(850, 1500, caf=92, t=4),   # OVC
+        _lv(700, 3100, caf=88, t=-2),  # OVC
+        _lv(600, 4250, caf=65, t=-12), # BKN — single level
+        _lv(500, 5600, caf=35, t=-22), # SCT — single level
+    ]
+    layers = build_nwp_cloud_layers_from_fraction(levels)
+    assert layers is not None
+    bkn = next(layer for layer in layers if layer.coverage == CloudCoverage.BKN)
+    assert bkn.base_pressure_hpa is not None and bkn.top_pressure_hpa is not None
+    assert bkn.base_pressure_hpa > bkn.top_pressure_hpa, (
+        f"Single-level BKN deck collapsed: base={bkn.base_pressure_hpa} "
+        f"top={bkn.top_pressure_hpa} hPa"
+    )
+    # Interpolated edges — base sits between 700 (denser) and 600 (in deck),
+    # top sits between 600 (in deck) and 500 (lighter SCT).
+    assert 600 < bkn.base_pressure_hpa < 700
+    assert 500 < bkn.top_pressure_hpa < 600
+
+
 def test_category_change_splits():
     """Transition between coverage categories splits decks."""
     levels = [

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -797,6 +797,12 @@ label {
   white-space: nowrap;
 }
 
+.assessment-pending {
+  font-style: italic;
+  opacity: 0.7;
+  font-weight: normal;
+}
+
 /* --- Alternate departure time banner (separate from main assessment) --- */
 
 .alt-assessment-banner {

--- a/web/ts/managers/briefing-ui.ts
+++ b/web/ts/managers/briefing-ui.ts
@@ -221,9 +221,15 @@ export function renderAssessment(
     } else {
       const level = pack.assessment.toUpperCase();
       el.className = `assessment-banner assessment-${level.toLowerCase()}`;
-      el.innerHTML = `
-        <strong>${level}</strong>${pack.assessment_reason ? ` \u2014 ${escapeHtml(pack.assessment_reason)}` : ''}
-      `;
+      // Only show ``assessment_reason`` once the AI digest is ready.
+      // Pre-digest, the backend fills it with a machine-readable concern
+      // list ("fiki_icing=RED, flight_category=AMBER, \u2026") that's noise
+      // for users \u2014 the structured advisory chips below already convey
+      // the same information in a friendlier form.
+      const reasonHtml = pack.has_digest && pack.assessment_reason
+        ? ` \u2014 ${escapeHtml(pack.assessment_reason)}`
+        : ` <span class="assessment-pending">${escapeHtml(t('digest.generating'))}</span>`;
+      el.innerHTML = `<strong>${level}</strong>${reasonHtml}`;
     }
   }
 


### PR DESCRIPTION
## Summary

Two related fixes flowing from the OBIMO/ICON debug session:

- **Cloud-layer pressures interpolated alongside altitudes** so the Skew-T (pressure axis) renders the same decks as the cross-section (altitude axis). Single-level decks were collapsing to zero pressure span and disappearing from the Skew-T while the cross-section drew them correctly.
- **`apply_nwp_coverage` ICAO-band overlay disabled by default.** Now that the category-split DD detector (PR #142) produces good per-deck OVC/BKN/SCT classes, the overlay was destroying that signal — splitting decks at 6500/20000 ft and creating segments with `base_pressure_hpa=None` that the Skew-T also skipped. Function and tests kept callable; gated by `_APPLY_NWP_COVERAGE_OVERLAY` (hard-coded False, with a re-enable path documented).
- **Assessment banner**: while the AI digest is still generating (provisional pack, `has_digest=false`), hide the raw `assessment_reason` (a debug-shaped `fiki_icing=RED, flight_category=AMBER, …` list) and show a subtle "Generating summary…" placeholder instead. The advisory chips below the banner still convey structured concerns.

## Test plan

- [x] Existing cloud-layer test suite still green (42 → 44, 2 new regression tests added)
- [x] Full backend test suite: 1825 passed, 0 failed
- [x] Vitest: 245/245
- [x] Playwright briefing: 4/4
- [x] End-to-end on local server: refreshed an OBIMO-route briefing — Skew-T now shows all DD decks consistent with the cross-section
- [ ] Bot review

## Notes

- Edge-helper functions in `clouds.py` were renamed (`_dd_crossing_altitude` → `_dd_crossing_edge`, `_layer_edge_*` now return `(altitude_ft, pressure_hpa)` tuples) — all callers within `clouds.py` updated, no external callers.
- New design-doc section (`Stage 6: Active cloud_layers slot` in `designs/cloud-layers-analysis.md`) explains the active-slot resolution and how to re-enable the overlay if it ever proves useful again (e.g. as a per-user preference).

🤖 Generated with [Claude Code](https://claude.com/claude-code)