### PR TITLE
feat(ios): real byte-level progress for offline pack download

### DIFF
--- a/app/flyfun-weather/flyfun-weather/Services/APIClient.swift
+++ b/app/flyfun-weather/flyfun-weather/Services/APIClient.swift
@@ -159,6 +159,10 @@ actor APIClient {
         var request = URLRequest(url: url)
         request.httpMethod = "GET"
         request.setValue("Bearer \(jwt)", forHTTPHeaderField: "Authorization")
+        // The session's default 30s is an idle timeout; the server can spend longer than
+        // that building the bundle (sounding analysis per point × model) before sending any
+        // bytes, which would otherwise abort the download during the "Preparing…" phase.
+        request.timeoutInterval = 300
 
         Self.logger.debug("GET \(path) (streaming)")
 

--- a/app/flyfun-weather/flyfun-weather/Services/APIClient.swift
+++ b/app/flyfun-weather/flyfun-weather/Services/APIClient.swift
@@ -145,6 +145,31 @@ actor APIClient {
         return try await _fetch(url: url, method: method, body: body, label: path)
     }
 
+    /// Fetch raw data while reporting transfer progress as bytes arrive.
+    ///
+    /// `progress` receives `(receivedBytes, totalBytes)`. The total comes from the server's
+    /// `X-Uncompressed-Length` header: `Content-Length` reflects the gzip-compressed size, but
+    /// URLSession transparently decompresses, so we count decompressed bytes against the
+    /// decompressed total. If the header is absent, `totalBytes` is `-1` (size unknown).
+    func requestDataStreaming(
+        _ path: String,
+        progress: @Sendable @escaping (_ receivedBytes: Int64, _ totalBytes: Int64) -> Void
+    ) async throws -> Data {
+        let url = baseURL.appendingPathComponent(path)
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(jwt)", forHTTPHeaderField: "Authorization")
+
+        Self.logger.debug("GET \(path) (streaming)")
+
+        return try await withCheckedThrowingContinuation { continuation in
+            let delegate = StreamingDownloadDelegate(onProgress: progress, continuation: continuation)
+            let task = session.dataTask(with: request)
+            task.delegate = delegate
+            task.resume()
+        }
+    }
+
     private func _fetch(url: URL, method: String, body: Data?, label: String) async throws -> Data {
         var request = URLRequest(url: url)
         request.httpMethod = method
@@ -181,6 +206,81 @@ actor APIClient {
         default:
             let msg = String(data: data, encoding: .utf8)
             throw APIError.serverError(http.statusCode, msg)
+        }
+    }
+}
+
+/// URLSession delegate that streams a response into memory while reporting progress.
+/// State is touched only on URLSession's serial per-task delegate queue; `keepAlive`
+/// retains the delegate (task-delegate retention is not guaranteed) until completion.
+private final class StreamingDownloadDelegate: NSObject, URLSessionDataDelegate, @unchecked Sendable {
+    private var buffer = Data()
+    private var total: Int64 = -1
+    private var lastReportedBytes: Int64 = 0
+    private let onProgress: @Sendable (Int64, Int64) -> Void
+    private var continuation: CheckedContinuation<Data, Error>?
+    private var keepAlive: StreamingDownloadDelegate?
+
+    init(onProgress: @escaping @Sendable (Int64, Int64) -> Void,
+         continuation: CheckedContinuation<Data, Error>) {
+        self.onProgress = onProgress
+        self.continuation = continuation
+        super.init()
+        self.keepAlive = self
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        dataTask: URLSessionDataTask,
+        didReceive response: URLResponse,
+        completionHandler: @escaping (URLSession.ResponseDisposition) -> Void
+    ) {
+        if let http = response as? HTTPURLResponse,
+           let header = http.value(forHTTPHeaderField: "X-Uncompressed-Length"),
+           let len = Int64(header) {
+            total = len
+            if len > 0, len < 64 * 1024 * 1024 { buffer.reserveCapacity(Int(len)) }
+            // Report the total up front so the UI can show the size before bytes arrive.
+            onProgress(0, len)
+        }
+        completionHandler(.allow)
+    }
+
+    func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
+        buffer.append(data)
+        let received = Int64(buffer.count)
+        // Throttle to ~128 KB steps (or the final byte when the total is known)
+        // so we don't spawn a UI update per network chunk.
+        if received - lastReportedBytes >= 131_072 || (total > 0 && received >= total) {
+            lastReportedBytes = received
+            onProgress(received, total)
+        }
+    }
+
+    func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+        defer { keepAlive = nil }
+        guard let continuation else { return }
+        self.continuation = nil
+
+        if let error {
+            continuation.resume(throwing: APIError.networkError(error))
+            return
+        }
+        guard let http = task.response as? HTTPURLResponse else {
+            continuation.resume(throwing: APIError.networkError(URLError(.badServerResponse)))
+            return
+        }
+        switch http.statusCode {
+        case 200...299:
+            continuation.resume(returning: buffer)
+        case 401:
+            continuation.resume(throwing: APIError.unauthorized)
+        case 403:
+            continuation.resume(throwing: APIError.forbidden("Forbidden"))
+        case 404:
+            continuation.resume(throwing: APIError.notFound)
+        default:
+            continuation.resume(throwing: APIError.serverError(http.statusCode, String(data: buffer, encoding: .utf8)))
         }
     }
 }

