### PR TITLE
perf(cache-rebuild): index + light-cycle skip + IN-subquery rewrite

### DIFF
--- a/alembic/versions/055_verification_scores_days_out_time_index.py
+++ b/alembic/versions/055_verification_scores_days_out_time_index.py
@@ -1,0 +1,32 @@
+"""Add composite index on (source, days_out, observation_time) to verification_scores.
+
+The verification map cache rebuild runs 16 aggregates per cycle, each filtering
+``WHERE source=? AND days_out=? AND observation_time BETWEEN ?``.  Migration 038
+added ``(source, observation_time)`` which already helps the stats queries that
+group across all days_out, but the map query also pins days_out and would scan
+4x more rows than necessary with that index.  This composite lets the planner
+jump straight to the relevant slice.
+
+Revision ID: 055
+Revises: 054
+"""
+
+revision = "055"
+down_revision = "054"
+
+from alembic import op
+
+
+def upgrade() -> None:
+    op.create_index(
+        "ix_verif_scores_source_days_time",
+        "verification_scores",
+        ["source", "days_out", "observation_time"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_verif_scores_source_days_time",
+        table_name="verification_scores",
+    )

--- a/src/weatherbrief/db/models.py
+++ b/src/weatherbrief/db/models.py
@@ -474,6 +474,10 @@ class VerificationScoreRow(Base):
         Index("ix_verif_scores_icao", "icao"),
         Index("ix_verif_scores_lead", "lead_hours"),
         Index("ix_verif_scores_source_model_days", "source", "model", "days_out"),
+        Index(
+            "ix_verif_scores_source_days_time",
+            "source", "days_out", "observation_time",
+        ),
     )
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)

--- a/src/weatherbrief/scheduler.py
+++ b/src/weatherbrief/scheduler.py
@@ -856,15 +856,20 @@ def _run_standalone_once(
         result["duration_ms"],
     )
 
-    # Rebuild dashboard + map caches after cycle completes (snapshots changed
-    # for fetch cycles, scores changed for verification cycles — both feed UI).
+    # Rebuild dashboard + map caches after cycle completes. Light (score-only)
+    # cycles don't touch forecast snapshots, so the forecast_map cache would be
+    # regenerated to identical content — skip it to halve the rebuild cost on
+    # the four hourly light cycles.
     try:
         from flyfun_common.db import SessionLocal
         from weatherbrief.tasks.cache_builder import rebuild_all
 
         cache_db = SessionLocal()
         try:
