### PR TITLE
perf(flights): eliminate per-flight pack N+1 and paginate the past section

### DIFF
--- a/src/weatherbrief/api/flights.py
+++ b/src/weatherbrief/api/flights.py
@@ -9,7 +9,7 @@ import re
 from datetime import datetime, timedelta, timezone
 from typing import Literal
 
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException, Request, Response
 from pydantic import BaseModel, Field, field_validator
 from sqlalchemy import func, select
 from sqlalchemy.orm import Session
@@ -33,6 +33,7 @@ from weatherbrief.storage.flights import (
     save_flight,
     subscribe_flight,
     unsubscribe_flight,
+    _resolve_artifact_path,
 )
 
 router = APIRouter(prefix="/flights", tags=["flights"])
@@ -100,13 +101,20 @@ class AircraftInfo(BaseModel):
 
 
 class BriefingStatusInfo(BaseModel):
-    """Summary of latest briefing pack, included in flight listings."""
+    """Summary of latest briefing pack, included in flight listings.
+
+    Carries everything the flights-list card and the debrief form need so
+    the page renders from the single ``/flights`` response — no per-flight
+    ``/packs/latest`` round-trips. ``has_advisories`` lets the debrief form
+    decide whether to fetch the advisories manifest at all.
+    """
 
     assessment: str | None = None
     assessment_reason: str | None = None
     has_digest: bool = False
     days_out: int | None = None
     fetch_timestamp: str | None = None
+    has_advisories: bool = False
 
 
 class FlightResponse(BaseModel):
@@ -407,6 +415,19 @@ def _get_latest_packs(db: Session, flight_ids: list[str]) -> dict[str, BriefingS
         )
     ).scalars().all()
 
