### PR TITLE
fix(grib): window-midpoint cloud-diag interp + RH/condensate gate (#148)

### DIFF
--- a/designs/cloud-layers-analysis.md
+++ b/designs/cloud-layers-analysis.md
@@ -78,9 +78,12 @@ ICON-EU GRIB2 ──→ decode_icon_eu_cloud_diag_per_point() ──→ build_ic
 
 ### Stage 2: Temporal Interpolation
 
-`fill.py:_forward_fill_cloud_diagnostics()` — forward-fills `nwp_cloud_diagnostics` from native GRIB hours to Open-Meteo interpolated hours. Cloud layer geometry changes slowly between 3-hour GFS steps.
+`fill.py:_fill_cloud_diagnostics()` (invoked from `propagate_all`) fills `nwp_cloud_diagnostics` on gap hours between native GRIB steps.
 
-Open-Meteo `cloud_cover_*_pct` values are NOT forward-filled — they have their own hourly interpolation from Open-Meteo. This means cloud cover percentages and cloud diagnostic boundaries can come from different time anchors (up to 3 hours apart at longer lead times).
+- **GFS, when `gfs_init` is provided** — `_interp_gfs_diag_hourly` does **window-midpoint linear interpolation** for low/mid/high cover (LCDC/MCDC/HCDC are averaged-window fields in GFS pgrb2, so each anchor sits at `step - window_length/2`). Layer geometry (`base_ft`, `top_ft`, `top_temp_c`) holds over from the higher-cover endpoint; sub-5 % covers drop the layer entirely. Convective, boundary, total, ceiling, and freezing level interpolate linearly with step-time anchoring. A follow-up `apply_gfs_rh_condensate_gate` drops bands whose pressure-level RH and condensate inside `[base_ft, top_ft]` contradict the averaged cover. See [future/meteorology-decisions.md §3](./future/meteorology-decisions.md#3-gfs-cloud-diagnostics-window-midpoint-interp--rhcondensate-gate).
+- **ICON-EU, ECMWF, and the GFS fallback path** (no `gfs_init`) — `_fill_diag_hourly` forward-fills. ICON-EU and ECMWF publish instantaneous cover; persistence is the right semantic.
+
+Open-Meteo `cloud_cover_*_pct` values are NOT temporally smoothed by this module — they have their own hourly interpolation from Open-Meteo. This means cloud cover percentages and cloud diagnostic boundaries can come from different time anchors (up to ~1.5 hours apart on the GFS path with window-midpoint interp; up to 3 hours on the forward-fill path).
 
 ### Stage 3: Spatial Interpolation
 
@@ -313,7 +316,10 @@ The ceiling and convective base/top from ICON-EU diagnostics ARE used elsewhere 
 
 ### 4. Temporal desynchronization between cover % and boundaries
 
-Open-Meteo provides hourly-interpolated cloud cover percentages. GRIB2 provides native-step diagnostics (1h or 3h intervals) that are forward-filled. Between native steps, the percentage can be freshly interpolated while the boundaries are stale (up to 3 hours old). This is documented in `fill.py` and accepted as a reasonable approximation.
+Open-Meteo provides hourly-interpolated cloud cover percentages. GRIB2 native-step diagnostics arrive at 1h or 3h intervals.
+
+- **GFS path (with `gfs_init`)** — low/mid/high cover is now window-midpoint linearly interpolated and the RH/condensate gate drops phantom layers (see [future/meteorology-decisions.md §3](./future/meteorology-decisions.md#3-gfs-cloud-diagnostics-window-midpoint-interp--rhcondensate-gate) and Stage 2). The remaining desync is between the freshly-interpolated cover and held-over layer geometry — bounded by the bracketing native steps' window length (≤ 1.5 h on either side past f120).
+- **ICON-EU / ECMWF / GFS fallback** — forward-fill leaves boundaries stale up to one full native step behind (3 h at longer lead times). Cover and boundaries can disagree by that much. Accepted as a reasonable approximation; ICON-EU and ECMWF cover is instantaneous, so persistence of both cover and geometry together is consistent.
 
 ---
 
@@ -414,9 +420,11 @@ SFIP proxy uses a wider gate (3°C, includes SCT) because it has no pass-2 NWP f
 
 | Axis | What | Method | Notes |
 |------|------|--------|-------|
-| **Temporal** | Cloud diagnostics | Forward-fill from native GRIB hours | Up to 3h gap at longer lead times |
-| **Temporal** | Cloud water (CLW/ICMR) | Forward-fill from native GRIB hours | Same timing as diagnostics |
-| **Temporal** | Cloud cover % | Open-Meteo hourly interpolation | Independent of GRIB timing |
+| **Temporal** | GFS cloud diagnostics (low/mid/high cover) | Window-midpoint linear interp between native steps (requires `gfs_init`); geometry held from higher-cover endpoint; sub-5 % drops layer; RH/condensate gate drops phantom layers post-interp | See [future/meteorology-decisions.md §3](./future/meteorology-decisions.md#3-gfs-cloud-diagnostics-window-midpoint-interp--rhcondensate-gate) |
+| **Temporal** | GFS cloud diagnostics (instantaneous: convective, boundary, total, ceiling, freezing level) | Step-time linear interp (requires `gfs_init`) | Instantaneous fields in GFS pgrb2 — no midpoint offset |
+| **Temporal** | ICON-EU / ECMWF cloud diagnostics + GFS fallback path | Forward-fill from preceding native GRIB hour | Up to 3h gap at longer lead times |
+| **Temporal** | Cloud water (CLW/ICMR) | GFS: step-time linear interp (requires `gfs_init`), otherwise forward-fill; ECMWF / ICON-EU rebuild via `_linear_interp_pressure_levels` | Instantaneous mixing ratios — step-time anchoring |
+| **Temporal** | Cloud cover % (`cloud_cover_low/mid/high_pct`) | Open-Meteo hourly interpolation | Independent of GRIB timing |
 | **Spatial** | Cloud diagnostics | Linear between route points | One-sided fallback; max 100nm gap |
 | **Spatial** | Cloud water (CLW/ICMR) | Linear between route points | Sets `clw_interpolated=True` |
 | **Spatial** | Cloud cover % | Not interpolated | Each point has own API response |

--- a/designs/fetch.md
+++ b/designs/fetch.md
@@ -211,7 +211,7 @@ enrich_forecasts(cross_sections, all_forecasts, route_points,
 | `icon_eu_levels.py` | Log-pressure interpolation from ICON-EU model levels to pressure levels |
 | `ecmwf_fetch.py` | Parse ECPDS filenames, scan delivery directory, find latest run. No HTTP — files land on local disk via ECPDS push |
 | `decode.py` | cfgrib → xarray decode, bilinear interpolation to route points. Chunked ICON-EU decoder (`decode_icon_eu_per_point_chunked()`) processes one variable at a time with explicit `gc.collect()` between — peak ~270MB vs ~800MB. ECMWF decoders handle multi-grid files (first-wins per point) |
-| `fill.py` | Forward-fill GRIB-enriched fields across time axis (cloud diagnostics + microphysics) |
+| `fill.py` | Time-axis fill of GRIB-enriched fields. Linear interp for GFS cloud diagnostics (window-midpoint, see meteorology-decisions §3) and CLW/ICMR when `gfs_init` is provided; forward-fill for ICON-EU/ECMWF and the GFS fallback path. Also hosts `apply_gfs_rh_condensate_gate` — drops GFS phantom layers where pressure-level RH and condensate disagree with the averaged cover |
 | `cache.py` | Disk cache per model (`data/.cache/grib/{model}/{date}_{cycle}z/`) with 48h TTL |
 
 ### How It Works
@@ -245,13 +245,20 @@ enrich_forecasts(cross_sections, all_forecasts, route_points,
 
 **Gap-filling for GRIB-enriched fields:** GRIB enrichment only targets native model forecast hours (e.g. every 3h for GFS at longer lead times), and some grid cells may return None. Two gap-filling passes ensure all route points and hours have data:
 
-1. **Time axis — forward-fill** (`fetch/grib/fill.py`): After all GRIB enrichment completes, `propagate_all()` forward-fills from the preceding native hour for both cloud diagnostics (`nwp_cloud_diagnostics`) and microphysics (`cloud_liquid_water_kg_kg`, `ice_mixing_ratio_kg_kg`). Cloud geometry and microphysics change slowly between 3h GFS steps.
+1. **Time axis** (`fetch/grib/fill.py`): After all GRIB enrichment completes, `propagate_all()` fills gap hours between native steps. The strategy depends on the field and source:
+   - **GFS cloud diagnostics** — when `gfs_init` is provided, `_fill_cloud_diagnostics` uses **window-midpoint linear interpolation** (`_interp_gfs_diag_hourly`) for low/mid/high cover. GFS publishes only the time-averaged form of LCDC/MCDC/HCDC, so the value at each native step is anchored at `step - window_length/2` and interpolated between neighbouring midpoints. Layer geometry (base/top/temp) is held over from the higher-cover endpoint; sub-5 % covers drop the layer entirely. Convective, boundary, total cover, and ceiling are instantaneous and use step-time anchoring. See [meteorology-decisions §3](./future/meteorology-decisions.md#3-gfs-cloud-diagnostics-window-midpoint-interp--rhcondensate-gate) for the rationale.
+   - **GFS CLW/ICMR overlay** — when `gfs_init` is provided, `_fill_cloud_water` uses step-time linear interp via `_interp_gfs_clw_hourly` (instantaneous mixing ratios — no midpoint adjustment).
+   - **ICON-EU / ECMWF cloud diagnostics** and the **GFS fallback path** (no `gfs_init`) — forward-fill from the preceding native hour. ICON-EU and ECMWF publish instantaneous cover; forward-fill is the right persistence semantic.
+   - **ECMWF / ICON-EU pressure-level soundings** — `_linear_interp_pressure_levels` rebuilds the full `pressure_levels` list on gap hours via per-level linear interp; dewpoint is derived from interpolated (T, RH) via Magnus rather than interpolated directly.
+   - **ECMWF surface scalars** — `_linear_interp_ecmwf_surface` linearly interpolates between GRIB anchors (identified via `nwp_cloud_diagnostics`); wind direction uses circular interp with a calm-speed gate.
+
+   After `propagate_all`, **`apply_gfs_rh_condensate_gate`** runs on GFS sections: each low/mid/high band is dropped when its pressure-level `max(RH)` is below the per-band threshold (`_GFS_GATE_RH_LOW_PCT` = 60, `_GFS_GATE_RH_MID_PCT` = 70, `_GFS_GATE_RH_HIGH_PCT` = 70) AND `sum(CLMR + ICMR)` within `[base_ft, top_ft]` is zero. This protects against averaged-window phantom layers that survive interpolation — see [meteorology-decisions §3](./future/meteorology-decisions.md#3-gfs-cloud-diagnostics-window-midpoint-interp--rhcondensate-gate).
 
 2. **Spatial axis — linear interpolation** (`analysis/spatial_interpolation.py`): Before sounding analysis, `interpolate_all_spatially()` fills gaps where a route point's GRIB grid cell returned None by linearly interpolating in distance-space from left/right neighbors. Applies to both CLW/ICMR (per-pressure-level) and cloud diagnostics (all numeric sub-fields). Requires both neighbors; max gap 100 nm; edge gaps skipped.
 
 3. **Vertical axis — linear in pressure** (`analysis/sounding/__init__.py`): During sounding analysis, `_interpolate_cloud_water()` fills intermediate pressure levels (25-hPa spacing) between native GRIB levels (50-hPa spacing) by linear interpolation in pressure-space. Only applies to CLW/ICMR.
 
-**When adding new GRIB-enriched fields:** add a forward-fill in `fill.py` (time axis) and a spatial interpolation function in `spatial_interpolation.py` (spatial axis). If the field is per-pressure-level, also add vertical interpolation in the sounding analysis.
+**When adding new GRIB-enriched fields:** add a time-axis fill in `fill.py` (linear interp where the field is meaningfully continuous, forward-fill where persistence is the right semantic) and a spatial interpolation function in `spatial_interpolation.py` (spatial axis). If the field is per-pressure-level, also add vertical interpolation in the sounding analysis.
 
 ### Key Choices
 - **GFS + ICON-EU + ECMWF IFS** — GFS for global coverage, ICON-EU for higher-resolution European data (~6.5km vs ~27km), ECMWF IFS for model-native cloud microphysics on ECMWF cross-sections

--- a/designs/future/known-issues.md
+++ b/designs/future/known-issues.md
@@ -66,4 +66,31 @@ The ECMWF `ceil` (ceiling) field in the a1 surface GRIB is ~50% NaN. ECMWF only 
 
 ## Resolved
 
-_(none yet)_
+### GFS cloud-diagnostic forward-fill produced phantom layers
+
+**Added:** 2026-05-12
+**Resolved:** 2026-05-13 (issue #148, PR #149)
+**Location:** `src/weatherbrief/fetch/grib/fill.py` —
+`_fill_cloud_diagnostics`, `_fill_cloud_water`,
+`apply_gfs_rh_condensate_gate`
+
+GFS LCDC/MCDC/HCDC are averaged-window fields (1/2/3 h windows depending on
+the step's position in the 3-h reset cycle, always 3 h past f120). Past
+f120 the 3-hourly cadence meant gap hours were forward-filled from the
+preceding native step, smearing each window's average forward up to 2 h
+beyond where it applied. At pt11 of flight
+`lfrq_ercoz_jsy_revtu_tujag_rudmo_egtf-2026-05-17` this produced a 100 %
+mid deck at 14:00 Z (FL180–222) that no instantaneous signal supported
+(RH 11–26 %, CLMR + ICMR = 0, GRAMET clear).
+
+Fix replaces the forward-fill with window-midpoint linear interpolation
+for GFS cloud diagnostics (`_interp_gfs_diag_hourly`) and adds an
+RH/condensate gate (`apply_gfs_rh_condensate_gate`) that drops any band
+whose pressure-level RH and condensate inside `[base_ft, top_ft]` don't
+support the averaged cover. ICON-EU / ECMWF publish instantaneous cover
+and are unaffected. See [meteorology-decisions.md §3](./meteorology-decisions.md#3-gfs-cloud-diagnostics-window-midpoint-interp--rhcondensate-gate)
+for the full rationale.
+
+The longer-term cleanup — drop the averaged MCDC entirely and re-derive
+cloud cover from instantaneous RH + condensate (Sundqvist-style) — is
+deliberately deferred as a separate follow-up.

--- a/designs/future/meteorology-decisions.md
+++ b/designs/future/meteorology-decisions.md
@@ -249,3 +249,151 @@ absent, option (1) is justified.
 Algorithm code in `src/weatherbrief/analysis/sounding/icing.py` is unchanged.
 This entry exists to document the decision so the next reviewer doesn't
 re-investigate the same width and conclude it's a bug.
+
+---
+
+## 3. GFS cloud diagnostics: window-midpoint interp + RH/condensate gate
+
+**Date:** 2026-05-13
+**Status:** Implemented (issue #148, PR #149)
+**Context:** Investigation of a 14:00 Z snapshot at pt11 of flight
+`lfrq_ercoz_jsy_revtu_tujag_rudmo_egtf-2026-05-17` showed
+`nwp_cloud_diagnostics.mid.cover_pct = 100%` at FL180–222 while every
+instantaneous signal at the same point disagreed: Open-Meteo bulk
+`cloud_cover_mid_pct` = 33 %, GFS pressure-level RH at 500–450 hPa = 11–26 %,
+CLMR + ICMR = 0, and GRAMET showed no mid deck. The pilot saw a phantom
+layer that no other source supported.
+
+### Background
+
+Two compounding effects in the GFS pgrb2 product:
+
+1. **Averaged cloud cover past f0.** NCEP publishes only the time-averaged
+   form of LCDC/MCDC/HCDC (and the matching cloud-band PRES bottoms/tops) for
+   forecast hours > 0. The averaging window has length 1/2/3 h depending on
+   the step's position in the 3-h reset cycle (1 h at f001/f004/…, 2 h at
+   f002/f005/…, 3 h at f003/f006/…/f120); past f120 it's always 3 h. There
+   is no instantaneous variant in pgrb2. Our decoder already accepts the
+   averaged form (`gfs_idx.py: parse_cloud_diag_idx`) and maps it onto the
+   same internal slots as a hypothetical instantaneous (`decode.py:
+   _CLOUD_DIAG_FIELD_MAP`).
+
+2. **3-hourly cadence past f120.** GRIB enrichment snaps to native steps
+   (… f120, f123, f126, f129 …). Gap hours between those steps used to
+   inherit the preceding step's diagnostics via forward-fill.
+
+For the pt11 case the chain was: f132 native step carries the average over
+**09–12 Z** (100 % cover), forward-fill propagated that value across 13:00
+and 14:00 Z, the next native step f135 (window 12–15 Z, 0 % cover) overwrote
+15:00 Z. The 100 % at 14:00 Z was thus an **08–14 Z back-smear** of a window
+that had ended two hours earlier.
+
+ICON-EU and ECMWF publish instantaneous cloud cover and are not affected.
+
+### The decision
+
+Three coupled changes, GFS-only:
+
+**A. Window-midpoint linear interpolation** (in
+`src/weatherbrief/fetch/grib/fill.py`). When `gfs_init` is provided to
+`propagate_all`, GFS cloud diagnostics are interpolated linearly between
+native steps in **window-midpoint space** rather than forward-filled.
+Each averaged native step's anchor sits at `step - window_length/2`. For
+the pt11 case f135's midpoint is 13:30 Z, so 14:00 Z sits past it and
+interpolates toward the next anchor's 0 % rather than holding f132's 100 %.
+
+**B. Geometry hold-over with sub-5% drop.** `base_ft`, `top_ft`, and
+`top_temp_c` are not numerically interpolatable — interpolating altitudes
+between two dissimilar layer geometries would create phantom intermediate
+layers. The gap-hour layer reuses the geometry of whichever bracketing
+endpoint has the higher cover; when interpolated cover falls below
+`_GFS_LAYER_DROP_THRESHOLD_PCT` (5 %) the entire `NWPCloudLayerDiag` is
+emptied. Visually a dissipating deck thins toward zero and then drops out.
+
+**C. RH/condensate gate** (`apply_gfs_rh_condensate_gate` in `fill.py`).
+After interpolation, for each GFS hourly with both pressure_levels and
+diagnostics, each low/mid/high band is rechecked: compute `max(RH)` and
+`sum(CLMR + ICMR)` over the pressure levels falling inside `[base_ft,
+top_ft]`. If the band has positive cover but `max(RH) < threshold` AND
+`sum(CLMR + ICMR) == 0`, the layer is dropped. Per-band thresholds are
+conservative starting values:
+
+| Band | RH threshold |
+|------|------:|
+| low | `_GFS_GATE_RH_LOW_PCT` = 60 % |
+| mid | `_GFS_GATE_RH_MID_PCT` = 70 % |
+| high | `_GFS_GATE_RH_HIGH_PCT` = 70 % |
+
+The gate requires at least one observed condensate value inside the band —
+otherwise it cannot distinguish "no condensate" from "no data" and leaves
+the forecast as-is. Convective and boundary bands are instantaneous in GFS
+pgrb2 and not gated.
+
+### Reasoning
+
+1. **Time-truth of the averaged value.** A 3-h-averaged 09–12 Z cover
+   carries no information about 14:00 Z. The cleanest way to use it is to
+   place it where its time-mean actually applies — the window midpoint —
+   and trust the next anchor to constrain the snapshot. Forward-fill silently
+   asserted "this 09–12 Z mean still applies 2 hours after the window ended";
+   midpoint interp makes the temporal logic explicit.
+
+2. **Geometry interpolation creates noise.** Two adjacent native steps can
+   report cloud at very different altitudes (deck rising, deck dissipating,
+   different deck altogether). Linearly blending their `base_ft` / `top_ft`
+   yields a halfway altitude that neither step supports. The higher-cover
+   hold-over biases toward the better-resolved deck and the 5 % drop
+   threshold prevents thin phantom layers from outliving their forecast
+   support.
+
+3. **The RH/condensate gate is the truth check.** Even with correct timing,
+   the averaged cover can be inflated relative to instantaneous reality
+   (e.g. when half of the 3-h window had cloud and half was clear). The
+   pressure-level RH + CLMR/ICMR at the snapshot hour are instantaneous by
+   construction. Requiring **both** sources to agree before declaring a
+   cloud-free band keeps the gate conservative — a single moist or
+   condensate-bearing level survives.
+
+4. **GFS-only by design.** ICON-EU and ECMWF publish instantaneous cover.
+   Applying the same gate there would compete with model physics rather
+   than catch a pipeline artifact.
+
+### What we decided against
+
+**Dropping the averaged MCDC/LCDC/HCDC entirely** and re-deriving cloud
+cover from instantaneous pressure-level RH + condensate (Sundqvist-style
+diagnostic). This is the cleaner long-term end-state — no averaged-window
+back-smear is possible if we never read the averaged value — but the change
+surface is much larger (new diagnostic, new calibration against
+observations, replaces the current GRIB-bulk path used by ceiling and other
+downstream consumers). Tracked as a follow-up.
+
+**Step-time linear interp without the midpoint adjustment.** This would
+have fixed the forward-fill smear in one direction but still anchored the
+3-h-averaged value at the step time, so 14:00 Z would have interpolated
+between values that mis-represent their own time bracket. Midpoint
+anchoring is the correct fix for averaged data.
+
+### Real-world validation needed
+
+- **Marine stratocumulus calibration of `_GFS_GATE_RH_LOW_PCT`.** Sub-grid
+  inversion-trapped sheets can produce real low cover at pressure-level
+  RH below 60 %. The conservative 60 % threshold may suppress these. A
+  coastal SW UK / Brittany briefing on a stable-PBL day is the canonical
+  test case.
+- **Negative-control surveillance.** Confirm that strongly-supported decks
+  (e.g. ERCOZ low layer 86.9 % @ 4781–10383 ft with RH 80–98 % and non-zero
+  CLMR) survive both the interpolation and the gate unchanged.
+
+### Files changed
+
+- `src/weatherbrief/fetch/grib/fill.py` — `_fill_cloud_diagnostics` now
+  branches on `gfs_init`: GFS sections use `_interp_gfs_diag_hourly`
+  (window-midpoint linear), others fall back to `_fill_diag_hourly`
+  (forward-fill). `_fill_cloud_water` similarly branches between
+  `_interp_gfs_clw_hourly` (step-time linear) and `_fill_clw_hourly`
+  (forward-fill). New `apply_gfs_rh_condensate_gate` runs after
+  `propagate_all` and drops phantom layers per the gate rule.
+- `src/weatherbrief/fetch/grib/__init__.py` — wires `gfs_init` through
+  `propagate_all` and invokes `apply_gfs_rh_condensate_gate` after
+  enrichment completes.

--- a/designs/time-alignment-audit.md
+++ b/designs/time-alignment-audit.md
@@ -114,16 +114,33 @@ Open-Meteo provides **hourly** forecast data for the full 24h cross-section, inc
 
 **What's affected on interpolated hours:**
 
-| Field | Native hours | Interpolated hours | Impact |
-|-------|-------------|-------------------|--------|
-| `nwp_cloud_diagnostics` | GRIB base/top/cover | Was `None` → **now propagated** | Was critical — see below |
-| `cloud_cover_low/mid/high_pct` | Overridden by GRIB | Was Open-Meteo → **now propagated** | Consistent source |
-| `cloud_liquid_water_g_m3` | GRIB CLWMR per level | `None` | Low impact — see below |
-| `ice_mixing_ratio_g_m3` | GRIB ICMR per level | `None` | Low impact — see below |
+| Field | Native hours | Interpolated hours (GFS, `gfs_init` set) | Interpolated hours (ICON-EU / ECMWF / GFS fallback) |
+|-------|-------------|-----------------|------------------------------------|
+| `nwp_cloud_diagnostics.low/mid/high.cover_pct` | GRIB averaged-window cover (GFS) or instantaneous cover | **Window-midpoint linear interp**; sub-5 % drops layer; RH/condensate gate may also drop layer post-interp | Forward-filled |
+| `nwp_cloud_diagnostics.low/mid/high.base_ft/top_ft/top_temp_c` | GRIB geometry | Held over from the bracketing higher-cover endpoint | Forward-filled |
+| `nwp_cloud_diagnostics` instantaneous fields (convective, boundary, total, ceiling, freezing level) | GRIB instantaneous | Step-time linear interp | Forward-filled |
+| `cloud_cover_low/mid/high_pct` | Overridden by GRIB | Propagated from GRIB diagnostics | Propagated from GRIB diagnostics |
+| `cloud_liquid_water_kg_kg` / `ice_mixing_ratio_kg_kg` (per level) | GRIB CLMR / ICMR | Step-time linear interp (`_interp_gfs_clw_hourly`) | Forward-filled (`_fill_clw_hourly`) for GFS without `gfs_init`; ECMWF / ICON-EU rebuild full `pressure_levels` via `_linear_interp_pressure_levels` |
 
-**Cloud diagnostics propagation** (`_propagate_cloud_diagnostics` in `grib/__init__.py`):
+**Cloud diagnostics propagation** (`_fill_cloud_diagnostics` in `fetch/grib/fill.py`, called from `propagate_all`):
 
-After all GRIB enrichment completes, `enrich_forecasts()` forward-fills `nwp_cloud_diagnostics` (and the associated `cloud_cover_*_pct` overrides) from each native hour to subsequent interpolated hours. Cloud layer geometry (base/top) changes slowly between 3h GFS steps, making this meteorologically sound.
+After all GRIB enrichment completes, `propagate_all` fills `nwp_cloud_diagnostics` on gap hours between native GRIB steps. The strategy is source-dependent:
+
+- **GFS, when `gfs_init` is provided** — window-midpoint linear interpolation (`_interp_gfs_diag_hourly`). NCEP publishes only the averaged form of LCDC/MCDC/HCDC, so each anchor sits at `step - window_length/2` (1/2/3 h depending on step position; 3 h past f120) and low/mid/high cover interpolate linearly between bracketing midpoints. Layer geometry (`base_ft`, `top_ft`, `top_temp_c`) holds over from the higher-cover endpoint; sub-5 % (`_GFS_LAYER_DROP_THRESHOLD_PCT`) covers drop the layer entirely. Convective, boundary, total cover, ceiling, and freezing level interpolate linearly with **step-time** anchoring (instantaneous in GFS pgrb2). A follow-up `apply_gfs_rh_condensate_gate` drops any layer whose pressure-level RH and condensate inside `[base_ft, top_ft]` contradict the averaged cover (per-band thresholds `_GFS_GATE_RH_LOW_PCT` = 60, `_GFS_GATE_RH_MID_PCT` = 70, `_GFS_GATE_RH_HIGH_PCT` = 70). See [meteorology-decisions §3](./future/meteorology-decisions.md#3-gfs-cloud-diagnostics-window-midpoint-interp--rhcondensate-gate) for the rationale.
+- **ICON-EU, ECMWF, and the GFS fallback** (no `gfs_init`) — forward-fill (`_fill_diag_hourly`). ICON-EU and ECMWF publish instantaneous cover, so persistence is the right semantic.
+
+GFS path (with `gfs_init`), illustrating the f132 / f135 case past f120:
+
+```
+Hour 12 Z (f132 native, avg over 09–12 Z) → midpoint anchor at 10:30 Z
+Hour 13 Z (interp) → linearly interpolated between f132 midpoint (10:30) and f135 midpoint (13:30)
+Hour 14 Z (interp) → just past f135 midpoint, so dominated by f135's value
+Hour 15 Z (f135 native, avg over 12–15 Z) → midpoint anchor at 13:30 Z
+Hour 16 Z (interp) → linearly interpolated between f135 midpoint and f138 midpoint
+...
+```
+
+Forward-fill path (ICON-EU / ECMWF / GFS fallback):
 
 ```
 Hour 06 (native) → diagnostics from GRIB
@@ -186,7 +203,8 @@ GFS enriches first. ICON-EU checks `hourly.nwp_cloud_diagnostics is None` before
 
 | File | Role |
 |------|------|
-| `fetch/grib/__init__.py` | GRIB enrichment entry point, per-hour merge logic |
+| `fetch/grib/__init__.py` | GRIB enrichment entry point, per-hour merge logic; invokes `propagate_all` and `apply_gfs_rh_condensate_gate` after enrichment |
+| `fetch/grib/fill.py` | Time-axis fill — window-midpoint interp for GFS cloud diagnostics, step-time interp for GFS CLW/ICMR + ECMWF surface + ECMWF / ICON-EU sounding rebuild, forward-fill for ICON-EU / ECMWF cloud diagnostics, and the GFS RH/condensate phantom-layer gate (see [meteorology-decisions §3](./future/meteorology-decisions.md#3-gfs-cloud-diagnostics-window-midpoint-interp--rhcondensate-gate)) |
 | `fetch/grib/grib_fetch.py` | GFS HTTP range downloads, `compute_flight_window_hours()` |
 | `fetch/grib/icon_eu_fetch.py` | ICON-EU downloads, `compute_icon_eu_flight_window_hours()` |
 | `fetch/grib/decode.py` | GRIB2 decode and spatial interpolation |

--- a/designs/weather-engine-specs.md
+++ b/designs/weather-engine-specs.md
@@ -246,7 +246,8 @@ GRIB enrichment targets native model forecast hours only (e.g. every 3h for GFS 
 
 | Axis | Strategy | Module | Applies to |
 |------|----------|--------|------------|
-| **Time** | Forward-fill from preceding native GRIB hour | `fetch/grib/fill.py` | Cloud diagnostics, CLW, ICMR |
+| **Time — GFS averaged fields** | Window-midpoint linear interp between native steps; layer geometry held from higher-cover endpoint; sub-5 % covers dropped; followed by RH/condensate gate that drops bands where pressure-level RH and condensate disagree with averaged cover. Requires `gfs_init`. See [meteorology-decisions §3](./future/meteorology-decisions.md#3-gfs-cloud-diagnostics-window-midpoint-interp--rhcondensate-gate). | `fetch/grib/fill.py` | GFS low/mid/high cloud cover + geometry |
+| **Time — everything else** | Forward-fill for ICON-EU / ECMWF cloud diagnostics and the GFS fallback path (no `gfs_init`); step-time linear interp for GFS CLW/ICMR overlay; linear interp for ECMWF surface scalars and ECMWF / ICON-EU pressure-level soundings (dewpoint derived from interpolated T+RH via Magnus). | `fetch/grib/fill.py` | Cloud diagnostics (non-GFS bands), CLW, ICMR, ECMWF surface, sounding rebuild |
 | **Spatial** | Linear interpolation between neighboring route points (max 100 nm gap, both neighbors required) | `analysis/spatial_interpolation.py` | Cloud diagnostics, CLW, ICMR |
 | **Vertical** | Linear interpolation in pressure-space between native GRIB pressure levels | `analysis/sounding/__init__.py` | CLW, ICMR only |
 
@@ -276,7 +277,7 @@ GRIB enrichment targets native model forecast hours only (e.g. every 3h for GFS 
 - `CAPE`, `CIN` — surface-based convective indices at 0.25° resolution
 - Full temperature/wind column — could enable full sounding replacement for GFS too
 
-**5. Time interpolation (linear)** — Forward-fill is implemented for all GRIB fields. A future improvement would fetch *both* bracketing forecast hours and linearly interpolate. Infrastructure exists (`bracket_forecast_hours()`). Doubles download volume.
+**5. Time interpolation (linear)** — GFS cloud diagnostics now use window-midpoint linear interpolation when `gfs_init` is provided (see [meteorology-decisions §3](./future/meteorology-decisions.md#3-gfs-cloud-diagnostics-window-midpoint-interp--rhcondensate-gate)), GFS CLW/ICMR use step-time linear interp, and ECMWF / ICON-EU pressure-level soundings + ECMWF surface scalars are linearly interpolated between native steps. ICON-EU / ECMWF cloud diagnostics still use forward-fill (instantaneous fields where persistence is the right semantic). The remaining linear-interp opportunity is GFS pressure-level fields (T, RH, wind) — currently sourced from Open-Meteo, so this only becomes relevant if/when GFS moves to full GRIB-primary sourcing (item 7). Infrastructure exists (`bracket_forecast_hours()`).
 
 **6. Ellrod turbulence index** — Grid-based CAT metric:
 ```

--- a/src/weatherbrief/fetch/grib/__init__.py
+++ b/src/weatherbrief/fetch/grib/__init__.py
@@ -554,10 +554,21 @@ def _enrich_forecasts_inner(
     elif icon_skip is not None:
         grib_skip_reasons["icon"] = icon_skip
 
-    # Forward-fill all GRIB-enriched fields to interpolated hours
+    # Time-axis fill of all GRIB-enriched fields onto interpolated hours.
+    # When the GFS init is known, the cloud-diag pass uses window-midpoint
+    # interpolation for low/mid/high cover (issue #148 — averaged-window
+    # phantom-layer fix) and the gate drops layers unsupported by RH or
+    # condensate. Both are no-ops in the GFS=None fallback.
+    gfs_init_dt: datetime | None = None
+    if gfs_ts is not None:
+        gfs_init_dt = datetime.fromtimestamp(gfs_ts, tz=timezone.utc)
     with _grib_time("propagate_all"):
-        from weatherbrief.fetch.grib.fill import propagate_all
-        propagate_all(cross_sections, all_forecasts)
+        from weatherbrief.fetch.grib.fill import (
+            apply_gfs_rh_condensate_gate,
+            propagate_all,
+        )
+        propagate_all(cross_sections, all_forecasts, gfs_init=gfs_init_dt)
+        apply_gfs_rh_condensate_gate(cross_sections, all_forecasts)
 
     timer.rss_mark("enrich_end")
     return grib_init_times, grib_skip_reasons

--- a/src/weatherbrief/fetch/grib/fill.py
+++ b/src/weatherbrief/fetch/grib/fill.py
@@ -16,11 +16,20 @@ Interpolation policy:
     (T, RH) via the Magnus formula rather than interpolated directly. This
     matches operational practice (ECMWF MARS, WRF post-processing) and keeps
     derived quantities consistent with primitives.
-  - **Cloud diagnostics** (NWPCloudDiagnostics): forward-fill (persistence) —
-    cloud-layer geometry is categorical and slowly varying; linear interp of
-    base/top altitudes would be misleading mid-window.
+  - **GFS cloud diagnostics** (when ``gfs_init`` provided): low/mid/high
+    cover_pct interpolated linearly between **window midpoints** rather than
+    step times — NCEP publishes the averaged form (LCDC/MCDC/HCDC) past f0,
+    so the value at native step f is centred on the midpoint of its 1/2/3-h
+    window. Layer geometry (base/top/temp) is held over from the higher-cover
+    endpoint, not interpolated. Layers fall away when interpolated cover
+    < 5%. Convective/boundary/total cover and ceiling stay step-anchored
+    (instantaneous in pgrb2).
+  - **Non-GFS cloud diagnostics**: forward-fill (persistence) — ICON-EU and
+    ECMWF publish instantaneous cloud cover, and base/top interpolation
+    between dissimilar geometries would produce phantom layers.
   - **GFS CLW/ICMR overlays** (CLW/ICMR added onto OM pressure_levels without
-    list replacement): forward-fill, since GFS doesn't replace the level set.
+    list replacement): linear interp between native step times when
+    ``gfs_init`` provided; forward-fill otherwise.
 
 Interpolation rules (see also spatial_interpolation.py for the spatial axis):
 
@@ -32,6 +41,7 @@ Interpolation rules (see also spatial_interpolation.py for the spatial axis):
 from __future__ import annotations
 
 import logging
+from datetime import datetime, timedelta
 from typing import TYPE_CHECKING
 
 from weatherbrief.fetch.open_meteo import magnus_dewpoint
@@ -40,6 +50,7 @@ if TYPE_CHECKING:
     from weatherbrief.models import (
         HourlyForecast,
         NWPCloudDiagnostics,
+        NWPCloudLayerDiag,
         PressureLevelData,
         RouteCrossSection,
         WaypointForecast,
@@ -47,65 +58,88 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# Minimum cover after midpoint interpolation below which an averaged-window
+# layer is treated as dissipated (geometry dropped, cover set to None). See
+# issue #148 — protects against phantom thin layers when the averaged window
+# decays toward 0.
+_GFS_LAYER_DROP_THRESHOLD_PCT = 5.0
+
 
 def propagate_all(
     sections: list[RouteCrossSection],
     all_forecasts: list[WaypointForecast],
+    *,
+    gfs_init: datetime | None = None,
 ) -> None:
     """Apply all time-axis fills: linear interp where appropriate, forward-fill
     where persistence is the right semantic.
 
     Called once after all GRIB enrichment (GFS + ICON-EU + ECMWF) completes,
     before the analysis stage.
+
+    Args:
+        gfs_init: GFS model run init time. When provided, GFS sections use
+            window-midpoint linear interp for low/mid/high cover (fixing the
+            averaged-window phantom-layer pathology — issue #148) and linear
+            interp for CLW/ICMR. When None, all sections use forward-fill.
     """
-    # ECMWF surface linear interp must run BEFORE cloud-diag forward-fill: it
-    # uses ``nwp_cloud_diagnostics is not None`` as the GRIB-anchor detector,
-    # and cloud-diag fill propagates the diagnostics onto gap hours, making
+    # ECMWF surface linear interp must run BEFORE cloud-diag fill: it uses
+    # ``nwp_cloud_diagnostics is not None`` as the GRIB-anchor detector, and
+    # diag fill propagates / interpolates diagnostics onto gap hours, making
     # every hour look like an anchor afterwards.
     _linear_interp_ecmwf_surface(sections, all_forecasts)
-    _forward_fill_cloud_diagnostics(sections, all_forecasts)
+    _fill_cloud_diagnostics(sections, all_forecasts, gfs_init=gfs_init)
     _linear_interp_pressure_levels(sections, all_forecasts)
-    # GFS-only path: CLW/ICMR overlay onto OM pressure_levels (no list
-    # replacement). For ECMWF/ICON the linear interp above already populates
-    # CLW/ICMR within the rebuilt PressureLevelData, so this becomes a no-op.
-    _forward_fill_cloud_water(sections, all_forecasts)
+    # CLW/ICMR overlay onto OM pressure_levels (GFS path only — for ECMWF/ICON
+    # the pressure-level interp above already populates CLW/ICMR within the
+    # rebuilt PressureLevelData).
+    _fill_cloud_water(sections, all_forecasts, gfs_init=gfs_init)
 
 
 # ---------------------------------------------------------------------------
 # Cloud diagnostics (NWPCloudDiagnostics on HourlyForecast)
 # ---------------------------------------------------------------------------
 
-def _forward_fill_cloud_diagnostics(
+def _fill_cloud_diagnostics(
     sections: list[RouteCrossSection],
     all_forecasts: list[WaypointForecast],
+    *,
+    gfs_init: datetime | None,
 ) -> None:
-    """Forward-fill ``nwp_cloud_diagnostics`` from native GRIB hours.
+    """Fill ``nwp_cloud_diagnostics`` on hours between native GRIB steps.
 
-    Open-Meteo provides hourly data interpolated between native GFS steps (3h
-    at longer lead times).  GRIB enrichment only targets native steps, leaving
-    interpolated hours without diagnostics.  Without diagnostics the icing
-    fallback applies the bulk NWP cloud percentage across the full altitude
-    band, causing false positives.
-
-    This fills each gap by copying diagnostics from the preceding enriched
-    hour.  Cloud layer geometry (base/top) changes slowly between 3-hour GFS
-    steps, so the earlier step's diagnostics are a reasonable approximation.
+    For GFS sections, when ``gfs_init`` is provided, uses window-midpoint
+    linear interpolation for low/mid/high cover (see _interp_gfs_diag_hourly).
+    For non-GFS sections (ECMWF, ICON-EU) and the GFS fallback path, uses
+    forward-fill (persistence) — cloud-layer geometry is categorical and
+    slowly varying for these models.
     """
+    from weatherbrief.models import ModelSource
+
     total = 0
     for cs in sections:
+        gfs = cs.model == ModelSource.GFS and gfs_init is not None
         for wf in cs.point_forecasts:
-            total += _fill_diag_hourly(wf.hourly)
+            if gfs:
+                total += _interp_gfs_diag_hourly(wf.hourly, gfs_init)
+            else:
+                total += _fill_diag_hourly(wf.hourly)
     for wf in all_forecasts:
-        total += _fill_diag_hourly(wf.hourly)
+        gfs = wf.model == ModelSource.GFS and gfs_init is not None
+        if gfs:
+            total += _interp_gfs_diag_hourly(wf.hourly, gfs_init)
+        else:
+            total += _fill_diag_hourly(wf.hourly)
 
     if total:
         logger.info(
-            "Cloud diagnostics propagated to %d interpolated hourly entries",
-            total,
+            "Cloud diagnostics filled on %d hourly entries (gfs_midpoint=%s)",
+            total, gfs_init is not None,
         )
 
 
 def _fill_diag_hourly(hourly_list: list[HourlyForecast]) -> int:
+    """Forward-fill: copy each anchor's diag onto subsequent gap hours."""
     filled = 0
     last_diag: NWPCloudDiagnostics | None = None
     for h in sorted(hourly_list, key=lambda h: h.time):
@@ -117,36 +151,251 @@ def _fill_diag_hourly(hourly_list: list[HourlyForecast]) -> int:
     return filled
 
 
+def _interp_gfs_diag_hourly(
+    hourly_list: list[HourlyForecast],
+    gfs_init: datetime,
+) -> int:
+    """Window-midpoint linear interp for GFS cloud diagnostics.
+
+    NCEP publishes only the time-averaged form of LCDC/MCDC/HCDC (and the
+    matching PRES bottoms/tops) for forecast hours > 0. Each native step f
+    carries values averaged over the window ending at f, of length 1/2/3 h
+    depending on f's position in the GFS 3-h reset cycle (all 3-h past f120).
+    Anchoring the averaged value at the **window midpoint** rather than the
+    step time avoids forward-fill smearing the previous window's cover
+    forward across the snapshot hour.
+
+    Algorithm per route point:
+
+    1. Identify "anchor" hours (those with ``nwp_cloud_diagnostics`` set).
+    2. For each pair of consecutive anchors, compute each anchor's window
+       midpoint from its f-hour. Interpolate gap hours linearly between the
+       two midpoints, clamping to [0, 1] (no extrapolation past the bracket).
+    3. Layer geometry (base_ft / top_ft / top_temp_c) is **not** numerically
+       interpolated — it uses the higher-cover endpoint's geometry. When the
+       interpolated cover falls below 5%, the layer is dropped entirely.
+    4. Instantaneous fields (convective_cover_pct, boundary_cover_pct,
+       total_cover_pct, ceiling_ft, convective_base/top_ft, freezing_level_ft)
+       stay step-time-anchored and interpolate linearly with no midpoint
+       offset.
+    5. Hours after the last anchor are forward-filled (no upper bracket).
+    6. Hours before the first anchor are left as-is (matches the prior
+       forward-fill semantics — no data to extrapolate from).
+    """
+    from weatherbrief.models import NWPCloudDiagnostics
+
+    sorted_hours = sorted(hourly_list, key=lambda h: h.time)
+    if not sorted_hours:
+        return 0
+
+    anchor_indices = [
+        i for i, h in enumerate(sorted_hours)
+        if h.nwp_cloud_diagnostics is not None
+    ]
+    if not anchor_indices:
+        return 0
+
+    filled = 0
+
+    # Within-anchor segments: window-midpoint interp.
+    for k in range(len(anchor_indices) - 1):
+        prev_i = anchor_indices[k]
+        next_i = anchor_indices[k + 1]
+        if next_i - prev_i <= 1:
+            continue  # adjacent anchors — no gap
+        prev_h = sorted_hours[prev_i]
+        next_h = sorted_hours[next_i]
+        prev_diag = prev_h.nwp_cloud_diagnostics
+        next_diag = next_h.nwp_cloud_diagnostics
+        if prev_diag is None or next_diag is None:
+            continue
+
+        prev_fhour = _gfs_fhour(gfs_init, prev_h.time)
+        next_fhour = _gfs_fhour(gfs_init, next_h.time)
+        prev_mid = prev_h.time - timedelta(hours=_gfs_window_length_hours(prev_fhour) / 2.0)
+        next_mid = next_h.time - timedelta(hours=_gfs_window_length_hours(next_fhour) / 2.0)
+        mid_span = (next_mid - prev_mid).total_seconds()
+        step_span = (next_h.time - prev_h.time).total_seconds()
+        if mid_span <= 0 or step_span <= 0:
+            continue
+
+        for i in range(prev_i + 1, next_i):
+            h = sorted_hours[i]
+            # Averaged-window cover for low/mid/high uses midpoint anchoring.
+            mid_frac = (h.time - prev_mid).total_seconds() / mid_span
+            mid_frac = max(0.0, min(1.0, mid_frac))
+            # Instantaneous fields use step-time anchoring.
+            step_frac = (h.time - prev_h.time).total_seconds() / step_span
+            step_frac = max(0.0, min(1.0, step_frac))
+
+            interp_diag = _interp_diag_at(
+                prev_diag, next_diag, mid_frac=mid_frac, step_frac=step_frac,
+            )
+            h.nwp_cloud_diagnostics = interp_diag
+            filled += 1
+
+    # After the last anchor: forward-fill (no upper bracket to interp against).
+    last_idx = anchor_indices[-1]
+    last_diag = sorted_hours[last_idx].nwp_cloud_diagnostics
+    for i in range(last_idx + 1, len(sorted_hours)):
+        if sorted_hours[i].nwp_cloud_diagnostics is None:
+            sorted_hours[i].nwp_cloud_diagnostics = last_diag
+            filled += 1
+
+    return filled
+
+
+def _gfs_fhour(gfs_init: datetime, target: datetime) -> int:
+    """Forecast hour from init. Rounds to nearest integer — native anchors
+    sit on integer hours from init."""
+    return round((target - gfs_init).total_seconds() / 3600.0)
+
+
+def _gfs_window_length_hours(fhour: int) -> int:
+    """Width of the averaging window ending at GFS forecast step ``fhour``.
+
+    NCEP cadence:
+      - f001 / f004 / f007 / … → 1 h
+      - f002 / f005 / f008 / … → 2 h
+      - f003 / f006 / f009 / … / f120 → 3 h
+      - f > 120 → 3 h (3-hourly cadence past f120)
+
+    f000 is analysis (no window) and gets returned as 0.
+    """
+    if fhour <= 0:
+        return 0
+    if fhour > 120:
+        return 3
+    r = fhour % 3
+    return 3 if r == 0 else r
+
+
+def _interp_diag_at(
+    prev_diag: NWPCloudDiagnostics,
+    next_diag: NWPCloudDiagnostics,
+    *,
+    mid_frac: float,
+    step_frac: float,
+) -> NWPCloudDiagnostics:
+    """Build an interpolated NWPCloudDiagnostics for one gap hour.
+
+    ``mid_frac`` is the interpolation fraction in window-midpoint space —
+    used for low/mid/high cover_pct (the averaged-window fields).
+    ``step_frac`` is the fraction in step-time space — used for
+    instantaneous fields (convective, boundary, total, ceiling, etc.).
+    """
+    from weatherbrief.models import NWPCloudDiagnostics
+
+    low = _interp_layer(prev_diag.low, next_diag.low, mid_frac)
+    mid = _interp_layer(prev_diag.mid, next_diag.mid, mid_frac)
+    high = _interp_layer(prev_diag.high, next_diag.high, mid_frac)
+
+    return NWPCloudDiagnostics(
+        low=low,
+        mid=mid,
+        high=high,
+        convective_cover_pct=_lerp(
+            prev_diag.convective_cover_pct, next_diag.convective_cover_pct, step_frac,
+        ),
+        convective_base_ft=_lerp(
+            prev_diag.convective_base_ft, next_diag.convective_base_ft, step_frac,
+        ),
+        convective_top_ft=_lerp(
+            prev_diag.convective_top_ft, next_diag.convective_top_ft, step_frac,
+        ),
+        total_cover_pct=_lerp(
+            prev_diag.total_cover_pct, next_diag.total_cover_pct, step_frac,
+        ),
+        boundary_cover_pct=_lerp(
+            prev_diag.boundary_cover_pct, next_diag.boundary_cover_pct, step_frac,
+        ),
+        ceiling_ft=_lerp(prev_diag.ceiling_ft, next_diag.ceiling_ft, step_frac),
+        freezing_level_ft=_lerp(
+            prev_diag.freezing_level_ft, next_diag.freezing_level_ft, step_frac,
+        ),
+    )
+
+
+def _interp_layer(
+    prev: NWPCloudLayerDiag,
+    nxt: NWPCloudLayerDiag,
+    frac: float,
+) -> NWPCloudLayerDiag:
+    """Interpolate a single ICAO band (low/mid/high).
+
+    Cover interpolates linearly between the two endpoints (at midpoint frac
+    in the caller). Geometry holds over from the higher-cover endpoint —
+    interpolating altitudes between dissimilar layer geometries would create
+    phantom intermediate layers. When interpolated cover falls below 5%, the
+    whole layer drops out.
+    """
+    from weatherbrief.models import NWPCloudLayerDiag
+
+    prev_cover = prev.cover_pct
+    next_cover = nxt.cover_pct
+    cover = _lerp(prev_cover, next_cover, frac)
+
+    if cover is None or cover < _GFS_LAYER_DROP_THRESHOLD_PCT:
+        # No supportable layer at this hour.
+        return NWPCloudLayerDiag()
+
+    # Hold geometry from whichever endpoint has the higher cover. Ties go to
+    # the earlier endpoint (deterministic).
+    if (next_cover or 0.0) > (prev_cover or 0.0):
+        source = nxt
+    else:
+        source = prev
+    return NWPCloudLayerDiag(
+        cover_pct=cover,
+        base_ft=source.base_ft,
+        top_ft=source.top_ft,
+        top_temp_c=source.top_temp_c,
+    )
+
+
 # ---------------------------------------------------------------------------
 # Cloud water / ice mixing ratio (per-pressure-level on HourlyForecast)
 # ---------------------------------------------------------------------------
 
-def _forward_fill_cloud_water(
+def _fill_cloud_water(
     sections: list[RouteCrossSection],
     all_forecasts: list[WaypointForecast],
+    *,
+    gfs_init: datetime | None,
 ) -> None:
-    """Forward-fill CLW and ICMR from native GRIB hours to interpolated hours.
+    """Fill CLW and ICMR per pressure level on gap hours.
 
-    For each route point and each pressure level, walks hourly entries
-    chronologically.  If CLW is None but a preceding native hour had a value,
-    copies it forward.  Same for ICMR independently.
+    For GFS sections, when ``gfs_init`` is provided, linearly interpolates
+    between native step times (CLW/ICMR are instantaneous mixing ratios —
+    no midpoint adjustment needed). For non-GFS or the GFS fallback path,
+    forward-fills from the preceding anchor.
 
-    Microphysics values change slowly between GFS 3-hour steps, so this is
-    a reasonable approximation and prevents SFIP from falling back to the
-    less accurate "proxy" variant on interpolated hours.
+    Non-GFS sections normally have CLW/ICMR already populated by
+    _linear_interp_pressure_levels (which rebuilds the full pressure_levels
+    list for gap hours), so this is a no-op there.
     """
+    from weatherbrief.models import ModelSource
+
     total = 0
     for cs in sections:
+        gfs = cs.model == ModelSource.GFS and gfs_init is not None
         for wf in cs.point_forecasts:
-            total += _fill_clw_hourly(wf.hourly)
+            if gfs:
+                total += _interp_gfs_clw_hourly(wf.hourly)
+            else:
+                total += _fill_clw_hourly(wf.hourly)
     for wf in all_forecasts:
-        total += _fill_clw_hourly(wf.hourly)
+        gfs = wf.model == ModelSource.GFS and gfs_init is not None
+        if gfs:
+            total += _interp_gfs_clw_hourly(wf.hourly)
+        else:
+            total += _fill_clw_hourly(wf.hourly)
 
     if total:
         logger.info(
-            "Cloud water (CLW/ICMR) propagated to %d interpolated"
-            " (hour, level) entries",
-            total,
+            "Cloud water (CLW/ICMR) filled on %d (hour, level) entries"
+            " (gfs_linear=%s)",
+            total, gfs_init is not None,
         )
 
 
@@ -173,6 +422,243 @@ def _fill_clw_hourly(hourly_list: list[HourlyForecast]) -> int:
                         pl.ice_mixing_ratio_kg_kg = prev_icmr
                     filled += 1
     return filled
+
+
+def _interp_gfs_clw_hourly(hourly_list: list[HourlyForecast]) -> int:
+    """Linear interp of CLW/ICMR between native step times.
+
+    CLW/ICMR are instantaneous mixing ratios (no averaged-window pathology —
+    that's the cover-fraction issue), so step-time anchoring is correct here.
+    Hours after the last anchor forward-fill; hours before the first anchor
+    are left as-is.
+    """
+    sorted_hours = sorted(hourly_list, key=lambda h: h.time)
+    if not sorted_hours:
+        return 0
+
+    # Per-level anchor index lists: {hpa: [hour_index, ...]}
+    per_level_anchors: dict[int, list[int]] = {}
+    for i, h in enumerate(sorted_hours):
+        for pl in h.pressure_levels:
+            if pl.cloud_liquid_water_kg_kg is not None:
+                per_level_anchors.setdefault(pl.pressure_hpa, []).append(i)
+
+    if not per_level_anchors:
+        return 0
+
+    # Index each hour's pressure levels by pressure for O(1) lookup.
+    hour_levels: list[dict[int, PressureLevelData]] = [
+        {pl.pressure_hpa: pl for pl in h.pressure_levels}
+        for h in sorted_hours
+    ]
+
+    filled = 0
+    for p, anchors in per_level_anchors.items():
+        # Between-anchor segments: linear interp.
+        for k in range(len(anchors) - 1):
+            prev_i = anchors[k]
+            next_i = anchors[k + 1]
+            if next_i - prev_i <= 1:
+                continue
+            prev_pl = hour_levels[prev_i].get(p)
+            next_pl = hour_levels[next_i].get(p)
+            if prev_pl is None or next_pl is None:
+                continue
+            span = (sorted_hours[next_i].time - sorted_hours[prev_i].time).total_seconds()
+            if span <= 0:
+                continue
+            for i in range(prev_i + 1, next_i):
+                pl = hour_levels[i].get(p)
+                if pl is None or pl.cloud_liquid_water_kg_kg is not None:
+                    continue
+                frac = (sorted_hours[i].time - sorted_hours[prev_i].time).total_seconds() / span
+                clw = _lerp(prev_pl.cloud_liquid_water_kg_kg, next_pl.cloud_liquid_water_kg_kg, frac)
+                if clw is not None:
+                    pl.cloud_liquid_water_kg_kg = clw
+                    if pl.ice_mixing_ratio_kg_kg is None:
+                        icmr = _lerp(
+                            prev_pl.ice_mixing_ratio_kg_kg,
+                            next_pl.ice_mixing_ratio_kg_kg,
+                            frac,
+                        )
+                        if icmr is not None:
+                            pl.ice_mixing_ratio_kg_kg = icmr
+                    filled += 1
+
+        # After last anchor: forward-fill.
+        last_i = anchors[-1]
+        last_pl = hour_levels[last_i].get(p)
+        if last_pl is None or last_pl.cloud_liquid_water_kg_kg is None:
+            continue
+        for i in range(last_i + 1, len(sorted_hours)):
+            pl = hour_levels[i].get(p)
+            if pl is None or pl.cloud_liquid_water_kg_kg is not None:
+                continue
+            pl.cloud_liquid_water_kg_kg = last_pl.cloud_liquid_water_kg_kg
+            if pl.ice_mixing_ratio_kg_kg is None and last_pl.ice_mixing_ratio_kg_kg is not None:
+                pl.ice_mixing_ratio_kg_kg = last_pl.ice_mixing_ratio_kg_kg
+            filled += 1
+
+    return filled
+
+
+# ---------------------------------------------------------------------------
+# GFS RH / condensate gate
+# ---------------------------------------------------------------------------
+
+# Per-band RH thresholds for the dry-layer gate (issue #148). When the
+# averaged-window cover is positive but the pressure-level RH and condensate
+# inside the layer don't support cloud, the layer is dropped. Conservative
+# starting values — see issue's "Open question" for low-band marine
+# stratocumulus calibration follow-up.
+_GFS_GATE_RH_LOW_PCT = 60.0
+_GFS_GATE_RH_MID_PCT = 70.0
+_GFS_GATE_RH_HIGH_PCT = 70.0
+
+_M_TO_FT = 3.28084
+
+
+def apply_gfs_rh_condensate_gate(
+    sections: list[RouteCrossSection],
+    all_forecasts: list[WaypointForecast],
+) -> None:
+    """Drop GFS averaged-cover layers that lack RH and condensate support.
+
+    For each GFS hourly with both ``pressure_levels`` and
+    ``nwp_cloud_diagnostics``, gates the low/mid/high bands:
+
+      max(RH within [base_ft, top_ft]) < threshold  AND
+      sum(CLMR + ICMR within the same band) == 0
+
+    If both conditions hold the layer is replaced with a no-layer
+    ``NWPCloudLayerDiag()``. Convective and boundary bands are instantaneous
+    in GFS pgrb2 — not gated. ICON-EU and ECMWF cloud cover is instantaneous
+    too, so this routine is GFS-only by design.
+
+    This is a no-op when GFS pressure_levels carry no CLMR/ICMR values
+    (gate cannot verify "sum == 0" without observed zeros), preserving the
+    forecast as-is rather than dropping confidently.
+    """
+    from weatherbrief.models import ModelSource
+
+    dropped = 0
+    for cs in sections:
+        if cs.model != ModelSource.GFS:
+            continue
+        for wf in cs.point_forecasts:
+            for h in wf.hourly:
+                dropped += _gate_gfs_hourly(h)
+    for wf in all_forecasts:
+        if wf.model != ModelSource.GFS:
+            continue
+        for h in wf.hourly:
+            dropped += _gate_gfs_hourly(h)
+
+    if dropped:
+        logger.info(
+            "GFS RH/condensate gate dropped %d phantom cloud layers", dropped,
+        )
+
+
+def _gate_gfs_hourly(h: HourlyForecast) -> int:
+    """Apply the gate to one hourly forecast. Returns # layers dropped."""
+    from weatherbrief.models import NWPCloudDiagnostics
+
+    diag = h.nwp_cloud_diagnostics
+    if diag is None or not h.pressure_levels:
+        return 0
+
+    new_low, drop_low = _gate_layer(diag.low, h.pressure_levels, _GFS_GATE_RH_LOW_PCT)
+    new_mid, drop_mid = _gate_layer(diag.mid, h.pressure_levels, _GFS_GATE_RH_MID_PCT)
+    new_high, drop_high = _gate_layer(diag.high, h.pressure_levels, _GFS_GATE_RH_HIGH_PCT)
+    n_dropped = int(drop_low) + int(drop_mid) + int(drop_high)
+    if n_dropped == 0:
+        return 0
+
+    h.nwp_cloud_diagnostics = NWPCloudDiagnostics(
+        low=new_low, mid=new_mid, high=new_high,
+        convective_cover_pct=diag.convective_cover_pct,
+        convective_base_ft=diag.convective_base_ft,
+        convective_top_ft=diag.convective_top_ft,
+        total_cover_pct=diag.total_cover_pct,
+        boundary_cover_pct=diag.boundary_cover_pct,
+        ceiling_ft=diag.ceiling_ft,
+        freezing_level_ft=diag.freezing_level_ft,
+    )
+    return n_dropped
+
+
+def _gate_layer(
+    layer: NWPCloudLayerDiag,
+    pressure_levels: list[PressureLevelData],
+    rh_threshold_pct: float,
+) -> tuple[NWPCloudLayerDiag, bool]:
+    """Return (possibly-replaced layer, dropped?).
+
+    Drops only when:
+    - layer has positive cover and known base/top
+    - at least one pressure level falls within [base_ft, top_ft]
+    - max(RH) over those levels < rh_threshold_pct
+    - at least one level inside the band reports CLMR or ICMR (otherwise we
+      can't claim "sum == 0" — we'd be conflating "no condensate" with
+      "no data")
+    - sum(CLMR + ICMR) over those levels == 0
+    """
+    from weatherbrief.models import NWPCloudLayerDiag
+
+    if layer.cover_pct is None or layer.cover_pct <= 0:
+        return layer, False
+    if layer.base_ft is None or layer.top_ft is None:
+        return layer, False
+
+    base_ft = layer.base_ft
+    top_ft = layer.top_ft
+    if top_ft <= base_ft:
+        return layer, False
+
+    max_rh: float | None = None
+    cond_sum = 0.0
+    cond_observed = False
+    in_band = False
+
+    for pl in pressure_levels:
+        alt_ft = _pressure_level_altitude_ft(pl)
+        if alt_ft is None:
+            continue
+        if alt_ft < base_ft or alt_ft > top_ft:
+            continue
+        in_band = True
+        if pl.relative_humidity_pct is not None:
+            if max_rh is None or pl.relative_humidity_pct > max_rh:
+                max_rh = pl.relative_humidity_pct
+        if pl.cloud_liquid_water_kg_kg is not None:
+            cond_observed = True
+            cond_sum += pl.cloud_liquid_water_kg_kg
+        if pl.ice_mixing_ratio_kg_kg is not None:
+            cond_observed = True
+            cond_sum += pl.ice_mixing_ratio_kg_kg
+
+    # Need observations on both axes to gate confidently.
+    if not in_band or max_rh is None or not cond_observed:
+        return layer, False
+    if max_rh >= rh_threshold_pct:
+        return layer, False
+    if cond_sum > 0:
+        return layer, False
+
+    return NWPCloudLayerDiag(), True
+
+
+def _pressure_level_altitude_ft(pl: PressureLevelData) -> float | None:
+    """Altitude in feet for a pressure level. Prefers reported geopotential
+    height; falls back to standard-atmosphere pressure conversion."""
+    from weatherbrief.models.analysis import pressure_hpa_to_altitude_m
+
+    if pl.geopotential_height_m is not None:
+        return pl.geopotential_height_m * _M_TO_FT
+    if pl.pressure_hpa is None or pl.pressure_hpa <= 0:
+        return None
+    return pressure_hpa_to_altitude_m(float(pl.pressure_hpa)) * _M_TO_FT
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_grib_fill.py
+++ b/tests/test_grib_fill.py
@@ -8,7 +8,11 @@ from weatherbrief.analysis.spatial_interpolation import (
     interpolate_diagnostics_spatially,
     interpolate_all_spatially,
 )
-from weatherbrief.fetch.grib.fill import propagate_all
+from weatherbrief.fetch.grib.fill import (
+    _gfs_window_length_hours,
+    apply_gfs_rh_condensate_gate,
+    propagate_all,
+)
 from weatherbrief.models import (
     HourlyForecast,
     ModelSource,
@@ -361,3 +365,322 @@ class TestForwardFillPressureLevels:
 
         assert len(cs.point_forecasts[0].hourly[0].pressure_levels) == 19
         assert len(cs.point_forecasts[0].hourly[2].pressure_levels) == 19
+
+
+# ---------------------------------------------------------------------------
+# Issue #148 — GFS window-midpoint cloud-diag interp + RH/condensate gate
+# ---------------------------------------------------------------------------
+
+
+class TestGfsWindowLength:
+    """GFS averaging-window cadence: f001/4/7 → 1h, f002/5/8 → 2h, rest → 3h."""
+
+    @pytest.mark.parametrize("fhour,expected", [
+        (1, 1), (4, 1), (7, 1), (118, 1),
+        (2, 2), (5, 2), (8, 2), (119, 2),
+        (3, 3), (6, 3), (9, 3), (120, 3),
+        (123, 3), (126, 3), (132, 3), (168, 3), (384, 3),
+        (0, 0),  # analysis — no window
+    ])
+    def test_window_length(self, fhour, expected):
+        assert _gfs_window_length_hours(fhour) == expected
+
+
+def _make_cs_with_hourly_model(
+    point_hourly: list[list[HourlyForecast]],
+    model: ModelSource,
+) -> RouteCrossSection:
+    now = datetime.now(tz=timezone.utc)
+    wpt = Waypoint(icao="XXXX", name="Test", lat=50.0, lon=0.0)
+    point_forecasts = [
+        WaypointForecast(
+            waypoint=wpt, model=model, fetched_at=now,
+            hourly=hourly_list,
+        )
+        for hourly_list in point_hourly
+    ]
+    return RouteCrossSection(
+        model=model, route_points=[], fetched_at=now,
+        point_forecasts=point_forecasts,
+    )
+
+
+class TestGfsMidpointInterp:
+    """pt11-style regression: midpoint anchoring collapses the phantom layer.
+
+    init = 2026-05-12 00z, target hour = 134 → step f132 anchor at 12z
+    (window 09-12z, midpoint 10:30z) reading 100% mid, step f135 at 15z
+    (window 12-15z, midpoint 13:30z) reading 0%. Forward-fill would smear
+    100% across 13z/14z; midpoint interp collapses to 0% at 14z (past the
+    f135 midpoint).
+    """
+
+    def _build_pt11_section(self) -> tuple[datetime, RouteCrossSection]:
+        gfs_init = datetime(2026, 5, 12, 0, 0, tzinfo=timezone.utc)
+        # 12z (f132, 100%), 13z gap, 14z gap, 15z (f135, 0%), 16z gap, 17z gap,
+        # 18z (f138, 0%). Step span = 3 h, window midpoints at 10:30 and 13:30.
+        diag_high = NWPCloudDiagnostics(
+            mid=NWPCloudLayerDiag(cover_pct=100.0, base_ft=18000, top_ft=22200),
+        )
+        diag_zero = NWPCloudDiagnostics(mid=NWPCloudLayerDiag(cover_pct=0.0))
+        diag_zero_2 = NWPCloudDiagnostics(mid=NWPCloudLayerDiag(cover_pct=0.0))
+        hourly = [
+            _make_hourly(gfs_init + timedelta(hours=132), diag=diag_high),
+            _make_hourly(gfs_init + timedelta(hours=133)),
+            _make_hourly(gfs_init + timedelta(hours=134)),
+            _make_hourly(gfs_init + timedelta(hours=135), diag=diag_zero),
+            _make_hourly(gfs_init + timedelta(hours=136)),
+            _make_hourly(gfs_init + timedelta(hours=137)),
+            _make_hourly(gfs_init + timedelta(hours=138), diag=diag_zero_2),
+        ]
+        cs = _make_cs_with_hourly_model([hourly], ModelSource.GFS)
+        return gfs_init, cs
+
+    def test_phantom_layer_collapsed_at_14z(self):
+        gfs_init, cs = self._build_pt11_section()
+        propagate_all([cs], [], gfs_init=gfs_init)
+        hourly = cs.point_forecasts[0].hourly
+
+        # 12z (native f132): unchanged 100%.
+        assert hourly[0].nwp_cloud_diagnostics.mid.cover_pct == 100.0
+        # 14z (gap, past f135 midpoint 13:30): below the 5% drop threshold.
+        mid_14z = hourly[2].nwp_cloud_diagnostics.mid
+        assert mid_14z.cover_pct is None  # dropped layer
+        assert mid_14z.base_ft is None
+        # 15z native: unchanged 0%.
+        assert hourly[3].nwp_cloud_diagnostics.mid.cover_pct == 0.0
+
+    def test_intermediate_hour_interpolates_between_midpoints(self):
+        """13z sits between midpoints 10:30 (100%) and 13:30 (0%) →
+        frac = 2.5/3 = 0.833 → 16.7%. Above drop threshold → layer kept."""
+        gfs_init, cs = self._build_pt11_section()
+        propagate_all([cs], [], gfs_init=gfs_init)
+        mid_13z = cs.point_forecasts[0].hourly[1].nwp_cloud_diagnostics.mid
+        assert mid_13z.cover_pct == pytest.approx(100 - 100 * 2.5 / 3.0, abs=0.1)
+        # Geometry held over from higher-cover (prev) endpoint.
+        assert mid_13z.base_ft == 18000
+        assert mid_13z.top_ft == 22200
+
+    def test_fallback_path_unchanged_when_gfs_init_none(self):
+        """Without gfs_init, behavior matches forward-fill (back-compat)."""
+        gfs_init, cs = self._build_pt11_section()
+        propagate_all([cs], [])  # no gfs_init
+        # 14z forward-filled with 100% (the bug we're fixing).
+        assert (
+            cs.point_forecasts[0].hourly[2].nwp_cloud_diagnostics.mid.cover_pct
+            == 100.0
+        )
+
+    def test_ercoz_low_layer_survives(self):
+        """Negative control: stable low cover between two equal anchors stays."""
+        gfs_init = datetime(2026, 5, 12, 0, 0, tzinfo=timezone.utc)
+        # Both anchors carry the same 86.9% low layer @ 4781-10383 ft.
+        diag_a = NWPCloudDiagnostics(
+            low=NWPCloudLayerDiag(cover_pct=86.9, base_ft=4781, top_ft=10383),
+        )
+        diag_b = NWPCloudDiagnostics(
+            low=NWPCloudLayerDiag(cover_pct=86.9, base_ft=4781, top_ft=10383),
+        )
+        hourly = [
+            _make_hourly(gfs_init + timedelta(hours=129), diag=diag_a),
+            _make_hourly(gfs_init + timedelta(hours=130)),
+            _make_hourly(gfs_init + timedelta(hours=131)),
+            _make_hourly(gfs_init + timedelta(hours=132), diag=diag_b),
+        ]
+        cs = _make_cs_with_hourly_model([hourly], ModelSource.GFS)
+        propagate_all([cs], [], gfs_init=gfs_init)
+        for h in cs.point_forecasts[0].hourly:
+            assert h.nwp_cloud_diagnostics is not None
+            assert h.nwp_cloud_diagnostics.low.cover_pct == pytest.approx(86.9)
+            assert h.nwp_cloud_diagnostics.low.base_ft == 4781
+
+    def test_ecmwf_section_uses_forward_fill_not_midpoint(self):
+        """ICON / ECMWF cloud cover is instantaneous — midpoint interp must
+        NOT fire for them even when gfs_init is provided."""
+        gfs_init = datetime(2026, 5, 12, 0, 0, tzinfo=timezone.utc)
+        diag = NWPCloudDiagnostics(
+            mid=NWPCloudLayerDiag(cover_pct=100.0, base_ft=18000, top_ft=22000),
+        )
+        hourly = [
+            _make_hourly(gfs_init + timedelta(hours=132), diag=diag),
+            _make_hourly(gfs_init + timedelta(hours=133)),  # gap
+            _make_hourly(gfs_init + timedelta(hours=134)),  # gap
+            _make_hourly(gfs_init + timedelta(hours=135),
+                         diag=NWPCloudDiagnostics(mid=NWPCloudLayerDiag(cover_pct=0.0))),
+        ]
+        cs = _make_cs_with_hourly_model([hourly], ModelSource.ECMWF)
+        propagate_all([cs], [], gfs_init=gfs_init)
+        # Forward-fill semantics: gap hours inherit prev anchor's 100%.
+        assert cs.point_forecasts[0].hourly[1].nwp_cloud_diagnostics.mid.cover_pct == 100.0
+        assert cs.point_forecasts[0].hourly[2].nwp_cloud_diagnostics.mid.cover_pct == 100.0
+
+    def test_post_last_anchor_forward_fills(self):
+        """Hours past the last anchor have no upper bracket → forward-fill."""
+        gfs_init = datetime(2026, 5, 12, 0, 0, tzinfo=timezone.utc)
+        diag = NWPCloudDiagnostics(
+            high=NWPCloudLayerDiag(cover_pct=50.0, base_ft=30000, top_ft=40000),
+        )
+        hourly = [
+            _make_hourly(gfs_init + timedelta(hours=132), diag=diag),
+            _make_hourly(gfs_init + timedelta(hours=133)),
+            _make_hourly(gfs_init + timedelta(hours=134)),
+        ]
+        cs = _make_cs_with_hourly_model([hourly], ModelSource.GFS)
+        propagate_all([cs], [], gfs_init=gfs_init)
+        for h in cs.point_forecasts[0].hourly[1:]:
+            assert h.nwp_cloud_diagnostics.high.cover_pct == 50.0
+
+
+class TestGfsClwLinearInterp:
+    """CLW/ICMR are instantaneous — linear interp between native step times."""
+
+    def test_clw_interpolated_between_anchors(self):
+        gfs_init = datetime(2026, 5, 12, 0, 0, tzinfo=timezone.utc)
+        # f120 native at 12z with clw=1e-4; f123 native at 15z with clw=4e-4;
+        # 13z and 14z are gap hours → linear interp 2e-4 and 3e-4.
+        hourly = [
+            _make_hourly(gfs_init + timedelta(hours=120), clw=1e-4, icmr=0.0),
+            _make_hourly(gfs_init + timedelta(hours=121)),
+            _make_hourly(gfs_init + timedelta(hours=122)),
+            _make_hourly(gfs_init + timedelta(hours=123), clw=4e-4, icmr=0.0),
+        ]
+        cs = _make_cs_with_hourly_model([hourly], ModelSource.GFS)
+        propagate_all([cs], [], gfs_init=gfs_init)
+        pl1 = cs.point_forecasts[0].hourly[1].pressure_levels[0]
+        pl2 = cs.point_forecasts[0].hourly[2].pressure_levels[0]
+        assert pl1.cloud_liquid_water_kg_kg == pytest.approx(2e-4)
+        assert pl2.cloud_liquid_water_kg_kg == pytest.approx(3e-4)
+
+    def test_clw_forward_fills_when_gfs_init_none(self):
+        """Without gfs_init, falls back to forward-fill (back-compat)."""
+        hourly = [
+            _make_hourly(T0, clw=1e-4),
+            _make_hourly(T0 + timedelta(hours=1)),
+            _make_hourly(T0 + timedelta(hours=2), clw=4e-4),
+        ]
+        cs = _make_cs_with_hourly([hourly])
+        propagate_all([cs], [])  # no gfs_init → forward-fill
+        pl1 = cs.point_forecasts[0].hourly[1].pressure_levels[0]
+        assert pl1.cloud_liquid_water_kg_kg == pytest.approx(1e-4)
+
+
+class TestGfsRhCondensateGate:
+    """The dry-band gate drops phantom layers with no RH or condensate
+    support. Only fires for GFS sections."""
+
+    def _build_dry_pt11_hourly(self) -> HourlyForecast:
+        """pt11 at 14z native: mid 100% @ 18-22 kft, but pressure-level RH
+        and condensate inside the band are dry. The gate should drop it."""
+        # Pressure levels covering 18-22 kft (~500 hPa = 18 kft, ~450 hPa = 20 kft).
+        pls = [
+            PressureLevelData(pressure_hpa=500, relative_humidity_pct=11.0,
+                              cloud_liquid_water_kg_kg=0.0, ice_mixing_ratio_kg_kg=0.0,
+                              geopotential_height_m=18000 / 3.28084),
+            PressureLevelData(pressure_hpa=450, relative_humidity_pct=26.0,
+                              cloud_liquid_water_kg_kg=0.0, ice_mixing_ratio_kg_kg=0.0,
+                              geopotential_height_m=20000 / 3.28084),
+        ]
+        diag = NWPCloudDiagnostics(
+            mid=NWPCloudLayerDiag(cover_pct=100.0, base_ft=18000, top_ft=22200),
+        )
+        return HourlyForecast(
+            time=T0, nwp_cloud_diagnostics=diag, pressure_levels=pls,
+        )
+
+    def test_drops_dry_mid_layer(self):
+        h = self._build_dry_pt11_hourly()
+        cs = _make_cs_with_hourly_model([[h]], ModelSource.GFS)
+        apply_gfs_rh_condensate_gate([cs], [])
+        assert h.nwp_cloud_diagnostics.mid.cover_pct is None
+        assert h.nwp_cloud_diagnostics.mid.base_ft is None
+
+    def test_keeps_humid_low_layer(self):
+        """ERCOZ negative control: low @ 4781-10383 ft, RH 80-98%, CLW > 0."""
+        pls = [
+            PressureLevelData(pressure_hpa=850, relative_humidity_pct=80.0,
+                              cloud_liquid_water_kg_kg=1e-4, ice_mixing_ratio_kg_kg=0.0,
+                              geopotential_height_m=4900 / 3.28084),
+            PressureLevelData(pressure_hpa=700, relative_humidity_pct=92.0,
+                              cloud_liquid_water_kg_kg=2e-4, ice_mixing_ratio_kg_kg=0.0,
+                              geopotential_height_m=10000 / 3.28084),
+        ]
+        diag = NWPCloudDiagnostics(
+            low=NWPCloudLayerDiag(cover_pct=86.9, base_ft=4781, top_ft=10383),
+        )
+        h = HourlyForecast(time=T0, nwp_cloud_diagnostics=diag, pressure_levels=pls)
+        cs = _make_cs_with_hourly_model([[h]], ModelSource.GFS)
+        apply_gfs_rh_condensate_gate([cs], [])
+        assert h.nwp_cloud_diagnostics.low.cover_pct == 86.9
+        assert h.nwp_cloud_diagnostics.low.base_ft == 4781
+
+    def test_keeps_dry_layer_when_clw_data_absent(self):
+        """No CLMR/ICMR observations inside the band → cannot prove sum==0,
+        so don't drop. Conservative behavior."""
+        pls = [
+            PressureLevelData(pressure_hpa=500, relative_humidity_pct=20.0,
+                              geopotential_height_m=18000 / 3.28084),
+            PressureLevelData(pressure_hpa=450, relative_humidity_pct=22.0,
+                              geopotential_height_m=20000 / 3.28084),
+        ]
+        diag = NWPCloudDiagnostics(
+            mid=NWPCloudLayerDiag(cover_pct=100.0, base_ft=18000, top_ft=22200),
+        )
+        h = HourlyForecast(time=T0, nwp_cloud_diagnostics=diag, pressure_levels=pls)
+        cs = _make_cs_with_hourly_model([[h]], ModelSource.GFS)
+        apply_gfs_rh_condensate_gate([cs], [])
+        # Layer preserved (gate can't run without condensate observations).
+        assert h.nwp_cloud_diagnostics.mid.cover_pct == 100.0
+
+    def test_keeps_dry_layer_when_condensate_present(self):
+        """RH below threshold but CLW > 0 anywhere in band → keep."""
+        pls = [
+            PressureLevelData(pressure_hpa=500, relative_humidity_pct=20.0,
+                              cloud_liquid_water_kg_kg=1e-5, ice_mixing_ratio_kg_kg=0.0,
+                              geopotential_height_m=18000 / 3.28084),
+            PressureLevelData(pressure_hpa=450, relative_humidity_pct=22.0,
+                              cloud_liquid_water_kg_kg=0.0, ice_mixing_ratio_kg_kg=0.0,
+                              geopotential_height_m=20000 / 3.28084),
+        ]
+        diag = NWPCloudDiagnostics(
+            mid=NWPCloudLayerDiag(cover_pct=100.0, base_ft=18000, top_ft=22200),
+        )
+        h = HourlyForecast(time=T0, nwp_cloud_diagnostics=diag, pressure_levels=pls)
+        cs = _make_cs_with_hourly_model([[h]], ModelSource.GFS)
+        apply_gfs_rh_condensate_gate([cs], [])
+        assert h.nwp_cloud_diagnostics.mid.cover_pct == 100.0
+
+    def test_no_op_for_ecmwf(self):
+        """ECMWF cloud cover is instantaneous → gate must not fire even on a
+        synthetic dry layer matching the GFS pathology pattern."""
+        h = self._build_dry_pt11_hourly()
+        cs = _make_cs_with_hourly_model([[h]], ModelSource.ECMWF)
+        apply_gfs_rh_condensate_gate([cs], [])
+        assert h.nwp_cloud_diagnostics.mid.cover_pct == 100.0
+
+    def test_no_op_for_icon(self):
+        """ICON-EU cloud cover is instantaneous → gate must not fire."""
+        h = self._build_dry_pt11_hourly()
+        cs = _make_cs_with_hourly_model([[h]], ModelSource.ICON)
+        apply_gfs_rh_condensate_gate([cs], [])
+        assert h.nwp_cloud_diagnostics.mid.cover_pct == 100.0
+
+    def test_does_not_touch_convective_band(self):
+        """Convective cover is instantaneous in GFS pgrb2 → not gated."""
+        pls = [
+            PressureLevelData(pressure_hpa=500, relative_humidity_pct=20.0,
+                              cloud_liquid_water_kg_kg=0.0, ice_mixing_ratio_kg_kg=0.0,
+                              geopotential_height_m=18000 / 3.28084),
+        ]
+        diag = NWPCloudDiagnostics(
+            mid=NWPCloudLayerDiag(cover_pct=100.0, base_ft=18000, top_ft=22200),
+            convective_cover_pct=55.0,
+            convective_base_ft=2665.0,
+            convective_top_ft=12022.0,
+        )
+        h = HourlyForecast(time=T0, nwp_cloud_diagnostics=diag, pressure_levels=pls)
+        cs = _make_cs_with_hourly_model([[h]], ModelSource.GFS)
+        apply_gfs_rh_condensate_gate([cs], [])
+        # Mid dropped, convective unchanged.
+        assert h.nwp_cloud_diagnostics.mid.cover_pct is None
+        assert h.nwp_cloud_diagnostics.convective_cover_pct == 55.0
+        assert h.nwp_cloud_diagnostics.convective_base_ft == 2665.0


### PR DESCRIPTION
## Summary

Fixes #148 — phantom GFS cloud layers past f120 caused by forward-filling time-averaged LCDC/MCDC/HCDC across 3-hourly cadence gaps.

- **Window-midpoint interp** (`fill.py`): low/mid/high cover_pct interpolates linearly between each native step's *window midpoint* (1–3 h offset depending on f-step cadence; always 3 h past f120). Layer geometry holds over from the higher-cover endpoint, never numerically interpolated. Layers fall away when interpolated cover < 5 %. Convective/boundary/total/ceiling stay step-anchored — they're instantaneous in pgrb2.
- **CLW/ICMR**: switched from forward-fill to step-time linear interp (CLW/ICMR are instantaneous mixing ratios, so step time is correct anchoring).
- **RH/condensate gate** (`apply_gfs_rh_condensate_gate`): drops a GFS averaged-cover layer when in-band max(RH) is below threshold (60/70/70 for low/mid/high) AND in-band sum(CLMR+ICMR) == 0. ICON/ECMWF skipped (cover is instantaneous there).
- Gated on `gfs_init` so existing callers are unchanged (no-op fallback to forward-fill); production threads the GFS run timestamp from `_enrich_forecasts_inner` through `propagate_all`.

The pt11 case (init 2026-05-12 00z, target hour 134) collapses from 100 % phantom mid @ FL180-222 to a dropped layer at 14:00 Z, matching every other instantaneous signal (OM bulk 33 %, RH 11–26 %, CLMR+ICMR = 0).

## Test plan

- [x] Window-length parametrized tests cover f001/f004/f007 (1 h), f002/f005 (2 h), f003/f120 (3 h), f123/f168/f384 (3 h past f120), f000 (analysis).
- [x] pt11 regression test: 14 Z mid cover drops below the 5 % threshold; 13 Z interpolates to ≈ 16.7 % (above threshold, layer kept with prev-anchor geometry); native 12 Z and 15 Z values unchanged.
- [x] ERCOZ negative control: stable 86.9 % low layer @ 4781–10383 ft survives interpolation between equal anchors and the RH gate (RH 80–98 %, CLW > 0).
- [x] No-op tests: ECMWF and ICON sections retain forward-fill semantics even when `gfs_init` is passed; the RH/condensate gate doesn't fire on a synthetic dry layer for these models.
- [x] Convective/boundary bands unaffected (instantaneous; gate skips, midpoint anchoring doesn't apply).
- [x] Fallback path (`gfs_init=None`) keeps the old forward-fill behavior — all 16 pre-existing `test_grib_fill.py` tests pass unchanged.
- [x] Full local suite: 1886 passed, 9 skipped (the one remaining failure is a pre-existing `test_data_sources_catalog` flake reproducible on `main`).

## Out of scope (per issue)

Long-term cleanup — drop averaged MCDC entirely and re-derive cloud cover from instantaneous pressure-level RH + condensate (Sundqvist-style diagnostic). Larger change, follow-up.

## Open calibration question

Low-band RH threshold of 60 % is conservative. Issue's open question flags marine stratocumulus on stable-PBL days as a sanity check before tuning. Threshold lives in `_GFS_GATE_RH_LOW_PCT` for easy adjustment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)