### PR TITLE
feat(auth): wire magic-link email sign-in (#76)

### DIFF
--- a/alembic/versions/056_magic_link_tokens.py
+++ b/alembic/versions/056_magic_link_tokens.py
@@ -1,0 +1,70 @@
+"""Add magic-link auth tables and users.email index.
+
+Two new tables owned by flyfun-common's ``MagicLinkTokenRow`` and
+``MagicLinkConsumeAttemptRow``. Created here so weather's migration
+chain stays self-contained — each consumer app of flyfun-common ships
+its own copy of the same schema change.
+
+Also indexes ``users.email``: magic-link consume looks users up by
+email on every sign-in, and the column was previously unindexed.
+
+Revision ID: 056
+Revises: 055
+Create Date: 2026-05-14
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "056"
+down_revision: Union[str, None] = "055"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "magic_link_tokens",
+        sa.Column("id", sa.String(64), primary_key=True),
+        sa.Column("email", sa.String(256), nullable=False),
+        sa.Column("token_hash", sa.String(64), nullable=False),
+        sa.Column("otp_code_hash", sa.String(64), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("used_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("requested_ip", sa.String(64), nullable=True),
+        sa.Index("ix_magic_link_tokens_email", "email"),
+        sa.Index("ix_magic_link_tokens_token_hash", "token_hash", unique=True),
+        sa.Index("ix_magic_link_tokens_created_at", "created_at"),
+        sa.Index("ix_magic_link_tokens_requested_ip", "requested_ip"),
+    )
+
+    op.create_table(
+        "magic_link_consume_attempts",
+        sa.Column(
+            "id",
+            sa.BigInteger().with_variant(sa.Integer(), "sqlite"),
+            primary_key=True,
+            autoincrement=True,
+        ),
+        sa.Column("ip", sa.String(64), nullable=False),
+        sa.Column("attempted_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Index("ix_magic_link_consume_attempts_ip", "ip"),
+        sa.Index("ix_magic_link_consume_attempts_attempted_at", "attempted_at"),
+    )
+
+    # users.email was previously unindexed. Magic-link consume runs
+    # ``filter(UserRow.email == :email)`` on every sign-in, and the
+    # column is also probed by admin-style email lookups.
+    with op.batch_alter_table("users") as batch:
+        batch.create_index("ix_users_email", ["email"])
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("users") as batch:
+        batch.drop_index("ix_users_email")
+    op.drop_table("magic_link_consume_attempts")
+    op.drop_table("magic_link_tokens")

--- a/alembic/versions/059_magic_link_tokens.py
+++ b/alembic/versions/059_magic_link_tokens.py
@@ -8,8 +8,8 @@ its own copy of the same schema change.
 Also indexes ``users.email``: magic-link consume looks users up by
 email on every sign-in, and the column was previously unindexed.
 
-Revision ID: 056
-Revises: 055
+Revision ID: 059
+Revises: 058
 Create Date: 2026-05-14
 """
 from __future__ import annotations
@@ -19,8 +19,8 @@ from typing import Sequence, Union
 import sqlalchemy as sa
 from alembic import op
 
-revision: str = "056"
-down_revision: Union[str, None] = "055"
+revision: str = "059"
+down_revision: Union[str, None] = "058"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/designs/multi-user-deployment.md
+++ b/designs/multi-user-deployment.md
@@ -252,14 +252,35 @@ Auth, JWT, encryption, DB engine, and user models are provided by `flyfun-common
 
 ### OAuth flow
 
-Google Sign-In via `authlib`. JWT (HS256, 7-day expiry) in httpOnly secure cookie (`flyfun_auth`, cross-subdomain on `.flyfun.aero`).
+Google Sign-In and Sign in with Apple via `authlib`. JWT (HS256, 7-day expiry) in httpOnly secure cookie (`flyfun_auth`, cross-subdomain on `.flyfun.aero`).
 
-1. User clicks "Sign in with Google" → Google consent screen
+1. User clicks "Sign in with Google/Apple" → consent screen
 2. Callback exchanges code for ID token → lookup/create user (auto-approved)
 3. `on_new_user` callback creates `UserPreferencesRow` + sends welcome/admin emails
 4. Issue JWT cookie; all `/api/*` routes validate via `current_user_id()` dependency from flyfun-common
 
 Admin identity: `ADMIN_EMAILS` env var (comma-separated). Dev user is always admin. Custom `/auth/me` adds `is_admin` and `setup_completed` fields.
+
+### Magic-link (email) flow
+
+A third sign-in path alongside Google/Apple, for users who don't want to link their flying activity to either SSO. Mints the *same* `flyfun_auth` JWT — the only difference is identification. Implementation lives in `flyfun_common.auth.magic_link`; weather wires the email callback at `api/app.py:create_app`.
+
+1. `POST /auth/magic-link/request` `{email}` — issues a 256-bit token (`secrets.token_urlsafe(32)`) and a 6-digit OTP, stores SHA-256 hashes only in `magic_link_tokens`, invokes `weatherbrief.notify.magic_link_email.send_magic_link_email`. Always returns 200 (no account enumeration).
+2. `GET /auth/verify?token=...` — **does not consume the token**; 302s to `/auth-verify.html?token=...` so email scanners (Outlook ATP, Proofpoint, Mimecast) that pre-click links can't burn single-use tokens.
+3. `POST /auth/magic-link/consume` `{token}` — looks up by `lower(email)`, finds-or-creates user (case-insensitive). Existing Google/Apple users with the same email are **re-used as-is** — their `provider` field is preserved. Mints JWT + `flyfun_auth` cookie, 302s.
+4. `POST /auth/magic-link/consume-code` `{email, code}` — iOS OTP variant. Same logic, returns `{token, user_id}` JSON (no cookie). Lets the iOS app accept a 6-digit code typed in by a user reading the email on their laptop.
+
+**Token lifecycle.** 15-min expiry, single-use, deleted 24h after expiry by `purge_expired_magic_link_tokens` called from the daily retention loop (`scheduler.py`).
+
+**Rate limits.** DB-backed sliding windows (in `flyfun_common.auth.rate_limit`): 3 requests/hour per email, 10/hour per IP, 5 consume attempts/minute per IP. Bypassed when `is_dev_mode()`.
+
+**Apple Private Relay rejection.** `@privaterelay.appleid.com` addresses can't receive our mail; `/request` returns 400 with a "use Sign in with Apple" message.
+
+**Pending-user parity.** Magic-link consume for an unapproved user returns the same `/login.html?status=pending` redirect as the OAuth callback. The token is *not* marked used so the same link can succeed after admin approval (within 15 min).
+
+**Email content.** `weatherbrief.notify.magic_link_email.send_magic_link_email` sends an HTML + plain-text email containing both the click-through link and the 6-digit code, plus the requesting IP (so the user can spot misuse). Dev mode logs the link/code instead of sending.
+
+**Schema.** `magic_link_tokens` (id, email, token_hash, otp_code_hash, created_at, expires_at, used_at, requested_ip) and `magic_link_consume_attempts` (id, ip, attempted_at). Migration `056_magic_link_tokens.py` creates both tables and adds `ix_users_email` since email-keyed lookup runs on every consume.
 
 ### API Token Authentication (bot/agent users)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "Medium-range weather assessment for cross-country GA flights in Europe"
 requires-python = ">=3.11"
 dependencies = [
-    "flyfun-common>=0.3.11",
+    "flyfun-common>=0.4.0",
     "requests>=2.31",
     "pyyaml>=6.0",
     "pydantic>=2.0",

--- a/src/weatherbrief/api/app.py
+++ b/src/weatherbrief/api/app.py
@@ -419,9 +419,11 @@ def create_app() -> FastAPI:
         }
 
     # Auth router from flyfun-common (with weather-specific on_new_user callback)
+    from weatherbrief.notify.magic_link_email import send_magic_link_email
     auth_router = create_auth_router(
         on_new_user=_on_new_user,
         on_delete_user=_on_delete_user,
+        send_magic_link_email=send_magic_link_email,
     )
     app.include_router(create_autorouter_router())
     app.include_router(create_oauth_router())

--- a/src/weatherbrief/notify/magic_link_email.py
+++ b/src/weatherbrief/notify/magic_link_email.py
@@ -1,0 +1,124 @@
+"""Magic-link sign-in email.
+
+Builds a branded HTML + plain-text email containing both the click-through
+link (web flow) and a 6-digit code (iOS flow). flyfun-common calls this
+via the ``send_magic_link_email`` callback wired in ``api/app.py``.
+
+In dev mode the link/code are logged instead of sent, so local
+development doesn't depend on Resend/SMTP being configured.
+"""
+
+from __future__ import annotations
+
+import html
+import logging
+import os
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+
+from weatherbrief.notify.email import SmtpConfig, send_message
+
+logger = logging.getLogger(__name__)
+
+
+def send_magic_link_email(
+    email: str,
+    link: str,
+    code: str,
+    requesting_ip: str | None,
+) -> None:
+    """Send a sign-in email with the magic link and 6-digit code.
+
+    Signature matches flyfun-common's
+    ``SendMagicLinkEmail = Callable[[str, str, str, str | None], None]``.
+    """
+    from flyfun_common.auth import is_dev_mode
+
+    if is_dev_mode():
+        logger.info(
+            "Magic-link sign-in (dev mode, not sent) email=%s ip=%s code=%s link=%s",
+            email, requesting_ip, code, link,
+        )
+        return
+
+    # From-address resolution: prefer RESEND_FROM (works for Resend path
+    # without SMTP env vars); fall back to SMTP config; finally a placeholder
+    # so we never silently send from "" — the MIMEMultipart From header is
+    # used by Resend when RESEND_FROM is not set.
+    from_address = os.environ.get("RESEND_FROM")
+    if not from_address:
+        try:
+            from_address = SmtpConfig.from_env().from_address
+        except ValueError:
+            logger.warning(
+                "Neither RESEND_FROM nor SMTP configured — cannot send "
+                "magic-link email to %s",
+                email,
+            )
+            return
+
+    esc_email = html.escape(email)
+    esc_link = html.escape(link)
+    esc_code = html.escape(code)
+    esc_ip = html.escape(requesting_ip or "unknown")
+
+    subject = "Your FlyFun Weather sign-in link"
+    html_body = f"""\
+<html>
+<body style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;font-size:14px;color:#1a1a2e;max-width:560px;">
+  <h2 style="margin:0 0 12px;">Sign in to FlyFun Weather</h2>
+  <p>Click the button below to finish signing in as <strong>{esc_email}</strong>.</p>
+  <div style="margin:24px 0;">
+    <a href="{esc_link}"
+       style="display:inline-block;padding:12px 28px;background:#2563eb;color:#fff;
+              border-radius:6px;text-decoration:none;font-weight:600;font-size:15px;">
+      Sign in to FlyFun Weather
+    </a>
+  </div>
+  <p style="color:#555;font-size:13px;">
+    This link expires in 15 minutes and can only be used once.
+  </p>
+  <p style="margin-top:24px;font-size:13px;color:#555;">
+    If you're signing in from the FlyFun iOS app, enter this code instead:
+  </p>
+  <p style="font-family:'SF Mono',Menlo,monospace;font-size:24px;letter-spacing:4px;
+            font-weight:600;color:#1a1a2e;background:#f4f4f7;padding:12px 16px;
+            border-radius:6px;display:inline-block;margin:4px 0 16px;">
+    {esc_code}
+  </p>
+  <hr style="border:none;border-top:1px solid #eee;margin:24px 0;">
+  <p style="color:#6c757d;font-size:12px;">
+    Requested from IP <strong>{esc_ip}</strong>.<br>
+    If you didn't request this email, just ignore it — no one can sign in
+    without clicking the link or entering the code.
+  </p>
+</body>
+</html>"""
+
+    plain_body = (
+        f"Sign in to FlyFun Weather as {email}\n\n"
+        f"Click this link to finish signing in:\n"
+        f"  {link}\n\n"
+        f"This link expires in 15 minutes and can only be used once.\n\n"
+        f"If you're signing in from the FlyFun iOS app, enter this code:\n"
+        f"  {code}\n\n"
+        f"---\n"
+        f"Requested from IP {requesting_ip or 'unknown'}.\n"
+        f"If you didn't request this email, just ignore it.\n"
+    )
+
+    msg = MIMEMultipart("alternative")
+    msg["Subject"] = subject
+    msg["From"] = from_address
+    msg["To"] = email
+    msg.attach(MIMEText(plain_body, "plain"))
+    msg.attach(MIMEText(html_body, "html"))
+
+    logger.info("Sending magic-link sign-in email to %s", email)
+    try:
+        send_message(msg)
+    except Exception:
+        # Re-raise so flyfun-common can log; it intentionally swallows the
+        # error to avoid leaking account existence via response codes.
+        logger.exception("Magic-link email send failed for %s", email)
+        raise

--- a/src/weatherbrief/scheduler.py
+++ b/src/weatherbrief/scheduler.py
@@ -454,6 +454,28 @@ def _run_retention_once() -> None:
     finally:
         db.close()
 
+    # Purge expired magic-link tokens and old consume-attempt rows.
+    # flyfun-common ships the helper but does not schedule — consumer
+    # apps own the cadence. 24h cutoff: tokens themselves expire in
+    # 15 min, but we keep recent rows in-window so the rate limiter
+    # has data to count against.
+    try:
+        from flyfun_common.auth.magic_link import purge_expired_magic_link_tokens
+
+        db = SessionLocal()
+        try:
+            deleted = purge_expired_magic_link_tokens(db, older_than_hours=24)
+            db.commit()
+            if deleted:
+                logger.info("Purged %d expired magic-link tokens", deleted)
+        except Exception:
+            db.rollback()
+            raise
+        finally:
+            db.close()
+    except Exception:
+        logger.error("Magic-link token purge failed", exc_info=True)
+
     # Purge old ECMWF deliveries. Readers always pick max(base_time) of
     # ready runs, so older inits are never consulted; 36 h keeps the latest
     # run plus ~24 h of prior runs as headroom for in-flight deliveries.

--- a/web/auth-verify.html
+++ b/web/auth-verify.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="referrer" content="strict-origin-when-cross-origin">
+  <title>FlyFun Weather — Confirm Sign-In</title>
+  <script>((d,s)=>{const t=s.getItem('wb_theme');d.dataset.theme=t==='light'||t==='dark'?t:matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light'})(document.documentElement,localStorage)</script>
+  <link rel="stylesheet" href="/css/style.css">
+</head>
+<body>
+  <div class="container">
+    <div class="login-panel">
+      <h1>FlyFun Weather</h1>
+      <p class="login-subtitle">Confirm sign-in</p>
+
+      <div id="initial-state">
+        <p style="margin: 16px 0 24px;">
+          Click the button below to finish signing in to FlyFun Weather.
+        </p>
+        <button id="btn-confirm" class="btn-login" style="background:#2563eb;color:#fff;border:none;cursor:pointer;width:100%;">
+          Finish signing in
+        </button>
+        <p style="margin-top: 20px; color: #6c757d; font-size: 13px;">
+          Sign-in links expire 15 minutes after they're issued and can only
+          be used once.
+        </p>
+      </div>
+
+      <div id="loading-state" style="display:none;">
+        <p style="margin: 16px 0;">Signing you in…</p>
+      </div>
+
+      <div id="error-state" style="display:none;">
+        <p id="error-message" style="margin: 16px 0; color: #c00;">
+          This sign-in link is invalid or has expired.
+        </p>
+        <a href="/login.html" class="btn-login" style="background:#2563eb;color:#fff;text-decoration:none;display:inline-block;text-align:center;width:100%;">
+          Request a new link
+        </a>
+      </div>
+
+      <div id="missing-token-state" style="display:none;">
+        <p style="margin: 16px 0; color: #c00;">
+          No sign-in token found. Open the link from your sign-in email
+          again, or request a new one.
+        </p>
+        <a href="/login.html" class="btn-login" style="background:#2563eb;color:#fff;text-decoration:none;display:inline-block;text-align:center;width:100%;">
+          Go to sign-in
+        </a>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    const params = new URLSearchParams(window.location.search);
+    const token = params.get('token');
+    const next = params.get('next');
+
+    if (!token) {
+      document.getElementById('initial-state').style.display = 'none';
+      document.getElementById('missing-token-state').style.display = '';
+    }
+
+    document.getElementById('btn-confirm').addEventListener('click', async () => {
+      document.getElementById('initial-state').style.display = 'none';
+      document.getElementById('loading-state').style.display = '';
+
+      const body = { token };
+      if (next) body.next = next;
+
+      try {
+        // The endpoint responds 302 + Set-Cookie. fetch follows redirects
+        // and the browser applies the cookie during the chain, so a
+        // simple page nav after success is enough.
+        const resp = await fetch('/auth/magic-link/consume', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+          credentials: 'same-origin',
+        });
+        if (resp.ok || resp.redirected) {
+          // Either fetch followed the 302 (resp.ok) or — depending on
+          // the response shape — we got a final URL back. Navigate there.
+          window.location.href = resp.url || (next || '/');
+          return;
+        }
+        throw new Error(`Server responded ${resp.status}`);
+      } catch (err) {
+        document.getElementById('loading-state').style.display = 'none';
+        document.getElementById('error-state').style.display = '';
+        if (err && err.message) {
+          document.getElementById('error-message').textContent =
+            'Sign-in failed: ' + err.message + '. The link may have expired or already been used.';
+        }
+      }
+    });
+  </script>
+</body>
+</html>

--- a/web/login.html
+++ b/web/login.html
@@ -35,6 +35,45 @@
           </svg>
           Sign in with Apple
         </a>
+
+        <button type="button" id="btn-email-toggle" class="btn-login" style="display:none;background:transparent;border:1px solid currentColor;cursor:pointer;">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg">
+            <rect x="3" y="5" width="18" height="14" rx="2"/>
+            <path d="M3 7l9 6 9-6"/>
+          </svg>
+          Sign in with email
+        </button>
+      </div>
+
+      <form id="email-form" style="display:none;margin-top:8px;">
+        <label for="email-input" style="display:block;font-size:13px;margin-bottom:6px;">
+          Enter your email address
+        </label>
+        <input type="email" id="email-input" required autocomplete="email"
+               placeholder="you@example.com"
+               style="width:100%;padding:10px 12px;border-radius:6px;border:1px solid #ccc;
+                      font-size:14px;box-sizing:border-box;margin-bottom:8px;">
+        <button type="submit" id="btn-email-submit" class="btn-login"
+                style="background:#2563eb;color:#fff;border:none;cursor:pointer;width:100%;">
+          Send sign-in link
+        </button>
+        <button type="button" id="btn-email-cancel"
+                style="margin-top:8px;background:transparent;border:none;color:#6c757d;
+                       font-size:13px;cursor:pointer;width:100%;padding:6px;">
+          Cancel
+        </button>
+        <p id="email-error" style="display:none;color:#c00;font-size:13px;margin-top:8px;"></p>
+      </form>
+
+      <div id="email-sent" style="display:none;margin-top:8px;">
+        <p style="margin:16px 0;">
+          Check your email. We sent a sign-in link to
+          <strong id="email-sent-address"></strong>.
+        </p>
+        <p style="color:#6c757d;font-size:13px;">
+          The link expires in 15 minutes. You can close this tab —
+          the link will open a new session.
+        </p>
       </div>
     </div>
   </div>
@@ -65,6 +104,7 @@
         const providers = data.providers || [];
         if (providers.includes('google')) document.getElementById('btn-google').style.display = '';
         if (providers.includes('apple')) document.getElementById('btn-apple').style.display = '';
+        if (providers.includes('email')) document.getElementById('btn-email-toggle').style.display = '';
         // Fallback: if no providers configured (dev mode), show Google
         if (providers.length === 0) document.getElementById('btn-google').style.display = '';
       })
@@ -72,6 +112,65 @@
         // On error, show Google button as fallback
         document.getElementById('btn-google').style.display = '';
       });
+
+    // --- Email magic-link flow ---
+    const loginButtons = document.getElementById('login-buttons');
+    const emailForm = document.getElementById('email-form');
+    const emailInput = document.getElementById('email-input');
+    const emailSent = document.getElementById('email-sent');
+    const emailError = document.getElementById('email-error');
+    const submitBtn = document.getElementById('btn-email-submit');
+
+    document.getElementById('btn-email-toggle').addEventListener('click', () => {
+      loginButtons.style.display = 'none';
+      emailForm.style.display = '';
+      emailInput.focus();
+    });
+
+    document.getElementById('btn-email-cancel').addEventListener('click', () => {
+      emailForm.style.display = 'none';
+      loginButtons.style.display = '';
+      emailError.style.display = 'none';
+      emailInput.value = '';
+    });
+
+    emailForm.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      emailError.style.display = 'none';
+      submitBtn.disabled = true;
+      submitBtn.textContent = 'Sending…';
+
+      const email = emailInput.value.trim();
+      const body = { email };
+      if (nextParam) body.next = nextParam;
+
+      try {
+        const resp = await fetch('/auth/magic-link/request', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+        });
+        if (resp.status === 429) {
+          throw new Error('Too many requests. Wait a few minutes before trying again.');
+        }
+        if (resp.status === 400) {
+          const data = await resp.json().catch(() => ({}));
+          throw new Error(data.detail || 'That email address can’t be used for magic-link sign-in.');
+        }
+        if (!resp.ok) {
+          throw new Error('Server error (' + resp.status + '). Please try again.');
+        }
+        // Always returns 200 on success (account-enumeration safe).
+        emailForm.style.display = 'none';
+        document.getElementById('email-sent-address').textContent = email;
+        emailSent.style.display = '';
+      } catch (err) {
+        emailError.textContent = err.message || 'Something went wrong. Please try again.';
+        emailError.style.display = '';
+        submitBtn.disabled = false;
+        submitBtn.textContent = 'Send sign-in link';
+      }
+    });
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

Consumer-side wiring of magic-link email sign-in. The shared library (model, endpoints, rate-limit, OTP) lands in [roznet/flyfun-common#4](https://github.com/roznet/flyfun-common/pull/4); this PR mounts it inside flyfun-weather.

Magic-link is fundamentally another way to identify a user — once the JWT is minted, everything downstream (sliding refresh, expiry, cookie, `/auth/me`, logout, account delete) reuses the existing OAuth path. Google/Apple flows are untouched.

## What's in here

* `alembic/versions/056_magic_link_tokens.py` — creates `magic_link_tokens` + `magic_link_consume_attempts` tables and adds `ix_users_email` (email-keyed lookup runs on every consume)
* `src/weatherbrief/notify/magic_link_email.py` — branded HTML + plain text email with link, 6-digit OTP, requesting IP, and "ignore if not you" footer. Reuses the existing Resend/SMTP infra. Dev mode logs instead of sending
* `src/weatherbrief/api/app.py` — passes `send_magic_link_email=...` into `create_auth_router`. This both mounts the magic-link sub-router and adds `"email"` to `/auth/providers`
* `web/login.html` — third "Sign in with email" option, gated on the provider list. Inline email form → request → "check your email" state. Handles 429 (rate limit) and 400 (invalid / Apple Private Relay) explicitly
* `web/auth-verify.html` — confirmation page that `GET /auth/verify` 302s into. The GET endpoint never consumes the token (defends against corporate email scanners that pre-click links); only the explicit POST from this page burns it
* `src/weatherbrief/scheduler.py` — folds `purge_expired_magic_link_tokens` into the daily retention loop (24h cutoff)
* `designs/multi-user-deployment.md` — new "Magic-link (email) flow" subsection under Authentication
* `pyproject.toml` — bumps `flyfun-common>=0.4.0`

## End-to-end smoke test

Run against the real FastAPI app + dev SQLite via `TestClient`:

- [x] `/auth/providers` lists `"email"` when the callback is wired
- [x] `POST /auth/magic-link/request` returns 200, callback fired
- [x] `GET /auth/verify?token=...` 302s to `/auth-verify.html?token=...` and does NOT mark token used (scanner safety)
- [x] `POST /auth/magic-link/consume` mints the `flyfun_auth` cookie and 302s
- [x] `POST /auth/magic-link/consume-code` mints a JWT JSON (iOS path)
- [x] New magic-link user gets `provider="email"`
- [x] Existing Google user with the same email is re-used; `provider` stays `"google"`
- [x] `@privaterelay.appleid.com` rejected with 400 and a clear message

## Test plan

- [x] Existing test suite: 1905 passed, 1 pre-existing unrelated failure (`test_bootstrapped_store_populates_dynamic_fields` fails on main too)
- [ ] Real-world deliverability check once deployed: send to Gmail, Outlook, iCloud, ProtonMail, Fastmail and confirm inbox delivery (depends on SPF/DKIM/DMARC for `flyfun.aero` — out of scope for this PR)
- [ ] Manual prod test of the full sign-in journey including the Outlook ATP / Proofpoint scanner-safety guarantee (only meaningful behind the real corporate mail-scanning infrastructure)

## Dependency / sequencing

This PR pins `flyfun-common>=0.4.0`. That version is not yet published — it lands when [flyfun-common#4](https://github.com/roznet/flyfun-common/pull/4) merges and we cut a release. **CI on this PR will fail until then** (pip can't resolve the dep), which is the intended sequencing signal. Local dev was validated against an editable install of the local flyfun-common checkout.

## Risk

Low impact on existing auth:

- Magic-link sub-router only mounts when the callback is wired — Google/Apple paths are unchanged
- `_find_or_create_user` (OAuth path) is untouched; a sibling `_find_or_create_user_by_email` handles the new path
- JWT issuance, sliding-session refresh, cookie attributes, `/auth/me`, logout, account deletion are all provider-agnostic
- Migration is additive only (two new tables + one new index on `users.email`); no schema mutation, no data backfill

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)