### PR TITLE
Add sounding-profile sidecar to eliminate refresh-time recompute

### DIFF
--- a/designs/architecture.md
+++ b/designs/architecture.md
@@ -246,7 +246,8 @@ data/packs/
             ├── briefing.json           # ForecastSnapshot minus forecasts & cross_sections
             ├── forecasts.json          # Route + metadata + raw forecasts only
             ├── cross_section.json
-            ├── route_analyses.json    # RouteAnalysesManifest
+            ├── route_analyses.json    # RouteAnalysesManifest (derived_levels stripped)
+            ├── sounding_profiles.json.gz # Sidecar: shaped sounding profiles per (point,model); written at refresh from the in-memory manifest so bundle/Skew-T endpoints skip MetPy recompute. Online viewer never loads it. T1-stripped with cross_section.json.
             ├── elevation_profile.json # ElevationProfile (SRTM terrain)
             ├── gramet.pdf             # GRAMET cross-section (PDF)
             ├── skewt/

--- a/src/weatherbrief/api/packs.py
+++ b/src/weatherbrief/api/packs.py
@@ -48,6 +48,11 @@ from flyfun_common.db import current_user_id, get_db, SessionLocal
 from weatherbrief.fetch.freshness import registry as freshness_registry
 from weatherbrief.fetch.model_status import fetch_model_metadata
 from weatherbrief.tasks.artifacts import parse_target_time as _parse_target_time
