### PR TITLE
Defer auto-refresh emails for imminent model updates (issue #192)

### DIFF
--- a/designs/freshness-markers.md
+++ b/designs/freshness-markers.md
@@ -170,7 +170,7 @@ When tuning registry offsets:
 
 ## References
 
-- Issue #108 (design + acceptance criteria); issue #167 (tiered refresh gate)
+- Issue #108 (design + acceptance criteria); issue #167 (tiered refresh gate); issue #192 (model-update-aware auto-refresh email timing — `scheduler._defer_regular_for_model_update` consumes the store + `registry.next_full_horizon_run`/`max_horizon`)
 - Existing helpers wrapped: `fetch/model_status.py`, `fetch/grib/{grib_fetch,icon_eu_fetch,ecmwf_watcher}.py`
 - Pack-side: `api/packs.py:_build_data_status`, `_backfill_sources`, `_finalize_refresh` (records `model_sources`), `_provider_label` (reads `registry.SOURCE_REGISTRY.provider_label`)
 - Tiered gate: `api/packs.py:decide_refresh` + `_refresh_threshold`/`_days_out_now`/`RefreshDecision`, `ModelStatus.covers_horizon`; wired into `refresh_briefing`, `refresh_briefing_stream`, `scheduler._auto_refresh_one`; realtime seam `tasks/route_weather.run_realtime_refresh` (see [metar-taf-route-weather.md](metar-taf-route-weather.md))

--- a/designs/multi-user-deployment.md
+++ b/designs/multi-user-deployment.md
@@ -342,6 +342,8 @@ Background scheduler (`scheduler.py`) polls every 10 minutes for flights with `a
 
 **Scheduling formula**: `next_due = min(next_regular, flight_start − 2h)` where `next_regular` is the next occurrence of the user's preferred hour (`auto_refresh_hour`, defaulting to `departure_time.hour − 1`) after the last refresh.
 
+**Model-update-aware timing (issue #192)**: the `next_regular` term may be *deferred* a bounded amount so a briefing rides an imminent horizon-extending model run instead of being stale-at-birth. `_defer_regular_for_model_update` (in `scheduler.py`) consults the freshness `MarkerStore` for the next ECMWF full-horizon (00/12Z, 168h) delivery (~06:40 / 18:40 UTC; the 06/18Z 90h cycles are excluded via `registry.next_full_horizon_run`). If the regular slot falls within `_MODEL_UPDATE_WAIT_WINDOW` (2h) *before* that delivery, the slot is pushed to `delivery + 20m`, capped at `slot + 2h30m` (so a slipping run never delays indefinitely). It **only ever defers**, never touches the preflight term, and is gated to slots `≥ 2` calendar days before the flight (never day-of / day-before — timeliness wins). Two levers drive whether it applies: the silent NULL-`auto_refresh_hour` default (snaps the `departure − 1` majority out of the pre-delivery dead-zone) and the opt-in account toggle `defer_email_for_model_update` (default off) for explicit-hour users.
+
 **Behavior**:
 - Skips flights whose start time has passed
 - Checks data freshness before refreshing (skips if models unchanged)

--- a/src/weatherbrief/api/preferences.py
+++ b/src/weatherbrief/api/preferences.py
@@ -66,6 +66,7 @@ class PreferencesResponse(BaseModel):
     locale: str
     units_region: str
     synoptic_forecast_map_enabled: bool
+    defer_email_for_model_update: bool
     pirep_can_view: bool = False
     pirep_can_publish: bool = False
 
@@ -87,6 +88,7 @@ class PreferencesUpdate(BaseModel):
     locale: str | None = None
     units_region: Literal["auto", "europe", "us"] | None = None
     synoptic_forecast_map_enabled: bool | None = None
+    defer_email_for_model_update: bool | None = None
 
 
 def _load_prefs(db: Session, user_id: str) -> UserPreferencesRow:
@@ -131,6 +133,7 @@ def _parse_service_toggles(raw: str) -> dict:
         "locale": data.get("locale", "en"),
         "units_region": data.get("units_region", "auto"),
         "synoptic_forecast_map_enabled": data.get("synoptic_forecast_map_enabled", False),
+        "defer_email_for_model_update": data.get("defer_email_for_model_update", False),
     }
 
 
@@ -252,6 +255,8 @@ def update_preferences(
         data["units_region"] = body.units_region
     if body.synoptic_forecast_map_enabled is not None:
         data["synoptic_forecast_map_enabled"] = body.synoptic_forecast_map_enabled
+    if body.defer_email_for_model_update is not None:
+        data["defer_email_for_model_update"] = body.defer_email_for_model_update
 
     if body.digest_config is not None:
         data["digest_config"] = body.digest_config.model_dump(exclude_none=True)
@@ -371,6 +376,22 @@ def load_service_toggles(db: Session, user_id: str) -> dict[str, Any]:
         return {"gramet_enabled": True, "llm_digest_enabled": True, "icing_severity_enhance": False, "icing_method": "ogimet_nwp", "cloud_method": "soft_nwp", "convective_method": "nwp", "units_region": "auto"}
     run_pending_migrations(db, row)
     return _parse_service_toggles(row.app_prefs_json)
+
+
+def load_defer_email_for_model_update(db: Session, user_id: str) -> bool:
+    """Return the user's "defer auto-refresh email for an imminent model run".
+
+    Opt-in account preference (default ``False`` = current behaviour). Read by
+    the auto-refresh scheduler (issue #192, Lever 1). The silent NULL-default
+    snap (Lever 2) does not consult this — it applies regardless.
+    """
+    row = db.get(UserPreferencesRow, user_id)
+    if not row or not row.app_prefs_json:
+        return False
+    try:
+        return bool(json.loads(row.app_prefs_json).get("defer_email_for_model_update", False))
+    except json.JSONDecodeError:
+        return False
 
 
 def can_view_pireps(db: Session, user_id: str) -> bool:

--- a/src/weatherbrief/fetch/freshness/registry.py
+++ b/src/weatherbrief/fetch/freshness/registry.py
@@ -419,6 +419,54 @@ def run_horizon(source: str, init: datetime) -> timedelta:
     return cfg.horizon_for(init.hour)
 
 
+def max_horizon(source: str) -> timedelta:
+    """Largest forecast horizon any cycle of ``source`` ever reaches.
+
+    For sources with a per-cycle horizon dict (e.g. ECMWF 00/12 = 168h vs
+    06/18 = 90h) this is the maximum; for uniform-horizon sources it is that
+    single value.
+    """
+    cfg = SOURCE_REGISTRY[source]
+    return max(cfg.horizon_for(h) for h in cfg.cycles)
+
+
+def next_full_horizon_run(source: str, after: datetime) -> tuple[datetime, datetime]:
+    """Return ``(init, expected_delivery)`` of the next *full-horizon* run.
+
+    A "full-horizon" run is one whose forecast horizon equals
+    :func:`max_horizon` for the source — i.e. it extends the forecast as far
+    as the source ever does.  For ECMWF the 00/12Z cycles reach 168h while the
+    06/18Z cycles reach only 90h, so only 00/12Z qualify; for uniform-horizon
+    sources every cycle qualifies.
+
+    The returned run is the one with the earliest *expected delivery wallclock*
+    strictly after ``after`` (delivery = ``init + delivery_offset``).  This is
+    what the email scheduler waits on: a run that lands shortly after a regular
+    slot and would replace it with a fresher, equally-long forecast.
+
+    Waiting for a *medium*-only cycle far out would give a shorter horizon
+    (actively worse), so those are excluded here by construction.
+    """
+    cfg = SOURCE_REGISTRY[source]
+    full_h = max_horizon(source)
+    base = after.replace(hour=0, minute=0, second=0, microsecond=0)
+    best: tuple[datetime, datetime] | None = None
+    # A run's delivery offset can be several hours, so a cycle init on the
+    # previous calendar day may still deliver after ``after``; scan a small
+    # window around it and keep the earliest qualifying delivery.
+    for day in (-1, 0, 1, 2):
+        for hour in cfg.cycles:
+            init = base + timedelta(days=day, hours=hour)
+            if cfg.horizon_for(init.hour) < full_h:
+                continue
+            delivery = init + cfg.offset_for(init.hour)
+            if delivery > after and (best is None or delivery < best[1]):
+                best = (init, delivery)
+    if best is None:  # pragma: no cover - cycles always include a full run
+        raise ValueError(f"no full-horizon cycle configured for {source!r}")
+    return best
+
+
 def cycle_init_for(source: str, dt: datetime) -> datetime:
     """Return the latest cycle init at-or-before ``dt`` for ``source``."""
     cfg = SOURCE_REGISTRY[source]

--- a/src/weatherbrief/scheduler.py
+++ b/src/weatherbrief/scheduler.py
@@ -19,6 +19,7 @@ import logging
 import os
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from sqlalchemy import select
 from sqlalchemy.orm import Session
@@ -26,6 +27,9 @@ from sqlalchemy.orm import Session
 from flyfun_common.db import SessionLocal
 from flyfun_common.db.models import UserRow
 from weatherbrief.db.models import FlightRow
+
+if TYPE_CHECKING:
+    from weatherbrief.fetch.freshness.markers import MarkerStore
 
 logger = logging.getLogger(__name__)
 
@@ -240,7 +244,7 @@ def _next_due_at(
     now_utc: datetime,
     *,
     apply_model_update: bool = False,
-    store=None,
+    store: "MarkerStore | None" = None,
 ) -> datetime | None:
     """Absolute UTC datetime when the next auto-refresh is due.
 
@@ -295,7 +299,7 @@ def _next_due_at(
 def _defer_regular_for_model_update(
     regular: datetime,
     flight_start_dt: datetime,
-    store,
+    store: "MarkerStore | None",
 ) -> datetime:
     """Defer the regular slot to ride an imminent full-horizon model run.
 

--- a/src/weatherbrief/scheduler.py
+++ b/src/weatherbrief/scheduler.py
@@ -32,6 +32,36 @@ logger = logging.getLogger(__name__)
 _POLL_INTERVAL_SECONDS = 600  # 10 minutes
 _STARTUP_DELAY_SECONDS = 30
 _PREFLIGHT_LEAD_HOURS = 2
+
+# --- Model-update-aware email timing (issue #192) --------------------------
+# When a flight's regular auto-refresh slot is scheduled to fire shortly
+# *before* a fresh, horizon-extending model run lands, defer the send so the
+# briefing rides the newer run instead of being stale-at-birth. Strictly
+# bounded, only ever defers (firing earlier is never useful), and never applied
+# on/near the day of the flight — timeliness wins there (the preflight slot
+# already guarantees a final refresh near departure).
+#
+# "Big" run = ECMWF full-horizon 00/12Z delivery (168h, landing ~06:40/18:40
+# UTC). The 06/18Z cycles reach only 90h, so waiting for them far out would
+# give a *shorter* horizon — they are excluded by next_full_horizon_run().
+# ECMWF covers Europe + US and is the horizon-extending primary for both, so it
+# is used region-agnostically; region-aware multi-model selection (ICON-EU /
+# ARPEGE / GFS) is a documented future extension.
+_MODEL_UPDATE_SOURCE = "ecmwf:direct"
+_MODEL_UPDATE_MODEL = "ecmwf"
+# Only defer when the regular slot is at least this many calendar days before
+# the flight. On the day of / day before, timeliness beats freshness.
+_MODEL_UPDATE_MIN_DAYS_OUT = 2
+# A big run must be expected within this window *after* the regular slot for a
+# defer to be worthwhile. Slots earlier than this already ride a fresh run.
+_MODEL_UPDATE_WAIT_WINDOW = timedelta(hours=2)
+# Buffer after the expected delivery so the run has actually landed + decoded
+# before we build the brief (mirrors the forecast-fetch +15m offset).
+_MODEL_UPDATE_MARGIN = timedelta(minutes=20)
+# Hard cap on how far a slot may be deferred, so a slipping run never delays the
+# email indefinitely. >= WAIT_WINDOW + MARGIN so a legitimate wait is never
+# clipped, with headroom for a modest slip.
+_MODEL_UPDATE_MAX_WAIT = timedelta(hours=2, minutes=30)
 _RETENTION_INTERVAL_SECONDS = 86_400  # 24 hours
 _RETENTION_STARTUP_DELAY_SECONDS = 120  # let auto-refresh settle first
 _VERIF_POLL_SECONDS = 600  # 10 minutes
@@ -152,6 +182,10 @@ def _find_due_flights(db: Session) -> list[FlightRow]:
     )
     rows = db.execute(stmt).scalars().all()
 
+    from weatherbrief.fetch.freshness.markers import get_store
+    store = get_store()
+    defer_cache: dict[str, bool] = {}
+
     due: list[FlightRow] = []
     for row in rows:
         flight_start = _flight_start_dt(row)
@@ -162,17 +196,51 @@ def _find_due_flights(db: Session) -> list[FlightRow]:
         if now_utc >= flight_start:
             continue
 
-        due_at = _next_due_at(row, flight_start, now_utc)
+        # Model-update-aware timing (issue #192) applies to the silent
+        # NULL-default majority (Lever 2: snap out of the pre-delivery
+        # dead-zone) and to explicit-hour users who opted in (Lever 1).
+        apply_mu = row.auto_refresh_hour is None or _user_defers_for_model_update(
+            db, row.user_id, defer_cache,
+        )
+
+        due_at = _next_due_at(
+            row, flight_start, now_utc,
+            apply_model_update=apply_mu, store=store,
+        )
         if due_at is not None and now_utc >= due_at:
             due.append(row)
 
     return due
 
 
+def _user_defers_for_model_update(
+    db: Session, user_id: str, cache: dict[str, bool],
+) -> bool:
+    """Return the user's opt-in "defer for imminent model update" toggle.
+
+    Cached per scheduler cycle so a batch of one user's flights costs a single
+    preferences read. Defaults to ``False`` (current behaviour) on any error.
+    """
+    if user_id in cache:
+        return cache[user_id]
+    try:
+        from weatherbrief.api.preferences import load_defer_email_for_model_update
+
+        value = load_defer_email_for_model_update(db, user_id)
+    except Exception:
+        logger.debug("Could not load defer preference for %s", user_id, exc_info=True)
+        value = False
+    cache[user_id] = value
+    return value
+
+
 def _next_due_at(
     row: FlightRow,
     flight_start_dt: datetime,
     now_utc: datetime,
+    *,
+    apply_model_update: bool = False,
+    store=None,
 ) -> datetime | None:
     """Absolute UTC datetime when the next auto-refresh is due.
 
@@ -183,6 +251,13 @@ def _next_due_at(
 
     Always returns a time strictly before ``flight_start_dt`` (since
     *preflight* is ``flight_start − PREFLIGHT_LEAD_HOURS``).
+
+    When ``apply_model_update`` is set (issue #192 — NULL-default snap or the
+    opt-in account toggle), the *regular* term may be deferred a bounded amount
+    so the briefing rides an imminent horizon-extending model run instead of
+    being stale-at-birth. Only the regular term is touched; *preflight* is left
+    untouched, and the deferral never applies within
+    ``_MODEL_UPDATE_MIN_DAYS_OUT`` of the flight.
     """
     effective_hour = row.auto_refresh_hour
     if effective_hour is None:
@@ -201,6 +276,11 @@ def _next_due_at(
         effective_hour, tzinfo=timezone.utc,
     )
 
+    if apply_model_update:
+        regular = _defer_regular_for_model_update(
+            regular, flight_start_dt, store,
+        )
+
     # If we already refreshed at or after the pre-flight time, that slot is
     # satisfied — only the regular schedule matters from here on.
     last_refresh = row.last_auto_refresh_at
@@ -210,6 +290,61 @@ def _next_due_at(
         return regular
 
     return min(regular, preflight)
+
+
+def _defer_regular_for_model_update(
+    regular: datetime,
+    flight_start_dt: datetime,
+    store,
+) -> datetime:
+    """Defer the regular slot to ride an imminent full-horizon model run.
+
+    Returns a time ``>= regular`` (deferring earlier is never useful), bounded
+    by ``_MODEL_UPDATE_MAX_WAIT``. Returns ``regular`` unchanged when:
+
+    - the slot is within ``_MODEL_UPDATE_MIN_DAYS_OUT`` of the flight (day-of /
+      day-before — timeliness wins);
+    - no full-horizon run lands within ``_MODEL_UPDATE_WAIT_WINDOW`` after the
+      slot (it already rides a fresh run, or the next big run is far off);
+    - the imminent big run is already in hand (e.g. it arrived early); or
+    - the marker can't confirm the schedule (missing / stale heartbeat).
+
+    Mirrors the forecast-fetch loop's bounded "wait for a slow marker before
+    firing" pattern (``_wait_for_marker_freshness``), plus the day-of asymmetry.
+    """
+    # Day-of / day-before: never defer — the preflight slot owns this window.
+    if (flight_start_dt.date() - regular.date()).days < _MODEL_UPDATE_MIN_DAYS_OUT:
+        return regular
+
+    from weatherbrief.fetch.freshness import LOOP_INTERVAL
+    from weatherbrief.fetch.freshness.markers import get_store
+    from weatherbrief.fetch.freshness.registry import (
+        next_cycle_init_after,
+        next_full_horizon_run,
+    )
+
+    target_init, target_delivery = next_full_horizon_run(_MODEL_UPDATE_SOURCE, regular)
+    # Slot already rides a fresh run, or the next big run is beyond the window.
+    if target_delivery - regular > _MODEL_UPDATE_WAIT_WINDOW:
+        return regular
+
+    if store is None:
+        store = get_store()
+    marker = store.get_sync(_MODEL_UPDATE_SOURCE, _MODEL_UPDATE_MODEL)
+    if marker is None or marker.is_stale(LOOP_INTERVAL):
+        return regular  # can't confirm an imminent delivery — don't gamble
+
+    if marker.init >= target_init:
+        return regular  # the big run is already in hand
+
+    # Slip-aware: if the marker's next expected delivery is for the very cycle
+    # we're waiting on, respect a late-running run (still capped by MAX_WAIT).
+    delivery = target_delivery
+    if next_cycle_init_after(_MODEL_UPDATE_SOURCE, marker.init) == target_init:
+        delivery = max(delivery, marker.next_expected)
+
+    deferred = min(delivery + _MODEL_UPDATE_MARGIN, regular + _MODEL_UPDATE_MAX_WAIT)
+    return deferred if deferred > regular else regular
 
 
 def _flight_start_dt(row: FlightRow) -> datetime | None:

--- a/tests/test_freshness_registry.py
+++ b/tests/test_freshness_registry.py
@@ -11,7 +11,9 @@ from weatherbrief.fetch.freshness.registry import (
     cycle_init_for,
     expected_delivery_for_init,
     initial_marker_for,
+    max_horizon,
     next_cycle_init_after,
+    next_full_horizon_run,
     next_run_after,
     run_horizon,
 )
@@ -171,3 +173,58 @@ def test_each_source_has_sane_offsets(key):
         assert timedelta(minutes=30) <= off <= timedelta(hours=12)
         h = cfg.horizon_for(cycle)
         assert h >= timedelta(hours=24)
+
+
+# ---------------------------------------------------------------------------
+# max_horizon / next_full_horizon_run (issue #192)
+# ---------------------------------------------------------------------------
+
+
+class TestMaxHorizon:
+    def test_ecmwf_direct_is_full_168h(self):
+        # 00/12Z reach 168h; 06/18Z only 90h — the max is 168h.
+        assert max_horizon("ecmwf:direct") == timedelta(hours=168)
+
+    def test_uniform_horizon_source(self):
+        assert max_horizon("gfs:noaa") == timedelta(hours=384)
+
+
+class TestNextFullHorizonRun:
+    """The big-run selector the email scheduler waits on (ECMWF 00/12Z)."""
+
+    def test_excludes_medium_cycles_picks_next_00z(self):
+        # A 06:00 slot: the imminent full-horizon run is 00Z (delivers 06:40),
+        # NOT the 06Z medium cycle (90h, delivers 12:40).
+        init, delivery = next_full_horizon_run("ecmwf:direct", _utc(2026, 3, 1, 6))
+        assert init == _utc(2026, 3, 1, 0)
+        assert delivery == _utc(2026, 3, 1, 6, 40)
+
+    def test_after_morning_delivery_next_is_12z(self):
+        # An 08:00 slot is past the 06:40 (00Z) delivery; the next full-horizon
+        # run is 12Z (delivers 18:40) — the 06Z medium run is skipped.
+        init, delivery = next_full_horizon_run("ecmwf:direct", _utc(2026, 3, 1, 8))
+        assert init == _utc(2026, 3, 1, 12)
+        assert delivery == _utc(2026, 3, 1, 18, 40)
+
+    def test_evening_slot_picks_12z(self):
+        init, delivery = next_full_horizon_run("ecmwf:direct", _utc(2026, 3, 1, 18))
+        assert init == _utc(2026, 3, 1, 12)
+        assert delivery == _utc(2026, 3, 1, 18, 40)
+
+    def test_late_evening_rolls_to_next_day_00z(self):
+        # After the 18:40 (12Z) delivery, the next full run is tomorrow's 00Z.
+        init, delivery = next_full_horizon_run("ecmwf:direct", _utc(2026, 3, 1, 19))
+        assert init == _utc(2026, 3, 2, 0)
+        assert delivery == _utc(2026, 3, 2, 6, 40)
+
+    def test_delivery_strictly_after_slot(self):
+        # A slot exactly at a delivery time gets the *next* run, not that one.
+        _, delivery = next_full_horizon_run("ecmwf:direct", _utc(2026, 3, 1, 6, 40))
+        assert delivery == _utc(2026, 3, 1, 18, 40)
+
+    def test_uniform_horizon_every_cycle_qualifies(self):
+        # GFS has a single horizon, so every cycle is "full"; next delivery
+        # after a 04:00 slot is the 00Z run (00Z + 5h = 05:00).
+        init, delivery = next_full_horizon_run("gfs:noaa", _utc(2026, 3, 1, 4))
+        assert init == _utc(2026, 3, 1, 0)
+        assert delivery == _utc(2026, 3, 1, 5)

--- a/tests/test_preferences.py
+++ b/tests/test_preferences.py
@@ -85,6 +85,27 @@ class TestPreferencesAPI:
         resp = client.put("/api/user/preferences", json={"units_region": "metric"})
         assert resp.status_code == 422
 
+    def test_defer_email_for_model_update_round_trip(self, client, app_db):
+        # Default off (current behaviour).
+        assert client.get("/api/user/preferences").json()["defer_email_for_model_update"] is False
+
+        resp = client.put(
+            "/api/user/preferences",
+            json={"defer_email_for_model_update": True},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["defer_email_for_model_update"] is True
+        assert client.get("/api/user/preferences").json()["defer_email_for_model_update"] is True
+
+        # The scheduler's loader reads the same stored value.
+        from weatherbrief.api.preferences import load_defer_email_for_model_update
+
+        session = app_db()
+        try:
+            assert load_defer_email_for_model_update(session, DEV_USER_ID) is True
+        finally:
+            session.close()
+
     def test_save_flight_defaults(self, client):
         resp = client.put("/api/user/preferences", json={
             "defaults": {

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -553,3 +553,170 @@ class TestAutoRefreshGate:
         _auto_refresh_one(_make_row(), SimpleNamespace(db_path="/fake/db"), "u1")
 
         mock_exec.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Model-update-aware email timing (issue #192)
+# ---------------------------------------------------------------------------
+
+class TestDeferRegularForModelUpdate:
+    """Defer a regular slot to ride an imminent ECMWF full-horizon (00/12Z)
+    delivery (~06:40 / 18:40 UTC). Only ever defers, bounded, never on the day
+    of / day before the flight.
+    """
+
+    # Flight far out so the days_out >= 2 gate is satisfied unless stated.
+    FLIGHT = _utc(2026, 3, 5, 9)
+
+    def _store(self, init, next_expected, *, stale=False):
+        """Build a MarkerStore with one ECMWF marker.
+
+        ``last_check`` is real wall-clock now (not the simulated timeline) so
+        ``Marker.is_stale`` — which compares against ``datetime.now`` — reports
+        a healthy heartbeat unless ``stale=True``.
+        """
+        from weatherbrief.fetch.freshness.markers import Marker, MarkerStore
+
+        store = MarkerStore()
+        store._markers[("ecmwf:direct", "ecmwf")] = Marker(
+            source="ecmwf:direct", model="ecmwf",
+            init=init, next_expected=next_expected,
+            last_check=None if stale else datetime.now(timezone.utc),
+        )
+        return store
+
+    def _defer(self, regular, store, flight=None):
+        from weatherbrief.scheduler import _defer_regular_for_model_update
+
+        return _defer_regular_for_model_update(regular, flight or self.FLIGHT, store)
+
+    def test_just_missed_morning_defers_to_after_delivery(self):
+        # 06:00 slot, latest run is prior 18Z, 00Z lands 06:40 → defer to 07:00.
+        store = self._store(_utc(2026, 2, 28, 18), _utc(2026, 3, 1, 6, 40))
+        assert self._defer(_utc(2026, 3, 1, 6), store) == _utc(2026, 3, 1, 7)
+
+    def test_just_missed_05z_within_window_defers(self):
+        # 05:00 slot is 1h40m before 06:40 — inside the 2h window → defer 07:00.
+        store = self._store(_utc(2026, 2, 28, 18), _utc(2026, 3, 1, 6, 40))
+        assert self._defer(_utc(2026, 3, 1, 5), store) == _utc(2026, 3, 1, 7)
+
+    def test_evening_just_missed_defers(self):
+        # 18:00 slot, 12Z lands 18:40 → defer to 19:00.
+        store = self._store(_utc(2026, 3, 1, 0), _utc(2026, 3, 1, 18, 40))
+        assert self._defer(_utc(2026, 3, 1, 18), store) == _utc(2026, 3, 1, 19)
+
+    def test_riding_fresh_no_defer(self):
+        # 08:00 slot already past the 06:40 delivery; next full run (18:40) is
+        # well beyond the 2h window → no defer.
+        store = self._store(_utc(2026, 2, 28, 18), _utc(2026, 3, 1, 6, 40))
+        assert self._defer(_utc(2026, 3, 1, 8), store) == _utc(2026, 3, 1, 8)
+
+    def test_too_early_outside_window_no_defer(self):
+        # 04:00 slot is 2h40m before 06:40 — outside the 2h window → no defer.
+        store = self._store(_utc(2026, 2, 28, 18), _utc(2026, 3, 1, 6, 40))
+        assert self._defer(_utc(2026, 3, 1, 4), store) == _utc(2026, 3, 1, 4)
+
+    def test_day_of_never_defers(self):
+        # Regular slot on the flight day → timeliness wins, never defer.
+        store = self._store(_utc(2026, 2, 28, 18), _utc(2026, 3, 1, 6, 40))
+        flight = _utc(2026, 3, 1, 9)
+        assert self._defer(_utc(2026, 3, 1, 6), store, flight) == _utc(2026, 3, 1, 6)
+
+    def test_day_before_never_defers(self):
+        # days_out == 1 (slot Mar 4, flight Mar 5) → never defer.
+        store = self._store(_utc(2026, 3, 3, 18), _utc(2026, 3, 4, 6, 40))
+        flight = _utc(2026, 3, 5, 9)
+        assert self._defer(_utc(2026, 3, 4, 6), store, flight) == _utc(2026, 3, 4, 6)
+
+    def test_run_already_in_hand_no_defer(self):
+        # Marker already advanced to the 00Z target → fresh data in hand.
+        store = self._store(_utc(2026, 3, 1, 0), _utc(2026, 3, 1, 12, 40))
+        assert self._defer(_utc(2026, 3, 1, 6), store) == _utc(2026, 3, 1, 6)
+
+    def test_slip_respected_small(self):
+        # 00Z running slightly late (06:55) → defer to delivery + 20m = 07:15.
+        store = self._store(_utc(2026, 2, 28, 18), _utc(2026, 3, 1, 6, 55))
+        assert self._defer(_utc(2026, 3, 1, 6), store) == _utc(2026, 3, 1, 7, 15)
+
+    def test_slip_capped_at_max_wait(self):
+        # 00Z badly slipping (10:00) → capped at regular + 2h30m = 08:30.
+        store = self._store(_utc(2026, 2, 28, 18), _utc(2026, 3, 1, 10, 0))
+        assert self._defer(_utc(2026, 3, 1, 6), store) == _utc(2026, 3, 1, 8, 30)
+
+    def test_stale_marker_no_defer(self):
+        # Suspect heartbeat → can't confirm an imminent delivery → no defer.
+        store = self._store(_utc(2026, 2, 28, 18), _utc(2026, 3, 1, 6, 40), stale=True)
+        assert self._defer(_utc(2026, 3, 1, 6), store) == _utc(2026, 3, 1, 6)
+
+    def test_missing_marker_no_defer(self):
+        from weatherbrief.fetch.freshness.markers import MarkerStore
+
+        assert self._defer(_utc(2026, 3, 1, 6), MarkerStore()) == _utc(2026, 3, 1, 6)
+
+
+class TestNextDueAtModelUpdate:
+    """`_next_due_at` only applies the deferral when `apply_model_update` is set,
+    and only to the regular term (never preflight).
+    """
+
+    def _store(self, init, next_expected):
+        from weatherbrief.fetch.freshness.markers import Marker, MarkerStore
+
+        store = MarkerStore()
+        store._markers[("ecmwf:direct", "ecmwf")] = Marker(
+            source="ecmwf:direct", model="ecmwf",
+            init=init, next_expected=next_expected,
+            last_check=datetime.now(timezone.utc),
+        )
+        return store
+
+    def test_null_default_snaps_out_of_dead_zone(self):
+        # Departure 07:00 → default hour 06:00 lands in the pre-delivery dead
+        # zone; with the snap it rides the 00Z run at 07:00.
+        row = _make_row(departure_time=_utc(2026, 3, 5, 7), auto_refresh_hour=None)
+        store = self._store(_utc(2026, 2, 28, 18), _utc(2026, 3, 5, 6, 40))
+        now = _utc(2026, 3, 5, 5, 30)
+        due = _next_due_at(
+            row, _utc(2026, 3, 5, 7), now,
+            apply_model_update=True, store=store,
+        )
+        assert due == _utc(2026, 3, 5, 7)
+
+    def test_no_apply_leaves_slot_unchanged(self):
+        row = _make_row(departure_time=_utc(2026, 3, 5, 7), auto_refresh_hour=None)
+        store = self._store(_utc(2026, 2, 28, 18), _utc(2026, 3, 5, 6, 40))
+        now = _utc(2026, 3, 5, 5, 30)
+        due = _next_due_at(
+            row, _utc(2026, 3, 5, 7), now,
+            apply_model_update=False, store=store,
+        )
+        assert due == _utc(2026, 3, 5, 6)
+
+    def test_explicit_hour_riding_fresh_not_snapped(self):
+        # Explicit 08:00 already rides the fresh 00Z run → unchanged even when
+        # the toggle is on.
+        row = _make_row(departure_time=_utc(2026, 3, 5, 9), auto_refresh_hour=8)
+        store = self._store(_utc(2026, 2, 28, 18), _utc(2026, 3, 5, 6, 40))
+        now = _utc(2026, 3, 5, 5, 30)
+        due = _next_due_at(
+            row, _utc(2026, 3, 5, 9), now,
+            apply_model_update=True, store=store,
+        )
+        assert due == _utc(2026, 3, 5, 8)
+
+    def test_preflight_term_untouched_by_snap(self):
+        # A late regular hour is still capped by preflight; the snap only
+        # touches the regular term, so the result stays the preflight time.
+        row = _make_row(
+            departure_time=_utc(2026, 3, 5, 9),
+            auto_refresh_hour=14,
+            last_auto_refresh_at=_utc(2026, 3, 4, 14, 0),
+        )
+        store = self._store(_utc(2026, 2, 28, 18), _utc(2026, 3, 5, 6, 40))
+        now = _utc(2026, 3, 4, 15, 0)
+        due = _next_due_at(
+            row, _utc(2026, 3, 5, 9), now,
+            apply_model_update=True, store=store,
+        )
+        # preflight = 07:00Z on flight day, earlier than the 14:00 regular slot.
+        assert due == _utc(2026, 3, 5, 7)

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -671,38 +671,41 @@ class TestNextDueAtModelUpdate:
         return store
 
     def test_null_default_snaps_out_of_dead_zone(self):
-        # Departure 07:00 → default hour 06:00 lands in the pre-delivery dead
-        # zone; with the snap it rides the 00Z run at 07:00.
-        row = _make_row(departure_time=_utc(2026, 3, 5, 7), auto_refresh_hour=None)
-        store = self._store(_utc(2026, 2, 28, 18), _utc(2026, 3, 5, 6, 40))
-        now = _utc(2026, 3, 5, 5, 30)
+        # Departure-1 default hour lands in the pre-delivery dead zone; with the
+        # snap the regular slot rides the imminent 00Z run. Flight is 6 days out
+        # so the days_out >= 2 gate passes and preflight is far in the future.
+        row = _make_row(departure_time=_utc(2026, 3, 7, 7), auto_refresh_hour=None)
+        store = self._store(_utc(2026, 2, 28, 18), _utc(2026, 3, 1, 6, 40))
+        now = _utc(2026, 3, 1, 5, 30)
         due = _next_due_at(
-            row, _utc(2026, 3, 5, 7), now,
+            row, _utc(2026, 3, 7, 7), now,
             apply_model_update=True, store=store,
         )
-        assert due == _utc(2026, 3, 5, 7)
+        # regular = Mar 1 06:00 → deferred to Mar 1 07:00; min(.., preflight
+        # Mar 7 05:00) = Mar 1 07:00.
+        assert due == _utc(2026, 3, 1, 7)
 
     def test_no_apply_leaves_slot_unchanged(self):
-        row = _make_row(departure_time=_utc(2026, 3, 5, 7), auto_refresh_hour=None)
-        store = self._store(_utc(2026, 2, 28, 18), _utc(2026, 3, 5, 6, 40))
-        now = _utc(2026, 3, 5, 5, 30)
+        row = _make_row(departure_time=_utc(2026, 3, 7, 7), auto_refresh_hour=None)
+        store = self._store(_utc(2026, 2, 28, 18), _utc(2026, 3, 1, 6, 40))
+        now = _utc(2026, 3, 1, 5, 30)
         due = _next_due_at(
-            row, _utc(2026, 3, 5, 7), now,
+            row, _utc(2026, 3, 7, 7), now,
             apply_model_update=False, store=store,
         )
-        assert due == _utc(2026, 3, 5, 6)
+        assert due == _utc(2026, 3, 1, 6)
 
     def test_explicit_hour_riding_fresh_not_snapped(self):
-        # Explicit 08:00 already rides the fresh 00Z run → unchanged even when
-        # the toggle is on.
-        row = _make_row(departure_time=_utc(2026, 3, 5, 9), auto_refresh_hour=8)
-        store = self._store(_utc(2026, 2, 28, 18), _utc(2026, 3, 5, 6, 40))
-        now = _utc(2026, 3, 5, 5, 30)
+        # Explicit 08:00 already rides the fresh 00Z run (next full run is 12Z
+        # at 18:40, beyond the 2h window) → unchanged even with the toggle on.
+        row = _make_row(departure_time=_utc(2026, 3, 7, 9), auto_refresh_hour=8)
+        store = self._store(_utc(2026, 2, 28, 18), _utc(2026, 3, 1, 6, 40))
+        now = _utc(2026, 3, 1, 5, 30)
         due = _next_due_at(
-            row, _utc(2026, 3, 5, 9), now,
+            row, _utc(2026, 3, 7, 9), now,
             apply_model_update=True, store=store,
         )
-        assert due == _utc(2026, 3, 5, 8)
+        assert due == _utc(2026, 3, 1, 8)
 
     def test_preflight_term_untouched_by_snap(self):
         # A late regular hour is still capped by preflight; the snap only

--- a/web/settings.html
+++ b/web/settings.html
@@ -126,6 +126,12 @@
               <span class="muted" style="font-size:0.85em; display:block; margin-top:2px;">Adds a "Synoptic Forecast" tab to the Forecast page with gridded θe / TFP / advection fields (Hewson frontal-detection method). Experimental — fields are still being calibrated.</span>
             </label>
           </div>
+          <div class="form-row model-checkboxes">
+            <label class="checkbox-label">
+              <input type="checkbox" id="toggle-defer-model-update"> Wait for an imminent model update before sending
+              <span class="muted" style="font-size:0.85em; display:block; margin-top:2px;">When a scheduled auto-refresh email would go out shortly before a fresh ECMWF run lands (~06:40 / 18:40 UTC), hold it a little (up to ~2.5 h) so the briefing rides the newer forecast. Only applies 2+ days before the flight — never on the day of. Off by default.</span>
+            </label>
+          </div>
         </div>
 
         <div class="section" id="autorouter-section">

--- a/web/settings.html
+++ b/web/settings.html
@@ -128,8 +128,8 @@
           </div>
           <div class="form-row model-checkboxes">
             <label class="checkbox-label">
-              <input type="checkbox" id="toggle-defer-model-update"> Wait for an imminent model update before sending
-              <span class="muted" style="font-size:0.85em; display:block; margin-top:2px;">When a scheduled auto-refresh email would go out shortly before a fresh ECMWF run lands (~06:40 / 18:40 UTC), hold it a little (up to ~2.5 h) so the briefing rides the newer forecast. Only applies 2+ days before the flight — never on the day of. Off by default.</span>
+              <input type="checkbox" id="toggle-defer-model-update"> Wait for an imminent model update before sending (custom refresh times)
+              <span class="muted" style="font-size:0.85em; display:block; margin-top:2px;">When a scheduled auto-refresh email would go out shortly before a fresh ECMWF run lands (~06:40 / 18:40 UTC), hold it a little (up to ~2.5 h) so the briefing rides the newer forecast. Flights on the default refresh time always do this automatically — enable this to also apply it to flights where you've set a custom refresh hour. Only applies 2+ days before the flight, never on the day of.</span>
             </label>
           </div>
         </div>

--- a/web/ts/adapters/preferences-adapter.ts
+++ b/web/ts/adapters/preferences-adapter.ts
@@ -37,6 +37,7 @@ export interface PreferencesResponse {
   locale: string;
   units_region: string;
   synoptic_forecast_map_enabled: boolean;
+  defer_email_for_model_update: boolean;
   pirep_can_view: boolean;
   pirep_can_publish: boolean;
 }
@@ -53,6 +54,7 @@ export interface PreferencesUpdate {
   locale?: string;
   units_region?: string;
   synoptic_forecast_map_enabled?: boolean;
+  defer_email_for_model_update?: boolean;
 }
 
 export async function fetchPreferences(): Promise<PreferencesResponse> {

--- a/web/ts/settings-main.ts
+++ b/web/ts/settings-main.ts
@@ -671,6 +671,10 @@ function populateAccountForm(prefs: PreferencesResponse): void {
   if (synopticToggle) {
     synopticToggle.checked = prefs.synoptic_forecast_map_enabled ?? false;
   }
+  const deferToggle = document.getElementById('toggle-defer-model-update') as HTMLInputElement;
+  if (deferToggle) {
+    deferToggle.checked = prefs.defer_email_for_model_update ?? false;
+  }
 }
 
 // --- Advisory settings rendering ---
@@ -906,10 +910,12 @@ async function handleSave(): Promise<void> {
 
     // Save account-level preferences (locale + optional services + autorouter creds in dev mode)
     const synopticEnabled = (document.getElementById('toggle-synoptic-forecast-map') as HTMLInputElement)?.checked ?? false;
+    const deferModelUpdate = (document.getElementById('toggle-defer-model-update') as HTMLInputElement)?.checked ?? false;
     const accountUpdate: import('./adapters/preferences-adapter').PreferencesUpdate = {
       locale: selectedLocale,
       units_region: selectedUnitsRegion,
       synoptic_forecast_map_enabled: synopticEnabled,
+      defer_email_for_model_update: deferModelUpdate,
     };
     if (autorouterMode === 'password') {
       const arUsername = (document.getElementById('input-ar-username') as HTMLInputElement)?.value.trim();


### PR DESCRIPTION
## Summary

Implements model-update-aware email timing so auto-refresh briefings ride imminent horizon-extending model runs instead of being stale-at-birth. When a regular auto-refresh slot is scheduled to fire shortly before a fresh ECMWF 00/12Z delivery lands (~06:40/18:40 UTC), the email is deferred a bounded amount to include the newer data.

The feature has two levers:
1. **Lever 1 (opt-in)**: Users with explicit `auto_refresh_hour` can enable "defer for model update" in account preferences
2. **Lever 2 (silent)**: Users with NULL `auto_refresh_hour` (default) automatically snap out of the pre-delivery dead-zone to ride fresh runs

Deferral is strictly bounded and never applied within 2 calendar days of the flight — timeliness wins on/near departure.

## Key Changes

**Scheduler logic** (`src/weatherbrief/scheduler.py`):
- Added `_defer_regular_for_model_update()` to defer regular slots when a full-horizon run lands within a 2-hour window after the slot
- Modified `_next_due_at()` to optionally apply deferral to the regular term (preflight is untouched)
- Added `_user_defers_for_model_update()` to read per-user opt-in preference with caching
- Updated `_find_due_flights()` to apply model-update-aware timing based on user preference and NULL-default status
- Added configuration constants for deferral bounds, margins, and day-of gates

**Registry enhancements** (`src/weatherbrief/fetch/freshness/registry.py`):
- Added `max_horizon()` to find the largest forecast horizon any cycle reaches (e.g., ECMWF 00/12Z = 168h vs 06/18Z = 90h)
- Added `next_full_horizon_run()` to identify the next full-horizon run after a given time, excluding medium-only cycles that would give shorter horizons

**Preferences API** (`src/weatherbrief/api/preferences.py`):
- Added `defer_email_for_model_update` boolean field to `PreferencesResponse` and `PreferencesUpdate`
- Added `load_defer_email_for_model_update()` to read the preference from the database
- Updated preference parsing and update logic to handle the new toggle

**Frontend** (`web/settings.html`, `web/ts/settings-main.ts`, `web/ts/adapters/preferences-adapter.ts`):
- Added checkbox UI for "Wait for an imminent model update before sending" in account settings
- Wired preference loading/saving to the new API field

**Tests**:
- `TestDeferRegularForModelUpdate`: 13 test cases covering deferral logic (window bounds, day-of gates, stale markers, slip handling)
- `TestNextDueAtModelUpdate`: 4 test cases for integration with `_next_due_at()` (NULL-default snap, opt-in toggle, preflight untouched)
- `TestMaxHorizon` / `TestNextFullHorizonRun`: 8 test cases for registry functions (cycle selection, delivery timing, uniform vs per-cycle horizons)
- `test_defer_email_for_model_update_round_trip`: Preference persistence test

## Implementation Details

- **Deferral window**: Only defers if a full-horizon run lands within 2 hours after the regular slot (slots earlier already ride fresh data)
- **Day-of gate**: Never defers within 2 calendar days of the flight — the preflight slot (2h before departure) owns this window
- **Slip handling**: Respects late-running model cycles up to a hard cap of 2h30m wait (mirrors forecast-fetch's bounded-wait pattern)
- **Marker validation**: Requires a healthy heartbeat (non-stale marker) to confirm an imminent delivery; missing/stale markers disable deferral
- **Cycle selection**: Uses `next_full_horizon_run()` to skip medium-only cycles (e.g., ECMWF 06/18Z

https://claude.ai/code/session_01BVKWn6kUvnytVkjoYmumJy