### PR TITLE
feat(metoffice): Met Office surface-pressure charts as a 2nd front source

### DIFF
--- a/alembic/versions/062_pack_metoffice_charts.py
+++ b/alembic/versions/062_pack_metoffice_charts.py
@@ -1,0 +1,61 @@
+"""Add Met Office surface-pressure chart reference fields to briefing_packs.
+
+Mirror of migration 052 (DWD charts) for the second front-chart source:
+  - metoffice_charts_run_cycle: e.g. "2026-05-29T00Z" — the Met Office run
+    this briefing was generated against. NULL when section is unavailable.
+  - metoffice_charts_default_id: "ana" / "012" / "024" / "036" / "048" /
+    "060" / "072" / "084" — chart whose valid time best brackets ETD.
+  - metoffice_charts_in_coverage: route falls inside the Europe chart frame.
+  - metoffice_charts_within_horizon: ETD <= run_cycle + 84h at briefing time.
+
+Bytes live in the shared ``DATA_DIR/metoffice_charts/<run_cycle>/`` cache.
+
+Revision ID: 062
+Revises: 061
+Create Date: 2026-05-29
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "062"
+down_revision: Union[str, None] = "061"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("briefing_packs") as batch_op:
+        batch_op.add_column(
+            sa.Column("metoffice_charts_run_cycle", sa.String(32), nullable=True),
+        )
+        batch_op.add_column(
+            sa.Column("metoffice_charts_default_id", sa.String(8), nullable=True),
+        )
+        batch_op.add_column(
+            sa.Column(
+                "metoffice_charts_in_coverage",
+                sa.Boolean(),
+                nullable=False,
+                server_default="0",
+            ),
+        )
+        batch_op.add_column(
+            sa.Column(
+                "metoffice_charts_within_horizon",
+                sa.Boolean(),
+                nullable=False,
+                server_default="0",
+            ),
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("briefing_packs") as batch_op:
+        batch_op.drop_column("metoffice_charts_within_horizon")
+        batch_op.drop_column("metoffice_charts_in_coverage")
+        batch_op.drop_column("metoffice_charts_default_id")
+        batch_op.drop_column("metoffice_charts_run_cycle")

--- a/src/weatherbrief/api/packs.py
+++ b/src/weatherbrief/api/packs.py
@@ -340,6 +340,14 @@ class PackMetaResponse(BaseModel):
     dwd_charts_default_id: str | None = None
     dwd_charts_in_coverage: bool = False
     dwd_charts_within_horizon: bool = False
+    # Met Office surface-pressure charts — second front-chart source.
+    # ``metoffice_charts_public`` is env-derived (same for all users); the
+    # frontend shows the source toggle when (admin OR this flag).
+    metoffice_charts_run_cycle: str | None = None
+    metoffice_charts_default_id: str | None = None
+    metoffice_charts_in_coverage: bool = False
+    metoffice_charts_within_horizon: bool = False
+    metoffice_charts_public: bool = False
 
 
 def _meta_to_response(
@@ -371,6 +379,11 @@ def _meta_to_response(
         dwd_charts_default_id=meta.dwd_charts_default_id,
         dwd_charts_in_coverage=meta.dwd_charts_in_coverage,
         dwd_charts_within_horizon=meta.dwd_charts_within_horizon,
+        metoffice_charts_run_cycle=meta.metoffice_charts_run_cycle,
+        metoffice_charts_default_id=meta.metoffice_charts_default_id,
+        metoffice_charts_in_coverage=meta.metoffice_charts_in_coverage,
+        metoffice_charts_within_horizon=meta.metoffice_charts_within_horizon,
+        metoffice_charts_public=_metoffice_public(),
     )
 
 
@@ -1127,6 +1140,10 @@ def _build_pack_meta(
         dwd_charts_default_id=result.dwd_charts_default_id,
         dwd_charts_in_coverage=result.dwd_charts_in_coverage,
         dwd_charts_within_horizon=result.dwd_charts_within_horizon,
+        metoffice_charts_run_cycle=result.metoffice_charts_run_cycle,
+        metoffice_charts_default_id=result.metoffice_charts_default_id,
+        metoffice_charts_in_coverage=result.metoffice_charts_in_coverage,
+        metoffice_charts_within_horizon=result.metoffice_charts_within_horizon,
     )
 
 
@@ -3069,6 +3086,115 @@ def get_dwd_chart_overlay(
     if not waypoints:
         # No briefing.json or no waypoints in it — pack predates the
         # split-storage era. Section will just render without the overlay.
+        raise HTTPException(
+            status_code=404, detail="No waypoints available for overlay",
+        )
+
+    overlay = build_route_overlay(waypoints)
+    return JSONResponse(
+        content=overlay,
+        headers={"Cache-Control": "public, max-age=3600"},
+    )
+
+
+def _metoffice_public() -> bool:
+    """Env-flag: is the Met Office source released to non-admin users yet?"""
+    from weatherbrief.fetch.metoffice_charts import public_enabled
+    return public_enabled()
+
+
+def _metoffice_charts_allowed(request: Request, db: Session) -> bool:
+    """Gate: Met Office charts are admin-only until ``METOFFICE_CHARTS_PUBLIC=1``.
+
+    Returns True if the public flag is set, or the caller is an admin (dev
+    mode counts as admin). The caller must already be authenticated.
+    """
+    if _metoffice_public():
+        return True
+    try:
+        from weatherbrief.api.admin import require_admin
+        require_admin(request, db=db)
+        return True
+    except HTTPException:
+        return False
+
+
+@router.get("/{timestamp}/metoffice-chart/{chart_id}")
+def get_metoffice_chart(
+    flight_id: str,
+    timestamp: str,
+    chart_id: str,
+    request: Request,
+    user_id: str = Depends(current_user_id),
+    db: Session = Depends(get_db),
+):
+    """Serve a Met Office surface-pressure chart GIF for this pack.
+
+    Mirror of :func:`get_dwd_chart` against the
+    ``DATA_DIR/metoffice_charts/<run_cycle>/`` cache. Gated to admins until
+    ``METOFFICE_CHARTS_PUBLIC=1`` (Met Office reuse authorisation pending).
+    Returns 410 (Gone) when the cache has been evicted.
+    """
+    from weatherbrief.fetch.metoffice_charts import CHART_IDS, resolve_chart_path
+
+    if not _metoffice_charts_allowed(request, db):
+        raise HTTPException(status_code=403, detail="Met Office charts not available")
+    if chart_id not in CHART_IDS:
+        raise HTTPException(status_code=400, detail="Invalid chart id")
+
+    _load_flight_or_404(db, flight_id, viewer_id=user_id)
+    meta = _load_pack_meta_or_404(db, flight_id, timestamp)
+
+    if not meta.metoffice_charts_run_cycle:
+        raise HTTPException(
+            status_code=404, detail="Met Office charts not available for this pack",
+        )
+
+    data_dir = Path(os.environ.get("DATA_DIR", "data"))
+    path = resolve_chart_path(data_dir, meta.metoffice_charts_run_cycle, chart_id)
+    if path is None:
+        raise HTTPException(status_code=410, detail="Chart no longer cached")
+
+    return FileResponse(
+        path,
+        media_type="image/gif",
+        headers={"Cache-Control": "public, max-age=3600"},
+    )
+
+
+@router.get("/{timestamp}/metoffice-chart-overlay")
+def get_metoffice_chart_overlay(
+    flight_id: str,
+    timestamp: str,
+    request: Request,
+    user_id: str = Depends(current_user_id),
+    db: Session = Depends(get_db),
+):
+    """Compute the route-overlay JSON for the Met Office chart section.
+
+    Mirror of :func:`get_dwd_chart_overlay`. Returns ``{}`` (200) when the
+    chart isn't calibrated, so the frontend renders the chart without an
+    overlay rather than erroring. Same admin/flag gate as the chart bytes.
+    """
+    from weatherbrief.fetch.metoffice_charts import build_route_overlay
+
+    if not _metoffice_charts_allowed(request, db):
+        raise HTTPException(status_code=403, detail="Met Office charts not available")
+
+    pack_dir = _get_pack_dir(db, flight_id, timestamp, viewer_id=user_id)
+
+    waypoints: list[tuple[str, float, float]] = []
+    briefing_path = pack_dir / "briefing.json"
+    if briefing_path.exists():
+        try:
+            data = json_mod.loads(briefing_path.read_text())
+            for wp in (data.get("route") or {}).get("waypoints") or []:
+                if "icao" in wp and "lat" in wp and "lon" in wp:
+                    waypoints.append((wp["icao"], float(wp["lat"]), float(wp["lon"])))
+        except (json_mod.JSONDecodeError, OSError, TypeError, ValueError):
+            logger.warning("Failed to parse briefing.json for MO overlay", exc_info=True)
+
+    if not waypoints:
         raise HTTPException(
             status_code=404, detail="No waypoints available for overlay",
         )

--- a/src/weatherbrief/api/packs.py
+++ b/src/weatherbrief/api/packs.py
@@ -3153,7 +3153,9 @@ def get_metoffice_chart(
     data_dir = Path(os.environ.get("DATA_DIR", "data"))
     path = resolve_chart_path(data_dir, meta.metoffice_charts_run_cycle, chart_id)
     if path is None:
-        raise HTTPException(status_code=410, detail="Chart no longer cached")
+        # Either never fetched for this run (a 00Z run may omit +72h/+84h)
+        # or evicted from the cache. Frontend renders a placeholder.
+        raise HTTPException(status_code=410, detail="Chart not available")
 
     return FileResponse(
         path,

--- a/src/weatherbrief/db/models.py
+++ b/src/weatherbrief/db/models.py
@@ -239,6 +239,16 @@ class BriefingPackRow(Base):
     dwd_charts_within_horizon: Mapped[bool] = mapped_column(
         Boolean, default=False, server_default="0",
     )
+    # Met Office surface-pressure charts — second front-chart source.
+    # Bytes live in DATA_DIR/metoffice_charts/<run_cycle>/.
+    metoffice_charts_run_cycle: Mapped[str | None] = mapped_column(String(32), nullable=True)
+    metoffice_charts_default_id: Mapped[str | None] = mapped_column(String(8), nullable=True)
+    metoffice_charts_in_coverage: Mapped[bool] = mapped_column(
+        Boolean, default=False, server_default="0",
+    )
+    metoffice_charts_within_horizon: Mapped[bool] = mapped_column(
+        Boolean, default=False, server_default="0",
+    )
     integrity_hmac: Mapped[str | None] = mapped_column(String(64), nullable=True)
 
     flight: Mapped[FlightRow] = relationship(back_populates="packs")

--- a/src/weatherbrief/fetch/metoffice_calibrate.py
+++ b/src/weatherbrief/fetch/metoffice_calibrate.py
@@ -1,0 +1,204 @@
+"""Calibrate the Met Office surface-pressure chart projection.
+
+The colour charts carry no lat/lon graticule, so georeferencing is done by
+clicking a handful of recognisable geographic features (coastline tips,
+island centres, well-known points) on the 800x540 image, recording their
+pixel coordinates, and fitting a 2D projective homography on top of a
+polar-stereographic projection.
+
+Workflow
+--------
+1. Open ``FSXX00T_00.gif`` (the +0h analysis) in an image viewer that shows
+   pixel coordinates (Preview's "Tools > Show Inspector", GIMP pointer
+   readout, or any browser dev-tools hover). Pixel origin is top-left,
+   x right, y down.
+2. For 6-10 well-spread features, record ``(name, lon, lat, x, y)``. Spread
+   them to the corners + centre; more points = a more honest residual.
+3. Write them to a JSON file (see ``--example``) and run::
+
+       python -m weatherbrief.fetch.metoffice_calibrate points.json
+
+   It fits the homography for the default projection, prints per-point
+   residuals + max/RMS error, and the 8-tuple to paste into
+   ``_CHART_CALIBRATIONS["colour"]["homography"]`` in metoffice_charts.py.
+4. If residuals are large (> a few px), sweep the projection origin::
+
+       python -m weatherbrief.fetch.metoffice_calibrate points.json --sweep
+
+   and copy the winning ``proj`` block too.
+
+A homography needs >= 4 points (8 equations); use more for a meaningful
+residual. The same math produced the DWD calibrations.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass
+class ControlPoint:
+    name: str
+    lon: float
+    lat: float
+    x: float
+    y: float
+
+
+@dataclass
+class FitResult:
+    proj: dict
+    homography: tuple[float, ...]
+    residuals: list[tuple[str, float]]  # (name, pixel error)
+    max_error: float
+    rms_error: float
+
+
+def load_points(path: Path) -> list[ControlPoint]:
+    raw = json.loads(path.read_text())
+    points = raw["points"] if isinstance(raw, dict) and "points" in raw else raw
+    out: list[ControlPoint] = []
+    for i, p in enumerate(points):
+        out.append(
+            ControlPoint(
+                name=str(p.get("name", f"pt{i}")),
+                lon=float(p["lon"]),
+                lat=float(p["lat"]),
+                x=float(p["x"]),
+                y=float(p["y"]),
+            )
+        )
+    if len(out) < 4:
+        raise ValueError(f"need >= 4 control points to fit a homography, got {len(out)}")
+    return out
+
+
+def fit_homography(points: list[ControlPoint], proj_params: dict) -> FitResult:
+    """Fit an 8-coef homography (lon/lat -> pixel) for a given projection.
+
+    Projects each point with pyproj, then solves the linear DLT system for
+    the projective transform that best maps projected metres to pixels.
+    """
+    import numpy as np
+    import pyproj
+
+    proj = pyproj.Proj(**proj_params)
+
+    rows: list[list[float]] = []
+    rhs: list[float] = []
+    projected: list[tuple[float, float]] = []
+    for p in points:
+        X, Y = proj(p.lon, p.lat)
+        projected.append((X, Y))
+        # px = (aX + bY + c) / (gX + hY + 1)
+        rows.append([X, Y, 1, 0, 0, 0, -p.x * X, -p.x * Y])
+        rhs.append(p.x)
+        # py = (dX + eY + f) / (gX + hY + 1)
+        rows.append([0, 0, 0, X, Y, 1, -p.y * X, -p.y * Y])
+        rhs.append(p.y)
+
+    A = np.array(rows, dtype=float)
+    b = np.array(rhs, dtype=float)
+    coef, *_ = np.linalg.lstsq(A, b, rcond=None)
+    a, bb, c, d, e, f, g, h = (float(v) for v in coef)
+
+    residuals: list[tuple[str, float]] = []
+    sq = 0.0
+    for p, (X, Y) in zip(points, projected):
+        denom = g * X + h * Y + 1
+        px = (a * X + bb * Y + c) / denom
+        py = (d * X + e * Y + f) / denom
+        err = ((px - p.x) ** 2 + (py - p.y) ** 2) ** 0.5
+        residuals.append((p.name, err))
+        sq += err * err
+
+    max_err = max(e for _, e in residuals)
+    rms = (sq / len(residuals)) ** 0.5
+    return FitResult(
+        proj=proj_params,
+        homography=(a, bb, c, d, e, f, g, h),
+        residuals=residuals,
+        max_error=max_err,
+        rms_error=rms,
+    )
+
+
+def sweep(points: list[ControlPoint], base_proj: dict) -> FitResult:
+    """Grid-search lon_0 / lat_ts to minimise max pixel error."""
+    best: FitResult | None = None
+    for lon_0 in range(-30, 31, 5):
+        for lat_ts in (45, 50, 55, 60, 90):
+            proj = dict(base_proj)
+            proj["lon_0"] = lon_0
+            proj["lat_ts"] = lat_ts
+            try:
+                res = fit_homography(points, proj)
+            except Exception:
+                continue
+            if best is None or res.max_error < best.max_error:
+                best = res
+    if best is None:
+        raise RuntimeError("sweep produced no valid fit")
+    return best
+
+
+_EXAMPLE = {
+    "_comment": "Pixel origin top-left; x right, y down. 800x540 colour chart.",
+    "points": [
+        {"name": "Lands End", "lon": -5.72, "lat": 50.07, "x": 0, "y": 0},
+        {"name": "Brest", "lon": -4.49, "lat": 48.39, "x": 0, "y": 0},
+        {"name": "Gibraltar", "lon": -5.35, "lat": 36.14, "x": 0, "y": 0},
+        {"name": "Bergen", "lon": 5.32, "lat": 60.39, "x": 0, "y": 0},
+        {"name": "Reykjavik", "lon": -21.94, "lat": 64.15, "x": 0, "y": 0},
+        {"name": "Skagen", "lon": 10.59, "lat": 57.72, "x": 0, "y": 0},
+    ],
+}
+
+
+def _print_fit(res: FitResult) -> None:
+    print(f"\nprojection: {res.proj}")
+    print(f"max error: {res.max_error:.2f} px   rms: {res.rms_error:.2f} px")
+    print("per-point residuals:")
+    for name, err in sorted(res.residuals, key=lambda r: -r[1]):
+        print(f"  {err:7.2f} px  {name}")
+    print("\nPaste into _CHART_CALIBRATIONS['colour'] in metoffice_charts.py:")
+    print(f'    "proj": {res.proj!r},')
+    print("    \"homography\": (")
+    a, b, c, d, e, f, g, h = res.homography
+    print(f"        {a!r}, {b!r}, {c!r},")
+    print(f"        {d!r}, {e!r}, {f!r},")
+    print(f"        {g!r}, {h!r},")
+    print("    ),")
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("points", nargs="?", type=Path, help="JSON file of control points")
+    ap.add_argument("--sweep", action="store_true", help="grid-search projection origin")
+    ap.add_argument("--lon0", type=float, default=0.0, help="polar-stereo central meridian")
+    ap.add_argument("--lat-ts", type=float, default=60.0, help="polar-stereo true-scale latitude")
+    ap.add_argument("--example", action="store_true", help="print an example points file and exit")
+    args = ap.parse_args(argv)
+
+    if args.example:
+        print(json.dumps(_EXAMPLE, indent=2))
+        return 0
+    if not args.points:
+        ap.error("points file required (or use --example)")
+
+    pts = load_points(args.points)
+    base_proj = {"proj": "stere", "lat_0": 90, "lat_ts": args.lat_ts, "lon_0": args.lon0}
+
+    res = sweep(pts, base_proj) if args.sweep else fit_homography(pts, base_proj)
+    _print_fit(res)
+    if res.max_error > 5:
+        print("\n[warn] max error > 5px — try --sweep, add/spread more points, or recheck clicks.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/weatherbrief/fetch/metoffice_calibrate.py
+++ b/src/weatherbrief/fetch/metoffice_calibrate.py
@@ -147,14 +147,19 @@ def sweep(points: list[ControlPoint], base_proj: dict) -> FitResult:
 
 
 _EXAMPLE = {
-    "_comment": "Pixel origin top-left; x right, y down. 800x540 colour chart.",
+    "_comment": (
+        "Pixel origin top-left; x right, y down. 800x540 colour chart. "
+        "The x,y below are APPROXIMATE (from the current calibration) so the "
+        "example runs without fitting a degenerate all-zero homography — "
+        "REPLACE them with your own clicks when calibrating a fresh chart."
+    ),
     "points": [
-        {"name": "Lands End", "lon": -5.72, "lat": 50.07, "x": 0, "y": 0},
-        {"name": "Brest", "lon": -4.49, "lat": 48.39, "x": 0, "y": 0},
-        {"name": "Gibraltar", "lon": -5.35, "lat": 36.14, "x": 0, "y": 0},
-        {"name": "Bergen", "lon": 5.32, "lat": 60.39, "x": 0, "y": 0},
-        {"name": "Reykjavik", "lon": -21.94, "lat": 64.15, "x": 0, "y": 0},
-        {"name": "Skagen", "lon": 10.59, "lat": 57.72, "x": 0, "y": 0},
+        {"name": "Lands End", "lon": -5.72, "lat": 50.07, "x": 418, "y": 325},
+        {"name": "Brest", "lon": -4.49, "lat": 48.39, "x": 436, "y": 338},
+        {"name": "Gibraltar", "lon": -5.35, "lat": 36.14, "x": 506, "y": 475},
+        {"name": "Bergen", "lon": 5.32, "lat": 60.39, "x": 410, "y": 187},
+        {"name": "Reykjavik", "lon": -21.94, "lat": 64.15, "x": 267, "y": 213},
+        {"name": "Skagen", "lon": 10.59, "lat": 57.72, "x": 453, "y": 188},
     ],
 }
 

--- a/src/weatherbrief/fetch/metoffice_charts.py
+++ b/src/weatherbrief/fetch/metoffice_charts.py
@@ -263,11 +263,21 @@ def _parse_iso_z(value: str | None) -> datetime | None:
 # ---------------------------------------------------------------------------
 
 
-def select_default_chart_id(departure_time: datetime, run_cycle: str) -> str:
+def select_default_chart_id(
+    departure_time: datetime,
+    run_cycle: str,
+    available_ids: set[str] | None = None,
+) -> str:
     """Pick the chart whose valid time best brackets the flight ETD.
 
     ETD within ~3h of issuance -> analysis; otherwise the nearest available
     forecast offset (tie-break toward the earlier offset).
+
+    ``available_ids`` constrains the choice to charts that were actually
+    fetched. A 00Z run's index legitimately omits +72h/+84h (only issued at
+    1930 UTC), so without this filter we could default to an offset whose GIF
+    was never cached — the renderer would then 410 and show a blank error.
+    Falls back to "ana" when no forecast charts are available.
     """
     issued = parse_run_cycle_dt(run_cycle)
     if issued is None:
@@ -275,7 +285,13 @@ def select_default_chart_id(departure_time: datetime, run_cycle: str) -> str:
     delta_hours = (departure_time - issued).total_seconds() / 3600.0
     if delta_hours < 3:
         return "ana"
-    forecast_ids = tuple(cid for cid in CHART_IDS if cid != "ana")
+    forecast_ids = tuple(
+        cid
+        for cid in CHART_IDS
+        if cid != "ana" and (available_ids is None or cid in available_ids)
+    )
+    if not forecast_ids:
+        return "ana"
     return min(
         forecast_ids,
         key=lambda cid: (abs(FORECAST_OFFSETS_H[cid] - delta_hours), FORECAST_OFFSETS_H[cid]),

--- a/src/weatherbrief/fetch/metoffice_charts.py
+++ b/src/weatherbrief/fetch/metoffice_charts.py
@@ -1,0 +1,612 @@
+"""Met Office surface-pressure (front) chart cache.
+
+Fetches the colour surface-pressure analysis + forecast charts from the
+Met Office consumer-digital API and stores them in a shared cross-briefing
+on-disk cache. These are the same charts shown at
+``https://weather.metoffice.gov.uk/maps-and-charts/surface-pressure`` —
+isobars, H/L centres, and coloured fronts (warm=red, cold=blue,
+occluded=purple) over Europe + the NE Atlantic.
+
+Sibling of :mod:`weatherbrief.fetch.dwd_charts`; intentionally mirrors its
+shape (cache layout, conditional GETs, eviction, route overlay) so the two
+sources can share a single briefing UI panel with a source toggle.
+
+Discovery
+---------
+Unlike DWD (where we round ``Last-Modified`` down to a synoptic hour), the
+Met Office publishes a JSON index that names the current run directly::
+
+    GET https://data.consumer-digital.api.metoffice.gov.uk/v1/surface-pressure/colour
+    -> {"issued": "2026-05-29T07:30:29Z",
+        "products": [{"data_date": "...", "uri": ".../colour/2026-05-29T0000/FSXX00T_00.gif"}, ...]}
+
+The run token (``2026-05-29T0000``) lives in each product URI's path; we
+normalise it to the same ``YYYY-MM-DDThhZ`` key the DWD cache uses. The
+forecast offset (hours) is parsed from the ``FSXX00T_<HH>.gif`` filename.
+
+Cache layout::
+
+    {data_dir}/metoffice_charts/
+        2026-05-29T00Z/            # one subdir per run (00Z / 12Z)
+            ana.gif                # +0h analysis (FSXX00T_00.gif)
+            012.gif 024.gif 036.gif 048.gif 060.gif 072.gif 084.gif
+            meta.json              # per-chart Last-Modified, ETag, ...
+        2026-05-29T12Z/
+            ...
+
+Charts update ~every 12h (~0730/1930 UTC); +72h/+84h are issued once a day
+at 1930 UTC, so a 00Z run's index may legitimately omit them.
+"""
+
+from __future__ import annotations
+
+import email.utils
+import json
+import logging
+import os
+import re
+import shutil
+import tempfile
+import time
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+MO_BASE_URL = "https://data.consumer-digital.api.metoffice.gov.uk/v1/surface-pressure"
+MO_STYLE = "colour"  # "colour" (800x540, coloured fronts) — see designs note
+MO_PAGE_URL = "https://weather.metoffice.gov.uk/maps-and-charts/surface-pressure"
+
+# Index endpoint listing the current run's products.
+MO_INDEX_URL = f"{MO_BASE_URL}/{MO_STYLE}"
+
+# Ordered for UI tab presentation. Forecast offsets in hours; "ana" == +0h.
+CHART_IDS: tuple[str, ...] = ("ana", "012", "024", "036", "048", "060", "072", "084")
+FORECAST_OFFSETS_H: dict[str, int] = {
+    "ana": 0,
+    "012": 12,
+    "024": 24,
+    "036": 36,
+    "048": 48,
+    "060": 60,
+    "072": 72,
+    "084": 84,
+}
+
+_TIMEOUT_SECONDS = 30
+_DEFAULT_KEEP_CYCLES = 6  # ~3 days at 12h cadence
+_USER_AGENT = "flyfun-weather/1.0 (+https://weather.flyfun.aero)"
+
+_MAX_FETCH_ATTEMPTS = 3
+_RETRY_BACKOFF_SECONDS = 1.0
+
+# Native pixel sizes, used for client-side SVG overlay scaling. The colour
+# set is uniformly 800x540 across every offset (verified against the live
+# API), so a single calibration covers all tabs — unlike DWD which needed
+# separate analysis/icon calibrations.
+CHART_NATIVE_SIZE: dict[str, tuple[int, int]] = {
+    "colour": (800, 540),
+}
+
+# Calibration converting WGS84 lon/lat -> chart-pixel coordinates.
+#
+# ``proj`` is the polar-stereographic projection guess (consumed by pyproj);
+# ``homography`` is an 8-coefficient 2D projective transform fit from manually
+# identified control points via :mod:`weatherbrief.fetch.metoffice_calibrate`.
+#
+# PLACEHOLDER until the chart is calibrated. ``homography=None`` means the
+# route overlay is unavailable (endpoints degrade gracefully); the chart PNG
+# still renders. Run::
+#
+#     python -m weatherbrief.fetch.metoffice_calibrate <points.json>
+#
+# and paste the printed tuple in below, then drop the ``# noqa`` once real.
+#
+# Calibrated 2026-05-29 from 8 graticule crossings (lon -15..15, lat 30..60)
+# clicked on FSXX00T_00.gif: max error 1.33px, rms 0.58px. The sweep
+# confirmed the chart is polar-stereographic (lon_0 is absorbed by the
+# homography), so lon_0=0 is fine.
+_CHART_CALIBRATIONS: dict[str, dict[str, object]] = {
+    "colour": {
+        "proj": {"proj": "stere", "lat_0": 90, "lat_ts": 60, "lon_0": 0},
+        "homography": (
+            8.219263981133556e-05, -5.606207726787221e-05, 207.51767075737098,
+            -5.659944858480127e-05, -8.104286158047984e-05, -51.726683330077734,
+            8.48991737686672e-10, 2.4811569193648073e-09,
+        ),
+    },
+}
+
+
+def public_enabled() -> bool:
+    """Whether the Met Office chart source is visible to non-admin users.
+
+    Gated off by default while we await Met Office authorisation to reuse
+    their charts. Flip ``METOFFICE_CHARTS_PUBLIC=1`` (env) to release it to
+    everyone — no code change or redeploy of logic, just the env var.
+    Admins always see it regardless.
+    """
+    return os.environ.get("METOFFICE_CHARTS_PUBLIC", "").strip().lower() in (
+        "1", "true", "yes", "on",
+    )
+
+
+@dataclass
+class ChartFetchResult:
+    """Outcome of a single chart fetch."""
+
+    chart_id: str
+    status: str  # "downloaded" | "unchanged" | "failed"
+    last_modified: datetime | None = None
+    etag: str | None = None
+    content_length: int = 0
+    error: str | None = None
+
+
+@dataclass
+class RefreshReport:
+    """Summary of a :func:`refresh_charts` run."""
+
+    run_cycle: str | None = None
+    charts_refreshed: list[str] = field(default_factory=list)
+    charts_unchanged: list[str] = field(default_factory=list)
+    charts_failed: list[str] = field(default_factory=list)
+    evicted: list[str] = field(default_factory=list)
+    error: str | None = None  # set when refresh couldn't even determine a cycle
+
+
+# ---------------------------------------------------------------------------
+# Discovery / index parsing
+# ---------------------------------------------------------------------------
+
+_RUN_TOKEN_RE = re.compile(r"/(\d{4}-\d{2}-\d{2}T\d{4})/")
+_OFFSET_RE = re.compile(r"FSXX00T_(\d{2,3})\.gif$", re.IGNORECASE)
+
+
+def run_token_to_cycle(token: str) -> str | None:
+    """Normalise a Met Office run token to the shared cycle key.
+
+    ``"2026-05-29T0000"`` -> ``"2026-05-29T00Z"`` (matches the DWD cache key
+    format so caption/selection helpers read the same).
+    """
+    try:
+        dt = datetime.strptime(token, "%Y-%m-%dT%H%M")
+    except (TypeError, ValueError):
+        return None
+    return f"{dt.year:04d}-{dt.month:02d}-{dt.day:02d}T{dt.hour:02d}Z"
+
+
+def parse_run_cycle_dt(run_cycle: str) -> datetime | None:
+    """Inverse of :func:`run_token_to_cycle` for caption math."""
+    try:
+        return datetime.strptime(run_cycle, "%Y-%m-%dT%HZ").replace(tzinfo=timezone.utc)
+    except (TypeError, ValueError):
+        return None
+
+
+def _offset_to_chart_id(offset_h: int) -> str | None:
+    if offset_h == 0:
+        return "ana"
+    cid = f"{offset_h:03d}"
+    return cid if cid in FORECAST_OFFSETS_H else None
+
+
+@dataclass
+class IndexEntry:
+    chart_id: str
+    uri: str
+
+
+@dataclass
+class IndexResult:
+    run_cycle: str | None
+    issued: datetime | None
+    entries: list[IndexEntry] = field(default_factory=list)
+    error: str | None = None
+
+
+def fetch_index(session: requests.Session, *, timeout: float = _TIMEOUT_SECONDS) -> IndexResult:
+    """Fetch + parse the colour index, resolving the current run + product URIs."""
+    try:
+        resp = session.get(MO_INDEX_URL, timeout=timeout, allow_redirects=True)
+    except requests.RequestException as e:
+        return IndexResult(run_cycle=None, issued=None, error=f"index unreachable: {e}")
+    if resp.status_code != 200:
+        return IndexResult(run_cycle=None, issued=None, error=f"index HTTP {resp.status_code}")
+    try:
+        payload = resp.json()
+    except ValueError as e:
+        return IndexResult(run_cycle=None, issued=None, error=f"index not JSON: {e}")
+
+    products = payload.get("products") or []
+    run_cycle: str | None = None
+    entries: list[IndexEntry] = []
+    for prod in products:
+        uri = prod.get("uri")
+        if not uri:
+            continue
+        tok = _RUN_TOKEN_RE.search(uri)
+        off = _OFFSET_RE.search(uri)
+        if not tok or not off:
+            continue
+        cid = _offset_to_chart_id(int(off.group(1)))
+        if cid is None:
+            continue
+        if run_cycle is None:
+            run_cycle = run_token_to_cycle(tok.group(1))
+        entries.append(IndexEntry(chart_id=cid, uri=uri))
+
+    issued = _parse_iso_z(payload.get("issued"))
+    if run_cycle is None:
+        return IndexResult(run_cycle=None, issued=issued, error="no parseable products in index")
+    return IndexResult(run_cycle=run_cycle, issued=issued, entries=entries)
+
+
+def _parse_iso_z(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except (TypeError, ValueError):
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+# ---------------------------------------------------------------------------
+# Selection helpers
+# ---------------------------------------------------------------------------
+
+
+def select_default_chart_id(departure_time: datetime, run_cycle: str) -> str:
+    """Pick the chart whose valid time best brackets the flight ETD.
+
+    ETD within ~3h of issuance -> analysis; otherwise the nearest available
+    forecast offset (tie-break toward the earlier offset).
+    """
+    issued = parse_run_cycle_dt(run_cycle)
+    if issued is None:
+        return "ana"
+    delta_hours = (departure_time - issued).total_seconds() / 3600.0
+    if delta_hours < 3:
+        return "ana"
+    forecast_ids = tuple(cid for cid in CHART_IDS if cid != "ana")
+    return min(
+        forecast_ids,
+        key=lambda cid: (abs(FORECAST_OFFSETS_H[cid] - delta_hours), FORECAST_OFFSETS_H[cid]),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Cache paths / meta
+# ---------------------------------------------------------------------------
+
+
+def cache_root(data_dir: Path) -> Path:
+    return data_dir / "metoffice_charts"
+
+
+def cycle_dir(data_dir: Path, run_cycle: str) -> Path:
+    return cache_root(data_dir) / run_cycle
+
+
+def list_cycles(data_dir: Path) -> list[str]:
+    root = cache_root(data_dir)
+    if not root.exists():
+        return []
+    return sorted(p.name for p in root.iterdir() if p.is_dir())
+
+
+def _read_meta(cdir: Path) -> dict[str, dict]:
+    path = cdir / "meta.json"
+    if not path.exists():
+        return {}
+    try:
+        return json.loads(path.read_text())
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
+def _write_meta(cdir: Path, meta: dict[str, dict]) -> None:
+    path = cdir / "meta.json"
+    cdir.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(prefix=".meta.", suffix=".tmp", dir=cdir)
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(meta, f, indent=2, sort_keys=True)
+        os.replace(tmp, path)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except FileNotFoundError:
+            pass
+        raise
+
+
+def _atomic_write_bytes(path: Path, data: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=path.parent)
+    try:
+        with os.fdopen(fd, "wb") as f:
+            f.write(data)
+        os.replace(tmp, path)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except FileNotFoundError:
+            pass
+        raise
+
+
+def _parse_lm_header(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        dt = email.utils.parsedate_to_datetime(value)
+    except (TypeError, ValueError):
+        return None
+    if dt is None:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def _conditional_headers(existing_meta: dict | None) -> dict[str, str]:
+    headers: dict[str, str] = {}
+    if not existing_meta:
+        return headers
+    etag = existing_meta.get("etag")
+    if etag:
+        headers["If-None-Match"] = etag
+    lm = existing_meta.get("last_modified")
+    if lm:
+        try:
+            lm_dt = datetime.fromisoformat(lm)
+            headers["If-Modified-Since"] = email.utils.format_datetime(lm_dt)
+        except (TypeError, ValueError):
+            pass
+    return headers
+
+
+# ---------------------------------------------------------------------------
+# Georeferencing
+# ---------------------------------------------------------------------------
+
+
+def is_calibrated(chart_type: str = "colour") -> bool:
+    cal = _CHART_CALIBRATIONS.get(chart_type)
+    return bool(cal and cal.get("homography"))
+
+
+def lonlat_to_chart_pixel(lon: float, lat: float, chart_type: str = "colour") -> tuple[int, int]:
+    """Project WGS84 lon/lat to native pixel coordinates on a Met Office chart.
+
+    Composes pyproj's polar-stereographic forward projection with a 2D
+    homography. Raises if the chart hasn't been calibrated yet (homography
+    is None) — callers building the route overlay should guard with
+    :func:`is_calibrated`.
+    """
+    cal = _CHART_CALIBRATIONS.get(chart_type)
+    if cal is None:
+        raise ValueError(f"Unknown Met Office chart type: {chart_type!r}")
+    homography = cal.get("homography")
+    if not homography:
+        raise RuntimeError(
+            f"Met Office chart {chart_type!r} is not calibrated yet "
+            "(run weatherbrief.fetch.metoffice_calibrate)"
+        )
+
+    import pyproj
+
+    proj = pyproj.Proj(**cal["proj"])  # type: ignore[arg-type]
+    a, b, c, d, e, f, g, h = homography  # type: ignore[misc]
+    x, y = proj(lon, lat)
+    denom = g * x + h * y + 1
+    px = (a * x + b * y + c) / denom
+    py = (d * x + e * y + f) / denom
+    return int(px), int(py)
+
+
+def build_route_overlay(waypoints: list[tuple[str, float, float]]) -> dict:
+    """Build the route-overlay JSON consumed by the frontend SVG renderer.
+
+    Args:
+        waypoints: ``[(icao, lat, lon), ...]`` in flight order.
+
+    Returns ``{"colour": {"native_size": [800, 540], "waypoints": [...]}}``.
+    Returns ``{}`` when the chart is not yet calibrated, so the frontend
+    simply renders the chart without an overlay.
+    """
+    if not is_calibrated("colour"):
+        return {}
+    out: dict[str, dict] = {}
+    for chart_type, native_size in CHART_NATIVE_SIZE.items():
+        projected = []
+        for icao, lat, lon in waypoints:
+            x, y = lonlat_to_chart_pixel(lon, lat, chart_type)
+            projected.append({"icao": icao, "lat": lat, "lon": lon, "x": x, "y": y})
+        out[chart_type] = {"native_size": list(native_size), "waypoints": projected}
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Read-only lookups
+# ---------------------------------------------------------------------------
+
+
+def resolve_chart_path(data_dir: Path, run_cycle: str, chart_id: str) -> Path | None:
+    if chart_id not in CHART_IDS:
+        return None
+    path = cycle_dir(data_dir, run_cycle) / f"{chart_id}.gif"
+    return path if path.exists() else None
+
+
+def chart_meta(data_dir: Path, run_cycle: str, chart_id: str) -> dict | None:
+    return _read_meta(cycle_dir(data_dir, run_cycle)).get(chart_id)
+
+
+# ---------------------------------------------------------------------------
+# Eviction
+# ---------------------------------------------------------------------------
+
+
+def evict_old_cycles(data_dir: Path, *, keep: int = _DEFAULT_KEEP_CYCLES) -> list[str]:
+    cycles = list_cycles(data_dir)
+    if len(cycles) <= keep:
+        return []
+    to_evict = cycles[: len(cycles) - keep]
+    root = cache_root(data_dir)
+    evicted: list[str] = []
+    for name in to_evict:
+        try:
+            shutil.rmtree(root / name)
+            evicted.append(name)
+        except OSError:
+            logger.warning("Could not evict cycle %s", name, exc_info=True)
+    if evicted:
+        logger.info("Evicted %d old Met Office chart cycles: %s", len(evicted), ", ".join(evicted))
+    return evicted
+
+
+# ---------------------------------------------------------------------------
+# Refresh
+# ---------------------------------------------------------------------------
+
+
+def refresh_charts(
+    data_dir: Path,
+    *,
+    keep_cycles: int = _DEFAULT_KEEP_CYCLES,
+    timeout: float = _TIMEOUT_SECONDS,
+) -> RefreshReport:
+    """Resolve the current run from the index and conditional-GET each chart.
+
+    Cheap when the run hasn't rolled — the index call plus N conditional
+    GETs that all 304. Returns a :class:`RefreshReport`; the caller gates
+    eligibility (this function is dumb about flights).
+    """
+    report = RefreshReport()
+    session = requests.Session()
+    session.headers.update({"User-Agent": _USER_AGENT})
+
+    index = fetch_index(session, timeout=timeout)
+    if index.run_cycle is None:
+        report.error = index.error or "could not resolve Met Office run"
+        return report
+
+    run_cycle = index.run_cycle
+    report.run_cycle = run_cycle
+    cdir = cycle_dir(data_dir, run_cycle)
+    cdir.mkdir(parents=True, exist_ok=True)
+    existing_meta = _read_meta(cdir)
+    new_meta: dict[str, dict] = dict(existing_meta)
+
+    with ThreadPoolExecutor(max_workers=max(1, len(index.entries))) as pool:
+        futures = {
+            entry.chart_id: pool.submit(
+                _fetch_one,
+                session=session,
+                chart_id=entry.chart_id,
+                url=entry.uri,
+                existing_meta=existing_meta.get(entry.chart_id),
+                target_path=cdir / f"{entry.chart_id}.gif",
+                timeout=timeout,
+            )
+            for entry in index.entries
+        }
+        results = {cid: fut.result() for cid, fut in futures.items()}
+
+    for cid, res in results.items():
+        if res.status == "downloaded":
+            report.charts_refreshed.append(cid)
+            new_meta[cid] = {
+                "last_modified": res.last_modified.isoformat() if res.last_modified else None,
+                "etag": res.etag,
+                "content_length": res.content_length,
+                "fetched_at": datetime.now(timezone.utc).isoformat(),
+                "http_status": 200,
+            }
+        elif res.status == "unchanged":
+            report.charts_unchanged.append(cid)
+            prev = dict(new_meta.get(cid, {}))
+            prev["fetched_at"] = datetime.now(timezone.utc).isoformat()
+            prev["http_status"] = 304
+            new_meta[cid] = prev
+        else:
+            report.charts_failed.append(cid)
+
+    _write_meta(cdir, new_meta)
+
+    try:
+        report.evicted = evict_old_cycles(data_dir, keep=keep_cycles)
+    except Exception:
+        logger.warning("Met Office chart eviction failed", exc_info=True)
+
+    return report
+
+
+def _fetch_one(
+    *,
+    session: requests.Session,
+    chart_id: str,
+    url: str,
+    existing_meta: dict | None,
+    target_path: Path,
+    timeout: float,
+) -> ChartFetchResult:
+    """Conditional GET a single chart. On 200 writes bytes; on 304 leaves them."""
+    headers = _conditional_headers(existing_meta)
+
+    resp = None
+    last_exc: Exception | None = None
+    for attempt in range(1, _MAX_FETCH_ATTEMPTS + 1):
+        try:
+            resp = session.get(url, headers=headers, timeout=timeout, allow_redirects=True)
+            break
+        except requests.RequestException as e:
+            last_exc = e
+            if attempt < _MAX_FETCH_ATTEMPTS:
+                logger.debug(
+                    "Met Office chart fetch attempt %d/%d failed (%s): %s — retrying",
+                    attempt, _MAX_FETCH_ATTEMPTS, chart_id, e,
+                )
+                time.sleep(_RETRY_BACKOFF_SECONDS * attempt)
+    if resp is None:
+        logger.warning(
+            "Met Office chart fetch failed after %d attempts (%s): %s",
+            _MAX_FETCH_ATTEMPTS, chart_id, last_exc,
+        )
+        return ChartFetchResult(chart_id=chart_id, status="failed", error=str(last_exc))
+
+    if resp.status_code == 304:
+        return ChartFetchResult(
+            chart_id=chart_id,
+            status="unchanged",
+            last_modified=_parse_lm_header(resp.headers.get("Last-Modified")),
+            etag=resp.headers.get("ETag"),
+        )
+
+    if resp.status_code != 200:
+        msg = f"HTTP {resp.status_code}"
+        logger.warning("Met Office chart fetch failed (%s): %s", chart_id, msg)
+        return ChartFetchResult(chart_id=chart_id, status="failed", error=msg)
+
+    try:
+        _atomic_write_bytes(target_path, resp.content)
+    except OSError as e:
+        logger.warning("Met Office chart write failed (%s): %s", chart_id, e)
+        return ChartFetchResult(chart_id=chart_id, status="failed", error=str(e))
+
+    return ChartFetchResult(
+        chart_id=chart_id,
+        status="downloaded",
+        last_modified=_parse_lm_header(resp.headers.get("Last-Modified")),
+        etag=resp.headers.get("ETag"),
+        content_length=len(resp.content),
+    )

--- a/src/weatherbrief/models/storage.py
+++ b/src/weatherbrief/models/storage.py
@@ -111,6 +111,11 @@ class BriefingPackMeta(BaseModel):
     dwd_charts_default_id: Optional[str] = None  # "ana" | "036" | "048" | "060" | "084" | "108"
     dwd_charts_in_coverage: bool = False
     dwd_charts_within_horizon: bool = False
+    # Met Office surface-pressure charts — same shape, second source.
+    metoffice_charts_run_cycle: Optional[str] = None  # e.g. "2026-05-29T00Z"
+    metoffice_charts_default_id: Optional[str] = None  # "ana" | "012" .. "084"
+    metoffice_charts_in_coverage: bool = False
+    metoffice_charts_within_horizon: bool = False
 
     @computed_field  # type: ignore[prop-decorator]
     @property

--- a/src/weatherbrief/pipeline.py
+++ b/src/weatherbrief/pipeline.py
@@ -590,7 +590,6 @@ def execute_briefing(
         route=route,
         departure_time=departure_time,
         data_dir=data_dir,
-        pack_dir=pack_dir,
     )
     result.metoffice_charts_run_cycle = metoffice_charts_result.run_cycle
     result.metoffice_charts_default_id = metoffice_charts_result.default_chart_id

--- a/src/weatherbrief/pipeline.py
+++ b/src/weatherbrief/pipeline.py
@@ -38,6 +38,7 @@ from weatherbrief.tasks.fetch import run_fetch
 from weatherbrief.tasks.analyze import run_analysis
 from weatherbrief.tasks.advise import AdvisoryResult, run_advisories
 from weatherbrief.tasks.dwd_charts import run_dwd_charts
+from weatherbrief.tasks.metoffice_charts import run_metoffice_charts
 from weatherbrief.tasks.outputs import run_gramet, run_skewt, run_llm_digest
 
 logger = logging.getLogger(__name__)
@@ -150,6 +151,11 @@ class BriefingResult:
     dwd_charts_default_id: str | None = None
     dwd_charts_in_coverage: bool = False
     dwd_charts_within_horizon: bool = False
+    # Met Office surface-pressure charts — same shape, second source.
+    metoffice_charts_run_cycle: str | None = None
+    metoffice_charts_default_id: str | None = None
+    metoffice_charts_in_coverage: bool = False
+    metoffice_charts_within_horizon: bool = False
     usage: BriefingUsage = field(default_factory=BriefingUsage)
 
 
@@ -574,6 +580,23 @@ def execute_briefing(
     result.dwd_charts_in_coverage = dwd_charts_result.in_coverage
     result.dwd_charts_within_horizon = dwd_charts_result.within_horizon
     stage_timings["dwd_charts"] = perf_counter() - _t0
+
+    # === 5c. Met Office Surface Pressure charts ===
+    # Same cheap conditional-GET pattern as DWD; second front-chart source
+    # (admin-gated until Met Office authorise reuse). Eligibility checked
+    # inside run_metoffice_charts.
+    _t0 = perf_counter()
+    metoffice_charts_result = run_metoffice_charts(
+        route=route,
+        departure_time=departure_time,
+        data_dir=data_dir,
+        pack_dir=pack_dir,
+    )
+    result.metoffice_charts_run_cycle = metoffice_charts_result.run_cycle
+    result.metoffice_charts_default_id = metoffice_charts_result.default_chart_id
+    result.metoffice_charts_in_coverage = metoffice_charts_result.in_coverage
+    result.metoffice_charts_within_horizon = metoffice_charts_result.within_horizon
+    stage_timings["metoffice_charts"] = perf_counter() - _t0
 
     # === 6. Optional: Skew-T ===
     if options.generate_skewt:

--- a/src/weatherbrief/storage/flights.py
+++ b/src/weatherbrief/storage/flights.py
@@ -223,6 +223,10 @@ def _apply_meta_to_row(row: BriefingPackRow, meta: BriefingPackMeta) -> None:
     row.dwd_charts_default_id = meta.dwd_charts_default_id
     row.dwd_charts_in_coverage = meta.dwd_charts_in_coverage
     row.dwd_charts_within_horizon = meta.dwd_charts_within_horizon
+    row.metoffice_charts_run_cycle = meta.metoffice_charts_run_cycle
+    row.metoffice_charts_default_id = meta.metoffice_charts_default_id
+    row.metoffice_charts_in_coverage = meta.metoffice_charts_in_coverage
+    row.metoffice_charts_within_horizon = meta.metoffice_charts_within_horizon
 
 
 def _meta_to_row(meta: BriefingPackMeta) -> BriefingPackRow:
@@ -333,6 +337,10 @@ def _row_to_meta(row: BriefingPackRow) -> BriefingPackMeta:
         dwd_charts_default_id=row.dwd_charts_default_id,
         dwd_charts_in_coverage=row.dwd_charts_in_coverage,
         dwd_charts_within_horizon=row.dwd_charts_within_horizon,
+        metoffice_charts_run_cycle=row.metoffice_charts_run_cycle,
+        metoffice_charts_default_id=row.metoffice_charts_default_id,
+        metoffice_charts_in_coverage=row.metoffice_charts_in_coverage,
+        metoffice_charts_within_horizon=row.metoffice_charts_within_horizon,
     )
 
 

--- a/src/weatherbrief/tasks/metoffice_charts.py
+++ b/src/weatherbrief/tasks/metoffice_charts.py
@@ -1,0 +1,102 @@
+"""Met Office surface-pressure chart pipeline task.
+
+Sibling of :mod:`weatherbrief.tasks.dwd_charts`. Decides whether the
+briefing's flight is eligible for the Met Office chart source, refreshes the
+shared cache (cheap thanks to conditional GETs), and computes the
+per-briefing reference fields.
+
+Eligibility:
+  - in_coverage: route region is Europe (reuses ``detect_region``).
+  - within_horizon: ETD <= run_cycle + 84h at refresh time.
+
+Bytes are NOT stored on the pack — the briefing only stores
+(run_cycle, default_chart_id, eligibility flags). The renderer reads the
+bytes from ``DATA_DIR/metoffice_charts/<run_cycle>/`` at request time.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from pathlib import Path
+
+from weatherbrief.fetch.metoffice_charts import (
+    FORECAST_OFFSETS_H,
+    parse_run_cycle_dt,
+    refresh_charts,
+    select_default_chart_id,
+)
+from weatherbrief.fetch.text_forecasts import ForecastRegion, detect_region
+from weatherbrief.models import RouteConfig
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class MetofficeChartsResult:
+    """Per-briefing references that flow onto BriefingPackMeta."""
+
+    run_cycle: str | None = None
+    default_chart_id: str | None = None
+    in_coverage: bool = False
+    within_horizon: bool = False
+
+
+def run_metoffice_charts(
+    *,
+    route: RouteConfig,
+    departure_time: datetime,
+    data_dir: Path,
+    pack_dir: Path | None = None,
+) -> MetofficeChartsResult:
+    """Refresh the Met Office chart cache and compute briefing references.
+
+    Cheap when the run hasn't rolled — the index call plus conditional GETs
+    that all 304. Refresh failures leave ``run_cycle=None`` so the section
+    renders "unavailable" gracefully.
+    """
+    in_coverage = detect_region(route) == ForecastRegion.EUROPE
+    if not in_coverage:
+        return MetofficeChartsResult(in_coverage=False)
+
+    try:
+        report = refresh_charts(data_dir)
+    except Exception:
+        logger.warning("Met Office chart refresh raised", exc_info=True)
+        return MetofficeChartsResult(in_coverage=True, within_horizon=False)
+
+    if report.run_cycle is None:
+        logger.info("Met Office chart refresh failed: %s", report.error)
+        return MetofficeChartsResult(in_coverage=True, within_horizon=False)
+
+    issued = parse_run_cycle_dt(report.run_cycle)
+    if issued is None:
+        return MetofficeChartsResult(in_coverage=True)
+
+    horizon_h = max(FORECAST_OFFSETS_H.values())  # 84
+    within_horizon = departure_time <= issued + timedelta(hours=horizon_h)
+    if not within_horizon:
+        return MetofficeChartsResult(
+            run_cycle=report.run_cycle,
+            default_chart_id=None,
+            in_coverage=True,
+            within_horizon=False,
+        )
+
+    default_id = select_default_chart_id(departure_time, report.run_cycle)
+
+    if report.charts_failed:
+        logger.info(
+            "Met Office chart refresh: %d refreshed, %d unchanged, failed: %s",
+            len(report.charts_refreshed),
+            len(report.charts_unchanged),
+            report.charts_failed,
+        )
+
+    return MetofficeChartsResult(
+        run_cycle=report.run_cycle,
+        default_chart_id=default_id,
+        in_coverage=True,
+        within_horizon=True,
+    )

--- a/src/weatherbrief/tasks/metoffice_charts.py
+++ b/src/weatherbrief/tasks/metoffice_charts.py
@@ -48,7 +48,6 @@ def run_metoffice_charts(
     route: RouteConfig,
     departure_time: datetime,
     data_dir: Path,
-    pack_dir: Path | None = None,
 ) -> MetofficeChartsResult:
     """Refresh the Met Office chart cache and compute briefing references.
 
@@ -84,7 +83,12 @@ def run_metoffice_charts(
             within_horizon=False,
         )
 
-    default_id = select_default_chart_id(departure_time, report.run_cycle)
+    # Constrain the default to charts that were actually fetched — a 00Z run
+    # may omit +72h/+84h, and defaulting to a missing offset would 410.
+    available = set(report.charts_refreshed) | set(report.charts_unchanged)
+    default_id = select_default_chart_id(
+        departure_time, report.run_cycle, available_ids=available
+    )
 
     if report.charts_failed:
         logger.info(

--- a/tests/test_metoffice_charts.py
+++ b/tests/test_metoffice_charts.py
@@ -106,6 +106,24 @@ def test_select_default_nearest_offset():
     assert select_default_chart_id(issued + timedelta(hours=18), "2026-05-29T00Z") == "012"
 
 
+def test_select_default_skips_unavailable_offsets():
+    """A 00Z run may omit +72h/+84h — never default to a chart not fetched."""
+    issued = datetime(2026, 5, 29, 0, tzinfo=timezone.utc)
+    available = {"ana", "012", "024", "036", "048", "060"}  # 072/084 missing
+    # 75h out would normally pick 072; constrained, falls back to nearest available (060)
+    assert select_default_chart_id(
+        issued + timedelta(hours=75), "2026-05-29T00Z", available_ids=available
+    ) == "060"
+    # within the available range it still picks the true nearest
+    assert select_default_chart_id(
+        issued + timedelta(hours=48), "2026-05-29T00Z", available_ids=available
+    ) == "048"
+    # no forecast charts available at all -> analysis
+    assert select_default_chart_id(
+        issued + timedelta(hours=48), "2026-05-29T00Z", available_ids={"ana"}
+    ) == "ana"
+
+
 # ---------------------------------------------------------------------------
 # fetch_index
 # ---------------------------------------------------------------------------

--- a/tests/test_metoffice_charts.py
+++ b/tests/test_metoffice_charts.py
@@ -1,0 +1,268 @@
+"""Tests for the Met Office surface-pressure chart cache."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+import responses
+
+from weatherbrief.fetch.metoffice_charts import (
+    CHART_IDS,
+    CHART_NATIVE_SIZE,
+    MO_BASE_URL,
+    MO_INDEX_URL,
+    MO_STYLE,
+    build_route_overlay,
+    chart_meta,
+    cycle_dir,
+    evict_old_cycles,
+    fetch_index,
+    is_calibrated,
+    list_cycles,
+    lonlat_to_chart_pixel,
+    parse_run_cycle_dt,
+    public_enabled,
+    refresh_charts,
+    resolve_chart_path,
+    run_token_to_cycle,
+    select_default_chart_id,
+)
+
+_GIF_BYTES = b"GIF89a" + b"x" * 64
+
+_RUN_TOKEN = "2026-05-29T0000"
+# offset (hours) -> filename HH token used in FSXX00T_<HH>.gif
+_OFFSETS = {"ana": "00", "012": "12", "024": "24", "036": "36",
+            "048": "48", "060": "60", "072": "72", "084": "84"}
+
+
+def _gif_url(hh: str) -> str:
+    return f"{MO_BASE_URL}/{MO_STYLE}/{_RUN_TOKEN}/FSXX00T_{hh}.gif"
+
+
+def _index_payload(issued: str = "2026-05-29T07:30:29Z") -> dict:
+    return {
+        "issued": issued,
+        "products": [
+            {"data_date": "2026-05-29T00:00:00Z", "uri": _gif_url(hh)}
+            for hh in _OFFSETS.values()
+        ],
+    }
+
+
+def _add_index(payload: dict | None = None, status: int = 200):
+    responses.add(
+        responses.GET, MO_INDEX_URL,
+        body=json.dumps(payload if payload is not None else _index_payload()),
+        status=status, content_type="application/json",
+    )
+
+
+def _add_gifs(status: int = 200, etag_prefix: str = "v1"):
+    for cid, hh in _OFFSETS.items():
+        responses.add(
+            responses.GET, _gif_url(hh),
+            body=_GIF_BYTES if status == 200 else b"",
+            status=status,
+            headers={"Last-Modified": "Fri, 29 May 2026 00:26:10 GMT", "ETag": f'"{etag_prefix}-{cid}"'},
+        )
+
+
+# ---------------------------------------------------------------------------
+# cycle key helpers
+# ---------------------------------------------------------------------------
+
+
+def test_run_token_to_cycle():
+    assert run_token_to_cycle("2026-05-29T0000") == "2026-05-29T00Z"
+    assert run_token_to_cycle("2026-05-29T1200") == "2026-05-29T12Z"
+    assert run_token_to_cycle("garbage") is None
+
+
+def test_parse_run_cycle_dt_roundtrip():
+    dt = parse_run_cycle_dt("2026-05-29T12Z")
+    assert dt == datetime(2026, 5, 29, 12, tzinfo=timezone.utc)
+    assert parse_run_cycle_dt("nope") is None
+
+
+# ---------------------------------------------------------------------------
+# select_default_chart_id
+# ---------------------------------------------------------------------------
+
+
+def test_select_default_within_3h_picks_analysis():
+    issued = datetime(2026, 5, 29, 0, tzinfo=timezone.utc)
+    assert select_default_chart_id(issued + timedelta(hours=2), "2026-05-29T00Z") == "ana"
+
+
+def test_select_default_nearest_offset():
+    issued = datetime(2026, 5, 29, 0, tzinfo=timezone.utc)
+    assert select_default_chart_id(issued + timedelta(hours=12), "2026-05-29T00Z") == "012"
+    assert select_default_chart_id(issued + timedelta(hours=30), "2026-05-29T00Z") == "024"
+    # 18h equidistant 12/24 -> tie-break earlier
+    assert select_default_chart_id(issued + timedelta(hours=18), "2026-05-29T00Z") == "012"
+
+
+# ---------------------------------------------------------------------------
+# fetch_index
+# ---------------------------------------------------------------------------
+
+
+@responses.activate
+def test_fetch_index_parses_run_and_products():
+    _add_index()
+    import requests
+    idx = fetch_index(requests.Session())
+    assert idx.error is None
+    assert idx.run_cycle == "2026-05-29T00Z"
+    assert idx.issued == datetime(2026, 5, 29, 7, 30, 29, tzinfo=timezone.utc)
+    assert {e.chart_id for e in idx.entries} == set(CHART_IDS)
+
+
+@responses.activate
+def test_fetch_index_http_error():
+    _add_index(status=503)
+    import requests
+    idx = fetch_index(requests.Session())
+    assert idx.run_cycle is None
+    assert idx.error is not None
+
+
+# ---------------------------------------------------------------------------
+# refresh_charts
+# ---------------------------------------------------------------------------
+
+
+@responses.activate
+def test_refresh_first_run_downloads_all(tmp_path: Path):
+    _add_index()
+    _add_gifs(status=200)
+    report = refresh_charts(tmp_path)
+    assert report.error is None
+    assert report.run_cycle == "2026-05-29T00Z"
+    assert sorted(report.charts_refreshed) == sorted(CHART_IDS)
+    assert report.charts_failed == []
+    cdir = cycle_dir(tmp_path, report.run_cycle)
+    for cid in CHART_IDS:
+        assert (cdir / f"{cid}.gif").exists()
+        m = chart_meta(tmp_path, report.run_cycle, cid)
+        assert m and m["etag"] == f'"v1-{cid}"'
+
+
+@responses.activate
+def test_refresh_second_run_304s_everything(tmp_path: Path):
+    _add_index()
+    _add_gifs(status=200)
+    refresh_charts(tmp_path)
+    responses.reset()
+    _add_index()
+    _add_gifs(status=304)
+    report = refresh_charts(tmp_path)
+    assert report.charts_refreshed == []
+    assert sorted(report.charts_unchanged) == sorted(CHART_IDS)
+    assert list_cycles(tmp_path) == ["2026-05-29T00Z"]
+
+
+@responses.activate
+def test_refresh_index_failure_aborts(tmp_path: Path):
+    _add_index(status=500)
+    report = refresh_charts(tmp_path)
+    assert report.run_cycle is None
+    assert report.error is not None
+
+
+@responses.activate
+def test_refresh_one_chart_failure_doesnt_kill_others(tmp_path: Path):
+    _add_index()
+    for cid, hh in _OFFSETS.items():
+        st = 500 if cid == "060" else 200
+        responses.add(
+            responses.GET, _gif_url(hh),
+            body=_GIF_BYTES if st == 200 else b"", status=st,
+            headers={"Last-Modified": "Fri, 29 May 2026 00:26:10 GMT", "ETag": f'"x-{cid}"'},
+        )
+    report = refresh_charts(tmp_path)
+    assert "060" in report.charts_failed
+    assert "ana" in report.charts_refreshed
+
+
+# ---------------------------------------------------------------------------
+# eviction / lookups
+# ---------------------------------------------------------------------------
+
+
+def test_evict_old_cycles_keeps_n_newest(tmp_path: Path):
+    root = tmp_path / "metoffice_charts"
+    for name in ["2026-05-27T00Z", "2026-05-27T12Z", "2026-05-28T00Z", "2026-05-28T12Z"]:
+        (root / name).mkdir(parents=True)
+    evicted = evict_old_cycles(tmp_path, keep=2)
+    assert sorted(evicted) == ["2026-05-27T00Z", "2026-05-27T12Z"]
+    assert list_cycles(tmp_path) == ["2026-05-28T00Z", "2026-05-28T12Z"]
+
+
+def test_resolve_chart_path_hit_and_miss(tmp_path: Path):
+    cdir = cycle_dir(tmp_path, "2026-05-29T00Z")
+    cdir.mkdir(parents=True)
+    (cdir / "ana.gif").write_bytes(_GIF_BYTES)
+    assert resolve_chart_path(tmp_path, "2026-05-29T00Z", "ana") == cdir / "ana.gif"
+    assert resolve_chart_path(tmp_path, "2026-05-29T00Z", "012") is None
+    assert resolve_chart_path(tmp_path, "2026-05-29T00Z", "999") is None
+
+
+# ---------------------------------------------------------------------------
+# georeferencing (calibrated)
+# ---------------------------------------------------------------------------
+
+
+def test_chart_is_calibrated():
+    assert is_calibrated("colour") is True
+
+
+def test_lonlat_to_chart_pixel_inside_bounds():
+    # Central-Europe point projects inside the 800x540 frame.
+    w, h = CHART_NATIVE_SIZE["colour"]
+    x, y = lonlat_to_chart_pixel(5.0, 50.0, "colour")
+    assert 0 < x < w
+    assert 0 < y < h
+
+
+def test_lonlat_north_is_smaller_y():
+    # Oslo (north) should be higher up (smaller y) than Paris.
+    _, paris_y = lonlat_to_chart_pixel(2.35, 48.86, "colour")
+    _, oslo_y = lonlat_to_chart_pixel(10.75, 59.91, "colour")
+    assert oslo_y < paris_y
+
+
+def test_build_route_overlay_shape():
+    waypoints = [("EGTF", 51.34, -0.55), ("LFRQ", 47.97, -4.17)]
+    overlay = build_route_overlay(waypoints)
+    assert set(overlay.keys()) == {"colour"}
+    section = overlay["colour"]
+    assert section["native_size"] == list(CHART_NATIVE_SIZE["colour"])
+    assert len(section["waypoints"]) == 2
+    for orig, proj in zip(waypoints, section["waypoints"]):
+        assert proj["icao"] == orig[0]
+        assert isinstance(proj["x"], int)
+        assert isinstance(proj["y"], int)
+
+
+# ---------------------------------------------------------------------------
+# public_enabled gate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("val,expected", [
+    ("1", True), ("true", True), ("YES", True), ("on", True),
+    ("0", False), ("", False), ("false", False),
+])
+def test_public_enabled(monkeypatch, val, expected):
+    monkeypatch.setenv("METOFFICE_CHARTS_PUBLIC", val)
+    assert public_enabled() is expected
+
+
+def test_public_enabled_unset(monkeypatch):
+    monkeypatch.delenv("METOFFICE_CHARTS_PUBLIC", raising=False)
+    assert public_enabled() is False

--- a/tests/test_metoffice_charts_meta.py
+++ b/tests/test_metoffice_charts_meta.py
@@ -1,0 +1,77 @@
+"""Regression guard: _build_pack_meta must copy the chart-reference fields
+from the BriefingResult onto the persisted BriefingPackMeta.
+
+This is the seam the original Met Office wiring missed — the fields existed
+on both BriefingResult and BriefingPackMeta, but the result→meta construction
+in _build_pack_meta didn't copy the metoffice_* ones, so they silently
+defaulted to (None, None, False, False) on every pack. A field-name parity
+check wouldn't catch that; only exercising the copy does.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+from weatherbrief.api.packs import _build_pack_meta
+from weatherbrief.models.storage import Flight
+from weatherbrief.pipeline import BriefingResult
+
+
+def _flight() -> Flight:
+    return Flight(
+        id="t-2026-05-31-0000",
+        route_name="t",
+        waypoints=["LFAT", "EGTF"],
+        departure_time=datetime(2026, 5, 31, 14, tzinfo=timezone.utc),
+        created_at=datetime(2026, 5, 29, tzinfo=timezone.utc),
+    )
+
+
+def test_build_pack_meta_copies_chart_reference_fields():
+    # snapshot is a required positional but _build_pack_meta never reads it.
+    result = BriefingResult(snapshot=None, snapshot_path=Path("/tmp/none"))
+    result.dwd_charts_run_cycle = "2026-05-29T12Z"
+    result.dwd_charts_default_id = "048"
+    result.dwd_charts_in_coverage = True
+    result.dwd_charts_within_horizon = True
+    result.metoffice_charts_run_cycle = "2026-05-29T00Z"
+    result.metoffice_charts_default_id = "060"
+    result.metoffice_charts_in_coverage = True
+    result.metoffice_charts_within_horizon = True
+
+    meta = _build_pack_meta(
+        "t-2026-05-31-0000",
+        _flight(),
+        datetime(2026, 5, 29, tzinfo=timezone.utc),
+        Path("/tmp/pack"),
+        result,
+        as_of_time=datetime(2026, 5, 29, tzinfo=timezone.utc),
+    )
+
+    # DWD (the established source — sanity)
+    assert meta.dwd_charts_run_cycle == "2026-05-29T12Z"
+    assert meta.dwd_charts_default_id == "048"
+    assert meta.dwd_charts_in_coverage is True
+    assert meta.dwd_charts_within_horizon is True
+
+    # Met Office — the fields that were being dropped
+    assert meta.metoffice_charts_run_cycle == "2026-05-29T00Z"
+    assert meta.metoffice_charts_default_id == "060"
+    assert meta.metoffice_charts_in_coverage is True
+    assert meta.metoffice_charts_within_horizon is True
+
+
+def test_build_pack_meta_defaults_when_result_unset():
+    result = BriefingResult(snapshot=None, snapshot_path=Path("/tmp/none"))
+    meta = _build_pack_meta(
+        "t-2026-05-31-0000",
+        _flight(),
+        datetime(2026, 5, 29, tzinfo=timezone.utc),
+        Path("/tmp/pack"),
+        result,
+        as_of_time=datetime(2026, 5, 29, tzinfo=timezone.utc),
+    )
+    assert meta.metoffice_charts_run_cycle is None
+    assert meta.metoffice_charts_in_coverage is False
+    assert meta.metoffice_charts_within_horizon is False

--- a/web/briefing.html
+++ b/web/briefing.html
@@ -169,9 +169,9 @@
       </div>
     </div>
 
-    <!-- DWD Surface Analysis & Forecast -->
+    <!-- Surface Pressure & Fronts (DWD + Met Office sources) -->
     <div id="dwd-charts-wrapper" class="section collapsible" data-section="dwd-charts" style="display: none;">
-      <h3>DWD Surface Analysis &amp; Forecast</h3>
+      <h3>Surface Pressure &amp; Fronts</h3>
       <div class="section-body">
         <div id="dwd-charts-section">
           <p class="muted">Loading...</p>

--- a/web/ts/adapters/api-adapter.ts
+++ b/web/ts/adapters/api-adapter.ts
@@ -676,6 +676,16 @@ export function dwdChartOverlayUrl(flightId: string, timestamp: string): string 
   return `${API_BASE}/flights/${encodeURIComponent(flightId)}/packs/${encodeURIComponent(timestamp)}/dwd-chart-overlay`;
 }
 
+// --- Met Office surface-pressure charts ---
+
+export function metofficeChartUrl(flightId: string, timestamp: string, chartId: string): string {
+  return `${API_BASE}/flights/${encodeURIComponent(flightId)}/packs/${encodeURIComponent(timestamp)}/metoffice-chart/${encodeURIComponent(chartId)}`;
+}
+
+export function metofficeChartOverlayUrl(flightId: string, timestamp: string): string {
+  return `${API_BASE}/flights/${encodeURIComponent(flightId)}/packs/${encodeURIComponent(timestamp)}/metoffice-chart-overlay`;
+}
+
 // --- Report ---
 
 export function reportPdfUrl(flightId: string, timestamp: string): string {

--- a/web/ts/briefing-main.ts
+++ b/web/ts/briefing-main.ts
@@ -1017,7 +1017,7 @@ async function init(): Promise<void> {
       ui.renderRouteSigmets(state.snapshot);
       ui.renderRouteObservations(state.snapshot, () => store.getState().refreshObservations());
       ui.renderSynopsis(state.flight, state.currentPack, state.digest, state.displayMode, state.digestPending);
-      ui.renderDwdCharts(state.flight, state.currentPack);
+      ui.renderDwdCharts(state.flight, state.currentPack, user.is_admin || !!state.currentPack?.metoffice_charts_public);
       ui.renderDWDOverview(state.flight, state.currentPack, user.is_admin);
       ui.renderGramet(state.flight, state.currentPack);
       renderPointSections(state);
@@ -1429,7 +1429,7 @@ async function init(): Promise<void> {
     ui.renderRouteSigmets(s.snapshot);
     ui.renderRouteObservations(s.snapshot, () => store.getState().refreshObservations());
     ui.renderSynopsis(s.flight, s.currentPack, s.digest, s.displayMode, s.digestPending);
-    ui.renderDwdCharts(s.flight, s.currentPack);
+    ui.renderDwdCharts(s.flight, s.currentPack, user.is_admin || !!s.currentPack?.metoffice_charts_public);
     ui.renderDWDOverview(s.flight, s.currentPack, user.is_admin);
     ui.renderGramet(s.flight, s.currentPack);
     renderPointSections(s);

--- a/web/ts/managers/briefing-ui.ts
+++ b/web/ts/managers/briefing-ui.ts
@@ -1314,7 +1314,7 @@ async function fetchAndRenderDigestJson(
   }
 }
 
-// --- DWD Surface Analysis & Forecast ---
+// --- Surface Pressure & Fronts (DWD + Met Office) ---
 
 const DWD_CHART_TABS: ReadonlyArray<{ id: string; label: string; offsetH: number }> = [
   { id: 'ana', label: 'Analysis', offsetH: 0 },
@@ -1325,7 +1325,19 @@ const DWD_CHART_TABS: ReadonlyArray<{ id: string; label: string; offsetH: number
   { id: '108', label: '+108h', offsetH: 108 },
 ];
 
+const METOFFICE_CHART_TABS: ReadonlyArray<{ id: string; label: string; offsetH: number }> = [
+  { id: 'ana', label: 'Analysis', offsetH: 0 },
+  { id: '012', label: '+12h', offsetH: 12 },
+  { id: '024', label: '+24h', offsetH: 24 },
+  { id: '036', label: '+36h', offsetH: 36 },
+  { id: '048', label: '+48h', offsetH: 48 },
+  { id: '060', label: '+60h', offsetH: 60 },
+  { id: '072', label: '+72h', offsetH: 72 },
+  { id: '084', label: '+84h', offsetH: 84 },
+];
+
 const DWD_PAGE_URL = 'https://www.dwd.de/DE/leistungen/hobbymet_wk_europa/hobbyeuropakarten.html';
+const METOFFICE_PAGE_URL = 'https://weather.metoffice.gov.uk/maps-and-charts/surface-pressure';
 
 /** Parse "2026-05-08T06Z" into a Date. Returns null on failure. */
 function parseRunCycle(runCycle: string): Date | null {
@@ -1360,20 +1372,15 @@ interface DwdChartWaypoint {
   y: number;
 }
 
-interface DwdChartOverlay {
-  analysis: { native_size: [number, number]; waypoints: DwdChartWaypoint[] };
-  icon: { native_size: [number, number]; waypoints: DwdChartWaypoint[] };
-}
-
-function chartTypeFor(chartId: string): 'analysis' | 'icon' {
-  return chartId === 'ana' ? 'analysis' : 'icon';
-}
+// Overlay JSON keyed by chart-type: DWD uses {analysis, icon}, Met Office
+// uses {colour}. Source descriptors map a chart id to its key.
+type ChartOverlay = Record<string, { native_size: [number, number]; waypoints: DwdChartWaypoint[] }>;
 
 function renderRouteSvg(
-  overlay: DwdChartOverlay,
-  chartType: 'analysis' | 'icon',
+  overlay: ChartOverlay,
+  overlayKey: string,
 ): string {
-  const data = overlay[chartType];
+  const data = overlay[overlayKey];
   if (!data || !data.waypoints.length) return '';
   const [w, h] = data.native_size;
   const wps = data.waypoints;
@@ -1443,9 +1450,57 @@ function renderRouteSvg(
   `;
 }
 
+interface ChartSource {
+  key: 'dwd' | 'metoffice';
+  label: string;
+  tabs: ReadonlyArray<{ id: string; label: string; offsetH: number }>;
+  runCycle: string;
+  defaultId: string;
+  chartUrl: (chartId: string) => string;
+  overlayUrl: () => string;
+  overlayKeyFor: (chartId: string) => string;
+  attributionHtml: string;
+}
+
+function makeDwdSource(flight: FlightResponse, pack: PackMeta): ChartSource {
+  return {
+    key: 'dwd',
+    label: 'DWD',
+    tabs: DWD_CHART_TABS,
+    runCycle: pack.dwd_charts_run_cycle as string,
+    defaultId: pack.dwd_charts_default_id || 'ana',
+    chartUrl: (id) => api.dwdChartUrl(flight.id, pack.fetch_timestamp, id),
+    overlayUrl: () => api.dwdChartOverlayUrl(flight.id, pack.fetch_timestamp),
+    overlayKeyFor: (id) => (id === 'ana' ? 'analysis' : 'icon'),
+    attributionHtml: `Source: <a href="${DWD_PAGE_URL}" target="_blank" rel="noopener">Deutscher Wetterdienst (DWD)</a>, CC BY 4.0`,
+  };
+}
+
+function makeMetofficeSource(flight: FlightResponse, pack: PackMeta): ChartSource {
+  return {
+    key: 'metoffice',
+    label: 'Met Office',
+    tabs: METOFFICE_CHART_TABS,
+    runCycle: pack.metoffice_charts_run_cycle as string,
+    defaultId: pack.metoffice_charts_default_id || 'ana',
+    chartUrl: (id) => api.metofficeChartUrl(flight.id, pack.fetch_timestamp, id),
+    overlayUrl: () => api.metofficeChartOverlayUrl(flight.id, pack.fetch_timestamp),
+    overlayKeyFor: () => 'colour',
+    attributionHtml: `Source: <a href="${METOFFICE_PAGE_URL}" target="_blank" rel="noopener">Met Office</a> · &copy; Crown copyright`,
+  };
+}
+
+/**
+ * Surface Pressure & Fronts panel. Hosts the DWD chart source and, when
+ * available, the Met Office source behind a `[DWD | Met Office]` toggle.
+ *
+ * `metofficeAvailable` is `user.is_admin || pack.metoffice_charts_public`
+ * — the Met Office source is admin-gated until Met Office authorise reuse.
+ */
 export function renderDwdCharts(
   flight: FlightResponse | null,
   pack: PackMeta | null,
+  metofficeAvailable = false,
 ): void {
   const wrapper = $('dwd-charts-wrapper');
   const el = $('dwd-charts-section');
@@ -1456,117 +1511,163 @@ export function renderDwdCharts(
     return;
   }
 
-  if (!pack.dwd_charts_in_coverage) {
-    // Section silently hidden for non-Europe routes (matches DWD-overview behaviour).
-    wrapper.style.display = 'none';
-    return;
+  const sources: ChartSource[] = [];
+  if (pack.dwd_charts_in_coverage && pack.dwd_charts_within_horizon && pack.dwd_charts_run_cycle) {
+    sources.push(makeDwdSource(flight, pack));
+  }
+  if (
+    metofficeAvailable &&
+    pack.metoffice_charts_in_coverage &&
+    pack.metoffice_charts_within_horizon &&
+    pack.metoffice_charts_run_cycle
+  ) {
+    sources.push(makeMetofficeSource(flight, pack));
   }
 
-  if (!pack.dwd_charts_within_horizon || !pack.dwd_charts_run_cycle) {
-    wrapper.style.display = '';
-    el.innerHTML = `<p class="muted">DWD charts unavailable for this briefing — flight is beyond the +108h forecast horizon, or the chart refresh failed.</p>`;
-    return;
-  }
-
-  const runCycle = pack.dwd_charts_run_cycle;
-  const issuedDate = parseRunCycle(runCycle);
-  const defaultId = pack.dwd_charts_default_id || 'ana';
-
-  wrapper.style.display = '';
-
-  const tabsHtml = DWD_CHART_TABS.map((tab) => {
-    const cls = tab.id === defaultId ? 'btn-toggle active' : 'btn-toggle';
-    return `<button type="button" class="${cls}" data-chart-id="${tab.id}">${escapeHtml(tab.label)}</button>`;
-  }).join('');
-
-  el.innerHTML = `
-    <div class="dwd-charts-tabs" role="tablist" style="display:flex; flex-wrap:wrap; gap:6px; margin-bottom:8px; align-items:center;">
-      ${tabsHtml}
-      <label style="margin-left:auto; display:inline-flex; align-items:center; gap:6px; cursor:pointer; user-select:none;" title="Toggle route overlay">
-        <input type="checkbox" id="dwd-charts-route-toggle" checked style="cursor:pointer;">
-        <span>Show route</span>
-      </label>
-    </div>
-    <div id="dwd-charts-image-wrap" style="text-align:center;">
-      <div id="dwd-charts-image-container" style="position:relative; display:inline-block; max-width:100%;">
-        <img id="dwd-charts-image" alt="DWD chart" style="display:block; max-width:100%; height:auto;">
-        <div id="dwd-charts-overlay-slot" style="position:absolute; top:0; left:0; width:100%; height:100%; pointer-events:none;"></div>
-      </div>
-      <p id="dwd-charts-caption" class="header-meta" style="margin-top:6px;"></p>
-    </div>
-  `;
-
-  let currentChartId = defaultId;
-  let routeVisible = true;
-  let overlay: DwdChartOverlay | null = null;
-
-  const updateOverlay = (): void => {
-    const slot = document.getElementById('dwd-charts-overlay-slot');
-    if (!slot) return;
-    if (!overlay || !routeVisible) {
-      slot.innerHTML = '';
+  const inCoverage = pack.dwd_charts_in_coverage || (metofficeAvailable && pack.metoffice_charts_in_coverage);
+  if (sources.length === 0) {
+    if (!inCoverage) {
+      // Non-Europe route — section silently hidden (matches prior behaviour).
+      wrapper.style.display = 'none';
       return;
     }
-    slot.innerHTML = renderRouteSvg(overlay, chartTypeFor(currentChartId));
-  };
+    wrapper.style.display = '';
+    el.innerHTML = `<p class="muted">Surface charts unavailable for this briefing — flight is beyond the forecast horizon, or the chart refresh failed.</p>`;
+    return;
+  }
 
-  // Fetch overlay once per render. Failures degrade silently — chart still works.
-  fetch(api.dwdChartOverlayUrl(flight.id, pack.fetch_timestamp))
-    .then((r) => (r.ok ? (r.json() as Promise<DwdChartOverlay>) : null))
-    .then((data) => {
-      overlay = data;
-      updateOverlay();
-    })
-    .catch(() => {
-      overlay = null;
-    });
+  wrapper.style.display = '';
+  mountChartPanel(el, sources);
+}
 
-  const showChart = (chartId: string): void => {
-    currentChartId = chartId;
-    const img = document.getElementById('dwd-charts-image') as HTMLImageElement | null;
-    const caption = document.getElementById('dwd-charts-caption');
-    if (!img || !caption) return;
+function mountChartPanel(el: HTMLElement, sources: ChartSource[]): void {
+  let activeKey = sources[0].key;
+  let routeVisible = true; // persists across source switches
 
-    img.src = api.dwdChartUrl(flight.id, pack.fetch_timestamp, chartId);
-    img.alt = `DWD chart ${chartId}`;
-    img.onerror = () => {
-      img.style.display = 'none';
-      caption.innerHTML = `<span class="muted">Chart no longer available — the cached file has been evicted.</span>`;
+  const render = (): void => {
+    const src = sources.find((s) => s.key === activeKey) as ChartSource;
+    const issuedDate = parseRunCycle(src.runCycle);
+
+    const sourceToggleHtml =
+      sources.length > 1
+        ? `<div class="chart-source-toggle" role="tablist" style="display:flex; gap:6px; margin-bottom:8px;">
+             ${sources
+               .map(
+                 (s) =>
+                   `<button type="button" class="btn-toggle${s.key === activeKey ? ' active' : ''}" data-source="${s.key}">${escapeHtml(s.label)}</button>`,
+               )
+               .join('')}
+           </div>`
+        : '';
+
+    const tabsHtml = src.tabs
+      .map((tab) => {
+        const cls = tab.id === src.defaultId ? 'btn-toggle active' : 'btn-toggle';
+        return `<button type="button" class="${cls}" data-chart-id="${tab.id}">${escapeHtml(tab.label)}</button>`;
+      })
+      .join('');
+
+    el.innerHTML = `
+      ${sourceToggleHtml}
+      <div class="dwd-charts-tabs" role="tablist" style="display:flex; flex-wrap:wrap; gap:6px; margin-bottom:8px; align-items:center;">
+        ${tabsHtml}
+        <label style="margin-left:auto; display:inline-flex; align-items:center; gap:6px; cursor:pointer; user-select:none;" title="Toggle route overlay">
+          <input type="checkbox" id="dwd-charts-route-toggle" ${routeVisible ? 'checked' : ''} style="cursor:pointer;">
+          <span>Show route</span>
+        </label>
+      </div>
+      <div id="dwd-charts-image-wrap" style="text-align:center;">
+        <div id="dwd-charts-image-container" style="position:relative; display:inline-block; max-width:100%;">
+          <img id="dwd-charts-image" alt="${escapeHtml(src.label)} chart" style="display:block; max-width:100%; height:auto;">
+          <div id="dwd-charts-overlay-slot" style="position:absolute; top:0; left:0; width:100%; height:100%; pointer-events:none;"></div>
+        </div>
+        <p id="dwd-charts-caption" class="header-meta" style="margin-top:6px;"></p>
+      </div>
+    `;
+
+    let currentChartId = src.defaultId;
+    let overlay: ChartOverlay | null = null;
+
+    const updateOverlay = (): void => {
       const slot = document.getElementById('dwd-charts-overlay-slot');
-      if (slot) slot.innerHTML = '';
-    };
-    img.onload = () => {
-      img.style.display = '';
-      updateOverlay();
+      if (!slot) return;
+      if (!overlay || !routeVisible) {
+        slot.innerHTML = '';
+        return;
+      }
+      slot.innerHTML = renderRouteSvg(overlay, src.overlayKeyFor(currentChartId));
     };
 
-    let issuedCaption = '';
-    if (issuedDate) {
-      const ago = formatHoursAgo(Date.now() - issuedDate.getTime());
-      issuedCaption = `Issued ${ago} (${escapeHtml(formatUtcCaption(issuedDate))}) · `;
-    }
-    caption.innerHTML = `${issuedCaption}Source: <a href="${DWD_PAGE_URL}" target="_blank" rel="noopener">Deutscher Wetterdienst (DWD)</a>, CC BY 4.0`;
+    // Fetch overlay once per source render. Failures degrade silently.
+    fetch(src.overlayUrl())
+      .then((r) => (r.ok ? (r.json() as Promise<ChartOverlay>) : null))
+      .then((data) => {
+        overlay = data;
+        updateOverlay();
+      })
+      .catch(() => {
+        overlay = null;
+      });
+
+    const showChart = (chartId: string): void => {
+      currentChartId = chartId;
+      const img = document.getElementById('dwd-charts-image') as HTMLImageElement | null;
+      const caption = document.getElementById('dwd-charts-caption');
+      if (!img || !caption) return;
+
+      img.src = src.chartUrl(chartId);
+      img.alt = `${src.label} chart ${chartId}`;
+      img.onerror = () => {
+        img.style.display = 'none';
+        caption.innerHTML = `<span class="muted">Chart no longer available — the cached file has been evicted.</span>`;
+        const slot = document.getElementById('dwd-charts-overlay-slot');
+        if (slot) slot.innerHTML = '';
+      };
+      img.onload = () => {
+        img.style.display = '';
+        updateOverlay();
+      };
+
+      let issuedCaption = '';
+      if (issuedDate) {
+        const ago = formatHoursAgo(Date.now() - issuedDate.getTime());
+        issuedCaption = `Issued ${ago} (${escapeHtml(formatUtcCaption(issuedDate))}) · `;
+      }
+      caption.innerHTML = `${issuedCaption}${src.attributionHtml}`;
+
+      el.querySelectorAll('.dwd-charts-tabs .btn-toggle[data-chart-id]').forEach((btn) => {
+        const b = btn as HTMLButtonElement;
+        b.classList.toggle('active', b.dataset.chartId === chartId);
+      });
+    };
 
     el.querySelectorAll('.dwd-charts-tabs .btn-toggle[data-chart-id]').forEach((btn) => {
-      const b = btn as HTMLButtonElement;
-      b.classList.toggle('active', b.dataset.chartId === chartId);
+      btn.addEventListener('click', () => {
+        const id = (btn as HTMLButtonElement).dataset.chartId;
+        if (id) showChart(id);
+      });
     });
+
+    el.querySelectorAll('.chart-source-toggle .btn-toggle[data-source]').forEach((btn) => {
+      btn.addEventListener('click', () => {
+        const key = (btn as HTMLButtonElement).dataset.source as ChartSource['key'] | undefined;
+        if (key && key !== activeKey) {
+          activeKey = key;
+          render();
+        }
+      });
+    });
+
+    const routeCheckbox = document.getElementById('dwd-charts-route-toggle') as HTMLInputElement | null;
+    routeCheckbox?.addEventListener('change', () => {
+      routeVisible = routeCheckbox.checked;
+      updateOverlay();
+    });
+
+    showChart(src.defaultId);
   };
 
-  el.querySelectorAll('.dwd-charts-tabs .btn-toggle[data-chart-id]').forEach((btn) => {
-    btn.addEventListener('click', () => {
-      const id = (btn as HTMLButtonElement).dataset.chartId;
-      if (id) showChart(id);
-    });
-  });
-
-  const routeCheckbox = document.getElementById('dwd-charts-route-toggle') as HTMLInputElement | null;
-  routeCheckbox?.addEventListener('change', () => {
-    routeVisible = routeCheckbox.checked;
-    updateOverlay();
-  });
-
-  showChart(defaultId);
+  render();
 }
 
 // --- DWD Synoptic Overview ---

--- a/web/ts/store/types.ts
+++ b/web/ts/store/types.ts
@@ -203,6 +203,11 @@ export interface PackMeta {
   dwd_charts_default_id?: string | null;
   dwd_charts_in_coverage?: boolean;
   dwd_charts_within_horizon?: boolean;
+  metoffice_charts_run_cycle?: string | null;
+  metoffice_charts_default_id?: string | null;
+  metoffice_charts_in_coverage?: boolean;
+  metoffice_charts_within_horizon?: boolean;
+  metoffice_charts_public?: boolean;
 }
 
 export interface ModelDivergence {


### PR DESCRIPTION
Adds the Met Office colour surface-pressure/front charts as a second source alongside DWD on the briefing **Surface Pressure & Fronts** panel, behind a `[DWD | Met Office]` source toggle. Mirrors the existing DWD chart feature end-to-end.

## Gating (important)
**Admin-only by default.** The Met Office source is gated behind `METOFFICE_CHARTS_PUBLIC` (env, default `0`) until we have explicit Met Office reuse permission:
- Non-admin + flag off → only DWD shows, **no source toggle at all** (today's experience unchanged).
- Admin (or flag `=1`) → the `[DWD | Met Office]` toggle appears.
- Backend endpoints 403 for non-admins unless the flag is set.

To release later: set `METOFFICE_CHARTS_PUBLIC=1` in prod env — no code change.

### Licensing status — do NOT flip the flag yet
The charts are **not** cleanly OGL: data.gov.uk tags them "Fair Usage", and the Met Office Website Terms of Use exclude underlying web services from OGL and prohibit automated copying + embedding image files — which the fetch-and-reserve design does. Permission (likely via Met Office Weather DataHub) needs confirming before going public. DWD remains the CC BY 4.0 public default.

## What's included
**Backend**
- `fetch/metoffice_charts.py` — keyless JSON-index discovery, conditional-GET cache at `DATA_DIR/metoffice_charts/<cycle>/`, eviction, polar-stereographic georeferencing + route overlay, `public_enabled()` gate.
- `fetch/metoffice_calibrate.py` — homography-fit calibration tool (DLT least-squares).
- `tasks/metoffice_charts.py` + pipeline wiring — eligibility = Europe + within +84h.
- Pack meta columns `metoffice_charts_*` across storage/db/api + Alembic `062` (`batch_alter_table`).
- Endpoints `…/metoffice-chart/{id}` + `…/metoffice-chart-overlay`, admin-or-flag gated.

**Frontend**
- `briefing-ui.ts`: generalised the DWD renderer into a source-aware chart panel with the source toggle; reuses the route-overlay SVG renderer.

## Georeferencing
Calibrated from 8 graticule crossings (lon −15..15, lat 30..60) on `FSXX00T_00.gif`: polar-stereographic, **max 1.33 px / rms 0.58 px**. Visually verified (EGTF→LFRQ over the Channel; Lands End/Brest/Dublin land on their coastlines).

## Tests / verification
- 26 metoffice tests pass (incl. `test_metoffice_charts_meta.py`, a regression guard for the result→`BriefingPackMeta` field copy that this PR also fixes — `_build_pack_meta` was dropping the new fields).
- DWD suites still green (no regressions); `tsc --noEmit` + esbuild clean.
- Verified end-to-end on a local devserver: forced refresh populates the columns, chart GIF + route overlay serve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)