+from weatherbrief.storage.sounding_profiles import (
+    build_sounding_sidecar,
+    load_or_build_sounding_profile,
+    read_sounding_sidecar,
+)
 from weatherbrief.tasks.route_weather import run_realtime_refresh
 from weatherbrief.models.observations import RefreshDelta, RouteObservations, RouteSigmets
 from weatherbrief.models import (
@@ -2493,19 +2498,19 @@ def get_bundle(
                 bundle[endpoint] = json.loads(path.read_text())
                 break
 
-    # Sounding profiles for every (point, model) combination
-    ra_data = bundle.get("route-analyses")
-    cs_path = pack_dir / "cross_section.json"
-    if ra_data and cs_path.exists():
-        cs_data = json.loads(cs_path.read_text())
-        models = ra_data.get("models", [])
-        analyses = ra_data.get("analyses", [])
-        for point_data in analyses:
-            point_index = point_data["point_index"]
-            for model_name in models:
-                profile = _build_sounding_profile(ra_data, cs_data, point_index, model_name)
-                if profile:
-                    bundle[f"sounding-{point_index}-{model_name}"] = profile.model_dump(mode="json")
+    # Sounding profiles for every (point, model) combination. Prefer the
+    # gzipped sidecar written at refresh time (no MetPy recompute → the slow
+    # "Preparing…" phase vanishes); fall back to building them on the fly for
+    # packs that predate the sidecar.
+    sidecar = read_sounding_sidecar(pack_dir)
+    if sidecar is not None:
+        bundle.update(sidecar)
+    else:
+        ra_data = bundle.get("route-analyses")
+        cs_path = pack_dir / "cross_section.json"
+        if ra_data and cs_path.exists():
+            cs_data = json.loads(cs_path.read_text())
+            bundle.update(build_sounding_sidecar(ra_data, cs_data))
 
     payload = json.dumps(bundle, separators=(",", ":")).encode()
     compressed = gzip.compress(payload)
@@ -2609,249 +2614,6 @@ def get_route_skewt(
     return FileResponse(cache_path, media_type="image/png")
 
 
-class SoundingProfileLevel(BaseModel):
-    """A single pressure level in a sounding profile."""
-    pressure_hpa: int
-    altitude_ft: float | None = None
-    temperature_c: float
-    dewpoint_c: float | None = None
-    wind_speed_kt: float | None = None
-    wind_direction_deg: float | None = None
-    # Extended DerivedLevel fields for side panels
-    relative_humidity_pct: float | None = None
-    dewpoint_depression_c: float | None = None
-    wet_bulb_c: float | None = None
-    theta_e_k: float | None = None
-    lapse_rate_c_per_km: float | None = None
-    icing_index: float | None = None
-    icing_index_nwp: float | None = None
-    sfip_100: float | None = None
-    cloud_liquid_water_g_m3: float | None = None
-    ice_mixing_ratio_g_kg: float | None = None
-    cloud_area_fraction_pct: float | None = None
-    richardson_number: float | None = None
-    omega_pa_s: float | None = None
-    w_fpm: float | None = None
-
-
-class ParcelPathPointResponse(BaseModel):
-    """A single point on the parcel path for CAPE/CIN shading."""
-    pressure_hpa: float
-    temperature_c: float
-
-
-class SoundingProfileResponse(BaseModel):
-    """Sounding profile data for client-side Skew-T rendering (web + iOS)."""
-    point_index: int
-    lat: float
-    lon: float
-    distance_from_origin_nm: float
-    waypoint_icao: str | None = None
-    model: str
-    time: str
-    levels: list[SoundingProfileLevel]
-    cruise_altitude_ft: int | None = None
-    track_deg: float | None = None
-    label: str | None = None
-    # Thermodynamic indices
-    indices: dict | None = None
-    # Parcel path for CAPE/CIN shading
-    parcel_path: list[ParcelPathPointResponse] = Field(default_factory=list)
-    # Overlay data from sounding analysis
-    cloud_layers: list[dict] = Field(default_factory=list)
-    nwp_cloud_layers: list[dict] = Field(default_factory=list)
-    icing_zones: list[dict] = Field(default_factory=list)
-    icing_ogimet_nwp_zones: list[dict] = Field(default_factory=list)
-    sfip_zones: list[dict] = Field(default_factory=list)
-    inversion_layers: list[dict] = Field(default_factory=list)
-    convective: dict | None = None
-
-
-def _build_sounding_profile(
-    ra_data: dict, cs_data: dict, point_index: int, model: str,
-) -> SoundingProfileResponse | None:
-    """Build a SoundingProfileResponse from route analyses and cross-section data.
-
-    Returns None if the point/model combination has no usable data.
-    """
-    from weatherbrief.models import WaypointForecast
-
-    analyses = ra_data.get("analyses", [])
-    point_data = next((a for a in analyses if a["point_index"] == point_index), None)
-    if point_data is None:
-        return None
-
-    cross_sections = cs_data.get("cross_sections", [])
-    cs_match = next((cs for cs in cross_sections if cs["model"] == model), None)
-    if cs_match is None or point_index >= len(cs_match["point_forecasts"]):
-        return None
-
-    wf = WaypointForecast.model_validate(cs_match["point_forecasts"][point_index])
-    interp_time = datetime.fromisoformat(point_data["interpolated_time"])
-    hourly = wf.at_time(interp_time)
-    if not hourly or not hourly.pressure_levels:
-        return None
-
-    sounding_data = point_data.get("sounding", {}).get(model, {})
-
-    # Build a lookup from derived_levels for enriching profile levels.
-    # derived_levels are excluded from route_analyses.json to save space,
-    # so we run analyze_sounding on-the-fly to get the full set.
-    # The result also provides parcel_path as fallback for old packs.
-    derived_by_pressure: dict[int, dict] = {}
-    onthefly_result = None
-    stored_dls = sounding_data.get("derived_levels", [])
-    if stored_dls:
-        for dl in stored_dls:
-            derived_by_pressure[dl.get("pressure_hpa", 0)] = dl
-    else:
-        # On-the-fly sounding analysis (~50-200ms) for icing indices, Ri, etc.
-        try:
-            from weatherbrief.analysis.sounding import analyze_sounding
-            onthefly_result = analyze_sounding(hourly.pressure_levels, hourly)
-            if onthefly_result and onthefly_result.derived_levels:
-                for dl in onthefly_result.derived_levels:
-                    derived_by_pressure[dl.pressure_hpa] = dl.model_dump()
-        except Exception:
-            import logging
-            logging.getLogger(__name__).debug("On-the-fly sounding analysis failed", exc_info=True)
-
-    sorted_levels = sorted(hourly.pressure_levels, key=lambda x: x.pressure_hpa, reverse=True)
-    levels = []
-    prev_alt_ft: float | None = None
-    prev_temp_c: float | None = None
-    for pl in sorted_levels:
-        if pl.temperature_c is None:
-            continue
-        alt_ft = pl.geopotential_height_m * 3.28084 if pl.geopotential_height_m is not None else None
-        dl = derived_by_pressure.get(pl.pressure_hpa, {})
-
-        # Compute basic derived values inline when not available from stored analysis
-        dd = dl.get("dewpoint_depression_c")
-        rh = dl.get("relative_humidity_pct")
-        lapse = dl.get("lapse_rate_c_per_km")
-        if dd is None and pl.dewpoint_c is not None:
-            dd = round(pl.temperature_c - pl.dewpoint_c, 1)
-        if rh is None and pl.relative_humidity_pct is not None:
-            rh = pl.relative_humidity_pct
-        elif rh is None and pl.dewpoint_c is not None:
-            # Magnus formula: RH ≈ 100 × exp(17.67×Td/(Td+243.5) - 17.67×T/(T+243.5))
-            from math import exp
-            try:
-                rh = round(100.0 * exp(
-                    17.67 * pl.dewpoint_c / (pl.dewpoint_c + 243.5)
-                    - 17.67 * pl.temperature_c / (pl.temperature_c + 243.5)
-                ), 1)
-            except Exception:
-                pass
-        if lapse is None and prev_alt_ft is not None and alt_ft is not None and prev_temp_c is not None:
-            dz_km = (alt_ft - prev_alt_ft) / 3280.84
-            if abs(dz_km) > 0.01:
-                lapse = round((prev_temp_c - pl.temperature_c) / dz_km, 1)
-
-        # θe: Bolton (1980) approximation
-        theta_e = dl.get("theta_e_k")
-        if theta_e is None and pl.dewpoint_c is not None:
-            from math import exp as _exp, log as _log
-            try:
-                T_K = pl.temperature_c + 273.15
-                Td_K = pl.dewpoint_c + 273.15
-                # Mixing ratio from dewpoint
-                e = 6.112 * _exp(17.67 * pl.dewpoint_c / (pl.dewpoint_c + 243.5))
-                r = 0.622 * e / (pl.pressure_hpa - e)  # kg/kg
-                # Potential temperature
-                theta = T_K * (1000.0 / pl.pressure_hpa) ** 0.2854
-                # θe ≈ θ × exp(Lv × r / (cp × T))
-                theta_e = round(theta * _exp(2.501e6 * r / (1004.0 * T_K)), 1)
-            except Exception:
-                pass
-
-        # Omega / vertical velocity from raw pressure level data
-        omega = dl.get("omega_pa_s")
-        w_fpm = dl.get("w_fpm")
-        if omega is None and pl.vertical_velocity_pa_s is not None:
-            omega = round(pl.vertical_velocity_pa_s, 3)
-            # Convert omega (Pa/s) to w (ft/min): w ≈ -omega / (ρg) in m/s → ft/min
-            # Using standard density approximation: ρ ≈ p/(Rd×T)
-            if pl.temperature_c is not None:
-                T_K = pl.temperature_c + 273.15
-                rho = (pl.pressure_hpa * 100) / (287.05 * T_K)
-                w_ms = -pl.vertical_velocity_pa_s / (rho * 9.81)
-                w_fpm = round(w_ms * 196.85, 1)  # m/s → ft/min
-
-        # CLW from GRIB (already in kg/kg on PressureLevelData)
-        clw = dl.get("cloud_liquid_water_g_m3")
-        if clw is None and pl.cloud_liquid_water_kg_kg is not None and pl.temperature_c is not None:
-            T_K = pl.temperature_c + 273.15
-            rho = (pl.pressure_hpa * 100) / (287.05 * T_K)
-            clw = round(pl.cloud_liquid_water_kg_kg * rho * 1000, 4)  # kg/kg → g/m³
-
-        # ICE mixing ratio from GRIB
-        ice = dl.get("ice_mixing_ratio_g_kg")
-        if ice is None and pl.ice_mixing_ratio_kg_kg is not None:
-            ice = round(pl.ice_mixing_ratio_kg_kg * 1000, 4)  # kg/kg → g/kg
-
-        levels.append(SoundingProfileLevel(
-            pressure_hpa=pl.pressure_hpa,
-            altitude_ft=alt_ft or dl.get("altitude_ft"),
-            temperature_c=pl.temperature_c,
-            dewpoint_c=pl.dewpoint_c,
-            wind_speed_kt=pl.wind_speed_kt,
-            wind_direction_deg=pl.wind_direction_deg,
-            relative_humidity_pct=rh,
-            dewpoint_depression_c=dd,
-            wet_bulb_c=dl.get("wet_bulb_c"),
-            theta_e_k=theta_e,
-            lapse_rate_c_per_km=lapse,
-            icing_index=dl.get("icing_index"),
-            icing_index_nwp=dl.get("icing_index_nwp"),
-            sfip_100=dl.get("sfip_100"),
-            cloud_liquid_water_g_m3=clw,
-            ice_mixing_ratio_g_kg=ice,
-            cloud_area_fraction_pct=pl.cloud_area_fraction_pct,
-            richardson_number=dl.get("richardson_number"),
-            omega_pa_s=omega,
-            w_fpm=w_fpm,
-        ))
-        prev_alt_ft = alt_ft
-        prev_temp_c = pl.temperature_c
-
-    # Parcel path — from stored data, or fall back to on-the-fly analysis
-    stored_parcel = sounding_data.get("parcel_path", [])
-    if not stored_parcel and onthefly_result and onthefly_result.parcel_path:
-        stored_parcel = [pp.model_dump() for pp in onthefly_result.parcel_path]
-    parcel_path = [
-        ParcelPathPointResponse(pressure_hpa=pp["pressure_hpa"], temperature_c=pp["temperature_c"])
-        for pp in stored_parcel
-    ]
-
-    # Label: waypoint ICAO or name
-    label = point_data.get("waypoint_icao") or point_data.get("waypoint_name")
-
-    return SoundingProfileResponse(
-        point_index=point_index,
-        lat=point_data["lat"],
-        lon=point_data["lon"],
-        distance_from_origin_nm=point_data["distance_from_origin_nm"],
-        waypoint_icao=point_data.get("waypoint_icao"),
-        model=model,
-        time=point_data["interpolated_time"],
-        levels=levels,
-        cruise_altitude_ft=ra_data.get("cruise_altitude_ft"),
-        track_deg=point_data.get("track_deg"),
-        label=label,
-        indices=sounding_data.get("indices"),
-        parcel_path=parcel_path,
-        cloud_layers=sounding_data.get("cloud_layers", []),
-        nwp_cloud_layers=sounding_data.get("nwp_cloud_layers", []) or [],
-        icing_zones=sounding_data.get("icing_zones", []),
-        icing_ogimet_nwp_zones=sounding_data.get("icing_ogimet_nwp_zones", []),
-        sfip_zones=sounding_data.get("sfip_zones", []),
-        inversion_layers=sounding_data.get("inversion_layers", []),
-        convective=sounding_data.get("convective"),
-    )
-
-
 @router.get("/{timestamp}/sounding-profile/{point_index}/{model}")
 def get_sounding_profile(
     flight_id: str, timestamp: str, point_index: int, model: str,
@@ -2872,12 +2634,12 @@ def get_sounding_profile(
         raise HTTPException(status_code=404, detail="Route analyses not available")
     ra_data = json.loads(ra_path.read_text())
 
+    # Cross-section is only needed for the on-the-fly fallback; when the sidecar
+    # is present we serve from it without recompute.
     cs_path = pack_dir / "cross_section.json"
-    if not cs_path.exists():
-        raise HTTPException(status_code=404, detail="Cross-section data not available")
-    cs_data = json.loads(cs_path.read_text())
+    cs_data = json.loads(cs_path.read_text()) if cs_path.exists() else {}
 
-    result = _build_sounding_profile(ra_data, cs_data, point_index, model)
+    result = load_or_build_sounding_profile(pack_dir, ra_data, cs_data, point_index, model)
     if result is None:
         raise HTTPException(status_code=404, detail=f"No sounding data for point {point_index}/{model}")
     return result

--- a/src/weatherbrief/storage/sounding_profiles.py
+++ b/src/weatherbrief/storage/sounding_profiles.py
@@ -19,6 +19,7 @@ import gzip
 import json
 import logging
 from datetime import datetime
+from math import exp
 from pathlib import Path
 
 from pydantic import BaseModel, Field
@@ -137,7 +138,7 @@ def _build_sounding_profile(
                 for dl in onthefly_result.derived_levels:
                     derived_by_pressure[dl.pressure_hpa] = dl.model_dump()
         except Exception:
-            logging.getLogger(__name__).debug("On-the-fly sounding analysis failed", exc_info=True)
+            logger.debug("On-the-fly sounding analysis failed", exc_info=True)
 
     sorted_levels = sorted(hourly.pressure_levels, key=lambda x: x.pressure_hpa, reverse=True)
     levels = []
@@ -159,7 +160,6 @@ def _build_sounding_profile(
             rh = pl.relative_humidity_pct
         elif rh is None and pl.dewpoint_c is not None:
             # Magnus formula: RH ≈ 100 × exp(17.67×Td/(Td+243.5) - 17.67×T/(T+243.5))
-            from math import exp
             try:
                 rh = round(100.0 * exp(
                     17.67 * pl.dewpoint_c / (pl.dewpoint_c + 243.5)
@@ -175,16 +175,15 @@ def _build_sounding_profile(
         # θe: Bolton (1980) approximation
         theta_e = dl.get("theta_e_k")
         if theta_e is None and pl.dewpoint_c is not None:
-            from math import exp as _exp
             try:
                 T_K = pl.temperature_c + 273.15
                 # Mixing ratio from dewpoint
-                e = 6.112 * _exp(17.67 * pl.dewpoint_c / (pl.dewpoint_c + 243.5))
+                e = 6.112 * exp(17.67 * pl.dewpoint_c / (pl.dewpoint_c + 243.5))
                 r = 0.622 * e / (pl.pressure_hpa - e)  # kg/kg
                 # Potential temperature
                 theta = T_K * (1000.0 / pl.pressure_hpa) ** 0.2854
                 # θe ≈ θ × exp(Lv × r / (cp × T))
-                theta_e = round(theta * _exp(2.501e6 * r / (1004.0 * T_K)), 1)
+                theta_e = round(theta * exp(2.501e6 * r / (1004.0 * T_K)), 1)
             except Exception:
                 pass
 
@@ -215,7 +214,7 @@ def _build_sounding_profile(
 
         levels.append(SoundingProfileLevel(
             pressure_hpa=pl.pressure_hpa,
-            altitude_ft=alt_ft or dl.get("altitude_ft"),
+            altitude_ft=alt_ft if alt_ft is not None else dl.get("altitude_ft"),
             temperature_c=pl.temperature_c,
             dewpoint_c=pl.dewpoint_c,
             wind_speed_kt=pl.wind_speed_kt,

--- a/src/weatherbrief/storage/sounding_profiles.py
+++ b/src/weatherbrief/storage/sounding_profiles.py
@@ -1,0 +1,356 @@
+"""Shaped sounding-profile models, builder, and the gzipped pack sidecar.
+
+This module is deliberately neutral: both ``api/packs.py`` (HTTP endpoints) and
+``tasks/artifacts.py`` (refresh-time persistence) import from here, so it must
+not import from either of them (no ``tasks → api`` cycle).
+
+The *sidecar* (``sounding_profiles.json.gz``) is written at refresh time from
+the in-memory route-analyses manifest — which still has ``derived_levels``
+intact, before they are stripped from ``route_analyses.json`` for the online
+viewer. Endpoints read the sidecar instead of recomputing the MetPy sounding
+analysis for every (point × model). When the sidecar is absent (old packs, or
+after T1 retention), callers fall back to :func:`_build_sounding_profile`,
+which recomputes on the fly — so nothing ever hard-depends on the sidecar.
+"""
+
+from __future__ import annotations
+
+import gzip
+import json
+import logging
+from datetime import datetime
+from pathlib import Path
+
+from pydantic import BaseModel, Field
+
+logger = logging.getLogger(__name__)
+
+# Gzipped sidecar holding pre-shaped sounding profiles for every (point, model).
+SIDECAR_FILENAME = "sounding_profiles.json.gz"
+
+
+class SoundingProfileLevel(BaseModel):
+    """A single pressure level in a sounding profile."""
+    pressure_hpa: int
+    altitude_ft: float | None = None
+    temperature_c: float
+    dewpoint_c: float | None = None
+    wind_speed_kt: float | None = None
+    wind_direction_deg: float | None = None
+    # Extended DerivedLevel fields for side panels
+    relative_humidity_pct: float | None = None
+    dewpoint_depression_c: float | None = None
+    wet_bulb_c: float | None = None
+    theta_e_k: float | None = None
+    lapse_rate_c_per_km: float | None = None
+    icing_index: float | None = None
+    icing_index_nwp: float | None = None
+    sfip_100: float | None = None
+    cloud_liquid_water_g_m3: float | None = None
+    ice_mixing_ratio_g_kg: float | None = None
+    cloud_area_fraction_pct: float | None = None
+    richardson_number: float | None = None
+    omega_pa_s: float | None = None
+    w_fpm: float | None = None
+
+
+class ParcelPathPointResponse(BaseModel):
+    """A single point on the parcel path for CAPE/CIN shading."""
+    pressure_hpa: float
+    temperature_c: float
+
+
+class SoundingProfileResponse(BaseModel):
+    """Sounding profile data for client-side Skew-T rendering (web + iOS)."""
+    point_index: int
+    lat: float
+    lon: float
+    distance_from_origin_nm: float
+    waypoint_icao: str | None = None
+    model: str
+    time: str
+    levels: list[SoundingProfileLevel]
+    cruise_altitude_ft: int | None = None
+    track_deg: float | None = None
+    label: str | None = None
+    # Thermodynamic indices
+    indices: dict | None = None
+    # Parcel path for CAPE/CIN shading
+    parcel_path: list[ParcelPathPointResponse] = Field(default_factory=list)
+    # Overlay data from sounding analysis
+    cloud_layers: list[dict] = Field(default_factory=list)
+    nwp_cloud_layers: list[dict] = Field(default_factory=list)
+    icing_zones: list[dict] = Field(default_factory=list)
+    icing_ogimet_nwp_zones: list[dict] = Field(default_factory=list)
+    sfip_zones: list[dict] = Field(default_factory=list)
+    inversion_layers: list[dict] = Field(default_factory=list)
+    convective: dict | None = None
+
+
+def _build_sounding_profile(
+    ra_data: dict, cs_data: dict, point_index: int, model: str,
+) -> SoundingProfileResponse | None:
+    """Build a SoundingProfileResponse from route analyses and cross-section data.
+
+    Returns None if the point/model combination has no usable data.
+
+    When ``ra_data`` still carries ``derived_levels`` (the in-memory manifest at
+    refresh time), no recompute happens. When they have been stripped (the
+    on-disk ``route_analyses.json``), this runs ``analyze_sounding`` on the fly.
+    """
+    from weatherbrief.models import WaypointForecast
+
+    analyses = ra_data.get("analyses", [])
+    point_data = next((a for a in analyses if a["point_index"] == point_index), None)
+    if point_data is None:
+        return None
+
+    cross_sections = cs_data.get("cross_sections", [])
+    cs_match = next((cs for cs in cross_sections if cs["model"] == model), None)
+    if cs_match is None or point_index >= len(cs_match["point_forecasts"]):
+        return None
+
+    wf = WaypointForecast.model_validate(cs_match["point_forecasts"][point_index])
+    interp_time = datetime.fromisoformat(point_data["interpolated_time"])
+    hourly = wf.at_time(interp_time)
+    if not hourly or not hourly.pressure_levels:
+        return None
+
+    sounding_data = point_data.get("sounding", {}).get(model, {})
+
+    # Build a lookup from derived_levels for enriching profile levels.
+    # derived_levels are excluded from route_analyses.json to save space,
+    # so we run analyze_sounding on-the-fly to get the full set.
+    # The result also provides parcel_path as fallback for old packs.
+    derived_by_pressure: dict[int, dict] = {}
+    onthefly_result = None
+    stored_dls = sounding_data.get("derived_levels", [])
+    if stored_dls:
+        for dl in stored_dls:
+            derived_by_pressure[dl.get("pressure_hpa", 0)] = dl
+    else:
+        # On-the-fly sounding analysis (~50-200ms) for icing indices, Ri, etc.
+        try:
+            from weatherbrief.analysis.sounding import analyze_sounding
+            onthefly_result = analyze_sounding(hourly.pressure_levels, hourly)
+            if onthefly_result and onthefly_result.derived_levels:
+                for dl in onthefly_result.derived_levels:
+                    derived_by_pressure[dl.pressure_hpa] = dl.model_dump()
+        except Exception:
+            logging.getLogger(__name__).debug("On-the-fly sounding analysis failed", exc_info=True)
+
+    sorted_levels = sorted(hourly.pressure_levels, key=lambda x: x.pressure_hpa, reverse=True)
+    levels = []
+    prev_alt_ft: float | None = None
+    prev_temp_c: float | None = None
+    for pl in sorted_levels:
+        if pl.temperature_c is None:
+            continue
+        alt_ft = pl.geopotential_height_m * 3.28084 if pl.geopotential_height_m is not None else None
+        dl = derived_by_pressure.get(pl.pressure_hpa, {})
+
+        # Compute basic derived values inline when not available from stored analysis
+        dd = dl.get("dewpoint_depression_c")
+        rh = dl.get("relative_humidity_pct")
+        lapse = dl.get("lapse_rate_c_per_km")
+        if dd is None and pl.dewpoint_c is not None:
+            dd = round(pl.temperature_c - pl.dewpoint_c, 1)
+        if rh is None and pl.relative_humidity_pct is not None:
+            rh = pl.relative_humidity_pct
+        elif rh is None and pl.dewpoint_c is not None:
+            # Magnus formula: RH ≈ 100 × exp(17.67×Td/(Td+243.5) - 17.67×T/(T+243.5))
+            from math import exp
+            try:
+                rh = round(100.0 * exp(
+                    17.67 * pl.dewpoint_c / (pl.dewpoint_c + 243.5)
+                    - 17.67 * pl.temperature_c / (pl.temperature_c + 243.5)
+                ), 1)
+            except Exception:
+                pass
+        if lapse is None and prev_alt_ft is not None and alt_ft is not None and prev_temp_c is not None:
+            dz_km = (alt_ft - prev_alt_ft) / 3280.84
+            if abs(dz_km) > 0.01:
+                lapse = round((prev_temp_c - pl.temperature_c) / dz_km, 1)
+
+        # θe: Bolton (1980) approximation
+        theta_e = dl.get("theta_e_k")
+        if theta_e is None and pl.dewpoint_c is not None:
+            from math import exp as _exp
+            try:
+                T_K = pl.temperature_c + 273.15
+                # Mixing ratio from dewpoint
+                e = 6.112 * _exp(17.67 * pl.dewpoint_c / (pl.dewpoint_c + 243.5))
+                r = 0.622 * e / (pl.pressure_hpa - e)  # kg/kg
+                # Potential temperature
+                theta = T_K * (1000.0 / pl.pressure_hpa) ** 0.2854
+                # θe ≈ θ × exp(Lv × r / (cp × T))
+                theta_e = round(theta * _exp(2.501e6 * r / (1004.0 * T_K)), 1)
+            except Exception:
+                pass
+
+        # Omega / vertical velocity from raw pressure level data
+        omega = dl.get("omega_pa_s")
+        w_fpm = dl.get("w_fpm")
+        if omega is None and pl.vertical_velocity_pa_s is not None:
+            omega = round(pl.vertical_velocity_pa_s, 3)
+            # Convert omega (Pa/s) to w (ft/min): w ≈ -omega / (ρg) in m/s → ft/min
+            # Using standard density approximation: ρ ≈ p/(Rd×T)
+            if pl.temperature_c is not None:
+                T_K = pl.temperature_c + 273.15
+                rho = (pl.pressure_hpa * 100) / (287.05 * T_K)
+                w_ms = -pl.vertical_velocity_pa_s / (rho * 9.81)
+                w_fpm = round(w_ms * 196.85, 1)  # m/s → ft/min
+
+        # CLW from GRIB (already in kg/kg on PressureLevelData)
+        clw = dl.get("cloud_liquid_water_g_m3")
+        if clw is None and pl.cloud_liquid_water_kg_kg is not None and pl.temperature_c is not None:
+            T_K = pl.temperature_c + 273.15
+            rho = (pl.pressure_hpa * 100) / (287.05 * T_K)
+            clw = round(pl.cloud_liquid_water_kg_kg * rho * 1000, 4)  # kg/kg → g/m³
+
+        # ICE mixing ratio from GRIB
+        ice = dl.get("ice_mixing_ratio_g_kg")
+        if ice is None and pl.ice_mixing_ratio_kg_kg is not None:
+            ice = round(pl.ice_mixing_ratio_kg_kg * 1000, 4)  # kg/kg → g/kg
+
+        levels.append(SoundingProfileLevel(
+            pressure_hpa=pl.pressure_hpa,
+            altitude_ft=alt_ft or dl.get("altitude_ft"),
+            temperature_c=pl.temperature_c,
+            dewpoint_c=pl.dewpoint_c,
+            wind_speed_kt=pl.wind_speed_kt,
+            wind_direction_deg=pl.wind_direction_deg,
+            relative_humidity_pct=rh,
+            dewpoint_depression_c=dd,
+            wet_bulb_c=dl.get("wet_bulb_c"),
+            theta_e_k=theta_e,
+            lapse_rate_c_per_km=lapse,
+            icing_index=dl.get("icing_index"),
+            icing_index_nwp=dl.get("icing_index_nwp"),
+            sfip_100=dl.get("sfip_100"),
+            cloud_liquid_water_g_m3=clw,
+            ice_mixing_ratio_g_kg=ice,
+            cloud_area_fraction_pct=pl.cloud_area_fraction_pct,
+            richardson_number=dl.get("richardson_number"),
+            omega_pa_s=omega,
+            w_fpm=w_fpm,
+        ))
+        prev_alt_ft = alt_ft
+        prev_temp_c = pl.temperature_c
+
+    # Parcel path — from stored data, or fall back to on-the-fly analysis
+    stored_parcel = sounding_data.get("parcel_path", [])
+    if not stored_parcel and onthefly_result and onthefly_result.parcel_path:
+        stored_parcel = [pp.model_dump() for pp in onthefly_result.parcel_path]
+    parcel_path = [
+        ParcelPathPointResponse(pressure_hpa=pp["pressure_hpa"], temperature_c=pp["temperature_c"])
+        for pp in stored_parcel
+    ]
+
+    # Label: waypoint ICAO or name
+    label = point_data.get("waypoint_icao") or point_data.get("waypoint_name")
+
+    return SoundingProfileResponse(
+        point_index=point_index,
+        lat=point_data["lat"],
+        lon=point_data["lon"],
+        distance_from_origin_nm=point_data["distance_from_origin_nm"],
+        waypoint_icao=point_data.get("waypoint_icao"),
+        model=model,
+        time=point_data["interpolated_time"],
+        levels=levels,
+        cruise_altitude_ft=ra_data.get("cruise_altitude_ft"),
+        track_deg=point_data.get("track_deg"),
+        label=label,
+        indices=sounding_data.get("indices"),
+        parcel_path=parcel_path,
+        cloud_layers=sounding_data.get("cloud_layers", []),
+        nwp_cloud_layers=sounding_data.get("nwp_cloud_layers", []) or [],
+        icing_zones=sounding_data.get("icing_zones", []),
+        icing_ogimet_nwp_zones=sounding_data.get("icing_ogimet_nwp_zones", []),
+        sfip_zones=sounding_data.get("sfip_zones", []),
+        inversion_layers=sounding_data.get("inversion_layers", []),
+        convective=sounding_data.get("convective"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Sidecar build / read
+# ---------------------------------------------------------------------------
+
+
+def _sounding_key(point_index: int, model: str) -> str:
+    """Bundle/sidecar key for one (point, model) sounding profile."""
+    return f"sounding-{point_index}-{model}"
+
+
+def build_sounding_sidecar(ra_data: dict, cs_data: dict) -> dict[str, dict]:
+    """Build the ``{ "sounding-{pt}-{model}": <profile dict>, ... }`` mapping.
+
+    ``ra_data`` must be the *full* route-analyses dict (``derived_levels``
+    present) so :func:`_build_sounding_profile` does **not** recompute. Keys and
+    value shape are exactly what ``get_bundle`` produces today.
+    """
+    out: dict[str, dict] = {}
+    models = ra_data.get("models", [])
+    analyses = ra_data.get("analyses", [])
+    for point_data in analyses:
+        point_index = point_data["point_index"]
+        for model_name in models:
+            profile = _build_sounding_profile(ra_data, cs_data, point_index, model_name)
+            if profile:
+                out[_sounding_key(point_index, model_name)] = profile.model_dump(mode="json")
+    return out
+
+
+def write_sounding_sidecar(pack_dir: Path, ra_data: dict, cs_data: dict) -> int:
+    """Build and gzip-write the sidecar to *pack_dir*.
+
+    Returns the number of profiles written (0 if there was nothing to write, in
+    which case no file is created). Built from the in-memory manifest — no added
+    MetPy recompute.
+    """
+    sidecar = build_sounding_sidecar(ra_data, cs_data)
+    if not sidecar:
+        return 0
+    payload = json.dumps(sidecar, separators=(",", ":")).encode()
+    (pack_dir / SIDECAR_FILENAME).write_bytes(gzip.compress(payload))
+    return len(sidecar)
+
+
+def read_sounding_sidecar(pack_dir: Path) -> dict | None:
+    """Read and gunzip the sidecar, returning *None* if absent or unreadable."""
+    path = pack_dir / SIDECAR_FILENAME
+    if not path.exists():
+        return None
+    try:
+        return json.loads(gzip.decompress(path.read_bytes()))
+    except Exception:
+        logger.warning("Failed to read sounding sidecar %s — falling back to recompute", path, exc_info=True)
+        return None
+
+
+def load_or_build_sounding_profile(
+    pack_dir: Path,
+    ra_data: dict,
+    cs_data: dict,
+    point_index: int,
+    model: str,
+    *,
+    _sidecar: dict | None = None,
+) -> SoundingProfileResponse | None:
+    """Return one sounding profile, preferring the sidecar over recompute.
+
+    1. If the sidecar is present and holds ``sounding-{pt}-{model}``, validate
+       and return it (no MetPy recompute).
+    2. Otherwise fall back to :func:`_build_sounding_profile` (on-the-fly).
+
+    Pass ``_sidecar`` to reuse an already-gunzipped sidecar across calls within
+    one request.
+    """
+    sidecar = _sidecar if _sidecar is not None else read_sounding_sidecar(pack_dir)
+    if sidecar is not None:
+        entry = sidecar.get(_sounding_key(point_index, model))
+        if entry is not None:
+            return SoundingProfileResponse.model_validate(entry)
+    return _build_sounding_profile(ra_data, cs_data, point_index, model)

--- a/src/weatherbrief/tasks/artifacts.py
+++ b/src/weatherbrief/tasks/artifacts.py
@@ -129,6 +129,36 @@ def save_analysis_artifacts(
             )
         )
 
+        # Sounding-profile sidecar: shaped profiles for every (point, model),
+        # built from the FULL in-memory manifest (derived_levels intact, before
+        # the strip above) plus cross_section.json (already on disk from
+        # save_fetch_artifacts). No added MetPy recompute. Endpoints read this
+        # instead of recomputing, killing the multi-second offline-pack
+        # "Preparing…" stall (issue #188). The online viewer never loads it.
+        _write_sounding_sidecar(pack_dir, route_analyses_manifest)
+
+
+def _write_sounding_sidecar(pack_dir: Path, manifest: RouteAnalysesManifest) -> None:
+    """Build and write ``sounding_profiles.json.gz`` from the in-memory manifest.
+
+    Best-effort: a failure here must never fail the refresh — the endpoints
+    transparently fall back to on-the-fly recompute when the sidecar is absent.
+    """
+    cs_path = pack_dir / "cross_section.json"
+    if not cs_path.exists():
+        return
+    try:
+        from weatherbrief.storage.sounding_profiles import write_sounding_sidecar
+
+        # Dump WITHOUT the derived_levels exclude so _build_sounding_profile
+        # finds them present and does not recompute.
+        ra_full = json.loads(manifest.model_dump_json())
+        cs_data = json.loads(cs_path.read_text())
+        count = write_sounding_sidecar(pack_dir, ra_full, cs_data)
+        logger.debug("Wrote sounding sidecar with %d profiles to %s", count, pack_dir)
+    except Exception:
+        logger.warning("Failed to write sounding sidecar to %s", pack_dir, exc_info=True)
+
 
 def save_advisory_artifacts(
     pack_dir: Path,

--- a/src/weatherbrief/tasks/artifacts.py
+++ b/src/weatherbrief/tasks/artifacts.py
@@ -151,8 +151,10 @@ def _write_sounding_sidecar(pack_dir: Path, manifest: RouteAnalysesManifest) -> 
         from weatherbrief.storage.sounding_profiles import write_sounding_sidecar
 
         # Dump WITHOUT the derived_levels exclude so _build_sounding_profile
-        # finds them present and does not recompute.
-        ra_full = json.loads(manifest.model_dump_json())
+        # finds them present and does not recompute. mode="json" yields a dict
+        # with JSON-compatible types (datetime → ISO string) and skips the lossy
+        # serialise-then-parse float round-trip.
+        ra_full = manifest.model_dump(mode="json")
         cs_data = json.loads(cs_path.read_text())
         count = write_sounding_sidecar(pack_dir, ra_full, cs_data)
         logger.debug("Wrote sounding sidecar with %d profiles to %s", count, pack_dir)

--- a/src/weatherbrief/tasks/retention.py
+++ b/src/weatherbrief/tasks/retention.py
@@ -31,7 +31,16 @@ logger = logging.getLogger(__name__)
 
 # Files / directories removed during T1.  Everything else in the pack dir
 # is kept (briefing.json, route_analyses.json, advisories, digest, etc.).
-_HEAVY_FILES = ("cross_section.json", "forecasts.json", "gramet.pdf", "gramet.png")
+# sounding_profiles.json.gz is derived from cross_section.json and the
+# on-the-fly fallback also needs cross_section.json — so the sidecar must die
+# in the same T1 sweep that strips cross_section.json, not linger to T2.
+_HEAVY_FILES = (
+    "cross_section.json",
+    "forecasts.json",
+    "gramet.pdf",
+    "gramet.png",
+    "sounding_profiles.json.gz",
+)
 _HEAVY_DIRS = ("skewt",)
 
 

--- a/tests/test_retention.py
+++ b/tests/test_retention.py
@@ -53,6 +53,9 @@ def _make_pack_dir(tmp_path: Path, *, heavy: bool = True) -> Path:
         (pack_dir / "forecasts.json").write_bytes(b"x" * 2_000)
         (pack_dir / "gramet.pdf").write_bytes(b"%PDF" + b"x" * 5_000)
         (pack_dir / "gramet.png").write_bytes(b"\x89PNG" + b"x" * 3_000)
+        # Sounding-profile sidecar — derived from cross_section.json, so it must
+        # be stripped in the same T1 sweep (issue #188).
+        (pack_dir / "sounding_profiles.json.gz").write_bytes(b"\x1f\x8b" + b"x" * 4_000)
 
         skewt = pack_dir / "skewt" / "route"
         skewt.mkdir(parents=True)
@@ -158,6 +161,7 @@ class TestPurgeHeavyArtifacts:
         assert not (pack_dir / "forecasts.json").exists()
         assert not (pack_dir / "gramet.pdf").exists()
         assert not (pack_dir / "gramet.png").exists()
+        assert not (pack_dir / "sounding_profiles.json.gz").exists()
         assert not (pack_dir / "skewt").exists()
         # Light files preserved
         assert (pack_dir / "briefing.json").exists()

--- a/tests/test_sounding_sidecar.py
+++ b/tests/test_sounding_sidecar.py
@@ -1,0 +1,263 @@
+"""Tests for the sounding-profile sidecar (issue #188).
+
+The sidecar (``sounding_profiles.json.gz``) is written at refresh time from the
+in-memory route-analyses manifest (``derived_levels`` intact) so the bundle /
+sounding-profile endpoints don't recompute MetPy soundings on every request.
+
+The contract: serving from the sidecar must be value-identical to recomputing
+on the fly, and every read path must fall back to recompute when the sidecar is
+absent (backward compatibility for old packs and post-T1 packs).
+"""
+
+from __future__ import annotations
+
+import gzip
+import json
+from datetime import datetime, timezone
+
+import pytest
+
+from weatherbrief.analysis.sounding import analyze_sounding
+from weatherbrief.models import (
+    ForecastSnapshot,
+    HourlyForecast,
+    RouteConfig,
+    RouteCrossSection,
+    RoutePoint,
+    RoutePointAnalysis,
+    RouteAnalysesManifest,
+    WaypointForecast,
+    Waypoint,
+)
+from weatherbrief.storage.sounding_profiles import (
+    SIDECAR_FILENAME,
+    _build_sounding_profile,
+    build_sounding_sidecar,
+    load_or_build_sounding_profile,
+    read_sounding_sidecar,
+    write_sounding_sidecar,
+)
+from weatherbrief.tasks.artifacts import save_analysis_artifacts, save_fetch_artifacts
+
+
+_MODEL = "gfs"
+_T0 = datetime(2026, 6, 1, 12, 0, tzinfo=timezone.utc)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — build a realistic single-point, single-model pack
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def hourly(sample_pressure_levels_with_omega) -> HourlyForecast:
+    """An HourlyForecast carrying a full pressure-level profile."""
+    return HourlyForecast(
+        time=_T0,
+        temperature_2m_c=12.0,
+        dewpoint_2m_c=8.0,
+        cloud_cover_pct=40.0,
+        pressure_levels=sample_pressure_levels_with_omega,
+    )
+
+
+@pytest.fixture
+def manifest(hourly) -> RouteAnalysesManifest:
+    """RouteAnalysesManifest with one point whose sounding has derived_levels.
+
+    The sounding is produced by the *real* analyze_sounding so the stored
+    derived_levels match what the on-the-fly fallback would recompute — that's
+    what makes the sidecar-vs-fallback equality meaningful.
+    """
+    analysis = analyze_sounding(hourly.pressure_levels, hourly)
+    assert analysis is not None and analysis.derived_levels, "expected derived_levels"
+
+    point = RoutePointAnalysis(
+        point_index=0,
+        lat=51.8361,
+        lon=-1.32,
+        distance_from_origin_nm=0.0,
+        waypoint_icao="EGTK",
+        waypoint_name="Oxford Kidlington",
+        interpolated_time=_T0,
+        forecast_hour=_T0,
+        track_deg=120.0,
+        sounding={_MODEL: analysis},
+    )
+    return RouteAnalysesManifest(
+        route_name="Test",
+        target_date="2026-06-01",
+        departure_time=_T0,
+        flight_duration_hours=2.0,
+        total_distance_nm=100.0,
+        cruise_altitude_ft=8000,
+        models=[_MODEL],
+        analyses=[point],
+    )
+
+
+@pytest.fixture
+def cross_sections(hourly) -> list[RouteCrossSection]:
+    wp = Waypoint(icao="EGTK", name="Oxford Kidlington", lat=51.8361, lon=-1.32)
+    wf = WaypointForecast(waypoint=wp, model=_MODEL, fetched_at=_T0, hourly=[hourly])
+    rp = RoutePoint(lat=51.8361, lon=-1.32, distance_from_origin_nm=0.0, waypoint_icao="EGTK")
+    return [RouteCrossSection(model=_MODEL, route_points=[rp], fetched_at=_T0, point_forecasts=[wf])]
+
+
+@pytest.fixture
+def snapshot(cross_sections) -> ForecastSnapshot:
+    route = RouteConfig(
+        name="Test",
+        waypoints=[
+            Waypoint(icao="EGTK", name="Oxford Kidlington", lat=51.8361, lon=-1.32),
+            Waypoint(icao="LFPB", name="Paris Le Bourget", lat=48.9694, lon=2.4414),
+        ],
+        cruise_altitude_ft=8000,
+        flight_duration_hours=2.0,
+    )
+    return ForecastSnapshot(
+        route=route,
+        target_date="2026-06-01",
+        fetch_date="2026-05-29",
+        days_out=3,
+        departure_time=_T0,
+        cross_sections=cross_sections,
+    )
+
+
+@pytest.fixture
+def pack_dir(tmp_path, snapshot, manifest, cross_sections):
+    """A written pack dir: fetch + analysis artifacts, including the sidecar."""
+    pd = tmp_path / "pack"
+    save_fetch_artifacts(pd, cross_sections, None, cross_sections[0].route_points)
+    save_analysis_artifacts(pd, snapshot, manifest)
+    return pd
+
+
+# ---------------------------------------------------------------------------
+# Sidecar is written at refresh time
+# ---------------------------------------------------------------------------
+
+
+def test_refresh_writes_sidecar(pack_dir):
+    sidecar_path = pack_dir / SIDECAR_FILENAME
+    assert sidecar_path.exists(), "save_analysis_artifacts should write the sidecar"
+
+    sidecar = json.loads(gzip.decompress(sidecar_path.read_bytes()))
+    # One (point, model) combination -> one entry.
+    assert "sounding-0-gfs" in sidecar
+    assert sidecar["sounding-0-gfs"]["model"] == _MODEL
+    assert sidecar["sounding-0-gfs"]["levels"], "profile should have levels"
+
+
+def test_sidecar_built_without_recompute(monkeypatch, pack_dir, snapshot, manifest, cross_sections):
+    """The refresh-time build must NOT call analyze_sounding (no MetPy recompute)."""
+    import weatherbrief.analysis.sounding as snd
+
+    def _boom(*a, **k):
+        raise AssertionError("analyze_sounding must not run when derived_levels are present")
+
+    # _build_sounding_profile does `from weatherbrief.analysis.sounding import
+    # analyze_sounding` at call time, so patch the source module attribute.
+    monkeypatch.setattr(snd, "analyze_sounding", _boom)
+    # Re-build straight from the in-memory manifest (derived_levels present).
+    ra_full = json.loads(manifest.model_dump_json())
+    cs_data = {"cross_sections": [cs.model_dump(mode="json") for cs in cross_sections]}
+    out = build_sounding_sidecar(ra_full, cs_data)
+    assert "sounding-0-gfs" in out
+
+
+# ---------------------------------------------------------------------------
+# Sidecar vs on-the-fly fallback equality
+# ---------------------------------------------------------------------------
+
+
+def test_sounding_profile_sidecar_equals_fallback(pack_dir):
+    """get_sounding_profile: sidecar result == recompute result, value-identical."""
+    ra_data = json.loads((pack_dir / "route_analyses.json").read_text())
+    cs_data = json.loads((pack_dir / "cross_section.json").read_text())
+
+    # 1. Served from the sidecar (present).
+    from_sidecar = load_or_build_sounding_profile(pack_dir, ra_data, cs_data, 0, _MODEL)
+    assert from_sidecar is not None
+
+    # 2. Force the fallback by deleting the sidecar.
+    (pack_dir / SIDECAR_FILENAME).unlink()
+    assert read_sounding_sidecar(pack_dir) is None
+    from_fallback = load_or_build_sounding_profile(pack_dir, ra_data, cs_data, 0, _MODEL)
+    assert from_fallback is not None
+
+    assert from_sidecar.model_dump() == from_fallback.model_dump()
+
+
+def test_bundle_sidecar_equals_fallback(pack_dir):
+    """get_bundle sounding entries: sidecar == on-the-fly build, per key."""
+    ra_data = json.loads((pack_dir / "route_analyses.json").read_text())
+    cs_data = json.loads((pack_dir / "cross_section.json").read_text())
+
+    sidecar = read_sounding_sidecar(pack_dir)
+    assert sidecar is not None
+
+    fallback = build_sounding_sidecar(ra_data, cs_data)
+
+    assert set(sidecar) == set(fallback)
+    for key in sidecar:
+        assert sidecar[key] == fallback[key], f"mismatch for {key}"
+
+
+# ---------------------------------------------------------------------------
+# Backward compatibility — no sidecar
+# ---------------------------------------------------------------------------
+
+
+def test_pack_without_sidecar_still_serves(pack_dir):
+    """A pack with no sidecar (old packs) recomputes and still returns data."""
+    (pack_dir / SIDECAR_FILENAME).unlink()
+    ra_data = json.loads((pack_dir / "route_analyses.json").read_text())
+    cs_data = json.loads((pack_dir / "cross_section.json").read_text())
+
+    result = load_or_build_sounding_profile(pack_dir, ra_data, cs_data, 0, _MODEL)
+    assert result is not None
+    assert result.levels
+
+
+def test_post_t1_no_cross_section_returns_none(pack_dir):
+    """After T1 (sidecar + cross_section.json stripped) recompute yields None."""
+    (pack_dir / SIDECAR_FILENAME).unlink()
+    (pack_dir / "cross_section.json").unlink()
+    ra_data = json.loads((pack_dir / "route_analyses.json").read_text())
+
+    # No sidecar, no cross-section -> nothing to build from.
+    result = load_or_build_sounding_profile(pack_dir, ra_data, {}, 0, _MODEL)
+    assert result is None
+
+
+def test_route_analyses_strips_derived_levels(pack_dir):
+    """The lightweight route_analyses.json must NOT carry derived_levels."""
+    ra_data = json.loads((pack_dir / "route_analyses.json").read_text())
+    sounding = ra_data["analyses"][0]["sounding"][_MODEL]
+    assert not sounding.get("derived_levels"), "derived_levels must stay stripped on disk"
+
+
+# ---------------------------------------------------------------------------
+# write_sounding_sidecar edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_write_sidecar_returns_count(tmp_path, manifest, cross_sections):
+    pd = tmp_path / "pack"
+    pd.mkdir()
+    ra_full = json.loads(manifest.model_dump_json())
+    cs_data = {"cross_sections": [cs.model_dump(mode="json") for cs in cross_sections]}
+    count = write_sounding_sidecar(pd, ra_full, cs_data)
+    assert count == 1
+    assert (pd / SIDECAR_FILENAME).exists()
+
+
+def test_write_sidecar_empty_writes_nothing(tmp_path):
+    pd = tmp_path / "pack"
+    pd.mkdir()
+    # No analyses -> no profiles -> no file.
+    count = write_sounding_sidecar(pd, {"models": [], "analyses": []}, {"cross_sections": []})
+    assert count == 0
+    assert not (pd / SIDECAR_FILENAME).exists()


### PR DESCRIPTION
## Summary

Introduces a gzipped sidecar (`sounding_profiles.json.gz`) written at refresh time containing pre-shaped sounding profiles for every (point, model) combination. This eliminates the multi-second MetPy recompute that currently stalls the "Preparing…" phase when serving offline packs via `get_bundle` and `get_sounding_profile` endpoints.

## Key Changes

- **New module `src/weatherbrief/storage/sounding_profiles.py`**: Neutral storage layer (no `api` ↔ `tasks` cycle) containing:
  - `SoundingProfileLevel`, `ParcelPathPointResponse`, `SoundingProfileResponse` models (moved from `api/packs.py`)
  - `_build_sounding_profile()` function (moved from `api/packs.py`, enhanced with on-the-fly fallback)
  - `build_sounding_sidecar()`, `write_sounding_sidecar()`, `read_sounding_sidecar()`, `load_or_build_sounding_profile()` for sidecar lifecycle

- **Refresh-time write** (`tasks/artifacts.py`):
  - `save_analysis_artifacts()` now calls `_write_sounding_sidecar()` after stripping `derived_levels` from the on-disk manifest
  - Sidecar is built from the full in-memory manifest (with `derived_levels` intact) — no MetPy recompute at refresh time

- **Read paths** (`api/packs.py`):
  - `get_bundle()` now prefers the sidecar over on-the-fly build; falls back to `build_sounding_sidecar()` for old packs
  - `get_sounding_profile()` uses `load_or_build_sounding_profile()` to serve from sidecar or recompute as needed

- **Retention** (`tasks/retention.py`):
  - `sounding_profiles.json.gz` added to `_HEAVY_FILES` — stripped at T1 alongside `cross_section.json` (both are needed for the on-the-fly fallback)

- **Documentation** (`designs/architecture.md`):
  - Updated pack directory structure to document the sidecar

## Implementation Details

- **Backward compatibility**: Endpoints transparently fall back to on-the-fly `analyze_sounding()` when the sidecar is absent (old packs, post-T1 retention). Nothing hard-depends on the sidecar.
- **No recompute at refresh**: The sidecar is built from the in-memory manifest before `derived_levels` are stripped, so `_build_sounding_profile()` finds them present and skips the expensive MetPy analysis.
- **Fallback recompute**: When the sidecar is missing and `derived_levels` are not in the stored manifest, `_build_sounding_profile()` runs `analyze_sounding()` on the fly (~50–200ms per profile) to populate icing indices, Richardson number, etc.
- **Comprehensive test coverage** (`tests/test_sounding_sidecar.py`): Validates sidecar write, sidecar-vs-fallback equality, backward compatibility, and edge cases.

https://claude.ai/code/session_014E6Nzzy3dzsX17zKq3APv6