### PR TITLE
feat(viz): terrain always-on + render-time NWP→DD cloud/icing fallback

### DIFF
--- a/web/css/style.css
+++ b/web/css/style.css
@@ -2794,6 +2794,13 @@ label {
   cursor: not-allowed;
 }
 
+/* Auto-substituted layer (DD standing in for unavailable NWP): visible but
+   dimmed + italic so it reads as an automatic fallback, not a user choice. */
+.viz-layer-substituted {
+  opacity: 0.6;
+  font-style: italic;
+}
+
 .viz-tooltip {
   display: none;
   position: absolute;

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -2794,8 +2794,7 @@ label {
   cursor: not-allowed;
 }
 
-/* Auto-substituted layer (DD standing in for unavailable NWP): visible but
-   dimmed + italic so it reads as an automatic fallback, not a user choice. */
+/* Auto-substituted layer (DD standing in for unavailable NWP): dimmed + italic. */
 .viz-layer-substituted {
   opacity: 0.6;
   font-style: italic;

--- a/web/tests/unit/layer-registry.test.ts
+++ b/web/tests/unit/layer-registry.test.ts
@@ -137,17 +137,16 @@ describe('getPreferredLayerForGroup', () => {
 describe('getLayerGroups', () => {
   it('returns groups in stable display order', () => {
     const groups = getLayerGroups().map((g) => g.group);
-    // Order asserted in layer-registry.ts
-    const expected = ['terrain', 'reference', 'temperature', 'clouds', 'icing', 'turbulence', 'convection'];
-    // Filter expected to match what's actually present (some groups may be absent if no layers)
-    for (const g of expected) {
-      const idxActual = groups.indexOf(g as typeof groups[number]);
-      if (idxActual === -1) continue;
-      // Just check 'clouds' comes before 'icing' before 'turbulence' before 'convection'
-    }
     expect(groups.indexOf('clouds')).toBeLessThan(groups.indexOf('icing'));
     expect(groups.indexOf('icing')).toBeLessThan(groups.indexOf('turbulence'));
     expect(groups.indexOf('turbulence')).toBeLessThan(groups.indexOf('convection'));
+  });
+
+  it('omits the terrain group (terrain always renders, no toggle)', () => {
+    const groups = getLayerGroups().map((g) => g.group);
+    expect(groups).not.toContain('terrain');
+    // The terrain layer itself is still registered — it just has no UI toggle.
+    expect(getAllLayers().some((l) => l.id === 'terrain')).toBe(true);
   });
 
   it('every group entry has at least one layer', () => {

--- a/web/tests/unit/nwp-fallback.test.ts
+++ b/web/tests/unit/nwp-fallback.test.ts
@@ -1,0 +1,128 @@
+/** Tests for render-time NWP→DD layer substitution.
+ *
+ *  The fallback substitutes same-style DD cloud / Ogimet-DD icing layers when
+ *  the selected model lacks native NWP data — purely in a throwaway effective
+ *  map, never mutating the stored preference.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  applyNwpFallback,
+  getSubstitutedLayers,
+} from '../../ts/visualization/cross-section/nwp-fallback';
+
+// What getUnavailableLayers adds when a model has no native NWP cloud data.
+const NWP_UNAVAILABLE = new Set([
+  'nwp-cloud-bands',
+  'icing-ogimet-nwp-bands',
+  'ieng-icing-bands',
+]);
+
+describe('applyNwpFallback — clouds', () => {
+  it('NWP available: no DD injected', () => {
+    const enabled = { 'soft-nwp-cloud-bands': true };
+    const effective = applyNwpFallback(enabled, new Set());
+    expect(effective['soft-cloud-bands']).toBeUndefined();
+    expect(getSubstitutedLayers(enabled, effective).size).toBe(0);
+  });
+
+  it('NWP unavailable + soft NWP enabled → soft DD injected, same style', () => {
+    const enabled = { 'soft-nwp-cloud-bands': true };
+    const effective = applyNwpFallback(enabled, NWP_UNAVAILABLE);
+    expect(effective['soft-cloud-bands']).toBe(true);
+    expect(getSubstitutedLayers(enabled, effective).has('soft-cloud-bands')).toBe(true);
+  });
+
+  it('NWP unavailable + natural NWP enabled → natural DD injected', () => {
+    const enabled = { 'nwp-cloud-bands': true };
+    const effective = applyNwpFallback(enabled, NWP_UNAVAILABLE);
+    // The canonical NWP id is disabled by the unavailable loop...
+    expect(effective['nwp-cloud-bands']).toBe(false);
+    // ...and its DD pair is substituted in.
+    expect(effective['cloud-bands']).toBe(true);
+  });
+
+  it('NWP unavailable + square NWP enabled → square DD injected', () => {
+    const enabled = { 'square-nwp-cloud-bands': true };
+    const effective = applyNwpFallback(enabled, NWP_UNAVAILABLE);
+    expect(effective['square-cloud-bands']).toBe(true);
+  });
+
+  it('explicit DD choice stays and is not flagged as substituted', () => {
+    const enabled = { 'soft-nwp-cloud-bands': true, 'soft-cloud-bands': true };
+    const effective = applyNwpFallback(enabled, NWP_UNAVAILABLE);
+    expect(effective['soft-cloud-bands']).toBe(true);
+    // User already enabled DD — it renders, but isn't an auto-substitute.
+    expect(getSubstitutedLayers(enabled, effective).has('soft-cloud-bands')).toBe(false);
+  });
+
+  it('user genuinely chose DD only (NWP off): no injection, nothing substituted', () => {
+    const enabled = { 'soft-cloud-bands': true, 'soft-nwp-cloud-bands': false };
+    const effective = applyNwpFallback(enabled, NWP_UNAVAILABLE);
+    expect(effective['soft-cloud-bands']).toBe(true);
+    expect(getSubstitutedLayers(enabled, effective).size).toBe(0);
+  });
+
+  it('switching back to an NWP-capable model drops the substitute', () => {
+    const enabled = { 'soft-nwp-cloud-bands': true };
+    // No-NWP model substitutes DD...
+    const downgraded = applyNwpFallback(enabled, NWP_UNAVAILABLE);
+    expect(downgraded['soft-cloud-bands']).toBe(true);
+    // ...NWP-capable model (empty unavailable) restores NWP, no DD substitute.
+    const restored = applyNwpFallback(enabled, new Set());
+    expect(restored['soft-cloud-bands']).toBeUndefined();
+    expect(restored['soft-nwp-cloud-bands']).toBe(true);
+  });
+});
+
+describe('applyNwpFallback — icing', () => {
+  it('Ogimet-NWP unavailable + enabled → Ogimet-DD injected', () => {
+    const enabled = { 'icing-ogimet-nwp-bands': true };
+    const effective = applyNwpFallback(enabled, NWP_UNAVAILABLE);
+    expect(effective['icing-ogimet-nwp-bands']).toBe(false);
+    expect(effective['icing-bands']).toBe(true);
+    expect(getSubstitutedLayers(enabled, effective).has('icing-bands')).toBe(true);
+  });
+
+  it('explicit Ogimet-DD choice stays, not flagged substituted', () => {
+    const enabled = { 'icing-ogimet-nwp-bands': true, 'icing-bands': true };
+    const effective = applyNwpFallback(enabled, NWP_UNAVAILABLE);
+    expect(effective['icing-bands']).toBe(true);
+    expect(getSubstitutedLayers(enabled, effective).has('icing-bands')).toBe(false);
+  });
+
+  it('Ogimet-NWP disabled by user → no DD injection', () => {
+    const enabled = { 'icing-ogimet-nwp-bands': false };
+    const effective = applyNwpFallback(enabled, NWP_UNAVAILABLE);
+    expect(effective['icing-bands']).toBeUndefined();
+  });
+
+  it('IENG has no DD pair: disabled, nothing injected', () => {
+    const enabled = { 'ieng-icing-bands': true };
+    const effective = applyNwpFallback(enabled, NWP_UNAVAILABLE);
+    expect(effective['ieng-icing-bands']).toBe(false);
+    // No IENG-DD layer exists to inject.
+    expect(getSubstitutedLayers(enabled, effective).size).toBe(0);
+  });
+});
+
+describe('applyNwpFallback — invariants', () => {
+  it('never mutates the stored preference', () => {
+    const enabled = { 'soft-nwp-cloud-bands': true, 'icing-ogimet-nwp-bands': true };
+    const snapshot = { ...enabled };
+    applyNwpFallback(enabled, NWP_UNAVAILABLE);
+    expect(enabled).toEqual(snapshot);
+  });
+
+  it('does not touch terrain (force-on lives in the render path, not the helper)', () => {
+    const enabled = { terrain: false };
+    const effective = applyNwpFallback(enabled, NWP_UNAVAILABLE);
+    expect(effective['terrain']).toBe(false);
+  });
+
+  it('disables every unavailable layer', () => {
+    const enabled = { 'nwp-cloud-bands': true, 'icing-ogimet-nwp-bands': true, 'ieng-icing-bands': true };
+    const effective = applyNwpFallback(enabled, NWP_UNAVAILABLE);
+    for (const id of NWP_UNAVAILABLE) expect(effective[id]).toBe(false);
+  });
+});

--- a/web/tests/unit/nwp-fallback.test.ts
+++ b/web/tests/unit/nwp-fallback.test.ts
@@ -9,6 +9,7 @@ import { describe, it, expect } from 'vitest';
 import {
   applyNwpFallback,
   getSubstitutedLayers,
+  getDdSubstituteId,
 } from '../../ts/visualization/cross-section/nwp-fallback';
 
 // What getUnavailableLayers adds when a model has no native NWP cloud data.
@@ -26,10 +27,12 @@ describe('applyNwpFallback — clouds', () => {
     expect(getSubstitutedLayers(enabled, effective).size).toBe(0);
   });
 
-  it('NWP unavailable + soft NWP enabled → soft DD injected, same style', () => {
+  it('NWP unavailable + soft NWP enabled → soft DD injected, NWP variant disabled', () => {
     const enabled = { 'soft-nwp-cloud-bands': true };
     const effective = applyNwpFallback(enabled, NWP_UNAVAILABLE);
     expect(effective['soft-cloud-bands']).toBe(true);
+    // The replaced NWP variant must not stay enabled (renderer + panel state).
+    expect(effective['soft-nwp-cloud-bands']).toBe(false);
     expect(getSubstitutedLayers(enabled, effective).has('soft-cloud-bands')).toBe(true);
   });
 
@@ -42,10 +45,11 @@ describe('applyNwpFallback — clouds', () => {
     expect(effective['cloud-bands']).toBe(true);
   });
 
-  it('NWP unavailable + square NWP enabled → square DD injected', () => {
+  it('NWP unavailable + square NWP enabled → square DD injected, NWP variant disabled', () => {
     const enabled = { 'square-nwp-cloud-bands': true };
     const effective = applyNwpFallback(enabled, NWP_UNAVAILABLE);
     expect(effective['square-cloud-bands']).toBe(true);
+    expect(effective['square-nwp-cloud-bands']).toBe(false);
   });
 
   it('explicit DD choice stays and is not flagged as substituted', () => {
@@ -124,5 +128,24 @@ describe('applyNwpFallback — invariants', () => {
     const enabled = { 'nwp-cloud-bands': true, 'icing-ogimet-nwp-bands': true, 'ieng-icing-bands': true };
     const effective = applyNwpFallback(enabled, NWP_UNAVAILABLE);
     for (const id of NWP_UNAVAILABLE) expect(effective[id]).toBe(false);
+  });
+});
+
+describe('getDdSubstituteId', () => {
+  it('maps each NWP cloud style to its same-style DD layer', () => {
+    expect(getDdSubstituteId('soft-nwp-cloud-bands')).toBe('soft-cloud-bands');
+    expect(getDdSubstituteId('nwp-cloud-bands')).toBe('cloud-bands');
+    expect(getDdSubstituteId('square-nwp-cloud-bands')).toBe('square-cloud-bands');
+  });
+
+  it('maps Ogimet-NWP icing to Ogimet-DD', () => {
+    expect(getDdSubstituteId('icing-ogimet-nwp-bands')).toBe('icing-bands');
+  });
+
+  it('returns null for DD layers, IENG, and non-cloud/icing layers', () => {
+    expect(getDdSubstituteId('soft-cloud-bands')).toBeNull();
+    expect(getDdSubstituteId('ieng-icing-bands')).toBeNull();
+    expect(getDdSubstituteId('cat-bands')).toBeNull();
+    expect(getDdSubstituteId('terrain')).toBeNull();
   });
 });

--- a/web/ts/briefing-main.ts
+++ b/web/ts/briefing-main.ts
@@ -568,13 +568,10 @@ async function init(): Promise<void> {
     const data = extractVizData(state.routeAnalyses, state.selectedModel, state.flight?.flight_ceiling_ft, state.elevationProfile, extractOpts);
     const unavailable = getUnavailableLayers(data);
     const allLayers = getAllLayers();
-    // Render-time enable map: disable layers the model can't provide and
-    // substitute DD clouds/icing for unavailable NWP. The stored preference
-    // (state.vizSettings.enabledLayers) is never mutated.
+    // Render-time map only — never mutates the stored enabledLayers pref.
     const effectiveEnabled = applyNwpFallback(state.vizSettings.enabledLayers, unavailable);
     const substitutedLayers = getSubstitutedLayers(state.vizSettings.enabledLayers, effectiveEnabled);
-    // Terrain always renders — its toggle was removed, so force-on overrides
-    // any stale terrain:false left in localStorage from the old checkbox.
+    // Terrain always renders (toggle removed); force-on overrides stale terrain:false in localStorage.
     effectiveEnabled['terrain'] = true;
     const showCrossSection = layout === 'cross-section' || layout === 'split';
     const showCompare = layout === 'compare';

--- a/web/ts/briefing-main.ts
+++ b/web/ts/briefing-main.ts
@@ -14,6 +14,7 @@ import { initInfoPopup, showMetricInfo, showPopupContent } from './components/in
 import { CrossSectionRenderer } from './visualization/cross-section/renderer';
 import { extractVizData, getUnavailableLayers } from './visualization/data-extract';
 import { getAllLayers, getCompactLayerOverrides } from './visualization/cross-section/layer-registry';
+import { applyNwpFallback, getSubstitutedLayers } from './visualization/cross-section/nwp-fallback';
 import { renderVizControls, renderRouteGraphControls, renderMapControls, renderCompareControls } from './visualization/controls/panel';
 import { attachInteraction, type InteractionHandle } from './visualization/cross-section/interaction';
 import { CompareSectionRenderer, type CompareModelData } from './visualization/cross-section/compare-renderer';
@@ -567,6 +568,14 @@ async function init(): Promise<void> {
     const data = extractVizData(state.routeAnalyses, state.selectedModel, state.flight?.flight_ceiling_ft, state.elevationProfile, extractOpts);
     const unavailable = getUnavailableLayers(data);
     const allLayers = getAllLayers();
+    // Render-time enable map: disable layers the model can't provide and
+    // substitute DD clouds/icing for unavailable NWP. The stored preference
+    // (state.vizSettings.enabledLayers) is never mutated.
+    const effectiveEnabled = applyNwpFallback(state.vizSettings.enabledLayers, unavailable);
+    const substitutedLayers = getSubstitutedLayers(state.vizSettings.enabledLayers, effectiveEnabled);
+    // Terrain always renders — its toggle was removed, so force-on overrides
+    // any stale terrain:false left in localStorage from the old checkbox.
+    effectiveEnabled['terrain'] = true;
     const showCrossSection = layout === 'cross-section' || layout === 'split';
     const showCompare = layout === 'compare';
     const showMap = layout === 'map' || layout === 'split';
@@ -649,10 +658,6 @@ async function init(): Promise<void> {
       }
 
       vizRenderer.setData(data);
-      // Merge unavailable layers as disabled so they don't render,
-      // without modifying the stored user preference.
-      const effectiveEnabled = { ...state.vizSettings.enabledLayers };
-      for (const id of unavailable) effectiveEnabled[id] = false;
       vizRenderer.setLayers(allLayers, effectiveEnabled);
       vizRenderer.setSelectedPointIndex(state.selectedPointIndex ?? -1);
       vizRenderer.render();
@@ -847,7 +852,7 @@ async function init(): Promise<void> {
         onThemeChange: (themeId) => store.getState().setVizTheme(themeId),
         onPresetChange: (presetId) => store.getState().setVizPreset(presetId),
         onCloudStyleChange: (style) => store.getState().setCloudStyle(style),
-      }, state.selectedModel, availableModels.length > 0 ? availableModels : undefined, state.displayMode, preferredMethods, unavailable);
+      }, state.selectedModel, availableModels.length > 0 ? availableModels : undefined, state.displayMode, preferredMethods, unavailable, substitutedLayers);
 
       // Render route graph controls (below graph)
       if (routeGraphControlsContainer && showCrossSection) {

--- a/web/ts/i18n/locales/de.json
+++ b/web/ts/i18n/locales/de.json
@@ -265,6 +265,7 @@
   "viz.windy": "Windy",
   "viz.moreInfo": "Weitere Informationen",
   "viz.notAvailableModel": "Für dieses Modell nicht verfügbar",
+  "viz.substitutedNwp": "DD wird angezeigt — NWP für dieses Modell nicht verfügbar",
   "viz.previewTheme": "Thema-Vorschau",
   "viz.routeGraph": "Routengrafik",
   "viz.left": "Links:",

--- a/web/ts/i18n/locales/en.json
+++ b/web/ts/i18n/locales/en.json
@@ -327,6 +327,7 @@
   "viz.windy": "Windy",
   "viz.moreInfo": "More info",
   "viz.notAvailableModel": "Not available for this model",
+  "viz.substitutedNwp": "Showing DD — NWP not available for this model",
   "viz.previewTheme": "Preview theme",
   "viz.bandMode": "Mode:",
   "viz.bandMode.overlay": "Overlay",

--- a/web/ts/i18n/locales/es.json
+++ b/web/ts/i18n/locales/es.json
@@ -265,6 +265,7 @@
   "viz.windy": "Windy",
   "viz.moreInfo": "Más información",
   "viz.notAvailableModel": "No disponible para este modelo",
+  "viz.substitutedNwp": "Mostrando DD — NWP no disponible para este modelo",
   "viz.previewTheme": "Vista previa del tema",
   "viz.routeGraph": "Gráfico de ruta",
   "viz.left": "Izquierda:",

--- a/web/ts/i18n/locales/fr.json
+++ b/web/ts/i18n/locales/fr.json
@@ -265,6 +265,7 @@
   "viz.windy": "Windy",
   "viz.moreInfo": "Plus d'informations",
   "viz.notAvailableModel": "Non disponible pour ce modèle",
+  "viz.substitutedNwp": "Affichage DD — NWP non disponible pour ce modèle",
   "viz.previewTheme": "Aperçu du thème",
   "viz.routeGraph": "Graphique de route",
   "viz.left": "Gauche :",

--- a/web/ts/visualization/controls/panel.ts
+++ b/web/ts/visualization/controls/panel.ts
@@ -34,6 +34,10 @@ export interface LayerTogglesOptions {
   displayMode?: DisplayMode;
   preferredMethods?: Record<string, string>;
   unavailableLayers?: Set<string>;
+  /** Layers auto-substituted at render time (DD standing in for unavailable
+   *  NWP). Rendered as checked + dimmed with an explanatory tooltip so the
+   *  panel state matches what's actually drawn. */
+  substitutedLayers?: Set<string>;
   /** Persisted cloud-style preference; the compound control falls back to
    *  this when no cloud layers are enabled, so the dropdown remembers the
    *  user's last choice across re-renders and page reloads. */
@@ -74,6 +78,7 @@ function cloudCompoundHtml(
   enabledLayers: Record<string, boolean>,
   unavailable: Set<string> | undefined,
   persistedStyle: 'natural' | 'soft' | 'square' | undefined,
+  substituted: Set<string> | undefined,
 ): string {
   const { ddEnabled, nwpEnabled, style } = cloudState(enabledLayers, persistedStyle);
   // A source is "unavailable" iff its natural-style id (the canonical
@@ -81,17 +86,23 @@ function cloudCompoundHtml(
   // generally always available; NWP requires native cloud-cover data.
   const ddUnavail = unavailable?.has('cloud-bands') ?? false;
   const nwpUnavail = unavailable?.has('nwp-cloud-bands') ?? false;
+  // DD is auto-on (standing in for NWP) when the current-style DD layer was
+  // injected by the render-time fallback rather than picked by the user.
+  const ddSubstituted = substituted?.has(CLOUD_LAYER_BY_AXES.dd[style]) ?? false;
 
   const sourceCheckbox = (
     source: 'dd' | 'nwp',
     label: string,
     checked: boolean,
     unavail: boolean,
+    auto: boolean,
   ): string => {
-    const dimClass = unavail ? ' viz-layer-unavailable' : '';
-    const tooltip = unavail ? ` title="${t('viz.notAvailableModel')}"` : '';
+    const dimClass = unavail ? ' viz-layer-unavailable' : (auto ? ' viz-layer-substituted' : '');
+    const tooltip = unavail
+      ? ` title="${t('viz.notAvailableModel')}"`
+      : (auto ? ` title="${t('viz.substitutedNwp')}"` : '');
     const disabled = unavail ? 'disabled' : '';
-    const checkedAttr = checked && !unavail ? 'checked' : '';
+    const checkedAttr = (checked || auto) && !unavail ? 'checked' : '';
     return `<label class="viz-layer-checkbox${dimClass}"${tooltip}>`
       + `<input type="checkbox" data-cloud-source="${source}" ${checkedAttr} ${disabled}>`
       + `<span>${label}</span>`
@@ -99,8 +110,8 @@ function cloudCompoundHtml(
   };
 
   let html = '';
-  html += sourceCheckbox('nwp', 'NWP', nwpEnabled, nwpUnavail);
-  html += sourceCheckbox('dd', 'DD', ddEnabled, ddUnavail);
+  html += sourceCheckbox('nwp', 'NWP', nwpEnabled, nwpUnavail, false);
+  html += sourceCheckbox('dd', 'DD', ddEnabled, ddUnavail, ddSubstituted);
   html += `<select class="viz-model-select" data-cloud-style>`;
   html += `<option value="soft"${style === 'soft' ? ' selected' : ''}>${t('viz.cloudStyle.soft')}</option>`;
   html += `<option value="natural"${style === 'natural' ? ' selected' : ''}>${t('viz.cloudStyle.natural')}</option>`;
@@ -116,7 +127,7 @@ function layerTogglesHtml(
   enabledLayers: Record<string, boolean>,
   opts: LayerTogglesOptions = {},
 ): string {
-  const { displayMode, preferredMethods, unavailableLayers, cloudStyle } = opts;
+  const { displayMode, preferredMethods, unavailableLayers, cloudStyle, substitutedLayers } = opts;
   const groups = getLayerGroups();
   let html = '<div class="viz-layer-toggles">';
   for (const group of groups) {
@@ -132,16 +143,21 @@ function layerTogglesHtml(
     }
     // Clouds group in non-compact mode: compound source-toggles + style dropdown.
     if (group.group === 'clouds' && !isCompactCollapse) {
-      html += cloudCompoundHtml(enabledLayers, unavailableLayers, cloudStyle);
+      html += cloudCompoundHtml(enabledLayers, unavailableLayers, cloudStyle, substitutedLayers);
       html += '</div>';
       continue;
     }
     for (const layer of layersToRender) {
       const isUnavailable = unavailableLayers?.has(layer.id) ?? false;
-      const checked = !isUnavailable && enabledLayers[layer.id] !== false ? 'checked' : '';
+      const isSubstituted = !isUnavailable && (substitutedLayers?.has(layer.id) ?? false);
+      const checked = isSubstituted || (!isUnavailable && enabledLayers[layer.id] !== false) ? 'checked' : '';
       const disabled = isUnavailable ? 'disabled' : '';
-      const dimClass = isUnavailable ? ' viz-layer-unavailable' : '';
-      const tooltip = isUnavailable ? ` title="${t('viz.notAvailableModel')}"` : '';
+      const dimClass = isUnavailable
+        ? ' viz-layer-unavailable'
+        : (isSubstituted ? ' viz-layer-substituted' : '');
+      const tooltip = isUnavailable
+        ? ` title="${t('viz.notAvailableModel')}"`
+        : (isSubstituted ? ` title="${t('viz.substitutedNwp')}"` : '');
       html += `<label class="viz-layer-checkbox${dimClass}"${tooltip}>`;
       html += `<input type="checkbox" data-layer-id="${layer.id}" ${checked} ${disabled}>`;
       html += `<span>${isCompactCollapse ? group.label : t('viz.layer.' + layer.id)}</span>`;
@@ -286,6 +302,7 @@ export function renderVizControls(
   displayMode?: DisplayMode,
   preferredMethods?: Record<string, string>,
   unavailableLayers?: Set<string>,
+  substitutedLayers?: Set<string>,
 ): void {
   let html = '<div class="viz-toolbar">';
 
@@ -357,7 +374,7 @@ export function renderVizControls(
   // the airport-profile drawer); change listeners are wired below.
   if (settings.layout !== 'map') {
     html += layerTogglesHtml(settings.enabledLayers, {
-      displayMode, preferredMethods, unavailableLayers,
+      displayMode, preferredMethods, unavailableLayers, substitutedLayers,
       cloudStyle: settings.cloudStyle,
     });
   }

--- a/web/ts/visualization/controls/panel.ts
+++ b/web/ts/visualization/controls/panel.ts
@@ -8,6 +8,7 @@ import {
   ALL_CLOUD_LAYER_IDS,
   parseCloudLayerId,
 } from '../cross-section/layers/cloud-bands-factory';
+import { getDdSubstituteId } from '../cross-section/nwp-fallback';
 import { getComparableLayerGroups, getComparableLayer } from '../cross-section/compare-layers';
 import { showLayerInfo, showPopupContent } from '../../components/info-popup';
 import { modelLabel } from '../../utils';
@@ -149,13 +150,19 @@ function layerTogglesHtml(
     }
     for (const layer of layersToRender) {
       const isUnavailable = unavailableLayers?.has(layer.id) ?? false;
-      const isSubstituted = !isUnavailable && (substitutedLayers?.has(layer.id) ?? false);
-      const checked = isSubstituted || (!isUnavailable && enabledLayers[layer.id] !== false) ? 'checked' : '';
-      const disabled = isUnavailable ? 'disabled' : '';
-      const dimClass = isUnavailable
+      // In compact mode the group collapses to its preferred layer; if that's
+      // an NWP layer being served by a DD substitute, show the substitute state
+      // (checked+dimmed) instead of "unavailable" / a plain checkbox.
+      const compactSubId = isCompactCollapse ? getDdSubstituteId(layer.id) : null;
+      const isSubstituted = (compactSubId != null && (substitutedLayers?.has(compactSubId) ?? false))
+        || (!isUnavailable && (substitutedLayers?.has(layer.id) ?? false));
+      const showUnavailable = isUnavailable && !isSubstituted;
+      const checked = isSubstituted || (!showUnavailable && enabledLayers[layer.id] !== false) ? 'checked' : '';
+      const disabled = showUnavailable ? 'disabled' : '';
+      const dimClass = showUnavailable
         ? ' viz-layer-unavailable'
         : (isSubstituted ? ' viz-layer-substituted' : '');
-      const tooltip = isUnavailable
+      const tooltip = showUnavailable
         ? ` title="${t('viz.notAvailableModel')}"`
         : (isSubstituted ? ` title="${t('viz.substitutedNwp')}"` : '');
       html += `<label class="viz-layer-checkbox${dimClass}"${tooltip}>`;

--- a/web/ts/visualization/cross-section/layer-registry.ts
+++ b/web/ts/visualization/cross-section/layer-registry.ts
@@ -221,7 +221,10 @@ export function getLayerGroups(): LayerGroupInfo[] {
     reference: t('viz.group.reference'),
   };
 
-  const order: LayerGroup[] = ['terrain', 'reference', 'temperature', 'clouds', 'obscuration', 'icing', 'stability', 'turbulence', 'convection'];
+  // 'terrain' is intentionally omitted: terrain always renders (force-on at
+  // render time), so it has no UI toggle. The terrainFillLayer stays in
+  // ALL_LAYERS — only its panel group is dropped here.
+  const order: LayerGroup[] = ['reference', 'temperature', 'clouds', 'obscuration', 'icing', 'stability', 'turbulence', 'convection'];
 
   return order
     .filter((g) => groupMap.has(g))

--- a/web/ts/visualization/cross-section/nwp-fallback.ts
+++ b/web/ts/visualization/cross-section/nwp-fallback.ts
@@ -1,0 +1,82 @@
+/** Render-time layer substitution for models without native NWP data.
+ *
+ *  When the selected model lacks native NWP cloud data (e.g. ECMWF without
+ *  GRIB enrichment), the NWP cloud layers and the Ogimet-NWP icing layer have
+ *  no zones to draw and silently render nothing. Rather than letting the
+ *  clouds/icing vanish, we transparently substitute the same-style DD layer.
+ *
+ *  This works purely on a throwaway `effectiveEnabled` object built per render.
+ *  The user's stored `enabledLayers` preference is never mutated, so switching
+ *  back to an NWP-capable model auto-restores NWP and drops the DD substitute —
+ *  no persisted "downgraded" flag to track or distinguish from a genuine DD
+ *  choice (an explicit DD pick lives in `enabledLayers`; the substitute only
+ *  *adds* DD on top when NWP is unavailable).
+ */
+
+import {
+  ALL_CLOUD_LAYER_IDS,
+  CLOUD_LAYER_BY_AXES,
+  parseCloudLayerId,
+} from './layers/cloud-bands-factory';
+
+/** Source-level "NWP clouds unavailable" signal. `getUnavailableLayers` adds
+ *  only this canonical (natural-style) id, but it covers every NWP cloud
+ *  variant — soft/natural/square all read the same native NWP cloud feed. */
+const NWP_CLOUDS_SIGNAL = 'nwp-cloud-bands';
+
+/** Ogimet-NWP icing → Ogimet-DD icing fallback pair (per PREFERRED_METHOD_LAYER.icing). */
+const OGIMET_NWP = 'icing-ogimet-nwp-bands';
+const OGIMET_DD = 'icing-bands';
+
+/**
+ * Build the throwaway `effectiveEnabled` map for a single cross-section render:
+ *  1. start from the user's stored preference,
+ *  2. disable every layer the current model can't provide,
+ *  3. substitute same-style DD layers for any wanted-but-unavailable NWP layer.
+ *
+ * Returns a new object; never mutates the inputs.
+ */
+export function applyNwpFallback(
+  enabledLayers: Record<string, boolean>,
+  unavailable: Set<string>,
+): Record<string, boolean> {
+  const effective: Record<string, boolean> = { ...enabledLayers };
+
+  // Disable what the model can't provide (without touching the stored pref).
+  for (const id of unavailable) effective[id] = false;
+
+  // Clouds: when the NWP source has no native data, substitute the same-style
+  // DD layer for each NWP cloud style the user has enabled.
+  if (unavailable.has(NWP_CLOUDS_SIGNAL)) {
+    for (const id of ALL_CLOUD_LAYER_IDS) {
+      if (enabledLayers[id] !== true) continue;
+      const axes = parseCloudLayerId(id);
+      if (!axes || axes.source !== 'nwp') continue;
+      const ddId = CLOUD_LAYER_BY_AXES.dd[axes.style];
+      if (enabledLayers[ddId] !== true) effective[ddId] = true;
+    }
+  }
+
+  // Icing: Ogimet-NWP → Ogimet-DD (same mechanism). IENG has no DD pair, so it
+  // stays disabled by the unavailable loop above.
+  if (unavailable.has(OGIMET_NWP) && enabledLayers[OGIMET_NWP] === true
+      && enabledLayers[OGIMET_DD] !== true) {
+    effective[OGIMET_DD] = true;
+  }
+
+  return effective;
+}
+
+/** Layer ids the fallback turned on but the user did not — i.e. the auto
+ *  substitutes. The panel renders these as checked + dimmed with a tooltip so
+ *  it's clear DD is standing in for unavailable NWP. */
+export function getSubstitutedLayers(
+  enabledLayers: Record<string, boolean>,
+  effectiveEnabled: Record<string, boolean>,
+): Set<string> {
+  const substituted = new Set<string>();
+  for (const [id, on] of Object.entries(effectiveEnabled)) {
+    if (on && enabledLayers[id] !== true) substituted.add(id);
+  }
+  return substituted;
+}

--- a/web/ts/visualization/cross-section/nwp-fallback.ts
+++ b/web/ts/visualization/cross-section/nwp-fallback.ts
@@ -1,16 +1,8 @@
-/** Render-time layer substitution for models without native NWP data.
+/** Render-time NWP→DD substitution for models without native NWP data.
  *
- *  When the selected model lacks native NWP cloud data (e.g. ECMWF without
- *  GRIB enrichment), the NWP cloud layers and the Ogimet-NWP icing layer have
- *  no zones to draw and silently render nothing. Rather than letting the
- *  clouds/icing vanish, we transparently substitute the same-style DD layer.
- *
- *  This works purely on a throwaway `effectiveEnabled` object built per render.
- *  The user's stored `enabledLayers` preference is never mutated, so switching
- *  back to an NWP-capable model auto-restores NWP and drops the DD substitute —
- *  no persisted "downgraded" flag to track or distinguish from a genuine DD
- *  choice (an explicit DD pick lives in `enabledLayers`; the substitute only
- *  *adds* DD on top when NWP is unavailable).
+ *  Works purely on a throwaway `effectiveEnabled` map — the stored
+ *  `enabledLayers` preference is never mutated, so switching back to an
+ *  NWP-capable model auto-restores NWP with no persisted "downgraded" flag.
  */
 
 import {
@@ -19,46 +11,43 @@ import {
   parseCloudLayerId,
 } from './layers/cloud-bands-factory';
 
-/** Source-level "NWP clouds unavailable" signal. `getUnavailableLayers` adds
- *  only this canonical (natural-style) id, but it covers every NWP cloud
- *  variant — soft/natural/square all read the same native NWP cloud feed. */
+// Canonical "NWP clouds unavailable" signal — getUnavailableLayers emits only
+// this natural-style id, but it covers every NWP cloud variant (all read the
+// same native feed).
 const NWP_CLOUDS_SIGNAL = 'nwp-cloud-bands';
-
-/** Ogimet-NWP icing → Ogimet-DD icing fallback pair (per PREFERRED_METHOD_LAYER.icing). */
 const OGIMET_NWP = 'icing-ogimet-nwp-bands';
 const OGIMET_DD = 'icing-bands';
 
-/**
- * Build the throwaway `effectiveEnabled` map for a single cross-section render:
- *  1. start from the user's stored preference,
- *  2. disable every layer the current model can't provide,
- *  3. substitute same-style DD layers for any wanted-but-unavailable NWP layer.
- *
- * Returns a new object; never mutates the inputs.
- */
+/** Same-style DD layer that substitutes for an unavailable NWP layer, or null
+ *  if `id` has no NWP→DD pair (DD layers, IENG, non-cloud/icing layers). */
+export function getDdSubstituteId(id: string): string | null {
+  if (id === OGIMET_NWP) return OGIMET_DD;
+  const axes = parseCloudLayerId(id);
+  if (axes && axes.source === 'nwp') return CLOUD_LAYER_BY_AXES.dd[axes.style];
+  return null;
+}
+
+/** Build the throwaway effective-enable map for one render: start from the
+ *  stored pref, disable what the model can't provide, then substitute same-
+ *  style DD layers for any wanted-but-unavailable NWP layer. Never mutates. */
 export function applyNwpFallback(
   enabledLayers: Record<string, boolean>,
   unavailable: Set<string>,
 ): Record<string, boolean> {
   const effective: Record<string, boolean> = { ...enabledLayers };
-
-  // Disable what the model can't provide (without touching the stored pref).
   for (const id of unavailable) effective[id] = false;
 
-  // Clouds: when the NWP source has no native data, substitute the same-style
-  // DD layer for each NWP cloud style the user has enabled.
   if (unavailable.has(NWP_CLOUDS_SIGNAL)) {
     for (const id of ALL_CLOUD_LAYER_IDS) {
       if (enabledLayers[id] !== true) continue;
-      const axes = parseCloudLayerId(id);
-      if (!axes || axes.source !== 'nwp') continue;
-      const ddId = CLOUD_LAYER_BY_AXES.dd[axes.style];
+      const ddId = getDdSubstituteId(id);
+      if (!ddId) continue;
+      effective[id] = false;  // the replaced NWP variant must not stay enabled
       if (enabledLayers[ddId] !== true) effective[ddId] = true;
     }
   }
 
-  // Icing: Ogimet-NWP → Ogimet-DD (same mechanism). IENG has no DD pair, so it
-  // stays disabled by the unavailable loop above.
+  // IENG has no DD pair, so it stays disabled by the loop above.
   if (unavailable.has(OGIMET_NWP) && enabledLayers[OGIMET_NWP] === true
       && enabledLayers[OGIMET_DD] !== true) {
     effective[OGIMET_DD] = true;
@@ -67,9 +56,7 @@ export function applyNwpFallback(
   return effective;
 }
 
-/** Layer ids the fallback turned on but the user did not — i.e. the auto
- *  substitutes. The panel renders these as checked + dimmed with a tooltip so
- *  it's clear DD is standing in for unavailable NWP. */
+/** Layer ids the fallback turned on but the user did not — the auto substitutes. */
 export function getSubstitutedLayers(
   enabledLayers: Record<string, boolean>,
   effectiveEnabled: Record<string, boolean>,


### PR DESCRIPTION
Removes the terrain layer toggle (terrain now always renders, force-on at
render time so stale terrain:false in localStorage is overridden) and adds a
render-time substitution: when a model lacks native NWP data, the same-style
DD cloud layer (and Ogimet-DD icing) stands in for the unavailable NWP layer
so clouds/icing don't vanish. The stored preference is never mutated, so
switching back to an NWP-capable model auto-restores NWP with no downgraded
flag to track. Substituted layers render as checked+dimmed in the panel.

https://claude.ai/code/session_01Cc4zDeoXgVZRrjhc5zBw5Z