### PR TITLE
feat(grib): priority-aware, fault-tolerant decode dispatcher (#171)

### DIFF
--- a/designs/INDEX.md
+++ b/designs/INDEX.md
@@ -75,7 +75,7 @@ GRIB2 enrichment engine: GFS S3 (CLWMR/ICMR/cloud diagnostics), ICON-EU DWD (QC/
 
 ### grib-decode-dispatcher [project]
 Priority-aware, fault-tolerant admission layer in front of the GRIB decode process pool. `DecodePriority` (INTERACTIVE/SCHEDULED/BACKGROUND, lower=higher) propagated via a `_DECODE_PRIORITY` ContextVar; `PriorityDecodeDispatcher` orders pending jobs by priority (FIFO within a level), bounds in-flight to the worker count, and on a pool fault keeps completed work, reschedules interrupted work (crash=jittered backoff, timeout=immediate), and dead-letters poison jobs (timeout victim / retry cap / retry-rate budget). Idempotency-only invariant. Bypass via `GRIB_DECODE_WORKERS=0` or `GRIB_DECODE_PRIORITY_ENABLED=0`.
-Key exports: `DecodePriority`, `PriorityDecodeDispatcher`, `enrich_forecasts(priority=...)`, `_dispatch_decode`, `_dispatch_decode_parallel`, `decode_dead_letter_counts`
+Key exports: `DecodePriority`, `PriorityDecodeDispatcher`, `set_decode_priority`, `enrich_forecasts(priority=...)`, `_dispatch_decode`, `_dispatch_decode_parallel`, `decode_dead_letter_counts`
 → Full doc: grib-decode-dispatcher.md
 
 ### multi-user-deployment

--- a/designs/INDEX.md
+++ b/designs/INDEX.md
@@ -73,6 +73,11 @@ Key exports: `compute_flight_window_hours`, `compute_icon_eu_flight_window_hours
 GRIB2 enrichment engine: GFS S3 (CLWMR/ICMR/cloud diagnostics), ICON-EU DWD (QC/QI/cloud cover/ceiling), ECMWF IFS ECPDS (clwc/ciwc/cc/surface diagnostics), data source registry with bucket paths, variable reference tables, implementation gotchas, future extensions.
 → Full doc: weather-engine-specs.md
 
+### grib-decode-dispatcher [project]
+Priority-aware, fault-tolerant admission layer in front of the GRIB decode process pool. `DecodePriority` (INTERACTIVE/SCHEDULED/BACKGROUND, lower=higher) propagated via a `_DECODE_PRIORITY` ContextVar; `PriorityDecodeDispatcher` orders pending jobs by priority (FIFO within a level), bounds in-flight to the worker count, and on a pool fault keeps completed work, reschedules interrupted work (crash=jittered backoff, timeout=immediate), and dead-letters poison jobs (timeout victim / retry cap / retry-rate budget). Idempotency-only invariant. Bypass via `GRIB_DECODE_WORKERS=0` or `GRIB_DECODE_PRIORITY_ENABLED=0`.
+Key exports: `DecodePriority`, `PriorityDecodeDispatcher`, `enrich_forecasts(priority=...)`, `_dispatch_decode`, `_dispatch_decode_parallel`, `decode_dead_letter_counts`
+→ Full doc: grib-decode-dispatcher.md
+
 ### multi-user-deployment
 Deployment architecture for weather.flyfun.aero: Docker on DigitalOcean, auth via flyfun-common (OAuth, JWT, cross-subdomain SSO), MySQL/SQLite DB schema, rate limiting, encrypted credentials, account deletion, admin hub, Resend email, deploy commands, env vars.
 → Full doc: multi-user-deployment.md

--- a/designs/grib-decode-dispatcher.md
+++ b/designs/grib-decode-dispatcher.md
@@ -1,0 +1,125 @@
+# GRIB Decode Dispatcher
+
+> Priority-aware, fault-tolerant admission layer in front of the GRIB decode process pool.
+
+Lives in `src/weatherbrief/fetch/grib/__init__.py` (alongside the pool lifecycle and hang-diagnostics it wraps). Workers live in `fetch/grib/decode_worker.py`.
+
+## Why a pool at all
+
+GRIB decode (cfgrib + xarray + numpy interp) is GIL-bound. Two concurrent `enrich_forecasts()` calls in the uvicorn process serialise on the GIL and per-step times balloon even with idle cores. Decode is dispatched to a process pool (`ProcessPoolExecutor`, spawn) so each decode gets its own interpreter.
+
+The pool is a **lazy singleton** (`_get_decode_pool`), default **2 workers** (`GRIB_DECODE_WORKERS`; `0` = in-process kill switch). `max_tasks_per_child` recycling is **disabled by default** after a 2026-05-17 CPython recycle-race incident. Workers eagerly import cfgrib in `_worker_init` and register a SIGUSR1 faulthandler for hang dumps.
+
+Decode jobs are **pure**: read a GRIB file path from disk, return plain dicts/lists. Bytes are never pickled across the IPC boundary — only path strings + lat/lon lists go in, serialisable results come out.
+
+## The problem the dispatcher solves (issue #171)
+
+Three workloads share the one pool with **no ordering guarantee** (plain `pool.submit`, FIFO with races between submitter threads):
+
+| Workload | Priority |
+|---|---|
+| User refresh (`run_pipeline`), airport profile | **INTERACTIVE (10)** |
+| Scheduler auto-refresh | **SCHEDULED (50)** |
+| Standalone forecast/verification cycle, precache | **BACKGROUND (90)** |
+
+`concurrent.futures` executors have no priority support, so a user refresh routinely queued behind a background batch. Priority must be an **admission layer** in front of the pool.
+
+## Priority signal & propagation
+
+`DecodePriority(IntEnum)`: `INTERACTIVE=10`, `SCHEDULED=50`, `BACKGROUND=90`. **Lower value = higher priority** (Unix `nice`-style) so it composes directly with a min-heap and the FIFO `seq` tiebreak — no negation. Values are spread so finer levels can be inserted later without renumbering. Helpers accept `int | DecodePriority`. **No priority arithmetic** (aging / dynamic boosting) in v1.
+
+Propagation mirrors the existing `_GRIB_TIMER` pattern via a `ContextVar` `_DECODE_PRIORITY`:
+
+- `enrich_forecasts(..., priority=None)` resolves `explicit arg → ContextVar → SCHEDULED` and publishes it on the ContextVar for the call. Phase-1 worker threads inherit it via `_submit_with_context` (which copies the context), so nested `_dispatch_decode` calls see it.
+- `_dispatch_decode` / `_dispatch_decode_parallel` take an optional `priority` kwarg defaulting to the ContextVar value.
+- **Entry points set the value past context-copying boundaries:**
+  - `api/packs.py` user refresh (both `run_pipeline`s): set INTERACTIVE *inside* `run_pipeline` (`run_in_executor` does not copy the caller context).
+  - `api/airport_profile.py`: `enrich_forecasts(priority=INTERACTIVE)`.
+  - `scheduler.py` `_auto_refresh_one`: SCHEDULED. `_run_standalone_once`: BACKGROUND (runs in `asyncio.to_thread`, which copies the context).
+  - `tasks/standalone_verification.py`: both `_dispatch_decode` calls pass `priority=BACKGROUND` explicitly (their decode runs off the standalone context).
+  - Precache (`scheduler.py`): download-only, no decode → nothing to prioritise.
+
+## Dispatcher architecture
+
+`PriorityDecodeDispatcher` — process-wide lazy singleton (`_get_dispatcher`), one lock + condition guards all state. **Event-driven; no dedicated dispatch thread.**
+
+- `pending`: min-heap of `(priority, seq, JobHandle)`. `seq` is a monotonic counter → FIFO within a level (and makes heap entries totally ordered, so handles are never compared).
+- `inflight`: `dict[pool_future, JobHandle]`, capped at the worker count.
+- `JobHandle`: `worker_fn_name`, `args`, `caller_future`, `priority`, `seq`, `retries`, `deadline`, `last_exc`.
+
+`submit_one` / `submit_batch` create caller-facing futures, push handles, call `_pump`, and return the caller futures. **Callers block on these exactly as before** (`fut.result()`); the call-site shape is unchanged. The caller future is the *logical* operation — internally several pool futures may back it across retries, transparently.
+
+`_pump` (locked): while `len(inflight) < workers` and `pending`, pop the highest-priority handle, `pool.submit`, set `deadline = monotonic + GRIB_DECODE_TIMEOUT_S`, add to `inflight`. Done-callbacks are attached **outside** the lock (an already-done future fires the callback synchronously, and `_on_done` re-takes the non-reentrant lock). A `BrokenProcessPool` from `submit()` → `_handle_fault(CRASH)`.
+
+`_on_done` (pool manager thread): if draining/closed, ignore (a teardown owns it); `BrokenProcessPool` → leave the handle in `inflight` and `_handle_fault(CRASH)`; else resolve the caller future and `_pump`.
+
+**Watchdog** (one daemon thread): parks until the earliest `inflight` deadline; on wake, the in-flight job past its deadline becomes the `TIMEOUT` victim.
+
+### Per-job timeout (deliberate improvement)
+
+The legacy `_dispatch_decode_parallel` shared **one** deadline across a whole batch, which false-times-out large batches. The dispatcher gives **each job its own** `GRIB_DECODE_TIMEOUT_S`, which is also what makes timeout-victim identification possible.
+
+## Recovery — `_handle_fault(reason, victim=None)`
+
+```
+under lock: draining=True; snapshot=list(inflight.values()); inflight.clear()
+if TIMEOUT: _diag_snapshot_workers(pool, ...)        # reuse existing hang-diag
+pool_teardown(wait = reason != TIMEOUT)              # reuse shutdown_decode_pool
+for h in snapshot:
+    if h is victim:                 _dead_letter(h, "decode_hung")        # don't retry — re-running re-hangs
+    elif not retry_budget_ok():     _dead_letter(h, "retry_budget_exhausted")
+    elif h.retries >= RETRY_CAP:    _dead_letter(h, "retry_cap_exhausted")
+    else: h.retries+=1; reenqueue(h, after = 0 if TIMEOUT else jittered_backoff(h.retries))
+draining=False; _pump()                              # rebuild pool lazily, resume in priority order
+```
+
+Properties:
+
+- **Completed work is never touched** — already-resolved caller futures keep their results.
+- **The pending heap is the durable structure** — teardown never touches it, so after rebuild a waiting INTERACTIVE job jumps ahead of the rest of a BACKGROUND batch.
+- **Interrupted jobs are transparently rescheduled** by creating a new pool future for the same caller future. Strictly better than before, where an interrupted briefing degraded to Open-Meteo / a standalone step went empty.
+- **Timeout victim is dead-lettered, not retried** — breaks the infinite-teardown loop a corrupt GRIB would cause.
+- **Crash collateral backs off with jitter; timeout collateral retries immediately** (fresh pool, those jobs were healthy).
+- **Dead-letter, don't silently drop**: `_dead_letter` sets the caller-future exception (`DecodeDispatchError`) **and** emits a structured WARNING + per-reason counter (`decode_dead_letter_counts()`). Existing call sites already degrade on a decode exception, so they degrade exactly as before — just far less often.
+- **`RETRY_CAP`** bounds the crash case where stdlib can't attribute the culprit. **Retry budget** is a sliding-window cap on retry *rate* process-wide (per Google SRE: per-item caps alone allow retry amplification); when tripped, interrupted jobs are dead-lettered for the window so an OOM storm can't thrash.
+
+## Idempotency invariant (load-bearing)
+
+Auto-rescheduling interrupted work is **only safe because dispatched jobs are pure** (at-least-once delivery with idempotent consumers). Any future side-effecting job MUST NOT use this dispatcher, or MUST carry its own dedup — otherwise a reschedule double-applies the effect. Stated in the `PriorityDecodeDispatcher` docstring so it isn't silently violated.
+
+## Bypass paths
+
+- `GRIB_DECODE_WORKERS=0`: jobs run **inline** (resolved futures); priority moot. Identical to today's kill switch.
+- `GRIB_DECODE_PRIORITY_ENABLED=0`: `_dispatch_decode{,_parallel}` route to `_dispatch_decode{,_parallel}_legacy` — the pre-#171 FIFO path. Production rollback switch; covered by `test_grib_pool.py`.
+
+## App shutdown
+
+`shutdown_decode_pool(drain_dispatcher=True)` (called from the app lifespan) first drains the dispatcher — failing every pending/in-flight caller future with `DecodeDispatchError("dispatcher_shutdown")` so blocked callers are released rather than left waiting on a vanishing pool. The fault-recovery path uses `drain_dispatcher=False` (default) because it must **not** touch the durable pending heap.
+
+## Config / env vars
+
+| Var | Default | Meaning |
+|---|---|---|
+| `GRIB_DECODE_WORKERS` | 2 | Pool size; `0` = in-process |
+| `GRIB_DECODE_TIMEOUT_S` | 300 | **Per-job** deadline |
+| `GRIB_DECODE_PRIORITY_ENABLED` | on | `0` = legacy FIFO (rollback) |
+| `GRIB_DECODE_RETRY_CAP` | 2 | Max reschedules of one crash-interrupted job |
+| `GRIB_DECODE_RETRY_BUDGET` | 5 | Max retries within the window (rate cap) |
+| `GRIB_DECODE_RETRY_WINDOW_S` | 120 | Retry-rate window |
+| `GRIB_DECODE_BACKOFF_BASE_S` | 0.5 | Crash-retry backoff base (equal jitter); `0` disables delay |
+
+## Inherent tradeoffs (v1, documented not fixed)
+
+- **Global teardown kills collateral.** stdlib `ProcessPoolExecutor` can't replace one wedged worker (recycling disabled after `:712`), so one bad job tears down the whole pool. Auto-reschedule is a deliberate workaround. Escalation: per-worker supervision / `pebble`.
+- **Priority reduces queue latency, doesn't bound it.** Non-preemption + FIFO-within-level → head-of-line blocking (a long BACKGROUND decode holds a worker while INTERACTIVE waits, bounded by job runtime). Hard interactive SLA → reserved-worker **bulkhead**. Low-priority **starvation** → **aging**. Both deferred.
+
+## Observability
+
+- `_handle_fault` logs reason + victim + rescheduled/dead-lettered counts + `_diag_pool_summary`.
+- `_dead_letter` emits a structured WARNING (`fn`, `reason`, `retries`, args summary incl. file name, `last_exc`) and bumps `_DEAD_LETTER_COUNTS` (read via `decode_dead_letter_counts()`).
+- All existing hang-diagnostics (`_diag_snapshot_*`) are unchanged and still run before a timeout teardown.
+
+## Tests
+
+- `tests/test_grib_dispatcher.py` — dispatcher behaviour with an injected fake `worker_fn` + thread-backed `FakePool` (no cfgrib): priority ordering, slot bounding, crash reschedule, timeout dead-letter + collateral, crash-backoff vs timeout-immediacy, retry cap, retry budget + recovery, dead-letter observability, both bypass paths, and a ContextVar→ordering integration test through the real `_dispatch_decode`.
+- `tests/test_grib_pool.py` — the pool plumbing the dispatcher reuses (pinned to the legacy FIFO path).

--- a/designs/grib-decode-dispatcher.md
+++ b/designs/grib-decode-dispatcher.md
@@ -32,7 +32,7 @@ Propagation mirrors the existing `_GRIB_TIMER` pattern via a `ContextVar` `_DECO
 
 - `enrich_forecasts(..., priority=None)` resolves `explicit arg → ContextVar → SCHEDULED` and publishes it on the ContextVar for the call. Phase-1 worker threads inherit it via `_submit_with_context` (which copies the context), so nested `_dispatch_decode` calls see it.
 - `_dispatch_decode` / `_dispatch_decode_parallel` take an optional `priority` kwarg defaulting to the ContextVar value.
-- **Entry points set the value past context-copying boundaries:**
+- **Entry points set the value past context-copying boundaries** via the public `set_decode_priority(p)` helper (keeps call sites off the private ContextVar):
   - `api/packs.py` user refresh (both `run_pipeline`s): set INTERACTIVE *inside* `run_pipeline` (`run_in_executor` does not copy the caller context).
   - `api/airport_profile.py`: `enrich_forecasts(priority=INTERACTIVE)`.
   - `scheduler.py` `_auto_refresh_one`: SCHEDULED. `_run_standalone_once`: BACKGROUND (runs in `asyncio.to_thread`, which copies the context).

--- a/src/weatherbrief/api/airport_profile.py
+++ b/src/weatherbrief/api/airport_profile.py
@@ -459,7 +459,7 @@ def _grib_enrich_levels(
     if not (ecmwf_dir.is_dir() and next(ecmwf_dir.iterdir(), None) is not None):
         return {"sources": {}, "skipped": {"all": "no_local_grib_configured"}}
 
-    from weatherbrief.fetch.grib import enrich_forecasts
+    from weatherbrief.fetch.grib import DecodePriority, enrich_forecasts
     from weatherbrief.models import RouteCrossSection, RoutePoint
 
     src = _model_to_source(model)
@@ -482,6 +482,7 @@ def _grib_enrich_levels(
             departure_time=departure,
             data_dir=data_dir,
             flight_duration_hours=duration_h,
+            priority=DecodePriority.INTERACTIVE,
         )
     except Exception:
         logger.warning("Airport profile: GRIB enrichment failed", exc_info=True)

--- a/src/weatherbrief/api/app.py
+++ b/src/weatherbrief/api/app.py
@@ -273,8 +273,10 @@ async def lifespan(app: FastAPI):
     # processes hold ECCODES file handles and ~270 MB RSS each — leaking
     # them on uvicorn reload would accumulate fast. Run via to_thread so
     # the synchronous pool.shutdown(wait=True) doesn't block the event loop.
+    # drain_dispatcher=True also releases any caller blocked on a pending /
+    # in-flight decode so they fail fast rather than hang on a vanishing pool.
     from weatherbrief.fetch.grib import shutdown_decode_pool
-    await asyncio.to_thread(shutdown_decode_pool)
+    await asyncio.to_thread(lambda: shutdown_decode_pool(drain_dispatcher=True))
 
 
 def create_app() -> FastAPI:

--- a/src/weatherbrief/api/packs.py
+++ b/src/weatherbrief/api/packs.py
@@ -1425,6 +1425,12 @@ async def refresh_briefing(
 
     # Fire pipeline in background — uses its own DB session (same as /refresh/stream)
     def run_pipeline() -> None:
+        # User refresh is the highest-priority decode workload. Set it on the
+        # ContextVar *inside* run_pipeline: this runs in _refresh_executor and
+        # run_in_executor does not copy the caller's context, so the value must
+        # be established past that boundary for enrich_forecasts to see it.
+        from weatherbrief.fetch.grib import DecodePriority, _DECODE_PRIORITY
+        _DECODE_PRIORITY.set(int(DecodePriority.INTERACTIVE))
         refresh_registry.set_refreshing(flight_id)
         try:
             from weatherbrief.pipeline import execute_briefing
@@ -1681,6 +1687,11 @@ async def refresh_briefing_stream(
         asyncio.run_coroutine_threadsafe(queue.put(event), loop)
 
     def run_pipeline() -> None:
+        # User refresh (streaming): INTERACTIVE. Set past the _refresh_executor
+        # boundary — see the non-streaming run_pipeline for why the ContextVar
+        # must be established here rather than inherited.
+        from weatherbrief.fetch.grib import DecodePriority, _DECODE_PRIORITY
+        _DECODE_PRIORITY.set(int(DecodePriority.INTERACTIVE))
         refresh_registry.set_refreshing(flight_id)
         try:
             from weatherbrief.pipeline import execute_briefing

--- a/src/weatherbrief/api/packs.py
+++ b/src/weatherbrief/api/packs.py
@@ -1425,12 +1425,12 @@ async def refresh_briefing(
 
     # Fire pipeline in background — uses its own DB session (same as /refresh/stream)
     def run_pipeline() -> None:
-        # User refresh is the highest-priority decode workload. Set it on the
-        # ContextVar *inside* run_pipeline: this runs in _refresh_executor and
-        # run_in_executor does not copy the caller's context, so the value must
-        # be established past that boundary for enrich_forecasts to see it.
-        from weatherbrief.fetch.grib import DecodePriority, _DECODE_PRIORITY
-        _DECODE_PRIORITY.set(int(DecodePriority.INTERACTIVE))
+        # User refresh is the highest-priority decode workload. Set it *inside*
+        # run_pipeline: this runs in _refresh_executor and run_in_executor does
+        # not copy the caller's context, so the value must be established past
+        # that boundary for enrich_forecasts to see it.
+        from weatherbrief.fetch.grib import DecodePriority, set_decode_priority
+        set_decode_priority(DecodePriority.INTERACTIVE)
         refresh_registry.set_refreshing(flight_id)
         try:
             from weatherbrief.pipeline import execute_briefing
@@ -1688,10 +1688,10 @@ async def refresh_briefing_stream(
 
     def run_pipeline() -> None:
         # User refresh (streaming): INTERACTIVE. Set past the _refresh_executor
-        # boundary — see the non-streaming run_pipeline for why the ContextVar
+        # boundary — see the non-streaming run_pipeline for why the priority
         # must be established here rather than inherited.
-        from weatherbrief.fetch.grib import DecodePriority, _DECODE_PRIORITY
-        _DECODE_PRIORITY.set(int(DecodePriority.INTERACTIVE))
+        from weatherbrief.fetch.grib import DecodePriority, set_decode_priority
+        set_decode_priority(DecodePriority.INTERACTIVE)
         refresh_registry.set_refreshing(flight_id)
         try:
             from weatherbrief.pipeline import execute_briefing

--- a/src/weatherbrief/fetch/grib/__init__.py
+++ b/src/weatherbrief/fetch/grib/__init__.py
@@ -998,12 +998,17 @@ class DecodeDispatchError(RuntimeError):
         super().__init__(msg)
 
 
-@dataclass
+@dataclass(eq=False)
 class _JobHandle:
     """One logical decode operation. Carries the caller-facing future across
-    any number of internal pool futures (retries are transparent to callers)."""
+    any number of internal pool futures (retries are transparent to callers).
+
+    ``eq=False`` keeps identity equality/hash so handles can live in a set
+    (``_delayed_handles``); the heap orders by ``(priority, seq)`` and never
+    compares handles."""
 
     worker_fn_name: str
+    fn: Callable[..., Any]
     args: tuple
     caller_future: Future
     priority: int
@@ -1088,6 +1093,10 @@ class PriorityDecodeDispatcher:
         self._draining = False  # a fault teardown owns the pool right now
         self._closed = False    # app shutdown; reject + release everything
         self._retry_times: deque[float] = deque()  # monotonic ts of recent retries
+        # Crash-retry handles waiting out a backoff timer: in neither _pending
+        # nor _inflight, so drain() must fail them explicitly or their callers
+        # would hang on the timer that no-ops once _closed.
+        self._delayed_handles: set[_JobHandle] = set()
         self._watchdog: threading.Thread | None = None
 
     # -- public submission API ----------------------------------------------
@@ -1099,6 +1108,13 @@ class PriorityDecodeDispatcher:
         if self._workers_fn() == 0:
             return self._run_inline(worker_fn_name, args)
         caller: Future = Future()
+        # Resolve the worker (a lazy import on first use) OFF the lock — keeps
+        # the critical section free of imports / arbitrary resolver work.
+        try:
+            fn = self._resolve_worker(worker_fn_name)
+        except Exception as exc:  # bad name → fail just this caller
+            caller.set_exception(exc)
+            return caller
         with self._cond:
             if self._closed:
                 # Drain raced ahead of us: fail fast rather than push a handle
@@ -1108,7 +1124,7 @@ class PriorityDecodeDispatcher:
                 )
                 return caller
             self._ensure_watchdog_locked()
-            self._push_new_locked(worker_fn_name, args, caller, priority)
+            self._push_new_locked(worker_fn_name, fn, args, caller, priority)
         self._pump()
         return caller
 
@@ -1118,19 +1134,27 @@ class PriorityDecodeDispatcher:
         """Queue a batch at one priority. Returns caller futures in input order."""
         if self._workers_fn() == 0:
             return [self._run_inline(name, args) for name, args in jobs]
+        # Resolve workers off the lock; a bad name fails just that job.
+        prepared: list[tuple[str, Callable[..., Any] | None, tuple, Future, Exception | None]] = []
         callers: list[Future] = []
+        for name, args in jobs:
+            caller: Future = Future()
+            callers.append(caller)
+            try:
+                prepared.append((name, self._resolve_worker(name), args, caller, None))
+            except Exception as exc:
+                prepared.append((name, None, args, caller, exc))
         with self._cond:
-            if self._closed:
-                for name, _ in jobs:
-                    fut: Future = Future()
-                    fut.set_exception(DecodeDispatchError("dispatcher_shutdown", name))
-                    callers.append(fut)
-                return callers
-            self._ensure_watchdog_locked()
-            for name, args in jobs:
-                caller: Future = Future()
-                self._push_new_locked(name, args, caller, priority)
-                callers.append(caller)
+            closed = self._closed
+            if not closed:
+                self._ensure_watchdog_locked()
+            for name, fn, args, caller, exc in prepared:
+                if exc is not None:
+                    caller.set_exception(exc)
+                elif closed:
+                    caller.set_exception(DecodeDispatchError("dispatcher_shutdown", name))
+                else:
+                    self._push_new_locked(name, fn, args, caller, priority)
         self._pump()
         return callers
 
@@ -1143,17 +1167,25 @@ class PriorityDecodeDispatcher:
         """
         with self._cond:
             self._closed = True
-            handles = [h for _, _, h in self._pending] + list(self._inflight.values())
+            handles = (
+                [h for _, _, h in self._pending]
+                + list(self._inflight.values())
+                + list(self._delayed_handles)  # crash-retries mid-backoff
+            )
             self._pending.clear()
             self._inflight.clear()
+            self._delayed_handles.clear()
             self._cond.notify_all()
         for h in handles:
-            if not h.caller_future.done():
-                h.caller_future.set_exception(
-                    DecodeDispatchError("dispatcher_shutdown", h.worker_fn_name),
-                )
+            self._fail_caller(h, "dispatcher_shutdown")
 
     # -- internals ----------------------------------------------------------
+
+    def _fail_caller(self, handle: _JobHandle, reason: str) -> None:
+        if not handle.caller_future.done():
+            handle.caller_future.set_exception(
+                DecodeDispatchError(reason, handle.worker_fn_name),
+            )
 
     def _run_inline(self, worker_fn_name: str, args: tuple) -> Future:
         """In-process fallback (``GRIB_DECODE_WORKERS=0``) — priority is moot."""
@@ -1173,10 +1205,11 @@ class PriorityDecodeDispatcher:
         return self._seq
 
     def _push_new_locked(
-        self, worker_fn_name: str, args: tuple, caller: Future, priority: int,
+        self, worker_fn_name: str, fn: Callable[..., Any], args: tuple,
+        caller: Future, priority: int,
     ) -> None:
         handle = _JobHandle(
-            worker_fn_name=worker_fn_name, args=tuple(args),
+            worker_fn_name=worker_fn_name, fn=fn, args=tuple(args),
             caller_future=caller, priority=int(priority), seq=self._next_seq_locked(),
         )
         heapq.heappush(self._pending, (handle.priority, handle.seq, handle))
@@ -1209,7 +1242,7 @@ class PriorityDecodeDispatcher:
                     heapq.heappush(self._pending, (handle.priority, handle.seq, handle))
                     break
                 try:
-                    pf = pool.submit(self._resolve_worker(handle.worker_fn_name), *handle.args)
+                    pf = pool.submit(handle.fn, *handle.args)
                 except BrokenProcessPool:
                     heapq.heappush(self._pending, (handle.priority, handle.seq, handle))
                     fault = True
@@ -1407,21 +1440,41 @@ class PriorityDecodeDispatcher:
         """Return an interrupted job to the pending heap (optionally delayed).
 
         A new ``seq`` puts the retry at the back of its priority level so a
-        retried job can't starve fresh same-priority work."""
+        retried job can't starve fresh same-priority work. If the dispatcher is
+        closing, the caller is failed instead of left waiting — both the
+        immediate and the delayed path check ``_closed`` under the lock, and a
+        backed-off handle is tracked in ``_delayed_handles`` so ``drain()`` can
+        release it without waiting for the timer."""
         if after <= 0:
             with self._cond:
-                handle.seq = self._next_seq_locked()
-                heapq.heappush(self._pending, (handle.priority, handle.seq, handle))
-                self._cond.notify_all()
+                closed = self._closed
+                if not closed:
+                    handle.seq = self._next_seq_locked()
+                    heapq.heappush(self._pending, (handle.priority, handle.seq, handle))
+                    self._cond.notify_all()
+            if closed:
+                self._fail_caller(handle, "dispatcher_shutdown")
+            return
+
+        with self._cond:
+            closed = self._closed
+            if not closed:
+                self._delayed_handles.add(handle)
+        if closed:
+            self._fail_caller(handle, "dispatcher_shutdown")
             return
 
         def _delayed_push() -> None:
             with self._cond:
-                if self._closed:
-                    return
-                handle.seq = self._next_seq_locked()
-                heapq.heappush(self._pending, (handle.priority, handle.seq, handle))
-                self._cond.notify_all()
+                self._delayed_handles.discard(handle)
+                closed = self._closed
+                if not closed:
+                    handle.seq = self._next_seq_locked()
+                    heapq.heappush(self._pending, (handle.priority, handle.seq, handle))
+                    self._cond.notify_all()
+            if closed:
+                self._fail_caller(handle, "dispatcher_shutdown")
+                return
             self._pump()
 
         t = threading.Timer(after, _delayed_push)
@@ -1449,11 +1502,10 @@ _DISPATCHER_LOCK = threading.Lock()
 
 def _get_dispatcher() -> PriorityDecodeDispatcher:
     """Lazy process-wide dispatcher singleton (recreated if a prior one was
-    drained at shutdown)."""
+    drained at shutdown). The ``_closed`` check stays under ``_DISPATCHER_LOCK``
+    rather than an unsynchronised fast-path read; submit_* also recheck under
+    the dispatcher's own lock, so a returned-then-closed instance fails fast."""
     global _DISPATCHER
-    d = _DISPATCHER
-    if d is not None and not d._closed:
-        return d
     with _DISPATCHER_LOCK:
         if _DISPATCHER is None or _DISPATCHER._closed:
             _DISPATCHER = PriorityDecodeDispatcher()

--- a/src/weatherbrief/fetch/grib/__init__.py
+++ b/src/weatherbrief/fetch/grib/__init__.py
@@ -789,6 +789,20 @@ def _resolve_priority(priority: int | DecodePriority | None) -> int:
     return int(DecodePriority.SCHEDULED)
 
 
+def set_decode_priority(priority: int | DecodePriority) -> None:
+    """Publish *priority* on the decode-priority ContextVar for this context.
+
+    Entry points call this to establish the decode priority for an in-progress
+    operation that will reach ``enrich_forecasts`` / ``_dispatch_decode``
+    synchronously (e.g. inside ``run_pipeline``, which runs past a
+    non-context-copying ``run_in_executor`` boundary). Keeps callers off the
+    private ``_DECODE_PRIORITY`` ContextVar. No reset token: the entry points
+    own their context for its full lifetime (a dedicated executor thread, or a
+    copied context under ``asyncio.to_thread``).
+    """
+    _DECODE_PRIORITY.set(int(priority))
+
+
 def _int_env(name: str, default: int, *, minimum: int | None = None) -> int:
     raw = os.environ.get(name, "").strip()
     if not raw:
@@ -1086,6 +1100,13 @@ class PriorityDecodeDispatcher:
             return self._run_inline(worker_fn_name, args)
         caller: Future = Future()
         with self._cond:
+            if self._closed:
+                # Drain raced ahead of us: fail fast rather than push a handle
+                # that _pump (now a no-op) would never resolve.
+                caller.set_exception(
+                    DecodeDispatchError("dispatcher_shutdown", worker_fn_name),
+                )
+                return caller
             self._ensure_watchdog_locked()
             self._push_new_locked(worker_fn_name, args, caller, priority)
         self._pump()
@@ -1099,6 +1120,12 @@ class PriorityDecodeDispatcher:
             return [self._run_inline(name, args) for name, args in jobs]
         callers: list[Future] = []
         with self._cond:
+            if self._closed:
+                for name, _ in jobs:
+                    fut: Future = Future()
+                    fut.set_exception(DecodeDispatchError("dispatcher_shutdown", name))
+                    callers.append(fut)
+                return callers
             self._ensure_watchdog_locked()
             for name, args in jobs:
                 caller: Future = Future()
@@ -1133,8 +1160,12 @@ class PriorityDecodeDispatcher:
         fut: Future = Future()
         try:
             fut.set_result(self._resolve_worker(worker_fn_name)(*args))
-        except BaseException as exc:  # noqa: BLE001 — mirror to caller future
+        except Exception as exc:  # mirror ordinary decode errors to the future
             fut.set_exception(exc)
+        except BaseException:
+            # KeyboardInterrupt / SystemExit must propagate, not be absorbed
+            # into a future the caller might never inspect.
+            raise
         return fut
 
     def _next_seq_locked(self) -> int:
@@ -1302,7 +1333,9 @@ class PriorityDecodeDispatcher:
         try:
             # Reuse the existing hang-diagnostics on the live (hung) pool before
             # we tear it down — output is unchanged from the legacy timeout path.
-            pool = _DECODE_POOL
+            # Read under the pool lock for consistency with every other access.
+            with _DECODE_POOL_LOCK:
+                pool = _DECODE_POOL
             if reason == _FAULT_TIMEOUT:
                 names = ",".join(sorted({h.worker_fn_name for h in snapshot})) or "?"
                 try:

--- a/src/weatherbrief/fetch/grib/__init__.py
+++ b/src/weatherbrief/fetch/grib/__init__.py
@@ -8,14 +8,19 @@ from __future__ import annotations
 
 import contextvars
 import gc
+import heapq
 import logging
 import multiprocessing
 import os
+import random
 import signal
 import threading
 import time as _time_mod
-from concurrent.futures import Future, ProcessPoolExecutor, ThreadPoolExecutor
+from collections import deque
+from concurrent.futures import CancelledError, Future, ProcessPoolExecutor, ThreadPoolExecutor
 from concurrent.futures.process import BrokenProcessPool
+from dataclasses import dataclass
+from enum import IntEnum
 from typing import Any
 from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
@@ -746,6 +751,111 @@ def _decode_timeout_s() -> float:
         return _DECODE_TIMEOUT_DEFAULT_S
 
 
+# ---------------------------------------------------------------------------
+# Priority signal + dispatcher configuration (issue #171).
+# ---------------------------------------------------------------------------
+
+
+class DecodePriority(IntEnum):
+    """Decode-job priority. Lower value = higher priority (Unix nice-style).
+
+    Heap pops the smallest first, so INTERACTIVE jobs jump ahead of queued
+    BACKGROUND work for the next freed worker slot. Values are spread so finer
+    levels (e.g. ``30`` = "expedited background") can be inserted later without
+    renumbering. Helpers accept ``int | DecodePriority``; do **not** add
+    priority arithmetic (aging, dynamic boosting) — that complexity is
+    deliberately deferred (see issue #171 escalation paths).
+    """
+
+    INTERACTIVE = 10  # user refresh, airport profile
+    SCHEDULED = 50    # auto-refresh
+    BACKGROUND = 90   # standalone cycle, precache
+
+
+# Propagated like ``_GRIB_TIMER``: set by entry points / enrich_forecasts, read
+# by the dispatch helpers. ``None`` means "unset" → resolves to SCHEDULED.
+_DECODE_PRIORITY: contextvars.ContextVar[int | None] = contextvars.ContextVar(
+    "_decode_priority", default=None,
+)
+
+
+def _resolve_priority(priority: int | DecodePriority | None) -> int:
+    """Resolve an effective priority: explicit arg → ContextVar → SCHEDULED."""
+    if priority is not None:
+        return int(priority)
+    ctx_val = _DECODE_PRIORITY.get()
+    if ctx_val is not None:
+        return int(ctx_val)
+    return int(DecodePriority.SCHEDULED)
+
+
+def _int_env(name: str, default: int, *, minimum: int | None = None) -> int:
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return default
+    try:
+        v = int(raw)
+    except ValueError:
+        logger.warning("Invalid %s=%r, defaulting to %d", name, raw, default)
+        return default
+    if minimum is not None and v < minimum:
+        return minimum
+    return v
+
+
+def _float_env(name: str, default: float, *, minimum: float | None = None) -> float:
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return default
+    try:
+        v = float(raw)
+    except ValueError:
+        logger.warning("Invalid %s=%r, defaulting to %s", name, raw, default)
+        return default
+    if minimum is not None and v < minimum:
+        return minimum
+    return v
+
+
+def _priority_enabled() -> bool:
+    """Whether the priority dispatcher is on. Off = current FIFO (rollback)."""
+    raw = os.environ.get("GRIB_DECODE_PRIORITY_ENABLED", "").strip().lower()
+    return raw not in ("0", "false", "no", "off")
+
+
+def _retry_cap() -> int:
+    """Max reschedules of a single crash-interrupted job before dead-lettering."""
+    return _int_env("GRIB_DECODE_RETRY_CAP", 2, minimum=0)
+
+
+def _retry_budget() -> int:
+    """Max retries process-wide within ``_retry_window_s`` (retry-rate cap)."""
+    return _int_env("GRIB_DECODE_RETRY_BUDGET", 5, minimum=0)
+
+
+def _retry_window_s() -> float:
+    return _float_env("GRIB_DECODE_RETRY_WINDOW_S", 120.0, minimum=0.0)
+
+
+def _backoff_base_s() -> float:
+    return _float_env("GRIB_DECODE_BACKOFF_BASE_S", 0.5, minimum=0.0)
+
+
+def _jittered_backoff(retries: int) -> float:
+    """Exponential backoff with equal jitter for crash-collateral retries.
+
+    Returns ``0.0`` when the base is ``0`` (jitter disabled). Otherwise the
+    delay is always ``>= ceiling/2 > 0`` so a crash retry is observably
+    delayed (timeout-collateral retries pass ``0.0`` and skip this).
+    """
+    base = _backoff_base_s()
+    if base <= 0:
+        return 0.0
+    ceiling = base * (2 ** max(0, retries - 1))
+    half = ceiling / 2.0
+    return half + random.uniform(0.0, half)
+
+
 def _get_decode_pool() -> ProcessPoolExecutor | None:
     """Lazy singleton process pool. Returns None when pool is disabled."""
     global _DECODE_POOL
@@ -779,7 +889,7 @@ def _get_decode_pool() -> ProcessPoolExecutor | None:
     return _DECODE_POOL
 
 
-def shutdown_decode_pool(*, wait: bool = True) -> None:
+def shutdown_decode_pool(*, wait: bool = True, drain_dispatcher: bool = False) -> None:
     """Shut down the decode pool. Safe to call repeatedly; idempotent.
 
     ``wait=False`` is for the hung-worker recovery path: a worker stuck
@@ -787,7 +897,17 @@ def shutdown_decode_pool(*, wait: bool = True) -> None:
     would block forever. Trade-off: the orphaned worker process is left
     behind and reaped when the parent eventually exits — bounded leak
     (at most ``max_workers`` orphans per pool reset).
+
+    ``drain_dispatcher=True`` is the **app-shutdown** path: it also drains
+    the :class:`PriorityDecodeDispatcher` so any caller blocked on a pending
+    or in-flight job is released with an error rather than left waiting on a
+    pool that's going away. The default is ``False`` because the fault-recovery
+    path (``_handle_fault``) reuses this teardown and must **not** touch the
+    dispatcher's durable pending heap — that heap is what lets interrupted work
+    be rescheduled on the rebuilt pool.
     """
+    if drain_dispatcher:
+        _drain_dispatcher_for_shutdown()
     global _DECODE_POOL, _DECODE_POOL_INIT_TIME, _DECODE_TASKS_DISPATCHED
     with _DECODE_POOL_LOCK:
         pool = _DECODE_POOL
@@ -806,8 +926,555 @@ def shutdown_decode_pool(*, wait: bool = True) -> None:
             _DECODE_TASKS_DISPATCHED = 0
 
 
-def _dispatch_decode(worker_fn_name: str, *args) -> Any:
-    """Submit a decode job to the pool (or run in-process if disabled).
+# ---------------------------------------------------------------------------
+# Priority decode dispatcher (issue #171).
+#
+# A process-wide admission layer in front of the existing decode pool. It does
+# NOT replace the pool lifecycle (`_get_decode_pool`/`shutdown_decode_pool`) or
+# the hang-diagnostics (`_diag_snapshot_*`) — it *wraps* and reuses them, adding
+# only priority ordering + fault-tolerant rescheduling. See the class docstring
+# for the load-bearing idempotency invariant.
+# ---------------------------------------------------------------------------
+
+_FAULT_CRASH = "crash"
+_FAULT_TIMEOUT = "timeout"
+
+# Watchdog idle poll: how long it parks when nothing is in flight. A poll
+# (rather than an indefinite wait) is a cheap liveness backstop; submissions
+# notify the condition immediately, so this never gates real work.
+_WATCHDOG_IDLE_POLL_S = 30.0
+
+# Process-wide dead-letter counters, by reason. The DLQ-equivalent metric: a
+# corrupt GRIB becomes an observable counter, not a silently-degraded briefing.
+_DEAD_LETTER_COUNTS: dict[str, int] = {}
+_DEAD_LETTER_LOCK = threading.Lock()
+
+
+def _record_dead_letter(reason: str) -> None:
+    with _DEAD_LETTER_LOCK:
+        _DEAD_LETTER_COUNTS[reason] = _DEAD_LETTER_COUNTS.get(reason, 0) + 1
+
+
+def decode_dead_letter_counts() -> dict[str, int]:
+    """Snapshot of dead-letter counts per reason (observability / tests)."""
+    with _DEAD_LETTER_LOCK:
+        return dict(_DEAD_LETTER_COUNTS)
+
+
+class DecodeDispatchError(RuntimeError):
+    """Raised on a caller future when its decode job is dead-lettered.
+
+    Wraps the give-up *reason* (``decode_hung`` / ``retry_cap_exhausted`` /
+    ``retry_budget_exhausted`` / ``dispatcher_shutdown``) and the last
+    underlying exception. Existing call sites already degrade on a decode
+    exception (e.g. ``tasks/fetch.py`` drops to Open-Meteo-only), so they keep
+    degrading exactly as before — just far less often, because most interrupted
+    work is now transparently retried instead of failing.
+    """
+
+    def __init__(
+        self, reason: str, worker_fn_name: str, last_exc: BaseException | None = None,
+    ) -> None:
+        self.reason = reason
+        self.worker_fn_name = worker_fn_name
+        self.last_exc = last_exc
+        msg = f"decode job {worker_fn_name!r} dead-lettered: {reason}"
+        if last_exc is not None:
+            msg += f" (last error: {last_exc!r})"
+        super().__init__(msg)
+
+
+@dataclass
+class _JobHandle:
+    """One logical decode operation. Carries the caller-facing future across
+    any number of internal pool futures (retries are transparent to callers)."""
+
+    worker_fn_name: str
+    args: tuple
+    caller_future: Future
+    priority: int
+    seq: int
+    retries: int = 0
+    deadline: float = 0.0  # monotonic; set when a pool future is created
+    last_exc: BaseException | None = None
+
+
+def _default_worker_resolver(name: str) -> Callable[..., Any]:
+    from weatherbrief.fetch.grib import decode_worker
+    return getattr(decode_worker, name)
+
+
+def _summarize_args(args: tuple) -> str:
+    """Compact, log-safe summary of a job's args (file path / var set)."""
+    if not args:
+        return "()"
+    first = args[0]
+    if isinstance(first, str):
+        try:
+            return Path(first).name
+        except Exception:
+            return first[:80]
+    if isinstance(first, dict):
+        return "{" + ",".join(sorted(str(k) for k in first)) + "}"
+    return repr(first)[:80]
+
+
+class PriorityDecodeDispatcher:
+    """Process-wide priority admission layer over the GRIB decode pool.
+
+    Orders pending decode jobs by priority (INTERACTIVE > SCHEDULED >
+    BACKGROUND, FIFO within a level), bounds in-flight jobs to the pool's
+    worker count, and survives pool faults by **keeping completed work,
+    rescheduling interrupted work, and dead-lettering poison jobs**.
+
+    INVARIANT — IDEMPOTENCY ONLY. Auto-rescheduling interrupted work is only
+    safe because dispatched jobs are **pure**: read a GRIB file, return data,
+    no side effects (at-least-once delivery with idempotent consumers). Any
+    future side-effecting job MUST NOT use this dispatcher, or MUST carry its
+    own dedup — otherwise a crash/timeout reschedule will silently double-apply
+    the effect.
+
+    Non-preemptive: a running job is never killed. Priority only decides which
+    *pending* job takes the next freed worker slot. Head-of-line blocking is
+    therefore possible (a long BACKGROUND decode can hold a worker while an
+    INTERACTIVE job waits, bounded by job runtime); a hard interactive SLA
+    would need a reserved-worker bulkhead (deferred — see issue #171).
+
+    The pending priority heap is the durable structure: a pool fault tears the
+    pool down but never touches pending, so after the pool is rebuilt the
+    highest-priority waiting job is fed first.
+
+    Event-driven: no dedicated dispatch thread. ``submit_*`` and the pool's
+    done-callbacks drive a locked ``_pump``; a single daemon watchdog enforces
+    per-job timeouts. Pool lifecycle and hang-diagnostics are the existing
+    module primitives, reused (not reimplemented).
+    """
+
+    def __init__(
+        self,
+        *,
+        worker_resolver: Callable[[str], Callable[..., Any]] | None = None,
+        pool_factory: Callable[[], ProcessPoolExecutor | None] | None = None,
+        pool_teardown: Callable[..., None] | None = None,
+        workers_fn: Callable[[], int] | None = None,
+        timeout_fn: Callable[[], float] | None = None,
+    ) -> None:
+        # Injectable seams (default to the module primitives) so the dispatcher
+        # is unit-testable with a fake pool + fake worker_fn, per issue #171.
+        self._resolve_worker = worker_resolver or _default_worker_resolver
+        self._pool_factory = pool_factory or _get_decode_pool
+        self._pool_teardown = pool_teardown or shutdown_decode_pool
+        self._workers_fn = workers_fn or _decode_pool_workers
+        self._timeout_fn = timeout_fn or _decode_timeout_s
+
+        self._cond = threading.Condition(threading.Lock())
+        self._pending: list[tuple[int, int, _JobHandle]] = []  # min-heap
+        self._inflight: dict[Future, _JobHandle] = {}
+        self._seq = 0
+        self._draining = False  # a fault teardown owns the pool right now
+        self._closed = False    # app shutdown; reject + release everything
+        self._retry_times: deque[float] = deque()  # monotonic ts of recent retries
+        self._watchdog: threading.Thread | None = None
+
+    # -- public submission API ----------------------------------------------
+
+    def submit_one(
+        self, worker_fn_name: str, args: tuple, priority: int,
+    ) -> Future:
+        """Queue one decode job. Returns a caller-facing future to block on."""
+        if self._workers_fn() == 0:
+            return self._run_inline(worker_fn_name, args)
+        caller: Future = Future()
+        with self._cond:
+            self._ensure_watchdog_locked()
+            self._push_new_locked(worker_fn_name, args, caller, priority)
+        self._pump()
+        return caller
+
+    def submit_batch(
+        self, jobs: list[tuple[str, tuple]], priority: int,
+    ) -> list[Future]:
+        """Queue a batch at one priority. Returns caller futures in input order."""
+        if self._workers_fn() == 0:
+            return [self._run_inline(name, args) for name, args in jobs]
+        callers: list[Future] = []
+        with self._cond:
+            self._ensure_watchdog_locked()
+            for name, args in jobs:
+                caller: Future = Future()
+                self._push_new_locked(name, args, caller, priority)
+                callers.append(caller)
+        self._pump()
+        return callers
+
+    def drain(self) -> None:
+        """App-shutdown drain: release every blocked caller and stop pumping.
+
+        Pending is normally the durable structure; this is the *only* path that
+        empties it, because at process teardown blocked callers must be failed
+        rather than left waiting on a pool that's going away.
+        """
+        with self._cond:
+            self._closed = True
+            handles = [h for _, _, h in self._pending] + list(self._inflight.values())
+            self._pending.clear()
+            self._inflight.clear()
+            self._cond.notify_all()
+        for h in handles:
+            if not h.caller_future.done():
+                h.caller_future.set_exception(
+                    DecodeDispatchError("dispatcher_shutdown", h.worker_fn_name),
+                )
+
+    # -- internals ----------------------------------------------------------
+
+    def _run_inline(self, worker_fn_name: str, args: tuple) -> Future:
+        """In-process fallback (``GRIB_DECODE_WORKERS=0``) — priority is moot."""
+        fut: Future = Future()
+        try:
+            fut.set_result(self._resolve_worker(worker_fn_name)(*args))
+        except BaseException as exc:  # noqa: BLE001 — mirror to caller future
+            fut.set_exception(exc)
+        return fut
+
+    def _next_seq_locked(self) -> int:
+        self._seq += 1
+        return self._seq
+
+    def _push_new_locked(
+        self, worker_fn_name: str, args: tuple, caller: Future, priority: int,
+    ) -> None:
+        handle = _JobHandle(
+            worker_fn_name=worker_fn_name, args=tuple(args),
+            caller_future=caller, priority=int(priority), seq=self._next_seq_locked(),
+        )
+        heapq.heappush(self._pending, (handle.priority, handle.seq, handle))
+
+    def _ensure_watchdog_locked(self) -> None:
+        if self._watchdog is not None and self._watchdog.is_alive():
+            return
+        t = threading.Thread(
+            target=self._watchdog_loop, name="grib-decode-watchdog", daemon=True,
+        )
+        self._watchdog = t
+        t.start()
+
+    def _pump(self) -> None:
+        """Fill freed worker slots with the highest-priority pending jobs."""
+        fault = False
+        new_futures: list[Future] = []
+        with self._cond:
+            if self._draining or self._closed:
+                return
+            workers = self._workers_fn()
+            timeout = self._timeout_fn()
+            while len(self._inflight) < workers and self._pending:
+                _, _, handle = heapq.heappop(self._pending)
+                if handle.caller_future.cancelled():
+                    continue
+                pool = self._pool_factory()
+                if pool is None:
+                    # Workers dropped to 0 mid-flight; restore and stop.
+                    heapq.heappush(self._pending, (handle.priority, handle.seq, handle))
+                    break
+                try:
+                    pf = pool.submit(self._resolve_worker(handle.worker_fn_name), *handle.args)
+                except BrokenProcessPool:
+                    heapq.heappush(self._pending, (handle.priority, handle.seq, handle))
+                    fault = True
+                    break
+                except Exception as exc:  # noqa: BLE001 — e.g. unpicklable arg
+                    handle.caller_future.set_exception(exc)
+                    continue
+                _diag_record_dispatch(1)
+                _diag_register_workers(pool)
+                handle.deadline = _time_mod.monotonic() + timeout
+                self._inflight[pf] = handle
+                new_futures.append(pf)
+            self._cond.notify_all()  # wake watchdog to recompute earliest deadline
+        # Attach callbacks OUTSIDE the lock: a future that is already done fires
+        # the callback synchronously in this thread, and _on_done re-acquires
+        # the (non-reentrant) lock — doing this under the lock would deadlock.
+        for pf in new_futures:
+            pf.add_done_callback(self._on_done)
+        if fault:
+            self._spawn_recovery(_FAULT_CRASH)
+
+    def _on_done(self, pf: Future) -> None:
+        do_fault = False
+        with self._cond:
+            if self._draining or self._closed:
+                return  # a teardown / shutdown owns this future
+            handle = self._inflight.get(pf)
+            if handle is None:
+                return
+            try:
+                exc = pf.exception()
+            except CancelledError:
+                self._inflight.pop(pf, None)
+                return
+            if isinstance(exc, BrokenProcessPool):
+                # Leave the handle in _inflight so the fault snapshot includes
+                # it; _handle_fault decides reschedule-vs-dead-letter uniformly.
+                handle.last_exc = exc
+                do_fault = True
+            else:
+                self._inflight.pop(pf, None)
+                self._resolve_caller(handle, pf, exc)
+        if do_fault:
+            # _on_done runs on the pool's executor-manager thread; recovery
+            # tears that pool down (joining that very thread), so it must run
+            # elsewhere — see _spawn_recovery.
+            self._spawn_recovery(_FAULT_CRASH)
+        else:
+            self._pump()
+
+    def _resolve_caller(
+        self, handle: _JobHandle, pf: Future, exc: BaseException | None,
+    ) -> None:
+        caller = handle.caller_future
+        if caller.done():
+            return
+        if exc is not None:
+            caller.set_exception(exc)
+            return
+        try:
+            caller.set_result(pf.result())
+        except BaseException as e:  # noqa: BLE001
+            caller.set_exception(e)
+
+    def _watchdog_loop(self) -> None:
+        while True:
+            victim: _JobHandle | None = None
+            with self._cond:
+                if self._closed:
+                    return
+                now = _time_mod.monotonic()
+                earliest: float | None = None
+                for h in self._inflight.values():
+                    if h.deadline <= now:
+                        victim = h
+                        break
+                    if earliest is None or h.deadline < earliest:
+                        earliest = h.deadline
+                if victim is None:
+                    wait_s = (
+                        _WATCHDOG_IDLE_POLL_S if earliest is None
+                        else max(0.0, earliest - now)
+                    )
+                    self._cond.wait(timeout=wait_s)
+                    continue
+                victim.last_exc = TimeoutError(
+                    f"decode {victim.worker_fn_name!r} exceeded "
+                    f"{self._timeout_fn():.0f}s",
+                )
+            # Release the lock before the (slow) fault handling. The watchdog
+            # is its own thread, so a synchronous teardown here is safe (unlike
+            # the _on_done path — see _spawn_recovery).
+            self._handle_fault(_FAULT_TIMEOUT, victim=victim)
+
+    def _spawn_recovery(self, reason: str, victim: _JobHandle | None = None) -> None:
+        """Run fault recovery on a fresh daemon thread.
+
+        Crash faults are detected in ``_on_done`` / a ``_pump`` submit, both of
+        which can run on the pool's *executor-manager thread*. Recovery tears
+        that pool down — ``shutdown(wait=True)`` joins the manager thread — so
+        doing it inline would self-join (RuntimeError) and wedge the dispatcher
+        with ``draining`` stuck True. Off-thread teardown sidesteps that. The
+        ``draining`` guard in ``_handle_fault`` dedups concurrent spawns.
+        """
+        t = threading.Thread(
+            target=self._handle_fault, args=(reason, victim),
+            name="grib-decode-recovery", daemon=True,
+        )
+        t.start()
+
+    def _handle_fault(self, reason: str, victim: _JobHandle | None = None) -> None:
+        """Recover from a pool fault: keep completed, reschedule interrupted,
+        dead-letter poison. The single place that decides each job's fate."""
+        with self._cond:
+            if self._draining or self._closed:
+                return  # already being handled / shut down
+            self._draining = True
+            snapshot = list(self._inflight.values())
+            self._inflight.clear()
+
+        try:
+            # Reuse the existing hang-diagnostics on the live (hung) pool before
+            # we tear it down — output is unchanged from the legacy timeout path.
+            pool = _DECODE_POOL
+            if reason == _FAULT_TIMEOUT:
+                names = ",".join(sorted({h.worker_fn_name for h in snapshot})) or "?"
+                try:
+                    _diag_snapshot_workers(pool, hang_context=f"dispatcher:{names}")
+                except Exception:  # pragma: no cover — diag must never break recovery
+                    logger.warning("dispatcher: hang-diag snapshot failed", exc_info=True)
+
+            # Tear the pool down. TIMEOUT: workers are alive-but-stuck, wait=False
+            # so recovery doesn't block on them. CRASH: workers are dead, wait=True
+            # joins fast and avoids orphan accumulation.
+            try:
+                self._pool_teardown(wait=(reason != _FAULT_TIMEOUT))
+            except Exception:  # pragma: no cover — never leave draining stuck True
+                logger.warning("dispatcher: pool teardown failed", exc_info=True)
+
+            rescheduled = 0
+            dead = 0
+            for h in snapshot:
+                if victim is not None and h is victim:
+                    # An identifiable hang: re-running re-hangs, so do NOT retry —
+                    # this is what breaks the infinite-teardown loop a corrupt
+                    # GRIB would otherwise cause.
+                    self._dead_letter(h, "decode_hung")
+                    dead += 1
+                elif not self._retry_budget_ok():
+                    self._dead_letter(h, "retry_budget_exhausted")
+                    dead += 1
+                elif h.retries >= _retry_cap():
+                    self._dead_letter(h, "retry_cap_exhausted")
+                    dead += 1
+                else:
+                    h.retries += 1
+                    # Crash collateral may recur → back off with jitter. Timeout
+                    # collateral was healthy (a sibling hung) → retry immediately
+                    # on the fresh pool.
+                    delay = 0.0 if reason == _FAULT_TIMEOUT else _jittered_backoff(h.retries)
+                    self._reenqueue(h, after=delay)
+                    rescheduled += 1
+
+            logger.warning(
+                "GRIB decode dispatcher fault (%s): victim=%s rescheduled=%d "
+                "dead_lettered=%d (%s)",
+                reason,
+                victim.worker_fn_name if victim is not None else "none",
+                rescheduled, dead, _diag_pool_summary(pool),
+            )
+        finally:
+            with self._cond:
+                self._draining = False
+        self._pump()  # rebuilds the pool lazily; resumes pending in priority order
+
+    def _retry_budget_ok(self) -> bool:
+        """Sliding-window cap on retry RATE process-wide. Consumes one unit of
+        budget when it returns True. Single-threaded: only ``_handle_fault``
+        calls it, and the ``_draining`` flag serialises fault handling."""
+        budget = _retry_budget()
+        if budget <= 0:
+            return False
+        window = _retry_window_s()
+        now = _time_mod.monotonic()
+        while self._retry_times and (now - self._retry_times[0]) > window:
+            self._retry_times.popleft()
+        if len(self._retry_times) >= budget:
+            return False
+        self._retry_times.append(now)
+        return True
+
+    def _reenqueue(self, handle: _JobHandle, *, after: float) -> None:
+        """Return an interrupted job to the pending heap (optionally delayed).
+
+        A new ``seq`` puts the retry at the back of its priority level so a
+        retried job can't starve fresh same-priority work."""
+        if after <= 0:
+            with self._cond:
+                handle.seq = self._next_seq_locked()
+                heapq.heappush(self._pending, (handle.priority, handle.seq, handle))
+                self._cond.notify_all()
+            return
+
+        def _delayed_push() -> None:
+            with self._cond:
+                if self._closed:
+                    return
+                handle.seq = self._next_seq_locked()
+                heapq.heappush(self._pending, (handle.priority, handle.seq, handle))
+                self._cond.notify_all()
+            self._pump()
+
+        t = threading.Timer(after, _delayed_push)
+        t.daemon = True
+        t.start()
+
+    def _dead_letter(self, handle: _JobHandle, reason: str) -> None:
+        """Give up on a job: fail the caller future + emit a structured WARNING
+        and a per-reason counter. The DLQ-equivalent — never a silent drop."""
+        _record_dead_letter(reason)
+        logger.warning(
+            "GRIB decode dead-letter: fn=%s reason=%s retries=%d args=%s last_exc=%r",
+            handle.worker_fn_name, reason, handle.retries,
+            _summarize_args(handle.args), handle.last_exc,
+        )
+        if not handle.caller_future.done():
+            handle.caller_future.set_exception(
+                DecodeDispatchError(reason, handle.worker_fn_name, handle.last_exc),
+            )
+
+
+_DISPATCHER: PriorityDecodeDispatcher | None = None
+_DISPATCHER_LOCK = threading.Lock()
+
+
+def _get_dispatcher() -> PriorityDecodeDispatcher:
+    """Lazy process-wide dispatcher singleton (recreated if a prior one was
+    drained at shutdown)."""
+    global _DISPATCHER
+    d = _DISPATCHER
+    if d is not None and not d._closed:
+        return d
+    with _DISPATCHER_LOCK:
+        if _DISPATCHER is None or _DISPATCHER._closed:
+            _DISPATCHER = PriorityDecodeDispatcher()
+        return _DISPATCHER
+
+
+def _drain_dispatcher_for_shutdown() -> None:
+    with _DISPATCHER_LOCK:
+        d = _DISPATCHER
+    if d is not None:
+        d.drain()
+
+
+def _dispatch_decode(
+    worker_fn_name: str, *args, priority: int | DecodePriority | None = None,
+) -> Any:
+    """Submit one decode job; block on its result (call-site shape unchanged).
+
+    Routes through the :class:`PriorityDecodeDispatcher` by default. With
+    ``GRIB_DECODE_PRIORITY_ENABLED=0`` it falls back to the legacy FIFO path.
+    ``priority`` defaults to the ``_DECODE_PRIORITY`` ContextVar (else
+    SCHEDULED).
+    """
+    if not _priority_enabled():
+        return _dispatch_decode_legacy(worker_fn_name, *args)
+    eff = _resolve_priority(priority)
+    return _get_dispatcher().submit_one(worker_fn_name, args, eff).result()
+
+
+def _dispatch_decode_parallel(
+    jobs: list[tuple[str, tuple]], *, priority: int | DecodePriority | None = None,
+) -> list[Any]:
+    """Submit a batch of decode jobs; return results in input order.
+
+    Routes through the dispatcher by default (per-job timeout + fault
+    rescheduling). With ``GRIB_DECODE_PRIORITY_ENABLED=0`` it falls back to the
+    legacy FIFO batch path (one shared deadline).
+    """
+    if not jobs:
+        return []
+    if not _priority_enabled():
+        return _dispatch_decode_parallel_legacy(jobs)
+    eff = _resolve_priority(priority)
+    futures = _get_dispatcher().submit_batch(jobs, eff)
+    return [f.result() for f in futures]
+
+
+def _dispatch_decode_legacy(worker_fn_name: str, *args) -> Any:
+    """FIFO single-job dispatch — the pre-#171 path (rollback / kill switch).
+
+    Reached when ``GRIB_DECODE_PRIORITY_ENABLED=0``. Submits straight to the
+    pool with a per-call ``GRIB_DECODE_TIMEOUT_S`` and resets the pool on
+    fault. The priority dispatcher (default) wraps this same pool but adds
+    priority ordering + fault rescheduling on top.
 
     Pool is the default; the in-process fallback exists for tests and as
     a kill switch via ``GRIB_DECODE_WORKERS=0``. Both paths return the
@@ -853,8 +1520,10 @@ def _dispatch_decode(worker_fn_name: str, *args) -> Any:
         raise
 
 
-def _dispatch_decode_parallel(jobs: list[tuple[str, tuple]]) -> list[Any]:
-    """Submit a batch of decode jobs to the pool concurrently.
+def _dispatch_decode_parallel_legacy(jobs: list[tuple[str, tuple]]) -> list[Any]:
+    """FIFO batch dispatch — the pre-#171 path (rollback / kill switch).
+
+    Reached when ``GRIB_DECODE_PRIORITY_ENABLED=0``.
 
     Each job is ``(worker_fn_name, args_tuple)``; results are returned in the
     same order. Falls back to sequential in-process execution when the pool
@@ -996,6 +1665,7 @@ def enrich_forecasts(
     flight_duration_hours: float = 0.0,
     progress_callback: Callable[[str, str | None], None] | None = None,
     as_of_time: datetime | None = None,
+    priority: int | DecodePriority | None = None,
 ) -> tuple[dict[str, int], dict[str, str]]:
     """Enrich cross-section forecasts with cloud water from GRIB2 sources.
 
@@ -1012,6 +1682,13 @@ def enrich_forecasts(
         data_dir: Base data directory for caching.
         flight_duration_hours: Flight duration for per-hour enrichment.
         as_of_time: If set, only use model runs initialized before this time.
+        priority: Decode priority for this call's GRIB jobs. ``None`` (default)
+            resolves to the ``_DECODE_PRIORITY`` ContextVar set by the entry
+            point (INTERACTIVE for user refresh / airport profile, SCHEDULED
+            for auto-refresh), else SCHEDULED. The value is published on the
+            ContextVar for the duration so Phase-1 worker threads (which inherit
+            the context via ``_submit_with_context``) dispatch at the right
+            level.
 
     Returns:
         Tuple of (grib_init_times, grib_skip_reasons):
@@ -1023,6 +1700,7 @@ def enrich_forecasts(
 
     timer = _GribTimer()
     token = _GRIB_TIMER.set(timer)
+    ptoken = _DECODE_PRIORITY.set(_resolve_priority(priority))
     try:
         return _enrich_forecasts_inner(
             timer, cross_sections, all_forecasts, route_points,
@@ -1033,6 +1711,7 @@ def enrich_forecasts(
         )
     finally:
         timer.log_summary()
+        _DECODE_PRIORITY.reset(ptoken)
         _GRIB_TIMER.reset(token)
 
 

--- a/src/weatherbrief/scheduler.py
+++ b/src/weatherbrief/scheduler.py
@@ -266,14 +266,14 @@ def _auto_refresh_one(flight_row: FlightRow, app_state, user_id: str) -> None:
             flight, db_path, user_id, flight_row.id, db=db, is_privileged=True,
         )
 
-        from weatherbrief.fetch.grib import DecodePriority, _DECODE_PRIORITY
+        from weatherbrief.fetch.grib import DecodePriority, set_decode_priority
         from weatherbrief.pipeline import execute_briefing
 
         # Auto-refresh decode work is SCHEDULED — below interactive user
         # refreshes / airport profiles, above background standalone cycles.
         # Runs in asyncio.to_thread, which copies the context, so this set is
         # isolated to the cycle and visible to enrich_forecasts.
-        _DECODE_PRIORITY.set(int(DecodePriority.SCHEDULED))
+        set_decode_priority(DecodePriority.SCHEDULED)
 
         result = execute_briefing(
             route=route,
@@ -865,8 +865,8 @@ def _run_standalone_once(
     # so this set is isolated to the cycle. The explicit BACKGROUND on the
     # standalone-verification _dispatch_decode calls is belt-and-suspenders for
     # any decode that runs off this context.
-    from weatherbrief.fetch.grib import DecodePriority, _DECODE_PRIORITY
-    _DECODE_PRIORITY.set(int(DecodePriority.BACKGROUND))
+    from weatherbrief.fetch.grib import DecodePriority, set_decode_priority
+    set_decode_priority(DecodePriority.BACKGROUND)
 
     from weatherbrief.tasks.airport_watchlist import (
         get_configs_dir,

--- a/src/weatherbrief/scheduler.py
+++ b/src/weatherbrief/scheduler.py
@@ -266,7 +266,14 @@ def _auto_refresh_one(flight_row: FlightRow, app_state, user_id: str) -> None:
             flight, db_path, user_id, flight_row.id, db=db, is_privileged=True,
         )
 
+        from weatherbrief.fetch.grib import DecodePriority, _DECODE_PRIORITY
         from weatherbrief.pipeline import execute_briefing
+
+        # Auto-refresh decode work is SCHEDULED — below interactive user
+        # refreshes / airport profiles, above background standalone cycles.
+        # Runs in asyncio.to_thread, which copies the context, so this set is
+        # isolated to the cycle and visible to enrich_forecasts.
+        _DECODE_PRIORITY.set(int(DecodePriority.SCHEDULED))
 
         result = execute_briefing(
             route=route,
@@ -851,6 +858,15 @@ def _run_standalone_once(
     if not db_path:
         logger.warning("Standalone cycle: no AIRPORTS_DB configured")
         return
+
+    # Standalone fetch/verification is the lowest-priority decode workload, so
+    # a concurrent user refresh or auto-refresh always takes the next freed
+    # worker slot ahead of it. Runs in asyncio.to_thread (context is copied),
+    # so this set is isolated to the cycle. The explicit BACKGROUND on the
+    # standalone-verification _dispatch_decode calls is belt-and-suspenders for
+    # any decode that runs off this context.
+    from weatherbrief.fetch.grib import DecodePriority, _DECODE_PRIORITY
+    _DECODE_PRIORITY.set(int(DecodePriority.BACKGROUND))
 
     from weatherbrief.tasks.airport_watchlist import (
         get_configs_dir,

--- a/src/weatherbrief/tasks/standalone_verification.py
+++ b/src/weatherbrief/tasks/standalone_verification.py
@@ -619,7 +619,7 @@ def fetch_ecmwf_grib_snapshots(
     """
     from datetime import time as dt_time
 
-    from weatherbrief.fetch.grib import _dispatch_decode
+    from weatherbrief.fetch.grib import DecodePriority, _dispatch_decode
     from weatherbrief.fetch.grib.decode import (
         build_ecmwf_surface_snapshot,
         build_pressure_levels_from_grib,
@@ -662,6 +662,7 @@ def fetch_ecmwf_grib_snapshots(
         try:
             data, _ = _dispatch_decode(
                 "decode_ecmwf_surface", str(a1_path), lats, lons,
+                priority=DecodePriority.BACKGROUND,
             )
         except Exception:
             logger.warning("ECMWF a1 decode failed for step %dh", step_h, exc_info=True)
@@ -693,6 +694,7 @@ def fetch_ecmwf_grib_snapshots(
                 try:
                     pl_data, _ = _dispatch_decode(
                         "decode_ecmwf_pressure", str(a2_path), lats, lons,
+                        priority=DecodePriority.BACKGROUND,
                     )
                 except Exception:
                     logger.warning(

--- a/tests/test_grib_dispatcher.py
+++ b/tests/test_grib_dispatcher.py
@@ -29,8 +29,8 @@ from weatherbrief.fetch.grib import (
     DecodeDispatchError,
     DecodePriority,
     PriorityDecodeDispatcher,
-    _DECODE_PRIORITY,
     decode_dead_letter_counts,
+    set_decode_priority,
 )
 
 
@@ -515,6 +515,27 @@ def test_in_process_fallback_propagates_exception(make_dispatcher):
         fut.result()
 
 
+def test_submit_after_drain_fails_fast(make_dispatcher):
+    """A submit that races behind drain() fails its caller future immediately
+    rather than hanging on a _pump that will never run again."""
+    d, registry, _ = make_dispatcher(workers=2)
+    registry["echo"] = lambda v: v
+    d.drain()
+
+    fut = d.submit_one("echo", (1,), DecodePriority.SCHEDULED)
+    assert fut.done()
+    with pytest.raises(DecodeDispatchError) as exc:
+        fut.result()
+    assert exc.value.reason == "dispatcher_shutdown"
+
+    futs = d.submit_batch([("echo", (2,)), ("echo", (3,))], DecodePriority.SCHEDULED)
+    assert len(futs) == 2
+    for f in futs:
+        assert f.done()
+        with pytest.raises(DecodeDispatchError):
+            f.result()
+
+
 def test_priority_disabled_routes_to_legacy(monkeypatch):
     """``GRIB_DECODE_PRIORITY_ENABLED=0`` makes the wrappers bypass the
     dispatcher entirely and call the legacy FIFO functions."""
@@ -577,7 +598,6 @@ def test_contextvar_priority_ordering_concurrent(monkeypatch):
     o_lock = threading.Lock()
     gate_started = threading.Event()
     release = threading.Event()
-    queued = threading.Barrier(3)  # gate-thread, bg-thread, int-thread coordinate
 
     def _gate(_v):
         gate_started.set()
@@ -599,25 +619,33 @@ def test_contextvar_priority_ordering_concurrent(monkeypatch):
                                                  priority=DecodePriority.SCHEDULED)
 
     def _enrich(label, priority):
-        # Mimic an entry point setting the ContextVar, then dispatching with
-        # priority=None so the value is read from the ContextVar.
-        _DECODE_PRIORITY.set(int(priority))
-        queued.wait(5.0)  # ensure both jobs are submitted before gate releases
+        # Mimic an entry point setting the priority via the public helper, then
+        # dispatching with priority=None so the value is read from the context.
+        set_decode_priority(priority)
         results[label] = grib._dispatch_decode("record", label)
+
+    def _wait_pending(n: int, timeout: float = 5.0) -> bool:
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            with dispatcher._cond:
+                if len(dispatcher._pending) >= n:
+                    return True
+            time.sleep(0.005)
+        return False
 
     gt = threading.Thread(target=_gate_thread)
     gt.start()
-    assert gate_started.wait(2.0)
+    assert gate_started.wait(2.0), "gate never occupied the worker"
 
+    # Submission order (BACKGROUND before INTERACTIVE) is deliberately the
+    # opposite of priority order — the heap must reorder. Ordering is decided by
+    # the heap when the gate frees the worker, NOT by which thread submits first,
+    # so no sleeps are needed: just wait until both jobs are actually queued.
     bg = threading.Thread(target=_enrich, args=("bg", DecodePriority.BACKGROUND))
     it = threading.Thread(target=_enrich, args=("int", DecodePriority.INTERACTIVE))
-    # Start BACKGROUND first so, absent priority, it would queue ahead.
     bg.start()
-    time.sleep(0.1)
     it.start()
-    queued.wait(5.0)
-    # Both record-jobs are now queued behind the gate. Release it.
-    time.sleep(0.1)
+    assert _wait_pending(2), "both record jobs should be queued behind the gate"
     release.set()
 
     for t in (gt, bg, it):

--- a/tests/test_grib_dispatcher.py
+++ b/tests/test_grib_dispatcher.py
@@ -1,0 +1,681 @@
+"""Tests for the priority decode dispatcher (issue #171).
+
+These exercise the dispatcher's own behaviour — priority ordering, slot
+bounding, fault rescheduling, timeout dead-lettering, crash backoff, retry
+cap/budget, dead-letter observability, and the two bypass paths
+(``GRIB_DECODE_WORKERS=0`` / ``GRIB_DECODE_PRIORITY_ENABLED=0``).
+
+Design: an injectable fake ``worker_fn`` plus a ``FakePool`` (thread-backed,
+mimicking ``ProcessPoolExecutor``'s all-or-nothing failure on a worker death).
+No real cfgrib — the pool plumbing it wraps is covered by ``test_grib_pool.py``.
+The dispatcher takes its pool/teardown/workers/timeout/resolver as constructor
+seams, so each test drives it deterministically without touching the global
+singleton (except the integration test, which exercises the real
+``_dispatch_decode`` wrapper).
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from concurrent.futures import Future, ThreadPoolExecutor
+from concurrent.futures.process import BrokenProcessPool
+
+import pytest
+
+import weatherbrief.fetch.grib as grib
+from weatherbrief.fetch.grib import (
+    DecodeDispatchError,
+    DecodePriority,
+    PriorityDecodeDispatcher,
+    _DECODE_PRIORITY,
+    decode_dead_letter_counts,
+)
+
+
+# ---------------------------------------------------------------------------
+# Test doubles
+# ---------------------------------------------------------------------------
+
+
+class FakePool:
+    """Thread-backed stand-in for ``ProcessPoolExecutor``.
+
+    Mimics the failure mode that matters: when any job raises
+    ``BrokenProcessPool``, the *whole* pool breaks — that job's future plus
+    every other not-yet-done future get ``BrokenProcessPool`` set, and further
+    ``submit`` calls raise. Normal job exceptions only fail their own future.
+    """
+
+    def __init__(self, workers: int) -> None:
+        self._ex = ThreadPoolExecutor(max_workers=max(1, workers))
+        self._lock = threading.Lock()
+        self._broken = False
+        self._live: set[Future] = set()
+
+    def submit(self, fn, *args):  # noqa: ANN001
+        with self._lock:
+            if self._broken:
+                raise BrokenProcessPool("fake pool already broken")
+        out: Future = Future()
+        with self._lock:
+            self._live.add(out)
+
+        def _runner() -> None:
+            try:
+                res = fn(*args)
+            except BrokenProcessPool as exc:
+                self._break(str(exc))
+                return
+            except BaseException as exc:  # noqa: BLE001 — normal job failure
+                if not out.done():
+                    out.set_exception(exc)
+                self._forget(out)
+                return
+            if not out.done():
+                out.set_result(res)
+            self._forget(out)
+
+        self._ex.submit(_runner)
+        return out
+
+    def _forget(self, fut: Future) -> None:
+        with self._lock:
+            self._live.discard(fut)
+
+    def _break(self, msg: str) -> None:
+        with self._lock:
+            self._broken = True
+            live = list(self._live)
+            self._live.clear()
+        for f in live:
+            if not f.done():
+                f.set_exception(BrokenProcessPool(msg))
+
+    def shutdown(self, wait: bool = True, cancel_futures: bool = False) -> None:  # noqa: ARG002
+        # wait=False mirrors the production hung-pool teardown: never join a
+        # stuck worker thread.
+        self._ex.shutdown(wait=False)
+
+
+class PoolHarness:
+    """Owns the current FakePool and rebuilds it on teardown (as the real
+    lazy ``_get_decode_pool`` does after ``shutdown_decode_pool``)."""
+
+    def __init__(self, workers: int) -> None:
+        self.workers = workers
+        self.pool = FakePool(workers)
+        self.teardown_waits: list[bool] = []
+
+    def factory(self):  # -> FakePool
+        return self.pool
+
+    def teardown(self, *, wait: bool = True) -> None:
+        self.teardown_waits.append(wait)
+        self.pool.shutdown(wait=False)
+        self.pool = FakePool(self.workers)
+
+    def workers_fn(self) -> int:
+        return self.workers
+
+
+@pytest.fixture
+def make_dispatcher():
+    """Factory for dispatchers wired to a FakePool + a worker registry.
+
+    Returns ``(dispatcher, registry, harness)``. ``registry`` is a name->fn
+    dict the test fills with fake workers. All dispatchers are drained on
+    teardown so their watchdog threads exit.
+    """
+    created: list[PriorityDecodeDispatcher] = []
+
+    def _make(workers: int = 2, timeout_s: float = 5.0):
+        registry: dict[str, object] = {}
+        harness = PoolHarness(workers)
+        d = PriorityDecodeDispatcher(
+            worker_resolver=lambda name: registry[name],
+            pool_factory=harness.factory,
+            pool_teardown=harness.teardown,
+            workers_fn=harness.workers_fn,
+            timeout_fn=lambda: timeout_s,
+        )
+        created.append(d)
+        return d, registry, harness
+
+    yield _make
+    for d in created:
+        d.drain()
+
+
+# ---------------------------------------------------------------------------
+# 1. Priority ordering
+# ---------------------------------------------------------------------------
+
+
+def test_priority_then_fifo_ordering(make_dispatcher):
+    """On a 1-worker pool, queued jobs dispatch priority-first, FIFO within
+    a level — an INTERACTIVE job jumps ahead of already-queued BACKGROUND."""
+    d, registry, _ = make_dispatcher(workers=1)
+    order: list[str] = []
+    order_lock = threading.Lock()
+    gate_started = threading.Event()
+    release_gate = threading.Event()
+
+    def _gate(_label):  # occupies the single worker until released
+        gate_started.set()
+        release_gate.wait(5.0)
+        return "gate"
+
+    def _record(label):
+        with order_lock:
+            order.append(label)
+        return label
+
+    registry["gate"] = _gate
+    registry["record"] = _record
+
+    gate_fut = d.submit_one("gate", ("g",), int(DecodePriority.BACKGROUND))
+    assert gate_started.wait(2.0), "gate job never started"
+
+    # Queue while the only worker is busy. Submission order deliberately does
+    # NOT match priority order, to prove the heap reorders.
+    futs = {
+        "b1": d.submit_one("record", ("b1",), DecodePriority.BACKGROUND),
+        "s1": d.submit_one("record", ("s1",), DecodePriority.SCHEDULED),
+        "i1": d.submit_one("record", ("i1",), DecodePriority.INTERACTIVE),
+        "b2": d.submit_one("record", ("b2",), DecodePriority.BACKGROUND),
+        "s2": d.submit_one("record", ("s2",), DecodePriority.SCHEDULED),
+    }
+
+    release_gate.set()
+    gate_fut.result(5.0)
+    for f in futs.values():
+        f.result(5.0)
+
+    assert order == ["i1", "s1", "s2", "b1", "b2"], order
+
+
+# ---------------------------------------------------------------------------
+# 2. Slot bounding
+# ---------------------------------------------------------------------------
+
+
+def test_never_exceeds_worker_slots(make_dispatcher):
+    """In-flight jobs never exceed the worker count, even with many queued."""
+    workers = 2
+    d, registry, _ = make_dispatcher(workers=workers)
+    concurrency = {"now": 0, "max": 0}
+    c_lock = threading.Lock()
+    proceed = threading.Event()
+
+    def _tracked(_label):
+        with c_lock:
+            concurrency["now"] += 1
+            concurrency["max"] = max(concurrency["max"], concurrency["now"])
+        proceed.wait(5.0)
+        with c_lock:
+            concurrency["now"] -= 1
+        return _label
+
+    registry["tracked"] = _tracked
+    futs = [d.submit_one("tracked", (i,), DecodePriority.SCHEDULED) for i in range(8)]
+    # Give the dispatcher a beat to fill all the slots it's allowed to.
+    time.sleep(0.3)
+    with c_lock:
+        peak = concurrency["max"]
+    proceed.set()
+    for f in futs:
+        f.result(5.0)
+    assert peak <= workers, f"saw {peak} concurrent jobs, expected <= {workers}"
+    assert peak == workers, f"expected to saturate {workers} workers, saw {peak}"
+
+
+# ---------------------------------------------------------------------------
+# 3. Fault -> reschedule (crash)
+# ---------------------------------------------------------------------------
+
+
+def test_crash_reschedules_interrupted_and_keeps_completed(make_dispatcher, monkeypatch):
+    """A worker crash: completed work keeps its result, the interrupted job is
+    transparently rescheduled and resolves, and no caller sees BrokenProcessPool."""
+    monkeypatch.setenv("GRIB_DECODE_BACKOFF_BASE_S", "0.01")  # fast retry
+    d, registry, harness = make_dispatcher(workers=2)
+
+    # Already-completed work, resolved before any fault.
+    registry["ok"] = lambda v: v
+    done_fut = d.submit_one("ok", ("r1",), DecodePriority.SCHEDULED)
+    assert done_fut.result(2.0) == "r1"
+
+    # A job that crashes on its first run, succeeds on the retry.
+    attempts = {"n": 0}
+    a_lock = threading.Lock()
+
+    def _flaky(_v):
+        with a_lock:
+            attempts["n"] += 1
+            n = attempts["n"]
+        if n == 1:
+            raise BrokenProcessPool("worker died")
+        return "flaky-ok"
+
+    registry["flaky"] = _flaky
+    # A healthy sibling submitted in the same wave.
+    registry["sibling"] = lambda v: v
+
+    flaky_fut = d.submit_one("flaky", ("x",), DecodePriority.SCHEDULED)
+    sib_fut = d.submit_one("sibling", ("sib",), DecodePriority.SCHEDULED)
+
+    assert flaky_fut.result(5.0) == "flaky-ok"
+    assert sib_fut.result(5.0) == "sib"
+    # Completed-before-fault work is untouched.
+    assert done_fut.result(0) == "r1"
+    # The fault tore the pool down (crash -> wait=True).
+    assert harness.teardown_waits and harness.teardown_waits[-1] is True
+    assert attempts["n"] == 2, "flaky job should have been rescheduled exactly once"
+
+
+# ---------------------------------------------------------------------------
+# 4. Timeout victim dead-lettered; collateral rescheduled
+# ---------------------------------------------------------------------------
+
+
+def test_timeout_victim_dead_lettered_collateral_rescheduled(make_dispatcher, monkeypatch):
+    """A job past its deadline is dead-lettered (not retried); a concurrent
+    healthy job that was in-flight is rescheduled and succeeds."""
+    monkeypatch.setenv("GRIB_DECODE_BACKOFF_BASE_S", "0")
+    before = decode_dead_letter_counts().get("decode_hung", 0)
+    d, registry, _ = make_dispatcher(workers=2, timeout_s=0.3)
+
+    def _hang(_v):
+        time.sleep(2.0)  # finite (no thread leak) but well past the 0.3s deadline
+        return "hang"
+
+    blk = {"n": 0}
+    b_lock = threading.Lock()
+
+    def _blocker(_v):
+        with b_lock:
+            blk["n"] += 1
+            n = blk["n"]
+        if n == 1:
+            time.sleep(1.0)  # still in flight when the watchdog fires
+            return "blocker-late"
+        return "blocker-ok"
+
+    registry["hang"] = _hang
+    registry["blocker"] = _blocker
+
+    hang_fut = d.submit_one("hang", ("h",), DecodePriority.SCHEDULED)
+    time.sleep(0.05)  # ensure hang's deadline is strictly earliest -> it is the victim
+    blocker_fut = d.submit_one("blocker", ("b",), DecodePriority.SCHEDULED)
+
+    with pytest.raises(DecodeDispatchError) as exc:
+        hang_fut.result(5.0)
+    assert exc.value.reason == "decode_hung"
+    assert blocker_fut.result(5.0) == "blocker-ok"
+    assert blk["n"] == 2, "healthy collateral should have been rescheduled once"
+    assert decode_dead_letter_counts().get("decode_hung", 0) == before + 1
+
+
+# ---------------------------------------------------------------------------
+# 5. Crash backoff vs timeout immediacy
+# ---------------------------------------------------------------------------
+
+
+def test_crash_retry_is_delayed(make_dispatcher, monkeypatch):
+    """A crash-collateral retry waits a (jittered) backoff before re-running."""
+    monkeypatch.setenv("GRIB_DECODE_BACKOFF_BASE_S", "0.6")
+    d, registry, _ = make_dispatcher(workers=1)
+    times: list[float] = []
+    t_lock = threading.Lock()
+    n = {"i": 0}
+
+    def _flaky(_v):
+        with t_lock:
+            times.append(time.monotonic())
+            n["i"] += 1
+            i = n["i"]
+        if i == 1:
+            raise BrokenProcessPool("die")
+        return "ok"
+
+    registry["flaky"] = _flaky
+    fut = d.submit_one("flaky", ("x",), DecodePriority.SCHEDULED)
+    assert fut.result(5.0) == "ok"
+    gap = times[1] - times[0]
+    # Equal-jitter backoff for base=0.6, attempt 1 => delay in [0.3, 0.6].
+    assert gap >= 0.25, f"crash retry gap {gap:.3f}s — expected a backoff delay"
+
+
+def test_timeout_collateral_retry_is_immediate(make_dispatcher, monkeypatch):
+    """Timeout collateral (healthy job, sibling hung) retries with no backoff."""
+    monkeypatch.setenv("GRIB_DECODE_BACKOFF_BASE_S", "0.6")  # would be obvious if applied
+    d, registry, _ = make_dispatcher(workers=2, timeout_s=0.3)
+    times: list[float] = []
+    t_lock = threading.Lock()
+    n = {"i": 0}
+
+    def _hang(_v):
+        time.sleep(2.0)
+        return "hang"
+
+    def _collateral(_v):
+        with t_lock:
+            times.append(time.monotonic())
+            n["i"] += 1
+            i = n["i"]
+        if i == 1:
+            time.sleep(1.0)  # in flight at watchdog
+            return "late"
+        return "ok"
+
+    registry["hang"] = _hang
+    registry["collateral"] = _collateral
+
+    d.submit_one("hang", ("h",), DecodePriority.SCHEDULED)
+    time.sleep(0.05)
+    fut = d.submit_one("collateral", ("c",), DecodePriority.SCHEDULED)
+    assert fut.result(5.0) == "ok"
+    # Re-run started essentially as soon as the first attempt's sleep returned;
+    # the gap is dominated by the 1s in-flight sleep, NOT the 0.6s backoff
+    # (which is skipped for timeout collateral). Just assert the retry ran.
+    assert n["i"] == 2
+
+
+# ---------------------------------------------------------------------------
+# 6. Retry cap
+# ---------------------------------------------------------------------------
+
+
+def test_retry_cap_dead_letters_persistent_crasher(make_dispatcher, monkeypatch):
+    """An always-crashing job is dead-lettered after RETRY_CAP reschedules."""
+    monkeypatch.setenv("GRIB_DECODE_RETRY_CAP", "2")
+    monkeypatch.setenv("GRIB_DECODE_RETRY_BUDGET", "100")  # don't trip budget first
+    monkeypatch.setenv("GRIB_DECODE_BACKOFF_BASE_S", "0.01")
+    d, registry, _ = make_dispatcher(workers=1)
+    runs = {"n": 0}
+    r_lock = threading.Lock()
+
+    def _always_crash(_v):
+        with r_lock:
+            runs["n"] += 1
+        raise BrokenProcessPool("always dies")
+
+    registry["crash"] = _always_crash
+    fut = d.submit_one("crash", ("x",), DecodePriority.SCHEDULED)
+    with pytest.raises(DecodeDispatchError) as exc:
+        fut.result(5.0)
+    assert exc.value.reason == "retry_cap_exhausted"
+    # cap=2 => attempts 1,2,3 (3rd fault sees retries==cap and gives up).
+    assert runs["n"] == 3, runs["n"]
+
+
+# ---------------------------------------------------------------------------
+# 7. Retry budget
+# ---------------------------------------------------------------------------
+
+
+def test_retry_budget_dead_letters_then_recovers(make_dispatcher, monkeypatch):
+    """When the process-wide retry RATE is exhausted, interrupted work is
+    dead-lettered fast; after the window clears, retries work again."""
+    monkeypatch.setenv("GRIB_DECODE_RETRY_BUDGET", "1")
+    monkeypatch.setenv("GRIB_DECODE_RETRY_WINDOW_S", "0.5")
+    monkeypatch.setenv("GRIB_DECODE_RETRY_CAP", "100")  # so cap doesn't trip first
+    monkeypatch.setenv("GRIB_DECODE_BACKOFF_BASE_S", "0.01")
+    d, registry, _ = make_dispatcher(workers=1)
+
+    def _always_crash(_v):
+        raise BrokenProcessPool("die")
+
+    registry["crash"] = _always_crash
+    fut = d.submit_one("crash", ("x",), DecodePriority.SCHEDULED)
+    with pytest.raises(DecodeDispatchError) as exc:
+        fut.result(5.0)
+    # First fault consumes the single budget unit (reschedule); second fault
+    # finds the budget exhausted -> dead-letter.
+    assert exc.value.reason == "retry_budget_exhausted"
+
+    # After the window clears, a transient (crash-once) job recovers.
+    time.sleep(0.7)
+    n = {"i": 0}
+
+    def _flaky(_v):
+        n["i"] += 1
+        if n["i"] == 1:
+            raise BrokenProcessPool("transient")
+        return "recovered"
+
+    registry["flaky"] = _flaky
+    fut2 = d.submit_one("flaky", ("y",), DecodePriority.SCHEDULED)
+    assert fut2.result(5.0) == "recovered"
+
+
+# ---------------------------------------------------------------------------
+# 8. Dead-letter observability
+# ---------------------------------------------------------------------------
+
+
+def test_dead_letter_emits_structured_log_and_counter(make_dispatcher, monkeypatch, caplog):
+    """A give-up emits a structured WARNING (fn / reason / retries / args) and
+    bumps the per-reason counter."""
+    monkeypatch.setenv("GRIB_DECODE_RETRY_CAP", "0")  # dead-letter on the first fault
+    monkeypatch.setenv("GRIB_DECODE_RETRY_BUDGET", "100")
+    d, registry, _ = make_dispatcher(workers=1)
+    before = decode_dead_letter_counts().get("retry_cap_exhausted", 0)
+
+    def _crash(_path):
+        raise BrokenProcessPool("boom")
+
+    registry["decode_thing"] = _crash
+    caplog.set_level(logging.WARNING, logger="weatherbrief.fetch.grib")
+    fut = d.submit_one("decode_thing", ("/data/grib/ecmwf_a2_step3.grib",),
+                       DecodePriority.BACKGROUND)
+    with pytest.raises(DecodeDispatchError):
+        fut.result(5.0)
+
+    assert decode_dead_letter_counts().get("retry_cap_exhausted", 0) == before + 1
+    dl = [r.getMessage() for r in caplog.records if "dead-letter" in r.getMessage()]
+    assert dl, "expected a dead-letter WARNING"
+    msg = dl[-1]
+    assert "fn=decode_thing" in msg
+    assert "reason=retry_cap_exhausted" in msg
+    assert "ecmwf_a2_step3.grib" in msg, f"args summary missing file name: {msg}"
+
+
+# ---------------------------------------------------------------------------
+# 9. Bypass paths
+# ---------------------------------------------------------------------------
+
+
+def test_in_process_fallback_when_workers_zero(make_dispatcher):
+    """``workers==0`` runs jobs inline and returns resolved futures (priority
+    moot) — never touches the pool."""
+    d, registry, harness = make_dispatcher(workers=0)
+    registry["echo"] = lambda v: {"got": v}
+    fut = d.submit_one("echo", (7,), DecodePriority.INTERACTIVE)
+    assert fut.done()
+    assert fut.result() == {"got": 7}
+    # Batch too.
+    registry["id"] = lambda v: v
+    futs = d.submit_batch([("id", (i,)) for i in range(3)], DecodePriority.SCHEDULED)
+    assert [f.result() for f in futs] == [0, 1, 2]
+    assert harness.teardown_waits == [], "inline path must not tear down a pool"
+
+
+def test_in_process_fallback_propagates_exception(make_dispatcher):
+    d, registry, _ = make_dispatcher(workers=0)
+
+    def _boom(_v):
+        raise RuntimeError("inline-bang")
+
+    registry["boom"] = _boom
+    fut = d.submit_one("boom", (1,), DecodePriority.SCHEDULED)
+    with pytest.raises(RuntimeError, match="inline-bang"):
+        fut.result()
+
+
+def test_priority_disabled_routes_to_legacy(monkeypatch):
+    """``GRIB_DECODE_PRIORITY_ENABLED=0`` makes the wrappers bypass the
+    dispatcher entirely and call the legacy FIFO functions."""
+    monkeypatch.setenv("GRIB_DECODE_PRIORITY_ENABLED", "0")
+    assert grib._priority_enabled() is False
+
+    called: dict[str, object] = {}
+
+    def _fake_single(name, *args):
+        called["single"] = (name, args)
+        return "legacy-result"
+
+    def _fake_batch(jobs):
+        called["batch"] = jobs
+        return ["legacy-batch"]
+
+    monkeypatch.setattr(grib, "_dispatch_decode_legacy", _fake_single)
+    monkeypatch.setattr(grib, "_dispatch_decode_parallel_legacy", _fake_batch)
+    # A fresh sentinel dispatcher that must NOT be used.
+    monkeypatch.setattr(grib, "_DISPATCHER", _ExplodingDispatcher())
+
+    assert grib._dispatch_decode("decode_x", "p", priority=DecodePriority.INTERACTIVE) == "legacy-result"
+    assert called["single"] == ("decode_x", ("p",))
+    assert grib._dispatch_decode_parallel([("decode_y", ("q",))]) == ["legacy-batch"]
+    assert called["batch"] == [("decode_y", ("q",))]
+
+
+class _ExplodingDispatcher:
+    def submit_one(self, *a, **k):  # noqa: ANN001, ANN002, ANN003
+        raise AssertionError("dispatcher must not be used when priority disabled")
+
+    def submit_batch(self, *a, **k):  # noqa: ANN001, ANN002, ANN003
+        raise AssertionError("dispatcher must not be used when priority disabled")
+
+    _closed = False
+
+
+# ---------------------------------------------------------------------------
+# 10. Integration: ContextVar-driven priority through the real wrapper
+# ---------------------------------------------------------------------------
+
+
+def test_contextvar_priority_ordering_concurrent(monkeypatch):
+    """INTERACTIVE context's decode is dispatched ahead of a BACKGROUND
+    context's decode that was queued first (1 worker)."""
+    monkeypatch.setenv("GRIB_DECODE_PRIORITY_ENABLED", "1")
+
+    registry: dict[str, object] = {}
+    harness = PoolHarness(1)
+    dispatcher = PriorityDecodeDispatcher(
+        worker_resolver=lambda name: registry[name],
+        pool_factory=harness.factory,
+        pool_teardown=harness.teardown,
+        workers_fn=harness.workers_fn,
+        timeout_fn=lambda: 5.0,
+    )
+    monkeypatch.setattr(grib, "_DISPATCHER", dispatcher)
+
+    order: list[str] = []
+    o_lock = threading.Lock()
+    gate_started = threading.Event()
+    release = threading.Event()
+    queued = threading.Barrier(3)  # gate-thread, bg-thread, int-thread coordinate
+
+    def _gate(_v):
+        gate_started.set()
+        release.wait(5.0)
+        return "gate"
+
+    def _record(label):
+        with o_lock:
+            order.append(label)
+        return label
+
+    registry["gate"] = _gate
+    registry["record"] = _record
+
+    results: dict[str, object] = {}
+
+    def _gate_thread():
+        results["gate"] = grib._dispatch_decode("gate", "g",
+                                                 priority=DecodePriority.SCHEDULED)
+
+    def _enrich(label, priority):
+        # Mimic an entry point setting the ContextVar, then dispatching with
+        # priority=None so the value is read from the ContextVar.
+        _DECODE_PRIORITY.set(int(priority))
+        queued.wait(5.0)  # ensure both jobs are submitted before gate releases
+        results[label] = grib._dispatch_decode("record", label)
+
+    gt = threading.Thread(target=_gate_thread)
+    gt.start()
+    assert gate_started.wait(2.0)
+
+    bg = threading.Thread(target=_enrich, args=("bg", DecodePriority.BACKGROUND))
+    it = threading.Thread(target=_enrich, args=("int", DecodePriority.INTERACTIVE))
+    # Start BACKGROUND first so, absent priority, it would queue ahead.
+    bg.start()
+    time.sleep(0.1)
+    it.start()
+    queued.wait(5.0)
+    # Both record-jobs are now queued behind the gate. Release it.
+    time.sleep(0.1)
+    release.set()
+
+    for t in (gt, bg, it):
+        t.join(5.0)
+    dispatcher.drain()
+
+    assert results["int"] == "int" and results["bg"] == "bg"
+    assert order == ["int", "bg"], f"INTERACTIVE should dispatch first: {order}"
+
+
+# ---------------------------------------------------------------------------
+# 11. Real ProcessPool — manager-thread recovery (FakePool can't reproduce this)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def real_pool_dispatch(monkeypatch):
+    """Drive the real ``_dispatch_decode`` through a real ``ProcessPoolExecutor``
+    and the global dispatcher singleton. This is the only way to exercise the
+    executor-manager-thread recovery path: with a real pool, a worker death sets
+    ``BrokenProcessPool`` on the manager thread, which invokes ``_on_done`` —
+    recovery must tear the pool down off that thread (it joins the manager
+    thread) or it self-joins and wedges with ``draining`` stuck True."""
+    monkeypatch.setenv("GRIB_DECODE_PRIORITY_ENABLED", "1")
+    monkeypatch.setenv("GRIB_DECODE_WORKERS", "2")
+    grib.shutdown_decode_pool()
+    grib._DISPATCHER = None
+    yield
+    try:
+        grib._drain_dispatcher_for_shutdown()
+    finally:
+        grib._DISPATCHER = None
+        grib.shutdown_decode_pool()
+
+
+def test_real_pool_dispatch_returns_result(real_pool_dispatch):
+    assert grib._dispatch_decode("_test_echo", "hi") == "hi"
+
+
+def test_real_pool_crash_recovers_off_manager_thread(real_pool_dispatch, monkeypatch):
+    """A SIGKILL'd worker breaks the pool; recovery runs off the manager thread,
+    so the dispatcher doesn't wedge. An always-crashing job is dead-lettered
+    after RETRY_CAP, and the pool recovers for the next dispatch.
+
+    The test completing (not hanging) is itself the regression check for the
+    manager-thread self-join bug."""
+    monkeypatch.setenv("GRIB_DECODE_RETRY_CAP", "1")
+    monkeypatch.setenv("GRIB_DECODE_RETRY_BUDGET", "100")
+    monkeypatch.setenv("GRIB_DECODE_BACKOFF_BASE_S", "0.01")
+    monkeypatch.setenv("GRIB_DECODE_TIMEOUT_S", "30")
+
+    assert grib._dispatch_decode("_test_echo", "warm") == "warm"
+
+    t0 = time.monotonic()
+    with pytest.raises(DecodeDispatchError) as exc:
+        grib._dispatch_decode("_test_crash")
+    assert exc.value.reason == "retry_cap_exhausted"
+    assert time.monotonic() - t0 < 25, "recovery appears wedged (manager-thread self-join?)"
+
+    # Pool rebuilt lazily — a subsequent dispatch succeeds.
+    assert grib._dispatch_decode("_test_echo", "recovered") == "recovered"

--- a/tests/test_grib_dispatcher.py
+++ b/tests/test_grib_dispatcher.py
@@ -218,10 +218,20 @@ def test_never_exceeds_worker_slots(make_dispatcher):
             concurrency["now"] -= 1
         return _label
 
+    def _wait_now(target: int, timeout: float = 5.0) -> bool:
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            with c_lock:
+                if concurrency["now"] >= target:
+                    return True
+            time.sleep(0.005)
+        return False
+
     registry["tracked"] = _tracked
     futs = [d.submit_one("tracked", (i,), DecodePriority.SCHEDULED) for i in range(8)]
-    # Give the dispatcher a beat to fill all the slots it's allowed to.
-    time.sleep(0.3)
+    # Deterministic: wait until both slots are actually occupied (bounded to
+    # `workers`, so `now` can only reach `workers`, never exceed it).
+    assert _wait_now(workers), "dispatcher should saturate all worker slots"
     with c_lock:
         peak = concurrency["max"]
     proceed.set()
@@ -534,6 +544,41 @@ def test_submit_after_drain_fails_fast(make_dispatcher):
         assert f.done()
         with pytest.raises(DecodeDispatchError):
             f.result()
+
+
+def test_drain_during_crash_backoff_releases_floating_handle(make_dispatcher, monkeypatch):
+    """A crash-retry handle waiting out its backoff timer lives in neither
+    _pending nor _inflight. drain() must still release its caller — otherwise
+    the caller blocked on .result() hangs until (or past) process exit."""
+    monkeypatch.setenv("GRIB_DECODE_BACKOFF_BASE_S", "2.0")  # wide backoff window
+    monkeypatch.setenv("GRIB_DECODE_RETRY_CAP", "5")
+    d, registry, _ = make_dispatcher(workers=1)
+
+    crashed = threading.Event()
+
+    def _crash_once(_v):
+        crashed.set()
+        raise BrokenProcessPool("die")
+
+    registry["crash"] = _crash_once
+    fut = d.submit_one("crash", ("x",), DecodePriority.SCHEDULED)
+    assert crashed.wait(5.0), "job should have run and crashed"
+
+    # Wait until recovery has reached _reenqueue and the handle is floating
+    # in the backoff timer (tracked in _delayed_handles).
+    deadline = time.monotonic() + 5.0
+    while time.monotonic() < deadline:
+        with d._cond:
+            if d._delayed_handles:
+                break
+        time.sleep(0.01)
+    with d._cond:
+        assert d._delayed_handles, "handle should be mid-backoff (floating)"
+
+    d.drain()  # must release the floating handle, not just _pending/_inflight
+    with pytest.raises(DecodeDispatchError) as exc:
+        fut.result(5.0)
+    assert exc.value.reason == "dispatcher_shutdown"
 
 
 def test_priority_disabled_routes_to_legacy(monkeypatch):

--- a/tests/test_grib_pool.py
+++ b/tests/test_grib_pool.py
@@ -90,8 +90,17 @@ def _settle_pool(monkeypatch):
     in-process fallback (returns None) instead of spawning a fresh pool.
     Each test then sets its own ``GRIB_DECODE_WORKERS`` value via its own
     ``monkeypatch.setenv``, which overrides this default.
+
+    ``GRIB_DECODE_PRIORITY_ENABLED=0`` pins this whole module to the legacy
+    FIFO dispatch path. These tests exercise the pool *plumbing* (lazy startup,
+    crash/hang teardown semantics, worker recycling, vanished-worker diag) that
+    the priority dispatcher reuses unchanged; the dispatcher's own behaviour
+    (priority ordering, fault rescheduling, dead-lettering) is covered in
+    ``test_grib_dispatcher.py``. The legacy path is also the production rollback
+    switch, so it deserves dedicated coverage.
     """
     monkeypatch.setenv("GRIB_DECODE_WORKERS", "0")
+    monkeypatch.setenv("GRIB_DECODE_PRIORITY_ENABLED", "0")
     _drain_background_dispatches()
     _settle_pool_to_none()
     yield


### PR DESCRIPTION
Add a process-wide PriorityDecodeDispatcher in front of the GRIB decode
pool. It orders pending jobs by priority (INTERACTIVE > SCHEDULED >
BACKGROUND, FIFO within a level), bounds in-flight jobs to the worker
count, and on a pool fault keeps completed work, transparently reschedules
interrupted work, and dead-letters poison jobs (timeout victim / retry cap
/ sliding-window retry-rate budget). Each job now gets its own
GRIB_DECODE_TIMEOUT_S instead of one shared batch deadline.

Priority propagates via a _DECODE_PRIORITY ContextVar set at the entry
points: user refresh / airport profile = INTERACTIVE, auto-refresh =
SCHEDULED, standalone cycle = BACKGROUND. The dispatcher wraps and reuses
the existing pool lifecycle and hang-diagnostics rather than replacing
them; crash recovery runs off the executor-manager thread to avoid a
self-join wedge.

Bypass paths preserved: GRIB_DECODE_WORKERS=0 (in-process) and
GRIB_DECODE_PRIORITY_ENABLED=0 (legacy FIFO, rollback switch). App shutdown
drains the dispatcher so blocked callers fail fast. New tests in
test_grib_dispatcher.py (fake pool + injected workers, plus a real-pool
crash-recovery regression); test_grib_pool.py pinned to the legacy path.
Adds designs/grib-decode-dispatcher.md.

https://claude.ai/code/session_01Namje5Z84nNErYho5xf5eq