### PR TITLE
config(aircraft): add Aeropro EuroFOX (EFOX)

### DIFF
--- a/configs/icao_aircraft_types.json
+++ b/configs/icao_aircraft_types.json
@@ -79,6 +79,7 @@
     {"icao": "E55P", "manufacturer": "Embraer", "model": "Phenom 300", "category": "JET"},
     {"icao": "EA50", "manufacturer": "Eclipse", "model": "Eclipse 500", "category": "JET"},
     {"icao": "EC20", "manufacturer": "Eurocopter", "model": "EC120 Colibri", "category": "SET"},
+    {"icao": "EFOX", "manufacturer": "Aeropro", "model": "EuroFOX", "category": "SEP"},
     {"icao": "EUFI", "manufacturer": "Robin", "model": "DR400 Ecoflyer", "category": "SEP"},
     {"icao": "EVOT", "manufacturer": "Evector", "model": "EV-97 Eurostar", "category": "SEP"},
     {"icao": "F2TH", "manufacturer": "Dassault", "model": "Falcon 2000", "category": "JET"},


### PR DESCRIPTION
## Summary
- Add Aeropro EuroFOX (ICAO `EFOX`) to `configs/icao_aircraft_types.json`, category `SEP`.

Slovak-built two-seat high-wing Rotax 912 aircraft, commonly used in Europe for training and glider towing.

## Test plan
- [x] JSON parses; total count is now 166 types.
- [ ] `GET /aircraft/types?q=EFOX` returns the new entry after server restart (cache reload).

https://claude.ai/code/session_01LWqVs7HivvrTJmdZfCM14d

---
_Generated by [Claude Code](https://claude.ai/code/session_01LWqVs7HivvrTJmdZfCM14d)_