### PR TITLE
chore(verification): post-#154 review cleanup

### DIFF
--- a/designs/INDEX.md
+++ b/designs/INDEX.md
@@ -116,8 +116,8 @@ Sync engine spec (offline queue, `NWPathMonitor` flush, append-only semantics, W
 → Full doc: ios-app-roadmap.md
 
 ### forecast-page
-Pan-European weather overview map with per-airport forecast visualization (8 metrics incl. runway crosswind/headwind, consensus modes) and model accuracy heatmaps, powered by standalone verification snapshots. Cache layer serves pre-computed JSON with staleness tracking; falls back to live queries.
-Key exports: `get_forecast_map_data`, `get_verification_map_data`, `WeatherMap`, `fetchForecastMap`
+Pan-European weather overview map with per-airport forecast visualization (8 metrics incl. runway crosswind/headwind, consensus modes). Cache layer serves pre-computed JSON with staleness tracking; falls back to live queries. (The model accuracy heatmap was removed in #154; the replacement view consumes ``get_optimistic_bias_leaderboard`` from the verification stats module — see `metar-taf-accuracy.md`.)
+Key exports: `get_forecast_map_data`, `WeatherMap`, `fetchForecastMap`
 → Full doc: forecast-page.md
 
 ### metar-taf-accuracy [project]

--- a/designs/forecast-page.md
+++ b/designs/forecast-page.md
@@ -1,10 +1,12 @@
 # Forecast Page
 
-> Pan-European weather overview map with per-airport forecast visualization and model accuracy heatmaps, powered by standalone verification snapshots.
+> Pan-European weather overview map with per-airport forecast visualization, powered by standalone verification snapshots.
 
 ## Intent
 
-Provide a spatial overview of current weather conditions and model accuracy across ~830 European airports. Three tabs: forecast overview (color-coded map by metric), model accuracy (verification heatmap), and detailed stats (embedded verification dashboard). This page reuses data already collected by the standalone verification pipeline — no additional data fetching required.
+Provide a spatial overview of current weather conditions across ~830 European airports. The page reuses data already collected by the standalone verification pipeline — no additional data fetching required.
+
+**Removed in #154**: the Model Accuracy Map tab and its underlying `get_verification_map_data` query / `verif_map:*` cache keys / `GET /maps/verification` endpoint are gone. Per-airport accuracy is now surfaced via the optimistic-bias leaderboard (see ``metar-taf-accuracy.md``).
 
 ## Architecture
 
@@ -14,22 +16,19 @@ Backend                                    Frontend
 api/maps.py                                maps.html (template)
 ├── GET /maps/forecast                     maps-main.ts (controller)
 │   → cache or map_queries.get_forecast_   ├── state mgmt (day/hour/model/metric)
-│     map_data()                           ├── tab switching (forecast/accuracy/stats)
-├── GET /maps/forecast/hours               └── data loading + rerender
-│   → available hours for a day            adapters/maps-adapter.ts (API client)
-├── GET /maps/verification                 ├── fetchForecastMap()
-│   → cache or map_queries.get_            ├── fetchVerificationMap()
-│     verification_map_data()              └── fetchAvailableHours()
+│     map_data()                           ├── tab switching (forecast/synoptic/stats)
+└── GET /maps/forecast/hours               └── data loading + rerender
+    → available hours for a day            adapters/maps-adapter.ts (API client)
+                                           ├── fetchForecastMap()
+                                           └── fetchAvailableHours()
                                            visualization/weather-map.ts (Leaflet map)
-Cache layer:                               ├── setForecastData()
-  verification_cache table (JSON blobs)    └── setVerificationData()
+Cache layer:                               └── setForecastData()
+  verification_cache table (JSON blobs)
   ├── forecast_map:{day}:{hour}
-  ├── verif_map:{model}:{days_out}:{period}
   └── staleness: source_max_time vs live MAX
 
 Data source:
   airport_forecast_snapshots table
-  verification_scores table
   (from standalone verification pipeline)
 ```
 
@@ -42,12 +41,6 @@ Data source:
 - **Model modes**: Worst consensus, Majority consensus, or individual model (GFS/ICON/ECMWF)
 - **Agreement indicator**: Border color shows model divergence (good/moderate/poor) in consensus modes
 - Switching metric or model is client-side rerender; switching day/hour/consensus mode triggers API call
-
-### Model Accuracy
-- Per-airport verification accuracy, marker size scales with sample count
-- **Filters**: Period (7d/30d), days-out (D-0 to D-3), model, metric
-- **Metrics**: Category Match %, Ceiling MAE, Wind MAE, Temperature MAE
-- Authenticated users (same as forecast tab)
 
 ### Accuracy Stats
 - Embedded iframe to `/verification.html?embed`
@@ -79,9 +72,7 @@ Both map endpoints use a `verification_cache` table (see [metar-taf-accuracy.md]
 
 **Forecast map**: Cached for "worst" consensus mode only (default). Cache key: `forecast_map:{day}:{hour}`. Staleness checked against `MAX(AirportForecastSnapshotRow.fetched_at)`. Individual model or majority consensus always runs live.
 
-**Verification map**: Cached for days_out 0 and 1 only. Cache key: `verif_map:{model}:{days_out}:{period}`. Staleness checked against `MAX(VerificationScoreRow.observation_time)` filtered by source='standalone'. Other days_out values run live.
-
-**Fallback**: If cache is stale or missing, both endpoints fall back to live queries transparently.
+**Fallback**: If cache is stale or missing, the endpoint falls back to a live query transparently.
 
 ## Key Queries
 
@@ -91,10 +82,6 @@ Both map endpoints use a `verification_cache` table (see [metar-taf-accuracy.md]
 3. Derive `flight_category` from ceiling + visibility via `classify_flight_category()`
 4. Enrich each snapshot with runway crosswind/headwind: load runway headings from airports DB, compute `compute_runway_winds()` per model, select best runway (min crosswind, max headwind), attach `crosswind_kt`, `headwind_kt`, `best_runway_id`, and gust equivalents
 5. Group by airport → per-model data + computed consensus
-
-### Verification Map (`get_verification_map_data`)
-1. Filter `VerificationScoreRow` by source='standalone', days_out, time window, optional model
-2. Aggregate per ICAO: sample_count, category_match_rate, MAE for ceiling/wind/temp/vis, ceiling_bias
 
 ## Color Scales
 
@@ -118,7 +105,7 @@ Both map endpoints use a `verification_cache` table (see [metar-taf-accuracy.md]
 - **Per-model-only metrics**: `convective_risk` uses worst-across-models in consensus mode; `cloud_cover_pct` uses the average; `crosswind_kt`/`headwind_kt` use max (worst) across models
 - **Runway wind data**: Crosswind/headwind require runway headings from the airports database; airports without runway data show no crosswind/headwind values. Best runway is selected by minimizing crosswind then maximizing headwind
 - **Marker sizing**: Radius scales with zoom level (3-8px) for readability at all zoom levels
-- **All map endpoints require authentication**: Both forecast and verification data are available to any authenticated user
+- **All map endpoints require authentication**: forecast data is available to any authenticated user
 
 ## References
 

--- a/designs/future/us-expansion-plan.md
+++ b/designs/future/us-expansion-plan.md
@@ -48,7 +48,7 @@ Score table growth is the storage concern. Activate the existing `verification_m
 
 ## Cache rebuild scaling
 
-`tasks/cache_builder.py` rebuilds all three cache categories (stats / verif_map / forecast_map) after each cycle. Currently 42 entries. With per-region split for forecast_map and verif_map: ~62 entries. Each entry runs aggregation queries against snapshots/scores. Watch the `Cache rebuild: ... (%dms)` log line — should stay under 30s.
+`tasks/cache_builder.py` rebuilds all three cache categories (stats / bias_leaderboard / forecast_map) after each cycle. Currently ~33 entries (6 stats + 27 leaderboard + N forecast_map per available day/hour). With per-region split for forecast_map and bias_leaderboard: ~50 entries. Each entry runs an aggregation query against the rollup / snapshots. Watch the `Cache rebuild: ... (%dms)` log line — should stay well under 30s (post-#154 typical is ~2s on the current dataset).
 
 ## Implementation order
 

--- a/src/weatherbrief/models/verification.py
+++ b/src/weatherbrief/models/verification.py
@@ -122,9 +122,17 @@ class CategoryBiasStats(BaseModel):
 class OptimisticBiasLeaderboardRow(BaseModel):
     """One airport in the optimistic-bias leaderboard.
 
-    Score is the issue-#154 formula:
-        ``(n_cat_opt_1 + 2 * n_cat_opt_2) / n``
-    — bigger = model over-promises more at this airport.
+    Score formula:
+        ``(n_cat_opt_1 + 2 * n_cat_opt_2) / n_with_cat``
+
+    where ``n_with_cat`` is the count of scores with valid category pairs
+    (``n_cat_match + n_cat_opt_1 + n_cat_opt_2 + n_cat_pess_1 + n_cat_pess_2``).
+    Issue #154 spec said ``/ n``; we tightened the denominator so NULL-category
+    rows don't deflate the score. See
+    ``verification_stats.get_optimistic_bias_leaderboard`` for the rationale.
+
+    ``n`` (this field) is the total sample count including NULL-category rows
+    — useful for the ``n < 10`` noise threshold and the public sample display.
     """
 
     icao: str

--- a/tests/test_verification_daily_rollup.py
+++ b/tests/test_verification_daily_rollup.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import date, datetime, timezone
+from datetime import date, datetime, timedelta, timezone
 
 from sqlalchemy import select
 
@@ -16,6 +16,7 @@ from weatherbrief.tasks.verification_daily_rollup import (
     rebuild_all_days,
     rollup_all_complete_days,
     rollup_day,
+    rollup_today_and_pending,
 )
 
 
@@ -356,3 +357,76 @@ class TestOrchestrators:
         assert n == 1
         rows = db_session.execute(select(VerificationDailyStatsRow)).scalars().all()
         assert len(rows) == 1
+
+
+class TestRollupTodayAndPending:
+    """Direct coverage of the scheduler hot-path function — composition of
+    rollup_all_complete_days + explicit today + explicit yesterday re-roll.
+    """
+
+    def test_today_and_yesterday_both_appear(self, db_session):
+        today = datetime.now(timezone.utc).date()
+        yesterday = today - timedelta(days=1)
+        # Place scores on today and yesterday with hours that won't roll
+        # over due to timezones (use noon UTC).
+        for d in (today, yesterday):
+            ts = datetime(d.year, d.month, d.day, 12, 0, tzinfo=timezone.utc)
+            oid = _make_obs(db_session, "LFPG", ts)
+            db_session.add(_score(oid, "LFPG", ts))
+        db_session.flush()
+
+        n = rollup_today_and_pending(db_session)
+        assert n >= 2  # at least one row each for today + yesterday
+
+        dates_in_rollup = {
+            r.date
+            for r in db_session.execute(
+                select(VerificationDailyStatsRow)
+            ).scalars().all()
+        }
+        assert today in dates_in_rollup, "today missing from rollup"
+        assert yesterday in dates_in_rollup, "yesterday missing from rollup"
+
+    def test_late_arriving_yesterday_score_picked_up(self, db_session):
+        """A score arriving for yesterday after yesterday was already
+        rolled up must be picked up on the next cycle — the explicit
+        yesterday re-roll in rollup_today_and_pending is what protects
+        against silent drift across the UTC midnight boundary.
+        """
+        today = datetime.now(timezone.utc).date()
+        yesterday = today - timedelta(days=1)
+        ts = datetime(yesterday.year, yesterday.month, yesterday.day,
+                      12, 0, tzinfo=timezone.utc)
+
+        # First pass: one score for yesterday, rolled up
+        oid1 = _make_obs(db_session, "LFPG", ts)
+        db_session.add(_score(oid1, "LFPG", ts))
+        db_session.flush()
+        rollup_today_and_pending(db_session)
+
+        first_n = db_session.execute(
+            select(VerificationDailyStatsRow.n)
+            .where(VerificationDailyStatsRow.date == yesterday)
+            .where(VerificationDailyStatsRow.icao == "LFPG")
+        ).scalar()
+        assert first_n == 1
+
+        # Late-arriving score for yesterday (different model so it doesn't
+        # collide with the existing UNIQUE constraint).
+        oid2 = _make_obs(
+            db_session, "LFPG",
+            ts.replace(hour=13),  # different observation_time
+        )
+        db_session.add(_score(
+            oid2, "LFPG", ts.replace(hour=13), model="ecmwf",
+        ))
+        db_session.flush()
+
+        # Second pass picks it up because yesterday is re-rolled explicitly
+        rollup_today_and_pending(db_session)
+        yesterday_groups = db_session.execute(
+            select(VerificationDailyStatsRow)
+            .where(VerificationDailyStatsRow.date == yesterday)
+        ).scalars().all()
+        # One group for gfs, one for ecmwf
+        assert len(yesterday_groups) == 2

--- a/tests/test_verification_stats_rollup_gate.py
+++ b/tests/test_verification_stats_rollup_gate.py
@@ -284,6 +284,7 @@ class TestValidationGate:
 
         # Per-icao expectation for (gfs, d-1)
         per_icao_n = defaultdict(int)
+        per_icao_n_with_cat = defaultdict(int)
         per_icao_opt1 = defaultdict(int)
         per_icao_opt2 = defaultdict(int)
         for s in scores:
@@ -295,6 +296,7 @@ class TestValidationGate:
             per_icao_n[s.icao] += 1
             if s.obs_flight_category is None or s.model_flight_category is None:
                 continue
+            per_icao_n_with_cat[s.icao] += 1
             diff = (
                 _CAT_IDX[s.model_flight_category]
                 - _CAT_IDX[s.obs_flight_category]
@@ -318,14 +320,62 @@ class TestValidationGate:
             assert r.n == n
             assert r.n_cat_opt_1 == per_icao_opt1[icao]
             assert r.n_cat_opt_2 == per_icao_opt2[icao]
+            # Denominator is the with-category count, not raw n (issue #154
+            # follow-up — protects against NULL-category dilution).
             want_score = (
                 per_icao_opt1[icao] + 2 * per_icao_opt2[icao]
-            ) / n
+            ) / per_icao_n_with_cat[icao]
             assert _close(r.score, want_score, rel_tol=1e-6, abs_tol=1e-6)
 
         # Sorted descending by score
         scores_seq = [r.score for r in rows]
         assert scores_seq == sorted(scores_seq, reverse=True)
+
+    def test_optimistic_bias_leaderboard_uses_n_with_cat_denominator(
+        self, db_session,
+    ):
+        """Synthetic dataset with deliberate NULL-category rows: the
+        leaderboard's score must use ``n_with_cat`` (5-bucket sum) as the
+        denominator, not raw ``n``. With the prior ``/ n`` formula, the
+        added NULL rows would deflate the score and this assertion would
+        fail.
+        """
+        when = _utc(2026, 4, 5, 12)
+        obs = VerificationObservationRow(
+            icao="LFPG", observation_time=when, collected_at=when,
+        )
+        db_session.add(obs)
+        db_session.flush()
+        # 10 scores for LFPG / gfs / d-1: 6 optimistic_1, 4 with NULL cats.
+        for i in range(10):
+            init = when - timedelta(hours=i + 1)
+            obs_cat = "MVFR" if i < 6 else None
+            mod_cat = "VFR" if i < 6 else None
+            db_session.add(VerificationScoreRow(
+                observation_id=obs.id, icao="LFPG",
+                observation_time=when,
+                model="gfs", model_init_time=init,
+                lead_hours=24, days_out=1, source=_SOURCE,
+                obs_flight_category=obs_cat,
+                model_flight_category=mod_cat,
+                category_match=(obs_cat == mod_cat) if obs_cat else None,
+            ))
+        db_session.flush()
+        rollup_all_complete_days(db_session)
+
+        rows = get_optimistic_bias_leaderboard(
+            db_session, _utc(2026, 4, 5, 0), _utc(2026, 4, 5, 23),
+            model="gfs", days_out=1, source=_SOURCE,
+        )
+        assert len(rows) == 1
+        r = rows[0]
+        assert r.icao == "LFPG"
+        assert r.n == 10  # total scores
+        assert r.n_cat_opt_1 == 6
+        assert r.n_cat_opt_2 == 0
+        # With /n_with_cat: (6 + 0) / 6 = 1.0
+        # With /n (old broken formula): (6 + 0) / 10 = 0.6 → would fail
+        assert _close(r.score, 1.0, rel_tol=1e-6, abs_tol=1e-6)
 
     def test_digest_data_orchestrator_runs(self, db_session):
         """Smoke test: full digest payload assembles without errors."""

--- a/web/ts/adapters/admin-adapter.ts
+++ b/web/ts/adapters/admin-adapter.ts
@@ -324,6 +324,7 @@ export interface CategoryBiasStats {
 export interface WindAdvisoryStats {
   model: string;
   accuracy_pct: number | null;
+  sample_count: number;
 }
 
 export interface MissedWarning {


### PR DESCRIPTION
Single-commit follow-up addressing the 3 important + 3 minor non-blocker findings from the third claude-review pass on #158 (which merged as-is per Option C).

## Items addressed

1. **`OptimisticBiasLeaderboardRow` docstring**: said `/n`, code uses `/n_with_cat` since #158 round-2. Docstring updated to match. Gate test `want_score` was a silent tautology because synthetic data has no NULL categories; updated to divide by `n_with_cat` + added `test_optimistic_bias_leaderboard_uses_n_with_cat_denominator` with deliberate NULL rows so the divergence is exercised.

2. **`designs/INDEX.md`**: removed `get_verification_map_data` from forecast-page exports list. **`designs/forecast-page.md`**: tombstoned the Verification Map section + `verif_map` cache key docs, matching the treatment `designs/metar-taf-accuracy.md` got in #158.

3. **TS `WindAdvisoryStats`**: added `sample_count: number` to match the Python model (was always serialized but never typed).

4. **`designs/future/us-expansion-plan.md`**: `verif_map` → `bias_leaderboard` in the scaling-headroom paragraph.

5. **New `TestRollupTodayAndPending`**: direct coverage of the scheduler hot-path function — asserts today + yesterday both land in the rollup after one call, and that a late-arriving score for yesterday is picked up on the next cycle.

## Test plan
- [x] 1947 python tests pass (5 pre-existing pireps/api `500 == 422` failures unrelated to verification)
- [x] TypeScript typecheck clean
- [x] All 3 new tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)