### PR TITLE
feat(units): region-aware display units (visibility EU/US, auto default)

### DIFF
--- a/src/weatherbrief/analysis/airport_conditions.py
+++ b/src/weatherbrief/analysis/airport_conditions.py
@@ -21,8 +21,8 @@ from weatherbrief.models.airport_conditions import (
     RunwayWind,
 )
 
-# Visibility conversion: meters to statute miles
-_M_PER_SM = 1609.34
+# Visibility conversion: meters to statute miles (single source of truth in units.py)
+from weatherbrief.units import M_PER_SM as _M_PER_SM
 
 # Standard aviation flight category thresholds (ceiling ft / visibility SM)
 _CEIL_LIFR, _CEIL_IFR, _CEIL_MVFR = 500, 1000, 3000
@@ -191,6 +191,7 @@ def _compute_for_airport(
         sounding = rpa.sounding.get(model)
         ceiling_ft = reconcile_ceiling(sounding, hourly)
 
+        visibility_m: float | None = None
         visibility_sm: float | None = None
         wind_speed_kt: float | None = None
         wind_direction_deg: float | None = None
@@ -198,6 +199,7 @@ def _compute_for_airport(
 
         if hourly:
             if hourly.visibility_m is not None:
+                visibility_m = round(hourly.visibility_m)
                 visibility_sm = round(hourly.visibility_m / _M_PER_SM, 1)
             wind_speed_kt = hourly.wind_speed_10m_kt
             wind_direction_deg = hourly.wind_direction_10m_deg
@@ -218,6 +220,7 @@ def _compute_for_airport(
             model=model,
             flight_category=flight_category,
             ceiling_ft=round(ceiling_ft) if ceiling_ft is not None else None,
+            visibility_m=visibility_m,
             visibility_sm=visibility_sm,
             wind_speed_kt=round(wind_speed_kt, 1) if wind_speed_kt is not None else None,
             wind_direction_deg=round(wind_direction_deg) if wind_direction_deg is not None else None,

--- a/src/weatherbrief/api/app.py
+++ b/src/weatherbrief/api/app.py
@@ -397,19 +397,17 @@ def create_app() -> FastAPI:
         if not user:
             raise _HTTPException(status_code=401, detail="User not found")
         prefs = db.get(UserPreferencesRow, user_id)
-        # Surface the synoptic-map opt-in so the maps page can decide
-        # whether to show the Synoptic Forecast tab without a second
-        # round-trip to /user/preferences.
-        synoptic_enabled = False
+        # Surface a few display prefs so pages can configure themselves without
+        # a second round-trip to /user/preferences: the synoptic-map opt-in
+        # (maps tab visibility) and the display-units region (visibility m vs SM).
+        prefs_data: dict = {}
         if prefs and prefs.app_prefs_json:
             try:
-                synoptic_enabled = bool(
-                    _json.loads(prefs.app_prefs_json).get(
-                        "synoptic_forecast_map_enabled", False
-                    )
-                )
+                prefs_data = _json.loads(prefs.app_prefs_json)
             except _json.JSONDecodeError:
-                synoptic_enabled = False
+                prefs_data = {}
+        synoptic_enabled = bool(prefs_data.get("synoptic_forecast_map_enabled", False))
+        units_region = "us" if prefs_data.get("units_region") == "us" else "europe"
         return {
             "id": user.id,
             "email": user.email,
@@ -418,6 +416,7 @@ def create_app() -> FastAPI:
             "is_admin": is_dev_mode() or is_admin_email(user.email),
             "setup_completed": prefs.setup_completed if prefs else False,
             "synoptic_forecast_map_enabled": synoptic_enabled,
+            "units_region": units_region,
         }
 
     # Auth router from flyfun-common (with weather-specific on_new_user callback)

--- a/src/weatherbrief/api/app.py
+++ b/src/weatherbrief/api/app.py
@@ -407,7 +407,8 @@ def create_app() -> FastAPI:
             except _json.JSONDecodeError:
                 prefs_data = {}
         synoptic_enabled = bool(prefs_data.get("synoptic_forecast_map_enabled", False))
-        units_region = "us" if prefs_data.get("units_region") == "us" else "europe"
+        _ur = prefs_data.get("units_region")
+        units_region = _ur if _ur in ("auto", "europe", "us") else "auto"
         return {
             "id": user.id,
             "email": user.email,

--- a/src/weatherbrief/api/packs.py
+++ b/src/weatherbrief/api/packs.py
@@ -869,13 +869,19 @@ def _prepare_refresh(flight, db_path, user_id, flight_id, db=None, *, is_privile
     convective_method = None
     digest_guidance = None
     locale = None
+    units_region = "europe"
     profile_name_for_digest = None
     if db is not None:
-        from weatherbrief.api.preferences import load_autorouter_token, load_user_locale
+        from weatherbrief.api.preferences import (
+            load_autorouter_token,
+            load_units_region,
+            load_user_locale,
+        )
         from weatherbrief.api.profiles import load_profile_context
 
         autorouter_creds = load_autorouter_token(db, user_id)
         locale = load_user_locale(db, user_id)
+        units_region = load_units_region(db, user_id)
         profile_ctx = load_profile_context(db, flight.profile_id, user_id)
         profile_settings = profile_ctx.settings
         profile_name_for_digest = profile_ctx.name
@@ -955,6 +961,7 @@ def _prepare_refresh(flight, db_path, user_id, flight_id, db=None, *, is_privile
         options.advisory_params = adv_config["params"]
     if locale:
         options.locale = locale
+    options.units_region = units_region
     options.profile_id = flight.profile_id
     options.profile_name = profile_name_for_digest
     if digest_guidance:

--- a/src/weatherbrief/api/packs.py
+++ b/src/weatherbrief/api/packs.py
@@ -869,7 +869,7 @@ def _prepare_refresh(flight, db_path, user_id, flight_id, db=None, *, is_privile
     convective_method = None
     digest_guidance = None
     locale = None
-    units_region = "europe"
+    units_region = "auto"
     profile_name_for_digest = None
     if db is not None:
         from weatherbrief.api.preferences import (
@@ -961,7 +961,13 @@ def _prepare_refresh(flight, db_path, user_id, flight_id, db=None, *, is_privile
         options.advisory_params = adv_config["params"]
     if locale:
         options.locale = locale
-    options.units_region = units_region
+    # Resolve an 'auto' units preference against the route's detected region so
+    # the LLM prompt formats visibility in US units for US flights.
+    from weatherbrief.fetch.variables import ModelRegion, detect_model_region
+    from weatherbrief.units import resolve_units_region
+
+    detected = "us" if detect_model_region(route) == ModelRegion.NORTH_AMERICA else "europe"
+    options.units_region = resolve_units_region(units_region, detected)
     options.profile_id = flight.profile_id
     options.profile_name = profile_name_for_digest
     if digest_guidance:

--- a/src/weatherbrief/api/preferences.py
+++ b/src/weatherbrief/api/preferences.py
@@ -63,6 +63,7 @@ class PreferencesResponse(BaseModel):
     cloud_method: str
     convective_method: str
     locale: str
+    units_region: str
     synoptic_forecast_map_enabled: bool
     pirep_can_view: bool = False
     pirep_can_publish: bool = False
@@ -83,6 +84,7 @@ class PreferencesUpdate(BaseModel):
     cloud_method: str | None = None
     convective_method: str | None = None
     locale: str | None = None
+    units_region: str | None = None
     synoptic_forecast_map_enabled: bool | None = None
 
 
@@ -126,6 +128,7 @@ def _parse_service_toggles(raw: str) -> dict:
         "cloud_method": data.get("cloud_method", "soft_nwp"),
         "convective_method": data.get("convective_method", "nwp"),
         "locale": data.get("locale", "en"),
+        "units_region": data.get("units_region", "europe"),
         "synoptic_forecast_map_enabled": data.get("synoptic_forecast_map_enabled", False),
     }
 
@@ -244,6 +247,8 @@ def update_preferences(
         data["convective_method"] = body.convective_method
     if body.locale is not None:
         data["locale"] = body.locale
+    if body.units_region is not None:
+        data["units_region"] = body.units_region
     if body.synoptic_forecast_map_enabled is not None:
         data["synoptic_forecast_map_enabled"] = body.synoptic_forecast_map_enabled
 
@@ -311,6 +316,22 @@ def load_user_locale(db: Session, user_id: str) -> str | None:
         return None
 
 
+def load_units_region(db: Session, user_id: str) -> str:
+    """Load the user's display-units region ('europe' or 'us').
+
+    Returns 'europe' (the default) when unset. Used at briefing generation
+    time to format region-variable units (visibility) in the LLM prompt.
+    """
+    row = db.get(UserPreferencesRow, user_id)
+    if not row or not row.app_prefs_json:
+        return "europe"
+    try:
+        region = json.loads(row.app_prefs_json).get("units_region", "europe")
+        return "us" if region == "us" else "europe"
+    except json.JSONDecodeError:
+        return "europe"
+
+
 def load_advisory_prefs(db: Session, user_id: str) -> AdvisoryPreferences:
     """Load advisory preferences for a user.
 
@@ -343,7 +364,7 @@ def load_service_toggles(db: Session, user_id: str) -> dict[str, bool]:
     """
     row = db.get(UserPreferencesRow, user_id)
     if not row:
-        return {"gramet_enabled": True, "llm_digest_enabled": True, "icing_severity_enhance": False, "icing_method": "ogimet_nwp", "cloud_method": "soft_nwp", "convective_method": "nwp"}
+        return {"gramet_enabled": True, "llm_digest_enabled": True, "icing_severity_enhance": False, "icing_method": "ogimet_nwp", "cloud_method": "soft_nwp", "convective_method": "nwp", "units_region": "europe"}
     run_pending_migrations(db, row)
     return _parse_service_toggles(row.app_prefs_json)
 

--- a/src/weatherbrief/api/preferences.py
+++ b/src/weatherbrief/api/preferences.py
@@ -128,7 +128,7 @@ def _parse_service_toggles(raw: str) -> dict:
         "cloud_method": data.get("cloud_method", "soft_nwp"),
         "convective_method": data.get("convective_method", "nwp"),
         "locale": data.get("locale", "en"),
-        "units_region": data.get("units_region", "europe"),
+        "units_region": data.get("units_region", "auto"),
         "synoptic_forecast_map_enabled": data.get("synoptic_forecast_map_enabled", False),
     }
 
@@ -317,19 +317,21 @@ def load_user_locale(db: Session, user_id: str) -> str | None:
 
 
 def load_units_region(db: Session, user_id: str) -> str:
-    """Load the user's display-units region ('europe' or 'us').
+    """Load the user's display-units preference ('auto', 'europe', or 'us').
 
-    Returns 'europe' (the default) when unset. Used at briefing generation
-    time to format region-variable units (visibility) in the LLM prompt.
+    Returns the raw preference (default 'auto'); callers resolve 'auto' against
+    the flight's detected region. Used at briefing generation time to format
+    region-variable units (visibility) in the LLM prompt.
     """
+    from weatherbrief.units import normalize_preference
+
     row = db.get(UserPreferencesRow, user_id)
     if not row or not row.app_prefs_json:
-        return "europe"
+        return "auto"
     try:
-        region = json.loads(row.app_prefs_json).get("units_region", "europe")
-        return "us" if region == "us" else "europe"
+        return normalize_preference(json.loads(row.app_prefs_json).get("units_region"))
     except json.JSONDecodeError:
-        return "europe"
+        return "auto"
 
 
 def load_advisory_prefs(db: Session, user_id: str) -> AdvisoryPreferences:
@@ -364,7 +366,7 @@ def load_service_toggles(db: Session, user_id: str) -> dict[str, bool]:
     """
     row = db.get(UserPreferencesRow, user_id)
     if not row:
-        return {"gramet_enabled": True, "llm_digest_enabled": True, "icing_severity_enhance": False, "icing_method": "ogimet_nwp", "cloud_method": "soft_nwp", "convective_method": "nwp", "units_region": "europe"}
+        return {"gramet_enabled": True, "llm_digest_enabled": True, "icing_severity_enhance": False, "icing_method": "ogimet_nwp", "cloud_method": "soft_nwp", "convective_method": "nwp", "units_region": "auto"}
     run_pending_migrations(db, row)
     return _parse_service_toggles(row.app_prefs_json)
 

--- a/src/weatherbrief/digest/llm_digest.py
+++ b/src/weatherbrief/digest/llm_digest.py
@@ -188,6 +188,7 @@ def run_digest(
     route_advisories=None,  # RouteAdvisoriesManifest | None
     flight_rules: str | None = None,
     locale: str | None = None,
+    units_region: str | None = None,
     guidance_key: str | None = None,
 ) -> DigestState:
     """Run the full digest pipeline and return final state.
@@ -207,6 +208,7 @@ def run_digest(
         previous_digest=previous_digest,
         route_advisories=route_advisories,
         flight_rules=flight_rules,
+        units_region=units_region,
         dwd_translated=dwd_translated,
         dwd_is_synoptic_extract=dwd_is_synoptic_extract,
     )

--- a/src/weatherbrief/digest/prompt_builder.py
+++ b/src/weatherbrief/digest/prompt_builder.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING
 
 from weatherbrief.digest.format_utils import format_flight_level
+from weatherbrief.units import format_visibility
 from weatherbrief.models import (
     AgreementLevel,
     ConvectiveRisk,
@@ -41,6 +42,7 @@ def build_digest_context(
     previous_digest: WeatherDigest | None = None,
     route_advisories: RouteAdvisoriesManifest | None = None,
     flight_rules: str | None = None,
+    units_region: str | None = None,
     dwd_translated: list[tuple[DWDDayBlock, str]] | None = None,
     dwd_is_synoptic_extract: bool = False,
 ) -> str:
@@ -110,7 +112,7 @@ def build_digest_context(
             if hourly.cloud_cover_pct is not None:
                 wx_parts.append(f"Cloud={hourly.cloud_cover_pct:.0f}%")
             if hourly.visibility_m is not None:
-                wx_parts.append(f"Vis={hourly.visibility_m/1000:.1f}km")
+                wx_parts.append(f"Vis={format_visibility(hourly.visibility_m, units_region)}")
             if hourly.precipitation_mm is not None:
                 wx_parts.append(f"Precip={hourly.precipitation_mm:.1f}mm")
                 if hourly.rain_mm is not None:

--- a/src/weatherbrief/models/airport_conditions.py
+++ b/src/weatherbrief/models/airport_conditions.py
@@ -61,7 +61,8 @@ class AirportModelCondition(BaseModel):
     model: str
     flight_category: FlightCategory
     ceiling_ft: int | None = None  # lowest BKN/OVC base
-    visibility_sm: float | None = None  # statute miles
+    visibility_m: float | None = None  # raw meters (canonical; format by user region)
+    visibility_sm: float | None = None  # statute miles (derived; kept for back-compat)
     wind_speed_kt: float | None = None
     wind_direction_deg: float | None = None
     wind_gust_kt: float | None = None

--- a/src/weatherbrief/pipeline.py
+++ b/src/weatherbrief/pipeline.py
@@ -93,6 +93,7 @@ class BriefingOptions:
     as_of_time: datetime | None = None  # For historical: the date "as of" which to fetch data
     alt_departure_time: datetime | None = None  # optional same-day alt departure for lite advisory re-run
     locale: str | None = None  # user locale for LLM digest language (en/fr/de/es)
+    units_region: str | None = None  # display-units region for LLM prompt ('europe'/'us')
     profile_id: int | None = None  # flight profile ID for digest tracking
     profile_name: str | None = None  # flight profile name for digest tracking
     guidance_key: str | None = None  # digest guidance preset (conservative/balanced/tolerant)
@@ -625,6 +626,7 @@ def execute_briefing(
             flight_rules=options.flight_rules,
             previous_digest=previous_digest,
             locale=options.locale,
+            units_region=options.units_region,
             profile_id=options.profile_id,
             profile_name=options.profile_name,
             guidance_key=options.guidance_key,

--- a/src/weatherbrief/tasks/outputs.py
+++ b/src/weatherbrief/tasks/outputs.py
@@ -217,6 +217,7 @@ def run_llm_digest(
     flight_rules: str | None = None,
     previous_digest=None,  # WeatherDigest | None
     locale: str | None = None,
+    units_region: str | None = None,
     profile_id: int | None = None,
     profile_name: str | None = None,
     guidance_key: str | None = None,
@@ -235,6 +236,7 @@ def run_llm_digest(
             route_advisories=route_advisories,
             flight_rules=flight_rules,
             locale=locale,
+            units_region=units_region,
             guidance_key=guidance_key,
         )
 

--- a/src/weatherbrief/units.py
+++ b/src/weatherbrief/units.py
@@ -15,7 +15,26 @@ from __future__ import annotations
 from typing import Literal
 
 UnitsRegion = Literal["europe", "us"]
+# Stored user preference: a concrete region or "auto" (resolve per flight).
+UnitsPreference = Literal["auto", "europe", "us"]
 DEFAULT_REGION: UnitsRegion = "europe"
+DEFAULT_PREFERENCE: UnitsPreference = "auto"
+
+
+def normalize_preference(pref: str | None) -> UnitsPreference:
+    """Coerce a stored value to a known preference (default auto)."""
+    return pref if pref in ("auto", "europe", "us") else "auto"
+
+
+def resolve_units_region(pref: str | None, detected: str | None) -> UnitsRegion:
+    """Resolve a stored preference + a detected flight region to a concrete region.
+
+    A forced "europe"/"us" preference wins. "auto" (and anything unknown) uses
+    the detected flight region, falling back to europe when it can't be told.
+    """
+    if pref == "us" or pref == "europe":
+        return pref
+    return "us" if detected == "us" else "europe"
 
 # Conversion constants (single source of truth — was duplicated as _M_PER_SM).
 M_PER_SM = 1609.34

--- a/src/weatherbrief/units.py
+++ b/src/weatherbrief/units.py
@@ -1,0 +1,77 @@
+"""Display-unit conversion and formatting, keyed by a user's region preference.
+
+Canonical storage is always SI/aviation-canonical (visibility in meters, pressure
+in hPa, temperature in Celsius, altitude in feet, wind in knots, distance in nm).
+These helpers convert + format to the region the user prefers, at the display edge,
+so we never derive a precise unit from an already-rounded one.
+
+Only visibility is wired into display surfaces today. ``format_qnh`` and
+``format_temperature`` exist so QNH (hPa vs inHg) and temperature (C vs F) plug in
+at their call sites without new plumbing once those fields are surfaced.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+UnitsRegion = Literal["europe", "us"]
+DEFAULT_REGION: UnitsRegion = "europe"
+
+# Conversion constants (single source of truth — was duplicated as _M_PER_SM).
+M_PER_SM = 1609.34
+HPA_PER_INHG = 33.8639  # 1 inHg == 33.8639 hPa
+
+
+def normalize_region(region: str | None) -> UnitsRegion:
+    """Coerce an arbitrary stored value to a known region (default europe)."""
+    return "us" if region == "us" else "europe"
+
+
+def format_visibility(meters: float | None, region: str | None = DEFAULT_REGION) -> str | None:
+    """Format a visibility in meters for display.
+
+    europe -> meters below 5 km, km up to a >10 km cap.
+    us     -> statute miles, capped at >10 SM.
+    """
+    if meters is None:
+        return None
+    if normalize_region(region) == "us":
+        sm = meters / M_PER_SM
+        if sm >= 10:
+            return ">10 SM"
+        return f"{sm:.1f} SM"
+    # europe
+    if meters >= 10000:
+        return ">10 km"
+    if meters >= 5000:
+        return f"{meters / 1000:.0f} km"
+    return f"{round(meters)} m"
+
+
+def format_qnh(hpa: float | None, region: str | None = DEFAULT_REGION) -> str | None:
+    """Format an altimeter setting / QNH in hPa for display.
+
+    europe -> integer hPa.  us -> inHg to 2 decimals.
+    """
+    if hpa is None:
+        return None
+    if normalize_region(region) == "us":
+        return f"{hpa / HPA_PER_INHG:.2f} inHg"
+    return f"{round(hpa)} hPa"
+
+
+def format_temperature(
+    celsius: float | None,
+    region: str | None = DEFAULT_REGION,
+    decimals: int = 0,
+) -> str | None:
+    """Format a temperature in Celsius for display.
+
+    europe -> degrees C.  us -> degrees F.  (US METARs are still C; F is a US
+    pilot "thinking" preference, bundled with the us region.)
+    """
+    if celsius is None:
+        return None
+    if normalize_region(region) == "us":
+        return f"{celsius * 9 / 5 + 32:.{decimals}f}°F"
+    return f"{celsius:.{decimals}f}°C"

--- a/tests/test_preferences.py
+++ b/tests/test_preferences.py
@@ -71,6 +71,15 @@ class TestPreferencesAPI:
         assert data["autorouter_mode"] == "password"  # dev environment
         assert data["defaults"]["cruise_altitude_ft"] is None
         assert data["defaults"]["models"] is None
+        assert data["units_region"] == "europe"  # default
+
+    def test_units_region_round_trip(self, client):
+        resp = client.put("/api/user/preferences", json={"units_region": "us"})
+        assert resp.status_code == 200
+        assert resp.json()["units_region"] == "us"
+        # persists and is surfaced on the current-user payload
+        assert client.get("/api/user/preferences").json()["units_region"] == "us"
+        assert client.get("/auth/me").json()["units_region"] == "us"
 
     def test_save_flight_defaults(self, client):
         resp = client.put("/api/user/preferences", json={

--- a/tests/test_preferences.py
+++ b/tests/test_preferences.py
@@ -71,7 +71,7 @@ class TestPreferencesAPI:
         assert data["autorouter_mode"] == "password"  # dev environment
         assert data["defaults"]["cruise_altitude_ft"] is None
         assert data["defaults"]["models"] is None
-        assert data["units_region"] == "europe"  # default
+        assert data["units_region"] == "auto"  # default
 
     def test_units_region_round_trip(self, client):
         resp = client.put("/api/user/preferences", json={"units_region": "us"})

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -1,0 +1,77 @@
+"""Tests for region-aware display-unit formatting."""
+
+from weatherbrief.units import (
+    format_qnh,
+    format_temperature,
+    format_visibility,
+    normalize_region,
+)
+
+
+class TestNormalizeRegion:
+    def test_us_passes_through(self):
+        assert normalize_region("us") == "us"
+
+    def test_europe_and_unknown_default_to_europe(self):
+        assert normalize_region("europe") == "europe"
+        assert normalize_region(None) == "europe"
+        assert normalize_region("garbage") == "europe"
+
+
+class TestFormatVisibility:
+    def test_none(self):
+        assert format_visibility(None, "us") is None
+        assert format_visibility(None, "europe") is None
+
+    def test_us_statute_miles(self):
+        assert format_visibility(4500, "us") == "2.8 SM"
+        assert format_visibility(1609.34, "us") == "1.0 SM"
+
+    def test_us_caps_at_10_sm(self):
+        assert format_visibility(20000, "us") == ">10 SM"
+
+    def test_europe_meters_below_5km(self):
+        assert format_visibility(4500, "europe") == "4500 m"
+        assert format_visibility(800, "europe") == "800 m"
+
+    def test_europe_km_between_5_and_10(self):
+        assert format_visibility(6000, "europe") == "6 km"
+        assert format_visibility(8000, "europe") == "8 km"
+
+    def test_europe_caps_at_10km(self):
+        assert format_visibility(10000, "europe") == ">10 km"
+        assert format_visibility(24140, "europe") == ">10 km"
+
+    def test_default_region_is_europe(self):
+        assert format_visibility(4500) == "4500 m"
+
+
+class TestFormatQnh:
+    def test_none(self):
+        assert format_qnh(None, "us") is None
+
+    def test_europe_hpa(self):
+        assert format_qnh(1013, "europe") == "1013 hPa"
+        assert format_qnh(1013.25, "europe") == "1013 hPa"
+
+    def test_us_inhg(self):
+        assert format_qnh(1013.25, "us") == "29.92 inHg"
+
+    def test_default_region_is_europe(self):
+        assert format_qnh(1013, ) == "1013 hPa"
+
+
+class TestFormatTemperature:
+    def test_none(self):
+        assert format_temperature(None, "us") is None
+
+    def test_europe_celsius(self):
+        assert format_temperature(12, "europe") == "12°C"
+        assert format_temperature(12.6, "europe", decimals=1) == "12.6°C"
+
+    def test_us_fahrenheit(self):
+        assert format_temperature(0, "us") == "32°F"
+        assert format_temperature(20, "us") == "68°F"
+
+    def test_default_region_is_europe(self):
+        assert format_temperature(15) == "15°C"

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -4,7 +4,9 @@ from weatherbrief.units import (
     format_qnh,
     format_temperature,
     format_visibility,
+    normalize_preference,
     normalize_region,
+    resolve_units_region,
 )
 
 
@@ -16,6 +18,27 @@ class TestNormalizeRegion:
         assert normalize_region("europe") == "europe"
         assert normalize_region(None) == "europe"
         assert normalize_region("garbage") == "europe"
+
+
+class TestPreferenceResolution:
+    def test_normalize_preference(self):
+        assert normalize_preference("auto") == "auto"
+        assert normalize_preference("us") == "us"
+        assert normalize_preference("europe") == "europe"
+        assert normalize_preference(None) == "auto"
+        assert normalize_preference("garbage") == "auto"
+
+    def test_forced_preference_wins(self):
+        assert resolve_units_region("us", "europe") == "us"
+        assert resolve_units_region("europe", "us") == "europe"
+
+    def test_auto_uses_detected_region(self):
+        assert resolve_units_region("auto", "us") == "us"
+        assert resolve_units_region("auto", "europe") == "europe"
+
+    def test_auto_falls_back_to_europe(self):
+        assert resolve_units_region("auto", None) == "europe"
+        assert resolve_units_region(None, None) == "europe"
 
 
 class TestFormatVisibility:

--- a/web/settings.html
+++ b/web/settings.html
@@ -105,7 +105,15 @@
                 <option value="es">Español</option>
               </select>
             </div>
+            <div class="form-group">
+              <label for="input-units-region">Units</label>
+              <select id="input-units-region" class="input-select">
+                <option value="europe">Europe — visibility in m / km</option>
+                <option value="us">US — visibility in statute miles</option>
+              </select>
+            </div>
           </div>
+          <p class="muted section-hint">Altitude (ft), wind (kt) and distance (nm) are the same in both. Only visibility differs today; QNH and temperature will follow this setting when added.</p>
         </div>
 
         <div class="section">

--- a/web/settings.html
+++ b/web/settings.html
@@ -108,12 +108,13 @@
             <div class="form-group">
               <label for="input-units-region">Units</label>
               <select id="input-units-region" class="input-select">
+                <option value="auto">Automatic (by flight region)</option>
                 <option value="europe">Europe — visibility in m / km</option>
                 <option value="us">US — visibility in statute miles</option>
               </select>
             </div>
           </div>
-          <p class="muted section-hint">Altitude (ft), wind (kt) and distance (nm) are the same in both. Only visibility differs today; QNH and temperature will follow this setting when added.</p>
+          <p class="muted section-hint">Automatic uses US units for US flights and metric for European flights. Altitude (ft), wind (kt) and distance (nm) are the same in both — only visibility differs today; QNH and temperature will follow this setting when added.</p>
         </div>
 
         <div class="section">

--- a/web/tests/unit/units.test.ts
+++ b/web/tests/unit/units.test.ts
@@ -4,7 +4,9 @@ import {
   formatQNH,
   formatTemperature,
   getUnitsRegion,
-  setUnitsRegion,
+  setUnitsPreference,
+  setFlightRegion,
+  regionFromIcaos,
 } from '../../ts/units';
 
 describe('formatVisibility', () => {
@@ -41,14 +43,40 @@ describe('formatTemperature', () => {
   });
 });
 
-describe('units region singleton', () => {
-  it('defaults to europe and updates via setUnitsRegion', () => {
-    expect(getUnitsRegion()).toBe('europe');
-    setUnitsRegion('us');
+describe('regionFromIcaos', () => {
+  it('classifies US, European, and mixed routes', () => {
+    expect(regionFromIcaos(['KJFK', 'KBOS'])).toBe('us');
+    expect(regionFromIcaos(['CYYZ', 'KORD'])).toBe('us');
+    expect(regionFromIcaos(['LFPG', 'EGLL'])).toBe('europe');
+    expect(regionFromIcaos(['KJFK', 'LFPG'])).toBe(null); // mixed
+    expect(regionFromIcaos([])).toBe(null);
+  });
+});
+
+describe('units preference + auto resolution', () => {
+  it('forced preference ignores flight region', () => {
+    setUnitsPreference('us');
+    expect(getUnitsRegion()).toBe('us');
+    setFlightRegion('europe');
     expect(getUnitsRegion()).toBe('us');
     // formatters with no explicit region follow the active singleton
     expect(formatVisibility(4500)).toBe('2.8 SM');
-    setUnitsRegion('garbage');
+  });
+
+  it('auto resolves from the flight region, defaulting to europe', () => {
+    setUnitsPreference('auto');
+    expect(getUnitsRegion()).toBe('europe'); // no hint yet
+    setFlightRegion('us');
+    expect(getUnitsRegion()).toBe('us');
+    setFlightRegion(null);
     expect(getUnitsRegion()).toBe('europe');
+  });
+
+  it('unknown preference value falls back to auto', () => {
+    setUnitsPreference('garbage');
+    setFlightRegion(null);
+    expect(getUnitsRegion()).toBe('europe');
+    setFlightRegion('us');
+    expect(getUnitsRegion()).toBe('us');
   });
 });

--- a/web/tests/unit/units.test.ts
+++ b/web/tests/unit/units.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import {
+  formatVisibility,
+  formatQNH,
+  formatTemperature,
+  getUnitsRegion,
+  setUnitsRegion,
+} from '../../ts/units';
+
+describe('formatVisibility', () => {
+  it('returns empty string for null/undefined', () => {
+    expect(formatVisibility(null, 'us')).toBe('');
+    expect(formatVisibility(undefined, 'europe')).toBe('');
+  });
+
+  it('formats statute miles for us', () => {
+    expect(formatVisibility(4500, 'us')).toBe('2.8 SM');
+    expect(formatVisibility(20000, 'us')).toBe('>10 SM');
+  });
+
+  it('formats meters/km for europe', () => {
+    expect(formatVisibility(4500, 'europe')).toBe('4500 m');
+    expect(formatVisibility(6000, 'europe')).toBe('6 km');
+    expect(formatVisibility(10000, 'europe')).toBe('>10 km');
+  });
+});
+
+describe('formatQNH', () => {
+  it('formats hPa for europe and inHg for us', () => {
+    expect(formatQNH(1013, 'europe')).toBe('1013 hPa');
+    expect(formatQNH(1013.25, 'us')).toBe('29.92 inHg');
+    expect(formatQNH(null, 'us')).toBe('');
+  });
+});
+
+describe('formatTemperature', () => {
+  it('formats C for europe and F for us', () => {
+    expect(formatTemperature(12, 'europe')).toBe('12°C');
+    expect(formatTemperature(0, 'us')).toBe('32°F');
+    expect(formatTemperature(20, 'us')).toBe('68°F');
+  });
+});
+
+describe('units region singleton', () => {
+  it('defaults to europe and updates via setUnitsRegion', () => {
+    expect(getUnitsRegion()).toBe('europe');
+    setUnitsRegion('us');
+    expect(getUnitsRegion()).toBe('us');
+    // formatters with no explicit region follow the active singleton
+    expect(formatVisibility(4500)).toBe('2.8 SM');
+    setUnitsRegion('garbage');
+    expect(getUnitsRegion()).toBe('europe');
+  });
+});

--- a/web/ts/adapters/auth-adapter.ts
+++ b/web/ts/adapters/auth-adapter.ts
@@ -8,6 +8,7 @@ export interface CurrentUser {
   is_admin: boolean;
   setup_completed: boolean;
   synoptic_forecast_map_enabled: boolean;
+  units_region: string;
 }
 
 export async function fetchCurrentUser(): Promise<CurrentUser | null> {

--- a/web/ts/adapters/preferences-adapter.ts
+++ b/web/ts/adapters/preferences-adapter.ts
@@ -35,6 +35,7 @@ export interface PreferencesResponse {
   cloud_method: string;
   convective_method: string;
   locale: string;
+  units_region: string;
   synoptic_forecast_map_enabled: boolean;
   pirep_can_view: boolean;
   pirep_can_publish: boolean;
@@ -50,6 +51,7 @@ export interface PreferencesUpdate {
   llm_digest_enabled?: boolean;
   icing_severity_enhance?: boolean;
   locale?: string;
+  units_region?: string;
   synoptic_forecast_map_enabled?: boolean;
 }
 

--- a/web/ts/briefing-main.ts
+++ b/web/ts/briefing-main.ts
@@ -28,7 +28,7 @@ import { attachMapInteraction, type MapInteractionHandle } from './visualization
 import { renderMapLegend } from './visualization/route-map/legend';
 import { renderAltitudeSlider } from './visualization/route-map/altitude-slider';
 import { initTheme } from './theme';
-import { setUnitsRegion } from './units';
+import { setUnitsPreference, setFlightRegion, regionFromIcaos } from './units';
 import { track, trackOncePerBriefing, setBriefingContext, EVENTS } from './analytics/track';
 import { initI18n, t } from './i18n/i18n';
 import { SkewTRenderer } from './visualization/skewt/renderer';
@@ -68,7 +68,7 @@ async function init(): Promise<void> {
     return;
   }
   initTheme();
-  setUnitsRegion(user.units_region);
+  setUnitsPreference(user.units_region);
   renderUserInfo(user, 'briefing');
 
   // Load model catalog + preferred methods (non-blocking)
@@ -927,6 +927,11 @@ async function init(): Promise<void> {
 
   // --- Subscribe to state changes ---
   store.subscribe((state, prev) => {
+    // Resolve 'auto' units against this flight's region (US flights → US units)
+    // before any sub-render reads getUnitsRegion(). No-op for a forced pref.
+    if (state.snapshot !== prev.snapshot && state.snapshot) {
+      setFlightRegion(regionFromIcaos(state.snapshot.route.waypoints.map(w => w.icao)));
+    }
     if (state.flight !== prev.flight || state.snapshot !== prev.snapshot) {
       ui.renderHeader(state.flight, state.snapshot);
     }

--- a/web/ts/briefing-main.ts
+++ b/web/ts/briefing-main.ts
@@ -28,6 +28,7 @@ import { attachMapInteraction, type MapInteractionHandle } from './visualization
 import { renderMapLegend } from './visualization/route-map/legend';
 import { renderAltitudeSlider } from './visualization/route-map/altitude-slider';
 import { initTheme } from './theme';
+import { setUnitsRegion } from './units';
 import { track, trackOncePerBriefing, setBriefingContext, EVENTS } from './analytics/track';
 import { initI18n, t } from './i18n/i18n';
 import { SkewTRenderer } from './visualization/skewt/renderer';
@@ -67,6 +68,7 @@ async function init(): Promise<void> {
     return;
   }
   initTheme();
+  setUnitsRegion(user.units_region);
   renderUserInfo(user, 'briefing');
 
   // Load model catalog + preferred methods (non-blocking)

--- a/web/ts/managers/advisories-ui.ts
+++ b/web/ts/managers/advisories-ui.ts
@@ -6,6 +6,15 @@ import { showPopupContent } from '../components/info-popup';
 import { renderAdvisoryPopup } from '../helpers/advisory-popup';
 import { $, escapeHtml, formatAlt, modelLabel } from '../utils';
 import { t } from '../i18n/i18n';
+import { formatVisibility } from '../units';
+
+/** Visibility for an airport condition, region-aware.
+ *  Prefers raw meters (visibility_m); falls back to legacy SM for old packs. */
+function formatCondVis(cond: AirportModelCondition): string | null {
+  if (cond.visibility_m != null) return formatVisibility(cond.visibility_m);
+  if (cond.visibility_sm !== null) return `${cond.visibility_sm} SM`;
+  return null;
+}
 
 /** Advisory categories hidden in compact mode (informational, not actionable). */
 const COMPACT_HIDDEN_CATEGORIES = new Set(['model']);
@@ -131,6 +140,7 @@ function computeSummaryCondition(
   // Pick worst values from the pool (lowest ceiling/vis, highest wind)
   let worstCeiling: number | null = null;
   let worstVis: number | null = null;
+  let worstVisM: number | null = null;
   let worstWindSpd: number | null = null;
   let worstWindDir: number | null = null;
   let worstGust: number | null = null;
@@ -143,6 +153,9 @@ function computeSummaryCondition(
     }
     if (c.visibility_sm !== null) {
       worstVis = worstVis === null ? c.visibility_sm : Math.min(worstVis, c.visibility_sm);
+    }
+    if (c.visibility_m != null) {
+      worstVisM = worstVisM === null ? c.visibility_m : Math.min(worstVisM, c.visibility_m);
     }
     if (c.wind_speed_kt !== null) {
       if (worstWindSpd === null || c.wind_speed_kt > worstWindSpd) {
@@ -159,6 +172,7 @@ function computeSummaryCondition(
     model: 'Summary',
     flight_category: winningCat,
     ceiling_ft: worstCeiling,
+    visibility_m: worstVisM,
     visibility_sm: worstVis,
     wind_speed_kt: worstWindSpd,
     wind_direction_deg: worstWindDir,
@@ -171,7 +185,8 @@ function computeSummaryCondition(
 function renderSummaryRow(cond: AirportModelCondition): string {
   const catLabel = cond.flight_category;
   const catClass = flightCatBadgeClass(cond.flight_category);
-  const vis = cond.visibility_sm !== null ? `vis ${cond.visibility_sm}sm` : '';
+  const visStr = formatCondVis(cond);
+  const vis = visStr ? `vis ${visStr}` : '';
   const ceil = cond.ceiling_ft !== null ? `ceil ${cond.ceiling_ft}ft` : 'CLR';
   const wind = formatWind(cond);
   const rwyComp = cond.best_runway && cond.wind_direction_deg != null
@@ -191,7 +206,7 @@ function renderSummaryRow(cond: AirportModelCondition): string {
 function renderConditionRow(cond: AirportModelCondition): string {
   const catLabel = cond.flight_category;
   const catClass = flightCatBadgeClass(cond.flight_category);
-  const vis = cond.visibility_sm !== null ? `${cond.visibility_sm}sm` : 'N/A';
+  const vis = formatCondVis(cond) ?? 'N/A';
   const ceil = cond.ceiling_ft !== null ? `${cond.ceiling_ft}ft` : 'CLR';
 
   const wind = formatWind(cond);

--- a/web/ts/maps-main.ts
+++ b/web/ts/maps-main.ts
@@ -19,7 +19,7 @@ import { initInfoPopup, showPopupContent } from './components/info-popup';
 import { renderHewsonInfo } from './helpers/hewson-info';
 import { redirectToLogin, renderUserInfo, $ } from './utils';
 import { initI18n, t } from './i18n/i18n';
-import { setUnitsRegion } from './units';
+import { setUnitsPreference } from './units';
 import { createUrlState } from './utils/url-state';
 import { shareCurrentUrl } from './utils/share-link';
 
@@ -703,7 +703,8 @@ async function main(): Promise<void> {
     return;
   }
   renderUserInfo(user, 'maps');
-  setUnitsRegion(user.units_region);
+  // Pan-European overview — no single flight, so 'auto' falls back to europe.
+  setUnitsPreference(user.units_region);
 
   // Synoptic Forecast is opt-in per user. Hide the tab unless the user
   // enabled it in Settings → Account → Optional Services. The toggle is

--- a/web/ts/maps-main.ts
+++ b/web/ts/maps-main.ts
@@ -19,6 +19,7 @@ import { initInfoPopup, showPopupContent } from './components/info-popup';
 import { renderHewsonInfo } from './helpers/hewson-info';
 import { redirectToLogin, renderUserInfo, $ } from './utils';
 import { initI18n, t } from './i18n/i18n';
+import { setUnitsRegion } from './units';
 import { createUrlState } from './utils/url-state';
 import { shareCurrentUrl } from './utils/share-link';
 
@@ -702,6 +703,7 @@ async function main(): Promise<void> {
     return;
   }
   renderUserInfo(user, 'maps');
+  setUnitsRegion(user.units_region);
 
   // Synoptic Forecast is opt-in per user. Hide the tab unless the user
   // enabled it in Settings → Account → Optional Services. The toggle is

--- a/web/ts/settings-main.ts
+++ b/web/ts/settings-main.ts
@@ -44,6 +44,7 @@ import {
 } from './adapters/tokens-adapter';
 import { initTheme } from './theme';
 import { initI18n, t, setLocale, getLocale, getDateLocale } from './i18n/i18n';
+import { setUnitsRegion } from './units';
 import { initInfoPopup, showPopupContent } from './components/info-popup';
 import { renderAdvisoryPopup } from './helpers/advisory-popup';
 
@@ -658,6 +659,12 @@ function populateAccountForm(prefs: PreferencesResponse): void {
     localeSelect.value = prefs.locale || getLocale();
   }
 
+  // Units region picker — reflect server-stored preference
+  const unitsRegionSelect = document.getElementById('input-units-region') as HTMLSelectElement;
+  if (unitsRegionSelect) {
+    unitsRegionSelect.value = prefs.units_region === 'us' ? 'us' : 'europe';
+  }
+
   // Account-level optional services
   const synopticToggle = document.getElementById('toggle-synoptic-forecast-map') as HTMLInputElement;
   if (synopticToggle) {
@@ -885,6 +892,7 @@ async function handleSave(): Promise<void> {
 
   // Account-level settings
   const selectedLocale = (document.getElementById('input-locale') as HTMLSelectElement)?.value || 'en';
+  const selectedUnitsRegion = (document.getElementById('input-units-region') as HTMLSelectElement)?.value === 'us' ? 'us' : 'europe';
 
   try {
     // Save profile settings
@@ -898,6 +906,7 @@ async function handleSave(): Promise<void> {
     const synopticEnabled = (document.getElementById('toggle-synoptic-forecast-map') as HTMLInputElement)?.checked ?? false;
     const accountUpdate: import('./adapters/preferences-adapter').PreferencesUpdate = {
       locale: selectedLocale,
+      units_region: selectedUnitsRegion,
       synoptic_forecast_map_enabled: synopticEnabled,
     };
     if (autorouterMode === 'password') {
@@ -908,6 +917,7 @@ async function handleSave(): Promise<void> {
     }
 
     const result = await savePreferences(accountUpdate);
+    setUnitsRegion(result.units_region);
     updateAutorouterStatus(result.has_autorouter_creds, autorouterMode);
     if (autorouterMode === 'password') {
       const arPwdInput = document.getElementById('input-ar-password') as HTMLInputElement;

--- a/web/ts/settings-main.ts
+++ b/web/ts/settings-main.ts
@@ -44,7 +44,7 @@ import {
 } from './adapters/tokens-adapter';
 import { initTheme } from './theme';
 import { initI18n, t, setLocale, getLocale, getDateLocale } from './i18n/i18n';
-import { setUnitsRegion } from './units';
+import { setUnitsPreference } from './units';
 import { initInfoPopup, showPopupContent } from './components/info-popup';
 import { renderAdvisoryPopup } from './helpers/advisory-popup';
 
@@ -659,10 +659,11 @@ function populateAccountForm(prefs: PreferencesResponse): void {
     localeSelect.value = prefs.locale || getLocale();
   }
 
-  // Units region picker — reflect server-stored preference
+  // Units region picker — reflect server-stored preference (auto/europe/us)
   const unitsRegionSelect = document.getElementById('input-units-region') as HTMLSelectElement;
   if (unitsRegionSelect) {
-    unitsRegionSelect.value = prefs.units_region === 'us' ? 'us' : 'europe';
+    const ur = prefs.units_region;
+    unitsRegionSelect.value = ur === 'us' || ur === 'europe' ? ur : 'auto';
   }
 
   // Account-level optional services
@@ -892,7 +893,8 @@ async function handleSave(): Promise<void> {
 
   // Account-level settings
   const selectedLocale = (document.getElementById('input-locale') as HTMLSelectElement)?.value || 'en';
-  const selectedUnitsRegion = (document.getElementById('input-units-region') as HTMLSelectElement)?.value === 'us' ? 'us' : 'europe';
+  const unitsRegionVal = (document.getElementById('input-units-region') as HTMLSelectElement)?.value;
+  const selectedUnitsRegion = unitsRegionVal === 'us' || unitsRegionVal === 'europe' ? unitsRegionVal : 'auto';
 
   try {
     // Save profile settings
@@ -917,7 +919,7 @@ async function handleSave(): Promise<void> {
     }
 
     const result = await savePreferences(accountUpdate);
-    setUnitsRegion(result.units_region);
+    setUnitsPreference(result.units_region);
     updateAutorouterStatus(result.has_autorouter_creds, autorouterMode);
     if (autorouterMode === 'password') {
       const arPwdInput = document.getElementById('input-ar-password') as HTMLInputElement;

--- a/web/ts/types/advisories.ts
+++ b/web/ts/types/advisories.ts
@@ -62,6 +62,7 @@ export interface AirportModelCondition {
   model: string;
   flight_category: FlightCategory;
   ceiling_ft: number | null;
+  visibility_m?: number | null;
   visibility_sm: number | null;
   wind_speed_kt: number | null;
   wind_direction_deg: number | null;

--- a/web/ts/units.ts
+++ b/web/ts/units.ts
@@ -10,39 +10,78 @@
  * new plumbing once those fields are surfaced.
  */
 
+/** Concrete region used for formatting. */
 export type UnitsRegion = 'europe' | 'us';
+/** Stored user preference: a forced region, or 'auto' (resolve per flight). */
+export type UnitsPreference = 'auto' | 'europe' | 'us';
 
 const STORAGE_KEY = 'wb_units_region';
 const M_PER_SM = 1609.34;
 const HPA_PER_INHG = 33.8639;
 
-function readStored(): UnitsRegion {
+function normalizePref(pref: string | null | undefined): UnitsPreference {
+  return pref === 'us' || pref === 'europe' || pref === 'auto' ? pref : 'auto';
+}
+
+function resolve(pref: UnitsPreference, hint: UnitsRegion | null): UnitsRegion {
+  if (pref === 'us' || pref === 'europe') return pref;
+  return hint ?? 'europe'; // auto
+}
+
+function readStored(): UnitsPreference {
   try {
-    return localStorage.getItem(STORAGE_KEY) === 'us' ? 'us' : 'europe';
+    return normalizePref(localStorage.getItem(STORAGE_KEY));
   } catch {
-    return 'europe';
+    return 'auto';
   }
 }
 
-let unitsRegion: UnitsRegion = readStored();
+let unitsPreference: UnitsPreference = readStored();
+let activeRegion: UnitsRegion = resolve(unitsPreference, null);
 
 export function getUnitsRegion(): UnitsRegion {
-  return unitsRegion;
+  return activeRegion;
 }
 
-export function setUnitsRegion(region: string | null | undefined): void {
-  unitsRegion = region === 'us' ? 'us' : 'europe';
+export function getUnitsPreference(): UnitsPreference {
+  return unitsPreference;
+}
+
+/** Set the stored preference (auto/europe/us) and persist it. Resets the active
+ *  region to the preference's default; a later setFlightRegion() supplies the
+ *  per-flight hint that 'auto' needs. */
+export function setUnitsPreference(pref: string | null | undefined): void {
+  unitsPreference = normalizePref(pref);
+  activeRegion = resolve(unitsPreference, null);
   try {
-    localStorage.setItem(STORAGE_KEY, unitsRegion);
+    localStorage.setItem(STORAGE_KEY, unitsPreference);
   } catch {
     /* localStorage unavailable — keep in-memory value */
   }
 }
 
+/** Apply a detected flight region. Only affects the active region when the
+ *  preference is 'auto'; a forced europe/us preference ignores the hint. */
+export function setFlightRegion(hint: UnitsRegion | null): void {
+  activeRegion = resolve(unitsPreference, hint);
+}
+
+/** Classify a set of waypoint ICAOs the same way the backend does
+ *  (K/C/P prefix → US). Returns null for a mixed/unknown route. */
+export function regionFromIcaos(icaos: Array<string | null | undefined>): UnitsRegion | null {
+  const regions = new Set<UnitsRegion>();
+  for (const icao of icaos) {
+    const c = (icao ?? '').trim().toUpperCase()[0];
+    if (!c) continue;
+    regions.add(c === 'K' || c === 'C' || c === 'P' ? 'us' : 'europe');
+  }
+  return regions.size === 1 ? [...regions][0] : null;
+}
+
 /** Format a visibility in meters for the active (or given) region. */
 export function formatVisibility(
   meters: number | null | undefined,
-  region: UnitsRegion = unitsRegion,
+  region: UnitsRegion = activeRegion,
 ): string {
   if (meters == null) return '';
   if (region === 'us') {
@@ -58,7 +97,7 @@ export function formatVisibility(
 /** Format an altimeter setting / QNH in hPa. (Not yet wired into surfaces.) */
 export function formatQNH(
   hpa: number | null | undefined,
-  region: UnitsRegion = unitsRegion,
+  region: UnitsRegion = activeRegion,
 ): string {
   if (hpa == null) return '';
   if (region === 'us') return `${(hpa / HPA_PER_INHG).toFixed(2)} inHg`;
@@ -68,7 +107,7 @@ export function formatQNH(
 /** Format a temperature in Celsius. (Not yet wired into surfaces.) */
 export function formatTemperature(
   celsius: number | null | undefined,
-  region: UnitsRegion = unitsRegion,
+  region: UnitsRegion = activeRegion,
   decimals = 0,
 ): string {
   if (celsius == null) return '';

--- a/web/ts/units.ts
+++ b/web/ts/units.ts
@@ -1,0 +1,77 @@
+/**
+ * Region-aware display-unit formatting (module-level singleton, like i18n/theme).
+ *
+ * Canonical values cross the wire raw (visibility in meters, pressure in hPa,
+ * temperature in Celsius); these helpers convert + format at the display edge so
+ * we never derive a precise unit from an already-rounded one.
+ *
+ * v1 wires in visibility only. formatQNH / formatTemperature exist so QNH
+ * (hPa vs inHg) and temperature (C vs F) plug in at their call sites without
+ * new plumbing once those fields are surfaced.
+ */
+
+export type UnitsRegion = 'europe' | 'us';
+
+const STORAGE_KEY = 'wb_units_region';
+const M_PER_SM = 1609.34;
+const HPA_PER_INHG = 33.8639;
+
+function readStored(): UnitsRegion {
+  try {
+    return localStorage.getItem(STORAGE_KEY) === 'us' ? 'us' : 'europe';
+  } catch {
+    return 'europe';
+  }
+}
+
+let unitsRegion: UnitsRegion = readStored();
+
+export function getUnitsRegion(): UnitsRegion {
+  return unitsRegion;
+}
+
+export function setUnitsRegion(region: string | null | undefined): void {
+  unitsRegion = region === 'us' ? 'us' : 'europe';
+  try {
+    localStorage.setItem(STORAGE_KEY, unitsRegion);
+  } catch {
+    /* localStorage unavailable — keep in-memory value */
+  }
+}
+
+/** Format a visibility in meters for the active (or given) region. */
+export function formatVisibility(
+  meters: number | null | undefined,
+  region: UnitsRegion = unitsRegion,
+): string {
+  if (meters == null) return '';
+  if (region === 'us') {
+    const sm = meters / M_PER_SM;
+    if (sm >= 10) return '>10 SM';
+    return `${sm.toFixed(1)} SM`;
+  }
+  if (meters >= 10000) return '>10 km';
+  if (meters >= 5000) return `${(meters / 1000).toFixed(0)} km`;
+  return `${Math.round(meters)} m`;
+}
+
+/** Format an altimeter setting / QNH in hPa. (Not yet wired into surfaces.) */
+export function formatQNH(
+  hpa: number | null | undefined,
+  region: UnitsRegion = unitsRegion,
+): string {
+  if (hpa == null) return '';
+  if (region === 'us') return `${(hpa / HPA_PER_INHG).toFixed(2)} inHg`;
+  return `${Math.round(hpa)} hPa`;
+}
+
+/** Format a temperature in Celsius. (Not yet wired into surfaces.) */
+export function formatTemperature(
+  celsius: number | null | undefined,
+  region: UnitsRegion = unitsRegion,
+  decimals = 0,
+): string {
+  if (celsius == null) return '';
+  if (region === 'us') return `${(celsius * 9 / 5 + 32).toFixed(decimals)}°F`;
+  return `${celsius.toFixed(decimals)}°C`;
+}

--- a/web/ts/visualization/cross-section/tooltip-formatters.ts
+++ b/web/ts/visualization/cross-section/tooltip-formatters.ts
@@ -9,6 +9,7 @@
 
 import type { VizPoint, VizCloudLayer, VizIcingZone, VizSfipZone, VizSldZone, VizCATLayer, VizInversionLayer, VizSurfaceObscuration } from '../types';
 import { fmtFL } from '../interaction-utils';
+import { formatVisibility } from '../../units';
 
 export interface LayerTooltipDef {
   /** Primary layer id (the toggle that owns the data). */
@@ -237,7 +238,7 @@ const surfaceObscuration: LayerTooltipDef = {
     // 1–3 km radiation-fog signature.
     const metar = z.severity === 'lifr' ? 'FG' : z.severity === 'ifr' ? 'BR/MIFG' : 'BR';
     const cat = z.severity.toUpperCase();
-    const vis = z.visM !== null ? `vis ${Math.round(z.visM)} m` : 'vis n/a';
+    const vis = z.visM !== null ? `vis ${formatVisibility(z.visM)}` : 'vis n/a';
     const t = z.surfaceTC !== null ? `${z.surfaceTC.toFixed(0)}°C` : '—';
     const td = z.surfaceTdC !== null ? `${z.surfaceTdC.toFixed(0)}°C` : '—';
     const rh = z.surfaceRhPct !== null ? `${Math.round(z.surfaceRhPct)}%` : '—';

--- a/web/ts/visualization/weather-map.ts
+++ b/web/ts/visualization/weather-map.ts
@@ -4,6 +4,7 @@ import * as L from 'leaflet';
 import type {
   ForecastAirport, ForecastMapResponse, ModelForecast, ConsensusForecast,
 } from '../adapters/maps-adapter';
+import { formatVisibility, getUnitsRegion } from '../units';
 
 const LIGHT_TILES = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
 const DARK_TILES = 'https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png';
@@ -128,10 +129,25 @@ function fmtCeiling(ft: number | null | undefined): string {
 }
 
 function fmtVisibility(m: number | null | undefined): string {
-  if (m == null) return '';
-  const sm = m / 1609.34;
-  if (sm >= 10) return '>10 SM';
-  return `${sm.toFixed(1)} SM`;
+  return formatVisibility(m);
+}
+
+/** Region-aware legend rows for the visibility metric (flight-category bands). */
+function visibilityLegendItems(): Array<{ color: string; label: string }> {
+  if (getUnitsRegion() === 'us') {
+    return [
+      { color: '#22c55e', label: '>= 5 SM (VFR)' },
+      { color: '#3b82f6', label: '3-5 SM (MVFR)' },
+      { color: '#ef4444', label: '1-3 SM (IFR)' },
+      { color: '#a855f7', label: '< 1 SM (LIFR)' },
+    ];
+  }
+  return [
+    { color: '#22c55e', label: '>= 8 km (VFR)' },
+    { color: '#3b82f6', label: '5-8 km (MVFR)' },
+    { color: '#ef4444', label: '1.5-5 km (IFR)' },
+    { color: '#a855f7', label: '< 1.5 km (LIFR)' },
+  ];
 }
 
 function fmtWind(speed: number | null | undefined, dir: number | null | undefined, gust: number | null | undefined): string {
@@ -454,7 +470,10 @@ export class WeatherMap {
     }
 
     this.attachZoomHandler();
-    this.renderLegend(FORECAST_LEGENDS[metric]);
+    const legend = metric === 'visibility_m'
+      ? { ...FORECAST_LEGENDS.visibility_m, items: visibilityLegendItems() }
+      : FORECAST_LEGENDS[metric];
+    this.renderLegend(legend);
 
     // Re-apply highlight if the currently-highlighted airport is still on the map.
     if (this.highlightedIcao) {


### PR DESCRIPTION
## Summary

Adds a user display-units preference so visibility renders in the convention the pilot expects — meters/km in Europe, statute miles in the US. Most aviation units are universal (ft, kt, nm) and intentionally unchanged; only visibility genuinely differs region-to-region today.

- **`units_region` preference** (`auto` | `europe` | `us`, default **`auto`**), stored in `app_prefs_json`, following the `cloud_method`/`icing_method` template. Surfaced on `/auth/me` so every page self-configures with no extra round-trip.
- **`auto`** resolves per flight via the existing `detect_model_region` (ICAO K/C/P → North America): US flights get SM, European flights get metric. A forced europe/us choice overrides. The pan-European maps page (no single flight) falls back to europe.
- **New `units` module** (backend `units.py` + frontend `units.ts`) centralizes conversion/formatting — kills the duplicated `_M_PER_SM`. `formatVisibility` is wired into surfaces now; `formatQNH`/`formatTemperature` exist and are unit-tested so QNH (hPa/inHg) and temperature (C/F) plug in at their call sites when those fields get displayed.
- **Visibility wired into:** forecast-map tooltip + legend, cross-section tooltip, advisory airport conditions (departure/arrival cards).
- Added raw **`visibility_m`** to `AirportModelCondition` (was SM-only, which blocked client-side metric display); old packs fall back to the legacy SM until regenerated.
- **LLM prompt** visibility follows the flight owner's resolved region at generation time (prompt is an input, not a stored artifact). Stored digest prose freezes the owner's region at generation, by design.
- Settings → Account control (Automatic / Europe / US) with a hint that ft/kt/nm are common to both.

No DB migration (JSON-only). Flight-category classification stays canonical (FAA SM thresholds) — this is purely a display change.

## Test plan

- [x] Backend: `test_units.py` (formatters + `resolve_units_region`/`normalize_preference`), `test_preferences.py` (default `auto`, round-trip incl. `/auth/me`), `test_packs.py` — 107 passed across touched suites
- [x] Frontend: `tsc --noEmit` clean; vitest `units.test.ts` (9 cases incl. `regionFromIcaos` + auto resolution); 3 bundles build with logic present
- [x] Live runtime: `/auth/me` default + `auto`/`europe`/`us` round-trip; settings control served
- [x] **Manual browser (EGMC→LFAT, auto):** forecast map shows km; departure card shows km after refresh (regenerated pack carries `visibility_m: 9560.0`); confirmed 5–10 km band renders as whole km ("10 km") per product decision
- [ ] Reviewer: sanity-check a US route (ICAO K*) renders SM under `auto`

🤖 Generated with [Claude Code](https://claude.com/claude-code)