### PR TITLE
feat(climatology): map views #1-#4 + Top airports leaderboard

### DIFF
--- a/src/weatherbrief/api/app.py
+++ b/src/weatherbrief/api/app.py
@@ -50,6 +50,7 @@ from weatherbrief.analytics.api import router as analytics_router
 from weatherbrief.analytics.admin_api import router as analytics_admin_router
 from weatherbrief.api.messages import admin_router as messages_admin_router, router as messages_router
 from weatherbrief.api.maps import router as maps_router
+from weatherbrief.api.climatology import router as climatology_router
 from weatherbrief.api.airport_profile import router as airport_profile_router
 from weatherbrief.api.hewson_map import router as hewson_map_router
 from weatherbrief.api.data_sources import router as data_sources_router
@@ -454,6 +455,7 @@ def create_app() -> FastAPI:
     app.include_router(messages_router, prefix="/api")
     app.include_router(messages_admin_router, prefix="/api")
     app.include_router(maps_router, prefix="/api")
+    app.include_router(climatology_router, prefix="/api")
     app.include_router(airport_profile_router, prefix="/api")
     app.include_router(hewson_map_router, prefix="/api")
     app.include_router(tokens_router, prefix="/api")

--- a/src/weatherbrief/api/climatology.py
+++ b/src/weatherbrief/api/climatology.py
@@ -13,7 +13,7 @@ change per route, no other refactor needed.
   GET /climatology/phenomena       — view #2 (TS or fog frequency)
   GET /climatology/wind            — view #3 (wind metric)
   GET /climatology/volatility      — view #4 (category transitions per obs)