-            cache_result = rebuild_all(cache_db, db_path)
+            cache_result = rebuild_all(
+                cache_db, db_path,
+                include_forecast_map=(result["cycle_type"] != "light"),
+            )
             logger.info(
                 "Standalone %s cycle: cache rebuilt (%dms)",
                 result["cycle_type"], cache_result["duration_ms"],

--- a/src/weatherbrief/tasks/cache_builder.py
+++ b/src/weatherbrief/tasks/cache_builder.py
@@ -228,8 +228,17 @@ def rebuild_forecast_map_cache(db: Session, airports_db_path: str) -> int:
     return count
 
 
-def rebuild_all(db: Session, airports_db_path: str) -> dict:
+def rebuild_all(
+    db: Session,
+    airports_db_path: str,
+    *,
+    include_forecast_map: bool = True,
+) -> dict:
     """Rebuild all caches. Called after standalone verification cycles.
+
+    ``include_forecast_map=False`` skips the forecast_map rebuild — used by
+    light (score-only) cycles where snapshots haven't changed and the
+    forecast_map cache would be regenerated to identical content.
 
     Returns a summary dict with counts.
     """
@@ -237,7 +246,10 @@ def rebuild_all(db: Session, airports_db_path: str) -> dict:
 
     stats_count = rebuild_stats_cache(db)
     verif_map_count = rebuild_verification_map_cache(db, airports_db_path)
-    forecast_map_count = rebuild_forecast_map_cache(db, airports_db_path)
+    if include_forecast_map:
+        forecast_map_count = rebuild_forecast_map_cache(db, airports_db_path)
+    else:
+        forecast_map_count = 0
 
     db.commit()
     duration_ms = int((time.monotonic() - t0) * 1000)

--- a/src/weatherbrief/tasks/verification_stats.py
+++ b/src/weatherbrief/tasks/verification_stats.py
@@ -59,28 +59,24 @@ def get_activity_summary(
     icao_filter: list[str] | None = None,
 ) -> ActivitySummary:
     """High-level counts for a date range, scoped by source."""
-    # Count observations and airports that have scores for this source,
-    # so flight vs standalone dashboards show relevant counts only.
-    scored_obs_ids = (
-        select(func.distinct(VerificationScoreRow.observation_id))
-        .where(
+    # Count observations and airports that have scores for this source.
+    # VerificationScoreRow has a denormalised icao column and a CASCADE FK on
+    # observation_id, so both counts can be answered directly from the score
+    # table in a single aggregate.  The previous IN(scalar_subquery) pattern
+    # materialised the subquery twice and planned poorly on MySQL at 30-day
+    # windows.
+    score_counts = db.execute(
+        select(
+            func.count(func.distinct(VerificationScoreRow.observation_id)),
+            func.count(func.distinct(VerificationScoreRow.icao)),
+        ).where(
             VerificationScoreRow.observation_time.between(since, until),
             VerificationScoreRow.source == source,
             _icao_clause(VerificationScoreRow.icao, icao_filter),
         )
-        .scalar_subquery()
-    )
-    obs_count = db.execute(
-        select(func.count(VerificationObservationRow.id)).where(
-            VerificationObservationRow.id.in_(scored_obs_ids),
-        )
-    ).scalar() or 0
-
-    airport_count = db.execute(
-        select(func.count(func.distinct(VerificationObservationRow.icao))).where(
-            VerificationObservationRow.id.in_(scored_obs_ids),
-        )
-    ).scalar() or 0
+    ).one()
+    obs_count = score_counts[0] or 0
+    airport_count = score_counts[1] or 0
 
     # Flight-specific counts (only relevant for source='flight')
     flights_verified = 0


### PR DESCRIPTION
## Summary
Cache rebuild after standalone cycles was taking ~33 min/cycle in prod (observed 2026-05-14, full forecast cycle = 31 min + 34 min rebuild). Three independent improvements that together should drop rebuild well under 5 min today and keep it bounded as data grows:

- **Composite index** `(source, days_out, observation_time)` on `verification_scores` (migration 055). The verification map cache rebuild fires 16 aggregates per cycle, all filtering by exactly those three columns; migration 038's `(source, observation_time)` index is used today but forces a 4x row-scan overhead because `days_out` is not pinned by it.
- **Skip `rebuild_forecast_map_cache` on light cycles** (`scheduler.py:867`). Light (score-only) cycles don't touch forecast snapshots, so the forecast_map cache would be regenerated to identical content. Halves the rebuild cost of the four hourly light cycles per day.
- **Collapse `get_activity_summary` IN-subqueries** into a single aggregate over `verification_scores` (the score table already carries a denormalised `icao` column and a CASCADE FK on `observation_id`). The previous `IN(scalar_subquery)` pattern materialised the subquery twice on MySQL and planned poorly at 30-day windows.

## Test plan
- [x] `pytest tests/test_cache_builder.py tests/test_standalone_verification.py` — 46/46 pass
- [x] Full suite (excluding pre-existing unrelated failure in `test_data_sources_catalog.py` and GRIB/chart tests skipped) — 1718 pass, 9 skipped
- [ ] On prod after deploy: confirm "Standalone light cycle: cache rebuilt" wall time drops materially (forecast_map skipped) and "Standalone forecast cycle: cache rebuilt" drops thanks to the new index
- [ ] Verify alembic upgrade applies cleanly to both SQLite (dev) and MySQL (prod) — `op.create_index` works on both without batch mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)