+    from pathlib import Path
+
+    def _has_advisories(artifact_path: str | None) -> bool:
+        # Mirrors packs._meta_to_response: advisories presence is the
+        # route_advisories.json file on disk, not a DB column. A cheap local
+        # stat per latest pack, all in this one request — far cheaper than the
+        # per-flight /packs/latest round-trips it replaces. Resolve the stored
+        # path against the current DATA_DIR first (worktrees run from a
+        # different CWD than where the pack was written).
+        if not artifact_path:
+            return False
+        return (Path(_resolve_artifact_path(artifact_path)) / "route_advisories.json").exists()
+
     return {
         row.flight_id: BriefingStatusInfo(
             assessment=row.assessment,
@@ -414,6 +435,7 @@ def _get_latest_packs(db: Session, flight_ids: list[str]) -> dict[str, BriefingS
             has_digest=row.has_digest,
             days_out=row.days_out,
             fetch_timestamp=row.fetch_timestamp.isoformat(),
+            has_advisories=_has_advisories(row.artifact_path),
         )
         for row in rows
     }
@@ -421,6 +443,9 @@ def _get_latest_packs(db: Session, flight_ids: list[str]) -> dict[str, BriefingS
 
 @router.get("", response_model=list[FlightResponse])
 def list_all_flights(
+    response: Response,
+    past_limit: int | None = None,
+    past_offset: int = 0,
     user_id: str = Depends(current_user_id),
     db: Session = Depends(get_db),
 ):
@@ -428,6 +453,16 @@ def list_all_flights(
 
     Subscribed flights are filtered out when the owner has flipped them to
     private (see storage.flights.list_flights_with_role).
+
+    Pagination (opt-in, web flights page): ``future`` + ``recent`` flights are
+    always returned in full (small, time-sensitive). The ``past`` section can
+    be paginated via ``past_limit`` / ``past_offset`` — when ``past_limit`` is
+    omitted (iOS/MCP clients), the full past list is returned unchanged. The
+    ``X-Past-Total`` response header always carries the full past count so the
+    client knows whether more pages exist.
+
+    Section computation runs over the *full* owned set before slicing, so
+    ``_compute_recent_section`` still sees every past flight.
     """
     paired = list_flights_with_role(db, user_id)
     pack_status = _get_latest_packs(db, [f.id for f, _, _ in paired])
@@ -438,24 +473,34 @@ def list_all_flights(
     ]
     recent_set = _compute_recent_section(owned_pairs)
 
-    out: list[FlightResponse] = []
+    # Build responses, splitting past (paginated) from future+recent (always
+    # full). Order within each group follows ``list_flights_with_role``
+    # (departure_time desc); the frontend re-buckets by ``section`` so the
+    # concatenation order below only needs to preserve per-section order.
+    other: list[FlightResponse] = []  # future + recent
+    past: list[FlightResponse] = []
     for f, role, owner_name in paired:
         debrief = debrief_map.get(f.id) if role == "owner" else None
         section = _classify_section(f, has_debrief=debrief is not None, recent_set=recent_set)
-        out.append(
-            _flight_to_response(
-                f,
-                db,
-                viewer_id=user_id,
-                latest_briefing=pack_status.get(f.id),
-                role=role,
-                subscribed=(role == "subscriber"),
-                owner_display_name=owner_name,
-                debrief=debrief,
-                section=section,
-            )
+        resp = _flight_to_response(
+            f,
+            db,
+            viewer_id=user_id,
+            latest_briefing=pack_status.get(f.id),
+            role=role,
+            subscribed=(role == "subscriber"),
+            owner_display_name=owner_name,
+            debrief=debrief,
+            section=section,
         )
-    return out
+        (past if section == "past" else other).append(resp)
+
+    response.headers["X-Past-Total"] = str(len(past))
+    if past_limit is not None:
+        start = max(0, past_offset)
+        past = past[start : start + max(0, past_limit)]
+
+    return other + past
 
 
 def _bulk_debriefs_for_owned(

--- a/src/weatherbrief/api/flights.py
+++ b/src/weatherbrief/api/flights.py
@@ -9,7 +9,7 @@ import re
 from datetime import datetime, timedelta, timezone
 from typing import Literal
 
-from fastapi import APIRouter, Depends, HTTPException, Request, Response
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
 from pydantic import BaseModel, Field, field_validator
 from sqlalchemy import func, select
 from sqlalchemy.orm import Session
@@ -29,11 +29,11 @@ from weatherbrief.storage.flights import (
     is_subscribed,
     list_flights_with_role,
     load_flight,
+    pack_has_advisories,
     safe_path_component,
     save_flight,
     subscribe_flight,
     unsubscribe_flight,
-    _resolve_artifact_path,
 )
 
 router = APIRouter(prefix="/flights", tags=["flights"])
@@ -415,19 +415,9 @@ def _get_latest_packs(db: Session, flight_ids: list[str]) -> dict[str, BriefingS
         )
     ).scalars().all()
 
-    from pathlib import Path
-
-    def _has_advisories(artifact_path: str | None) -> bool:
-        # Mirrors packs._meta_to_response: advisories presence is the
-        # route_advisories.json file on disk, not a DB column. A cheap local
-        # stat per latest pack, all in this one request — far cheaper than the
-        # per-flight /packs/latest round-trips it replaces. Resolve the stored
-        # path against the current DATA_DIR first (worktrees run from a
-        # different CWD than where the pack was written).
-        if not artifact_path:
-            return False
-        return (Path(_resolve_artifact_path(artifact_path)) / "route_advisories.json").exists()
-
+    # has_advisories is a per-pack disk stat (route_advisories.json), all in
+    # this one request — far cheaper than the per-flight /packs/latest
+    # round-trips it replaces.
     return {
         row.flight_id: BriefingStatusInfo(
             assessment=row.assessment,
@@ -435,7 +425,7 @@ def _get_latest_packs(db: Session, flight_ids: list[str]) -> dict[str, BriefingS
             has_digest=row.has_digest,
             days_out=row.days_out,
             fetch_timestamp=row.fetch_timestamp.isoformat(),
-            has_advisories=_has_advisories(row.artifact_path),
+            has_advisories=pack_has_advisories(row.artifact_path),
         )
         for row in rows
     }
@@ -444,8 +434,8 @@ def _get_latest_packs(db: Session, flight_ids: list[str]) -> dict[str, BriefingS
 @router.get("", response_model=list[FlightResponse])
 def list_all_flights(
     response: Response,
-    past_limit: int | None = None,
-    past_offset: int = 0,
+    past_limit: int | None = Query(default=None, ge=0),
+    past_offset: int = Query(default=0, ge=0),
     user_id: str = Depends(current_user_id),
     db: Session = Depends(get_db),
 ):
@@ -497,8 +487,8 @@ def list_all_flights(
 
     response.headers["X-Past-Total"] = str(len(past))
     if past_limit is not None:
-        start = max(0, past_offset)
-        past = past[start : start + max(0, past_limit)]
+        # past_offset / past_limit are validated >= 0 by Query(ge=0).
+        past = past[past_offset : past_offset + past_limit]
 
     return other + past
 

--- a/src/weatherbrief/api/packs.py
+++ b/src/weatherbrief/api/packs.py
@@ -63,6 +63,7 @@ from weatherbrief.storage.flights import (
     list_packs,
     load_pack_meta,
     pack_dir_for,
+    pack_has_advisories,
     save_pack_meta,
     update_pack_meta,
 )
@@ -345,11 +346,7 @@ def _meta_to_response(
     meta: BriefingPackMeta,
     data_status: DataStatus | None = None,
 ) -> PackMetaResponse:
-    # Check for advisories file on disk
-    has_advisories = False
-    if meta.artifact_path:
-        from pathlib import Path
-        has_advisories = (Path(meta.artifact_path) / "route_advisories.json").exists()
+    has_advisories = pack_has_advisories(meta.artifact_path)
 
     return PackMetaResponse(
         flight_id=meta.flight_id,

--- a/src/weatherbrief/storage/flights.py
+++ b/src/weatherbrief/storage/flights.py
@@ -257,6 +257,20 @@ def _resolve_artifact_path(raw: str) -> str:
     return raw
 
 
+def pack_has_advisories(artifact_path: str | None) -> bool:
+    """True when a pack's ``route_advisories.json`` exists on disk.
+
+    Advisories presence is a file on disk, not a DB column — this is the
+    single source of truth for that check, used by both the per-pack
+    response builder and the bulk flight-list query. Resolves the stored
+    path against the current DATA_DIR first (worktrees run from a different
+    CWD than where the pack was written).
+    """
+    if not artifact_path:
+        return False
+    return (Path(_resolve_artifact_path(artifact_path)) / "route_advisories.json").exists()
+
+
 def _parse_diagnostics(raw: str | None) -> list[Diagnostic]:
     """Parse diagnostics_json into typed Diagnostic entries.
 

--- a/tests/test_flights_api_sections.py
+++ b/tests/test_flights_api_sections.py
@@ -194,6 +194,99 @@ def _save_flight(app_db, *, route: str, days_offset: int, idx: int) -> Flight:
     return f
 
 
+def _save_pack(
+    app_db,
+    flight_id: str,
+    *,
+    assessment: str | None,
+    days_out: int,
+    artifact_path: str = "",
+) -> None:
+    """Insert a minimal latest briefing pack row for a flight."""
+    from weatherbrief.db.models import BriefingPackRow
+
+    s = app_db()
+    s.add(BriefingPackRow(
+        flight_id=flight_id,
+        fetch_timestamp=datetime.now(timezone.utc),
+        days_out=days_out,
+        assessment=assessment,
+        assessment_reason="test",
+        has_digest=True,
+        artifact_path=artifact_path,
+    ))
+    s.commit()
+    s.close()
+
+
+class TestLatestBriefingInline:
+    """The list response carries enough per-flight briefing data to paint the
+    card and drive the debrief form — no per-flight /packs/latest calls."""
+
+    def test_card_data_present_inline(self, client, app_db):
+        # assessment / days_out / fetch_timestamp are exactly the three fields
+        # the card consumed from the old /packs/latest round-trip.
+        f = _save_flight(app_db, route="rcard", days_offset=+5, idx=1)
+        _save_pack(app_db, f.id, assessment="AMBER", days_out=3)
+        rec = next(x for x in client.get("/api/flights").json() if x["id"] == f.id)
+        lb = rec["latest_briefing"]
+        assert lb is not None
+        assert lb["assessment"] == "AMBER"
+        assert lb["days_out"] == 3
+        assert lb["fetch_timestamp"] is not None
+        # No route_advisories.json on disk → flag is False.
+        assert lb["has_advisories"] is False
+
+    def test_no_pack_yields_null_briefing(self, client, app_db):
+        f = _save_flight(app_db, route="rnone", days_offset=+5, idx=2)
+        rec = next(x for x in client.get("/api/flights").json() if x["id"] == f.id)
+        assert rec["latest_briefing"] is None
+
+    def test_has_advisories_true_when_manifest_on_disk(self, client, app_db, tmp_path):
+        f = _save_flight(app_db, route="radv", days_offset=+5, idx=3)
+        adv_dir = tmp_path / "pack-radv"
+        adv_dir.mkdir(parents=True, exist_ok=True)
+        (adv_dir / "route_advisories.json").write_text("{}")
+        _save_pack(app_db, f.id, assessment="GREEN", days_out=2, artifact_path=str(adv_dir))
+        rec = next(x for x in client.get("/api/flights").json() if x["id"] == f.id)
+        assert rec["latest_briefing"]["has_advisories"] is True
+
+
+class TestPastPagination:
+    """Only the past section paginates; future + recent always come back full."""
+
+    def test_past_limit_slices_and_sets_total_header(self, client, app_db):
+        # 5 flights older than the 30-day recent window (all "past"), plus one
+        # future flight that must appear on every page.
+        for i in range(5):
+            _save_flight(app_db, route=f"p{i}", days_offset=-(40 + i), idx=i)
+        _save_flight(app_db, route="fut", days_offset=+5, idx=99)
+
+        resp = client.get("/api/flights?past_limit=2&past_offset=0")
+        assert resp.headers["X-Past-Total"] == "5"
+        body = resp.json()
+        page1 = [f["id"] for f in body if f["section"] == "past"]
+        assert len(page1) == 2
+        assert sum(1 for f in body if f["section"] == "future") == 1
+
+        resp2 = client.get("/api/flights?past_limit=2&past_offset=2")
+        page2 = [f["id"] for f in resp2.json() if f["section"] == "past"]
+        assert len(page2) == 2
+        assert set(page1).isdisjoint(page2)  # no overlap across pages
+        # Future still present on the second page.
+        assert sum(1 for f in resp2.json() if f["section"] == "future") == 1
+
+        resp3 = client.get("/api/flights?past_limit=2&past_offset=4")
+        assert len([f for f in resp3.json() if f["section"] == "past"]) == 1
+
+    def test_no_past_limit_returns_all_past(self, client, app_db):
+        for i in range(3):
+            _save_flight(app_db, route=f"q{i}", days_offset=-(40 + i), idx=i)
+        resp = client.get("/api/flights")
+        assert resp.headers["X-Past-Total"] == "3"
+        assert len([f for f in resp.json() if f["section"] == "past"]) == 3
+
+
 class TestApiSections:
     def test_listing_includes_section_field(self, client, app_db):
         _save_flight(app_db, route="rt1", days_offset=+5, idx=1)

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -447,6 +447,16 @@ label {
   display: none;
 }
 
+.btn-show-more-past {
+  margin-top: 0.5rem;
+}
+
+/* The "Show more" affordance belongs to the past list — hide it whenever the
+   section is collapsed, alongside the list itself. */
+.past-flights-section.collapsed .btn-show-more-past {
+  display: none;
+}
+
 .flight-status {
   display: flex;
   gap: 0.5rem;

--- a/web/ts/adapters/api-adapter.ts
+++ b/web/ts/adapters/api-adapter.ts
@@ -26,8 +26,44 @@ export class RefreshStreamError extends Error {
 
 // --- Flights ---
 
-export async function fetchFlights(): Promise<FlightResponse[]> {
-  return apiFetch<FlightResponse[]>('/flights');
+export interface FlightsPage {
+  flights: FlightResponse[];
+  /** Full count of the user's "past" flights, regardless of pagination, read
+   *  from the X-Past-Total response header. Lets the page decide whether to
+   *  show a "Show more" affordance. Falls back to the returned past count when
+   *  the header is absent (older server). */
+  pastTotal: number;
+}
+
+/** Fetch the flights list. ``pastLimit`` paginates only the past section;
+ *  future + recent are always returned in full. Omit ``pastLimit`` for the
+ *  full, unpaginated list. */
+export async function fetchFlights(opts?: {
+  pastLimit?: number;
+  pastOffset?: number;
+}): Promise<FlightsPage> {
+  const params = new URLSearchParams();
+  if (opts?.pastLimit != null) params.set('past_limit', String(opts.pastLimit));
+  if (opts?.pastOffset != null) params.set('past_offset', String(opts.pastOffset));
+  const qs = params.toString();
+
+  let pastTotal: number | null = null;
+  const flights = await apiFetch<FlightResponse[]>(
+    `/flights${qs ? `?${qs}` : ''}`,
+    undefined,
+    (resp) => {
+      const header = resp.headers.get('X-Past-Total');
+      if (header != null) {
+        const parsed = parseInt(header, 10);
+        if (!Number.isNaN(parsed)) pastTotal = parsed;
+      }
+    },
+  );
+
+  return {
+    flights,
+    pastTotal: pastTotal ?? flights.filter((f) => f.section === 'past').length,
+  };
 }
 
 export async function fetchFlight(id: string): Promise<FlightResponse> {

--- a/web/ts/flights-main.ts
+++ b/web/ts/flights-main.ts
@@ -557,20 +557,21 @@ async function init(): Promise<void> {
   store.subscribe((state, prev) => {
     if (
       state.flights !== prev.flights ||
-      state.latestPacks !== prev.latestPacks ||
+      state.pastTotal !== prev.pastTotal ||
       state.activeRefreshes !== prev.activeRefreshes ||
       state.selectedIds !== prev.selectedIds ||
       state.debriefStats !== prev.debriefStats
     ) {
       ui.renderFlightList(
         state.flights,
-        state.latestPacks,
         state.activeRefreshes,
         state.selectedIds,
+        state.pastTotal,
         (id) => navigateToBriefing(id),
         (id) => navigateToFlight(id),
         (id) => store.getState().deleteFlight(id),
         selectionHandlers,
+        () => store.getState().loadMorePast(),
         (id) => store.getState().unsubscribeFlight(id),
         state.debriefStats,
         refreshAfterDebrief,

--- a/web/ts/i18n/locales/de.json
+++ b/web/ts/i18n/locales/de.json
@@ -10,6 +10,7 @@
   "theme.dark": "Dunkel",
   "flights.empty": "Noch keine Flüge vorhanden. Erstellen Sie einen, um zu beginnen.",
   "flights.past": "Vergangene Flüge ({count})",
+  "flights.showMorePast": "Mehr anzeigen ({count})",
   "flights.deleteConfirm": "Flug {id} löschen? Damit wird der gesamte Briefing-Verlauf entfernt.",
   "flights.noBriefings": "Noch keine Briefings vorhanden",
   "flights.pastBadge": "Vergangen",

--- a/web/ts/i18n/locales/en.json
+++ b/web/ts/i18n/locales/en.json
@@ -12,6 +12,7 @@
 
   "flights.empty": "No flights yet. Create one to get started.",
   "flights.past": "Past flights ({count})",
+  "flights.showMorePast": "Show more ({count})",
   "flights.deleteConfirm": "Delete flight {id}? This removes all briefing history.",
   "flights.noBriefings": "No briefings yet",
   "flights.pastBadge": "Past",

--- a/web/ts/i18n/locales/es.json
+++ b/web/ts/i18n/locales/es.json
@@ -10,6 +10,7 @@
   "theme.dark": "Oscuro",
   "flights.empty": "Aún no hay vuelos. Cree uno para comenzar.",
   "flights.past": "Vuelos pasados ({count})",
+  "flights.showMorePast": "Mostrar más ({count})",
   "flights.deleteConfirm": "¿Eliminar el vuelo {id}? Se eliminará todo el historial de briefings.",
   "flights.noBriefings": "Aún no hay briefings",
   "flights.pastBadge": "Pasado",

--- a/web/ts/i18n/locales/fr.json
+++ b/web/ts/i18n/locales/fr.json
@@ -10,6 +10,7 @@
   "theme.dark": "Sombre",
   "flights.empty": "Aucun vol pour le moment. Créez-en un pour commencer.",
   "flights.past": "Vols passés ({count})",
+  "flights.showMorePast": "Afficher plus ({count})",
   "flights.deleteConfirm": "Supprimer le vol {id} ? Tout l'historique des briefings sera supprimé.",
   "flights.noBriefings": "Aucun briefing pour le moment",
   "flights.pastBadge": "Passé",

--- a/web/ts/managers/flights-ui.ts
+++ b/web/ts/managers/flights-ui.ts
@@ -1,6 +1,6 @@
 /** DOM management for the Flights list page. */
 
-import type { DebriefStats, FlightResponse, PackMeta } from '../store/types';
+import type { DebriefStats, FlightResponse } from '../store/types';
 import { fetchRouteAdvisories, type RefreshEntry } from '../adapters/api-adapter';
 import { $, escapeHtml, formatDate, formatDepartureTime, formatAlt, isFlightPast, flightTitle, flightRouteCompact } from '../utils';
 import { t, getDateLocale } from '../i18n/i18n';
@@ -30,7 +30,6 @@ let recentExpanded = true;
 /** Render a single flight card. */
 function renderFlightCard(
   f: FlightResponse,
-  pack: PackMeta | null,
   refreshEntry: RefreshEntry | undefined,
   selected: boolean,
 ): string {
@@ -63,9 +62,12 @@ function renderFlightCard(
     refreshBadge = `<span class="badge badge-refreshing">${label}${spinner}</span> `;
   }
 
-  const packInfo = pack
-    ? `<span class="pack-info">D-${pack.days_out} (${new Date(pack.fetch_timestamp).toLocaleDateString(getDateLocale(), { day: 'numeric', month: 'short', hour: '2-digit', minute: '2-digit', timeZone: 'UTC' })} UTC)</span>
-       <span class="badge ${assessmentClass(pack.assessment)}">${escapeHtml(pack.assessment || '\u2014')}</span>`
+  // Card status reads from the flight's inline latest_briefing \u2014 same three
+  // fields the old per-flight /packs/latest call surfaced, with no extra round-trip.
+  const lb = f.latest_briefing;
+  const packInfo = lb && lb.fetch_timestamp
+    ? `<span class="pack-info">D-${lb.days_out} (${new Date(lb.fetch_timestamp).toLocaleDateString(getDateLocale(), { day: 'numeric', month: 'short', hour: '2-digit', minute: '2-digit', timeZone: 'UTC' })} UTC)</span>
+       <span class="badge ${assessmentClass(lb.assessment)}">${escapeHtml(lb.assessment || '\u2014')}</span>`
     : `<span class="pack-info">${t('flights.noBriefings')}</span>`;
 
   const routeLine = compactRoute
@@ -139,13 +141,14 @@ export interface SelectionHandlers {
 
 export function renderFlightList(
   flights: FlightResponse[],
-  latestPacks: Record<string, PackMeta | null>,
   activeRefreshes: Record<string, RefreshEntry>,
   selectedIds: Set<string>,
+  pastTotal: number,
   onBriefing: (id: string) => void,
   onEdit: (id: string) => void,
   onDelete: (id: string) => void,
   selection: SelectionHandlers,
+  onShowMorePast: () => void,
   onUnsubscribe?: (id: string) => void,
   stats?: DebriefStats | null,
   onDebriefChanged?: () => void,
@@ -178,14 +181,14 @@ export function renderFlightList(
   }
 
   const futureCards = future.map(f =>
-    renderFlightCard(f, latestPacks[f.id], activeRefreshes[f.id], selectedIds.has(f.id)),
+    renderFlightCard(f, activeRefreshes[f.id], selectedIds.has(f.id)),
   ).join('');
 
   let recentSection = '';
   if (recent.length > 0) {
     const expandedClass = recentExpanded ? '' : ' collapsed';
     const recentCards = recent.map(f =>
-      renderFlightCard(f, latestPacks[f.id], activeRefreshes[f.id], selectedIds.has(f.id)),
+      renderFlightCard(f, activeRefreshes[f.id], selectedIds.has(f.id)),
     ).join('');
     recentSection = `
       <div class="recent-flights-section${expandedClass}">
@@ -205,14 +208,23 @@ export function renderFlightList(
   if (past.length > 0) {
     const expandedClass = pastExpanded ? '' : ' collapsed';
     const pastCards = past.map(f =>
-      renderFlightCard(f, latestPacks[f.id], activeRefreshes[f.id], selectedIds.has(f.id)),
+      renderFlightCard(f, activeRefreshes[f.id], selectedIds.has(f.id)),
     ).join('');
+    // The past section is paginated: the header shows the full count while
+    // only `past.length` rows are loaded. "Show more" appears while more
+    // remain to be fetched.
+    const totalPast = Math.max(pastTotal, past.length);
+    const remaining = totalPast - past.length;
+    const showMoreBtn = remaining > 0
+      ? `<button type="button" class="btn btn-outline btn-show-more-past" id="show-more-past">${t('flights.showMorePast', { count: remaining })}</button>`
+      : '';
     pastSection = `
       <div class="past-flights-section${expandedClass}">
         <button class="past-flights-toggle" id="past-flights-toggle">
-          ${t('flights.past', { count: past.length })}
+          ${t('flights.past', { count: totalPast })}
         </button>
         <div class="past-flights-list">${pastCards}</div>
+        ${showMoreBtn}
       </div>
     `;
   }
@@ -226,6 +238,9 @@ export function renderFlightList(
     const section = toggleBtn.closest('.past-flights-section');
     section?.classList.toggle('collapsed', !pastExpanded);
   });
+
+  const showMoreBtn = document.getElementById('show-more-past');
+  showMoreBtn?.addEventListener('click', () => onShowMorePast());
 
   const recentToggleBtn = document.getElementById('recent-flights-toggle');
   recentToggleBtn?.addEventListener('click', () => {
@@ -314,13 +329,15 @@ export function renderFlightList(
       host.dataset.open = '1';
       host.innerHTML = `<div class="debrief-loading">${escapeHtml(t('debrief.loading'))}</div>`;
       // Lazy-fetch advisories for the latest pack so the form knows which
-      // categories to surface as outcome questions. Empty list if the pack
-      // doesn't have advisories or the call fails.
-      const pack = latestPacks[id];
+      // categories to surface as outcome questions. The flight's inline
+      // latest_briefing already tells us whether advisories exist and at which
+      // timestamp, so we only hit the network when there's something to fetch.
+      // Empty list if the pack has no advisories or the call fails.
+      const lb = flight.latest_briefing;
       let flaggedCategories: ReturnType<typeof flaggedTagsFromAdvisories> = [];
-      if (pack && pack.has_advisories) {
+      if (lb && lb.has_advisories && lb.fetch_timestamp) {
         try {
-          const manifest = await fetchRouteAdvisories(id, pack.fetch_timestamp);
+          const manifest = await fetchRouteAdvisories(id, lb.fetch_timestamp);
           flaggedCategories = flaggedTagsFromAdvisories(manifest);
         } catch {
           flaggedCategories = [];

--- a/web/ts/store/flights-store.ts
+++ b/web/ts/store/flights-store.ts
@@ -1,16 +1,19 @@
 /** Zustand vanilla store for the Flights management page. */
 
 import { createStore } from 'zustand/vanilla';
-import type { DebriefStats, FlightResponse, PackMeta } from './types';
+import type { DebriefStats, FlightResponse } from './types';
 import type { RefreshEntry } from '../adapters/api-adapter';
 import * as api from '../adapters/api-adapter';
 import { fetchDebriefStats } from '../adapters/debrief-adapter';
 import { errorToMessage } from '../utils';
 
+/** Past-section page size. Future + recent are never paginated. */
+export const PAST_PAGE_SIZE = 20;
+
 export interface FlightsState {
   // Data
   flights: FlightResponse[];
-  latestPacks: Record<string, PackMeta | null>; // flight_id → latest pack
+  pastTotal: number;  // full count of "past" flights (for the "Show more" gate)
   activeRefreshes: Record<string, RefreshEntry>; // flight_id → active refresh entry
   debriefStats: DebriefStats | null;
 
@@ -21,6 +24,7 @@ export interface FlightsState {
 
   // Actions
   loadFlights: () => Promise<void>;
+  loadMorePast: () => Promise<void>;
   loadDebriefStats: () => Promise<void>;
   pollActiveRefreshes: () => Promise<void>;
   createFlight: (waypoints: string[], targetDate: string, opts?: {
@@ -44,7 +48,7 @@ export interface FlightsState {
 
 export const flightsStore = createStore<FlightsState>((set, get) => ({
   flights: [],
-  latestPacks: {},
+  pastTotal: 0,
   activeRefreshes: {},
   debriefStats: null,
   loading: false,
@@ -54,23 +58,32 @@ export const flightsStore = createStore<FlightsState>((set, get) => ({
   loadFlights: async () => {
     set({ loading: true, error: null });
     try {
-      const flights = await api.fetchFlights();
-      set({ flights, loading: false });
-
-      // Load latest pack for each flight (in parallel)
-      const packs: Record<string, PackMeta | null> = {};
-      await Promise.all(
-        flights.map(async (f) => {
-          try {
-            packs[f.id] = await api.fetchLatestPack(f.id);
-          } catch {
-            packs[f.id] = null;
-          }
-        })
-      );
-      set({ latestPacks: packs });
+      // The card and the debrief form read everything they need from each
+      // flight's inline `latest_briefing`, so a single request paints the
+      // page — no per-flight /packs/latest round-trips. Only the past section
+      // is paginated; future + recent always come back in full.
+      const { flights, pastTotal } = await api.fetchFlights({ pastLimit: PAST_PAGE_SIZE });
+      set({ flights, pastTotal, loading: false });
     } catch (err) {
       set({ loading: false, error: `Failed to load flights: ${err}` });
+    }
+  },
+
+  loadMorePast: async () => {
+    const current = get().flights;
+    const loadedPast = current.filter((f) => f.section === 'past').length;
+    try {
+      const { flights: page, pastTotal } = await api.fetchFlights({
+        pastLimit: PAST_PAGE_SIZE,
+        pastOffset: loadedPast,
+      });
+      // The page also re-lists future + recent (always returned in full); keep
+      // only the genuinely new past rows and append them to the past bucket.
+      const existingIds = new Set(current.map((f) => f.id));
+      const newPast = page.filter((f) => f.section === 'past' && !existingIds.has(f.id));
+      set({ flights: [...current, ...newPast], pastTotal });
+    } catch (err) {
+      set({ error: `Failed to load more flights: ${err}` });
     }
   },
 

--- a/web/ts/store/flights-store.ts
+++ b/web/ts/store/flights-store.ts
@@ -19,6 +19,7 @@ export interface FlightsState {
 
   // UI state
   loading: boolean;
+  loadingMore: boolean;  // a "Show more" past-page fetch is in flight
   error: string | null;
   selectedIds: Set<string>;  // flights ticked for bulk actions
 
@@ -52,6 +53,7 @@ export const flightsStore = createStore<FlightsState>((set, get) => ({
   activeRefreshes: {},
   debriefStats: null,
   loading: false,
+  loadingMore: false,
   error: null,
   selectedIds: new Set(),
 
@@ -70,8 +72,13 @@ export const flightsStore = createStore<FlightsState>((set, get) => ({
   },
 
   loadMorePast: async () => {
+    // Guard against rapid double-clicks: until the in-flight page lands,
+    // loadedPast wouldn't advance, so concurrent calls would all request the
+    // same offset and waste round-trips.
+    if (get().loadingMore) return;
     const current = get().flights;
     const loadedPast = current.filter((f) => f.section === 'past').length;
+    set({ loadingMore: true });
     try {
       const { flights: page, pastTotal } = await api.fetchFlights({
         pastLimit: PAST_PAGE_SIZE,
@@ -81,9 +88,9 @@ export const flightsStore = createStore<FlightsState>((set, get) => ({
       // only the genuinely new past rows and append them to the past bucket.
       const existingIds = new Set(current.map((f) => f.id));
       const newPast = page.filter((f) => f.section === 'past' && !existingIds.has(f.id));
-      set({ flights: [...current, ...newPast], pastTotal });
+      set({ flights: [...current, ...newPast], pastTotal, loadingMore: false });
     } catch (err) {
-      set({ error: `Failed to load more flights: ${err}` });
+      set({ error: `Failed to load more flights: ${err}`, loadingMore: false });
     }
   },
 

--- a/web/ts/store/types.ts
+++ b/web/ts/store/types.ts
@@ -8,6 +8,18 @@ export interface AircraftInfo {
   nickname: string | null;
 }
 
+/** Summary of a flight's latest briefing pack, inlined in /flights responses.
+ *  Carries everything the flights-list card and the debrief form need, so the
+ *  page renders without per-flight /packs/latest round-trips. */
+export interface BriefingStatusInfo {
+  assessment: string | null;
+  assessment_reason: string | null;
+  has_digest: boolean;
+  days_out: number | null;
+  fetch_timestamp: string | null;
+  has_advisories: boolean;
+}
+
 export interface FlightResponse {
   id: string;
   user_id: string;
@@ -27,6 +39,7 @@ export interface FlightResponse {
   auto_refresh: boolean;
   auto_refresh_hour: number | null;
   created_at: string;
+  latest_briefing?: BriefingStatusInfo | null;
   role: 'owner' | 'subscriber';
   owner_display_name: string | null;
   is_subscribed: boolean;

--- a/web/ts/utils.ts
+++ b/web/ts/utils.ts
@@ -355,6 +355,11 @@ export function redirectToLogin(): void {
 
 export const API_BASE = '/api';
 
+/**
+ * @param onResponse Inspect response metadata (e.g. read a header) before the
+ *   body is parsed. Read headers only — do NOT consume the body (e.g. by
+ *   calling `resp.json()`/`resp.text()`), or the `resp.json()` below will reject.
+ */
 export async function apiFetch<T>(
   path: string,
   init?: RequestInit,

--- a/web/ts/utils.ts
+++ b/web/ts/utils.ts
@@ -355,7 +355,11 @@ export function redirectToLogin(): void {
 
 export const API_BASE = '/api';
 
-export async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> {
+export async function apiFetch<T>(
+  path: string,
+  init?: RequestInit,
+  onResponse?: (resp: Response) => void,
+): Promise<T> {
   const resp = await fetch(`${API_BASE}${path}`, {
     headers: {
       'Content-Type': 'application/json',
@@ -392,6 +396,7 @@ export async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> 
     }
     throw new Error(`API ${resp.status}: ${detail}`);
   }
+  onResponse?.(resp);
   if (resp.status === 204) return undefined as T;
   return resp.json();
 }


### PR DESCRIPTION
Part A — render flight cards and drive the debrief form from the inline
latest_briefing in the /flights response instead of firing one
/packs/latest request per flight. Adds has_advisories to
BriefingStatusInfo (disk-derived, like packs._meta_to_response) so the
debrief form needs zero extra requests. First paint now issues a single
list request regardless of flight count.

Part B — paginate only the past section. /flights gains optional
past_limit/past_offset query params (omitted = unchanged full list for
iOS/MCP) and an X-Past-Total header carrying the full past count.
future + recent are always returned in full. The web page loads 20 past
flights initially with a "Show more" button that appends the next page.

https://claude.ai/code/session_01MuqT3zeXU4CtDrPPKFAhoF