### PR TITLE
feat(advisories): convective DD-vs-model cross-check (popup + digest)

### DIFF
--- a/configs/weather_digest/prompts/briefer_v1.md
+++ b/configs/weather_digest/prompts/briefer_v1.md
@@ -72,6 +72,11 @@ Structure your response as JSON with these exact fields:
   component). Do NOT re-analyze wind for other runways or worry about tailwind
   on the reported runway — it is always the into-wind direction. Only discuss
   crosswind and gust values as presented.
+- Prefer the configured analysis method for the assessment. When the alternate
+  method (e.g. the model's convective scheme vs the sounding-derived CAPE risk)
+  diverges materially, mention it as a confidence/uncertainty caveat in the
+  relevant section — do NOT flip the GREEN/AMBER/RED assessment on the alternate
+  method alone.
 - All wind speeds should be in knots, altitudes in feet, temperatures in
   Celsius.
 - The DATE header includes the day-of-week — use it for the flight date.

--- a/src/weatherbrief/analysis/advisories/convective.py
+++ b/src/weatherbrief/analysis/advisories/convective.py
@@ -6,6 +6,7 @@ from weatherbrief.analysis.advisories import RouteContext
 from weatherbrief.analysis.advisories._helpers import format_extent, pct_above_threshold
 from weatherbrief.analysis.advisories.registry import register
 from weatherbrief.analysis.advisories.strings import adv_t
+from weatherbrief.analysis.sounding.convective import convective_cross_check
 from weatherbrief.models import (
     AdvisoryCatalogEntry,
     AdvisoryParameterDef,
@@ -124,12 +125,28 @@ class ConvectiveEvaluator:
             worst_risk = ConvectiveRisk.NONE
             below_cruise_count = 0  # risky points skipped because tops below cruise
             max_cover_pct: float | None = None
+            # Details-only DD-vs-model-scheme cross-check tally (never grades).
+            xcheck_fired = 0
+            xcheck_dirs: dict[str, int] = {}
+            xcheck_worst_dd_risk = ConvectiveRisk.NONE
 
             for rpa in ctx.analyses:
                 sounding = rpa.sounding.get(model)
                 if sounding is None:
                     continue
                 total += 1
+
+                # Independent of the grade filters below: compare the chosen
+                # thermo risk against the model's own convective scheme.
+                xc = convective_cross_check(sounding.convective, sounding.convective_nwp)
+                if xc is not None:
+                    xcheck_fired += 1
+                    xcheck_dirs[xc.direction] = xcheck_dirs.get(xc.direction, 0) + 1
+                    if xc.direction == "dd_not_corroborated" and sounding.convective is not None:
+                        if _RISK_ORDER.index(sounding.convective.risk_level) > _RISK_ORDER.index(
+                            xcheck_worst_dd_risk
+                        ):
+                            xcheck_worst_dd_risk = sounding.convective.risk_level
 
                 conv = sounding.convective
                 if conv is None:
@@ -179,10 +196,26 @@ class ConvectiveEvaluator:
                     status = AdvisoryStatus.AMBER
                 detail = adv_t("convective.risk_over", loc, risk=worst_risk.value.upper(), extent=ext) + cover_suffix
 
+            cross_check: str | None = None
+            if xcheck_fired > 0:
+                dominant = max(xcheck_dirs, key=lambda d: xcheck_dirs[d])
+                xc_ext = format_extent(xcheck_fired, total, ctx.total_distance_nm)
+                if dominant == "dd_not_corroborated":
+                    cross_check = (
+                        f"DD {xcheck_worst_dd_risk.value.upper()} not corroborated — "
+                        f"model convective scheme quiet over {xc_ext}"
+                    )
+                else:  # model_active_dd_quiet
+                    cross_check = (
+                        f"model convective scheme active where DD shows little/none "
+                        f"over {xc_ext}"
+                    )
+
             per_model.append(ModelAdvisoryResult.build(
                 model=model, status=status, detail=detail,
                 affected=affected, total=total,
                 total_distance_nm=ctx.total_distance_nm,
+                cross_check=cross_check,
             ))
 
         return RouteAdvisoryResult.from_per_model("convective", per_model, params)

--- a/src/weatherbrief/analysis/advisories/convective.py
+++ b/src/weatherbrief/analysis/advisories/convective.py
@@ -137,16 +137,20 @@ class ConvectiveEvaluator:
                 total += 1
 
                 # Independent of the grade filters below: compare the chosen
-                # thermo risk against the model's own convective scheme.
-                xc = convective_cross_check(sounding.convective, sounding.convective_nwp)
+                # thermo (CAPE-derived) risk against the model's own convective
+                # scheme. Use convective_thermo explicitly (matches the digest
+                # and dd_nwp_agreement) so this stays a DD-vs-NWP comparison even
+                # if convective ever becomes the chosen (possibly NWP) method.
+                thermo_conv = sounding.convective_thermo or sounding.convective
+                xc = convective_cross_check(thermo_conv, sounding.convective_nwp)
                 if xc is not None:
                     xcheck_fired += 1
                     xcheck_dirs[xc.direction] = xcheck_dirs.get(xc.direction, 0) + 1
-                    if xc.direction == "dd_not_corroborated" and sounding.convective is not None:
-                        if _RISK_ORDER.index(sounding.convective.risk_level) > _RISK_ORDER.index(
+                    if xc.direction == "dd_not_corroborated" and thermo_conv is not None:
+                        if _RISK_ORDER.index(thermo_conv.risk_level) > _RISK_ORDER.index(
                             xcheck_worst_dd_risk
                         ):
-                            xcheck_worst_dd_risk = sounding.convective.risk_level
+                            xcheck_worst_dd_risk = thermo_conv.risk_level
 
                 conv = sounding.convective
                 if conv is None:
@@ -199,7 +203,10 @@ class ConvectiveEvaluator:
             cross_check: str | None = None
             if xcheck_fired > 0:
                 dominant = max(xcheck_dirs, key=lambda d: xcheck_dirs[d])
-                xc_ext = format_extent(xcheck_fired, total, ctx.total_distance_nm)
+                # Extent reflects only the dominant direction's points, not the
+                # combined fire count — otherwise a mix of both directions would
+                # overstate the extent of the direction we're describing.
+                xc_ext = format_extent(xcheck_dirs[dominant], total, ctx.total_distance_nm)
                 if dominant == "dd_not_corroborated":
                     cross_check = (
                         f"DD {xcheck_worst_dd_risk.value.upper()} not corroborated — "

--- a/src/weatherbrief/analysis/sounding/convective.py
+++ b/src/weatherbrief/analysis/sounding/convective.py
@@ -6,7 +6,7 @@ and returns ConvectiveAssessment.
 
 from __future__ import annotations
 
-from typing import NamedTuple
+from typing import Literal, NamedTuple
 
 from weatherbrief.models import (
     ConvectiveAssessment,
@@ -548,7 +548,7 @@ class ConvectiveCrossCheck(NamedTuple):
     otherwise the caller gets ``None``.
     """
 
-    direction: str  # "dd_not_corroborated" | "model_active_dd_quiet"
+    direction: Literal["dd_not_corroborated", "model_active_dd_quiet"]
     note: str
 
 
@@ -586,6 +586,10 @@ def convective_cross_check(
         and not model_has_geom
     )
 
+    # LOW is intentionally in neither band: it is too weak to call a quiet model
+    # a "missed" high risk (dd_not_corroborated), yet not weak enough for an
+    # active model to be a surprise (model_active_dd_quiet). Only material
+    # divergences fire — LOW thermo never triggers a cross-check.
     thermo_high = _RISK_LEVELS.index(thermo.risk_level) >= _RISK_LEVELS.index(
         ConvectiveRisk.MODERATE
     )

--- a/src/weatherbrief/analysis/sounding/convective.py
+++ b/src/weatherbrief/analysis/sounding/convective.py
@@ -6,6 +6,8 @@ and returns ConvectiveAssessment.
 
 from __future__ import annotations
 
+from typing import NamedTuple
+
 from weatherbrief.models import (
     ConvectiveAssessment,
     ConvectiveRegime,
@@ -528,3 +530,83 @@ def assess_convective_nwp(
         cover_pct=cover,
         method=method,
     )
+
+
+# Convective DD-vs-model cross-check thresholds (tunable module constants).
+# These gate the "does the model's own convective scheme corroborate the
+# CAPE-derived risk" signal surfaced in the advisory popup and LLM digest.
+# They never affect the grade.
+_XCHECK_MODEL_QUIET_COVER_PCT = 10.0   # cover <= this (and no convective geom) => model "quiet"
+_XCHECK_MODEL_ACTIVE_COVER_PCT = 25.0  # cover >= this => model "active"
+
+
+class ConvectiveCrossCheck(NamedTuple):
+    """Material divergence between the thermo (CAPE) risk and the model scheme.
+
+    ``direction`` names the kind of disagreement; ``note`` is a human-readable
+    explanation. Only returned when the two derivations disagree materially —
+    otherwise the caller gets ``None``.
+    """
+
+    direction: str  # "dd_not_corroborated" | "model_active_dd_quiet"
+    note: str
+
+
+def convective_cross_check(
+    thermo: ConvectiveAssessment | None,
+    nwp: ConvectiveAssessment | None,
+) -> ConvectiveCrossCheck | None:
+    """Cross-check the chosen thermo risk against the model's convective scheme.
+
+    The genuinely independent signal is the model's convective-cover diagnostic
+    (``cover_pct``) or, for models that only emit convective geometry (ICON-EU
+    hybrid, ECMWF hcct), the presence of a convective base/top. The model's own
+    ``risk_level`` is deliberately NOT used: it is derived from the same CAPE
+    thresholds as thermo, so comparing the two would be near-circular.
+
+    Returns ``None`` (silent) unless one of two material divergences fires:
+    - ``dd_not_corroborated`` — thermo MODERATE+ but the model scheme is quiet
+      (low cover, no convective geometry).
+    - ``model_active_dd_quiet`` — thermo NONE/MARGINAL but the model scheme is
+      active (meaningful cover, or convective geometry present).
+
+    A model that reports convective base/top but no ``cover_pct`` (ECMWF/ICON)
+    counts as model-active.
+    """
+    if nwp is None or thermo is None:
+        return None
+
+    model_has_geom = nwp.base_ft is not None and nwp.top_ft is not None
+    model_active = (
+        nwp.cover_pct is not None and nwp.cover_pct >= _XCHECK_MODEL_ACTIVE_COVER_PCT
+    ) or (nwp.cover_pct is None and model_has_geom)
+    model_quiet = (
+        nwp.cover_pct is not None
+        and nwp.cover_pct <= _XCHECK_MODEL_QUIET_COVER_PCT
+        and not model_has_geom
+    )
+
+    thermo_high = _RISK_LEVELS.index(thermo.risk_level) >= _RISK_LEVELS.index(
+        ConvectiveRisk.MODERATE
+    )
+    thermo_low = thermo.risk_level in (ConvectiveRisk.NONE, ConvectiveRisk.MARGINAL)
+
+    if thermo_high and model_quiet:
+        cape_txt = f" (CAPE {thermo.cape_jkg:.0f})" if thermo.cape_jkg is not None else ""
+        note = (
+            f"DD {thermo.risk_level.value.upper()}{cape_txt} but model convective "
+            f"cover {nwp.cover_pct:.0f}% — not corroborated by model scheme"
+        )
+        return ConvectiveCrossCheck(direction="dd_not_corroborated", note=note)
+
+    if thermo_low and model_active:
+        bits: list[str] = []
+        if nwp.cover_pct is not None:
+            bits.append(f"{nwp.cover_pct:.0f}% cover")
+        if nwp.top_ft is not None:
+            bits.append(f"tops {nwp.top_ft:.0f}ft")
+        desc = " / ".join(bits) if bits else "model scheme"
+        note = f"model convective scheme active ({desc}) despite weak DD instability"
+        return ConvectiveCrossCheck(direction="model_active_dd_quiet", note=note)
+
+    return None

--- a/src/weatherbrief/digest/prompt_builder.py
+++ b/src/weatherbrief/digest/prompt_builder.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import TYPE_CHECKING
 
+from weatherbrief.analysis.sounding.convective import convective_cross_check
 from weatherbrief.digest.format_utils import format_flight_level
 from weatherbrief.units import format_visibility
 from weatherbrief.models import (
@@ -314,6 +315,29 @@ def _format_sounding_context(soundings: dict[str, SoundingAnalysis]) -> list[str
                 lines.append(f"    - {sup}")
             for mod in conv.severe_modifiers:
                 lines.append(f"    ! {mod}")
+
+        # Model convective-scheme diagnostic — the independent vote on whether
+        # convection fires (cover/geometry), distinct from the CAPE-derived risk.
+        nwp_conv = sa.convective_nwp
+        if nwp_conv is not None:
+            mparts: list[str] = []
+            if nwp_conv.cover_pct is not None:
+                mparts.append(f"cover={nwp_conv.cover_pct:.0f}%")
+            if nwp_conv.base_ft is not None and nwp_conv.top_ft is not None:
+                mparts.append(f"base={nwp_conv.base_ft:.0f}ft, top={nwp_conv.top_ft:.0f}ft")
+            elif nwp_conv.top_ft is not None:
+                mparts.append(f"top={nwp_conv.top_ft:.0f}ft")
+            if mparts:
+                lines.append(
+                    f"  Convective model scheme [{model}] ({nwp_conv.method}): "
+                    f"{', '.join(mparts)}"
+                )
+
+        # DD-vs-model cross-check — emitted even when the thermo risk is NONE so
+        # the "model active where DD shows none" direction reaches the LLM.
+        xc = convective_cross_check(sa.convective_thermo or sa.convective, sa.convective_nwp)
+        if xc is not None:
+            lines.append(f"    → cross-check: {xc.note}")
 
         for zone in sa.icing_zones:
             sld = " SLD!" if zone.sld_risk else ""

--- a/src/weatherbrief/models/advisories.py
+++ b/src/weatherbrief/models/advisories.py
@@ -95,6 +95,10 @@ class ModelAdvisoryResult(BaseModel):
     affected_pct: float = 0.0
     affected_nm: float = 0.0
     total_nm: float = 0.0
+    # Optional details-only metadata: divergence between the chosen method and
+    # an independent second derivation (e.g. convective DD-vs-model scheme).
+    # Never affects the grade; surfaced only in the info popup and LLM digest.
+    cross_check: str | None = None
 
     @classmethod
     def build(
@@ -106,6 +110,7 @@ class ModelAdvisoryResult(BaseModel):
         affected: int,
         total: int,
         total_distance_nm: float,
+        cross_check: str | None = None,
     ) -> ModelAdvisoryResult:
         """Build a result, computing pct and nm from point counts."""
         return cls(
@@ -117,6 +122,7 @@ class ModelAdvisoryResult(BaseModel):
             affected_pct=round(100 * affected / total, 1) if total > 0 else 0,
             affected_nm=round(total_distance_nm * affected / total, 1) if total > 0 else 0,
             total_nm=round(total_distance_nm, 1),
+            cross_check=cross_check,
         )
 
 

--- a/tests/analysis/advisories/test_evaluators.py
+++ b/tests/analysis/advisories/test_evaluators.py
@@ -92,6 +92,78 @@ class TestConvective:
         # All 10 points have MODERATE risk → 100% > red threshold
         assert result.aggregate_status == AdvisoryStatus.RED
 
+    def test_cross_check_populated_grade_unchanged(self):
+        """High-CAPE thermo + zero-cover NWP scheme populates per-model
+        cross_check, but the grade is identical to the same context with no
+        NWP scheme attached (cross-check is additive metadata only)."""
+        from datetime import datetime
+
+        from weatherbrief.models import (
+            ConvectiveAssessment,
+            ConvectiveRisk,
+            RoutePointAnalysis,
+            SoundingAnalysis,
+            ThermodynamicIndices,
+        )
+
+        thermo = ConvectiveAssessment(
+            risk_level=ConvectiveRisk.MODERATE,
+            cape_jkg=1100.0,
+            top_ft=25000.0,
+            method="thermo",
+        )
+        nwp_quiet = ConvectiveAssessment(
+            risk_level=ConvectiveRisk.MODERATE, cover_pct=0.0, method="nwp"
+        )
+
+        def _ctx(conv_nwp: ConvectiveAssessment | None) -> RouteContext:
+            analyses = [
+                RoutePointAnalysis(
+                    point_index=i,
+                    lat=48.0 + i * 0.5,
+                    lon=2.0 + i * 0.5,
+                    distance_from_origin_nm=i * 20.0,
+                    interpolated_time=datetime(2026, 3, 1, 10, 0),
+                    forecast_hour=datetime(2026, 3, 1, 9, 0),
+                    track_deg=135.0,
+                    sounding={
+                        "gfs": SoundingAnalysis(
+                            indices=ThermodynamicIndices(),
+                            convective=thermo,
+                            convective_thermo=thermo,
+                            convective_nwp=conv_nwp,
+                        )
+                    },
+                )
+                for i in range(10)
+            ]
+            return RouteContext(
+                analyses=analyses,
+                cross_sections=[],
+                elevation=None,
+                models=["gfs"],
+                cruise_altitude_ft=8000,
+                flight_ceiling_ft=18000,
+                total_distance_nm=200,
+            )
+
+        params = {
+            "min_risk": 2,
+            "affected_pct_amber": 20,
+            "affected_pct_red": 50,
+            "top_clearance_ft": 2000,
+        }
+
+        res_with = ConvectiveEvaluator.evaluate(_ctx(nwp_quiet), params)
+        res_without = ConvectiveEvaluator.evaluate(_ctx(None), params)
+
+        assert res_with.per_model[0].cross_check is not None
+        assert "not corroborated" in res_with.per_model[0].cross_check
+        assert res_without.per_model[0].cross_check is None
+        # Grade must be unchanged by the cross-check.
+        assert res_with.aggregate_status == res_without.aggregate_status
+        assert res_with.per_model[0].status == res_without.per_model[0].status
+
 
 class TestCloudTop:
     def test_green_no_clouds(self, clear_context: RouteContext):

--- a/tests/test_convective.py
+++ b/tests/test_convective.py
@@ -1,10 +1,12 @@
 """Tests for convective risk assessment (sounding/convective.py)."""
 
 from weatherbrief.analysis.sounding.convective import (
+    ConvectiveCrossCheck,
     _effective_cape,
     assess_convective_nwp,
     assess_convective_thermo,
     classify_regime,
+    convective_cross_check,
     effective_cape,
 )
 from weatherbrief.models import (
@@ -874,3 +876,106 @@ def test_sounding_analysis_backward_compat_convective_thermo():
     conv = ConvectiveAssessment(risk_level=ConvectiveRisk.LOW, method="thermo")
     sa = SoundingAnalysis(convective=conv)
     assert sa.convective_thermo is conv
+
+
+# ---------------------------------------------------------------------------
+# convective_cross_check — DD-vs-model-scheme divergence (details-only)
+# ---------------------------------------------------------------------------
+
+
+def test_cross_check_dd_not_corroborated():
+    """Thermo MODERATE + model cover 0% (no geom) → dd_not_corroborated."""
+    thermo = ConvectiveAssessment(
+        risk_level=ConvectiveRisk.MODERATE, cape_jkg=1100.0, method="thermo"
+    )
+    nwp = ConvectiveAssessment(
+        risk_level=ConvectiveRisk.MODERATE, cover_pct=0.0, method="nwp"
+    )
+    xc = convective_cross_check(thermo, nwp)
+    assert isinstance(xc, ConvectiveCrossCheck)
+    assert xc.direction == "dd_not_corroborated"
+    assert "not corroborated" in xc.note
+    assert "MODERATE" in xc.note
+    assert "1100" in xc.note
+    assert "0%" in xc.note
+
+
+def test_cross_check_model_active_dd_quiet():
+    """Thermo NONE + model cover 40% → model_active_dd_quiet."""
+    thermo = ConvectiveAssessment(risk_level=ConvectiveRisk.NONE, method="thermo")
+    nwp = ConvectiveAssessment(
+        risk_level=ConvectiveRisk.NONE, cover_pct=40.0, method="nwp"
+    )
+    xc = convective_cross_check(thermo, nwp)
+    assert xc is not None
+    assert xc.direction == "model_active_dd_quiet"
+    assert "active" in xc.note
+    assert "40% cover" in xc.note
+
+
+def test_cross_check_geom_only_active():
+    """ECMWF/ICON geom-only (cover None + base/top) counts as model-active."""
+    thermo = ConvectiveAssessment(risk_level=ConvectiveRisk.MARGINAL, method="thermo")
+    nwp = ConvectiveAssessment(
+        risk_level=ConvectiveRisk.MARGINAL,
+        cover_pct=None,
+        base_ft=4000.0,
+        top_ft=20000.0,
+        method="nwp_hybrid",
+    )
+    xc = convective_cross_check(thermo, nwp)
+    assert xc is not None
+    assert xc.direction == "model_active_dd_quiet"
+    assert "tops 20000ft" in xc.note
+
+
+def test_cross_check_none_when_nwp_missing():
+    """No NWP convective scheme → silent (None)."""
+    thermo = ConvectiveAssessment(
+        risk_level=ConvectiveRisk.HIGH, cape_jkg=1500.0, method="thermo"
+    )
+    assert convective_cross_check(thermo, None) is None
+
+
+def test_cross_check_none_when_agree_both_active():
+    """Thermo MODERATE + model active (60% cover) → both agree, None."""
+    thermo = ConvectiveAssessment(
+        risk_level=ConvectiveRisk.MODERATE, cape_jkg=900.0, method="thermo"
+    )
+    nwp = ConvectiveAssessment(
+        risk_level=ConvectiveRisk.MODERATE, cover_pct=60.0, method="nwp"
+    )
+    assert convective_cross_check(thermo, nwp) is None
+
+
+def test_cross_check_none_when_agree_both_quiet():
+    """Thermo NONE + model quiet (0% cover) → both agree, None."""
+    thermo = ConvectiveAssessment(risk_level=ConvectiveRisk.NONE, method="thermo")
+    nwp = ConvectiveAssessment(
+        risk_level=ConvectiveRisk.NONE, cover_pct=0.0, method="nwp"
+    )
+    assert convective_cross_check(thermo, nwp) is None
+
+
+def test_cross_check_cover_with_geom_not_quiet():
+    """Cover 0% but convective geometry present → not 'quiet', so no false signal."""
+    thermo = ConvectiveAssessment(
+        risk_level=ConvectiveRisk.MODERATE, cape_jkg=1000.0, method="thermo"
+    )
+    # cover 0 but base/top present → model_has_geom True → model_quiet False
+    nwp = ConvectiveAssessment(
+        risk_level=ConvectiveRisk.MODERATE,
+        cover_pct=0.0,
+        base_ft=4000.0,
+        top_ft=18000.0,
+        method="nwp",
+    )
+    assert convective_cross_check(thermo, nwp) is None
+
+
+def test_cross_check_none_when_thermo_missing():
+    """No thermo assessment → nothing to compare against (None)."""
+    nwp = ConvectiveAssessment(
+        risk_level=ConvectiveRisk.NONE, cover_pct=40.0, method="nwp"
+    )
+    assert convective_cross_check(None, nwp) is None

--- a/tests/test_prompt_builder.py
+++ b/tests/test_prompt_builder.py
@@ -239,3 +239,55 @@ def test_build_context_divergence_poor_included(sample_snapshot):
     assert "Divergence:" in context
     assert "cloud_cover_pct poor" in context
     assert "spread=70.0" in context
+
+
+def test_build_context_convective_model_scheme_and_cross_check(sample_snapshot):
+    """Divergent sounding emits the model-scheme line and a cross-check note
+    (dd_not_corroborated: thermo MODERATE but model convective cover 0%)."""
+    from weatherbrief.models import ConvectiveAssessment, ConvectiveRisk, ThermodynamicIndices
+
+    thermo = ConvectiveAssessment(
+        risk_level=ConvectiveRisk.MODERATE, cape_jkg=1100.0, method="thermo"
+    )
+    nwp = ConvectiveAssessment(
+        risk_level=ConvectiveRisk.MODERATE, cover_pct=0.0, method="nwp"
+    )
+    sample_snapshot.analyses[0].sounding["gfs"] = SoundingAnalysis(
+        indices=ThermodynamicIndices(),
+        convective=thermo,
+        convective_thermo=thermo,
+        convective_nwp=nwp,
+    )
+
+    target_time = datetime(2026, 2, 17, 9, 0, 0)
+    context = build_digest_context(sample_snapshot, target_time)
+
+    assert "Convective model scheme [gfs]" in context
+    assert "cover=0%" in context
+    assert "cross-check:" in context
+    assert "not corroborated" in context
+
+
+def test_build_context_convective_cross_check_when_thermo_none(sample_snapshot):
+    """The model-active / DD-quiet direction is emitted even when the thermo
+    risk is NONE (the old risk!=NONE guard would have hidden it)."""
+    from weatherbrief.models import ConvectiveAssessment, ConvectiveRisk, ThermodynamicIndices
+
+    thermo = ConvectiveAssessment(risk_level=ConvectiveRisk.NONE, method="thermo")
+    nwp = ConvectiveAssessment(
+        risk_level=ConvectiveRisk.NONE, cover_pct=40.0, top_ft=22000.0, method="nwp"
+    )
+    sample_snapshot.analyses[0].sounding["gfs"] = SoundingAnalysis(
+        indices=ThermodynamicIndices(),
+        convective=thermo,
+        convective_thermo=thermo,
+        convective_nwp=nwp,
+    )
+
+    target_time = datetime(2026, 2, 17, 9, 0, 0)
+    context = build_digest_context(sample_snapshot, target_time)
+
+    assert "Convective model scheme [gfs]" in context
+    assert "cover=40%" in context
+    assert "cross-check:" in context
+    assert "model convective scheme active" in context

--- a/web/ts/helpers/advisory-popup.ts
+++ b/web/ts/helpers/advisory-popup.ts
@@ -1,15 +1,21 @@
 /** Shared advisory info popup renderer — used in both briefing and settings pages. */
 
-import type { AdvisoryCatalogEntry, AdvisoryParameterDef } from '../types/advisories';
-import { escapeHtml } from '../utils';
+import type { AdvisoryCatalogEntry, AdvisoryParameterDef, RouteAdvisoryResult } from '../types/advisories';
+import { escapeHtml, modelLabel } from '../utils';
 import { t } from '../i18n/i18n';
 
 /**
  * Render advisory info popup HTML content.
  * @param entry - Advisory catalog entry with full metadata
  * @param paramsUsed - Parameter values to display (user-configured or defaults)
+ * @param adv - Optional evaluated result; supplies per-model cross-check notes.
+ *   Omitted on the settings page (no evaluation yet) — that path is unaffected.
  */
-export function renderAdvisoryPopup(entry: AdvisoryCatalogEntry, paramsUsed: Record<string, number>): string {
+export function renderAdvisoryPopup(
+  entry: AdvisoryCatalogEntry,
+  paramsUsed: Record<string, number>,
+  adv?: RouteAdvisoryResult,
+): string {
   const paramsHtml = entry.parameters.length > 0
     ? `<table class="advisory-params-table">
         <thead><tr><th>${t('advisories.parameter')}</th><th>${t('advisories.value')}</th><th>${t('advisories.description')}</th></tr></thead>
@@ -24,10 +30,19 @@ export function renderAdvisoryPopup(entry: AdvisoryCatalogEntry, paramsUsed: Rec
       </table>`
     : '';
 
+  const crossChecks = (adv?.per_model ?? []).filter((m) => m.cross_check);
+  const crossCheckHtml = crossChecks.length > 0
+    ? `<p class="advisory-popup-crosscheck-title">${escapeHtml(t('advisories.crossCheck'))}</p>
+       <ul class="advisory-popup-crosscheck">${crossChecks.map((m) =>
+         `<li>${escapeHtml(modelLabel(m.model))}: ${escapeHtml(m.cross_check as string)}</li>`
+       ).join('')}</ul>`
+    : '';
+
   return `
     <div class="popup-header"><h3>${escapeHtml(entry.name)}</h3></div>
     <p class="advisory-popup-category">${escapeHtml(entry.category)}</p>
     <p style="margin: 0.75rem 0;">${escapeHtml(entry.description)}</p>
+    ${crossCheckHtml}
     ${paramsHtml}
   `;
 }

--- a/web/ts/helpers/advisory-popup.ts
+++ b/web/ts/helpers/advisory-popup.ts
@@ -34,7 +34,7 @@ export function renderAdvisoryPopup(
   const crossCheckHtml = crossChecks.length > 0
     ? `<p class="advisory-popup-crosscheck-title">${escapeHtml(t('advisories.crossCheck'))}</p>
        <ul class="advisory-popup-crosscheck">${crossChecks.map((m) =>
-         `<li>${escapeHtml(modelLabel(m.model))}: ${escapeHtml(m.cross_check as string)}</li>`
+         `<li>${escapeHtml(modelLabel(m.model))}: ${escapeHtml(m.cross_check!)}</li>`
        ).join('')}</ul>`
     : '';
 

--- a/web/ts/i18n/locales/de.json
+++ b/web/ts/i18n/locales/de.json
@@ -252,6 +252,7 @@
   "advisories.parameter": "Parameter",
   "advisories.value": "Wert",
   "advisories.description": "Beschreibung",
+  "advisories.crossCheck": "Gegenprüfung (Modellschema)",
   "viz.xSection": "Querschnitt",
   "viz.compare": "Vergleich",
   "viz.split": "Teilen",

--- a/web/ts/i18n/locales/en.json
+++ b/web/ts/i18n/locales/en.json
@@ -313,6 +313,7 @@
   "advisories.parameter": "Parameter",
   "advisories.value": "Value",
   "advisories.description": "Description",
+  "advisories.crossCheck": "Cross-check (model scheme)",
 
   "viz.xSection": "X-Section",
   "viz.compare": "Compare",

--- a/web/ts/i18n/locales/es.json
+++ b/web/ts/i18n/locales/es.json
@@ -252,6 +252,7 @@
   "advisories.parameter": "Parámetro",
   "advisories.value": "Valor",
   "advisories.description": "Descripción",
+  "advisories.crossCheck": "Verificación cruzada (esquema del modelo)",
   "viz.xSection": "Sección transversal",
   "viz.compare": "Comparar",
   "viz.split": "Dividir",

--- a/web/ts/i18n/locales/fr.json
+++ b/web/ts/i18n/locales/fr.json
@@ -252,6 +252,7 @@
   "advisories.parameter": "Paramètre",
   "advisories.value": "Valeur",
   "advisories.description": "Description",
+  "advisories.crossCheck": "Vérification croisée (schéma du modèle)",
   "viz.xSection": "Coupe",
   "viz.compare": "Comparer",
   "viz.split": "Diviser",

--- a/web/ts/managers/advisories-ui.ts
+++ b/web/ts/managers/advisories-ui.ts
@@ -592,7 +592,7 @@ export function renderAdvisories(
     const entry = catalog.get(advId);
     if (!entry) return;
     const adv = manifest.advisories.find(a => a.advisory_id === advId);
-    showPopupContent(renderAdvisoryPopup(entry, adv?.parameters_used ?? {}));
+    showPopupContent(renderAdvisoryPopup(entry, adv?.parameters_used ?? {}, adv));
   });
 
   // Wire runway info popups (event delegation)

--- a/web/ts/types/advisories.ts
+++ b/web/ts/types/advisories.ts
@@ -34,6 +34,7 @@ export interface ModelAdvisoryResult {
   affected_pct: number;
   affected_nm: number;
   total_nm: number;
+  cross_check?: string | null;
 }
 
 export interface RouteAdvisoryResult {


### PR DESCRIPTION
Surface a details-only second opinion when the sounding-derived (DD/CAPE)
convective risk diverges from the model's own convective-scheme diagnostic.
The chosen method still sets the grade; the cross-check is additive metadata
shown only in the advisory info popup and the LLM digest — never on the
compact card and never affecting GREEN/AMBER/RED.

- add convective_cross_check() + ConvectiveCrossCheck to sounding/convective.py;
  the independent signal is the model's convective cover/geometry, not its
  CAPE-derived risk_level (which would be near-circular)
- ModelAdvisoryResult gains an optional cross_check field (back-compatible)
- ConvectiveEvaluator tallies per-model divergence into a concise note
- digest prompt_builder emits the model-scheme line + a cross-check line,
  including the thermo-NONE / model-active direction
- briefer_v1 guidance: treat the alternate method as a confidence caveat
- frontend popup renders a per-model cross-check section (i18n en/fr/de/es)

https://claude.ai/code/session_01XcgZwAM3fCW2LeDBMjNvqA