### PR TITLE
fix(api): 422 handler JSON serialization + waypoint test update

### DIFF
--- a/src/weatherbrief/api/app.py
+++ b/src/weatherbrief/api/app.py
@@ -325,6 +325,7 @@ def create_app() -> FastAPI:
     # Log Pydantic request-validation failures so 422s are diagnosable.
     # FastAPI's default returns the detail to the client but logs nothing;
     # that left iOS create-flight failures (and other 422s) opaque server-side.
+    from fastapi.encoders import jsonable_encoder
     from fastapi.exceptions import RequestValidationError
     from fastapi.responses import JSONResponse
     from starlette.exceptions import HTTPException as StarletteHTTPException
@@ -344,9 +345,14 @@ def create_app() -> FastAPI:
             exc.errors(),
             body,
         )
+        # Use jsonable_encoder — pydantic v2 puts the raw exception object
+        # in ctx.error for custom validators (``raise ValueError(...)``),
+        # which the default json encoder can't serialise. Without this
+        # the response serialisation throws and Starlette turns it into
+        # a 500, which is exactly what this handler exists to prevent.
         return JSONResponse(
             status_code=422,
-            content={"detail": exc.errors()},
+            content={"detail": jsonable_encoder(exc.errors())},
         )
 
     @app.exception_handler(StarletteHTTPException)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1328,17 +1328,17 @@ class TestInterpretRoute:
         assert data["skipped"] == []
 
     @patch("weatherbrief.airports._load_airport_model")
-    def test_round_trip_middle_waypoint_off_route(self, mock_load, client):
-        """Round-trip routes (dep == dest) trigger an upstream euro_aip
-        bug: the detour gate sees ``leg_nm = 0`` and rejects every middle
-        waypoint as a detour, even recognised airports. The UI must
-        surface those as ``off_route`` (so pilots see "too far from
-        direct leg") rather than ``skipped`` ("not recognized") — the
-        airport *was* recognised, the geometry just collapsed.
+    def test_round_trip_middle_waypoint_resolves_cleanly(self, mock_load, client):
+        """Round-trip routes (dep == dest) used to trigger an upstream
+        euro_aip bug: the detour gate saw ``leg_nm = 0`` and rejected
+        every middle waypoint as off-route, even recognised airports.
+        The upstream fix (roznet/rzflight#8) has landed, so a recognised
+        middle airport on a round-trip now resolves cleanly into
+        ``interpreted`` instead of being surfaced as ``off_route``.
 
-        Tracked upstream as roznet/rzflight#8. Once the euro_aip fix
-        lands, EGTK will move to ``interpreted`` and this test should
-        be updated to assert the clean-resolve path.
+        Guards against the bug regressing — if euro_aip's detour gate
+        starts rejecting zero-leg waypoints again, EGTK would drop out
+        of ``interpreted`` and this test would catch it.
         """
         mock_load.return_value = mock_model(TEST_AIRPORTS)
         client.app.state.db_path = "/fake/db"
@@ -1346,9 +1346,10 @@ class TestInterpretRoute:
         resp = self._post(client, "EGBJ EGTK EGBJ")
         assert resp.status_code == 200
         data = resp.json()
-        # EGTK is recognised but rejected by the degenerate detour gate;
-        # only dep/dest survive. Either way, EGTK must NOT appear in
-        # ``skipped`` — that would mislead the pilot.
-        assert "EGTK" not in data["skipped"]
+        # EGTK is now recognised and kept in the interpreted route.
+        assert data["interpreted"] == ["EGBJ", "EGTK", "EGBJ"]
+        assert data["off_route"] == []
         assert data["skipped"] == []
-        assert data["off_route"] == ["EGTK"]
+        # All three positions resolve to real coordinates.
+        icaos = [w["icao"] for w in data["waypoints"]]
+        assert icaos == ["EGBJ", "EGTK", "EGBJ"]


### PR DESCRIPTION
Two test-suite cleanups, no #154 dependency. Direct-to-main per Option C ladder.

## Commits

1. **`fix(api): wrap exc.errors() in jsonable_encoder for 422 responses`** — real bug. The diag commit `6a1492ce` added a custom `RequestValidationError` handler that returns `JSONResponse(content={"detail": exc.errors()})`. In pydantic v2, `exc.errors()` puts the raw `ValueError` object in `ctx.error` for any custom validator that does `raise ValueError(...)` — JSON serialization fails, Starlette converts to 500. iOS clients hitting any custom-validator error have been silently getting 500s instead of 422s. Ironic: the diag commit that added this logging to surface 422s introduced the bug it was trying to diagnose. Fix is one line.

2. **`test(interpret-route): update round-trip middle-waypoint expectation`** — test update only. The original test docstring predicted "Once the euro_aip fix lands, EGTK will move to `interpreted` and this test should be updated". The upstream fix landed in `009861e1` and earlier; test now asserts the clean-resolve path.

## Validation

- 4 previously-failing tests pass (Pattern A): `test_invalid_icao_type`, `test_invalid_tail_number`, `test_invalid_uuid_format_returns_422`, `test_create_flight_rejects_unparseable_token`
- 1 previously-failing test pass (Pattern B): `test_round_trip_middle_waypoint_resolves_cleanly`
- Full suite: **1953 passed, 0 failed** (the catalog test that was occasionally flaky is also passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)