### PR TITLE
feat(refresh): tiered manual-refresh gating + reusable real-time seam

### DIFF
--- a/designs/freshness-markers.md
+++ b/designs/freshness-markers.md
@@ -66,6 +66,31 @@ if not status.fresh:
 # drift_p90_vs_config_s.
 ```
 
+## Tiered Refresh Gate (issue #167)
+
+`_build_data_status` answers "is anything stale?" with a **min-rule** — one newer covering run flips `fresh=False`. That's the right signal for the auto-refresh *scheduler's* freshness loop, but it makes the **manual refresh button** wasteful: any single model tick triggers a full token+compute+disk refresh, even when one model update can't move a multi-day-out picture. `decide_refresh` (in `api/packs.py`) layers a lead-time-aware gate on top of the same per-model states.
+
+It is a **pure function of the `DataStatus`** that `_build_data_status` already computes (no extra I/O):
+
+```python
+from weatherbrief.api.packs import decide_refresh, _days_out_now
+decision = decide_refresh(status, _days_out_now(flight))
+# decision.mode ∈ {"full", "realtime", "none"}; .reason; .eta_useful; .needed/.n_eligible/.n_updated
+```
+
+- `n_eligible` = models whose **latest available run covers the flight horizon** (`ModelStatus.covers_horizon`, set from the same `(init + run_horizon) >= flight_end` test used for staleness).
+- `n_updated` = eligible models with a newer-than-pack covering run (== `len(stale_models)`; `state == "stale"`).
+- `needed = min(threshold[days_out], n_eligible)` with **threshold `{>=2: 3, 1: 2, 0: 1}`** (module constants `_REFRESH_THRESHOLD_*`, not env-tunable for v1).
+- mode: `full` if `n_updated >= needed`; `realtime` if `days_out == 0` and not full (a D-0 press always at least pulls fresh METAR/TAF); else `none`.
+- `eta_useful` (for `none`/`realtime`) = the `(needed − n_updated)`-th soonest `next_expected` among not-yet-updated eligible models — i.e. when the threshold will next be crossed.
+
+The `min(…, n_eligible)` cap handles small selections: 2 models selected → D-2/D-1 both need both; 1 model → every press runs. (Default selection is the 3 mains, so "count ≥ 3" == "all mains" for nearly everyone.)
+
+**Wiring:**
+- Both manual-refresh endpoints (`refresh_briefing`, `refresh_briefing_stream`): `full` → run the pipeline (unchanged); `realtime` → run `tasks/route_weather.run_realtime_refresh` and return updated observations; `none` → 200 / SSE-complete no-op carrying `reason` + `eta_useful`.
+- Auto-refresh scheduler (`scheduler._auto_refresh_one`): same **full/none** policy, but **no** realtime fallback — live METAR/TAF is the verification loop's job. So a non-`full` decision means skip.
+- `force=true` (admin) still bypasses the gate entirely.
+
 ## Key Choices
 
 - **In-memory only.** Lost on restart, ~2s bootstrap cost. Admin endpoint provides debugging visibility; no DB persistence in scope.
@@ -137,12 +162,13 @@ When tuning registry offsets:
 
 ## References
 
-- Issue #108 (design + acceptance criteria)
+- Issue #108 (design + acceptance criteria); issue #167 (tiered refresh gate)
 - Existing helpers wrapped: `fetch/model_status.py`, `fetch/grib/{grib_fetch,icon_eu_fetch,ecmwf_watcher}.py`
 - Pack-side: `api/packs.py:_build_data_status`, `_backfill_sources`, `_finalize_refresh` (records `model_sources`), `_provider_label` (reads `registry.SOURCE_REGISTRY.provider_label`)
+- Tiered gate: `api/packs.py:decide_refresh` + `_refresh_threshold`/`_days_out_now`/`RefreshDecision`, `ModelStatus.covers_horizon`; wired into `refresh_briefing`, `refresh_briefing_stream`, `scheduler._auto_refresh_one`; realtime seam `tasks/route_weather.run_realtime_refresh` (see [metar-taf-route-weather.md](metar-taf-route-weather.md))
 - Loop wiring: `scheduler.py:run_freshness_loop`, `api/app.py:lifespan`
 - Admin endpoint: `api/admin.py:freshness_markers`
 - Public catalog: `fetch/freshness/catalog.py`, `api/data_sources.py` (GET `/api/data-sources`)
 - Frontend consumers: `web/help.html` + `web/ts/data-sources-table.ts` (data-driven help table), `web/ts/managers/briefing-ui.ts:renderSourcesPopupContent` (per-flight popover)
 - Storage: `BriefingPackMeta.model_sources`, `BriefingPackRow.model_sources_json` (Text JSON, alembic 050)
-- Tests: `tests/test_freshness_{registry,markers,sources,admin}.py`, `tests/test_data_sources_catalog.py`
+- Tests: `tests/test_freshness_{registry,markers,sources,admin}.py`, `tests/test_data_sources_catalog.py`, `tests/test_packs.py::TestDecideRefresh`

--- a/designs/metar-taf-route-weather.md
+++ b/designs/metar-taf-route-weather.md
@@ -19,9 +19,13 @@ tasks/route_weather.py
 │     RouteWeatherService → AvWxSource → aviationweather.gov
 │     compute_wind_advisory()    ← runway crosswind assessment per airport
 │     _applicable_taf_lines()    ← TAF line indices for UI highlighting
-└── run_observation_comparison() ← compare obs vs model predictions
-      _interpolate_airport_time()← per-airport time for model lookup
-      classify_flight_category() from analysis/airport_conditions.py
+├── run_observation_comparison() ← compare obs vs model predictions
+│     _interpolate_airport_time()← per-airport time for model lookup
+│     classify_flight_category() from analysis/airport_conditions.py
+└── run_realtime_refresh()       ← cheap real-time refresh seam (issue #167)
+      load_briefing/forecasts/route_analyses from pack_dir
+      run_route_weather() + run_observation_comparison()
+      patch route_observations back into briefing.json
 
 models/observations.py
 ├── AirportObservation     ← per-airport METAR/TAF data (flat, serializable)
@@ -87,6 +91,14 @@ For each airport with a METAR:
 4. Compute visibility and wind deltas for detail annotation
 
 **Model ceiling**: When `route_analyses` are provided, model flight category uses `sounding_ceiling_ft` from the nearest `RoutePointAnalysis` (via `classify_flight_category(ceiling, visibility)`). This allows ceiling-driven IFR comparisons. Falls back to visibility-only when route analyses are unavailable.
+
+### Real-time refresh seam (`run_realtime_refresh`)
+
+`run_realtime_refresh(pack_dir, db_path)` is the **cheap** refresh path (issue #167 Part A): re-fetch METAR/TAF and recompute the comparison from a pack's **stored** forecasts, then patch `route_observations` back into `briefing.json`. **No** model fetch, **no** GRIB, **no** LLM. It reads `briefing.json` (route + stored `corridor_nm` + target time via `parse_target_time`), `forecasts.json`, and `route_analyses.json` off disk, calls `run_route_weather()` + `run_observation_comparison()`, and writes the result back. Raises `FileNotFoundError` if the pack has no briefing data.
+
+Two callers share this seam:
+- `POST .../observations/refresh` — the standalone METAR/TAF refresh button (a thin endpoint wrapper that adds auth + the D-0 400 guard).
+- The tiered refresh gate's `realtime` mode (`api/packs.decide_refresh`) — when a D-0 manual refresh isn't worth a full pipeline run, both refresh-button endpoints invoke `run_realtime_refresh` instead so a D-0 press is always at least cheap-useful. See [freshness-markers.md](freshness-markers.md) for the gate.
 
 ### Digest Integration
 
@@ -157,9 +169,10 @@ metar_taf_airports: int = 0
 
 ## References
 
-- Key code: `src/weatherbrief/tasks/route_weather.py`, `src/weatherbrief/models/observations.py`
+- Key code: `src/weatherbrief/tasks/route_weather.py` (incl. `run_realtime_refresh`), `src/weatherbrief/models/observations.py`
 - Pipeline integration: `src/weatherbrief/pipeline.py` (step 3.5)
+- Realtime seam + tiered gate: `tasks/route_weather.py:run_realtime_refresh`, `api/packs.py:refresh_observations` (thin wrapper), `api/packs.py:decide_refresh`; shared helper `tasks/artifacts.py:parse_target_time`
 - Digest: `src/weatherbrief/digest/prompt_builder.py`, `src/weatherbrief/digest/text.py`
 - Report: `src/weatherbrief/report/templates/briefing.html`, `src/weatherbrief/report/render.py`
-- Tests: `tests/test_route_weather.py` (21 tests)
+- Tests: `tests/test_route_weather.py` (incl. `TestRunRealtimeRefresh`), `tests/test_packs.py::TestDecideRefresh`
 - euro_aip weather module: [briefing_weather.md](rzflight design doc)

--- a/src/weatherbrief/api/packs.py
+++ b/src/weatherbrief/api/packs.py
@@ -48,6 +48,8 @@ from flyfun_common.db import current_user_id, get_db, SessionLocal
 from weatherbrief.fetch.freshness import registry as freshness_registry
 from weatherbrief.fetch.model_status import fetch_model_metadata
 from weatherbrief.tasks.artifacts import parse_target_time as _parse_target_time
+from weatherbrief.tasks.route_weather import run_realtime_refresh
+from weatherbrief.models.observations import RouteObservations
 from weatherbrief.models import (
     BriefingPackMeta,
     DiagnosticPublic,
@@ -678,7 +680,7 @@ def decide_refresh(status: DataStatus, days_out: int) -> RefreshDecision:
     """
     models = list(status.models.values())
     n_eligible = sum(1 for ms in models if ms.covers_horizon)
-    n_updated = sum(1 for ms in models if ms.state == "stale")
+    n_updated = sum(1 for ms in models if ms.covers_horizon and ms.state == "stale")
     threshold = _refresh_threshold(days_out)
 
     # No model's latest run reaches the flight horizon yet — a full refresh
@@ -1266,7 +1268,7 @@ class RefreshAccepted(BaseModel):
     mode: str | None = None  # "full" | "realtime" | "none"
     reason: str | None = None
     eta_useful: str | None = None  # ISO wallclock of next useful model update
-    observations: dict | None = None  # updated RouteObservations (realtime mode)
+    observations: RouteObservations | None = None  # updated obs (realtime mode)
 
 
 @router.post(
@@ -1340,12 +1342,10 @@ async def refresh_briefing(
                 resp_status = "already_fresh"
                 if decision.mode == "realtime":
                     resp_status = "realtime"
-                    from weatherbrief.tasks.route_weather import run_realtime_refresh
                     try:
-                        new_obs = await asyncio.to_thread(
+                        observations = await asyncio.to_thread(
                             run_realtime_refresh, Path(latest.artifact_path), db_path,
                         )
-                        observations = new_obs.model_dump(mode="json")
                     except Exception:
                         logger.warning(
                             "Real-time refresh failed for %s — returning no-op",
@@ -1496,12 +1496,13 @@ async def refresh_briefing_stream(
                         "Refresh gate for %s (stream): mode=%s (%s)",
                         flight_id, decision.mode, decision.reason,
                     )
+                    obs_payload = None
                     if decision.mode == "realtime":
-                        from weatherbrief.tasks.route_weather import run_realtime_refresh
                         try:
-                            await asyncio.to_thread(
+                            new_obs = await asyncio.to_thread(
                                 run_realtime_refresh, Path(latest.artifact_path), db_path,
                             )
+                            obs_payload = new_obs.model_dump(mode="json")
                         except Exception:
                             logger.warning(
                                 "Real-time refresh failed for %s (stream) — completing no-op",
@@ -1515,6 +1516,7 @@ async def refresh_briefing_stream(
                             "type": "complete",
                             "pack": pack_resp,
                             "refresh_decision": decision_payload,
+                            "observations": obs_payload,
                         }
                         yield f"event: complete\ndata: {json_mod.dumps(event, default=str)}\n\n"
 
@@ -1838,8 +1840,6 @@ def refresh_observations(
     db_path = getattr(request.app.state, "db_path", "")
     if not db_path:
         raise HTTPException(status_code=503, detail="Airport database not configured")
-
-    from weatherbrief.tasks.route_weather import run_realtime_refresh
 
     try:
         new_obs = run_realtime_refresh(pack_dir, db_path)

--- a/src/weatherbrief/api/packs.py
+++ b/src/weatherbrief/api/packs.py
@@ -47,6 +47,7 @@ from weatherbrief.api.flights import _load_flight_or_404, _load_owned_flight
 from flyfun_common.db import current_user_id, get_db, SessionLocal
 from weatherbrief.fetch.freshness import registry as freshness_registry
 from weatherbrief.fetch.model_status import fetch_model_metadata
+from weatherbrief.tasks.artifacts import parse_target_time as _parse_target_time
 from weatherbrief.models import (
     BriefingPackMeta,
     DiagnosticPublic,
@@ -218,6 +219,10 @@ class ModelStatus(BaseModel):
     # DWD's HTTP Last-Modified, ECMWF's local sentinel mtime.
     published_at: str | None = None
     state: str  # "current" | "stale" | "awaiting" | "delayed"
+    # True when this source's latest available run reaches the flight's end
+    # time.  Drives the tiered refresh gate (issue #167): only models whose
+    # latest run covers the flight count toward the refresh threshold.
+    covers_horizon: bool = False
 
 
 class ModelSourceDetail(BaseModel):
@@ -534,6 +539,7 @@ def _build_data_status(pack: BriefingPackMeta, flight: Flight) -> DataStatus:
             next_expected=nxt.isoformat(),
             published_at=published_at_iso,
             state=state,
+            covers_horizon=run_covers_flight,
         )
         next_expected_candidates.append((nxt, model))
 
@@ -607,6 +613,132 @@ def _build_data_status(pack: BriefingPackMeta, flight: Flight) -> DataStatus:
     )
 
 
+
+
+# ---------------------------------------------------------------------------
+# Tiered refresh gating (issue #167)
+# ---------------------------------------------------------------------------
+
+# How many *eligible* models (latest run covers the flight) must have a newer
+# covering run before a manual refresh runs the full pipeline.  Stricter the
+# further out the flight is — a single model tick shouldn't trigger a full
+# token+compute+disk refresh of a multi-day-out picture.  Capped by the number
+# of eligible models so small selections still work (see ``decide_refresh``).
+_REFRESH_THRESHOLD_DEFAULT = 3  # days_out >= 2
+_REFRESH_THRESHOLD_BY_DAYS_OUT = {0: 1, 1: 2}
+
+
+def _refresh_threshold(days_out: int) -> int:
+    """Models-updated threshold for a given lead time (uncapped)."""
+    if days_out <= 0:
+        return _REFRESH_THRESHOLD_BY_DAYS_OUT[0]
+    return _REFRESH_THRESHOLD_BY_DAYS_OUT.get(days_out, _REFRESH_THRESHOLD_DEFAULT)
+
+
+def _days_out_now(flight: Flight) -> int:
+    """Lead time in whole days from now (UTC) to the flight's departure date."""
+    now = datetime.now(timezone.utc)
+    return (flight.departure_time.date() - now.date()).days
+
+
+class RefreshDecision(BaseModel):
+    """Outcome of the tiered refresh gate (issue #167)."""
+
+    mode: str  # "full" | "realtime" | "none"
+    reason: str
+    needed: int          # models-updated threshold, capped by n_eligible
+    n_eligible: int      # selected models whose latest run covers the flight
+    n_updated: int       # eligible models with a newer-than-pack covering run
+    days_out: int
+    # ISO wallclock when enough not-yet-updated covering models will have
+    # refreshed to cross the threshold — populated when mode != "full".
+    eta_useful: str | None = None
+
+
+def decide_refresh(status: DataStatus, days_out: int) -> RefreshDecision:
+    """Decide whether a manual refresh runs the full pipeline, a cheap
+    real-time observations refresh, or nothing (issue #167 Part B).
+
+    Pure function of the per-model freshness states already computed by
+    :func:`_build_data_status` (which encodes flight-horizon coverage in each
+    ``ModelStatus.covers_horizon``).  The gate is progressively stricter the
+    further out the flight is:
+
+    - ``needed = min(threshold[days_out], n_eligible)`` with threshold
+      ``{>=2: 3, 1: 2, 0: 1}``.
+    - ``full`` when ``n_updated >= needed`` (enough covering models have a
+      newer run to be worth a full re-run).
+    - ``realtime`` at D-0 when not ``full`` — a D-0 press always at least
+      pulls fresh METAR/TAF (the caller runs ``run_realtime_refresh``).
+    - ``none`` otherwise — a no-op carrying a reason and the ETA of the next
+      useful update.
+
+    The ``min(..., n_eligible)`` cap means small model selections still work:
+    2 models selected -> D-2/D-1 both need both; 1 model -> every press runs.
+    """
+    models = list(status.models.values())
+    n_eligible = sum(1 for ms in models if ms.covers_horizon)
+    n_updated = sum(1 for ms in models if ms.state == "stale")
+    threshold = _refresh_threshold(days_out)
+
+    # No model's latest run reaches the flight horizon yet — a full refresh
+    # can't help, so never "full" (n_updated is necessarily 0 here too).
+    if n_eligible == 0:
+        if days_out == 0:
+            return RefreshDecision(
+                mode="realtime",
+                reason="D-0: refreshing live METAR/TAF (no model run covers the flight horizon)",
+                needed=threshold, n_eligible=0, n_updated=0, days_out=days_out,
+            )
+        return RefreshDecision(
+            mode="none",
+            reason="No model run covers the flight horizon yet",
+            needed=threshold, n_eligible=0, n_updated=0, days_out=days_out,
+            eta_useful=status.next_expected_update,
+        )
+
+    needed = min(threshold, n_eligible)
+
+    if n_updated >= needed:
+        return RefreshDecision(
+            mode="full",
+            reason=(
+                f"{n_updated} of {n_eligible} covering model(s) have a newer "
+                f"run (need {needed}) — running full refresh"
+            ),
+            needed=needed, n_eligible=n_eligible, n_updated=n_updated, days_out=days_out,
+        )
+
+    # Not enough covering models updated. Compute the wallclock at which enough
+    # not-yet-updated covering models will have refreshed to cross threshold.
+    k = needed - n_updated
+    pending_next = sorted(
+        (datetime.fromisoformat(ms.next_expected), ms.next_expected)
+        for ms in models
+        if ms.covers_horizon and ms.state != "stale" and ms.next_expected
+    )
+    eta_useful = pending_next[k - 1][1] if 0 < k <= len(pending_next) else None
+
+    if days_out == 0:
+        return RefreshDecision(
+            mode="realtime",
+            reason=(
+                f"D-0: only {n_updated} of {needed} covering model(s) updated "
+                f"— refreshing live METAR/TAF"
+            ),
+            needed=needed, n_eligible=n_eligible, n_updated=n_updated, days_out=days_out,
+            eta_useful=eta_useful,
+        )
+
+    return RefreshDecision(
+        mode="none",
+        reason=(
+            f"Only {n_updated} of {needed} covering model(s) updated for a "
+            f"D-{days_out} flight — no refresh needed"
+        ),
+        needed=needed, n_eligible=n_eligible, n_updated=n_updated, days_out=days_out,
+        eta_useful=eta_useful,
+    )
 
 
 def _can_force_refresh(request: Request, db: Session) -> bool:
@@ -1124,11 +1256,17 @@ def _finalize_refresh(
 
 
 class RefreshAccepted(BaseModel):
-    """Response for accepted (queued) refresh requests."""
+    """Response for accepted (queued) or gated refresh requests."""
 
-    status: str  # "queued" | "already_fresh"
+    status: str  # "queued" | "already_fresh" | "realtime"
     flight_id: str
     message: str
+    # Tiered refresh gate detail (issue #167) — present when the request was
+    # gated to a real-time-only refresh or skipped entirely.
+    mode: str | None = None  # "full" | "realtime" | "none"
+    reason: str | None = None
+    eta_useful: str | None = None  # ISO wallclock of next useful model update
+    observations: dict | None = None  # updated RouteObservations (realtime mode)
 
 
 @router.post(
@@ -1185,19 +1323,44 @@ async def refresh_briefing(
     if not db_path:
         raise HTTPException(status_code=503, detail="AIRPORTS_DB not configured")
 
-    # Smart check: skip pipeline if data is fresh (skip for historical flights)
+    # Tiered refresh gate (issue #167): full -> pipeline, realtime -> cheap
+    # METAR/TAF refresh, none -> 200 no-op (skip for historical flights).
     if not force and not is_historical:
         packs = list_packs(db, flight_id)
         if packs:
             latest = packs[0]
             status = _build_data_status(latest, flight)
-            if status.fresh:
-                logger.info("Data is fresh for %s, skipping pipeline", flight_id)
+            decision = decide_refresh(status, _days_out_now(flight))
+            if decision.mode != "full":
+                logger.info(
+                    "Refresh gate for %s: mode=%s (%s)",
+                    flight_id, decision.mode, decision.reason,
+                )
+                observations = None
+                resp_status = "already_fresh"
+                if decision.mode == "realtime":
+                    resp_status = "realtime"
+                    from weatherbrief.tasks.route_weather import run_realtime_refresh
+                    try:
+                        new_obs = await asyncio.to_thread(
+                            run_realtime_refresh, Path(latest.artifact_path), db_path,
+                        )
+                        observations = new_obs.model_dump(mode="json")
+                    except Exception:
+                        logger.warning(
+                            "Real-time refresh failed for %s — returning no-op",
+                            flight_id, exc_info=True,
+                        )
+                        resp_status = "already_fresh"
                 return Response(
                     content=RefreshAccepted(
-                        status="already_fresh",
+                        status=resp_status,
                         flight_id=flight_id,
-                        message="Data is already current — no refresh needed.",
+                        message=decision.reason,
+                        mode=decision.mode,
+                        reason=decision.reason,
+                        eta_useful=decision.eta_useful,
+                        observations=observations,
                     ).model_dump_json(),
                     status_code=200,
                     media_type="application/json",
@@ -1320,22 +1483,43 @@ async def refresh_briefing_stream(
         if not db_path:
             raise HTTPException(status_code=503, detail="AIRPORTS_DB not configured")
 
-        # Smart check: skip pipeline if data is fresh (skip for historical flights)
+        # Tiered refresh gate (issue #167): full -> pipeline, realtime -> cheap
+        # METAR/TAF refresh, none -> complete no-op (skip for historical).
         if not force and not is_historical:
             packs = list_packs(db, flight_id)
             if packs:
                 latest = packs[0]
                 status = _build_data_status(latest, flight)
-                if status.fresh:
-                    logger.info("Data is fresh for %s, skipping pipeline (stream)", flight_id)
+                decision = decide_refresh(status, _days_out_now(flight))
+                if decision.mode != "full":
+                    logger.info(
+                        "Refresh gate for %s (stream): mode=%s (%s)",
+                        flight_id, decision.mode, decision.reason,
+                    )
+                    if decision.mode == "realtime":
+                        from weatherbrief.tasks.route_weather import run_realtime_refresh
+                        try:
+                            await asyncio.to_thread(
+                                run_realtime_refresh, Path(latest.artifact_path), db_path,
+                            )
+                        except Exception:
+                            logger.warning(
+                                "Real-time refresh failed for %s (stream) — completing no-op",
+                                flight_id, exc_info=True,
+                            )
                     pack_resp = _meta_to_response(latest, data_status=status).model_dump(mode="json")
+                    decision_payload = decision.model_dump(mode="json")
 
-                    async def fresh_generator() -> AsyncGenerator[str, None]:
-                        event = {"type": "complete", "pack": pack_resp}
+                    async def gate_generator() -> AsyncGenerator[str, None]:
+                        event = {
+                            "type": "complete",
+                            "pack": pack_resp,
+                            "refresh_decision": decision_payload,
+                        }
                         yield f"event: complete\ndata: {json_mod.dumps(event, default=str)}\n\n"
 
                     return StreamingResponse(
-                        fresh_generator(),
+                        gate_generator(),
                         media_type="text/event-stream",
                         headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
                     )
@@ -1638,10 +1822,10 @@ def refresh_observations(
     Re-runs route_weather + observation_comparison using existing forecast data,
     then patches the snapshot on disk.
     """
-    flight = _load_owned_flight(db, flight_id, user_id)
+    _load_owned_flight(db, flight_id, user_id)  # authz: owner only
     pack_dir = _get_pack_dir(db, flight_id, timestamp, viewer_id=user_id)
 
-    from weatherbrief.tasks.artifacts import load_briefing, load_forecasts as load_forecasts_json
+    from weatherbrief.tasks.artifacts import load_briefing
 
     briefing_data = load_briefing(pack_dir)
     if not briefing_data:
@@ -1655,74 +1839,11 @@ def refresh_observations(
     if not db_path:
         raise HTTPException(status_code=503, detail="Airport database not configured")
 
+    from weatherbrief.tasks.route_weather import run_realtime_refresh
+
     try:
-        from weatherbrief.models import ForecastSnapshot, RouteConfig, WaypointForecast
-        from weatherbrief.models.observations import RouteObservations
-        from weatherbrief.tasks.route_weather import (
-            run_observation_comparison,
-            run_route_weather,
-        )
-
-        route = RouteConfig.model_validate(briefing_data["route"])
-        target_dt = _parse_target_time(briefing_data)
-
-        # Options for corridor width
-        corridor_nm = 30.0
-        if briefing_data.get("route_observations"):
-            corridor_nm = briefing_data["route_observations"].get("corridor_nm", 30.0)
-
-        # Fetch fresh METAR/TAF
-        new_obs = run_route_weather(
-            route=route,
-            target_time=target_dt,
-            corridor_nm=corridor_nm,
-            airports_db_path=db_path,
-        )
-
-        # Run observation-vs-model comparison using stored forecasts
-        forecasts_data = load_forecasts_json(pack_dir)
-        forecasts = [
-            WaypointForecast.model_validate(f)
-            for f in (forecasts_data or {}).get("forecasts", [])
-        ]
-
-        # Load route analyses for sounding ceiling data
-        route_analyses = None
-        ra_path = pack_dir / "route_analyses.json"
-        if ra_path.exists():
-            from weatherbrief.tasks.artifacts import load_route_analyses
-            ra_manifest = load_route_analyses(pack_dir)
-            route_analyses = ra_manifest.analyses
-
-        # Runway data for wind advisory comparison
-        obs_runway_data = None
-        try:
-            from weatherbrief.airports import get_runway_ends
-            obs_icaos = list({a.icao for a in new_obs.airports})
-            obs_runway_data = get_runway_ends(obs_icaos, db_path)
-        except Exception:
-            pass
-
-        new_obs = run_observation_comparison(
-            observations=new_obs,
-            snapshot_forecasts=forecasts,
-            target_time=target_dt,
-            route=route,
-            runway_data=obs_runway_data,
-            route_analyses=route_analyses,
-        )
-
-        # Patch briefing on disk (prefer briefing.json, fall back to snapshot.json)
-        briefing_data["route_observations"] = new_obs.model_dump(mode="json")
-        briefing_path = pack_dir / "briefing.json"
-        if briefing_path.exists():
-            briefing_path.write_text(json_mod.dumps(briefing_data, indent=2, default=str))
-        else:
-            snapshot_path = pack_dir / "snapshot.json"
-            snapshot_path.write_text(json_mod.dumps(briefing_data, indent=2, default=str))
-
+        new_obs = run_realtime_refresh(pack_dir, db_path)
         return new_obs.model_dump(mode="json")
-
     except HTTPException:
         raise
     except Exception as exc:
@@ -3001,24 +3122,3 @@ def _get_pack_dir(db: Session, flight_id: str, timestamp: str, *, viewer_id: str
     return pack_path
 
 
-def _parse_target_time(snapshot_data: dict) -> datetime:
-    """Extract target datetime from snapshot JSON data.
-
-    Returns a timezone-aware UTC datetime.  Old packs that stored naive
-    timestamps are promoted to aware UTC so comparisons against both
-    old (naive HourlyForecast.time) and new (aware) data work correctly
-    — ``at_time()`` is patched below to handle the mixed case gracefully.
-    """
-    # Prefer departure_time (new packs)
-    dt_str = snapshot_data.get("departure_time")
-    if dt_str:
-        dt = datetime.fromisoformat(dt_str)
-        return dt.replace(tzinfo=timezone.utc) if dt.tzinfo is None else dt
-    # Fallback: first analysis target_time
-    analyses = snapshot_data.get("analyses", [])
-    if analyses and "target_time" in analyses[0]:
-        dt = datetime.fromisoformat(analyses[0]["target_time"])
-        return dt.replace(tzinfo=timezone.utc) if dt.tzinfo is None else dt
-    target_date = snapshot_data.get("target_date", "")
-    year, month, day = (int(x) for x in target_date.split("-"))
-    return datetime(year, month, day, 9, tzinfo=timezone.utc)

--- a/src/weatherbrief/scheduler.py
+++ b/src/weatherbrief/scheduler.py
@@ -233,7 +233,8 @@ def _flight_start_dt(row: FlightRow) -> datetime | None:
 def _auto_refresh_one(flight_row: FlightRow, app_state, user_id: str) -> None:
     """Run the briefing pipeline for a single flight (called in a thread)."""
     from weatherbrief.api.packs import (
-        _build_data_status, _finalize_refresh, _prepare_refresh, refresh_registry,
+        _build_data_status, _days_out_now, _finalize_refresh, _prepare_refresh,
+        decide_refresh, refresh_registry,
     )
     from weatherbrief.storage.flights import _row_to_flight, list_packs
 
@@ -241,13 +242,19 @@ def _auto_refresh_one(flight_row: FlightRow, app_state, user_id: str) -> None:
     try:
         flight = _row_to_flight(flight_row)
 
-        # Check freshness — skip if no source has fresher data covering the flight.
+        # Tiered refresh gate (issue #167): the scheduler applies the same
+        # full/none policy as the manual button but never the realtime
+        # fallback — live METAR/TAF is the verification loop's job.
         packs = list_packs(db, flight_row.id)
         if packs:
             latest = packs[0]
             status = _build_data_status(latest, flight)
-            if status.fresh:
-                logger.info("Auto-refresh: data is fresh for %s, skipping", flight_row.id)
+            decision = decide_refresh(status, _days_out_now(flight))
+            if decision.mode != "full":
+                logger.info(
+                    "Auto-refresh: gate=%s for %s (%s), skipping",
+                    decision.mode, flight_row.id, decision.reason,
+                )
                 return
 
         db_path = getattr(app_state, "db_path", "")

--- a/src/weatherbrief/tasks/artifacts.py
+++ b/src/weatherbrief/tasks/artifacts.py
@@ -210,6 +210,28 @@ def load_forecasts(pack_dir: Path) -> dict | None:
     return _load_json_with_fallback(pack_dir, "forecasts.json")
 
 
+def parse_target_time(snapshot_data: dict) -> datetime:
+    """Extract the flight target datetime from snapshot/briefing JSON.
+
+    Returns a timezone-aware UTC datetime.  Old packs that stored naive
+    timestamps are promoted to aware UTC so comparisons against both old
+    (naive ``HourlyForecast.time``) and new (aware) data work correctly.
+    """
+    # Prefer departure_time (new packs)
+    dt_str = snapshot_data.get("departure_time")
+    if dt_str:
+        dt = datetime.fromisoformat(dt_str)
+        return dt.replace(tzinfo=timezone.utc) if dt.tzinfo is None else dt
+    # Fallback: first analysis target_time
+    analyses = snapshot_data.get("analyses", [])
+    if analyses and "target_time" in analyses[0]:
+        dt = datetime.fromisoformat(analyses[0]["target_time"])
+        return dt.replace(tzinfo=timezone.utc) if dt.tzinfo is None else dt
+    target_date = snapshot_data.get("target_date", "")
+    year, month, day = (int(x) for x in target_date.split("-"))
+    return datetime(year, month, day, 9, tzinfo=timezone.utc)
+
+
 # ---------------------------------------------------------------------------
 # Alt advisory artifacts
 # ---------------------------------------------------------------------------

--- a/src/weatherbrief/tasks/route_weather.py
+++ b/src/weatherbrief/tasks/route_weather.py
@@ -5,8 +5,10 @@ Only used on D-0 (day of flight) when real observations add value.
 
 from __future__ import annotations
 
+import json
 import logging
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 
 from weatherbrief.models.analysis import RouteConfig, WaypointForecast
 from weatherbrief.models.airport_conditions import RunwayEnd
@@ -509,3 +511,90 @@ def run_observation_comparison(
     observations.comparisons = comparisons
     observations.has_conflicts = has_conflicts
     return observations
+
+
+def run_realtime_refresh(
+    pack_dir: Path,
+    db_path: str,
+    *,
+    default_corridor_nm: float = 30.0,
+) -> RouteObservations:
+    """Re-fetch METAR/TAF and recompute the obs-vs-model comparison from a
+    pack's *stored* forecasts, then patch ``briefing.json`` in place.
+
+    This is the cheap real-time path (issue #167 Part A): no model fetch, no
+    GRIB, no LLM.  Shared by the observations refresh button endpoint and the
+    tiered refresh gate's ``realtime`` mode.
+
+    Reads the pack's route, forecasts and route analyses off disk, fetches
+    fresh observations for the route corridor, recomputes the comparison
+    against the stored forecasts, writes the result back into
+    ``briefing.json`` (or legacy ``snapshot.json``), and returns the updated
+    :class:`RouteObservations`.
+
+    Raises :class:`FileNotFoundError` if the pack has no briefing data on disk.
+    """
+    from weatherbrief.tasks.artifacts import (
+        load_briefing,
+        load_forecasts,
+        load_route_analyses,
+        parse_target_time,
+    )
+
+    pack_dir = Path(pack_dir)
+    briefing_data = load_briefing(pack_dir)
+    if not briefing_data:
+        raise FileNotFoundError(f"No briefing data found in {pack_dir}")
+
+    route = RouteConfig.model_validate(briefing_data["route"])
+    target_dt = parse_target_time(briefing_data)
+
+    corridor_nm = default_corridor_nm
+    stored_obs = briefing_data.get("route_observations")
+    if stored_obs:
+        corridor_nm = stored_obs.get("corridor_nm", default_corridor_nm)
+
+    # Fetch fresh METAR/TAF along the route corridor.
+    new_obs = run_route_weather(
+        route=route,
+        target_time=target_dt,
+        corridor_nm=corridor_nm,
+        airports_db_path=db_path,
+    )
+
+    # Compare observations against the pack's *stored* forecasts.
+    forecasts_data = load_forecasts(pack_dir)
+    forecasts = [
+        WaypointForecast.model_validate(f)
+        for f in (forecasts_data or {}).get("forecasts", [])
+    ]
+
+    route_analyses = None
+    if (pack_dir / "route_analyses.json").exists():
+        route_analyses = load_route_analyses(pack_dir).analyses
+
+    obs_runway_data = None
+    try:
+        from weatherbrief.airports import get_runway_ends
+
+        obs_icaos = list({a.icao for a in new_obs.airports})
+        obs_runway_data = get_runway_ends(obs_icaos, db_path)
+    except Exception:
+        logger.warning("Failed to load runway data for observation comparison", exc_info=True)
+
+    new_obs = run_observation_comparison(
+        observations=new_obs,
+        snapshot_forecasts=forecasts,
+        target_time=target_dt,
+        route=route,
+        runway_data=obs_runway_data,
+        route_analyses=route_analyses,
+    )
+
+    # Patch the observations back into the briefing on disk.
+    briefing_data["route_observations"] = new_obs.model_dump(mode="json")
+    briefing_path = pack_dir / "briefing.json"
+    target_path = briefing_path if briefing_path.exists() else pack_dir / "snapshot.json"
+    target_path.write_text(json.dumps(briefing_data, indent=2, default=str))
+
+    return new_obs

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -819,6 +819,104 @@ class TestRefreshEndpoint:
         finally:
             refresh_registry.unregister(sample_flight.id)
 
+    def _gate_pack(self, flight_id, days_out):
+        from weatherbrief.models import BriefingPackMeta
+
+        return BriefingPackMeta(
+            flight_id=flight_id,
+            fetch_timestamp=datetime.now(timezone.utc),
+            days_out=days_out,
+            artifact_path="/tmp/gate-pack",
+        )
+
+    @patch("weatherbrief.api.packs.decide_refresh")
+    @patch("weatherbrief.api.packs._build_data_status")
+    @patch("weatherbrief.api.packs.list_packs")
+    def test_refresh_gate_none(
+        self, mock_list, mock_status, mock_decide, client, sample_flight,
+    ):
+        """A ``none`` decision returns 200 already_fresh with reason + ETA."""
+        from weatherbrief.api.packs import DataStatus, RefreshDecision
+
+        mock_list.return_value = [self._gate_pack(sample_flight.id, 2)]
+        mock_status.return_value = DataStatus(fresh=True)
+        mock_decide.return_value = RefreshDecision(
+            mode="none", reason="not enough models updated",
+            needed=3, n_eligible=3, n_updated=1, days_out=2,
+            eta_useful="2026-05-21T06:00:00+00:00",
+        )
+        client.app.state.db_path = "/fake/db"
+        try:
+            resp = client.post(f"/api/flights/{sample_flight.id}/packs/refresh")
+            assert resp.status_code == 200
+            data = resp.json()
+            assert data["status"] == "already_fresh"
+            assert data["mode"] == "none"
+            assert data["eta_useful"] == "2026-05-21T06:00:00+00:00"
+            assert data["observations"] is None
+        finally:
+            client.app.state.db_path = ""
+
+    @patch("weatherbrief.tasks.route_weather.run_realtime_refresh")
+    @patch("weatherbrief.api.packs.decide_refresh")
+    @patch("weatherbrief.api.packs._build_data_status")
+    @patch("weatherbrief.api.packs.list_packs")
+    def test_refresh_gate_realtime(
+        self, mock_list, mock_status, mock_decide, mock_rt, client, sample_flight,
+    ):
+        """A ``realtime`` decision runs the cheap path and returns observations."""
+        from weatherbrief.api.packs import DataStatus, RefreshDecision
+        from weatherbrief.models.observations import RouteObservations
+
+        mock_list.return_value = [self._gate_pack(sample_flight.id, 0)]
+        mock_status.return_value = DataStatus(fresh=True)
+        mock_decide.return_value = RefreshDecision(
+            mode="realtime", reason="D-0 live METAR/TAF",
+            needed=1, n_eligible=3, n_updated=0, days_out=0,
+        )
+        mock_rt.return_value = RouteObservations(
+            corridor_nm=30.0, fetch_time=datetime.now(timezone.utc),
+            airports_found=2, airports_with_metar=2, airports_with_taf=1, airports=[],
+        )
+        client.app.state.db_path = "/fake/db"
+        try:
+            resp = client.post(f"/api/flights/{sample_flight.id}/packs/refresh")
+            assert resp.status_code == 200
+            data = resp.json()
+            assert data["status"] == "realtime"
+            assert data["mode"] == "realtime"
+            assert data["observations"]["airports_found"] == 2
+            mock_rt.assert_called_once()
+        finally:
+            client.app.state.db_path = ""
+
+    @patch("weatherbrief.tasks.route_weather.run_realtime_refresh")
+    @patch("weatherbrief.api.packs.decide_refresh")
+    @patch("weatherbrief.api.packs._build_data_status")
+    @patch("weatherbrief.api.packs.list_packs")
+    def test_refresh_gate_realtime_failure_degrades_to_noop(
+        self, mock_list, mock_status, mock_decide, mock_rt, client, sample_flight,
+    ):
+        """If the real-time path fails, the request degrades to a 200 no-op."""
+        from weatherbrief.api.packs import DataStatus, RefreshDecision
+
+        mock_list.return_value = [self._gate_pack(sample_flight.id, 0)]
+        mock_status.return_value = DataStatus(fresh=True)
+        mock_decide.return_value = RefreshDecision(
+            mode="realtime", reason="D-0 live METAR/TAF",
+            needed=1, n_eligible=3, n_updated=0, days_out=0,
+        )
+        mock_rt.side_effect = RuntimeError("aviationweather down")
+        client.app.state.db_path = "/fake/db"
+        try:
+            resp = client.post(f"/api/flights/{sample_flight.id}/packs/refresh")
+            assert resp.status_code == 200
+            data = resp.json()
+            assert data["status"] == "already_fresh"
+            assert data["observations"] is None
+        finally:
+            client.app.state.db_path = ""
+
 
 class TestRefreshStreamEncoder:
     """Guard the JSON-encoder path used by ``/refresh/stream`` SSE events.

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -857,7 +857,7 @@ class TestRefreshEndpoint:
         finally:
             client.app.state.db_path = ""
 
-    @patch("weatherbrief.tasks.route_weather.run_realtime_refresh")
+    @patch("weatherbrief.api.packs.run_realtime_refresh")
     @patch("weatherbrief.api.packs.decide_refresh")
     @patch("weatherbrief.api.packs._build_data_status")
     @patch("weatherbrief.api.packs.list_packs")
@@ -890,7 +890,7 @@ class TestRefreshEndpoint:
         finally:
             client.app.state.db_path = ""
 
-    @patch("weatherbrief.tasks.route_weather.run_realtime_refresh")
+    @patch("weatherbrief.api.packs.run_realtime_refresh")
     @patch("weatherbrief.api.packs.decide_refresh")
     @patch("weatherbrief.api.packs._build_data_status")
     @patch("weatherbrief.api.packs.list_packs")

--- a/tests/test_packs.py
+++ b/tests/test_packs.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -159,3 +160,186 @@ class TestPrepareRefresh:
 
         assert options.fetch_gramet is False
         assert options.generate_llm_digest is False
+
+
+# --- decide_refresh (tiered refresh gate, issue #167) ---
+
+
+def _ms(state, covers=True, next_expected="2026-05-20T12:00:00+00:00"):
+    """Build a ModelStatus for gate tests."""
+    from weatherbrief.api.packs import ModelStatus
+
+    return ModelStatus(
+        source="m:openmeteo",
+        pack_init=1,
+        latest_available=2,
+        next_expected=next_expected,
+        state=state,
+        covers_horizon=covers,
+    )
+
+
+def _status(*models, next_expected_update=None):
+    """Build a DataStatus from (state, covers[, next_expected]) tuples."""
+    from weatherbrief.api.packs import DataStatus
+
+    out = {}
+    for i, spec in enumerate(models):
+        state, covers = spec[0], spec[1]
+        nx = spec[2] if len(spec) > 2 else "2026-05-20T12:00:00+00:00"
+        out[f"m{i}"] = _ms(state, covers, nx)
+    stale = [m for m, ms in out.items() if ms.state == "stale"]
+    return DataStatus(
+        fresh=not stale,
+        stale_models=stale,
+        models=out,
+        next_expected_update=next_expected_update,
+    )
+
+
+class TestRefreshThreshold:
+    """_refresh_threshold: {>=2: 3, 1: 2, 0: 1}."""
+
+    def test_thresholds(self):
+        from weatherbrief.api.packs import _refresh_threshold
+
+        assert _refresh_threshold(0) == 1
+        assert _refresh_threshold(1) == 2
+        assert _refresh_threshold(2) == 3
+        assert _refresh_threshold(5) == 3
+
+
+class TestDaysOutNow:
+    def test_days_out_from_departure(self):
+        from weatherbrief.api.packs import _days_out_now
+
+        flight = SimpleNamespace(
+            departure_time=datetime.now(timezone.utc) + timedelta(days=2, hours=1),
+        )
+        assert _days_out_now(flight) == 2
+
+    def test_d0(self):
+        from weatherbrief.api.packs import _days_out_now
+
+        flight = SimpleNamespace(departure_time=datetime.now(timezone.utc) + timedelta(hours=3))
+        assert _days_out_now(flight) == 0
+
+
+class TestDecideRefresh:
+    """Matrix from issue #167 acceptance criteria.
+
+    Threshold: D-0 needs 1 updated, D-1 needs 2, D-2+ needs 3 (capped by the
+    number of models whose latest run covers the flight horizon).
+    """
+
+    def test_d2_partial_updated_is_none(self):
+        from weatherbrief.api.packs import decide_refresh
+
+        status = _status(
+            ("stale", True),
+            ("stale", True),
+            ("awaiting", True, "2026-05-20T18:00:00+00:00"),
+        )
+        d = decide_refresh(status, 2)
+        assert d.mode == "none"
+        assert d.needed == 3
+        assert d.n_updated == 2
+        assert d.eta_useful == "2026-05-20T18:00:00+00:00"
+
+    def test_d2_all_updated_is_full(self):
+        from weatherbrief.api.packs import decide_refresh
+
+        status = _status(("stale", True), ("stale", True), ("stale", True))
+        assert decide_refresh(status, 2).mode == "full"
+
+    def test_d1_two_updated_is_full(self):
+        from weatherbrief.api.packs import decide_refresh
+
+        status = _status(("stale", True), ("stale", True), ("awaiting", True))
+        assert decide_refresh(status, 1).mode == "full"
+
+    def test_d1_one_updated_is_none(self):
+        from weatherbrief.api.packs import decide_refresh
+
+        status = _status(("stale", True), ("awaiting", True), ("awaiting", True))
+        d = decide_refresh(status, 1)
+        assert d.mode == "none"
+        assert d.needed == 2
+
+    def test_d0_zero_updated_is_realtime(self):
+        from weatherbrief.api.packs import decide_refresh
+
+        status = _status(("awaiting", True), ("awaiting", True), ("awaiting", True))
+        assert decide_refresh(status, 0).mode == "realtime"
+
+    def test_d0_one_updated_is_full(self):
+        from weatherbrief.api.packs import decide_refresh
+
+        status = _status(("stale", True), ("awaiting", True), ("awaiting", True))
+        assert decide_refresh(status, 0).mode == "full"
+
+    def test_two_model_selection_caps_needed(self):
+        from weatherbrief.api.packs import decide_refresh
+
+        # 2 covering models -> D-2 needs both (min(3, 2) == 2).
+        one = _status(("stale", True), ("awaiting", True))
+        d = decide_refresh(one, 2)
+        assert d.mode == "none"
+        assert d.needed == 2
+        both = _status(("stale", True), ("stale", True))
+        assert decide_refresh(both, 2).mode == "full"
+
+    def test_one_model_selection_always_full_when_updated(self):
+        from weatherbrief.api.packs import decide_refresh
+
+        status = _status(("stale", True))
+        assert decide_refresh(status, 2).mode == "full"
+        assert decide_refresh(status, 5).mode == "full"
+
+    def test_one_model_not_updated_d2_none_d0_realtime(self):
+        from weatherbrief.api.packs import decide_refresh
+
+        status = _status(("awaiting", True))
+        assert decide_refresh(status, 2).mode == "none"
+        assert decide_refresh(status, 0).mode == "realtime"
+
+    def test_non_covering_models_excluded_from_eligible(self):
+        from weatherbrief.api.packs import decide_refresh
+
+        # Third model's latest run doesn't reach the flight -> not eligible.
+        status = _status(("stale", True), ("stale", True), ("current", False))
+        d = decide_refresh(status, 2)
+        assert d.n_eligible == 2
+        assert d.mode == "full"  # needed = min(3, 2) = 2, both eligible updated
+
+    def test_no_eligible_models_d2_none(self):
+        from weatherbrief.api.packs import decide_refresh
+
+        status = _status(
+            ("current", False), ("current", False),
+            next_expected_update="2026-05-21T06:00:00+00:00",
+        )
+        d = decide_refresh(status, 2)
+        assert d.mode == "none"
+        assert d.n_eligible == 0
+        assert d.eta_useful == "2026-05-21T06:00:00+00:00"
+
+    def test_no_eligible_models_d0_realtime(self):
+        from weatherbrief.api.packs import decide_refresh
+
+        status = _status(("current", False))
+        assert decide_refresh(status, 0).mode == "realtime"
+
+    def test_eta_useful_is_kth_soonest_pending(self):
+        from weatherbrief.api.packs import decide_refresh
+
+        # D-2 needs 3, only 1 updated -> k = 2; pending next_expected sorted
+        # [15:00, 18:00] -> the 2nd soonest (18:00) is when threshold is met.
+        status = _status(
+            ("stale", True),
+            ("awaiting", True, "2026-05-20T18:00:00+00:00"),
+            ("awaiting", True, "2026-05-20T15:00:00+00:00"),
+        )
+        d = decide_refresh(status, 2)
+        assert d.mode == "none"
+        assert d.eta_useful == "2026-05-20T18:00:00+00:00"

--- a/tests/test_route_weather.py
+++ b/tests/test_route_weather.py
@@ -371,3 +371,90 @@ def test_text_digest_no_observations_when_none():
 
     text = format_digest(snapshot, datetime(2024, 6, 1, 10, 0))
     assert "METAR/TAF" not in text
+
+
+# --- run_realtime_refresh (issue #167 Part A seam) ---
+
+class TestRunRealtimeRefresh:
+    """The cheap real-time refresh seam: re-fetch obs from stored forecasts,
+    patch briefing.json, return RouteObservations. No model/GRIB/LLM.
+    """
+
+    def _write_pack(self, pack_dir, two_wp_route):
+        import json
+
+        briefing = {
+            "route": two_wp_route.model_dump(mode="json"),
+            "departure_time": "2026-05-20T09:00:00+00:00",
+            "days_out": 0,
+        }
+        (pack_dir / "briefing.json").write_text(json.dumps(briefing))
+        (pack_dir / "forecasts.json").write_text(json.dumps({"forecasts": []}))
+
+    def test_patches_briefing_and_returns_obs(self, tmp_path, two_wp_route):
+        import json
+
+        from weatherbrief.tasks.route_weather import run_realtime_refresh
+
+        self._write_pack(tmp_path, two_wp_route)
+        fresh = RouteObservations(
+            corridor_nm=30.0,
+            fetch_time=datetime(2026, 5, 20, 9),
+            airports_found=1,
+            airports_with_metar=1,
+            airports_with_taf=0,
+            airports=[],
+        )
+        with patch(
+            "weatherbrief.tasks.route_weather.run_route_weather", return_value=fresh,
+        ) as mock_fetch, patch(
+            "weatherbrief.airports.get_runway_ends", return_value={},
+        ):
+            result = run_realtime_refresh(tmp_path, "/fake/db")
+
+        # Returned the refreshed observations.
+        assert result.corridor_nm == 30.0
+        assert result.airports_found == 1
+        # Used the pack's stored corridor/route and target time (not network).
+        mock_fetch.assert_called_once()
+        # Patched briefing.json on disk.
+        patched = json.loads((tmp_path / "briefing.json").read_text())
+        assert patched["route_observations"]["airports_found"] == 1
+
+    def test_uses_stored_corridor_nm(self, tmp_path, two_wp_route):
+        import json
+
+        from weatherbrief.tasks.route_weather import run_realtime_refresh
+
+        briefing = {
+            "route": two_wp_route.model_dump(mode="json"),
+            "departure_time": "2026-05-20T09:00:00+00:00",
+            "days_out": 0,
+            "route_observations": {
+                "corridor_nm": 45.0,
+                "fetch_time": "2026-05-20T08:00:00+00:00",
+                "airports_found": 0,
+                "airports_with_metar": 0,
+                "airports_with_taf": 0,
+            },
+        }
+        (tmp_path / "briefing.json").write_text(json.dumps(briefing))
+        (tmp_path / "forecasts.json").write_text(json.dumps({"forecasts": []}))
+        fresh = RouteObservations(
+            corridor_nm=45.0, fetch_time=datetime(2026, 5, 20, 9),
+            airports_found=0, airports_with_metar=0, airports_with_taf=0, airports=[],
+        )
+        with patch(
+            "weatherbrief.tasks.route_weather.run_route_weather", return_value=fresh,
+        ) as mock_fetch, patch(
+            "weatherbrief.airports.get_runway_ends", return_value={},
+        ):
+            run_realtime_refresh(tmp_path, "/fake/db")
+
+        assert mock_fetch.call_args.kwargs["corridor_nm"] == 45.0
+
+    def test_missing_briefing_raises(self, tmp_path):
+        from weatherbrief.tasks.route_weather import run_realtime_refresh
+
+        with pytest.raises(FileNotFoundError):
+            run_realtime_refresh(tmp_path, "/fake/db")

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -467,3 +467,89 @@ class TestSecondsUntilNext30MinBoundary:
         """Offset must be in [0, 1800) — otherwise minute=30+offset overflows."""
         with pytest.raises(ValueError, match="offset_seconds"):
             _seconds_until_next_30min_boundary(bad_offset)
+
+
+# ---------------------------------------------------------------------------
+# Tiered refresh gate in the scheduler (issue #167)
+# ---------------------------------------------------------------------------
+
+class TestAutoRefreshGate:
+    """The scheduler applies decide_refresh's full/none policy but never the
+    realtime fallback — a non-"full" decision means skip (no pipeline run).
+    """
+
+    @patch("weatherbrief.api.packs._prepare_refresh")
+    @patch("weatherbrief.pipeline.execute_briefing")
+    @patch("weatherbrief.api.packs.decide_refresh")
+    @patch("weatherbrief.api.packs._build_data_status")
+    @patch("weatherbrief.storage.flights.list_packs")
+    @patch("weatherbrief.storage.flights._row_to_flight")
+    @patch("weatherbrief.scheduler.SessionLocal")
+    def test_skips_when_gate_not_full(
+        self, mock_session, mock_row_to_flight, mock_list,
+        mock_status, mock_decide, mock_exec, mock_prepare,
+    ):
+        from unittest.mock import MagicMock
+
+        from weatherbrief.api.packs import DataStatus, RefreshDecision
+        from weatherbrief.models import BriefingPackMeta
+        from weatherbrief.scheduler import _auto_refresh_one
+
+        mock_session.return_value = MagicMock()
+        mock_row_to_flight.return_value = SimpleNamespace(
+            departure_time=datetime.now(timezone.utc) + timedelta(hours=3),
+        )
+        mock_list.return_value = [BriefingPackMeta(
+            flight_id="f", fetch_timestamp=datetime.now(timezone.utc),
+            days_out=0, artifact_path="/tmp/pack",
+        )]
+        mock_status.return_value = DataStatus(fresh=True)
+        # Realtime is button-only; the scheduler must skip it.
+        mock_decide.return_value = RefreshDecision(
+            mode="realtime", reason="d0", needed=1, n_eligible=3, n_updated=0, days_out=0,
+        )
+
+        _auto_refresh_one(_make_row(), SimpleNamespace(db_path="/fake/db"), "u1")
+
+        mock_exec.assert_not_called()
+        mock_prepare.assert_not_called()
+
+    @patch("weatherbrief.scheduler._try_send_email")
+    @patch("weatherbrief.api.packs._finalize_refresh")
+    @patch("weatherbrief.api.packs._prepare_refresh")
+    @patch("weatherbrief.pipeline.execute_briefing")
+    @patch("weatherbrief.api.packs.decide_refresh")
+    @patch("weatherbrief.api.packs._build_data_status")
+    @patch("weatherbrief.storage.flights.list_packs")
+    @patch("weatherbrief.storage.flights._row_to_flight")
+    @patch("weatherbrief.scheduler.SessionLocal")
+    def test_runs_pipeline_when_full(
+        self, mock_session, mock_row_to_flight, mock_list,
+        mock_status, mock_decide, mock_exec, mock_prepare, mock_finalize, mock_email,
+    ):
+        from unittest.mock import MagicMock
+
+        from weatherbrief.api.packs import DataStatus, RefreshDecision
+        from weatherbrief.models import BriefingPackMeta
+        from weatherbrief.scheduler import _auto_refresh_one
+
+        mock_session.return_value = MagicMock()
+        mock_row_to_flight.return_value = SimpleNamespace(
+            departure_time=datetime.now(timezone.utc) + timedelta(days=2),
+        )
+        mock_list.return_value = [BriefingPackMeta(
+            flight_id="f", fetch_timestamp=datetime.now(timezone.utc),
+            days_out=2, artifact_path="/tmp/pack",
+        )]
+        mock_status.return_value = DataStatus(fresh=False)
+        mock_decide.return_value = RefreshDecision(
+            mode="full", reason="all updated", needed=3, n_eligible=3, n_updated=3, days_out=2,
+        )
+        mock_prepare.return_value = (
+            MagicMock(), datetime.now(timezone.utc), "/tmp/pack", MagicMock(), {},
+        )
+        mock_exec.return_value = MagicMock()
+
+        _auto_refresh_one(_make_row(), SimpleNamespace(db_path="/fake/db"), "u1")
+
+        mock_exec.assert_called_once()

--- a/web/ts/adapters/api-adapter.ts
+++ b/web/ts/adapters/api-adapter.ts
@@ -345,6 +345,10 @@ export interface RefreshStreamEvent {
     days_out: number;
     eta_useful?: string | null;
   };
+  // Freshly fetched observations on the realtime gate path — mirrors the
+  // non-streaming RefreshAccepted.observations so SSE consumers don't need a
+  // separate reload. Null on the `none` path and full-pipeline completes.
+  observations?: RouteObservations | null;
 }
 
 /**

--- a/web/ts/adapters/api-adapter.ts
+++ b/web/ts/adapters/api-adapter.ts
@@ -289,9 +289,15 @@ export async function fetchPack(flightId: string, timestamp: string): Promise<Pa
 }
 
 export interface RefreshAccepted {
-  status: 'queued' | 'already_fresh';
+  status: 'queued' | 'already_fresh' | 'realtime';
   flight_id: string;
   message: string;
+  // Tiered refresh gate detail (issue #167) — present when the request was
+  // gated to a real-time-only refresh or skipped entirely.
+  mode?: 'full' | 'realtime' | 'none';
+  reason?: string;
+  eta_useful?: string | null;
+  observations?: RouteObservations | null;
 }
 
 export async function refreshBriefing(flightId: string): Promise<RefreshAccepted> {
@@ -328,6 +334,17 @@ export interface RefreshStreamEvent {
   pack?: PackMeta;
   message?: string;
   elapsed_seconds?: number;
+  // Present on the `complete` event when the tiered refresh gate (issue #167)
+  // returned a no-op or a real-time-only refresh instead of a full pipeline run.
+  refresh_decision?: {
+    mode: 'full' | 'realtime' | 'none';
+    reason: string;
+    needed: number;
+    n_eligible: number;
+    n_updated: number;
+    days_out: number;
+    eta_useful?: string | null;
+  };
 }
 
 /**

--- a/web/ts/store/types.ts
+++ b/web/ts/store/types.ts
@@ -98,6 +98,8 @@ export interface ModelStatus {
   next_expected: string;
   published_at?: string | null;
   state: "current" | "stale" | "awaiting" | "delayed";
+  // True when this source's latest run reaches the flight horizon (issue #167).
+  covers_horizon?: boolean;
 }
 
 export interface ModelSourceDetail {


### PR DESCRIPTION
## Summary

Implements #167 — make the **manual refresh button** progressively stricter with lead time so a single model tick no longer triggers a full token+compute+disk refresh of a multi-day-out picture, while keeping a **D-0 press always at least cheap-useful** (live METAR/TAF).

- **Part A — reusable real-time seam.** Factored the body of `refresh_observations` into `tasks/route_weather.py:run_realtime_refresh(pack_dir, db_path)`: re-fetch METAR/TAF + recompute the obs-vs-model comparison from a pack's **stored** forecasts, then patch `briefing.json`. No model fetch, no GRIB, no LLM. The `/observations/refresh` endpoint is now a thin auth+guard wrapper. Moved the shared `parse_target_time` helper down to `tasks/artifacts.py` so the task doesn't import `api.packs`.
- **Part B — tiered gate.** Pure `decide_refresh(status, days_out) -> RefreshDecision`, fed by a new `ModelStatus.covers_horizon` flag set in `_build_data_status`. `needed = min(threshold[days_out], n_eligible)` with threshold `{>=2: 3, 1: 2, 0: 1}`; modes `full` / `realtime` / `none` with `reason` + `eta_useful` (the k-th soonest pending model update).
- **Wiring.** Both `refresh_briefing` (202) and `refresh_briefing_stream` (SSE): `full` → pipeline, `realtime` → run the seam and return updated observations, `none` → 200/SSE-complete no-op carrying reason + ETA. Scheduler `_auto_refresh_one` applies the same full/none policy but **never** the realtime fallback (live obs is the verification loop's job). `force=true` (admin) still bypasses. TS adapter/types updated for the new response shape.

The `min(…, n_eligible)` cap means small model selections still work: 2 models → D-2/D-1 both need both; 1 model → every press runs. Default selection is the 3 mains, so "count ≥ 3" == "all mains" for nearly everyone.

## Test plan

- [x] `tests/test_packs.py::TestDecideRefresh` — full acceptance matrix (D-0/1/2, 1/2/3-model selections, non-covering exclusion, ETA = k-th soonest)
- [x] `tests/test_route_weather.py::TestRunRealtimeRefresh` — seam patches briefing.json, honors stored corridor, raises on missing pack
- [x] `tests/test_api.py::TestRefreshEndpoint` — `none` (200 + reason/ETA), `realtime` (returns observations), realtime-failure degrades to no-op
- [x] `tests/test_scheduler.py::TestAutoRefreshGate` — skips on non-`full` (incl. realtime); runs pipeline on `full`
- [x] Full suite: 2050 passed, 9 skipped (1 unrelated failure: `test_google_login_redirects`, Google OAuth not configured in env)
- [x] All web bundles build clean

Design docs updated: `designs/freshness-markers.md` (tiered gate section) + `designs/metar-taf-route-weather.md` (real-time seam).

Addresses #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)