### PR TITLE
fix(briefing-usage): widen flight_id to 256, add truncate+hash guard

### DIFF
--- a/alembic/versions/056_briefing_usage_flight_id_256.py
+++ b/alembic/versions/056_briefing_usage_flight_id_256.py
@@ -1,0 +1,42 @@
+"""Widen briefing_usage.flight_id from String(100) to String(256).
+
+Matches the canonical ``flights.id`` width and every other table that
+references a flight_id. The 100-char limit caused DataError(1406) for long
+multi-waypoint routes (e.g. 119-char ids).
+
+Revision ID: 056
+Revises: 055
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "056"
+down_revision: Union[str, None] = "055"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("briefing_usage") as batch_op:
+        batch_op.alter_column(
+            "flight_id",
+            existing_type=sa.String(100),
+            type_=sa.String(256),
+            existing_nullable=False,
+            existing_server_default="",
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("briefing_usage") as batch_op:
+        batch_op.alter_column(
+            "flight_id",
+            existing_type=sa.String(256),
+            type_=sa.String(100),
+            existing_nullable=False,
+            existing_server_default="",
+        )

--- a/src/weatherbrief/api/usage.py
+++ b/src/weatherbrief/api/usage.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import logging
 from datetime import datetime, timedelta, timezone
 
@@ -126,6 +127,23 @@ def check_service_limits(db: Session, user_id: str) -> dict[str, bool]:
     }
 
 
+# briefing_usage.flight_id is VARCHAR(256); leave room for "-" + 8 hex chars
+# so an over-length value still produces a unique, deterministic key.
+_FLIGHT_ID_COL_LIMIT = 256
+
+
+def _clip_flight_id(flight_id: str, max_len: int = _FLIGHT_ID_COL_LIMIT) -> str:
+    if len(flight_id) <= max_len:
+        return flight_id
+    digest = hashlib.sha1(flight_id.encode("utf-8")).hexdigest()[:8]
+    prefix = flight_id[: max_len - 9]
+    logger.warning(
+        "flight_id length %d exceeds %d, clipping to %s-%s",
+        len(flight_id), max_len, prefix, digest,
+    )
+    return f"{prefix}-{digest}"
+
+
 def log_briefing_usage(
     db: Session,
     user_id: str,
@@ -135,6 +153,7 @@ def log_briefing_usage(
     result_size_bytes: int | None = None,
 ) -> int:
     """Insert a BriefingUsageRow after a briefing refresh. Returns the row id."""
+    flight_id = _clip_flight_id(flight_id)
     row = BriefingUsageRow(
         user_id=user_id,
         flight_id=flight_id,

--- a/src/weatherbrief/db/models.py
+++ b/src/weatherbrief/db/models.py
@@ -251,7 +251,7 @@ class BriefingUsageRow(Base):
     user_id: Mapped[str] = mapped_column(
         String(64), ForeignKey("users.id", ondelete="CASCADE"), index=True
     )
-    flight_id: Mapped[str] = mapped_column(String(100), default="")
+    flight_id: Mapped[str] = mapped_column(String(256), default="")
     timestamp: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
     )


### PR DESCRIPTION
## Summary
- Long multi-waypoint routes (119-char id observed in prod) overflow the 100-char `briefing_usage.flight_id` column, raising `pymysql.err.DataError(1406)` when `log_briefing_usage` tries to insert after a successful refresh.
- Migration 056 widens the column to `String(256)` to match the canonical `flights.id` width (every other table referencing a flight_id is already 256).
- Adds `_clip_flight_id()` in `api/usage.py` as defense-in-depth: if a flight_id ever exceeds 256 chars, it's clipped to `<prefix>-<sha1[:8]>` (deterministic, logged as a warning). Called from `log_briefing_usage`.

## Test plan
- [x] `alembic upgrade head` from scratch on SQLite — runs through 056, column shows as `VARCHAR(256)`
- [x] Insert of the original 119-char flight_id succeeds
- [x] Helper unit-checked: short id unchanged, 119-char unchanged, 302-char clipped to exactly 256 with deterministic `-XXXXXXXX` suffix
- [x] `tests/test_usage.py` (13) and `tests/test_db_models.py` (10) pass
- [ ] After deploy: run alembic upgrade against MySQL, watch for any further `DataError(1406)` on briefing_usage inserts

🤖 Generated with [Claude Code](https://claude.com/claude-code)