-  GET /climatology/volatility/top  — view #4 leaderboard (top N airports)
+  GET /climatology/leaderboard     — Top airports for any (dataset, sub)
 """
 
 from __future__ import annotations
@@ -124,17 +124,26 @@ def get_volatility_map(
     return get_volatility_climatology(db, window, airports_db)
 
 
-@router.get("/volatility/top")
-def get_volatility_leaderboard_endpoint(
+@router.get("/leaderboard")
+def get_leaderboard_endpoint(
     month: str = Query(..., description="Month as 'YYYY-MM'"),
+    dataset: str = Query(..., description="'category', 'phenomena', 'wind', or 'volatility'"),
+    sub: str | None = Query(default=None, description="Sub-metric (required except for volatility)"),
     limit: int = Query(default=20, ge=1, le=100),
     _user_id: str = Depends(current_user_id),
     db: Session = Depends(get_db),
     airports_db: str = Depends(_airports_db),
 ):
-    """Top airports ranked by category_changes / n_obs."""
+    """Top airports for any (dataset, sub) combination, sorted by value DESC.
+
+    Sub-metric:
+      - category: 'vfr' | 'mvfr' | 'ifr' | 'lifr'
+      - phenomena: 'ts' | 'fog'
+      - wind: 'over25' | 'p95' | 'gust' (MTD restricts to 'gust' only)
+      - volatility: (none — sub is ignored)
+    """
     from weatherbrief.tasks.climatology_queries import (
-        get_volatility_leaderboard,
+        get_leaderboard,
         resolve_month_window,
     )
 
@@ -143,4 +152,5 @@ def get_volatility_leaderboard_endpoint(
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
-    return get_volatility_leaderboard(db, window, airports_db, limit=limit)
+    return get_leaderboard(db, window, airports_db,
+                           dataset=dataset, sub=sub, limit=limit)

--- a/src/weatherbrief/api/climatology.py
+++ b/src/weatherbrief/api/climatology.py
@@ -1,0 +1,146 @@
+"""Climatology / patterns endpoints (issue #155).
+
+Read-only endpoints over ``airport_monthly_summary`` and
+``airport_daily_summary``. All ~830 watchlist airports plot per query;
+indexed table reads are cheap (<200ms target), so no cache layer.
+
+Gating note: every route currently authenticates via ``current_user_id``.
+To gate the whole feature behind a user preference later, swap the
+dependency for one that checks ``climatology_views_enabled`` — single-line
+change per route, no other refactor needed.
+
+  GET /climatology/category        — view #1 (VFR/MVFR/IFR/LIFR %)
+  GET /climatology/phenomena       — view #2 (TS or fog frequency)
+  GET /climatology/wind            — view #3 (wind metric)
+  GET /climatology/volatility      — view #4 (category transitions per obs)
+  GET /climatology/volatility/top  — view #4 leaderboard (top N airports)
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.orm import Session
+
+from flyfun_common.db import current_user_id, get_db
+
+from weatherbrief.api.deps import airports_db as _airports_db
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/climatology", tags=["climatology"])
+
+
+@router.get("/category")
+def get_category_map(
+    month: str = Query(..., description="Month as 'YYYY-MM' (e.g. '2026-05')"),
+    _user_id: str = Depends(current_user_id),
+    db: Session = Depends(get_db),
+    airports_db: str = Depends(_airports_db),
+):
+    """Per-airport flight-category counts and percentages for ``month``.
+
+    For a completed month: reads ``airport_monthly_summary`` directly.
+    For the current UTC month: SUMs ``airport_daily_summary`` over the
+    completed UTC days in the month so far (``is_mtd=True`` in the
+    response, plus ``as_of_date``).
+    """
+    from weatherbrief.tasks.climatology_queries import (
+        get_category_climatology,
+        resolve_month_window,
+    )
+
+    try:
+        window = resolve_month_window(month)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    return get_category_climatology(db, window, airports_db)
+
+
+@router.get("/phenomena")
+def get_phenomena_map(
+    month: str = Query(..., description="Month as 'YYYY-MM'"),
+    kind: str = Query(..., description="'ts' or 'fog'"),
+    _user_id: str = Depends(current_user_id),
+    db: Session = Depends(get_db),
+    airports_db: str = Depends(_airports_db),
+):
+    """TS or fog frequency (% of observations) per airport."""
+    from weatherbrief.tasks.climatology_queries import (
+        get_phenomena_climatology,
+        resolve_month_window,
+    )
+
+    try:
+        window = resolve_month_window(month)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    return get_phenomena_climatology(db, window, airports_db, kind)
+
+
+@router.get("/wind")
+def get_wind_map(
+    month: str = Query(..., description="Month as 'YYYY-MM'"),
+    metric: str = Query(..., description="'over25', 'p95', or 'gust'"),
+    _user_id: str = Depends(current_user_id),
+    db: Session = Depends(get_db),
+    airports_db: str = Depends(_airports_db),
+):
+    """Wind metric per airport. MTD restricts to 'gust' only."""
+    from weatherbrief.tasks.climatology_queries import (
+        get_wind_climatology,
+        resolve_month_window,
+    )
+
+    try:
+        window = resolve_month_window(month)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    return get_wind_climatology(db, window, airports_db, metric)
+
+
+@router.get("/volatility")
+def get_volatility_map(
+    month: str = Query(..., description="Month as 'YYYY-MM'"),
+    _user_id: str = Depends(current_user_id),
+    db: Session = Depends(get_db),
+    airports_db: str = Depends(_airports_db),
+):
+    """Category transitions per observation, per airport."""
+    from weatherbrief.tasks.climatology_queries import (
+        get_volatility_climatology,
+        resolve_month_window,
+    )
+
+    try:
+        window = resolve_month_window(month)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    return get_volatility_climatology(db, window, airports_db)
+
+
+@router.get("/volatility/top")
+def get_volatility_leaderboard_endpoint(
+    month: str = Query(..., description="Month as 'YYYY-MM'"),
+    limit: int = Query(default=20, ge=1, le=100),
+    _user_id: str = Depends(current_user_id),
+    db: Session = Depends(get_db),
+    airports_db: str = Depends(_airports_db),
+):
+    """Top airports ranked by category_changes / n_obs."""
+    from weatherbrief.tasks.climatology_queries import (
+        get_volatility_leaderboard,
+        resolve_month_window,
+    )
+
+    try:
+        window = resolve_month_window(month)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    return get_volatility_leaderboard(db, window, airports_db, limit=limit)

--- a/src/weatherbrief/tasks/climatology_queries.py
+++ b/src/weatherbrief/tasks/climatology_queries.py
@@ -331,21 +331,37 @@ def get_wind_climatology(
         values = {icao: tup[0] for icao, tup in rows.items()}
         n_obs_by_icao = {icao: tup[1] for icao, tup in rows.items()}
 
+    # MTD path didn't collect n_obs yet — pull it now so the leaderboard
+    # can apply its min-obs gate.
+    if window.is_mtd and window.as_of_date is not None:
+        n_stmt = (
+            select(
+                AirportDailySummaryRow.icao,
+                func.sum(AirportDailySummaryRow.n_obs).label("n_obs"),
+            )
+            .where(AirportDailySummaryRow.date >= window.month)
+            .where(AirportDailySummaryRow.date <= window.as_of_date)
+            .group_by(AirportDailySummaryRow.icao)
+        )
+        n_obs_by_icao = {r[0]: r[1] for r in db.execute(n_stmt).all()}
+    elif window.is_mtd:
+        n_obs_by_icao = {}
+
     airports: list[dict[str, Any]] = []
     unit = "%" if metric == "over25" else "kt"
     for icao in sorted(coords):
         lat, lon = coords[icao]
         raw = values.get(icao)
+        n_obs = n_obs_by_icao.get(icao, 0) or 0
         if raw is None:
             value: float | None = None
         elif metric == "over25":
-            # Convert count → percentage of observations.
-            n_obs = n_obs_by_icao.get(icao, 0) or 0
             value = round(100.0 * raw / n_obs, 2) if n_obs > 0 else None
         else:
             value = round(float(raw), 1)
         airports.append({
-            "icao": icao, "lat": lat, "lon": lon, "value": value, "raw": raw,
+            "icao": icao, "lat": lat, "lon": lon,
+            "value": value, "raw": raw, "n_obs": n_obs,
         })
 
     return _envelope(window, dataset="wind", metric=metric, unit=unit,
@@ -406,48 +422,106 @@ def get_volatility_climatology(
                      unit="ratio", airports=airports)
 
 
-def get_volatility_leaderboard(
+def get_leaderboard(
     db: Session,
     window: MonthWindow,
     airports_db_path: str,
+    dataset: str,
+    sub: str | None,
     limit: int = 20,
 ) -> dict[str, Any]:
-    """Return the top ``limit`` airports ranked by ``category_changes / n_obs``.
+    """Top ``limit`` airports for any (dataset, sub) combination.
 
-    Min-obs gate excludes sparse-data outliers (see ``_VOLATILITY_MIN_OBS_*``).
+    Reuses the same per-airport computations as the map endpoints, then
+    applies a min-obs gate and sorts by value descending. Min-obs uses
+    the same defaults as the original volatility leaderboard:
+    ``_LEADERBOARD_MIN_OBS_COMPLETED`` for completed months and
+    ``_LEADERBOARD_MIN_OBS_MTD`` for MTD windows.
+
+    Sort direction is always ``DESC`` — for VFR% the leaderboard reads as
+    "most consistently VFR"; for unfavorable metrics (IFR/MVFR/LIFR/TS/Fog/
+    wind/volatility) it reads as "most extreme". One consistent direction
+    avoids an off-by-one UX trap.
     """
-    if window.is_mtd:
-        rows = _read_counts_by_icao(db, window, _VOLATILITY_FIELDS)
-        changes_field = "n_category_changes"
-        min_obs = _VOLATILITY_MIN_OBS_MTD
-    else:
-        rows = _read_counts_by_icao(db, window, _VOLATILITY_FIELDS_MONTHLY)
-        changes_field = "category_changes"
-        min_obs = _VOLATILITY_MIN_OBS_COMPLETED
+    min_obs = _VOLATILITY_MIN_OBS_MTD if window.is_mtd else _VOLATILITY_MIN_OBS_COMPLETED
 
-    ranked: list[dict[str, Any]] = []
-    for icao, counts in rows.items():
-        n_obs = counts["n_obs"] or 0
-        n_changes = counts[changes_field] or 0
-        if n_obs < min_obs:
-            continue
-        ranked.append({
-            "icao": icao,
-            "n_obs": n_obs,
-            "n_changes": n_changes,
-            "value": round(n_changes / n_obs, 3),
-        })
-    ranked.sort(key=lambda r: (-r["value"], r["icao"]))
-    ranked = ranked[:limit]
+    # Dispatch: get the per-airport map response, then collapse into
+    # leaderboard rows (icao, value, n_obs, …) ranked by value desc.
+    if dataset == "category":
+        if sub not in ("vfr", "mvfr", "ifr", "lifr"):
+            raise HTTPException(status_code=400, detail=f"category sub must be vfr/mvfr/ifr/lifr, got {sub!r}")
+        data = get_category_climatology(db, window, airports_db_path)
+        value_key = f"pct_{sub}"
+        rows = [
+            {"icao": a["icao"], "value": a[value_key],
+             "n_obs": a["n_obs"], "extra": {"n_vfr": a["n_vfr"], "n_mvfr": a["n_mvfr"],
+                                            "n_ifr": a["n_ifr"], "n_lifr": a["n_lifr"]}}
+            for a in data["airports"]
+            if value_key in a and a["n_obs"] >= min_obs
+        ]
+        unit = "%"
+        label = f"{sub.upper()} %"
+    elif dataset == "phenomena":
+        if sub not in ("ts", "fog"):
+            raise HTTPException(status_code=400, detail=f"phenomena sub must be 'ts' or 'fog', got {sub!r}")
+        data = get_phenomena_climatology(db, window, airports_db_path, sub)
+        key = "n_ts" if sub == "ts" else "n_fg"
+        rows = [
+            {"icao": a["icao"], "value": a["value"],
+             "n_obs": a["n_obs"], "extra": {key: a[key]}}
+            for a in data["airports"]
+            if a["value"] is not None and a["n_obs"] >= min_obs
+        ]
+        unit = "%"
+        label = "TS %" if sub == "ts" else "Fog %"
+    elif dataset == "wind":
+        if sub not in WIND_METRICS:
+            raise HTTPException(status_code=400, detail=f"wind sub must be one of {WIND_METRICS}, got {sub!r}")
+        data = get_wind_climatology(db, window, airports_db_path, sub)
+        unit = "%" if sub == "over25" else "kt"
+        rows = [
+            {"icao": a["icao"], "value": a["value"],
+             "n_obs": a.get("n_obs", 0), "extra": {"raw": a.get("raw")}}
+            for a in data["airports"]
+            if a["value"] is not None and a.get("n_obs", 0) >= min_obs
+        ]
+        label = {"over25": "% hrs > 25 kt", "p95": "Wind p95 (kt)",
+                 "gust": "Peak gust (kt)"}[sub]
+    elif dataset == "volatility":
+        data = get_volatility_climatology(db, window, airports_db_path)
+        rows = [
+            {"icao": a["icao"], "value": a["value"],
+             "n_obs": a["n_obs"], "extra": {"n_changes": a["n_changes"]}}
+            for a in data["airports"]
+            if a["value"] is not None and a["n_obs"] >= min_obs
+        ]
+        unit = "ratio"
+        label = "Changes / obs"
+    else:
+        raise HTTPException(status_code=400, detail=f"unknown dataset {dataset!r}")
+
+    rows.sort(key=lambda r: (-(r["value"] or 0), r["icao"]))
+    rows = rows[:limit]
 
     return {
         "month": window.month.strftime("%Y-%m"),
         "is_mtd": window.is_mtd,
         **({"as_of_date": window.as_of_date.isoformat()}
            if window.is_mtd and window.as_of_date else {}),
+        "dataset": dataset,
+        "sub": sub,
+        "unit": unit,
+        "label": label,
         "min_n_obs": min_obs,
-        "rows": ranked,
+        "rows": rows,
     }
+
+
+# Backwards-compat alias used by the old endpoint name during transition.
+# Kept only because tests/import it; remove once they migrate to get_leaderboard.
+def get_volatility_leaderboard(db, window, airports_db_path, limit=20):
+    return get_leaderboard(db, window, airports_db_path,
+                           dataset="volatility", sub=None, limit=limit)
 
 
 # ---------------------------------------------------------------------------

--- a/src/weatherbrief/tasks/climatology_queries.py
+++ b/src/weatherbrief/tasks/climatology_queries.py
@@ -1,0 +1,477 @@
+"""Queries for the climatology / patterns views (issue #155).
+
+Read paths for the 7 new frontend views built on top of the airport
+observation climatology tables. All views share the same MTD-vs-completed
+month dispatch:
+
+- **Completed month** (month < current UTC month): read directly from
+  ``airport_monthly_summary`` (one row per airport).
+- **Month-to-date** (month == current UTC month): SUM rows from
+  ``airport_daily_summary`` for the dates in that month so far.
+
+Percentile fields are not derivable from daily sums; views that consume
+them (climatology card, etc.) must hide those columns when ``is_mtd`` is
+True. The window resolver surfaces that flag explicitly.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, datetime, timezone
+from typing import Any
+
+from fastapi import HTTPException
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
+
+from weatherbrief.db.models import (
+    AirportDailySummaryRow,
+    AirportMonthlySummaryRow,
+)
+from weatherbrief.tasks.map_queries import _get_coords
+
+
+# ---------------------------------------------------------------------------
+# Month window resolution (shared by all month-backed views)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class MonthWindow:
+    """Resolved month, with the dispatch decision baked in.
+
+    ``month`` is always the first UTC day of the requested calendar month.
+    ``is_mtd`` is True when that month == current UTC month, meaning the
+    consumer should SUM ``airport_daily_summary`` rows whose ``date`` falls
+    in [month, as_of_date]. ``as_of_date`` is the last completed UTC day
+    included in the MTD aggregation (yesterday-UTC); None for completed
+    months.
+    """
+
+    month: date
+    is_mtd: bool
+    as_of_date: date | None
+
+
+def resolve_month_window(
+    month_str: str,
+    now_utc: datetime | None = None,
+) -> MonthWindow:
+    """Parse an ``'YYYY-MM'`` string into a MonthWindow.
+
+    Raises ValueError for malformed input or for future months (which have
+    no data on either table). Past months are accepted unconditionally —
+    queries return an empty list if no rows exist.
+    """
+    now = now_utc or datetime.now(timezone.utc)
+    current_month_start = date(now.year, now.month, 1)
+
+    try:
+        year_s, month_s = month_str.split("-", 1)
+        year, month = int(year_s), int(month_s)
+        month_start = date(year, month, 1)
+    except (ValueError, AttributeError) as exc:
+        raise ValueError(f"month must be 'YYYY-MM', got {month_str!r}") from exc
+
+    if month_start > current_month_start:
+        raise ValueError(f"month {month_str} is in the future")
+
+    if month_start == current_month_start:
+        # MTD: aggregate completed UTC days only (yesterday-UTC and earlier).
+        today_utc = now.date()
+        as_of = today_utc.fromordinal(today_utc.toordinal() - 1)
+        if as_of < month_start:
+            # First UTC day of the month — no completed days yet.
+            as_of = None
+        return MonthWindow(month=month_start, is_mtd=True, as_of_date=as_of)
+
+    return MonthWindow(month=month_start, is_mtd=False, as_of_date=None)
+
+
+# ---------------------------------------------------------------------------
+# View #1 — Climatology map (VFR/MVFR/IFR/LIFR % per airport)
+# ---------------------------------------------------------------------------
+
+
+# Fields read for the category map. Both daily and monthly summaries have
+# all five; daily rows are SUM-ed for MTD, monthly rows are read as-is.
+_CATEGORY_FIELDS = ("n_obs", "n_vfr", "n_mvfr", "n_ifr", "n_lifr")
+
+
+def get_category_climatology(
+    db: Session,
+    window: MonthWindow,
+    airports_db_path: str,
+) -> dict[str, Any]:
+    """Return per-airport flight-category counts and percentages.
+
+    Response shape (one entry per watchlist airport that has rows AND a
+    coord; airports with no data are omitted — the frontend renders them
+    as grey markers using the watchlist as the source of truth):
+
+        {
+          "month": "2026-05",
+          "is_mtd": True,
+          "as_of_date": "2026-05-18",  # only when is_mtd=True
+          "airports": [
+            {"icao": "EGKK", "lat": 51.1, "lon": 0.2,
+             "n_obs": 421, "n_vfr": 320, "n_mvfr": 60, "n_ifr": 30, "n_lifr": 11,
+             "pct_vfr": 76.0, "pct_mvfr": 14.3, "pct_ifr": 7.1, "pct_lifr": 2.6},
+            ...
+          ]
+        }
+    """
+    rows = _read_counts_by_icao(db, window, _CATEGORY_FIELDS)
+    coords = _get_coords(airports_db_path)
+
+    # Enumerate the full watchlist so airports without data still plot
+    # (rendered grey by the frontend). Issue #155 DoD: "all 830 airports
+    # plot correctly; airports with no data are styled distinctly".
+    airports: list[dict[str, Any]] = []
+    for icao in sorted(coords):
+        lat, lon = coords[icao]
+        counts = rows.get(icao)
+        entry: dict[str, Any] = {"icao": icao, "lat": lat, "lon": lon}
+        if counts is None:
+            entry.update({f: 0 for f in _CATEGORY_FIELDS})
+        else:
+            entry.update(counts)
+            n_obs = counts["n_obs"] or 0
+            if n_obs > 0:
+                entry["pct_vfr"] = round(100.0 * counts["n_vfr"] / n_obs, 1)
+                entry["pct_mvfr"] = round(100.0 * counts["n_mvfr"] / n_obs, 1)
+                entry["pct_ifr"] = round(100.0 * counts["n_ifr"] / n_obs, 1)
+                entry["pct_lifr"] = round(100.0 * counts["n_lifr"] / n_obs, 1)
+        airports.append(entry)
+
+    response: dict[str, Any] = {
+        "month": window.month.strftime("%Y-%m"),
+        "is_mtd": window.is_mtd,
+        "airports": airports,
+    }
+    if window.is_mtd and window.as_of_date is not None:
+        response["as_of_date"] = window.as_of_date.isoformat()
+    return response
+
+
+# ---------------------------------------------------------------------------
+# Shared read helper (count fields only — percentile fields go through a
+# separate path because they can't be SUM-ed across daily rows)
+# ---------------------------------------------------------------------------
+
+
+def _read_counts_by_icao(
+    db: Session,
+    window: MonthWindow,
+    fields: tuple[str, ...],
+) -> dict[str, dict[str, int]]:
+    """Return ``{icao: {field: count, ...}}`` for the resolved window.
+
+    For completed months reads ``airport_monthly_summary`` directly.
+    For MTD sums ``airport_daily_summary`` rows in the window. Both
+    paths return identical key shapes; the caller stays agnostic.
+    """
+    if window.is_mtd:
+        if window.as_of_date is None:
+            return {}
+        cols = [
+            AirportDailySummaryRow.icao,
+            *[func.sum(getattr(AirportDailySummaryRow, f)).label(f) for f in fields],
+        ]
+        stmt = (
+            select(*cols)
+            .where(AirportDailySummaryRow.date >= window.month)
+            .where(AirportDailySummaryRow.date <= window.as_of_date)
+            .group_by(AirportDailySummaryRow.icao)
+        )
+    else:
+        cols = [
+            AirportMonthlySummaryRow.icao,
+            *[getattr(AirportMonthlySummaryRow, f).label(f) for f in fields],
+        ]
+        # month is stored as a DATETIME at midnight UTC; compare on the date.
+        stmt = select(*cols).where(
+            func.date(AirportMonthlySummaryRow.month) == window.month
+        )
+
+    out: dict[str, dict[str, int]] = {}
+    for row in db.execute(stmt).all():
+        icao = row[0]
+        out[icao] = {field: int(getattr(row, field) or 0) for field in fields}
+    return out
+
+
+# ---------------------------------------------------------------------------
+# View #2 — Phenomena map (TS / fog)
+# ---------------------------------------------------------------------------
+
+_PHENOMENA_FIELDS = ("n_obs", "n_ts", "n_fg")
+
+
+def get_phenomena_climatology(
+    db: Session,
+    window: MonthWindow,
+    airports_db_path: str,
+    kind: str,
+) -> dict[str, Any]:
+    """Per-airport TS or fog frequency (``n_<kind> / n_obs``).
+
+    ``kind``: ``'ts'`` or ``'fog'``. The response shape is metric-agnostic
+    so the frontend can render all four datasets through one pipeline:
+
+        {
+          "month": "2026-04", "is_mtd": False,
+          "dataset": "phenomena", "metric": "ts", "unit": "%",
+          "airports": [
+            {"icao": "EGKK", "lat": ..., "lon": ...,
+             "value": 2.3,          # color driver (% TS)
+             "n_obs": 720, "n_ts": 17, "n_fg": 4},
+            ...
+          ]
+        }
+
+    ``value`` is the metric being color-coded; the extra count fields are
+    included for the popup. Airports with ``n_obs == 0`` get ``value = null``.
+    """
+    if kind not in ("ts", "fog"):
+        raise HTTPException(status_code=400, detail=f"kind must be 'ts' or 'fog'")
+    field = "n_ts" if kind == "ts" else "n_fg"
+
+    rows = _read_counts_by_icao(db, window, _PHENOMENA_FIELDS)
+    coords = _get_coords(airports_db_path)
+
+    airports: list[dict[str, Any]] = []
+    for icao in sorted(coords):
+        lat, lon = coords[icao]
+        entry: dict[str, Any] = {
+            "icao": icao, "lat": lat, "lon": lon,
+            "n_obs": 0, "n_ts": 0, "n_fg": 0, "value": None,
+        }
+        counts = rows.get(icao)
+        if counts is not None:
+            entry.update(counts)
+            n_obs = counts["n_obs"] or 0
+            if n_obs > 0:
+                entry["value"] = round(100.0 * counts[field] / n_obs, 2)
+        airports.append(entry)
+
+    return _envelope(window, dataset="phenomena", metric=kind, unit="%",
+                     airports=airports)
+
+
+# ---------------------------------------------------------------------------
+# View #3 — High-wind frequency map
+# ---------------------------------------------------------------------------
+
+WIND_METRICS = ("over25", "p95", "gust")
+# Metrics available in MTD mode (daily summary doesn't carry the others).
+WIND_METRICS_MTD = ("gust",)
+
+
+def get_wind_climatology(
+    db: Session,
+    window: MonthWindow,
+    airports_db_path: str,
+    metric: str,
+) -> dict[str, Any]:
+    """Per-airport wind metric.
+
+    Metrics:
+      - ``over25``: ``n_wind_over_25kt / n_obs`` (%). Completed months only —
+        daily summary doesn't carry the per-row hour count, so MTD cannot
+        reconstruct it without joining raw observations.
+      - ``p95``: wind_p95_kt (kt). Completed months only — percentiles
+        can't be SUM-ed across daily rows.
+      - ``gust``: gust_max_kt (kt). Both modes; MTD uses ``MAX(gust_max_kt)``
+        across daily rows.
+
+    400 if the metric is requested in MTD when unavailable.
+    """
+    if metric not in WIND_METRICS:
+        raise HTTPException(
+            status_code=400, detail=f"metric must be one of {WIND_METRICS}",
+        )
+    if window.is_mtd and metric not in WIND_METRICS_MTD:
+        raise HTTPException(
+            status_code=400,
+            detail=f"metric '{metric}' is not available month-to-date "
+                   f"(available MTD: {WIND_METRICS_MTD})",
+        )
+
+    coords = _get_coords(airports_db_path)
+    if window.is_mtd:
+        # MTD: only 'gust' lands here. Read MAX(gust_max_kt) per airport.
+        if window.as_of_date is None:
+            values: dict[str, int | None] = {}
+        else:
+            stmt = (
+                select(
+                    AirportDailySummaryRow.icao,
+                    func.max(AirportDailySummaryRow.gust_max_kt).label("gust"),
+                )
+                .where(AirportDailySummaryRow.date >= window.month)
+                .where(AirportDailySummaryRow.date <= window.as_of_date)
+                .group_by(AirportDailySummaryRow.icao)
+            )
+            values = {row[0]: row[1] for row in db.execute(stmt).all()}
+    else:
+        # Completed month: straight read from monthly summary.
+        select_col = {
+            "over25": AirportMonthlySummaryRow.n_wind_over_25kt,
+            "p95":    AirportMonthlySummaryRow.wind_p95_kt,
+            "gust":   AirportMonthlySummaryRow.gust_max_kt,
+        }[metric]
+        # We also fetch n_obs so we can compute n_wind_over_25kt as a percentage.
+        stmt = select(
+            AirportMonthlySummaryRow.icao,
+            select_col.label("raw"),
+            AirportMonthlySummaryRow.n_obs.label("n_obs"),
+        ).where(func.date(AirportMonthlySummaryRow.month) == window.month)
+        rows = {r[0]: (r[1], r[2]) for r in db.execute(stmt).all()}
+        values = {icao: tup[0] for icao, tup in rows.items()}
+        n_obs_by_icao = {icao: tup[1] for icao, tup in rows.items()}
+
+    airports: list[dict[str, Any]] = []
+    unit = "%" if metric == "over25" else "kt"
+    for icao in sorted(coords):
+        lat, lon = coords[icao]
+        raw = values.get(icao)
+        if raw is None:
+            value: float | None = None
+        elif metric == "over25":
+            # Convert count → percentage of observations.
+            n_obs = n_obs_by_icao.get(icao, 0) or 0
+            value = round(100.0 * raw / n_obs, 2) if n_obs > 0 else None
+        else:
+            value = round(float(raw), 1)
+        airports.append({
+            "icao": icao, "lat": lat, "lon": lon, "value": value, "raw": raw,
+        })
+
+    return _envelope(window, dataset="wind", metric=metric, unit=unit,
+                     airports=airports)
+
+
+# ---------------------------------------------------------------------------
+# View #4 — Volatility map + leaderboard
+# ---------------------------------------------------------------------------
+
+_VOLATILITY_FIELDS = ("n_obs", "n_category_changes")
+# Monthly summary stores the SUM of within-day transitions as `category_changes`.
+_VOLATILITY_FIELDS_MONTHLY = ("n_obs", "category_changes")
+
+# Minimum observation count an airport needs before it can rank on the
+# leaderboard — keeps sparse-data outliers (a handful of obs with one
+# flip) from dominating the top of the list.
+_VOLATILITY_MIN_OBS_COMPLETED = 100
+_VOLATILITY_MIN_OBS_MTD = 50
+
+
+def get_volatility_climatology(
+    db: Session,
+    window: MonthWindow,
+    airports_db_path: str,
+) -> dict[str, Any]:
+    """Per-airport ``category_changes / n_obs`` (transitions per observation).
+
+    Stored as ``n_category_changes`` on daily and ``category_changes`` on
+    monthly — the column rename is hidden inside this function.
+    """
+    if window.is_mtd:
+        rows = _read_counts_by_icao(db, window, _VOLATILITY_FIELDS)
+        changes_field = "n_category_changes"
+    else:
+        rows = _read_counts_by_icao(db, window, _VOLATILITY_FIELDS_MONTHLY)
+        changes_field = "category_changes"
+
+    coords = _get_coords(airports_db_path)
+    airports: list[dict[str, Any]] = []
+    for icao in sorted(coords):
+        lat, lon = coords[icao]
+        entry: dict[str, Any] = {
+            "icao": icao, "lat": lat, "lon": lon,
+            "n_obs": 0, "n_changes": 0, "value": None,
+        }
+        counts = rows.get(icao)
+        if counts is not None:
+            n_obs = counts["n_obs"] or 0
+            n_changes = counts[changes_field] or 0
+            entry["n_obs"] = n_obs
+            entry["n_changes"] = n_changes
+            if n_obs > 0:
+                entry["value"] = round(n_changes / n_obs, 3)
+        airports.append(entry)
+
+    return _envelope(window, dataset="volatility", metric="changes_per_obs",
+                     unit="ratio", airports=airports)
+
+
+def get_volatility_leaderboard(
+    db: Session,
+    window: MonthWindow,
+    airports_db_path: str,
+    limit: int = 20,
+) -> dict[str, Any]:
+    """Return the top ``limit`` airports ranked by ``category_changes / n_obs``.
+
+    Min-obs gate excludes sparse-data outliers (see ``_VOLATILITY_MIN_OBS_*``).
+    """
+    if window.is_mtd:
+        rows = _read_counts_by_icao(db, window, _VOLATILITY_FIELDS)
+        changes_field = "n_category_changes"
+        min_obs = _VOLATILITY_MIN_OBS_MTD
+    else:
+        rows = _read_counts_by_icao(db, window, _VOLATILITY_FIELDS_MONTHLY)
+        changes_field = "category_changes"
+        min_obs = _VOLATILITY_MIN_OBS_COMPLETED
+
+    ranked: list[dict[str, Any]] = []
+    for icao, counts in rows.items():
+        n_obs = counts["n_obs"] or 0
+        n_changes = counts[changes_field] or 0
+        if n_obs < min_obs:
+            continue
+        ranked.append({
+            "icao": icao,
+            "n_obs": n_obs,
+            "n_changes": n_changes,
+            "value": round(n_changes / n_obs, 3),
+        })
+    ranked.sort(key=lambda r: (-r["value"], r["icao"]))
+    ranked = ranked[:limit]
+
+    return {
+        "month": window.month.strftime("%Y-%m"),
+        "is_mtd": window.is_mtd,
+        **({"as_of_date": window.as_of_date.isoformat()}
+           if window.is_mtd and window.as_of_date else {}),
+        "min_n_obs": min_obs,
+        "rows": ranked,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Shared response envelope
+# ---------------------------------------------------------------------------
+
+
+def _envelope(
+    window: MonthWindow,
+    *,
+    dataset: str,
+    metric: str,
+    unit: str,
+    airports: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Common map-response wrapper used by views #2, #3, #4."""
+    response: dict[str, Any] = {
+        "month": window.month.strftime("%Y-%m"),
+        "is_mtd": window.is_mtd,
+        "dataset": dataset,
+        "metric": metric,
+        "unit": unit,
+        "airports": airports,
+    }
+    if window.is_mtd and window.as_of_date is not None:
+        response["as_of_date"] = window.as_of_date.isoformat()
+    return response

--- a/tests/test_climatology_queries.py
+++ b/tests/test_climatology_queries.py
@@ -1,0 +1,515 @@
+"""Tests for the climatology helper + view #1 endpoint (issue #155)."""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy.orm import sessionmaker
+from starlette.testclient import TestClient
+
+from weatherbrief.api.app import create_app  # noqa: F401 (avoid circular import)
+from flyfun_common.db import DEV_USER_ID, current_user_id, get_db
+from flyfun_common.db.models import UserPreferencesRow, UserRow
+from weatherbrief.db.models import (
+    AirportDailySummaryRow,
+    AirportMonthlySummaryRow,
+)
+from weatherbrief.tasks.climatology_queries import (
+    MonthWindow,
+    get_category_climatology,
+    get_phenomena_climatology,
+    get_volatility_climatology,
+    get_volatility_leaderboard,
+    get_wind_climatology,
+    resolve_month_window,
+)
+
+
+FAKE_COORDS = {
+    "EGKK": (51.15, -0.19),
+    "LFPG": (49.01, 2.55),
+    "EDDF": (50.03, 8.57),
+}
+
+
+@pytest.fixture
+def db_engine():
+    """Per-test engine — these tests call db_session.commit()."""
+    from conftest import make_app_engine
+    engine = make_app_engine()
+    yield engine
+    engine.dispose()
+
+
+# ---------------------------------------------------------------------------
+# resolve_month_window
+# ---------------------------------------------------------------------------
+
+
+class TestResolveMonthWindow:
+    def test_completed_month(self):
+        now = datetime(2026, 5, 19, 12, 0, tzinfo=timezone.utc)
+        w = resolve_month_window("2026-04", now_utc=now)
+        assert w == MonthWindow(month=date(2026, 4, 1), is_mtd=False, as_of_date=None)
+
+    def test_current_month_is_mtd(self):
+        now = datetime(2026, 5, 19, 12, 0, tzinfo=timezone.utc)
+        w = resolve_month_window("2026-05", now_utc=now)
+        assert w.is_mtd is True
+        assert w.month == date(2026, 5, 1)
+        assert w.as_of_date == date(2026, 5, 18)  # yesterday-UTC
+
+    def test_first_of_month_has_no_completed_days(self):
+        now = datetime(2026, 5, 1, 6, 0, tzinfo=timezone.utc)
+        w = resolve_month_window("2026-05", now_utc=now)
+        assert w.is_mtd is True
+        assert w.as_of_date is None
+
+    def test_future_month_rejected(self):
+        now = datetime(2026, 5, 19, 12, 0, tzinfo=timezone.utc)
+        with pytest.raises(ValueError, match="future"):
+            resolve_month_window("2026-06", now_utc=now)
+
+    def test_malformed_rejected(self):
+        with pytest.raises(ValueError, match="YYYY-MM"):
+            resolve_month_window("not-a-month")
+
+
+# ---------------------------------------------------------------------------
+# get_category_climatology
+# ---------------------------------------------------------------------------
+
+
+def _seed_monthly(db, *, icao, month, **counts):
+    defaults = dict(
+        n_obs=0, n_vfr=0, n_mvfr=0, n_ifr=0, n_lifr=0,
+        n_ts=0, n_fg=0, n_wind_over_25kt=0, category_changes=0,
+    )
+    defaults.update(counts)
+    db.add(AirportMonthlySummaryRow(
+        icao=icao,
+        month=datetime(month.year, month.month, 1, tzinfo=timezone.utc),
+        **defaults,
+    ))
+
+
+def _seed_daily(db, *, icao, day, **counts):
+    defaults = dict(
+        n_obs=0, n_vfr=0, n_mvfr=0, n_ifr=0, n_lifr=0,
+        n_ts=0, n_fg=0, n_category_changes=0,
+    )
+    defaults.update(counts)
+    db.add(AirportDailySummaryRow(icao=icao, date=day, **defaults))
+
+
+@patch(
+    "weatherbrief.tasks.climatology_queries._get_coords",
+    return_value=FAKE_COORDS,
+)
+class TestGetCategoryClimatology:
+    def test_completed_month_reads_monthly_summary(self, _mock_coords, db_session):
+        # April 2026 — fully completed
+        _seed_monthly(db_session, icao="EGKK", month=date(2026, 4, 1),
+                      n_obs=100, n_vfr=80, n_mvfr=10, n_ifr=7, n_lifr=3)
+        _seed_monthly(db_session, icao="LFPG", month=date(2026, 4, 1),
+                      n_obs=200, n_vfr=100, n_mvfr=50, n_ifr=40, n_lifr=10)
+        db_session.commit()
+
+        window = MonthWindow(month=date(2026, 4, 1), is_mtd=False, as_of_date=None)
+        result = get_category_climatology(db_session, window, "/fake/airports.db")
+
+        assert result["month"] == "2026-04"
+        assert result["is_mtd"] is False
+        assert "as_of_date" not in result
+        airports = {a["icao"]: a for a in result["airports"]}
+        assert airports["EGKK"]["n_obs"] == 100
+        assert airports["EGKK"]["pct_vfr"] == 80.0
+        assert airports["LFPG"]["pct_ifr"] == 20.0
+
+    def test_mtd_sums_daily_summary(self, _mock_coords, db_session):
+        # May 2026 — MTD through May 3
+        for day, n_vfr in [(date(2026, 5, 1), 20), (date(2026, 5, 2), 15),
+                           (date(2026, 5, 3), 10)]:
+            _seed_daily(db_session, icao="EGKK", day=day,
+                        n_obs=24, n_vfr=n_vfr,
+                        n_mvfr=24 - n_vfr - 2, n_ifr=1, n_lifr=1)
+        db_session.commit()
+
+        window = MonthWindow(
+            month=date(2026, 5, 1), is_mtd=True, as_of_date=date(2026, 5, 3),
+        )
+        result = get_category_climatology(db_session, window, "/fake/airports.db")
+
+        assert result["is_mtd"] is True
+        assert result["as_of_date"] == "2026-05-03"
+        airports = {a["icao"]: a for a in result["airports"]}
+        # SUM check: 3 days × 24 obs = 72, vfr = 20+15+10 = 45
+        assert airports["EGKK"]["n_obs"] == 72
+        assert airports["EGKK"]["n_vfr"] == 45
+        assert airports["EGKK"]["pct_vfr"] == round(100.0 * 45 / 72, 1)
+
+    def test_mtd_excludes_dates_outside_window(self, _mock_coords, db_session):
+        # April rows should not appear in May MTD result
+        _seed_daily(db_session, icao="EGKK", day=date(2026, 4, 30),
+                    n_obs=24, n_vfr=24)
+        _seed_daily(db_session, icao="EGKK", day=date(2026, 5, 1),
+                    n_obs=24, n_vfr=10, n_mvfr=14)
+        db_session.commit()
+
+        window = MonthWindow(
+            month=date(2026, 5, 1), is_mtd=True, as_of_date=date(2026, 5, 1),
+        )
+        result = get_category_climatology(db_session, window, "/fake/airports.db")
+        airports = {a["icao"]: a for a in result["airports"]}
+        assert airports["EGKK"]["n_obs"] == 24  # not 48
+        assert airports["EGKK"]["n_vfr"] == 10
+
+    def test_skips_airports_without_coords(self, _mock_coords, db_session):
+        _seed_monthly(db_session, icao="ZZZZ", month=date(2026, 4, 1),
+                      n_obs=10, n_vfr=10)
+        db_session.commit()
+        window = MonthWindow(month=date(2026, 4, 1), is_mtd=False, as_of_date=None)
+        result = get_category_climatology(db_session, window, "/fake/airports.db")
+        assert all(a["icao"] != "ZZZZ" for a in result["airports"])
+
+    def test_empty_mtd_when_no_completed_days(self, _mock_coords, db_session):
+        window = MonthWindow(month=date(2026, 5, 1), is_mtd=True, as_of_date=None)
+        result = get_category_climatology(db_session, window, "/fake/airports.db")
+        # All watchlist airports still plot (with zero counts); none has data.
+        assert len(result["airports"]) == len(FAKE_COORDS)
+        assert all(a["n_obs"] == 0 for a in result["airports"])
+        assert all("pct_vfr" not in a for a in result["airports"])
+
+
+# ---------------------------------------------------------------------------
+# Endpoint test (mirrors test_map_queries _make_client pattern)
+# ---------------------------------------------------------------------------
+
+
+TEST_SECRET = "test-jwt-secret"
+
+
+@pytest.fixture
+def app_db():
+    from conftest import make_app_engine
+    engine = make_app_engine()
+    TestSession = sessionmaker(bind=engine)
+    session = TestSession()
+    session.add(UserRow(
+        id=DEV_USER_ID, provider="local", provider_sub="dev",
+        email="dev@localhost", display_name="Dev User", approved=True,
+    ))
+    session.flush()
+    session.add(UserPreferencesRow(user_id=DEV_USER_ID))
+    session.commit()
+    session.close()
+    yield TestSession
+    engine.dispose()
+
+
+def _make_client(app_db, tmp_path, monkeypatch):
+    monkeypatch.setenv("DATA_DIR", str(tmp_path / "data"))
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.setenv("JWT_SECRET", TEST_SECRET)
+    monkeypatch.setenv("ADMIN_EMAILS", "admin@test.com")
+    monkeypatch.setenv("DISABLE_SCHEDULER", "1")
+    monkeypatch.setenv("DISABLE_RETENTION", "1")
+    monkeypatch.setenv("DISABLE_VERIFICATION", "1")
+    monkeypatch.setenv("DISABLE_DIGEST", "1")
+    monkeypatch.setenv("DISABLE_STANDALONE_VERIFICATION", "1")
+
+    app = create_app()
+
+    def _override_get_db():
+        session = app_db()
+        try:
+            yield session
+            session.commit()
+        except Exception:
+            session.rollback()
+            raise
+        finally:
+            session.close()
+
+    app.dependency_overrides[get_db] = _override_get_db
+    app.dependency_overrides[current_user_id] = lambda: DEV_USER_ID
+    return TestClient(app, raise_server_exceptions=False)
+
+
+@patch(
+    "weatherbrief.tasks.climatology_queries._get_coords",
+    return_value=FAKE_COORDS,
+)
+class TestCategoryEndpoint:
+    def test_returns_completed_month(self, _mock_coords, app_db, tmp_path, monkeypatch):
+        client = _make_client(app_db, tmp_path, monkeypatch)
+        session = app_db()
+        _seed_monthly(session, icao="EGKK", month=date(2026, 4, 1),
+                      n_obs=100, n_vfr=80, n_mvfr=10, n_ifr=7, n_lifr=3)
+        session.commit()
+        session.close()
+
+        resp = client.get("/api/climatology/category?month=2026-04")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["month"] == "2026-04"
+        assert data["is_mtd"] is False
+        # All watchlist airports plot; only EGKK has data this test.
+        assert len(data["airports"]) == len(FAKE_COORDS)
+        by_icao = {a["icao"]: a for a in data["airports"]}
+        assert by_icao["EGKK"]["pct_vfr"] == 80.0
+        assert "pct_vfr" not in by_icao["LFPG"]   # no data → no pct fields
+
+    def test_rejects_bad_month(self, _mock_coords, app_db, tmp_path, monkeypatch):
+        client = _make_client(app_db, tmp_path, monkeypatch)
+        resp = client.get("/api/climatology/category?month=bogus")
+        assert resp.status_code == 400
+
+    def test_rejects_future_month(self, _mock_coords, app_db, tmp_path, monkeypatch):
+        client = _make_client(app_db, tmp_path, monkeypatch)
+        resp = client.get("/api/climatology/category?month=2099-12")
+        assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# View #2 — Phenomena (TS / fog)
+# ---------------------------------------------------------------------------
+
+
+@patch(
+    "weatherbrief.tasks.climatology_queries._get_coords",
+    return_value=FAKE_COORDS,
+)
+class TestPhenomenaClimatology:
+    def test_ts_percentage(self, _mock_coords, db_session):
+        _seed_monthly(db_session, icao="EGKK", month=date(2026, 4, 1),
+                      n_obs=1000, n_ts=23, n_fg=4)
+        db_session.commit()
+        window = MonthWindow(month=date(2026, 4, 1), is_mtd=False, as_of_date=None)
+        result = get_phenomena_climatology(db_session, window, "/fake/airports.db", "ts")
+        assert result["dataset"] == "phenomena"
+        assert result["metric"] == "ts"
+        assert result["unit"] == "%"
+        by_icao = {a["icao"]: a for a in result["airports"]}
+        assert by_icao["EGKK"]["value"] == 2.3
+        assert by_icao["EGKK"]["n_ts"] == 23
+
+    def test_fog_percentage(self, _mock_coords, db_session):
+        _seed_monthly(db_session, icao="EGKK", month=date(2026, 4, 1),
+                      n_obs=720, n_fg=18)
+        db_session.commit()
+        window = MonthWindow(month=date(2026, 4, 1), is_mtd=False, as_of_date=None)
+        result = get_phenomena_climatology(db_session, window, "/fake/airports.db", "fog")
+        assert result["metric"] == "fog"
+        by_icao = {a["icao"]: a for a in result["airports"]}
+        assert by_icao["EGKK"]["value"] == 2.5
+
+    def test_invalid_kind_400(self, _mock_coords, db_session):
+        from fastapi import HTTPException
+        window = MonthWindow(month=date(2026, 4, 1), is_mtd=False, as_of_date=None)
+        with pytest.raises(HTTPException) as exc:
+            get_phenomena_climatology(db_session, window, "/fake/airports.db", "snow")
+        assert exc.value.status_code == 400
+
+    def test_mtd_sums_ts_from_daily(self, _mock_coords, db_session):
+        for d, n_ts in [(date(2026, 5, 1), 2), (date(2026, 5, 2), 5)]:
+            _seed_daily(db_session, icao="EGKK", day=d, n_obs=24, n_ts=n_ts)
+        db_session.commit()
+        window = MonthWindow(month=date(2026, 5, 1), is_mtd=True,
+                             as_of_date=date(2026, 5, 2))
+        result = get_phenomena_climatology(db_session, window, "/fake/airports.db", "ts")
+        by_icao = {a["icao"]: a for a in result["airports"]}
+        # 7 ts events / 48 obs * 100 ≈ 14.58
+        assert by_icao["EGKK"]["n_ts"] == 7
+        assert by_icao["EGKK"]["value"] == round(100.0 * 7 / 48, 2)
+
+
+# ---------------------------------------------------------------------------
+# View #3 — Wind
+# ---------------------------------------------------------------------------
+
+
+@patch(
+    "weatherbrief.tasks.climatology_queries._get_coords",
+    return_value=FAKE_COORDS,
+)
+class TestWindClimatology:
+    def test_over25_as_percentage(self, _mock_coords, db_session):
+        _seed_monthly(db_session, icao="EGKK", month=date(2026, 4, 1),
+                      n_obs=720, n_wind_over_25kt=72)
+        db_session.commit()
+        window = MonthWindow(month=date(2026, 4, 1), is_mtd=False, as_of_date=None)
+        result = get_wind_climatology(db_session, window, "/fake/airports.db", "over25")
+        assert result["unit"] == "%"
+        by_icao = {a["icao"]: a for a in result["airports"]}
+        assert by_icao["EGKK"]["value"] == 10.0
+
+    def test_p95_returns_kt(self, _mock_coords, db_session):
+        _seed_monthly(db_session, icao="EGKK", month=date(2026, 4, 1),
+                      n_obs=720, wind_p95_kt=28.5)
+        db_session.commit()
+        window = MonthWindow(month=date(2026, 4, 1), is_mtd=False, as_of_date=None)
+        result = get_wind_climatology(db_session, window, "/fake/airports.db", "p95")
+        assert result["unit"] == "kt"
+        by_icao = {a["icao"]: a for a in result["airports"]}
+        assert by_icao["EGKK"]["value"] == 28.5
+
+    def test_gust_max_completed(self, _mock_coords, db_session):
+        _seed_monthly(db_session, icao="EGKK", month=date(2026, 4, 1),
+                      n_obs=720, gust_max_kt=47)
+        db_session.commit()
+        window = MonthWindow(month=date(2026, 4, 1), is_mtd=False, as_of_date=None)
+        result = get_wind_climatology(db_session, window, "/fake/airports.db", "gust")
+        by_icao = {a["icao"]: a for a in result["airports"]}
+        assert by_icao["EGKK"]["value"] == 47.0
+
+    def test_gust_max_mtd_uses_max_not_sum(self, _mock_coords, db_session):
+        # MAX semantics: peak gust across days, not the sum.
+        for d, gust in [(date(2026, 5, 1), 30), (date(2026, 5, 2), 55),
+                        (date(2026, 5, 3), 22)]:
+            _seed_daily(db_session, icao="EGKK", day=d, n_obs=24, gust_max_kt=gust)
+        db_session.commit()
+        window = MonthWindow(month=date(2026, 5, 1), is_mtd=True,
+                             as_of_date=date(2026, 5, 3))
+        result = get_wind_climatology(db_session, window, "/fake/airports.db", "gust")
+        by_icao = {a["icao"]: a for a in result["airports"]}
+        assert by_icao["EGKK"]["value"] == 55.0
+
+    def test_mtd_rejects_over25(self, _mock_coords, db_session):
+        from fastapi import HTTPException
+        window = MonthWindow(month=date(2026, 5, 1), is_mtd=True,
+                             as_of_date=date(2026, 5, 1))
+        with pytest.raises(HTTPException) as exc:
+            get_wind_climatology(db_session, window, "/fake/airports.db", "over25")
+        assert exc.value.status_code == 400
+        assert "month-to-date" in str(exc.value.detail).lower()
+
+    def test_mtd_rejects_p95(self, _mock_coords, db_session):
+        from fastapi import HTTPException
+        window = MonthWindow(month=date(2026, 5, 1), is_mtd=True,
+                             as_of_date=date(2026, 5, 1))
+        with pytest.raises(HTTPException) as exc:
+            get_wind_climatology(db_session, window, "/fake/airports.db", "p95")
+        assert exc.value.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# View #4 — Volatility
+# ---------------------------------------------------------------------------
+
+
+@patch(
+    "weatherbrief.tasks.climatology_queries._get_coords",
+    return_value=FAKE_COORDS,
+)
+class TestVolatility:
+    def test_completed_month_uses_category_changes_column(self, _mock_coords, db_session):
+        _seed_monthly(db_session, icao="EGKK", month=date(2026, 4, 1),
+                      n_obs=720, category_changes=48)
+        db_session.commit()
+        window = MonthWindow(month=date(2026, 4, 1), is_mtd=False, as_of_date=None)
+        result = get_volatility_climatology(db_session, window, "/fake/airports.db")
+        by_icao = {a["icao"]: a for a in result["airports"]}
+        # 48 / 720 = 0.067
+        assert by_icao["EGKK"]["value"] == round(48 / 720, 3)
+        assert by_icao["EGKK"]["n_changes"] == 48
+
+    def test_mtd_sums_n_category_changes(self, _mock_coords, db_session):
+        for d, chg in [(date(2026, 5, 1), 3), (date(2026, 5, 2), 5)]:
+            _seed_daily(db_session, icao="EGKK", day=d,
+                        n_obs=24, n_category_changes=chg)
+        db_session.commit()
+        window = MonthWindow(month=date(2026, 5, 1), is_mtd=True,
+                             as_of_date=date(2026, 5, 2))
+        result = get_volatility_climatology(db_session, window, "/fake/airports.db")
+        by_icao = {a["icao"]: a for a in result["airports"]}
+        assert by_icao["EGKK"]["n_changes"] == 8
+        assert by_icao["EGKK"]["value"] == round(8 / 48, 3)
+
+    def test_leaderboard_min_obs_filter(self, _mock_coords, db_session):
+        # 50 obs is below the completed-month min (100) — should be filtered out.
+        _seed_monthly(db_session, icao="EGKK", month=date(2026, 4, 1),
+                      n_obs=50, category_changes=10)
+        _seed_monthly(db_session, icao="LFPG", month=date(2026, 4, 1),
+                      n_obs=200, category_changes=20)
+        db_session.commit()
+        window = MonthWindow(month=date(2026, 4, 1), is_mtd=False, as_of_date=None)
+        result = get_volatility_leaderboard(db_session, window, "/fake/airports.db", limit=10)
+        icaos = [r["icao"] for r in result["rows"]]
+        assert "EGKK" not in icaos
+        assert "LFPG" in icaos
+        assert result["min_n_obs"] == 100
+
+    def test_leaderboard_ranks_by_value_desc(self, _mock_coords, db_session):
+        _seed_monthly(db_session, icao="EGKK", month=date(2026, 4, 1),
+                      n_obs=200, category_changes=40)  # 0.2
+        _seed_monthly(db_session, icao="LFPG", month=date(2026, 4, 1),
+                      n_obs=200, category_changes=10)  # 0.05
+        _seed_monthly(db_session, icao="EDDF", month=date(2026, 4, 1),
+                      n_obs=200, category_changes=60)  # 0.3
+        db_session.commit()
+        window = MonthWindow(month=date(2026, 4, 1), is_mtd=False, as_of_date=None)
+        result = get_volatility_leaderboard(db_session, window, "/fake/airports.db", limit=10)
+        icaos = [r["icao"] for r in result["rows"]]
+        assert icaos == ["EDDF", "EGKK", "LFPG"]
+
+
+# ---------------------------------------------------------------------------
+# Endpoint smoke tests for the new routes
+# ---------------------------------------------------------------------------
+
+
+@patch(
+    "weatherbrief.tasks.climatology_queries._get_coords",
+    return_value=FAKE_COORDS,
+)
+class TestNewEndpoints:
+    def test_phenomena_endpoint(self, _mock_coords, app_db, tmp_path, monkeypatch):
+        client = _make_client(app_db, tmp_path, monkeypatch)
+        session = app_db()
+        _seed_monthly(session, icao="EGKK", month=date(2026, 4, 1),
+                      n_obs=720, n_ts=18, n_fg=9)
+        session.commit()
+        session.close()
+
+        resp = client.get("/api/climatology/phenomena?month=2026-04&kind=ts")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["dataset"] == "phenomena"
+        assert data["metric"] == "ts"
+
+    def test_wind_endpoint_rejects_mtd_over25(self, _mock_coords, app_db, tmp_path, monkeypatch):
+        client = _make_client(app_db, tmp_path, monkeypatch)
+        now = datetime.now(timezone.utc)
+        current_month = now.strftime("%Y-%m")
+        resp = client.get(f"/api/climatology/wind?month={current_month}&metric=over25")
+        assert resp.status_code == 400
+
+    def test_volatility_endpoint(self, _mock_coords, app_db, tmp_path, monkeypatch):
+        client = _make_client(app_db, tmp_path, monkeypatch)
+        session = app_db()
+        _seed_monthly(session, icao="EGKK", month=date(2026, 4, 1),
+                      n_obs=720, category_changes=48)
+        session.commit()
+        session.close()
+
+        resp = client.get("/api/climatology/volatility?month=2026-04")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["dataset"] == "volatility"
+
+    def test_volatility_leaderboard_endpoint(self, _mock_coords, app_db, tmp_path, monkeypatch):
+        client = _make_client(app_db, tmp_path, monkeypatch)
+        session = app_db()
+        _seed_monthly(session, icao="EGKK", month=date(2026, 4, 1),
+                      n_obs=200, category_changes=40)
+        session.commit()
+        session.close()
+
+        resp = client.get("/api/climatology/volatility/top?month=2026-04&limit=5")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "rows" in data
+        assert any(r["icao"] == "EGKK" for r in data["rows"])

--- a/tests/test_climatology_queries.py
+++ b/tests/test_climatology_queries.py
@@ -19,9 +19,9 @@ from weatherbrief.db.models import (
 from weatherbrief.tasks.climatology_queries import (
     MonthWindow,
     get_category_climatology,
+    get_leaderboard,
     get_phenomena_climatology,
     get_volatility_climatology,
-    get_volatility_leaderboard,
     get_wind_climatology,
     resolve_month_window,
 )
@@ -428,7 +428,7 @@ class TestVolatility:
         assert by_icao["EGKK"]["n_changes"] == 8
         assert by_icao["EGKK"]["value"] == round(8 / 48, 3)
 
-    def test_leaderboard_min_obs_filter(self, _mock_coords, db_session):
+    def test_volatility_leaderboard_min_obs_filter(self, _mock_coords, db_session):
         # 50 obs is below the completed-month min (100) — should be filtered out.
         _seed_monthly(db_session, icao="EGKK", month=date(2026, 4, 1),
                       n_obs=50, category_changes=10)
@@ -436,13 +436,14 @@ class TestVolatility:
                       n_obs=200, category_changes=20)
         db_session.commit()
         window = MonthWindow(month=date(2026, 4, 1), is_mtd=False, as_of_date=None)
-        result = get_volatility_leaderboard(db_session, window, "/fake/airports.db", limit=10)
+        result = get_leaderboard(db_session, window, "/fake/airports.db",
+                                 dataset="volatility", sub=None, limit=10)
         icaos = [r["icao"] for r in result["rows"]]
         assert "EGKK" not in icaos
         assert "LFPG" in icaos
         assert result["min_n_obs"] == 100
 
-    def test_leaderboard_ranks_by_value_desc(self, _mock_coords, db_session):
+    def test_volatility_leaderboard_ranks_by_value_desc(self, _mock_coords, db_session):
         _seed_monthly(db_session, icao="EGKK", month=date(2026, 4, 1),
                       n_obs=200, category_changes=40)  # 0.2
         _seed_monthly(db_session, icao="LFPG", month=date(2026, 4, 1),
@@ -451,9 +452,91 @@ class TestVolatility:
                       n_obs=200, category_changes=60)  # 0.3
         db_session.commit()
         window = MonthWindow(month=date(2026, 4, 1), is_mtd=False, as_of_date=None)
-        result = get_volatility_leaderboard(db_session, window, "/fake/airports.db", limit=10)
+        result = get_leaderboard(db_session, window, "/fake/airports.db",
+                                 dataset="volatility", sub=None, limit=10)
         icaos = [r["icao"] for r in result["rows"]]
         assert icaos == ["EDDF", "EGKK", "LFPG"]
+
+
+# ---------------------------------------------------------------------------
+# Unified leaderboard — coverage for non-volatility datasets
+# ---------------------------------------------------------------------------
+
+
+@patch(
+    "weatherbrief.tasks.climatology_queries._get_coords",
+    return_value=FAKE_COORDS,
+)
+class TestUnifiedLeaderboard:
+    def test_category_vfr_ranks_highest_first(self, _mock_coords, db_session):
+        _seed_monthly(db_session, icao="EGKK", month=date(2026, 4, 1),
+                      n_obs=200, n_vfr=190)  # 95%
+        _seed_monthly(db_session, icao="LFPG", month=date(2026, 4, 1),
+                      n_obs=200, n_vfr=120)  # 60%
+        _seed_monthly(db_session, icao="EDDF", month=date(2026, 4, 1),
+                      n_obs=200, n_vfr=170)  # 85%
+        db_session.commit()
+        window = MonthWindow(month=date(2026, 4, 1), is_mtd=False, as_of_date=None)
+        result = get_leaderboard(db_session, window, "/fake/airports.db",
+                                 dataset="category", sub="vfr", limit=10)
+        icaos = [r["icao"] for r in result["rows"]]
+        assert icaos == ["EGKK", "EDDF", "LFPG"]
+        assert result["label"] == "VFR %"
+
+    def test_category_ifr_excludes_below_min_obs(self, _mock_coords, db_session):
+        _seed_monthly(db_session, icao="EGKK", month=date(2026, 4, 1),
+                      n_obs=200, n_ifr=20)  # 10%
+        _seed_monthly(db_session, icao="LFPG", month=date(2026, 4, 1),
+                      n_obs=50, n_ifr=40)   # 80% but only 50 obs
+        db_session.commit()
+        window = MonthWindow(month=date(2026, 4, 1), is_mtd=False, as_of_date=None)
+        result = get_leaderboard(db_session, window, "/fake/airports.db",
+                                 dataset="category", sub="ifr", limit=10)
+        icaos = [r["icao"] for r in result["rows"]]
+        assert "LFPG" not in icaos
+        assert icaos == ["EGKK"]
+
+    def test_phenomena_ts(self, _mock_coords, db_session):
+        _seed_monthly(db_session, icao="EGKK", month=date(2026, 4, 1),
+                      n_obs=200, n_ts=10)  # 5%
+        _seed_monthly(db_session, icao="LFPG", month=date(2026, 4, 1),
+                      n_obs=200, n_ts=2)   # 1%
+        db_session.commit()
+        window = MonthWindow(month=date(2026, 4, 1), is_mtd=False, as_of_date=None)
+        result = get_leaderboard(db_session, window, "/fake/airports.db",
+                                 dataset="phenomena", sub="ts", limit=10)
+        icaos = [r["icao"] for r in result["rows"]]
+        assert icaos == ["EGKK", "LFPG"]
+        assert result["unit"] == "%"
+
+    def test_wind_gust_includes_n_obs(self, _mock_coords, db_session):
+        _seed_monthly(db_session, icao="EGKK", month=date(2026, 4, 1),
+                      n_obs=200, gust_max_kt=55)
+        _seed_monthly(db_session, icao="LFPG", month=date(2026, 4, 1),
+                      n_obs=200, gust_max_kt=30)
+        db_session.commit()
+        window = MonthWindow(month=date(2026, 4, 1), is_mtd=False, as_of_date=None)
+        result = get_leaderboard(db_session, window, "/fake/airports.db",
+                                 dataset="wind", sub="gust", limit=10)
+        icaos = [r["icao"] for r in result["rows"]]
+        assert icaos == ["EGKK", "LFPG"]
+        assert result["rows"][0]["n_obs"] == 200
+
+    def test_invalid_dataset_400(self, _mock_coords, db_session):
+        from fastapi import HTTPException
+        window = MonthWindow(month=date(2026, 4, 1), is_mtd=False, as_of_date=None)
+        with pytest.raises(HTTPException) as exc:
+            get_leaderboard(db_session, window, "/fake/airports.db",
+                            dataset="bogus", sub=None, limit=10)
+        assert exc.value.status_code == 400
+
+    def test_invalid_sub_for_category_400(self, _mock_coords, db_session):
+        from fastapi import HTTPException
+        window = MonthWindow(month=date(2026, 4, 1), is_mtd=False, as_of_date=None)
+        with pytest.raises(HTTPException) as exc:
+            get_leaderboard(db_session, window, "/fake/airports.db",
+                            dataset="category", sub="bogus", limit=10)
+        assert exc.value.status_code == 400
 
 
 # ---------------------------------------------------------------------------
@@ -500,7 +583,7 @@ class TestNewEndpoints:
         data = resp.json()
         assert data["dataset"] == "volatility"
 
-    def test_volatility_leaderboard_endpoint(self, _mock_coords, app_db, tmp_path, monkeypatch):
+    def test_leaderboard_endpoint(self, _mock_coords, app_db, tmp_path, monkeypatch):
         client = _make_client(app_db, tmp_path, monkeypatch)
         session = app_db()
         _seed_monthly(session, icao="EGKK", month=date(2026, 4, 1),
@@ -508,8 +591,22 @@ class TestNewEndpoints:
         session.commit()
         session.close()
 
-        resp = client.get("/api/climatology/volatility/top?month=2026-04&limit=5")
+        resp = client.get("/api/climatology/leaderboard?month=2026-04&dataset=volatility&limit=5")
         assert resp.status_code == 200
         data = resp.json()
         assert "rows" in data
+        assert data["dataset"] == "volatility"
         assert any(r["icao"] == "EGKK" for r in data["rows"])
+
+    def test_leaderboard_category_vfr(self, _mock_coords, app_db, tmp_path, monkeypatch):
+        client = _make_client(app_db, tmp_path, monkeypatch)
+        session = app_db()
+        _seed_monthly(session, icao="EGKK", month=date(2026, 4, 1),
+                      n_obs=200, n_vfr=180)
+        session.commit()
+        session.close()
+        resp = client.get("/api/climatology/leaderboard?month=2026-04&dataset=category&sub=vfr")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["label"] == "VFR %"
+        assert data["rows"][0]["icao"] == "EGKK"

--- a/web/maps.html
+++ b/web/maps.html
@@ -56,6 +56,49 @@
 
     .map-wrapper { position: relative; }
 
+    /* Climatology sub-tabs (Map | Top airports) */
+    .settings-tabs-inner { margin-bottom: 0.75rem; }
+    .clim-subpanel { display: none; }
+    .clim-subpanel.active { display: block; }
+
+    .map-legend {
+      position: absolute; bottom: 20px; left: 12px; z-index: 1000;
+      background: var(--surface); border: 1px solid var(--border);
+      border-radius: 6px; padding: 0.5rem 0.7rem; font-size: 0.7rem;
+      color: var(--text); min-width: 110px;
+    }
+    .map-legend-title { font-weight: 600; margin-bottom: 0.3rem; font-size: 0.75rem; }
+    .legend-item { display: flex; align-items: center; gap: 0.35rem; margin: 0.12rem 0; }
+    .legend-dot {
+      width: 10px; height: 10px; border-radius: 50%;
+      flex-shrink: 0; border: 1px solid rgba(0,0,0,0.3);
+    }
+    .clim-popup-title { font-size: 0.95rem; margin-bottom: 0.3rem; }
+    .clim-popup-table { width: 100%; border-collapse: collapse; font-size: 0.8rem; }
+    .clim-popup-table td { padding: 0.1rem 0.25rem; }
+    .clim-popup-foot {
+      margin-top: 0.3rem; padding-top: 0.25rem;
+      border-top: 1px solid var(--border);
+      font-size: 0.7rem; color: var(--text-muted);
+    }
+
+    .clim-leaderboard-wrap { padding: 0.75rem 0.5rem; }
+    .clim-leaderboard-table {
+      width: 100%; border-collapse: collapse; font-size: 0.85rem;
+      font-variant-numeric: tabular-nums;
+    }
+    .clim-leaderboard-table th {
+      text-align: left; padding: 0.3rem 0.5rem;
+      border-bottom: 1px solid var(--border);
+      color: var(--text-muted); font-weight: 600; font-size: 0.75rem;
+      text-transform: uppercase; letter-spacing: 0.04em;
+    }
+    .clim-leaderboard-table td {
+      padding: 0.3rem 0.5rem;
+      border-bottom: 1px solid var(--border);
+    }
+    .clim-leaderboard-table tr:hover td { background: var(--bg); }
+
     /* --- Airport profile panel (right-click on a forecast marker) --- */
     /* Forecast tab switches to a 2-column grid when the panel is open;
      * the map keeps its existing height and the panel claims the right
@@ -348,6 +391,7 @@
     <div class="settings-tabs" id="tabs">
       <button class="tab-btn active" data-tab="forecast">Forecast Overview</button>
       <button class="tab-btn" data-tab="synoptic">Synoptic Forecast</button>
+      <button class="tab-btn" data-tab="climatology">Climatology</button>
       <button class="tab-btn" data-tab="stats">Accuracy Stats</button>
     </div>
 
@@ -465,6 +509,34 @@
         <div id="map-container-synoptic" style="width:100%; height:calc(100vh - 280px); min-height:400px; border-radius:8px; border:1px solid var(--border); overflow:hidden; position:relative;"></div>
       </div>
       <div class="map-info" id="map-info-synoptic"></div>
+    </div>
+
+    <!-- Tab: Climatology (observation climatology over the watchlist) -->
+    <div id="panel-climatology" class="tab-panel">
+      <div class="settings-tabs settings-tabs-inner" id="clim-subtabs">
+        <button class="tab-btn active" data-subtab="map">Map</button>
+        <button class="tab-btn" data-subtab="top">Top airports</button>
+      </div>
+
+      <div id="clim-subpanel-map" class="clim-subpanel active">
+        <div class="maps-controls">
+          <label for="clim-month-picker">Month</label>
+          <select id="clim-month-picker"></select>
+          <label for="clim-dataset-picker">Dataset</label>
+          <select id="clim-dataset-picker"></select>
+          <label>Color by</label>
+          <div class="btn-group" id="clim-metric-picker"></div>
+        </div>
+        <div class="map-wrapper">
+          <div id="clim-map-container" style="width:100%; height:calc(100vh - 280px); min-height:400px; border-radius:8px; border:1px solid var(--border); overflow:hidden;"></div>
+          <div id="clim-legend" class="map-legend"></div>
+        </div>
+        <div class="map-info" id="clim-status"></div>
+      </div>
+
+      <div id="clim-subpanel-top" class="clim-subpanel">
+        <div id="clim-leaderboard"></div>
+      </div>
     </div>
 
     <!-- Tab: Accuracy Stats (embedded verification page) -->

--- a/web/ts/adapters/climatology-adapter.ts
+++ b/web/ts/adapters/climatology-adapter.ts
@@ -1,0 +1,126 @@
+/** API adapter for climatology / patterns views (issue #155). */
+
+import { API_BASE } from '../utils';
+
+const apiBase = API_BASE;
+
+// --- Shared envelope (views #2-#4) -----------------------------------------
+
+export interface ClimatologyAirport {
+  icao: string;
+  lat: number;
+  lon: number;
+  // ``value`` is the metric being colored; null when no data.
+  value: number | null;
+  // Extra count fields are dataset-specific. Carried as-is for popup display.
+  [extra: string]: unknown;
+}
+
+export interface ClimatologyMapEnvelope {
+  month: string;
+  is_mtd: boolean;
+  as_of_date?: string;
+  dataset: 'category' | 'phenomena' | 'wind' | 'volatility';
+  metric: string;
+  unit: '%' | 'kt' | 'ratio';
+  airports: ClimatologyAirport[];
+}
+
+// --- View #1: Category (pre-existing shape, slightly different) ------------
+
+export interface CategoryAirport {
+  icao: string;
+  lat: number;
+  lon: number;
+  n_obs: number;
+  n_vfr: number;
+  n_mvfr: number;
+  n_ifr: number;
+  n_lifr: number;
+  pct_vfr?: number;
+  pct_mvfr?: number;
+  pct_ifr?: number;
+  pct_lifr?: number;
+}
+
+export interface CategoryMapResponse {
+  month: string;
+  is_mtd: boolean;
+  as_of_date?: string;
+  airports: CategoryAirport[];
+}
+
+// --- View #4 leaderboard ---------------------------------------------------
+
+export interface VolatilityRow {
+  icao: string;
+  n_obs: number;
+  n_changes: number;
+  value: number;
+}
+
+export interface VolatilityLeaderboardResponse {
+  month: string;
+  is_mtd: boolean;
+  as_of_date?: string;
+  min_n_obs: number;
+  rows: VolatilityRow[];
+}
+
+// --- Fetchers --------------------------------------------------------------
+
+export async function fetchCategoryMap(month: string): Promise<CategoryMapResponse> {
+  const resp = await fetch(
+    `${apiBase}/climatology/category?month=${encodeURIComponent(month)}`,
+    { credentials: 'include' },
+  );
+  if (!resp.ok) throw new Error(`Climatology category: ${resp.status}`);
+  return resp.json();
+}
+
+export async function fetchPhenomenaMap(
+  month: string, kind: 'ts' | 'fog',
+): Promise<ClimatologyMapEnvelope> {
+  const resp = await fetch(
+    `${apiBase}/climatology/phenomena?month=${encodeURIComponent(month)}&kind=${kind}`,
+    { credentials: 'include' },
+  );
+  if (!resp.ok) throw new Error(`Climatology phenomena: ${resp.status}`);
+  return resp.json();
+}
+
+export type WindMetric = 'over25' | 'p95' | 'gust';
+
+export async function fetchWindMap(
+  month: string, metric: WindMetric,
+): Promise<ClimatologyMapEnvelope> {
+  const resp = await fetch(
+    `${apiBase}/climatology/wind?month=${encodeURIComponent(month)}&metric=${metric}`,
+    { credentials: 'include' },
+  );
+  if (!resp.ok) {
+    const body = await resp.text();
+    throw new Error(`Climatology wind ${resp.status}: ${body}`);
+  }
+  return resp.json();
+}
+
+export async function fetchVolatilityMap(month: string): Promise<ClimatologyMapEnvelope> {
+  const resp = await fetch(
+    `${apiBase}/climatology/volatility?month=${encodeURIComponent(month)}`,
+    { credentials: 'include' },
+  );
+  if (!resp.ok) throw new Error(`Climatology volatility: ${resp.status}`);
+  return resp.json();
+}
+
+export async function fetchVolatilityLeaderboard(
+  month: string, limit: number = 20,
+): Promise<VolatilityLeaderboardResponse> {
+  const resp = await fetch(
+    `${apiBase}/climatology/volatility/top?month=${encodeURIComponent(month)}&limit=${limit}`,
+    { credentials: 'include' },
+  );
+  if (!resp.ok) throw new Error(`Volatility leaderboard: ${resp.status}`);
+  return resp.json();
+}

--- a/web/ts/adapters/climatology-adapter.ts
+++ b/web/ts/adapters/climatology-adapter.ts
@@ -50,21 +50,25 @@ export interface CategoryMapResponse {
   airports: CategoryAirport[];
 }
 
-// --- View #4 leaderboard ---------------------------------------------------
+// --- Leaderboard (Top airports sub-tab) ------------------------------------
 
-export interface VolatilityRow {
+export interface LeaderboardRow {
   icao: string;
   n_obs: number;
-  n_changes: number;
-  value: number;
+  value: number | null;
+  extra: Record<string, unknown>;
 }
 
-export interface VolatilityLeaderboardResponse {
+export interface LeaderboardResponse {
   month: string;
   is_mtd: boolean;
   as_of_date?: string;
+  dataset: string;
+  sub: string | null;
+  unit: '%' | 'kt' | 'ratio';
+  label: string;
   min_n_obs: number;
-  rows: VolatilityRow[];
+  rows: LeaderboardRow[];
 }
 
 // --- Fetchers --------------------------------------------------------------
@@ -114,13 +118,18 @@ export async function fetchVolatilityMap(month: string): Promise<ClimatologyMapE
   return resp.json();
 }
 
-export async function fetchVolatilityLeaderboard(
-  month: string, limit: number = 20,
-): Promise<VolatilityLeaderboardResponse> {
+export async function fetchLeaderboard(
+  month: string, dataset: string, sub: string | null, limit: number = 20,
+): Promise<LeaderboardResponse> {
+  const params = new URLSearchParams({ month, dataset, limit: String(limit) });
+  if (sub) params.set('sub', sub);
   const resp = await fetch(
-    `${apiBase}/climatology/volatility/top?month=${encodeURIComponent(month)}&limit=${limit}`,
+    `${apiBase}/climatology/leaderboard?${params.toString()}`,
     { credentials: 'include' },
   );
-  if (!resp.ok) throw new Error(`Volatility leaderboard: ${resp.status}`);
+  if (!resp.ok) {
+    const body = await resp.text();
+    throw new Error(`Leaderboard ${resp.status}: ${body}`);
+  }
   return resp.json();
 }

--- a/web/ts/maps-main.ts
+++ b/web/ts/maps-main.ts
@@ -13,6 +13,7 @@ import {
 import { WeatherMap, type ForecastMetric } from './visualization/weather-map';
 import { AirportProfilePanel } from './visualization/airport-profile-panel';
 import { SynopticMap } from './visualization/synoptic-map';
+import { ClimatologyTab } from './visualization/climatology-tab';
 import { type HewsonMetric, type ColorScale, vRangeFor } from './visualization/hewson-colormaps';
 import { initInfoPopup, showPopupContent } from './components/info-popup';
 import { renderHewsonInfo } from './helpers/hewson-info';
@@ -23,7 +24,8 @@ import { shareCurrentUrl } from './utils/share-link';
 
 let forecastMap: WeatherMap | null = null;
 let synopticMap: SynopticMap | null = null;
-type Tab = 'forecast' | 'synoptic' | 'stats';
+let climatologyTab: ClimatologyTab | null = null;
+type Tab = 'forecast' | 'synoptic' | 'climatology' | 'stats';
 let currentTab: Tab = 'forecast';
 let statsLoaded = false;
 
@@ -77,7 +79,7 @@ let airportPanelIcao: string | null = null;
 // Defaults match the module-level state above and the HTML's pre-active
 // buttons, so an untouched view yields a bare `/maps.html` URL.
 const mapsUrlState = createUrlState({
-  tab:         { default: 'forecast' as Tab, values: ['forecast', 'synoptic', 'stats'] as readonly Tab[] },
+  tab:         { default: 'forecast' as Tab, values: ['forecast', 'synoptic', 'climatology', 'stats'] as readonly Tab[] },
   'fc.day':    { default: 0,  values: [0, 1, 2, 3] as readonly number[] },
   'fc.hour':   { default: 12, values: [6, 9, 12, 15, 18] as readonly number[] },
   'fc.model':  { default: 'worst', values: ['worst', 'majority', 'gfs', 'icon', 'ecmwf'] as readonly string[] },
@@ -675,6 +677,9 @@ function switchTab(tab: Tab): void {
     setTimeout(() => forecastMap?.invalidateSize(), 100);
   } else if (tab === 'synoptic') {
     setTimeout(() => { initSynopticTab(); }, 50);
+  } else if (tab === 'climatology') {
+    if (!climatologyTab) climatologyTab = new ClimatologyTab();
+    climatologyTab.show();
   } else if (tab === 'stats') {
     if (!statsLoaded) {
       const frame = $('stats-frame') as HTMLIFrameElement | null;

--- a/web/ts/visualization/climatology-datasets.ts
+++ b/web/ts/visualization/climatology-datasets.ts
@@ -1,0 +1,273 @@
+/** Per-dataset scales, popup builders, and "Color by" sub-metric lists.
+ *
+ * Adding a 5th dataset means: define a ``DatasetConfig`` here, fetch its
+ * envelope in ``climatology-tab.ts``, and add it to the dropdown. No other
+ * touch points.
+ */
+
+import { COLORS, type Scale, type PopupBuilder, type MapAirport } from './climatology-map';
+import type {
+  CategoryAirport,
+  ClimatologyAirport,
+} from '../adapters/climatology-adapter';
+
+// --- View #1: Category scales (per-metric thresholds) ----------------------
+
+const CATEGORY_SCALES: Record<'vfr' | 'mvfr' | 'ifr' | 'lifr', Scale> = {
+  vfr: {
+    title: 'VFR %', unit: '%',
+    stops: [
+      { bound: 95, color: COLORS.green },
+      { bound: 90, color: COLORS.lime },
+      { bound: 85, color: COLORS.yellow },
+      { bound: 80, color: COLORS.orange },
+      { bound: 70, color: COLORS.red },
+      { bound: 0,  color: COLORS.darkred },
+    ],
+  },
+  mvfr: {
+    title: 'MVFR %', unit: '%',
+    stops: [
+      { bound: 25, color: COLORS.darkred },
+      { bound: 15, color: COLORS.red },
+      { bound: 10, color: COLORS.orange },
+      { bound: 5,  color: COLORS.yellow },
+      { bound: 2,  color: COLORS.lime },
+      { bound: 0,  color: COLORS.green },
+    ],
+  },
+  ifr: {
+    title: 'IFR %', unit: '%',
+    stops: [
+      { bound: 10,  color: COLORS.darkred },
+      { bound: 5,   color: COLORS.red },
+      { bound: 3,   color: COLORS.orange },
+      { bound: 1.5, color: COLORS.yellow },
+      { bound: 0.5, color: COLORS.lime },
+      { bound: 0,   color: COLORS.green },
+    ],
+  },
+  lifr: {
+    title: 'LIFR %', unit: '%',
+    // LIFR is binary-ish — the 0.1/0.3/0.7 bands all caught the same set
+    // of airports in April. Widened to give meaningful separation.
+    stops: [
+      { bound: 5,   color: COLORS.darkred },
+      { bound: 3,   color: COLORS.red },
+      { bound: 2,   color: COLORS.orange },
+      { bound: 1,   color: COLORS.yellow },
+      { bound: 0.3, color: COLORS.lime },
+      { bound: 0,   color: COLORS.green },
+    ],
+  },
+};
+
+export type CategoryKey = keyof typeof CATEGORY_SCALES;
+
+// Map CategoryAirport → MapAirport using the selected sub-metric.
+export function categoryAirportToMapAirport(
+  a: CategoryAirport, sub: CategoryKey,
+): MapAirport {
+  const value = a[`pct_${sub}` as 'pct_vfr'] ?? null;
+  return { ...a, value: value ?? null };
+}
+
+export const CategoryDataset = {
+  subOptions: [
+    { value: 'vfr',  label: 'VFR %' },
+    { value: 'mvfr', label: 'MVFR %' },
+    { value: 'ifr',  label: 'IFR %' },
+    { value: 'lifr', label: 'LIFR %' },
+  ] as { value: CategoryKey; label: string }[],
+  scaleFor: (sub: CategoryKey): Scale => CATEGORY_SCALES[sub],
+  /** Same popup regardless of which sub-metric is selected. */
+  popup: (a: MapAirport): string => {
+    const ca = a as unknown as CategoryAirport;
+    const rows = (['vfr', 'mvfr', 'ifr', 'lifr'] as const).map((k) => {
+      const pct = ca[`pct_${k}` as 'pct_vfr'];
+      const cell = pct === undefined ? '—' : `${pct.toFixed(1)}%`;
+      return `<tr><td>${k.toUpperCase()}</td><td style="text-align:right">${cell}</td></tr>`;
+    }).join('');
+    return `
+      <div class="clim-popup">
+        <div class="clim-popup-title"><b>${ca.icao}</b></div>
+        <table class="clim-popup-table">${rows}</table>
+        <div class="clim-popup-foot">${ca.n_obs.toLocaleString()} obs</div>
+      </div>
+    `;
+  },
+};
+
+// --- View #2: Phenomena (TS / fog) -----------------------------------------
+
+const TS_SCALE: Scale = {
+  title: 'TS %', unit: '%',
+  stops: [
+    { bound: 5,   color: COLORS.darkred },
+    { bound: 3,   color: COLORS.red },
+    { bound: 2,   color: COLORS.orange },
+    { bound: 1,   color: COLORS.yellow },
+    { bound: 0.3, color: COLORS.lime },
+    { bound: 0,   color: COLORS.green },
+  ],
+};
+
+const FOG_SCALE: Scale = {
+  title: 'Fog %', unit: '%',
+  stops: [
+    { bound: 10,  color: COLORS.darkred },
+    { bound: 5,   color: COLORS.red },
+    { bound: 3,   color: COLORS.orange },
+    { bound: 1.5, color: COLORS.yellow },
+    { bound: 0.5, color: COLORS.lime },
+    { bound: 0,   color: COLORS.green },
+  ],
+};
+
+export type PhenomenaKey = 'ts' | 'fog';
+
+export const PhenomenaDataset = {
+  subOptions: [
+    { value: 'ts',  label: 'TS' },
+    { value: 'fog', label: 'Fog' },
+  ] as { value: PhenomenaKey; label: string }[],
+  scaleFor: (sub: PhenomenaKey): Scale => sub === 'ts' ? TS_SCALE : FOG_SCALE,
+  popup: (a: MapAirport): string => {
+    const pa = a as unknown as ClimatologyAirport & {
+      n_obs: number; n_ts: number; n_fg: number;
+    };
+    const tsPct = pa.n_obs > 0 ? (100 * pa.n_ts / pa.n_obs).toFixed(2) : '—';
+    const fgPct = pa.n_obs > 0 ? (100 * pa.n_fg / pa.n_obs).toFixed(2) : '—';
+    return `
+      <div class="clim-popup">
+        <div class="clim-popup-title"><b>${pa.icao}</b></div>
+        <table class="clim-popup-table">
+          <tr><td>TS</td><td style="text-align:right">${pa.n_ts} (${tsPct}%)</td></tr>
+          <tr><td>Fog</td><td style="text-align:right">${pa.n_fg} (${fgPct}%)</td></tr>
+        </table>
+        <div class="clim-popup-foot">${pa.n_obs.toLocaleString()} obs</div>
+      </div>
+    `;
+  },
+};
+
+// --- View #3: Wind ---------------------------------------------------------
+
+const WIND_OVER25_SCALE: Scale = {
+  title: '% hrs > 25 kt', unit: '%',
+  // April max was 13% — the ≥15 darkred caught nobody. Compressed.
+  stops: [
+    { bound: 10, color: COLORS.darkred },
+    { bound: 7,  color: COLORS.red },
+    { bound: 5,  color: COLORS.orange },
+    { bound: 3,  color: COLORS.yellow },
+    { bound: 1,  color: COLORS.lime },
+    { bound: 0,  color: COLORS.green },
+  ],
+};
+
+const WIND_P95_SCALE: Scale = {
+  title: 'Wind p95', unit: ' kt',
+  // April max was 31 kt — the original ≥35 / ≥30 bounds left half the map
+  // in the "green" bucket. Recentred so p10..p90 spreads across the palette.
+  stops: [
+    { bound: 25, color: COLORS.darkred },
+    { bound: 20, color: COLORS.red },
+    { bound: 17, color: COLORS.orange },
+    { bound: 14, color: COLORS.yellow },
+    { bound: 11, color: COLORS.lime },
+    { bound: 0,  color: COLORS.green },
+  ],
+};
+
+const WIND_GUST_SCALE: Scale = {
+  title: 'Peak gust', unit: ' kt',
+  // 40 kt is already a meaningful warning level for GA; 50/60 kt peaks
+  // are rare enough that giving them their own buckets wastes the palette.
+  stops: [
+    { bound: 40, color: COLORS.darkred },
+    { bound: 35, color: COLORS.red },
+    { bound: 30, color: COLORS.orange },
+    { bound: 25, color: COLORS.yellow },
+    { bound: 20, color: COLORS.lime },
+    { bound: 0,  color: COLORS.green },
+  ],
+};
+
+export type WindKey = 'over25' | 'p95' | 'gust';
+
+export const WindDataset = {
+  subOptions: [
+    { value: 'over25', label: 'Hrs > 25 kt', mtd: false },
+    { value: 'p95',    label: 'Wind p95',    mtd: false },
+    { value: 'gust',   label: 'Peak gust',   mtd: true },
+  ] as { value: WindKey; label: string; mtd: boolean }[],
+  scaleFor: (sub: WindKey): Scale => ({
+    over25: WIND_OVER25_SCALE, p95: WIND_P95_SCALE, gust: WIND_GUST_SCALE,
+  }[sub]),
+  popup: (a: MapAirport): string => {
+    const v = a.value;
+    const sub = a._sub as WindKey | undefined;
+    const unit = sub === 'over25' ? '%' : 'kt';
+    const valStr = v === null ? '—' : `${v}${unit === '%' ? '%' : ' kt'}`;
+    const label = sub === 'over25' ? 'Hrs > 25 kt'
+                : sub === 'p95'    ? 'Wind p95'
+                : 'Peak gust';
+    return `
+      <div class="clim-popup">
+        <div class="clim-popup-title"><b>${a.icao}</b></div>
+        <table class="clim-popup-table">
+          <tr><td>${label}</td><td style="text-align:right">${valStr}</td></tr>
+        </table>
+      </div>
+    `;
+  },
+};
+
+// --- View #4: Volatility ---------------------------------------------------
+
+const VOLATILITY_SCALE: Scale = {
+  title: 'Changes / obs', unit: '',
+  // April real range was 0..0.333 — original ≥0.5 / ≥0.8 stops never
+  // activated. Recentred so the coastal/maritime cluster (EGPL, BIKF, EKVG,
+  // LPLA at 0.30+) lands in darkred where they belong.
+  stops: [
+    { bound: 0.30, color: COLORS.darkred },
+    { bound: 0.20, color: COLORS.red },
+    { bound: 0.15, color: COLORS.orange },
+    { bound: 0.10, color: COLORS.yellow },
+    { bound: 0.05, color: COLORS.lime },
+    { bound: 0,    color: COLORS.green },
+  ],
+};
+
+export const VolatilityDataset = {
+  // No sub-metric — single value (changes/n_obs).
+  subOptions: [] as { value: string; label: string }[],
+  scaleFor: (): Scale => VOLATILITY_SCALE,
+  popup: (a: MapAirport): string => {
+    const va = a as MapAirport & { n_obs: number; n_changes: number };
+    const cell = a.value === null ? '—' : a.value.toFixed(3);
+    return `
+      <div class="clim-popup">
+        <div class="clim-popup-title"><b>${va.icao}</b></div>
+        <table class="clim-popup-table">
+          <tr><td>Changes / obs</td><td style="text-align:right">${cell}</td></tr>
+          <tr><td>Changes</td><td style="text-align:right">${va.n_changes}</td></tr>
+        </table>
+        <div class="clim-popup-foot">${va.n_obs.toLocaleString()} obs</div>
+      </div>
+    `;
+  },
+};
+
+// --- Dataset registry ------------------------------------------------------
+
+export type DatasetKey = 'category' | 'phenomena' | 'wind' | 'volatility';
+
+export const DATASET_LABEL: Record<DatasetKey, string> = {
+  category: 'Flight Category',
+  phenomena: 'TS / Fog',
+  wind: 'Wind',
+  volatility: 'Volatility',
+};

--- a/web/ts/visualization/climatology-map.ts
+++ b/web/ts/visualization/climatology-map.ts
@@ -1,0 +1,163 @@
+/** Climatology map — Leaflet circle markers colored by a single per-airport value.
+ *
+ * Generic over dataset: takes a ``Scale`` (color stops + legend labels) and a
+ * popup-HTML builder per render. The same map instance serves all 4 dataset
+ * variants in views #1–#4; switching datasets is just ``setScale`` + ``setData``.
+ */
+
+import * as L from 'leaflet';
+
+const LIGHT_TILES = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
+const DARK_TILES = 'https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png';
+const ATTR = '&copy; <a href="https://www.openstreetmap.org/copyright">OSM</a>';
+
+function isDark(): boolean {
+  return document.documentElement.dataset.theme === 'dark';
+}
+
+// --- Color palette (named so dataset scales stay readable) -----------------
+
+export const COLORS = {
+  green:   '#22c55e',
+  lime:    '#84cc16',
+  yellow:  '#eab308',
+  orange:  '#f97316',
+  red:     '#ef4444',
+  darkred: '#991b1b',
+  grey:    '#888',
+} as const;
+
+// --- Scale definitions -----------------------------------------------------
+
+export interface Stop {
+  /** Inclusive lower bound. The first stop that ``value >= bound`` wins. */
+  bound: number;
+  color: string;
+}
+
+export interface Scale {
+  title: string;
+  unit: string;
+  /** Stops ordered worst→best for unfavorable metrics, best→worst for VFR.
+   *  ``pctColor`` walks them top-to-bottom and returns the first match. */
+  stops: Stop[];
+}
+
+export function pctColor(value: number, scale: Scale): string {
+  for (const s of scale.stops) {
+    if (value >= s.bound) return s.color;
+  }
+  return COLORS.grey;
+}
+
+/** Build legend rows (color + label) from a scale's stops. */
+export function legendRows(scale: Scale): { color: string; label: string }[] {
+  const stops = scale.stops;
+  const rows: { color: string; label: string }[] = [];
+  for (let i = 0; i < stops.length; i++) {
+    const s = stops[i];
+    const next = stops[i - 1];
+    const formatBound = (v: number) =>
+      v >= 10 || v === 0 ? `${v}` : v.toFixed(1);
+    if (i === 0) {
+      rows.push({ color: s.color, label: `≥ ${formatBound(s.bound)}${scale.unit}` });
+    } else {
+      const prev = stops[i - 1].bound;
+      rows.push({
+        color: s.color,
+        label: `${formatBound(s.bound)}–${formatBound(prev)}${scale.unit}`,
+      });
+    }
+    void next;
+  }
+  return rows;
+}
+
+// --- Map class -------------------------------------------------------------
+
+export interface MapAirport {
+  icao: string;
+  lat: number;
+  lon: number;
+  value: number | null;
+  [extra: string]: unknown;
+}
+
+export type PopupBuilder = (a: MapAirport) => string;
+
+export class ClimatologyMap {
+  private map: L.Map;
+  private tileLayer: L.TileLayer;
+  private markersLayer: L.LayerGroup;
+  private themeObserver: MutationObserver;
+  private airports: MapAirport[] = [];
+  private scale: Scale | null = null;
+  private buildPopup: PopupBuilder = () => '';
+
+  constructor(containerId: string) {
+    const el = document.getElementById(containerId);
+    if (!el) throw new Error(`No element #${containerId}`);
+
+    this.map = L.map(el, {
+      center: [48, 10],
+      zoom: 5,
+      worldCopyJump: true,
+    });
+    this.tileLayer = L.tileLayer(isDark() ? DARK_TILES : LIGHT_TILES, {
+      attribution: ATTR, maxZoom: 10,
+    }).addTo(this.map);
+    this.markersLayer = L.layerGroup().addTo(this.map);
+
+    this.themeObserver = new MutationObserver(() => {
+      this.tileLayer.setUrl(isDark() ? DARK_TILES : LIGHT_TILES);
+    });
+    this.themeObserver.observe(document.documentElement, {
+      attributes: true, attributeFilter: ['data-theme'],
+    });
+  }
+
+  /** Switch the color scale and popup builder.
+   *
+   * Does NOT re-render — the caller is expected to follow with ``setData``
+   * carrying matching airport rows. Eagerly re-rendering here would apply
+   * the new popup builder to stale airports from the previous dataset,
+   * which fails when popups expect dataset-specific fields (e.g. the
+   * volatility popup reading ``n_obs`` from wind data that doesn't carry it).
+   */
+  setScale(scale: Scale, buildPopup: PopupBuilder): void {
+    this.scale = scale;
+    this.buildPopup = buildPopup;
+  }
+
+  setData(airports: MapAirport[]): void {
+    this.airports = airports;
+    this.render();
+  }
+
+  private render(): void {
+    this.markersLayer.clearLayers();
+    const scale = this.scale;
+    for (const a of this.airports) {
+      const color = a.value !== null && scale ? pctColor(a.value, scale) : COLORS.grey;
+      const marker = L.circleMarker([a.lat, a.lon], {
+        radius: 5,
+        fillColor: color,
+        color: '#111',
+        weight: 0.6,
+        opacity: 1,
+        fillOpacity: a.value === null ? 0.4 : 0.9,
+      });
+      marker.bindPopup(this.buildPopup(a));
+      marker.addTo(this.markersLayer);
+    }
+  }
+
+  invalidateSize(): void {
+    this.map.invalidateSize();
+  }
+
+  destroy(): void {
+    this.themeObserver.disconnect();
+    this.map.remove();
+  }
+}

--- a/web/ts/visualization/climatology-tab.ts
+++ b/web/ts/visualization/climatology-tab.ts
@@ -12,11 +12,14 @@
 
 import {
   fetchCategoryMap, fetchPhenomenaMap, fetchWindMap,
-  fetchVolatilityMap, fetchVolatilityLeaderboard,
+  fetchVolatilityMap, fetchLeaderboard,
   type CategoryMapResponse, type ClimatologyMapEnvelope,
-  type VolatilityLeaderboardResponse, type WindMetric,
+  type LeaderboardResponse, type WindMetric,
 } from '../adapters/climatology-adapter';
-import { ClimatologyMap, legendRows, type MapAirport, type Scale } from './climatology-map';
+import {
+  ClimatologyMap, legendRows, pctColor,
+  type MapAirport, type Scale,
+} from './climatology-map';
 import {
   CategoryDataset, PhenomenaDataset, WindDataset, VolatilityDataset,
   DATASET_LABEL,
@@ -151,21 +154,29 @@ export class ClimatologyTab {
             .forEach((b) => b.classList.remove('active'));
           btn.classList.add('active');
           this.sub = btn.dataset.sub!;
+          this.invalidateLeaderboard();
           this.reload();
         });
       });
+  }
+
+  private invalidateLeaderboard(): void {
+    this.leaderboardLoaded = false;
+    // If the user is currently viewing the leaderboard sub-tab, refresh it
+    // immediately so dataset/sub/month changes are reflected. Otherwise
+    // the next switch to that sub-tab will fetch.
+    if (this.currentSub === 'top') this.loadLeaderboard();
   }
 
   private wireControls(): void {
     const monthSel = $('clim-month-picker') as HTMLSelectElement | null;
     monthSel?.addEventListener('change', () => {
       this.month = monthSel.value;
-      // Recompute MTD flag from the selected month vs current UTC month.
       const now = new Date();
       const cur = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, '0')}`;
       this.monthIsMtd = this.month === cur;
-      this.renderSubPicker();   // wind sub may need to disable/enable
-      this.leaderboardLoaded = false;
+      this.renderSubPicker();
+      this.invalidateLeaderboard();
       this.reload();
     });
 
@@ -173,6 +184,7 @@ export class ClimatologyTab {
     dsSel?.addEventListener('change', () => {
       this.dataset = dsSel.value as DatasetKey;
       this.renderSubPicker();
+      this.invalidateLeaderboard();
       this.reload();
     });
 
@@ -296,12 +308,24 @@ export class ClimatologyTab {
     if (!host) return;
     host.innerHTML = '<div class="map-info" style="padding:1rem">Loading…</div>';
     try {
-      const data = await fetchVolatilityLeaderboard(this.month, 20);
-      host.innerHTML = renderLeaderboardHtml(data);
+      const subParam = this.dataset === 'volatility' ? null : (this.sub || null);
+      const data = await fetchLeaderboard(this.month, this.dataset, subParam, 20);
+      const scale = this.activeScale();
+      host.innerHTML = renderLeaderboardHtml(data, scale);
       this.leaderboardLoaded = true;
     } catch (err) {
       host.innerHTML = `<div class="map-info map-info-error" style="padding:1rem">
         Failed: ${(err as Error).message}</div>`;
+    }
+  }
+
+  /** Color scale currently in effect — used to dot leaderboard rows. */
+  private activeScale(): Scale | null {
+    switch (this.dataset) {
+      case 'category':   return CategoryDataset.scaleFor((this.sub || 'vfr') as CategoryKey);
+      case 'phenomena':  return PhenomenaDataset.scaleFor((this.sub || 'ts') as PhenomenaKey);
+      case 'wind':       return WindDataset.scaleFor((this.sub || 'gust') as WindKey);
+      case 'volatility': return VolatilityDataset.scaleFor();
     }
   }
 }
@@ -326,37 +350,49 @@ function headerFromEnvelope(data: ClimatologyMapEnvelope): string {
   return `${note} · ${plotted} plotted (${withData} with data)`;
 }
 
-function renderLeaderboardHtml(data: VolatilityLeaderboardResponse): string {
+function formatValue(value: number | null, unit: string): string {
+  if (value === null) return '—';
+  if (unit === '%') return `${value.toFixed(1)}%`;
+  if (unit === 'kt') return `${value.toFixed(0)} kt`;
+  return value.toFixed(3);  // ratio
+}
+
+function renderLeaderboardHtml(data: LeaderboardResponse, scale: Scale | null): string {
   if (data.rows.length === 0) {
     return `<div class="map-info" style="padding:1rem">
       No airports meet the minimum observation count
       (${data.min_n_obs} obs required) for this period.
     </div>`;
   }
-  const rows = data.rows.map((r, i) => `
-    <tr>
-      <td style="text-align:right; padding-right:0.5rem; color:var(--text-muted)">${i + 1}.</td>
-      <td><b>${r.icao}</b></td>
-      <td style="text-align:right">${r.value.toFixed(3)}</td>
-      <td style="text-align:right; color:var(--text-muted)">${r.n_changes}</td>
-      <td style="text-align:right; color:var(--text-muted)">${r.n_obs.toLocaleString()}</td>
-    </tr>
-  `).join('');
+  const rows = data.rows.map((r, i) => {
+    const color = (r.value !== null && scale) ? pctColor(r.value, scale) : '#888';
+    return `
+      <tr>
+        <td style="text-align:right; padding-right:0.5rem; color:var(--text-muted)">${i + 1}.</td>
+        <td>
+          <span class="legend-dot" style="background:${color}; display:inline-block; margin-right:0.4rem; vertical-align:middle"></span>
+          <b>${r.icao}</b>
+        </td>
+        <td style="text-align:right">${formatValue(r.value, data.unit)}</td>
+        <td style="text-align:right; color:var(--text-muted)">${r.n_obs.toLocaleString()}</td>
+      </tr>
+    `;
+  }).join('');
   const monthNote = data.is_mtd
     ? `${data.month} (to ${data.as_of_date ?? '—'})`
     : data.month;
   return `
     <div class="clim-leaderboard-wrap">
-      <h3 style="margin-top:0">Most volatile · ${monthNote}</h3>
+      <h3 style="margin-top:0">Top airports by ${data.label} · ${monthNote}</h3>
       <p style="color:var(--text-muted); font-size:0.8rem; margin:0.25rem 0 0.75rem">
-        Ranked by category changes per observation. Minimum ${data.min_n_obs} observations.
+        Ranked highest first. Minimum ${data.min_n_obs} observations.
+        Change Dataset / Color by on the Map tab to rank by a different metric.
       </p>
       <table class="clim-leaderboard-table">
         <thead>
           <tr>
             <th></th><th>Airport</th>
-            <th style="text-align:right">Changes / obs</th>
-            <th style="text-align:right">Changes</th>
+            <th style="text-align:right">${data.label}</th>
             <th style="text-align:right">Obs</th>
           </tr>
         </thead>

--- a/web/ts/visualization/climatology-tab.ts
+++ b/web/ts/visualization/climatology-tab.ts
@@ -1,0 +1,367 @@
+/** Climatology tab — orchestrates dataset dropdown, sub-metric picker,
+ *  map renders, and the volatility leaderboard.
+ *
+ * State machine per tab:
+ *   month  (str)            — YYYY-MM from the picker
+ *   dataset (DatasetKey)    — top-level dropdown (Category / Phenomena / Wind / Volatility)
+ *   sub    (string|null)    — sub-metric for datasets that have one
+ *
+ * Render flow: dataset/sub change → fetch envelope → ``map.setScale(scale, popup)``
+ * → ``map.setData(airports)``. Map class is dataset-agnostic.
+ */
+
+import {
+  fetchCategoryMap, fetchPhenomenaMap, fetchWindMap,
+  fetchVolatilityMap, fetchVolatilityLeaderboard,
+  type CategoryMapResponse, type ClimatologyMapEnvelope,
+  type VolatilityLeaderboardResponse, type WindMetric,
+} from '../adapters/climatology-adapter';
+import { ClimatologyMap, legendRows, type MapAirport, type Scale } from './climatology-map';
+import {
+  CategoryDataset, PhenomenaDataset, WindDataset, VolatilityDataset,
+  DATASET_LABEL,
+  type CategoryKey, type DatasetKey, type PhenomenaKey, type WindKey,
+} from './climatology-datasets';
+import { $ } from '../utils';
+
+type SubTab = 'map' | 'top';
+
+const MONTH_LABEL = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+                     'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+interface MonthOption { value: string; label: string; isMtd: boolean }
+
+function buildMonthOptions(months: number, now: Date): MonthOption[] {
+  const out: MonthOption[] = [];
+  const y = now.getUTCFullYear();
+  const m = now.getUTCMonth();
+  for (let i = 0; i < months; i++) {
+    const d = new Date(Date.UTC(y, m - i, 1));
+    const isMtd = i === 0;
+    const value = `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, '0')}`;
+    const label = `${MONTH_LABEL[d.getUTCMonth()]} ${d.getUTCFullYear()}` +
+                  (isMtd ? ' (to date)' : '');
+    out.push({ value, label, isMtd });
+  }
+  return out;
+}
+
+export class ClimatologyTab {
+  private mapView: ClimatologyMap | null = null;
+  private month = '';
+  private monthIsMtd = false;
+  private dataset: DatasetKey = 'category';
+  private sub: string = 'vfr';   // typed per-dataset; coerced at use site
+  private currentSub: SubTab = 'map';
+  private initialised = false;
+  private inFlight = false;
+  private leaderboardLoaded = false;
+
+  init(): void {
+    if (this.initialised) {
+      this.mapView?.invalidateSize();
+      return;
+    }
+    this.initialised = true;
+
+    this.populateMonthPicker();
+    this.populateDatasetPicker();
+    this.renderSubPicker();   // populates "Color by" for default dataset
+    this.mapView = new ClimatologyMap('clim-map-container');
+    this.wireControls();
+    this.reload();
+  }
+
+  show(): void {
+    if (this.initialised) {
+      setTimeout(() => this.mapView?.invalidateSize(), 50);
+    } else {
+      setTimeout(() => this.init(), 50);
+    }
+  }
+
+  // --- Pickers -------------------------------------------------------------
+
+  private populateMonthPicker(): void {
+    const sel = $('clim-month-picker') as HTMLSelectElement | null;
+    if (!sel) return;
+    const opts = buildMonthOptions(13, new Date());
+    sel.innerHTML = opts.map((o) => `<option value="${o.value}">${o.label}</option>`).join('');
+    this.month = opts[0].value;
+    this.monthIsMtd = opts[0].isMtd;
+    sel.value = this.month;
+  }
+
+  private populateDatasetPicker(): void {
+    const sel = $('clim-dataset-picker') as HTMLSelectElement | null;
+    if (!sel) return;
+    sel.innerHTML = (Object.keys(DATASET_LABEL) as DatasetKey[])
+      .map((k) => `<option value="${k}">${DATASET_LABEL[k]}</option>`)
+      .join('');
+    sel.value = this.dataset;
+  }
+
+  /** Repopulate the "Color by" row based on the active dataset. */
+  private renderSubPicker(): void {
+    const host = $('clim-metric-picker');
+    if (!host) return;
+    const opts = this.subOptionsForActiveDataset();
+    if (opts.length === 0) {
+      host.innerHTML = '<span style="color:var(--text-muted); font-size:0.75rem">(single metric)</span>';
+      this.sub = '';
+      return;
+    }
+    // Default sub: first eligible option (skips MTD-disabled ones if current month is MTD).
+    const firstEligible = opts.find((o) => !this.isSubDisabled(o.value)) ?? opts[0];
+    this.sub = firstEligible.value;
+    host.innerHTML = opts.map((o) => {
+      const disabled = this.isSubDisabled(o.value);
+      const active = o.value === this.sub ? ' active' : '';
+      const title = disabled ? ' title="Available for completed months only"' : '';
+      return `<button class="btn-toggle${active}" data-sub="${o.value}"${disabled ? ' disabled' : ''}${title}>${o.label}</button>`;
+    }).join('');
+    this.wireSubButtons();
+  }
+
+  private subOptionsForActiveDataset(): { value: string; label: string }[] {
+    switch (this.dataset) {
+      case 'category':   return CategoryDataset.subOptions.map((o) => ({ value: o.value, label: o.label }));
+      case 'phenomena':  return PhenomenaDataset.subOptions.map((o) => ({ value: o.value, label: o.label }));
+      case 'wind':       return WindDataset.subOptions.map((o) => ({ value: o.value, label: o.label }));
+      case 'volatility': return VolatilityDataset.subOptions;
+    }
+  }
+
+  private isSubDisabled(sub: string): boolean {
+    if (this.dataset === 'wind' && this.monthIsMtd) {
+      const opt = WindDataset.subOptions.find((o) => o.value === sub);
+      return !!opt && !opt.mtd;
+    }
+    return false;
+  }
+
+  // --- Wiring --------------------------------------------------------------
+
+  private wireSubButtons(): void {
+    document.querySelectorAll<HTMLButtonElement>('#clim-metric-picker .btn-toggle')
+      .forEach((btn) => {
+        btn.addEventListener('click', () => {
+          if (btn.hasAttribute('disabled')) return;
+          document.querySelectorAll('#clim-metric-picker .btn-toggle')
+            .forEach((b) => b.classList.remove('active'));
+          btn.classList.add('active');
+          this.sub = btn.dataset.sub!;
+          this.reload();
+        });
+      });
+  }
+
+  private wireControls(): void {
+    const monthSel = $('clim-month-picker') as HTMLSelectElement | null;
+    monthSel?.addEventListener('change', () => {
+      this.month = monthSel.value;
+      // Recompute MTD flag from the selected month vs current UTC month.
+      const now = new Date();
+      const cur = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, '0')}`;
+      this.monthIsMtd = this.month === cur;
+      this.renderSubPicker();   // wind sub may need to disable/enable
+      this.leaderboardLoaded = false;
+      this.reload();
+    });
+
+    const dsSel = $('clim-dataset-picker') as HTMLSelectElement | null;
+    dsSel?.addEventListener('change', () => {
+      this.dataset = dsSel.value as DatasetKey;
+      this.renderSubPicker();
+      this.reload();
+    });
+
+    document.querySelectorAll<HTMLButtonElement>('#clim-subtabs .tab-btn')
+      .forEach((btn) => {
+        btn.addEventListener('click', () => {
+          this.switchSubTab(btn.dataset.subtab as SubTab);
+        });
+      });
+  }
+
+  private switchSubTab(sub: SubTab): void {
+    this.currentSub = sub;
+    document.querySelectorAll('#clim-subtabs .tab-btn').forEach((b) => {
+      b.classList.toggle('active', (b as HTMLElement).dataset.subtab === sub);
+    });
+    document.querySelectorAll('.clim-subpanel').forEach((p) => {
+      p.classList.toggle('active', p.id === `clim-subpanel-${sub}`);
+    });
+    if (sub === 'map') {
+      setTimeout(() => this.mapView?.invalidateSize(), 50);
+    } else if (sub === 'top' && !this.leaderboardLoaded) {
+      this.loadLeaderboard();
+    }
+  }
+
+  // --- Status / legend -----------------------------------------------------
+
+  private setStatus(text: string, kind: 'info' | 'error' = 'info'): void {
+    const el = $('clim-status');
+    if (!el) return;
+    el.textContent = text;
+    el.className = 'map-info' + (kind === 'error' ? ' map-info-error' : '');
+  }
+
+  private renderLegend(scale: Scale): void {
+    const el = $('clim-legend');
+    if (!el) return;
+    const rows = legendRows(scale).map(
+      (s) => `<div class="legend-item">
+        <span class="legend-dot" style="background:${s.color}"></span>${s.label}
+      </div>`,
+    ).join('');
+    el.innerHTML = `
+      <div class="map-legend-title">${scale.title}</div>
+      ${rows}
+      <div class="legend-item" style="margin-top:0.25rem; opacity:0.7">
+        <span class="legend-dot" style="background:#888"></span>no data
+      </div>
+    `;
+  }
+
+  // --- Render --------------------------------------------------------------
+
+  private async reload(): Promise<void> {
+    if (this.inFlight) return;
+    this.inFlight = true;
+    this.setStatus('Loading…');
+    try {
+      const { scale, popup, airports, header } = await this.fetchActive();
+      this.renderLegend(scale);
+      this.mapView?.setScale(scale, popup);
+      this.mapView?.setData(airports);
+      this.setStatus(header);
+    } catch (err) {
+      this.setStatus(`Failed to load: ${(err as Error).message}`, 'error');
+    } finally {
+      this.inFlight = false;
+    }
+  }
+
+  private async fetchActive(): Promise<{
+    scale: Scale; popup: (a: MapAirport) => string;
+    airports: MapAirport[]; header: string;
+  }> {
+    switch (this.dataset) {
+      case 'category': {
+        const data: CategoryMapResponse = await fetchCategoryMap(this.month);
+        const sub = (this.sub || 'vfr') as CategoryKey;
+        const scale = CategoryDataset.scaleFor(sub);
+        const airports: MapAirport[] = data.airports.map((a) => {
+          const v = a[`pct_${sub}` as 'pct_vfr'];
+          return { ...a, value: v === undefined ? null : v };
+        });
+        return { scale, popup: CategoryDataset.popup, airports,
+                 header: headerFromCategory(data) };
+      }
+      case 'phenomena': {
+        const sub = (this.sub || 'ts') as PhenomenaKey;
+        const data = await fetchPhenomenaMap(this.month, sub);
+        return { scale: PhenomenaDataset.scaleFor(sub),
+                 popup: PhenomenaDataset.popup,
+                 airports: data.airports as MapAirport[],
+                 header: headerFromEnvelope(data) };
+      }
+      case 'wind': {
+        const sub = (this.sub || 'gust') as WindKey;
+        const data = await fetchWindMap(this.month, sub as WindMetric);
+        // Inject _sub so the popup knows which label to print.
+        const airports: MapAirport[] = data.airports.map(
+          (a) => ({ ...a, _sub: sub }),
+        );
+        return { scale: WindDataset.scaleFor(sub),
+                 popup: WindDataset.popup, airports,
+                 header: headerFromEnvelope(data) };
+      }
+      case 'volatility': {
+        const data = await fetchVolatilityMap(this.month);
+        return { scale: VolatilityDataset.scaleFor(),
+                 popup: VolatilityDataset.popup,
+                 airports: data.airports as MapAirport[],
+                 header: headerFromEnvelope(data) };
+      }
+    }
+  }
+
+  // --- Leaderboard (Top airports sub-tab) ----------------------------------
+
+  private async loadLeaderboard(): Promise<void> {
+    const host = $('clim-leaderboard');
+    if (!host) return;
+    host.innerHTML = '<div class="map-info" style="padding:1rem">Loading…</div>';
+    try {
+      const data = await fetchVolatilityLeaderboard(this.month, 20);
+      host.innerHTML = renderLeaderboardHtml(data);
+      this.leaderboardLoaded = true;
+    } catch (err) {
+      host.innerHTML = `<div class="map-info map-info-error" style="padding:1rem">
+        Failed: ${(err as Error).message}</div>`;
+    }
+  }
+}
+
+// --- Local helpers ---------------------------------------------------------
+
+function headerFromCategory(data: CategoryMapResponse): string {
+  const plotted = data.airports.length;
+  const withData = data.airports.filter((a) => a.n_obs > 0).length;
+  const note = data.is_mtd
+    ? `Month to date · ${data.as_of_date ?? 'no completed days yet'}`
+    : 'Completed month';
+  return `${note} · ${plotted} airports plotted (${withData} with data)`;
+}
+
+function headerFromEnvelope(data: ClimatologyMapEnvelope): string {
+  const plotted = data.airports.length;
+  const withData = data.airports.filter((a) => a.value !== null).length;
+  const note = data.is_mtd
+    ? `Month to date · ${data.as_of_date ?? 'no completed days yet'}`
+    : 'Completed month';
+  return `${note} · ${plotted} plotted (${withData} with data)`;
+}
+
+function renderLeaderboardHtml(data: VolatilityLeaderboardResponse): string {
+  if (data.rows.length === 0) {
+    return `<div class="map-info" style="padding:1rem">
+      No airports meet the minimum observation count
+      (${data.min_n_obs} obs required) for this period.
+    </div>`;
+  }
+  const rows = data.rows.map((r, i) => `
+    <tr>
+      <td style="text-align:right; padding-right:0.5rem; color:var(--text-muted)">${i + 1}.</td>
+      <td><b>${r.icao}</b></td>
+      <td style="text-align:right">${r.value.toFixed(3)}</td>
+      <td style="text-align:right; color:var(--text-muted)">${r.n_changes}</td>
+      <td style="text-align:right; color:var(--text-muted)">${r.n_obs.toLocaleString()}</td>
+    </tr>
+  `).join('');
+  const monthNote = data.is_mtd
+    ? `${data.month} (to ${data.as_of_date ?? '—'})`
+    : data.month;
+  return `
+    <div class="clim-leaderboard-wrap">
+      <h3 style="margin-top:0">Most volatile · ${monthNote}</h3>
+      <p style="color:var(--text-muted); font-size:0.8rem; margin:0.25rem 0 0.75rem">
+        Ranked by category changes per observation. Minimum ${data.min_n_obs} observations.
+      </p>
+      <table class="clim-leaderboard-table">
+        <thead>
+          <tr>
+            <th></th><th>Airport</th>
+            <th style="text-align:right">Changes / obs</th>
+            <th style="text-align:right">Changes</th>
+            <th style="text-align:right">Obs</th>
+          </tr>
+        </thead>
+        <tbody>${rows}</tbody>
+      </table>
+    </div>
+  `;
+}


### PR DESCRIPTION
## Summary

- New **Climatology** tab on `maps.html` (between Synoptic and Stats) with two sub-tabs:
  - **Map** — dataset dropdown (Category / TS-Fog / Wind / Volatility) + month picker + "Color by" sub-metric row. Per-dataset color scales calibrated against April prod data.
  - **Top airports** — leaderboard mirroring the map's dataset/sub selection. One selector, two views of the same query.
- **5 new read endpoints** under `/api/climatology/*` over `airport_monthly_summary` and `airport_daily_summary`. Shared `resolve_month_window` helper dispatches completed-month reads vs MTD live-sums. Percentile fields are blocked in MTD because they can't be SUM-ed across daily rows.
- **Generic leaderboard** (`/api/climatology/leaderboard?dataset=&sub=`) — top-N airports for any (dataset, sub) combination with min-obs gate.

Addresses #155 (views #1-#4 of 7 — climate card, calendar heatmap, and bias leaderboard remain).

## Test plan

- [x] **Backend**: 38 new tests covering window resolution, MTD vs completed-month dispatch, per-metric correctness, MTD restrictions, leaderboard min-obs gating
- [x] **Backend regression**: existing 21 `test_map_queries.py` tests pass unchanged
- [x] **TypeScript**: `tsc --noEmit` clean
- [x] **esbuild**: `dist/maps.js` rebuilds at 997 KB
- [x] **Live smoke**: 8 endpoints return 200 for completed/MTD; expected 400 for wind p95/over25 in MTD; leaderboards plausible (Mediterranean tops VFR%; Faroes/Azores top IFR%/volatility; Alpine LSZR tops gust at 66 kt)
- [ ] **Visual verify on the running dev server** — http://localhost:8001/maps.html → Climatology tab → flip Dataset/Color-by, switch between Map and Top airports sub-tabs
- [ ] **Production deploy validation**: hit each of the 5 endpoints, eyeball the legend bucket distributions vs deciles for May (full month, not just MTD)

## Out of scope (next PR)

- View #5 — per-airport climate card (`/airports/{icao}/climate`)
- View #6 — 90-day calendar heatmap (folds into #5)
- View #7 — optimistic-bias leaderboard on the Stats tab
- Recalibration after seeing summer months (TS scale especially — April had ~85% airports at 0% TS)

## Gating

Every endpoint authenticates via `current_user_id` — no preference gate yet. To gate the feature behind a user preference later: one-line `Depends(...)` swap per route, no other refactor (the Synoptic gating pattern from `7a3afd0e` is the template).

🤖 Generated with [Claude Code](https://claude.com/claude-code)