--- a/app/flyfun-weather/flyfun-weather/Services/CachingBriefingRepository.swift
+++ b/app/flyfun-weather/flyfun-weather/Services/CachingBriefingRepository.swift
@@ -215,14 +215,14 @@ final class CachingBriefingRepository: BriefingRepository {
             throw APIError.decodingError(NSError(domain: "BundleDownload", code: 0, userInfo: [NSLocalizedDescriptionKey: "Invalid bundle format"]))
         }
 
-        var totalBytes: Int64 = 0
+        var diskBytes: Int64 = 0
         var downloaded: Set<String> = []
 
         for (endpoint, value) in bundle {
             do {
                 let entryData = try JSONSerialization.data(withJSONObject: value)
                 try await cache.writeData(entryData, flightId: flightId, timestamp: timestamp, endpoint: endpoint)
-                totalBytes += Int64(entryData.count)
+                diskBytes += Int64(entryData.count)
                 downloaded.insert(endpoint)
             } catch {
                 Self.logger.warning("Failed to cache \(endpoint): \(error)")
@@ -236,13 +236,13 @@ final class CachingBriefingRepository: BriefingRepository {
             flightTitle: flightTitle,
             assessment: assessment,
             endpoints: downloaded,
-            totalBytes: totalBytes
+            totalBytes: diskBytes
         )
         // Cache pack metadata for offline latestPack() recovery
         if let packMeta, let metaData = try? JSONEncoder.weatherBrief.encode(packMeta) {
             try? await cache.writeFlightMetadata(metaData, flightId: flightId, name: "pack-meta")
         }
-        Self.logger.info("Downloaded pack \(flightId)/\(timestamp): \(downloaded.count) endpoints, \(totalBytes) bytes")
+        Self.logger.info("Downloaded pack \(flightId)/\(timestamp): \(downloaded.count) endpoints, \(diskBytes) bytes")
     }
 
     func deletePack(flightId: String, timestamp: String) async {

--- a/app/flyfun-weather/flyfun-weather/Services/CachingBriefingRepository.swift
+++ b/app/flyfun-weather/flyfun-weather/Services/CachingBriefingRepository.swift
@@ -2,9 +2,10 @@ import Foundation
 import OSLog
 
 /// Download state for a pack.
+/// `totalBytes <= 0` means the size is unknown (server didn't send the length header).
 enum DownloadState: Equatable {
     case notDownloaded
-    case downloading(progress: Double)
+    case downloading(progress: Double, receivedBytes: Int64, totalBytes: Int64)
     case downloaded
     case error(String)
 }
@@ -195,14 +196,19 @@ final class CachingBriefingRepository: BriefingRepository {
         flightTitle: String,
         assessment: String?,
         packMeta: PackMetaResponse? = nil,
-        progress: @Sendable @escaping (Double) -> Void
+        progress: @Sendable @escaping (_ fraction: Double, _ receivedBytes: Int64, _ totalBytes: Int64) -> Void
     ) async throws {
-        progress(0.1)
+        progress(0, 0, 0)
 
-        // Single request fetches everything (gzip-compressed by server)
+        // Single streaming request fetches everything (gzip-compressed by server).
+        // The network transfer is the slow part on poor connections; the percentage
+        // tracks bytes received. The local disk writes below are near-instant.
         let path = "/api/flights/\(flightId)/packs/\(timestamp)/bundle"
-        let data = try await client.requestData(path)
-        progress(0.7)
+        let data = try await client.requestDataStreaming(path) { received, total in
+            let fraction = total > 0 ? min(Double(received) / Double(total), 1.0) : 0
+            progress(fraction, received, total)
+        }
+        let networkBytes = Int64(data.count)
 
         // Parse the bundle: { "endpoint-name": { ... }, ... }
         guard let bundle = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
@@ -212,7 +218,7 @@ final class CachingBriefingRepository: BriefingRepository {
         var totalBytes: Int64 = 0
         var downloaded: Set<String> = []
 
-        for (i, (endpoint, value)) in bundle.enumerated() {
+        for (endpoint, value) in bundle {
             do {
                 let entryData = try JSONSerialization.data(withJSONObject: value)
                 try await cache.writeData(entryData, flightId: flightId, timestamp: timestamp, endpoint: endpoint)
@@ -221,8 +227,8 @@ final class CachingBriefingRepository: BriefingRepository {
             } catch {
                 Self.logger.warning("Failed to cache \(endpoint): \(error)")
             }
-            progress(0.7 + 0.3 * Double(i + 1) / Double(bundle.count))
         }
+        progress(1.0, networkBytes, networkBytes)
 
         await cache.registerDownload(
             flightId: flightId,

--- a/app/flyfun-weather/flyfun-weather/ViewModels/BriefingViewModel.swift
+++ b/app/flyfun-weather/flyfun-weather/ViewModels/BriefingViewModel.swift
@@ -148,7 +148,7 @@ final class BriefingViewModel {
     /// Download the current pack for offline access.
     func downloadCurrentPack() async {
         guard let pack, let caching = repository as? CachingBriefingRepository else { return }
-        downloadState = .downloading(progress: 0)
+        downloadState = .downloading(progress: 0, receivedBytes: 0, totalBytes: 0)
         do {
             try await caching.downloadPack(
                 flightId: flight.id,
@@ -156,9 +156,9 @@ final class BriefingViewModel {
                 flightTitle: flight.shortTitle,
                 assessment: pack.assessment,
                 packMeta: pack
-            ) { [weak self] progress in
+            ) { [weak self] fraction, received, total in
                 Task { @MainActor in
-                    self?.downloadState = .downloading(progress: progress)
+                    self?.downloadState = .downloading(progress: fraction, receivedBytes: received, totalBytes: total)
                 }
             }
             downloadState = .downloaded

--- a/app/flyfun-weather/flyfun-weather/Views/Briefing/BriefingContainerView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Briefing/BriefingContainerView.swift
@@ -23,6 +23,7 @@ struct BriefingContainerView: View {
             if let viewModel {
                 VStack(spacing: 0) {
                     RefreshBannerView(state: viewModel.refreshState)
+                    DownloadBannerView(state: viewModel.downloadState)
                     BriefingContentView(viewModel: viewModel, trackingService: trackingService)
                 }
             } else {
@@ -145,7 +146,7 @@ private struct BriefingToolbarView: View {
                 } label: {
                     Image(systemName: "arrow.down.circle")
                 }
-            case .downloading(let progress):
+            case .downloading(let progress, _, _):
                 ProgressView(value: progress)
                     .progressViewStyle(.circular)
                     .controlSize(.small)
@@ -247,6 +248,67 @@ private struct RefreshBannerView: View {
             .padding(.vertical, 6)
             .background(.red.opacity(0.1))
         }
+    }
+}
+
+/// Banner showing pack download progress (size + percentage) while downloading.
+private struct DownloadBannerView: View {
+    let state: DownloadState
+
+    private static let byteFormatter: ByteCountFormatter = {
+        let f = ByteCountFormatter()
+        f.countStyle = .file
+        f.allowedUnits = [.useKB, .useMB]
+        f.allowsNonnumericFormatting = false  // "0 KB", not "Zero KB"
+        return f
+    }()
+
+    var body: some View {
+        if case .downloading(let progress, let received, let total) = state {
+            // Before any bytes arrive the server is still building the bundle, so
+            // there's nothing to count yet — label that phase "Preparing…".
+            let isPreparing = total <= 0 && received == 0
+            VStack(spacing: 4) {
+                HStack(spacing: 8) {
+                    ProgressView()
+                        .controlSize(.small)
+                    Text(isPreparing ? "Preparing…" : "Downloading…")
+                        .font(.caption.bold())
+                    if let detail = sizeText(received: received, total: total) {
+                        Text(detail)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    Spacer()
+                    if total > 0 {
+                        Text("\(Int(progress * 100))%")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                if total > 0 {
+                    ProgressView(value: progress)
+                        .tint(.accentColor)
+                } else {
+                    ProgressView()
+                        .progressViewStyle(.linear)
+                }
+            }
+            .padding(.horizontal)
+            .padding(.vertical, 6)
+            .background(.regularMaterial)
+        }
+    }
+
+    private func sizeText(received: Int64, total: Int64) -> String? {
+        let f = Self.byteFormatter
+        if total > 0 {
+            return "\(f.string(fromByteCount: received)) / \(f.string(fromByteCount: total))"
+        }
+        if received > 0 {
+            return f.string(fromByteCount: received)
+        }
+        return nil
     }
 }
 

--- a/app/flyfun-weather/flyfun-weather/Views/Briefing/BriefingContainerView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Briefing/BriefingContainerView.swift
@@ -270,8 +270,11 @@ private struct DownloadBannerView: View {
             let isPreparing = total <= 0 && received == 0
             VStack(spacing: 4) {
                 HStack(spacing: 8) {
-                    ProgressView()
-                        .controlSize(.small)
+                    // Spinner only while there's no determinate bar to convey activity.
+                    if total <= 0 {
+                        ProgressView()
+                            .controlSize(.small)
+                    }
                     Text(isPreparing ? "Preparing…" : "Downloading…")
                         .font(.caption.bold())
                     if let detail = sizeText(received: received, total: total) {

--- a/src/weatherbrief/api/packs.py
+++ b/src/weatherbrief/api/packs.py
@@ -2275,10 +2275,16 @@ def get_bundle(
     payload = json.dumps(bundle, separators=(",", ":")).encode()
     compressed = gzip.compress(payload)
 
+    # X-Uncompressed-Length lets the client show accurate download progress:
+    # Content-Length is the compressed size, but URLSession transparently
+    # decompresses, so the client counts decompressed bytes against this total.
     return Response(
         content=compressed,
         media_type="application/json",
-        headers={"Content-Encoding": "gzip"},
+        headers={
+            "Content-Encoding": "gzip",
+            "X-Uncompressed-Length": str(len(payload)),
+        },
     )
 
 


### PR DESCRIPTION
## Summary
- Offline pack download previously made a single buffered request with a hardcoded progress indicator frozen at 10% during the transfer — confusing on slow connections, with no sense of size or "what's happening".
- **Server** (`packs.py`): the `/bundle` endpoint now sends an `X-Uncompressed-Length` header. `Content-Length` reflects the gzip-compressed size, but `URLSession` transparently decompresses, so the client counts decompressed bytes against this total.
- **Client** (`APIClient`): new `requestDataStreaming` streams the response via a per-task `URLSessionDataDelegate`, reporting `(receivedBytes, totalBytes)` as data arrives (throttled to ~128 KB steps).
- **UI** (`BriefingContainerView`): a banner shows **"Preparing…"** while the server builds the bundle (no bytes yet), then **"Downloading… X / Y MB" + %** with a real progress bar once bytes flow. Degrades gracefully (indeterminate bar + downloaded-size) if the size header is absent.

The server and client halves are independent: the server header can deploy to prod on its own, and the iOS app ships separately.

## Notes / follow-ups (not in this PR)
- The dominant "long wait" users hit is likely **server-side bundle generation** — `get_bundle` runs on-the-fly `analyze_sounding` per route-point × model. Byte progress can't mask that; a separate change to reuse cached sounding files / stored `derived_levels` would attack the actual latency.
- `CachingBriefingRepository.flights()` silently serves stale cached flights on a `401` (observed as "had to log out/in to see current flights") — worth a separate fix.

## Test plan
- [x] iOS app builds clean for the simulator (`xcodebuild`, iPhone 17 Pro)
- [x] Server `packs.py` compiles
- [ ] Deploy server header to prod, then confirm the banner shows live % during a real download
- [ ] Verify "Preparing…" → "Downloading… X / Y MB" transition on a throttled connection

🤖 Generated with [Claude Code](https://claude.com/claude-code)