### PR TITLE
fix(climatology): handle NULL flight_category in category map

### DIFF
--- a/src/weatherbrief/tasks/climatology_queries.py
+++ b/src/weatherbrief/tasks/climatology_queries.py
@@ -96,6 +96,16 @@ def resolve_month_window(
 # all five; daily rows are SUM-ed for MTD, monthly rows are read as-is.
 _CATEGORY_FIELDS = ("n_obs", "n_vfr", "n_mvfr", "n_ifr", "n_lifr")
 
+# AUTO stations that never had a ceilometer/visibility sensor (e.g. LGPA)
+# report ``////`` slashes, so the parser stores the obs but leaves
+# ``flight_category`` NULL. Such rows count toward ``n_obs`` but not toward
+# any of the four category counts. When the NULL share exceeds this
+# threshold, the four category percentages (computed over the categorizable
+# subset) rest on a small, potentially biased sample — flag the airport
+# low-confidence so the map can grey-tint it and the leaderboard can omit
+# it. See issue #173.
+_LOW_CONFIDENCE_NULL_SHARE_PCT = 25.0
+
 
 def get_category_climatology(
     db: Session,
@@ -104,9 +114,17 @@ def get_category_climatology(
 ) -> dict[str, Any]:
     """Return per-airport flight-category counts and percentages.
 
-    Response shape (one entry per watchlist airport that has rows AND a
-    coord; airports with no data are omitted — the frontend renders them
-    as grey markers using the watchlist as the source of truth):
+    The four ``pct_*`` values are computed over the *categorizable* subset
+    (``n_categorized = n_vfr + n_mvfr + n_ifr + n_lifr``), so they always sum
+    to ~100% even when an airport's METARs frequently omit visibility/cloud
+    (sensor-not-available AUTO stations leave ``flight_category`` NULL). The
+    data-completeness gap is surfaced separately via ``n_no_category`` /
+    ``pct_no_category`` (measured against raw ``n_obs``), and ``low_confidence``
+    is set when that gap exceeds ``_LOW_CONFIDENCE_NULL_SHARE_PCT``.
+
+    Response shape (one entry per watchlist airport with a coord; airports
+    with no rows still plot with zero counts so the frontend can render them
+    grey using the watchlist as the source of truth):
 
         {
           "month": "2026-05",
@@ -115,10 +133,15 @@ def get_category_climatology(
           "airports": [
             {"icao": "EGKK", "lat": 51.1, "lon": 0.2,
              "n_obs": 421, "n_vfr": 320, "n_mvfr": 60, "n_ifr": 30, "n_lifr": 11,
+             "n_categorized": 421, "n_no_category": 0, "pct_no_category": 0.0,
+             "low_confidence": False,
              "pct_vfr": 76.0, "pct_mvfr": 14.3, "pct_ifr": 7.1, "pct_lifr": 2.6},
             ...
           ]
         }
+
+    ``pct_*`` keys are absent when ``n_categorized == 0`` (an airport whose
+    obs are all uncategorizable) — those plot grey, same as no-data airports.
     """
     rows = _read_counts_by_icao(db, window, _CATEGORY_FIELDS)
     coords = _get_coords(airports_db_path)
@@ -133,14 +156,30 @@ def get_category_climatology(
         entry: dict[str, Any] = {"icao": icao, "lat": lat, "lon": lon}
         if counts is None:
             entry.update({f: 0 for f in _CATEGORY_FIELDS})
+            entry.update({
+                "n_categorized": 0, "n_no_category": 0,
+                "pct_no_category": 0.0, "low_confidence": False,
+            })
         else:
             entry.update(counts)
             n_obs = counts["n_obs"] or 0
-            if n_obs > 0:
-                entry["pct_vfr"] = round(100.0 * counts["n_vfr"] / n_obs, 1)
-                entry["pct_mvfr"] = round(100.0 * counts["n_mvfr"] / n_obs, 1)
-                entry["pct_ifr"] = round(100.0 * counts["n_ifr"] / n_obs, 1)
-                entry["pct_lifr"] = round(100.0 * counts["n_lifr"] / n_obs, 1)
+            n_categorized = (
+                counts["n_vfr"] + counts["n_mvfr"]
+                + counts["n_ifr"] + counts["n_lifr"]
+            )
+            n_no_category = max(n_obs - n_categorized, 0)
+            pct_no_category = round(100.0 * n_no_category / n_obs, 1) if n_obs > 0 else 0.0
+            entry["n_categorized"] = n_categorized
+            entry["n_no_category"] = n_no_category
+            entry["pct_no_category"] = pct_no_category
+            entry["low_confidence"] = (
+                n_obs > 0 and pct_no_category > _LOW_CONFIDENCE_NULL_SHARE_PCT
+            )
+            if n_categorized > 0:
+                entry["pct_vfr"] = round(100.0 * counts["n_vfr"] / n_categorized, 1)
+                entry["pct_mvfr"] = round(100.0 * counts["n_mvfr"] / n_categorized, 1)
+                entry["pct_ifr"] = round(100.0 * counts["n_ifr"] / n_categorized, 1)
+                entry["pct_lifr"] = round(100.0 * counts["n_lifr"] / n_categorized, 1)
         airports.append(entry)
 
     response: dict[str, Any] = {
@@ -448,12 +487,20 @@ def get_leaderboard(
             raise ValueError(f"category sub must be vfr/mvfr/ifr/lifr, got {sub!r}")
         data = get_category_climatology(db, window, airports_db_path)
         value_key = f"pct_{sub}"
+        # Gate on the categorizable obs count (the sample the % is computed
+        # over), not raw n_obs, and omit low-confidence airports (high NULL
+        # share) so sensor-starved AUTO stations like LGPA can't top the
+        # ranking on a small biased sample. See issue #173.
         rows = [
             {"icao": a["icao"], "value": a[value_key],
-             "n_obs": a["n_obs"], "extra": {"n_vfr": a["n_vfr"], "n_mvfr": a["n_mvfr"],
-                                            "n_ifr": a["n_ifr"], "n_lifr": a["n_lifr"]}}
+             "n_obs": a["n_categorized"],
+             "extra": {"n_vfr": a["n_vfr"], "n_mvfr": a["n_mvfr"],
+                       "n_ifr": a["n_ifr"], "n_lifr": a["n_lifr"],
+                       "n_no_category": a["n_no_category"]}}
             for a in data["airports"]
-            if value_key in a and a["n_obs"] >= min_obs
+            if value_key in a
+            and not a["low_confidence"]
+            and a["n_categorized"] >= min_obs
         ]
         unit = "%"
         label = f"{sub.upper()} %"

--- a/src/weatherbrief/tasks/climatology_queries.py
+++ b/src/weatherbrief/tasks/climatology_queries.py
@@ -168,12 +168,15 @@ def get_category_climatology(
                 + counts["n_ifr"] + counts["n_lifr"]
             )
             n_no_category = max(n_obs - n_categorized, 0)
-            pct_no_category = round(100.0 * n_no_category / n_obs, 1) if n_obs > 0 else 0.0
+            # Compare the unrounded share against the threshold; round only for
+            # the stored field. Rounding first would mis-flag airports within
+            # ±0.05% of exactly 25% (e.g. 24.95% → 25.0, then 25.0 > 25.0 fails).
+            raw_null_pct = (100.0 * n_no_category / n_obs) if n_obs > 0 else 0.0
             entry["n_categorized"] = n_categorized
             entry["n_no_category"] = n_no_category
-            entry["pct_no_category"] = pct_no_category
+            entry["pct_no_category"] = round(raw_null_pct, 1)
             entry["low_confidence"] = (
-                n_obs > 0 and pct_no_category > _LOW_CONFIDENCE_NULL_SHARE_PCT
+                n_obs > 0 and raw_null_pct > _LOW_CONFIDENCE_NULL_SHARE_PCT
             )
             if n_categorized > 0:
                 entry["pct_vfr"] = round(100.0 * counts["n_vfr"] / n_categorized, 1)

--- a/tests/test_climatology_queries.py
+++ b/tests/test_climatology_queries.py
@@ -233,6 +233,21 @@ class TestCategoryNullCategory:
         assert a["low_confidence"] is False
         assert a["pct_vfr"] == round(100.0 * 80 / 90, 1)  # 88.9
 
+    def test_threshold_uses_raw_share_not_rounded(self, _mock_coords, db_session):
+        # 626/2500 = 25.04% NULL share. It rounds to 25.0 for the stored
+        # field, but the raw share exceeds 25% so the airport must still be
+        # flagged — guards against comparing the rounded value (which would
+        # give 25.0 > 25.0 == False and miss it).
+        _seed_monthly(db_session, icao="EGKK", month=date(2026, 4, 1),
+                      n_obs=2500, n_vfr=1874)  # categorizable=1874, no_cat=626
+        db_session.commit()
+        window = MonthWindow(month=date(2026, 4, 1), is_mtd=False, as_of_date=None)
+        result = get_category_climatology(db_session, window, "/fake/airports.db")
+        a = {x["icao"]: x for x in result["airports"]}["EGKK"]
+        assert a["n_no_category"] == 626
+        assert a["pct_no_category"] == 25.0      # rounded for display
+        assert a["low_confidence"] is True       # raw 25.04% > 25% → flagged
+
     def test_all_uncategorizable_airport_has_no_pct_keys(
         self, _mock_coords, db_session,
     ):

--- a/tests/test_climatology_queries.py
+++ b/tests/test_climatology_queries.py
@@ -181,6 +181,107 @@ class TestGetCategoryClimatology:
         assert len(result["airports"]) == len(FAKE_COORDS)
         assert all(a["n_obs"] == 0 for a in result["airports"])
         assert all("pct_vfr" not in a for a in result["airports"])
+        # No-data airports carry zeroed gap fields, not missing keys.
+        assert all(a["n_no_category"] == 0 for a in result["airports"])
+        assert all(a["low_confidence"] is False for a in result["airports"])
+
+
+# ---------------------------------------------------------------------------
+# NULL flight_category handling (issue #173 — LGPA-style AUTO stations)
+# ---------------------------------------------------------------------------
+
+
+@patch(
+    "weatherbrief.tasks.climatology_queries._get_coords",
+    return_value=FAKE_COORDS,
+)
+class TestCategoryNullCategory:
+    def test_lgpa_case_percentages_sum_to_100_and_flag_low_confidence(
+        self, _mock_coords, db_session,
+    ):
+        # Mirrors the issue: 502 obs, 293 categorizable (292 VFR + 1 MVFR),
+        # 209 uncategorizable (41.6%).
+        _seed_monthly(db_session, icao="EGKK", month=date(2026, 4, 1),
+                      n_obs=502, n_vfr=292, n_mvfr=1, n_ifr=0, n_lifr=0)
+        db_session.commit()
+        window = MonthWindow(month=date(2026, 4, 1), is_mtd=False, as_of_date=None)
+        result = get_category_climatology(db_session, window, "/fake/airports.db")
+        a = {x["icao"]: x for x in result["airports"]}["EGKK"]
+
+        assert a["n_categorized"] == 293
+        assert a["n_no_category"] == 209
+        assert a["pct_no_category"] == 41.6
+        assert a["low_confidence"] is True
+        # Percentages computed over the categorizable subset → sum to ~100%.
+        assert a["pct_vfr"] == round(100.0 * 292 / 293, 1)   # 99.7
+        assert a["pct_mvfr"] == round(100.0 * 1 / 293, 1)    # 0.3
+        total = a["pct_vfr"] + a["pct_mvfr"] + a["pct_ifr"] + a["pct_lifr"]
+        assert abs(total - 100.0) < 0.11
+
+    def test_small_gap_below_threshold_not_low_confidence(
+        self, _mock_coords, db_session,
+    ):
+        # 10% NULL share is below the 25% threshold → not flagged.
+        _seed_monthly(db_session, icao="EGKK", month=date(2026, 4, 1),
+                      n_obs=100, n_vfr=80, n_mvfr=10)  # categorizable=90
+        db_session.commit()
+        window = MonthWindow(month=date(2026, 4, 1), is_mtd=False, as_of_date=None)
+        result = get_category_climatology(db_session, window, "/fake/airports.db")
+        a = {x["icao"]: x for x in result["airports"]}["EGKK"]
+        assert a["n_no_category"] == 10
+        assert a["pct_no_category"] == 10.0
+        assert a["low_confidence"] is False
+        assert a["pct_vfr"] == round(100.0 * 80 / 90, 1)  # 88.9
+
+    def test_all_uncategorizable_airport_has_no_pct_keys(
+        self, _mock_coords, db_session,
+    ):
+        # Every obs uncategorizable (all slashes) → no category split; plots grey.
+        _seed_monthly(db_session, icao="EGKK", month=date(2026, 4, 1), n_obs=50)
+        db_session.commit()
+        window = MonthWindow(month=date(2026, 4, 1), is_mtd=False, as_of_date=None)
+        result = get_category_climatology(db_session, window, "/fake/airports.db")
+        a = {x["icao"]: x for x in result["airports"]}["EGKK"]
+        assert a["n_categorized"] == 0
+        assert a["n_no_category"] == 50
+        assert a["pct_no_category"] == 100.0
+        assert a["low_confidence"] is True
+        assert "pct_vfr" not in a
+
+    def test_leaderboard_gates_on_categorizable_not_raw_obs(
+        self, _mock_coords, db_session,
+    ):
+        # EGKK: raw n_obs=110 (would clear an n_obs>=100 gate) but only 90
+        # categorizable, NULL share 18.2% (not low-confidence) → excluded by
+        # the categorizable gate. LFPG: 200 categorizable → included.
+        _seed_monthly(db_session, icao="EGKK", month=date(2026, 4, 1),
+                      n_obs=110, n_vfr=85, n_mvfr=5)   # categorizable=90
+        _seed_monthly(db_session, icao="LFPG", month=date(2026, 4, 1),
+                      n_obs=200, n_vfr=180, n_mvfr=20)  # categorizable=200
+        db_session.commit()
+        window = MonthWindow(month=date(2026, 4, 1), is_mtd=False, as_of_date=None)
+        result = get_leaderboard(db_session, window, "/fake/airports.db",
+                                 dataset="category", sub="vfr", limit=10)
+        icaos = [r["icao"] for r in result["rows"]]
+        assert "EGKK" not in icaos
+        assert "LFPG" in icaos
+
+    def test_leaderboard_omits_low_confidence_airport(
+        self, _mock_coords, db_session,
+    ):
+        # EGKK: 200 categorizable (clears min-obs) but 33.3% NULL share →
+        # low-confidence → omitted, even though pct_vfr would be 100% (top).
+        _seed_monthly(db_session, icao="EGKK", month=date(2026, 4, 1),
+                      n_obs=300, n_vfr=200)            # categorizable=200, 33% null
+        _seed_monthly(db_session, icao="LFPG", month=date(2026, 4, 1),
+                      n_obs=200, n_vfr=150, n_mvfr=50)  # categorizable=200, 0% null
+        db_session.commit()
+        window = MonthWindow(month=date(2026, 4, 1), is_mtd=False, as_of_date=None)
+        result = get_leaderboard(db_session, window, "/fake/airports.db",
+                                 dataset="category", sub="vfr", limit=10)
+        icaos = [r["icao"] for r in result["rows"]]
+        assert "EGKK" not in icaos
+        assert icaos == ["LFPG"]
 
 
 # ---------------------------------------------------------------------------
@@ -462,12 +563,14 @@ class TestVolatility:
 )
 class TestUnifiedLeaderboard:
     def test_category_vfr_ranks_highest_first(self, _mock_coords, db_session):
+        # Full breakdowns (categorizable == n_obs) so pct_vfr is over the
+        # whole sample; pct now uses the categorizable denominator.
         _seed_monthly(db_session, icao="EGKK", month=date(2026, 4, 1),
-                      n_obs=200, n_vfr=190)  # 95%
+                      n_obs=200, n_vfr=190, n_mvfr=10)  # 95%
         _seed_monthly(db_session, icao="LFPG", month=date(2026, 4, 1),
-                      n_obs=200, n_vfr=120)  # 60%
+                      n_obs=200, n_vfr=120, n_mvfr=80)  # 60%
         _seed_monthly(db_session, icao="EDDF", month=date(2026, 4, 1),
-                      n_obs=200, n_vfr=170)  # 85%
+                      n_obs=200, n_vfr=170, n_mvfr=30)  # 85%
         db_session.commit()
         window = MonthWindow(month=date(2026, 4, 1), is_mtd=False, as_of_date=None)
         result = get_leaderboard(db_session, window, "/fake/airports.db",
@@ -478,9 +581,9 @@ class TestUnifiedLeaderboard:
 
     def test_category_ifr_excludes_below_min_obs(self, _mock_coords, db_session):
         _seed_monthly(db_session, icao="EGKK", month=date(2026, 4, 1),
-                      n_obs=200, n_ifr=20)  # 10%
+                      n_obs=200, n_vfr=180, n_ifr=20)  # 10%
         _seed_monthly(db_session, icao="LFPG", month=date(2026, 4, 1),
-                      n_obs=50, n_ifr=40)   # 80% but only 50 obs
+                      n_obs=50, n_vfr=10, n_ifr=40)   # 80% but only 50 obs
         db_session.commit()
         window = MonthWindow(month=date(2026, 4, 1), is_mtd=False, as_of_date=None)
         result = get_leaderboard(db_session, window, "/fake/airports.db",

--- a/web/ts/adapters/climatology-adapter.ts
+++ b/web/ts/adapters/climatology-adapter.ts
@@ -37,6 +37,13 @@ export interface CategoryAirport {
   n_mvfr: number;
   n_ifr: number;
   n_lifr: number;
+  // Categorizable subset (the four counts above); pct_* are computed over it.
+  n_categorized: number;
+  // Obs whose flight_category is NULL (sensor-not-available AUTO stations).
+  n_no_category: number;
+  pct_no_category: number;
+  // True when pct_no_category exceeds the backend low-confidence threshold.
+  low_confidence: boolean;
   pct_vfr?: number;
   pct_mvfr?: number;
   pct_ifr?: number;

--- a/web/ts/visualization/climatology-datasets.ts
+++ b/web/ts/visualization/climatology-datasets.ts
@@ -94,14 +94,14 @@ export const CategoryDataset = {
       const cell = pct === undefined ? '—' : `${pct.toFixed(1)}%`;
       return `<tr><td>${k.toUpperCase()}</td><td style="text-align:right">${cell}</td></tr>`;
     }).join('');
-    const noCat = ca.n_no_category ?? 0;
+    const noCat = ca.n_no_category;
     const sep = 'border-top:1px solid var(--border, #ccc); padding-top:2px';
     const gapRow = noCat > 0
       ? `<tr><td style="${sep}">No data</td>` +
         `<td style="${sep}; text-align:right">` +
-        `${noCat.toLocaleString()} (${(ca.pct_no_category ?? 0).toFixed(1)}%)</td></tr>`
+        `${noCat.toLocaleString()} (${ca.pct_no_category.toFixed(1)}%)</td></tr>`
       : '';
-    const nCat = ca.n_categorized ?? ca.n_obs;
+    const nCat = ca.n_categorized;
     const foot = noCat > 0
       ? `${nCat.toLocaleString()} of ${ca.n_obs.toLocaleString()} obs usable`
       : `${ca.n_obs.toLocaleString()} obs`;

--- a/web/ts/visualization/climatology-datasets.ts
+++ b/web/ts/visualization/climatology-datasets.ts
@@ -80,7 +80,13 @@ export const CategoryDataset = {
     { value: 'lifr', label: 'LIFR %' },
   ] as { value: CategoryKey; label: string }[],
   scaleFor: (sub: CategoryKey): Scale => CATEGORY_SCALES[sub],
-  /** Same popup regardless of which sub-metric is selected. */
+  /** Same popup regardless of which sub-metric is selected.
+   *
+   * Percentages are over the categorizable subset (they sum to ~100%). When
+   * the airport has uncategorizable obs (sensor-not-available AUTO stations),
+   * a "No data" row and a "M of N obs usable" footer make the gap explicit
+   * instead of letting the four numbers silently undercount. See issue #173.
+   */
   popup: (a: MapAirport): string => {
     const ca = a as unknown as CategoryAirport;
     const rows = (['vfr', 'mvfr', 'ifr', 'lifr'] as const).map((k) => {
@@ -88,11 +94,22 @@ export const CategoryDataset = {
       const cell = pct === undefined ? '—' : `${pct.toFixed(1)}%`;
       return `<tr><td>${k.toUpperCase()}</td><td style="text-align:right">${cell}</td></tr>`;
     }).join('');
+    const noCat = ca.n_no_category ?? 0;
+    const sep = 'border-top:1px solid var(--border, #ccc); padding-top:2px';
+    const gapRow = noCat > 0
+      ? `<tr><td style="${sep}">No data</td>` +
+        `<td style="${sep}; text-align:right">` +
+        `${noCat.toLocaleString()} (${(ca.pct_no_category ?? 0).toFixed(1)}%)</td></tr>`
+      : '';
+    const nCat = ca.n_categorized ?? ca.n_obs;
+    const foot = noCat > 0
+      ? `${nCat.toLocaleString()} of ${ca.n_obs.toLocaleString()} obs usable`
+      : `${ca.n_obs.toLocaleString()} obs`;
     return `
       <div class="clim-popup">
         <div class="clim-popup-title"><b>${ca.icao}</b></div>
-        <table class="clim-popup-table">${rows}</table>
-        <div class="clim-popup-foot">${ca.n_obs.toLocaleString()} obs</div>
+        <table class="clim-popup-table">${rows}${gapRow}</table>
+        <div class="clim-popup-foot">${foot}</div>
       </div>
     `;
   },

--- a/web/ts/visualization/climatology-map.ts
+++ b/web/ts/visualization/climatology-map.ts
@@ -137,13 +137,18 @@ export class ClimatologyMap {
     const scale = this.scale;
     for (const a of this.airports) {
       const color = a.value !== null && scale ? pctColor(a.value, scale) : COLORS.grey;
+      // Low-confidence airports (high NULL-category share, e.g. sensor-starved
+      // AUTO stations) keep their category color but render faded with a
+      // dashed grey ring so they read as "uncertain". See issue #173.
+      const lowConf = a.low_confidence === true && a.value !== null;
       const marker = L.circleMarker([a.lat, a.lon], {
         radius: 5,
         fillColor: color,
-        color: '#111',
-        weight: 0.6,
+        color: lowConf ? COLORS.grey : '#111',
+        weight: lowConf ? 1.4 : 0.6,
+        dashArray: lowConf ? '2,2' : undefined,
         opacity: 1,
-        fillOpacity: a.value === null ? 0.4 : 0.9,
+        fillOpacity: a.value === null ? 0.4 : (lowConf ? 0.45 : 0.9),
       });
       marker.bindPopup(this.buildPopup(a));
       marker.addTo(this.markersLayer);

--- a/web/ts/visualization/climatology-tab.ts
+++ b/web/ts/visualization/climatology-tab.ts
@@ -346,10 +346,14 @@ export class ClimatologyTab {
 function headerFromCategory(data: CategoryMapResponse): string {
   const plotted = data.airports.length;
   const withData = data.airports.filter((a) => a.n_obs > 0).length;
+  // Low-confidence airports (high NULL-category share) count as "with data"
+  // but render faded and are leaderboard-omitted — call them out separately.
+  const lowConf = data.airports.filter((a) => a.low_confidence).length;
   const note = data.is_mtd
     ? `Month to date · ${data.as_of_date ?? 'no completed days yet'}`
     : 'Completed month';
-  return `${note} · ${plotted} airports plotted (${withData} with data)`;
+  const lowConfNote = lowConf > 0 ? `, ${lowConf} low-confidence` : '';
+  return `${note} · ${plotted} airports plotted (${withData} with data${lowConfNote})`;
 }
 
 function headerFromEnvelope(data: ClimatologyMapEnvelope): string {
@@ -369,10 +373,15 @@ function formatValue(value: number | null, unit: string): string {
 }
 
 function renderLeaderboardHtml(data: LeaderboardResponse, scale: Scale | null): string {
+  // For the category dataset the gate + displayed count are categorizable
+  // obs (rows whose flight_category is non-NULL), not raw METAR count — label
+  // them "usable" so a lower number than the user's METAR provider is clear.
+  const obsLabel = data.dataset === 'category' ? 'Usable obs' : 'Obs';
+  const obsNoun = data.dataset === 'category' ? 'usable observations' : 'observations';
   if (data.rows.length === 0) {
     return `<div class="map-info" style="padding:1rem">
-      No airports meet the minimum observation count
-      (${data.min_n_obs} obs required) for this period.
+      No airports meet the minimum ${obsNoun} count
+      (${data.min_n_obs} required) for this period.
     </div>`;
   }
   const rows = data.rows.map((r, i) => {
@@ -396,7 +405,7 @@ function renderLeaderboardHtml(data: LeaderboardResponse, scale: Scale | null): 
     <div class="clim-leaderboard-wrap">
       <h3 style="margin-top:0">Top airports by ${data.label} · ${monthNote}</h3>
       <p style="color:var(--text-muted); font-size:0.8rem; margin:0.25rem 0 0.75rem">
-        Ranked highest first. Minimum ${data.min_n_obs} observations.
+        Ranked highest first. Minimum ${data.min_n_obs} ${obsNoun}.
         Change Dataset / Color by on the Map tab to rank by a different metric.
       </p>
       <table class="clim-leaderboard-table">
@@ -404,7 +413,7 @@ function renderLeaderboardHtml(data: LeaderboardResponse, scale: Scale | null): 
           <tr>
             <th></th><th>Airport</th>
             <th style="text-align:right">${data.label}</th>
-            <th style="text-align:right">Obs</th>
+            <th style="text-align:right">${obsLabel}</th>
           </tr>
         </thead>
         <tbody>${rows}</tbody>


### PR DESCRIPTION
## Summary

Fixes the LGPA-style climatology bug where AUTO stations that report `////` for visibility/cloud (sensor-not-available) leave `flight_category` NULL. Those rows counted toward `n_obs` but not the four category counts, so the percentages (divided by `n_obs`) summed to the *categorizable* fraction (~58% for LGPA) with no indication that ~42% of obs were unusable.

Implements the **combined** map treatment + **gate-and-omit** leaderboard (decided with @roznet):

- **Categorizable denominator** — `pct_vfr/mvfr/ifr/lifr` now divide by `n_categorized = n_vfr+n_mvfr+n_ifr+n_lifr`, so the four wedges sum to ~100% and the map color is meaningful.
- **Surface the gap** — response adds `n_categorized`, `n_no_category`, `pct_no_category` (vs raw `n_obs`), and a `low_confidence` flag (NULL share > 25%, `_LOW_CONFIDENCE_NULL_SHARE_PCT`). Popup shows a "No data: N (X%)" row and a "M of N obs usable" footer; low-confidence markers render faded with a dashed grey ring.
- **Leaderboard** — gates min-obs on categorizable obs (not raw `n_obs`) and omits low-confidence airports so sensor-starved stations can't top the ranking on a small biased sample.

**No migration:** `n_no_category` is derived from columns already stored in `airport_daily_summary` / `airport_monthly_summary`.

### LGPA (May MTD) result
| | |
|---|---|
| VFR | 99.7% |
| MVFR | 0.3% |
| IFR / LIFR | 0.0% |
| **No data** | **209 (41.6%)** |
| footer | 293 of 502 obs usable |

Marker: grey-tinted (low confidence). Omitted from leaderboards.

## Test plan
- [x] `pytest tests/test_climatology_queries.py` — 43 passed (2 existing leaderboard tests updated for the new denominator; 5 new tests cover the LGPA case, all-uncategorizable edge case, categorizable gating, and low-confidence omission)
- [x] `tsc --noEmit` clean; maps esbuild bundle builds
- [ ] Visual check in browser against live LGPA data (not done locally — no LGPA data in dev DB)

Addresses #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)