### PR TITLE
Implement Hewson front detection for route briefings (#195)

### DIFF
--- a/designs/frontal-detection.md
+++ b/designs/frontal-detection.md
@@ -18,15 +18,45 @@ Cross-section annotation is explicitly deferred — the cross-section already sh
 src/weatherbrief/frontal/
 ├── grid.py          — grid definition, Open-Meteo fetch, field prep, terrain mask
 ├── detect.py        — gradient thresholding, dual T850+θe, front type, Hewson diagnostics
+│                      (theta_e_gradient_components shared with the snapshot source)
 ├── zones.py         — 20 European zones, 19 route templates, zone intersection
 ├── tracking.py      — two-pass anomaly filtering, zone timeseries, persistence + clearance timing
-├── route_sampling.py — Hewson per-leg front-crossing locator + proximity gating (#168, WIP)
+├── gates.py         — FrontGateConfig (one serializable detection recipe) + preset registry
+├── sources.py       — HewsonFieldSource: SnapshotFieldSource (precompute NPZ, prod) +
+│                      CaseFieldSource (recompute, calibration). One detector, swappable data.
+├── route_sampling.py — on-track locator: sample → candidates → decisions (gated by config) +
+│                      off-track proximity gating (#168). Takes a source, not a Case.
+├── contour_fronts.py — 2-D TFP=0 front-line extractor (contourpy) gated by the same config (#195 §C2)
 ├── case.py          — calibration Case loader (Open-Meteo + ERA5 sources), field save/load
 ├── cache.py         — file cache keyed by (model, init_time) for dev iteration
 ├── cli.py           — analyze/zones/route/score/validate/diagnose/new-case/charts +
-│                      plot-hewson/redraw-zones/route-hewson/route-fronts/clear-cache
+│                      plot-hewson/redraw-zones/route-hewson/route-fronts/front-calibrate/clear-cache
 └── __main__.py      — python -m weatherbrief.frontal.cli
 ```
+
+### Front detection: source-agnostic, config-driven (#195)
+
+The per-leg locator (`route_sampling.py`) is split along two seams so one
+detection algorithm serves the briefing pipeline, calibration, and the 2-D map:
+
+- **Data source** (`sources.py`): `analyze_route_fronts(source, ...)` takes a
+  `HewsonFieldSource`. Production reads the precomputed Hewson NPZ snapshot
+  (`SnapshotFieldSource` — zero fetch, derivatives already on the full grid);
+  calibration/ERA5 recompute from a `Case` (`CaseFieldSource`). Chosen in code,
+  not a user toggle (design `hewson-fields-aviation-advisories.md` §6.2).
+- **Gate recipe** (`gates.py`): the ~10 scattered threshold constants collapse
+  into one frozen, serializable `FrontGateConfig` (carries the pressure level;
+  gates are level-specific). Presets: `default / strict / sensitive /
+  gradient-only`. Stamped into every `route_fronts.json` for reproducibility.
+- **Candidate/decision split**: sample once → `generate_front_candidates`
+  (all TFP zero-crossings, ungated) → `apply_gate_config` (`FrontDecision` with
+  `accepted` / `rejected_by` / margins). N configs re-score one candidate set
+  with zero re-sampling — the basis of the `front-calibrate` sweep CLI.
+
+Pipeline wiring lives in `tasks/fronts.py` (`run_fronts` + `run_fronts_from_pack`),
+gated by the experimental `auto_front_detection` preference (default off); the
+artifact is served at `GET .../packs/{ts}/route-fronts`. The 2-D extractor is
+served at `GET /api/hewson-map/fronts` and overlaid on the synoptic map.
 
 The zone-aggregation path (zones.py + tracking.py) is the original calibration
 target; `route_sampling.py` is the newer per-leg Hewson direction (see Key Choices /

--- a/designs/future/hewson-fields-aviation-advisories.md
+++ b/designs/future/hewson-fields-aviation-advisories.md
@@ -630,7 +630,8 @@ Opens after Phase D so the map + cross-section surface has something to show moi
 | **Phase D.2** (map layer + tooltips + ERA5 cases) | ✅ Done (2026-04-25, PR #96) — Synoptic Forecast tab on `/maps.html`, canvas grid overlay, cursor-following tooltip with all 6 metrics, default/storm scale toggle, briefing-style (i) modal with Discuss-with-AI prompts, `era5-case` CLI for historical events (Storm Ciarán test case) |
 | Phase D.3 (cross-section bands) | 🎯 **NEXT** — requires D.0 (done) |
 | Phase D.4 (stencil in GRIB era) | Gated on native-GRIB ingestion being live for the user's briefing model |
-| Phase C (advisory evaluators) | After Phase D, informed by what pilots actually use from the map/cross-section |
+| **Phase C data layer** (#195 Part 1) | ✅ Done — `FrontGateConfig` + `HewsonFieldSource` (snapshot/case), candidate/decision split, `run_fronts` stage + `route_fronts.json` + `auto_front_detection` pref + `GET .../route-fronts`, 2-D TFP=0 extractor + `GET /api/hewson-map/fronts` + synoptic-map overlay, `front-calibrate` sweep CLI + DWD chart overlay. Detection reads the precompute snapshot — milliseconds, zero fetch. |
+| Phase C advisory evaluators (#196 Part 2) | After #195 — front advisory evaluator, AI-digest wiring, cross-section bands, settings-page toggle UI |
 | Phase E (moisture cross-check) | After Phase D — RH₉₂₅, LCC, TP, CAPE, debrief feature #92 |
 | Retrospective validation | ✅ Pairwise cancel test 3/3 (all pilot-cancellation days scored higher than replacement-flown days) — best calibration signal we have |
 

--- a/src/weatherbrief/api/hewson_map.py
+++ b/src/weatherbrief/api/hewson_map.py
@@ -44,6 +44,7 @@ from weatherbrief.hewson.precompute import (
     resolve_output_dir,
     snapshot_path,
 )
+from weatherbrief.frontal.gates import get_preset, preset_names
 
 logger = logging.getLogger(__name__)
 
@@ -418,4 +419,125 @@ def get_all_metrics(
         # Some legacy snapshots may be missing a metric; surface this so
         # the client can hide tooltip rows for those.
         "missing_metrics": missing,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Gated front polylines (the 2-D TFP=0 extractor — calibration overlay)
+# ---------------------------------------------------------------------------
+
+
+def _load_cached_terrain_mask(lat: np.ndarray, lon: np.ndarray) -> np.ndarray | None:
+    """Return the precompute's cached terrain mask if it matches this grid.
+
+    The precompute loop writes ``${DATA_DIR}/hewson/terrain_mask.npz`` on first
+    run; reuse it so the front extractor rejects orographic θe ridges. Returns
+    ``None`` (no masking) when the cache is absent or grid-mismatched rather
+    than rebuilding from SRTM in the request path.
+    """
+    path = resolve_output_dir() / "terrain_mask.npz"
+    if not path.exists():
+        return None
+    try:
+        with np.load(path) as npz:
+            mask = npz["mask"]
+            cached_lat = npz["lat"]
+            cached_lon = npz["lon"]
+    except (OSError, KeyError, ValueError, zipfile.BadZipFile, EOFError):
+        logger.warning("Hewson fronts: unreadable terrain mask at %s", path)
+        return None
+    if (
+        mask.shape == (len(lat), len(lon))
+        and np.allclose(cached_lat, lat)
+        and np.allclose(cached_lon, lon)
+    ):
+        return mask
+    return None
+
+
+@router.get("/fronts")
+def get_fronts(
+    response: Response,
+    model: str = Query(..., description="ecmwf | gfs | icon"),
+    init: str = Query(..., description="ISO 8601 with Z"),
+    level: int = Query(..., description="Pressure level in hPa: 925, 850, or 700"),
+    hour: int = Query(..., ge=0, description="Forecast hour offset from init"),
+    gate: str = Query("default", description=" | ".join(preset_names())),
+    min_length_km: float = Query(200.0, ge=0, description="Drop axes shorter than this"),
+    _user_id: str = Depends(_synoptic_auth),
+):
+    """Gated TFP=0 **front polylines** for one (model, init, level, hour, gate).
+
+    The 2-D sibling of the route locator: extracts the Hewson front axes from the
+    snapshot's TFP grid and gates them with a named :class:`FrontGateConfig`
+    preset, so a calibrator can overlay "which gate reproduces the official
+    analysis?" on the synoptic map (issue #195 §C2). Returns GeoJSON-style
+    ``[lon, lat]`` coordinate pairs per polyline.
+
+    Admin/calibration-facing (same auth as the rest of the synoptic map). The
+    anomaly filter uses a time-mean background gradient computed from the
+    snapshot — a handful of extra slice reads, fine for an on-demand overlay.
+    """
+    _validate_common_params(model, level)
+    try:
+        config = get_preset(gate, level_hPa=level)
+    except KeyError as exc:
+        raise HTTPException(
+            status_code=400,
+            detail=f"unknown gate preset {gate!r}; available: {preset_names()}",
+        ) from exc
+
+    path, init_time_unix = _resolve_snapshot_path(model, init)
+
+    # Validate the hour against the snapshot stride/horizon before the heavier
+    # source work, reusing the slice endpoint's checks.
+    with _open_snapshot(path) as npz:
+        _, stride_hours, valid_time_iso = _resolve_hour_index(npz, hour)
+
+    from weatherbrief.frontal.contour_fronts import extract_front_lines
+    from weatherbrief.frontal.sources import SnapshotFieldSource
+
+    source = SnapshotFieldSource(path, model_name=model)
+    terrain_mask = _load_cached_terrain_mask(source.lat, source.lon)
+    source.terrain_mask = terrain_mask
+    grids = source.grids_at_hour(model, hour, level)
+    if grids is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Snapshot has no data at level={level} hour={hour}",
+        )
+
+    background = None
+    if config.use_anomaly_filter:
+        background = source.background_gradient(model, level)
+
+    polylines = extract_front_lines(
+        grids, source.lat, source.lon, config,
+        min_length_km=min_length_km, background=background,
+        terrain_mask=terrain_mask,
+    )
+
+    features = [
+        {
+            "kind": pl.kind,
+            "length_km": round(pl.length_km, 1),
+            "mean_gradient": round(pl.mean_gradient, 2),
+            "mean_delta_theta_e": round(pl.mean_delta_theta_e, 2),
+            # GeoJSON LineString order is [lon, lat].
+            "coordinates": [[round(p[1], 4), round(p[0], 4)] for p in pl.points],
+        }
+        for pl in polylines
+    ]
+
+    response.headers["Cache-Control"] = "private, max-age=86400, immutable"
+    return {
+        "model": model,
+        "init_time": _format_init(init_time_unix),
+        "valid_time": valid_time_iso,
+        "level": level,
+        "hour": hour,
+        "stride_hours": stride_hours,
+        "gate": config.name,
+        "gate_config": config.to_dict(),
+        "fronts": features,
     }

--- a/src/weatherbrief/api/packs.py
+++ b/src/weatherbrief/api/packs.py
@@ -879,6 +879,7 @@ def _prepare_refresh(flight, db_path, user_id, flight_id, db=None, *, is_privile
     do_gramet = True
     do_llm_digest = True
     do_icing_enhance = True
+    auto_front_detection = False  # experimental front-detection artifact (#195)
     icing_method = None
     cloud_method = None
     convective_method = None
@@ -912,6 +913,7 @@ def _prepare_refresh(flight, db_path, user_id, flight_id, db=None, *, is_privile
         do_gramet = profile_settings.get("gramet_enabled", True)
         do_llm_digest = profile_settings.get("llm_digest_enabled", True)
         do_icing_enhance = profile_settings.get("icing_severity_enhance", False)
+        auto_front_detection = profile_settings.get("auto_front_detection", False)
         icing_method = profile_settings.get("icing_method")
         cloud_method = profile_settings.get("cloud_method")
         convective_method = profile_settings.get("convective_method")
@@ -950,6 +952,7 @@ def _prepare_refresh(flight, db_path, user_id, flight_id, db=None, *, is_privile
         user_id=user_id,
         airports_db_path=db_path,
         icing_severity_enhance=do_icing_enhance,
+        auto_front_detection=auto_front_detection,
         historical_mode=is_historical,
     )
     if as_of_time:
@@ -2162,6 +2165,26 @@ def get_advisories(
     if not adv_path.exists():
         raise HTTPException(status_code=404, detail="Route advisories not available")
     return FileResponse(adv_path, media_type="application/json")
+
+
+@router.get("/{timestamp}/route-fronts")
+def get_route_fronts(
+    flight_id: str,
+    timestamp: str,
+    user_id: str = Depends(current_user_id),
+    db: Session = Depends(get_db),
+):
+    """Get the front-detection artifact (``route_fronts.json``) for a pack.
+
+    Written only when the experimental ``auto_front_detection`` preference is
+    on (default off) — 404 otherwise. The data half of #195; visualization /
+    advisory wiring is Part 2 (#196).
+    """
+    pack_dir = _get_pack_dir(db, flight_id, timestamp, viewer_id=user_id)
+    fronts_path = pack_dir / "route_fronts.json"
+    if not fronts_path.exists():
+        raise HTTPException(status_code=404, detail="Route fronts not available")
+    return FileResponse(fronts_path, media_type="application/json")
 
 
 @router.get("/{timestamp}/advisories/alt")

--- a/src/weatherbrief/frontal/cli.py
+++ b/src/weatherbrief/frontal/cli.py
@@ -1846,6 +1846,56 @@ def _draw_zones_on_dwd(
     Image.alpha_composite(img, overlay).convert("RGB").save(output_path)
 
 
+_FRONT_LINE_RGBA = {
+    "cold": (0, 90, 220, 255),     # blue
+    "warm": (220, 0, 0, 255),      # red
+    "quasi-stationary": (150, 0, 150, 255),  # purple
+}
+
+
+def _draw_fronts_on_dwd(
+    img_path: str | Path,
+    output_path: str | Path,
+    chart_type: str,
+    *,
+    crossings=None,
+    polylines=None,
+    route=None,
+) -> None:
+    """Overlay detected fronts on a georeferenced DWD chart.
+
+    Draws the route (grey), on-track :class:`FrontCrossing` markers (filled
+    circles, coloured by kind), and 2-D :class:`FrontPolyline` axes (coloured
+    lines). Lets a human eyeball gate output against the official drawn fronts
+    (issue #195 §C / §C2) — the cheapest, annotation-free calibration check.
+    """
+    from PIL import Image, ImageDraw
+
+    img = Image.open(img_path).convert("RGBA")
+    overlay = Image.new("RGBA", img.size, (0, 0, 0, 0))
+    draw = ImageDraw.Draw(overlay)
+
+    if route:
+        pts = [_dwd_lonlat_to_pixel(lo, la, chart_type) for la, lo in route]
+        if len(pts) >= 2:
+            draw.line(pts, fill=(80, 80, 80, 220), width=3)
+
+    for pl in (polylines or []):
+        pixels = [_dwd_lonlat_to_pixel(lo, la, chart_type) for la, lo in pl.points]
+        if len(pixels) >= 2:
+            color = _FRONT_LINE_RGBA.get(pl.kind, _FRONT_LINE_RGBA["quasi-stationary"])
+            draw.line(pixels, fill=color, width=4)
+
+    for xc in (crossings or []):
+        cx, cy = _dwd_lonlat_to_pixel(xc.lon, xc.lat, chart_type)
+        color = _FRONT_LINE_RGBA.get(xc.kind, _FRONT_LINE_RGBA["quasi-stationary"])
+        r = 12
+        draw.ellipse((cx - r, cy - r, cx + r, cy + r), fill=color,
+                     outline=(255, 255, 255, 255), width=2)
+
+    Image.alpha_composite(img, overlay).convert("RGB").save(output_path)
+
+
 def _load_expected_fronts(case_dir: Path, hour_offset: int = 0) -> dict[str, str]:
     """Read expected.yaml and return zone→front_type for the given hour_offset.
 
@@ -2223,6 +2273,134 @@ def _cmd_route_fronts(args: argparse.Namespace) -> None:
                   f"Δθe={nf.delta_theta_e:+.0f} K  {nf.trend.upper()}{rate}")
 
 
+def _cmd_front_calibrate(args: argparse.Namespace) -> None:
+    """Sweep gate configs over one (case, route, hour) and tabulate the verdicts.
+
+    Samples the route **once**, generates the unfiltered TFP-zero candidate set,
+    then applies each gate preset to that same set (zero re-sampling — the whole
+    point of the candidate/decision split). Prints a config × (#candidates,
+    #accepted, rejection breakdown, crossings) table so a calibrator can see
+    which recipe reproduces the expected fronts. Optionally overlays one gate's
+    detected fronts on a georeferenced DWD chart (§C / §C2).
+    """
+    from weatherbrief.airports import resolve_waypoints
+    from weatherbrief.frontal.case import load_case
+    from weatherbrief.frontal.gates import get_preset, preset_names
+    from weatherbrief.frontal.grid import build_terrain_mask
+    from weatherbrief.frontal.route_sampling import (
+        apply_gate_config,
+        decisions_to_crossings,
+        densify_route,
+        find_nearby_fronts,
+        generate_front_candidates,
+        grids_at_fractional_hour,
+        sample_hewson_at_route,
+    )
+    from weatherbrief.frontal.sources import CaseFieldSource
+
+    case = load_case(Path(args.case))
+    model = args.model or case.models[0]
+    if model not in case.models:
+        print(f"Error: model '{model}' not in case (available: {case.models})",
+              file=sys.stderr)
+        sys.exit(1)
+
+    codes = args.waypoints.split()
+    waypoints, rejected = resolve_waypoints(codes, args.airports_db)
+    for r in rejected:
+        print(f"  (rejected {r.name}: {r.reason})", file=sys.stderr)
+    pts = [(wp.lat, wp.lon) for wp in waypoints]
+    if len(pts) < 2:
+        print("Error: need at least 2 resolvable waypoints", file=sys.stderr)
+        sys.exit(1)
+
+    gate_names = (
+        [g.strip() for g in args.gates.split(",") if g.strip()]
+        if args.gates else list(preset_names())
+    )
+    try:
+        configs = [get_preset(g, level_hPa=args.level) for g in gate_names]
+    except KeyError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    terrain_mask = None if args.no_terrain_mask else build_terrain_mask(case.lat, case.lon)
+    source = CaseFieldSource(case, terrain_mask=terrain_mask)
+
+    # Sample ONCE at a shared (level, step, window). All swept gates here share
+    # level/step/window (only the threshold gates vary), so one candidate set
+    # serves them all.
+    base = configs[0]
+    dense = densify_route(pts, step_km=base.step_km)
+    samples = sample_hewson_at_route(
+        source, model, [(la, lo) for la, lo, _ in dense],
+        hours=args.hour, level_hPa=base.level_hPa,
+    )
+    for s, (_, _, dist_km) in zip(samples, dense):
+        s["distance_km"] = dist_km
+    candidates = generate_front_candidates(samples, airmass_window_km=base.airmass_window_km)
+
+    header = (
+        f"front-calibrate — {' '.join(wp.icao for wp in waypoints)}  "
+        f"model={model}  hour=+{args.hour:g}  level={base.level_hPa}hPa  "
+        f"candidates={len(candidates)}"
+    )
+    print(header)
+    print("=" * len(header))
+    print(f"{'gate':<14} {'accept':>6} {'rej:grad':>8} {'rej:Δθe':>8}  crossings")
+    print("-" * 78)
+
+    primary_crossings = []
+    for cfg in configs:
+        decisions = apply_gate_config(candidates, cfg)
+        crossings = decisions_to_crossings(decisions, cfg.merge_km)
+        rej_grad = sum(1 for d in decisions if d.rejected_by == "gradient")
+        rej_dthe = sum(1 for d in decisions if d.rejected_by == "delta_theta_e")
+        summary = ", ".join(
+            f"{c.kind[:4]}@{c.distance_km:.0f}km(|∇|{c.gradient:.0f})"
+            for c in crossings
+        ) or "—"
+        print(f"{cfg.name:<14} {len(crossings):>6} {rej_grad:>8} {rej_dthe:>8}  {summary}")
+        if cfg.name == base.name:
+            primary_crossings = crossings
+
+    # Off-track nearest front for the primary gate (one scan).
+    nearest = find_nearby_fronts(
+        source, model, pts, args.hour, level_hPa=base.level_hPa,
+        proximity_km=base.proximity_km, step_km=base.step_km,
+        gradient_min=base.gradient_min, delta_theta_e_min=base.delta_theta_e_min,
+        anomaly_min=base.anomaly_min, airmass_window_km=base.airmass_window_km,
+        use_anomaly_filter=base.use_anomaly_filter, approach_dh=base.approach_dh,
+    )
+    if nearest is not None:
+        loc = "on-track" if nearest.on_track else f"~{nearest.distance_km:.0f} km off-track"
+        print(f"\nnearest gated front ({base.name}): {loc} "
+              f"({nearest.lat:.2f},{nearest.lon:.2f}) |∇θe|={nearest.gradient:.1f} "
+              f"trend={nearest.trend}")
+
+    # Optional: overlay the primary gate's fronts on a DWD chart.
+    if args.draw:
+        polylines = None
+        if args.map_fronts:
+            from weatherbrief.frontal.contour_fronts import extract_front_lines
+            grids = grids_at_fractional_hour(
+                source, model, args.hour, level_hPa=base.level_hPa,
+                terrain_mask=terrain_mask,
+            )
+            if grids is not None:
+                background = source.background_gradient(model, base.level_hPa)
+                polylines = extract_front_lines(
+                    grids, case.lat, case.lon, base,
+                    min_length_km=args.min_length_km, background=background,
+                    terrain_mask=terrain_mask,
+                )
+        _draw_fronts_on_dwd(
+            args.chart, args.draw, args.chart_type,
+            crossings=primary_crossings, polylines=polylines, route=pts,
+        )
+        print(f"\nWrote overlay → {args.draw}")
+
+
 def _cmd_redraw_zones(args: argparse.Namespace) -> None:
     """Redraw analysis_with_zones.png for a case using its current expected.yaml."""
     case_dir = Path(args.case)
@@ -2576,6 +2754,43 @@ def build_parser() -> argparse.ArgumentParser:
         help="Path to euro_aip airports SQLite DB (default: data/nav.db)",
     )
 
+    # front-calibrate
+    p_cal = sub.add_parser(
+        "front-calibrate",
+        help="Sweep gate presets over a route and tabulate verdicts (+ chart overlay)",
+    )
+    p_cal.add_argument("--case", required=True, help="Calibration case dir")
+    p_cal.add_argument("--model", default=None, help="Model key (default: case's first)")
+    p_cal.add_argument(
+        "--waypoints", required=True,
+        help='Space-separated ICAO/navaid/fix codes',
+    )
+    p_cal.add_argument("--hour", type=float, default=0.0, help="Forecast hour offset")
+    p_cal.add_argument("--level", type=int, default=850, help="Pressure level hPa")
+    p_cal.add_argument(
+        "--gates", default=None,
+        help="Comma-separated gate presets (default: all registered presets)",
+    )
+    p_cal.add_argument("--no-terrain-mask", action="store_true")
+    p_cal.add_argument(
+        "--draw", default=None,
+        help="Output PNG: overlay the primary gate's fronts on a DWD chart",
+    )
+    p_cal.add_argument(
+        "--chart", default=None,
+        help="Input DWD chart PNG to draw on (required with --draw)",
+    )
+    p_cal.add_argument("--chart-type", default="analysis", help="analysis | forecast")
+    p_cal.add_argument(
+        "--map-fronts", action="store_true",
+        help="Also extract + draw 2-D TFP=0 front lines for the primary gate",
+    )
+    p_cal.add_argument("--min-length-km", type=float, default=200.0)
+    p_cal.add_argument(
+        "--airports-db", default="data/nav.db",
+        help="Path to euro_aip airports SQLite DB (default: data/nav.db)",
+    )
+
     # clear-cache
     p_clear = sub.add_parser("clear-cache", help="Delete cached grid data")
     p_clear.add_argument("--cache-dir")
@@ -2609,6 +2824,7 @@ def main() -> None:
         "plot-hewson": _cmd_plot_hewson,
         "route-hewson": _cmd_route_hewson,
         "route-fronts": _cmd_route_fronts,
+        "front-calibrate": _cmd_front_calibrate,
         "clear-cache": _cmd_clear_cache,
     }
     commands[args.command](args)

--- a/src/weatherbrief/frontal/cli.py
+++ b/src/weatherbrief/frontal/cli.py
@@ -2298,6 +2298,11 @@ def _cmd_front_calibrate(args: argparse.Namespace) -> None:
     )
     from weatherbrief.frontal.sources import CaseFieldSource
 
+    if args.draw and not args.chart:
+        print("Error: --chart <dwd_chart.png> is required when --draw is given",
+              file=sys.stderr)
+        sys.exit(2)
+
     case = load_case(Path(args.case))
     model = args.model or case.models[0]
     if model not in case.models:

--- a/src/weatherbrief/frontal/contour_fronts.py
+++ b/src/weatherbrief/frontal/contour_fronts.py
@@ -27,7 +27,11 @@ import numpy as np
 from contourpy import contour_generator
 
 from weatherbrief.frontal.gates import FrontGateConfig
-from weatherbrief.frontal.route_sampling import bilinear_sample, haversine_km
+from weatherbrief.frontal.route_sampling import (
+    _classify_kind,
+    bilinear_sample,
+    haversine_km,
+)
 from weatherbrief.frontal.sources import HewsonGrids
 
 
@@ -138,9 +142,14 @@ def _polyline_length_km(vertices: list[FrontVertex]) -> float:
 
 
 def _classify_run(vertices: list[FrontVertex], advection_min: float) -> str:
-    """Majority advection class along a gated run (warm / cold / stationary)."""
-    warm = sum(1 for v in vertices if v.advection > advection_min)
-    cold = sum(1 for v in vertices if v.advection < -advection_min)
+    """Majority advection class along a gated run (warm / cold / stationary).
+
+    Reuses :func:`_classify_kind` per vertex so the warm/cold threshold logic
+    lives in one place; this only adds the majority vote on top.
+    """
+    kinds = [_classify_kind(v.advection, advection_min) for v in vertices]
+    warm = kinds.count("warm")
+    cold = kinds.count("cold")
     if warm == 0 and cold == 0:
         return "quasi-stationary"
     return "warm" if warm >= cold else "cold"

--- a/src/weatherbrief/frontal/contour_fronts.py
+++ b/src/weatherbrief/frontal/contour_fronts.py
@@ -1,0 +1,223 @@
+"""2-D front-line extraction — the continental sibling of the route locator.
+
+``detect_front_crossings`` answers "does a front cross *my track*?" by walking a
+1-D route and finding gated TFP zero-crossings. This module generalises the same
+gate philosophy to the whole grid: extract the **TFP = 0 contours** (the Hewson
+front axes) from a snapshot's ``tfp`` field, gate each contour vertex by the
+*same* :class:`~weatherbrief.frontal.gates.FrontGateConfig`
+(``gradient_min`` + cross-contour ``delta_theta_e_min`` + optional anomaly),
+classify cold/warm by advection sign, and drop axes shorter than a minimum
+length. Output: a set of coloured front polylines for one
+``(model, init, level, hour, gate config)``.
+
+This is the primary continental-scale **calibration surface** — drawing
+gate-detected front lines on top of the official DWD / Met Office analysis
+(issue #195 §C2) gives a direct visual POD/FAR read of "which gate reproduces
+the drawn fronts?". It composes with the synoptic Hewson map overlay.
+
+Contours come from ``contourpy`` (matplotlib's engine, already a dependency) —
+no new package, and the same routine matplotlib uses for ``contour()``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+from contourpy import contour_generator
+
+from weatherbrief.frontal.gates import FrontGateConfig
+from weatherbrief.frontal.route_sampling import bilinear_sample, haversine_km
+from weatherbrief.frontal.sources import HewsonGrids
+
+
+@dataclass(frozen=True)
+class FrontVertex:
+    """One gated point on a TFP=0 contour."""
+    lat: float
+    lon: float
+    gradient: float        # |∇θe|  K/100km
+    delta_theta_e: float   # signed θe jump (warm − cold) across ±window, K
+    advection: float       # −V·∇θe  K/h
+
+
+@dataclass(frozen=True)
+class FrontPolyline:
+    """A contiguous run of gated front-axis vertices, with a single label.
+
+    ``kind`` is the majority advection class along the run; ``length_km`` is the
+    great-circle path length. Mean gradient / Δθe summarise the run's intensity.
+    """
+    kind: str              # "cold" | "warm" | "quasi-stationary"
+    vertices: list[FrontVertex]
+    length_km: float
+    mean_gradient: float
+    mean_delta_theta_e: float
+
+    @property
+    def points(self) -> list[tuple[float, float]]:
+        """``[(lat, lon), ...]`` — the drawable polyline."""
+        return [(v.lat, v.lon) for v in self.vertices]
+
+
+def _index_to_coord(idx: float, axis: np.ndarray) -> float:
+    """Map a fractional grid index along an ascending axis to its coordinate."""
+    n = len(axis)
+    if idx <= 0:
+        return float(axis[0])
+    if idx >= n - 1:
+        return float(axis[-1])
+    lo = int(np.floor(idx))
+    frac = idx - lo
+    return float(axis[lo] + frac * (axis[lo + 1] - axis[lo]))
+
+
+def _gate_vertex(
+    lat: float,
+    lon: float,
+    grids: HewsonGrids,
+    lat_axis: np.ndarray,
+    lon_axis: np.ndarray,
+    config: FrontGateConfig,
+    background: np.ndarray | None,
+    terrain_mask: np.ndarray | None,
+) -> FrontVertex | None:
+    """Evaluate the gate config at one contour vertex; ``None`` if it fails.
+
+    Mirrors :func:`extract_gated_fronts`' per-cell test: magnitude gate, optional
+    gradient-anomaly gate (rejects persistent orographic / sea-land gradients),
+    and the cross-axis θe-jump gate measured ±``airmass_window_km`` along the
+    unit gradient.
+    """
+    grad = bilinear_sample(grids.gradient, lat_axis, lon_axis, lat, lon)
+    if not np.isfinite(grad) or grad < config.gradient_min:
+        return None
+
+    if config.use_anomaly_filter and background is not None:
+        bg = bilinear_sample(background, lat_axis, lon_axis, lat, lon)
+        if np.isfinite(bg) and (grad - bg) < config.anomaly_min:
+            return None
+
+    if terrain_mask is not None:
+        # Reject vertices sitting on high terrain (orographic θe, not synoptic).
+        valid = bilinear_sample(
+            terrain_mask.astype(np.float64), lat_axis, lon_axis, lat, lon,
+        )
+        if np.isfinite(valid) and valid < 0.5:
+            return None
+
+    dtdx = bilinear_sample(grids.dT_dx, lat_axis, lon_axis, lat, lon)
+    dtdy = bilinear_sample(grids.dT_dy, lat_axis, lon_axis, lat, lon)
+    gmag = float(np.hypot(dtdx, dtdy))
+    if not np.isfinite(gmag) or gmag < 1e-9:
+        return None
+    ux, uy = dtdx / gmag, dtdy / gmag  # unit gradient, cold→warm
+
+    dlat = (uy * config.airmass_window_km) / 111.0
+    dlon = (ux * config.airmass_window_km) / (
+        111.0 * float(np.cos(np.radians(lat)))
+    )
+    warm = bilinear_sample(grids.theta_e, lat_axis, lon_axis, lat + dlat, lon + dlon)
+    cold = bilinear_sample(grids.theta_e, lat_axis, lon_axis, lat - dlat, lon - dlon)
+    dthe = warm - cold
+    if not np.isfinite(dthe) or abs(dthe) < config.delta_theta_e_min:
+        return None
+
+    adv = bilinear_sample(grids.advection, lat_axis, lon_axis, lat, lon)
+    return FrontVertex(
+        lat=lat, lon=lon, gradient=float(grad),
+        delta_theta_e=float(dthe), advection=float(adv) if np.isfinite(adv) else 0.0,
+    )
+
+
+def _polyline_length_km(vertices: list[FrontVertex]) -> float:
+    return sum(
+        haversine_km(a.lat, a.lon, b.lat, b.lon)
+        for a, b in zip(vertices[:-1], vertices[1:])
+    )
+
+
+def _classify_run(vertices: list[FrontVertex], advection_min: float) -> str:
+    """Majority advection class along a gated run (warm / cold / stationary)."""
+    warm = sum(1 for v in vertices if v.advection > advection_min)
+    cold = sum(1 for v in vertices if v.advection < -advection_min)
+    if warm == 0 and cold == 0:
+        return "quasi-stationary"
+    return "warm" if warm >= cold else "cold"
+
+
+def extract_front_lines(
+    grids: HewsonGrids,
+    lat_axis: np.ndarray,
+    lon_axis: np.ndarray,
+    config: FrontGateConfig,
+    *,
+    min_length_km: float = 200.0,
+    background: np.ndarray | None = None,
+    terrain_mask: np.ndarray | None = None,
+) -> list[FrontPolyline]:
+    """Gated TFP=0 front polylines for one snapshot hour.
+
+    Steps: (1) ``contourpy`` extracts the TFP=0 contours, (2) each vertex is
+    mapped to lat/lon and gated by ``config``, (3) contiguous runs of surviving
+    vertices become polylines, (4) runs shorter than ``min_length_km`` are
+    dropped. ``background`` (a time-mean |∇θe| grid) enables the anomaly filter
+    when ``config.use_anomaly_filter`` is set.
+    """
+    tfp = grids.tfp
+    if tfp is None or not np.isfinite(tfp).any():
+        return []
+
+    # contourpy works in grid-index space; x = column (lon), y = row (lat).
+    ny, nx = tfp.shape
+    z = np.where(np.isfinite(tfp), tfp, np.nan)
+    gen = contour_generator(
+        x=np.arange(nx), y=np.arange(ny), z=z,
+        # NaN handling: corner_mask keeps cells with NaN corners out of the
+        # contour, so terrain holes / edges don't spawn spurious axes.
+        corner_mask=True,
+    )
+
+    polylines: list[FrontPolyline] = []
+    for line in gen.lines(0.0):
+        # ``line`` is an (n, 2) array of (x=col, y=row) fractional indices.
+        run: list[FrontVertex] = []
+        for col, row in line:
+            lat = _index_to_coord(float(row), lat_axis)
+            lon = _index_to_coord(float(col), lon_axis)
+            vtx = _gate_vertex(
+                lat, lon, grids, lat_axis, lon_axis, config,
+                background, terrain_mask,
+            )
+            if vtx is not None:
+                run.append(vtx)
+            elif run:
+                # Gap in the gated axis — close the current run.
+                polylines.extend(
+                    _finish_run(run, config, min_length_km)
+                )
+                run = []
+        polylines.extend(_finish_run(run, config, min_length_km))
+
+    return polylines
+
+
+def _finish_run(
+    run: list[FrontVertex],
+    config: FrontGateConfig,
+    min_length_km: float,
+) -> list[FrontPolyline]:
+    if len(run) < 2:
+        return []
+    length = _polyline_length_km(run)
+    if length < min_length_km:
+        return []
+    return [
+        FrontPolyline(
+            kind=_classify_run(run, config.advection_min),
+            vertices=run,
+            length_km=length,
+            mean_gradient=float(np.mean([v.gradient for v in run])),
+            mean_delta_theta_e=float(np.mean([v.delta_theta_e for v in run])),
+        )
+    ]

--- a/src/weatherbrief/frontal/detect.py
+++ b/src/weatherbrief/frontal/detect.py
@@ -196,6 +196,38 @@ def compute_frontal_zones_dual(
     }
 
 
+def theta_e_gradient_components(
+    field: np.ndarray,
+    lat: np.ndarray,
+    lon: np.ndarray,
+    terrain_mask: np.ndarray | None = None,
+    smooth_sigma: float = 0.5,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Light-smoothed horizontal gradient ``(dT_dx, dT_dy)`` of a scalar field.
+
+    Returns components in **K/km** (lat-dependent dlon spacing handled per row).
+    Factored out of :func:`compute_hewson_diagnostics` so the snapshot field
+    source can re-derive the gradient *direction* from a stored θe grid — the
+    precompute NPZ deliberately does not persist ``dT_dx``/``dT_dy`` (design
+    §4.7), yet the off-track front extractor needs the unit gradient to measure
+    the cross-front θe jump. Sharing this keeps the recomputed direction bit-for
+    bit consistent with the precompute path.
+    """
+    field_input = field
+    if terrain_mask is not None:
+        field_input = fill_terrain(field, terrain_mask)
+    field_smooth = gaussian_filter(field_input, sigma=smooth_sigma)
+
+    dlat_km = 111.0
+    dlon_km = 111.0 * np.cos(np.radians(lat))
+    dlat_spacing = dlat_km * np.abs(np.diff(lat).mean())
+    dlon_col = (dlon_km * np.abs(np.diff(lon).mean()))[:, np.newaxis]
+
+    dT_dy = np.gradient(field_smooth, dlat_spacing, axis=0)
+    dT_dx = np.gradient(field_smooth, axis=1) / dlon_col
+    return dT_dx, dT_dy
+
+
 def compute_hewson_diagnostics(
     field: np.ndarray,
     lat: np.ndarray,
@@ -248,9 +280,12 @@ def compute_hewson_diagnostics(
     dlon_spacing_per_row = dlon_km * np.abs(np.diff(lon).mean())
     dlon_col = dlon_spacing_per_row[:, np.newaxis]
 
-    # Light-smoothed gradient (K/km, then /100 → K/100km)
-    dT_dy = np.gradient(field_smooth, dlat_spacing, axis=0)
-    dT_dx = np.gradient(field_smooth, axis=1) / dlon_col
+    # Light-smoothed gradient (K/km, then /100 → K/100km). Shares
+    # theta_e_gradient_components so the snapshot field source re-derives an
+    # identical direction from stored θe.
+    dT_dx, dT_dy = theta_e_gradient_components(
+        field_input, lat, lon, terrain_mask=None, smooth_sigma=smooth_sigma,
+    )
     grad_mag = np.sqrt(dT_dx**2 + dT_dy**2)
     grad_mag_100km = grad_mag * 100.0
 

--- a/src/weatherbrief/frontal/gates.py
+++ b/src/weatherbrief/frontal/gates.py
@@ -1,0 +1,151 @@
+"""Front-detection gate configuration — a complete, serializable recipe.
+
+Historically the ~10 acceptance/classification/geometry thresholds that decide
+"is this TFP zero-crossing a front?" lived as loose module constants
+(``_DEFAULT_GRADIENT_MIN`` &c. in ``route_sampling.py``) and were duplicated as
+keyword arguments across four function signatures
+(``detect_front_crossings`` / ``find_route_fronts`` / ``find_nearby_fronts`` /
+``analyze_route_fronts``). Adding a gate meant touching every signature and the
+CLI plumbing, and there was no way to vary a single gate without editing code.
+
+``FrontGateConfig`` collapses all of those into one frozen, serializable
+dataclass — a self-describing *detection recipe*. It deliberately carries the
+**pressure level** because gates are level-specific: θe gradients are naturally
+larger at 925 hPa (moist boundary layer) than at 700 hPa, so a single
+``gradient_min`` across all levels is wrong (the zone detector already scales
+its θe threshold 2× the T threshold for the same reason — ``detect.py``).
+
+Two payoffs:
+
+* **Calibration / sweeps** — a list of configs can be applied to the *same*
+  candidate set with zero re-sampling (see ``route_sampling.apply_gate_config``).
+* **Reproducibility** — the active config is stamped into ``route_fronts.json``
+  so every briefing records which recipe produced it.
+
+See ``designs/future/hewson-fields-aviation-advisories.md`` §6.2/§6.3 and
+``designs/frontal-detection.md``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, fields, replace
+from typing import Any, Mapping
+
+
+@dataclass(frozen=True)
+class FrontGateConfig:
+    """A complete front-detection recipe: which level, which gates, what geometry.
+
+    Field groups:
+
+    * **identity** — ``name`` (preset label) + ``level_hPa`` (which precomputed
+      level to detect at).
+    * **acceptance gates** — decide IS-a-front. ``gradient_min`` (the air-mass
+      boundary must be a real |∇θe| ridge) and ``delta_theta_e_min`` (the θe jump
+      across the boundary must be a genuine change of air mass, not a col).
+      ``anomaly_min`` is the off-track-only gradient-above-background gate that
+      rejects persistent orographic / sea-land gradients.
+    * **classification** — ``advection_min`` labels cold vs warm vs
+      quasi-stationary; it *rejects nothing*.
+    * **geometry / sampling** — route step, merge distance, the ±window the θe
+      jump is measured across, the off-track proximity radius, the approach
+      look-ahead, and whether the off-track anomaly filter runs.
+
+    All thresholds default to the values validated on the 2026-05-31 Channel
+    cold front (the historical module constants). Construct presets with
+    :func:`get_preset` or derive variants with :meth:`with_overrides`.
+    """
+
+    name: str = "default"
+    level_hPa: int = 850  # which precomputed level to detect at (925/850/700)
+
+    # --- acceptance gates (decide IS-a-front) ---
+    gradient_min: float = 6.0          # K/100km — significant (>4) .. classical (>8)
+    delta_theta_e_min: float = 5.0     # K — |θe jump| across the ±window (air-mass contrast)
+    anomaly_min: float = 2.0           # K/100km — off-track gradient above background
+
+    # --- classification (labels only, rejects nothing) ---
+    advection_min: float = 0.5         # K/h — below this: quasi-stationary
+
+    # --- geometry / sampling ---
+    step_km: float = 15.0              # densification step (~2 samples / 0.25° cell)
+    merge_km: float = 60.0             # collapse multiple zero-crossings on one front
+    airmass_window_km: float = 75.0    # ± window to measure the θe jump across a front
+    proximity_km: float = 120.0        # off-track lateral/ahead search radius
+    approach_dh: float | None = 2.0    # h look-ahead for closing/receding verdict
+    use_anomaly_filter: bool = True
+
+    # ------------------------------------------------------------------
+    # Serialization
+
+    def to_dict(self) -> dict[str, Any]:
+        """JSON-serializable mapping of every field (stamped into artifacts)."""
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "FrontGateConfig":
+        """Rebuild a config from :meth:`to_dict`, ignoring unknown keys.
+
+        Tolerant of schema drift: extra keys (e.g. a future gate this code
+        doesn't know) are dropped rather than raising, so an artifact written
+        by a newer build still loads. Missing keys fall back to defaults.
+        """
+        known = {f.name for f in fields(cls)}
+        return cls(**{k: v for k, v in data.items() if k in known})
+
+    def with_overrides(self, **overrides: Any) -> "FrontGateConfig":
+        """Return a copy with the given fields replaced (frozen-safe)."""
+        return replace(self, **overrides)
+
+
+# ---------------------------------------------------------------------------
+# Preset registry
+#
+# Mirrors the advisories param-override pattern (AdvisoryParameterDef): named,
+# self-describing recipes a user / calibrator can swap without editing code.
+# Eventually these become per-level (925/850/700) presets; for now the level is
+# a separate axis the caller sets (the route stage picks the level nearest
+# cruise, the map/calibration path sets it explicitly).
+# ---------------------------------------------------------------------------
+
+
+_PRESETS: dict[str, FrontGateConfig] = {
+    # The validated baseline (2026-05-31 Channel front).
+    "default": FrontGateConfig(name="default"),
+    # Fewer false alarms: stronger gradient + air-mass-jump requirement.
+    "strict": FrontGateConfig(
+        name="strict", gradient_min=8.0, delta_theta_e_min=7.0, anomaly_min=3.0,
+    ),
+    # Catch weaker / pre-frontal boundaries (more POD, more FAR).
+    "sensitive": FrontGateConfig(
+        name="sensitive", gradient_min=4.0, delta_theta_e_min=3.0, anomaly_min=1.5,
+    ),
+    # Gradient-only: drop the air-mass-jump gate to isolate the |∇θe| ridge
+    # (diagnostic — shows what the magnitude gate alone accepts).
+    "gradient-only": FrontGateConfig(
+        name="gradient-only", delta_theta_e_min=0.0,
+    ),
+}
+
+
+def get_preset(name: str, *, level_hPa: int | None = None) -> FrontGateConfig:
+    """Return a named preset, optionally overriding its detection level.
+
+    Raises ``KeyError`` (with the available names) for an unknown preset so a
+    typo in a CLI ``--gate`` arg fails loudly rather than silently detecting
+    with the default recipe.
+    """
+    try:
+        cfg = _PRESETS[name]
+    except KeyError:
+        raise KeyError(
+            f"unknown gate preset {name!r}; available: {sorted(_PRESETS)}"
+        ) from None
+    if level_hPa is not None and level_hPa != cfg.level_hPa:
+        cfg = cfg.with_overrides(level_hPa=level_hPa)
+    return cfg
+
+
+def preset_names() -> list[str]:
+    """Sorted list of registered preset names (for CLI help / pickers)."""
+    return sorted(_PRESETS)

--- a/src/weatherbrief/frontal/route_sampling.py
+++ b/src/weatherbrief/frontal/route_sampling.py
@@ -991,6 +991,7 @@ def find_nearby_fronts(
     waypoints: Sequence[tuple[float, float]],
     hour: float,
     *,
+    config: FrontGateConfig | None = None,
     level_hPa: int | None = None,
     terrain_mask: np.ndarray | None = None,
     proximity_km: float = _DEFAULT_PROXIMITY_KM,
@@ -1012,7 +1013,21 @@ def find_nearby_fronts(
     distance classifies the front as closing / receding / steady. Returns None
     when no gated front exists within the bbox. Pass a precomputed
     ``background`` to avoid recomputing it across calls.
+
+    Pass a :class:`FrontGateConfig` as ``config`` to source every gate / geometry
+    parameter from one recipe (preferred — avoids unpacking ~9 fields at the call
+    site). When ``config`` is given it overrides the individual keyword gates.
     """
+    if config is not None:
+        level_hPa = config.level_hPa
+        proximity_km = config.proximity_km
+        step_km = config.step_km
+        gradient_min = config.gradient_min
+        delta_theta_e_min = config.delta_theta_e_min
+        anomaly_min = config.anomaly_min
+        airmass_window_km = config.airmass_window_km
+        use_anomaly_filter = config.use_anomaly_filter
+        approach_dh = config.approach_dh
     source = _as_source(source, terrain_mask)
     if terrain_mask is None:
         terrain_mask = source.terrain_mask
@@ -1080,11 +1095,13 @@ def analyze_route_fronts(
     terrain_mask: np.ndarray | None = None,
     # Legacy per-gate overrides — used only when ``config`` is None, for the
     # handful of callers/tests that still pass individual thresholds. Prefer
-    # building a FrontGateConfig.
+    # building a FrontGateConfig. Each defaults to None meaning "not supplied"
+    # (the config default applies); to *disable* the approach look-ahead pass a
+    # full ``config=FrontGateConfig(approach_dh=None)`` rather than the legacy arg.
     level_hPa: int | None = None,
     step_km: float | None = None,
     proximity_km: float | None = None,
-    approach_dh: float | None = "__default__",  # sentinel: keep config value
+    approach_dh: float | None = None,
     gradient_min: float | None = None,
     delta_theta_e_min: float | None = None,
     advection_min: float | None = None,
@@ -1122,13 +1139,7 @@ def analyze_route_fronts(
     crossings = decisions_to_crossings(decisions, config.merge_km)
     nearest = find_nearby_fronts(
         source, model, waypoints, hour,
-        level_hPa=config.level_hPa, terrain_mask=terrain_mask,
-        proximity_km=config.proximity_km, step_km=config.step_km,
-        gradient_min=config.gradient_min,
-        delta_theta_e_min=config.delta_theta_e_min, anomaly_min=config.anomaly_min,
-        airmass_window_km=config.airmass_window_km,
-        use_anomaly_filter=config.use_anomaly_filter,
-        approach_dh=config.approach_dh,
+        config=config, terrain_mask=terrain_mask,
     )
     return RouteFrontAnalysis(
         model=model, hour=float(hour), crossings=crossings, nearest=nearest,
@@ -1138,14 +1149,8 @@ def analyze_route_fronts(
 
 def _build_config_from_legacy_kwargs(**kw) -> FrontGateConfig:
     """Build a :class:`FrontGateConfig` from the legacy per-gate keyword args,
-    dropping any left at their ``None`` sentinel so config defaults apply.
+    dropping any left at ``None`` (not supplied) so the config defaults apply.
     """
+    overrides = {name: value for name, value in kw.items() if value is not None}
     base = FrontGateConfig()
-    overrides: dict = {}
-    approach = kw.pop("approach_dh", "__default__")
-    if approach != "__default__":
-        overrides["approach_dh"] = approach
-    for name, value in kw.items():
-        if value is not None:
-            overrides[name] = value
     return base.with_overrides(**overrides) if overrides else base

--- a/src/weatherbrief/frontal/route_sampling.py
+++ b/src/weatherbrief/frontal/route_sampling.py
@@ -816,6 +816,41 @@ def _hewson_grids_at(
     return {k: (1.0 - w) * g0[k] + w * g1[k] for k in g0}
 
 
+def grids_at_fractional_hour(
+    source: HewsonFieldSource | Case,
+    model: str,
+    hour: float,
+    *,
+    level_hPa: int | None = None,
+    terrain_mask: np.ndarray | None = None,
+) -> HewsonGrids | None:
+    """Full :class:`HewsonGrids` at a fractional hour, linearly interpolated.
+
+    Brackets ``hour`` between the two bounding available integer hours and
+    blends every field. Returns ``None`` when the hour falls outside the
+    source's range. Used by the 2-D contour extractor / calibration map, which
+    want all diagnostics (advection for classification) at an arbitrary time.
+    """
+    source = _as_source(source, terrain_mask)
+    avail = source.available_hours(model)
+    lo, hi = _bracket(avail, hour)
+    if lo is None or hi is None:
+        return None
+    g_lo = source.grids_at_hour(model, lo, level_hPa)
+    if lo == hi:
+        return g_lo
+    g_hi = source.grids_at_hour(model, hi, level_hPa)
+    if g_lo is None or g_hi is None:
+        return None
+    w = (hour - lo) / (hi - lo)
+    fields = ("theta_e", "gradient", "tfp", "neg_laplacian",
+              "advection", "tendency", "dT_dx", "dT_dy")
+    return HewsonGrids(**{
+        f: (1.0 - w) * getattr(g_lo, f) + w * getattr(g_hi, f)
+        for f in fields
+    })
+
+
 def compute_background_gradient(
     source: HewsonFieldSource | Case,
     model: str,

--- a/src/weatherbrief/frontal/route_sampling.py
+++ b/src/weatherbrief/frontal/route_sampling.py
@@ -18,18 +18,39 @@ Output shape matches the design doc §Phase A:
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Sequence
 
 import numpy as np
 
 from weatherbrief.frontal.case import Case
-from weatherbrief.frontal.detect import (
-    compute_frontal_zones,
-    compute_hewson_diagnostics,
+from weatherbrief.frontal.gates import FrontGateConfig
+from weatherbrief.frontal.sources import (
+    CaseFieldSource,
+    HewsonFieldSource,
+    HewsonGrids,
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _as_source(
+    src: HewsonFieldSource | Case,
+    terrain_mask: np.ndarray | None = None,
+) -> HewsonFieldSource:
+    """Adapt a bare :class:`Case` to a :class:`CaseFieldSource`.
+
+    The detection functions all take a :class:`HewsonFieldSource`, but a great
+    deal of existing code (the ``route-hewson`` / ``route-fronts`` CLI, Phase A
+    tests, calibration scripts) calls them with a raw ``Case``. Auto-wrapping
+    keeps those call sites working while the production pipeline passes a
+    :class:`~weatherbrief.frontal.sources.SnapshotFieldSource`. When a source is
+    passed directly it already owns its terrain mask, so the ``terrain_mask``
+    argument is ignored in that case.
+    """
+    if isinstance(src, HewsonFieldSource):
+        return src
+    return CaseFieldSource(src, terrain_mask=terrain_mask)
 
 
 # Diagnostic field keys exposed per waypoint. `theta_e` is the raw
@@ -44,22 +65,8 @@ _FIELD_KEYS = (
 )
 
 
-@dataclass(frozen=True)
-class _HourGrids:
-    """Per-hour diagnostic grids + raw theta_e, keyed under _FIELD_KEYS.
-
-    Tendency is filled in separately because it needs adjacent hours.
-    """
-    theta_e: np.ndarray
-    gradient: np.ndarray
-    tfp: np.ndarray
-    neg_laplacian: np.ndarray
-    advection: np.ndarray
-    tendency: np.ndarray  # NaN-filled if neither neighbour is available
-
-
 def sample_hewson_at_route(
-    case: Case,
+    source: HewsonFieldSource | Case,
     model: str,
     waypoints: Sequence[tuple[float, float]],
     hours: Sequence[float] | float | None = None,
@@ -71,8 +78,9 @@ def sample_hewson_at_route(
 
     Parameters
     ----------
-    case : loaded Case (see `load_case`).
-    model : model key present in the case (e.g. "era5", "ecmwf").
+    source : a :class:`HewsonFieldSource` (snapshot or case-backed) or a bare
+        :class:`Case` (auto-wrapped in a ``CaseFieldSource``).
+    model : model key present in the source (e.g. "era5", "ecmwf").
     waypoints : iterable of (lat_deg, lon_deg) pairs.
     hours : forecast hour(s) at which to sample. One of:
         - None  → sample all waypoints at hour 0
@@ -93,21 +101,22 @@ def sample_hewson_at_route(
     Values are NaN when a waypoint sits outside the grid or the
     requested hour is outside the available range.
     """
+    source = _as_source(source, terrain_mask)
     wps = [(float(la), float(lo)) for la, lo in waypoints]
     hour_list = _normalize_hours(hours, len(wps))
 
-    if model not in case.models:
+    if model not in source.models:
         raise ValueError(
-            f"model {model!r} not in case (available: {case.models})"
+            f"model {model!r} not in source (available: {source.models})"
         )
 
-    avail_hours = case.available_hours(model)
+    avail_hours = source.available_hours(model)
     if not avail_hours:
-        raise ValueError(f"case has no available hours for model {model!r}")
+        raise ValueError(f"source has no available hours for model {model!r}")
 
-    # Unique integer hours we need to compute diagnostics for. For a
-    # fractional target hour h, we need ⌊h⌋ and ⌈h⌉ (both must be in
-    # avail_hours for the sample to be valid).
+    # Unique integer hours we need to fetch grids for. For a fractional target
+    # hour h, we need the two bounding available hours (both must be present for
+    # the sample to be valid).
     needed: set[int] = set()
     for h in hour_list:
         if h is None:
@@ -118,11 +127,14 @@ def sample_hewson_at_route(
         if hi is not None:
             needed.add(hi)
 
-    grids_by_hour: dict[int, _HourGrids] = {
-        h: _compute_hour_grids(case, model, h, avail_hours, terrain_mask, level_hPa)
-        for h in sorted(needed)
-    }
+    grids_by_hour: dict[int, HewsonGrids] = {}
+    for h in sorted(needed):
+        grids = source.grids_at_hour(model, h, level_hPa)
+        if grids is None:
+            raise ValueError(f"grids missing for model={model!r} hour={h}")
+        grids_by_hour[h] = grids
 
+    lat_axis, lon_axis = source.lat, source.lon
     results: list[dict] = []
     for (wp_lat, wp_lon), h in zip(wps, hour_list):
         entry: dict = {"lat": wp_lat, "lon": wp_lon, "hour": h}
@@ -140,13 +152,13 @@ def sample_hewson_at_route(
             continue
 
         if lo == hi:
-            sample = _sample_grids(grids_by_hour[lo], case.lat, case.lon,
+            sample = _sample_grids(grids_by_hour[lo], lat_axis, lon_axis,
                                    wp_lat, wp_lon)
         else:
             w = (h - lo) / (hi - lo)
-            s_lo = _sample_grids(grids_by_hour[lo], case.lat, case.lon,
+            s_lo = _sample_grids(grids_by_hour[lo], lat_axis, lon_axis,
                                  wp_lat, wp_lon)
-            s_hi = _sample_grids(grids_by_hour[hi], case.lat, case.lon,
+            s_hi = _sample_grids(grids_by_hour[hi], lat_axis, lon_axis,
                                  wp_lat, wp_lon)
             sample = {k: (1.0 - w) * s_lo[k] + w * s_hi[k] for k in _FIELD_KEYS}
 
@@ -193,77 +205,14 @@ def _bracket(
     return max(lo_candidates), min(hi_candidates)
 
 
-def _compute_hour_grids(
-    case: Case,
-    model: str,
-    hour: int,
-    avail_hours: list[int],
-    terrain_mask: np.ndarray | None,
-    level_hPa: int | None = None,
-) -> _HourGrids:
-    """Compute diagnostic grids + tendency for one integer hour."""
-    fields = case.fields(model, hour, level_hPa)
-    if fields is None:
-        raise ValueError(f"fields missing for model={model!r} hour={hour}")
-
-    diag = compute_hewson_diagnostics(
-        fields["theta_e"], case.lat, case.lon,
-        u=fields["u850"], v=fields["v850"],
-        terrain_mask=terrain_mask,
-    )
-
-    return _HourGrids(
-        theta_e=fields["theta_e"],
-        gradient=diag["gradient"],
-        tfp=diag["tfp"],
-        neg_laplacian=diag["neg_laplacian"],
-        advection=diag["advection"],
-        tendency=_tendency_grid(case, model, hour, avail_hours, level_hPa),
-    )
-
-
-def _tendency_grid(
-    case: Case,
-    model: str,
-    hour: int,
-    avail_hours: list[int],
-    level_hPa: int | None = None,
-) -> np.ndarray:
-    """∂θe/∂t at `hour`, using centered/forward/backward diff.
-
-    Mirrors the fallback logic in `_cmd_plot_hewson`: prefer centered
-    difference, fall back to one-sided at the ends of the range. Returns
-    a NaN-filled grid when neither neighbour is available.
-    """
-    prev_h = max((h for h in avail_hours if h < hour), default=None)
-    next_h = min((h for h in avail_hours if h > hour), default=None)
-
-    if prev_h is not None and next_h is not None:
-        f_prev = case.fields(model, prev_h, level_hPa)["theta_e"]
-        f_next = case.fields(model, next_h, level_hPa)["theta_e"]
-        return (f_next - f_prev) / (next_h - prev_h)
-    if next_h is not None:
-        f_here = case.fields(model, hour, level_hPa)["theta_e"]
-        f_next = case.fields(model, next_h, level_hPa)["theta_e"]
-        return (f_next - f_here) / (next_h - hour)
-    if prev_h is not None:
-        f_prev = case.fields(model, prev_h, level_hPa)["theta_e"]
-        f_here = case.fields(model, hour, level_hPa)["theta_e"]
-        return (f_here - f_prev) / (hour - prev_h)
-
-    # Single hour in the case — no tendency possible
-    shape = case.fields(model, hour, level_hPa)["theta_e"].shape
-    return np.full(shape, np.nan, dtype=np.float64)
-
-
 def _sample_grids(
-    grids: _HourGrids,
+    grids: HewsonGrids,
     lat_axis: np.ndarray,
     lon_axis: np.ndarray,
     wp_lat: float,
     wp_lon: float,
 ) -> dict[str, float]:
-    """Bilinear sample every field at one waypoint."""
+    """Bilinear sample every diagnostic field at one waypoint."""
     return {
         k: bilinear_sample(getattr(grids, k), lat_axis, lon_axis, wp_lat, wp_lon)
         for k in _FIELD_KEYS
@@ -405,39 +354,92 @@ def _airmass_delta(
     return float(theta_after - theta_before)
 
 
-def detect_front_crossings(
+# ---------------------------------------------------------------------------
+# Candidate / decision split
+#
+# The on-track locator is factored into three stages so the same expensive
+# sampling can be re-scored against many gate configs with zero re-sampling
+# (cheap calibration sweeps), and so every candidate records *why* it was
+# accepted or rejected and by what margin:
+#
+#   1. sample once          (sample_hewson_at_route on a densified route)
+#   2. generate candidates  (every TFP zero-crossing, carrying raw fields)
+#   3. apply a gate config  (FrontDecision per candidate: accepted / rejected_by)
+#
+# accepted decisions → FrontCrossing (merged within merge_km).
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class FrontCandidate:
+    """An *unfiltered* TFP zero-crossing along the route.
+
+    Carries the raw fields interpolated to the zero point plus the θe jump
+    measured across the generation window — everything a gate config needs to
+    accept/reject without touching the samples again. Distances are along-route
+    km from the first waypoint.
+    """
+    lat: float
+    lon: float
+    distance_km: float
+    gradient: float        # |∇θe|  K/100km
+    neg_laplacian: float   # −∇²θe  K/(100km)²  (sharpness, diagnostic only)
+    advection: float       # −V·∇θe  K/h
+    tfp_before: float
+    tfp_after: float
+    delta_theta_e: float   # θe(after) − θe(before) across the window, K
+    airmass_window_km: float  # window the Δθe above was measured across
+
+
+@dataclass(frozen=True)
+class FrontDecision:
+    """The verdict of one :class:`FrontGateConfig` on one :class:`FrontCandidate`.
+
+    ``rejected_by`` is the *first* acceptance gate the candidate failed
+    (``"gradient"`` or ``"delta_theta_e"``), or ``None`` when accepted.
+    ``margins`` gives each gate's signed slack (value − threshold; ≥ 0 means
+    the gate passed) so a calibrator can read "rejected: Δθe 4.2 K vs 5.0 gate"
+    straight off the trace. ``kind`` / ``intensity`` are always populated (they
+    are labels, computed regardless of acceptance).
+    """
+    candidate: FrontCandidate
+    accepted: bool
+    rejected_by: str | None
+    margins: dict[str, float]
+    kind: str              # "cold" | "warm" | "quasi-stationary"
+    intensity: str         # "significant" | "classical" | "sharp"
+
+    def to_crossing(self) -> FrontCrossing:
+        """Project an accepted decision onto the public :class:`FrontCrossing`."""
+        c = self.candidate
+        return FrontCrossing(
+            lat=c.lat, lon=c.lon, distance_km=c.distance_km,
+            gradient=c.gradient, neg_laplacian=c.neg_laplacian,
+            advection=c.advection, tfp_before=c.tfp_before,
+            tfp_after=c.tfp_after, delta_theta_e=c.delta_theta_e,
+            kind=self.kind, intensity=self.intensity,
+        )
+
+
+def generate_front_candidates(
     samples: Sequence[dict],
     *,
-    gradient_min: float = _DEFAULT_GRADIENT_MIN,
-    delta_theta_e_min: float = _DEFAULT_DELTA_THETA_E_MIN,
-    advection_min: float = _DEFAULT_ADVECTION_MIN,
-    merge_km: float = _DEFAULT_MERGE_KM,
     airmass_window_km: float = _DEFAULT_AIRMASS_WINDOW_KM,
-) -> list[FrontCrossing]:
-    """Locate front crossings in an ordered, densely-sampled route series.
+) -> list[FrontCandidate]:
+    """Every TFP zero-crossing in an ordered route series, **ungated**.
 
-    ``samples`` is an ordered list of dicts (one per dense route point), each
-    carrying at least ``lat, lon, distance_km, theta_e, gradient, tfp,
-    neg_laplacian, advection`` — the output shape of
-    :func:`sample_hewson_at_route` on a densified route, augmented with
-    ``distance_km``. Source-agnostic: a calibration ``Case`` or a live
-    precompute NPZ can both feed it.
+    ``samples`` is one dict per dense route point carrying at least ``lat, lon,
+    distance_km, theta_e, gradient, tfp, neg_laplacian, advection`` — the output
+    of :func:`sample_hewson_at_route` on a densified route, augmented with
+    ``distance_km``. Source-agnostic: a case-backed or snapshot-backed sampler
+    feeds it identically.
 
-    A crossing is a TFP sign change between adjacent samples whose interpolated
-    zero point clears the gradient (magnitude) gate AND whose θe jump across
-    ±``airmass_window_km`` clears the air-mass-jump gate. This is the Hewson
-    locator restricted to the route: the gradient gate rejects weak/dry
-    boundaries, the Δθe gate rejects gradient *cols* (which have a strong local
-    gradient but no net change of air mass). Adjacent surviving crossings within
-    ``merge_km`` are collapsed to the strongest (one physical front can straddle
-    several dense steps).
-
-    Note the air-mass-jump gate replaced an earlier −∇²θe "sharpness" gate: −∇²θe
-    is ≈0 at the TFP zero by construction, so gating on it there suppressed real
-    fronts (see the module-level threshold comment). −∇²θe is still reported on
-    each :class:`FrontCrossing` for diagnostics.
+    The θe jump is measured across ±``airmass_window_km`` here (a single ~15 km
+    step understates the air-mass contrast a pilot flies through), so a sweep
+    that only varies the threshold gates can reuse one candidate set; a sweep
+    that varies the *window* must regenerate.
     """
-    raw: list[FrontCrossing] = []
+    out: list[FrontCandidate] = []
     for a, b in zip(samples[:-1], samples[1:]):
         ta, tb = a["tfp"], b["tfp"]
         if not (np.isfinite(ta) and np.isfinite(tb)):
@@ -447,7 +449,6 @@ def detect_front_crossings(
         if ta * tb >= 0.0:  # no sign change → no zero-crossing on this step
             continue
 
-        # Linear interpolation fraction to the TFP zero between a and b.
         denom = ta - tb
         frac = ta / denom if denom != 0.0 else 0.5
 
@@ -456,39 +457,121 @@ def detect_front_crossings(
             return float(va + frac * (vb - va))
 
         grad = _interp("gradient")
-        if not np.isfinite(grad) or grad < gradient_min:
-            continue
-
+        if not np.isfinite(grad):
+            continue  # can't evaluate any gate without a finite gradient
         dist = _interp("distance_km")
-        delta_theta_e = _airmass_delta(samples, dist, airmass_window_km)
-        if not np.isfinite(delta_theta_e) or abs(delta_theta_e) < delta_theta_e_min:
-            continue
-
-        adv = _interp("advection")
-        if adv > advection_min:
-            kind = "warm"
-        elif adv < -advection_min:
-            kind = "cold"
-        else:
-            kind = "quasi-stationary"
-
-        raw.append(
-            FrontCrossing(
+        out.append(
+            FrontCandidate(
                 lat=_interp("lat"),
                 lon=_interp("lon"),
                 distance_km=dist,
                 gradient=grad,
                 neg_laplacian=_interp("neg_laplacian"),
-                advection=adv,
+                advection=_interp("advection"),
                 tfp_before=float(ta),
                 tfp_after=float(tb),
-                delta_theta_e=delta_theta_e,
-                kind=kind,
-                intensity=_intensity_label(grad),
+                delta_theta_e=_airmass_delta(samples, dist, airmass_window_km),
+                airmass_window_km=airmass_window_km,
             )
         )
+    return out
 
-    return _merge_crossings(raw, merge_km)
+
+def _classify_kind(advection: float, advection_min: float) -> str:
+    if advection > advection_min:
+        return "warm"
+    if advection < -advection_min:
+        return "cold"
+    return "quasi-stationary"
+
+
+def apply_gate_config(
+    candidates: Sequence[FrontCandidate],
+    config: FrontGateConfig,
+) -> list[FrontDecision]:
+    """Score each candidate against ``config`` → one :class:`FrontDecision` each.
+
+    Acceptance is the AND of the magnitude gate (|∇θe| ≥ ``gradient_min`` — a
+    significant air-mass boundary) and the air-mass-jump gate (|Δθe| ≥
+    ``delta_theta_e_min`` — a genuine change of air mass, not a gradient col).
+    The first failing gate is recorded in ``rejected_by``. Classification
+    (``advection_min``) and intensity (from |∇θe|) are labels only and reject
+    nothing.
+
+    The −∇²θe "sharpness" gate was deliberately *not* reinstated: −∇²θe ≈ 0 at
+    the TFP zero by construction, so gating on it there suppresses real fronts
+    (verified on the 2026-05-31 Channel front). It is still reported per
+    candidate as a diagnostic.
+    """
+    decisions: list[FrontDecision] = []
+    for c in candidates:
+        delta = c.delta_theta_e
+        margins = {
+            "gradient": c.gradient - config.gradient_min,
+            "delta_theta_e": (
+                abs(delta) - config.delta_theta_e_min
+                if np.isfinite(delta) else float("nan")
+            ),
+        }
+        rejected_by: str | None = None
+        if c.gradient < config.gradient_min:
+            rejected_by = "gradient"
+        elif not np.isfinite(delta) or abs(delta) < config.delta_theta_e_min:
+            rejected_by = "delta_theta_e"
+        decisions.append(
+            FrontDecision(
+                candidate=c,
+                accepted=rejected_by is None,
+                rejected_by=rejected_by,
+                margins=margins,
+                kind=_classify_kind(c.advection, config.advection_min),
+                intensity=_intensity_label(c.gradient),
+            )
+        )
+    return decisions
+
+
+def decisions_to_crossings(
+    decisions: Sequence[FrontDecision],
+    merge_km: float = _DEFAULT_MERGE_KM,
+) -> list[FrontCrossing]:
+    """Accepted decisions → merged :class:`FrontCrossing` list."""
+    accepted = [d.to_crossing() for d in decisions if d.accepted]
+    return _merge_crossings(accepted, merge_km)
+
+
+def detect_front_crossings(
+    samples: Sequence[dict],
+    *,
+    gradient_min: float = _DEFAULT_GRADIENT_MIN,
+    delta_theta_e_min: float = _DEFAULT_DELTA_THETA_E_MIN,
+    advection_min: float = _DEFAULT_ADVECTION_MIN,
+    merge_km: float = _DEFAULT_MERGE_KM,
+    airmass_window_km: float = _DEFAULT_AIRMASS_WINDOW_KM,
+    config: FrontGateConfig | None = None,
+) -> list[FrontCrossing]:
+    """Locate accepted front crossings in a densely-sampled route series.
+
+    Thin convenience wrapper over the candidate/decision split:
+    :func:`generate_front_candidates` → :func:`apply_gate_config` →
+    :func:`decisions_to_crossings`. Pass a :class:`FrontGateConfig` to gate with
+    a named recipe, or rely on the individual keyword gates (kept for backward
+    compatibility with existing callers/tests). When both are given the explicit
+    ``config`` wins.
+    """
+    if config is None:
+        config = FrontGateConfig(
+            gradient_min=gradient_min,
+            delta_theta_e_min=delta_theta_e_min,
+            advection_min=advection_min,
+            merge_km=merge_km,
+            airmass_window_km=airmass_window_km,
+        )
+    candidates = generate_front_candidates(
+        samples, airmass_window_km=config.airmass_window_km,
+    )
+    decisions = apply_gate_config(candidates, config)
+    return decisions_to_crossings(decisions, config.merge_km)
 
 
 def _merge_crossings(
@@ -514,8 +597,41 @@ def _merge_crossings(
     return merged
 
 
+def evaluate_route_fronts(
+    source: HewsonFieldSource | Case,
+    model: str,
+    waypoints: Sequence[tuple[float, float]],
+    hour: float,
+    config: FrontGateConfig,
+    *,
+    terrain_mask: np.ndarray | None = None,
+) -> list[FrontDecision]:
+    """Densify → sample → generate candidates → score against ``config``.
+
+    Returns the full per-candidate decision trace (accepted *and* rejected),
+    using ``config``'s level / step / window. Callers wanting just the accepted
+    crossings pass the result through :func:`decisions_to_crossings`; calibration
+    sweeps keep the trace and re-score the same candidate set with
+    :func:`apply_gate_config`.
+    """
+    dense = densify_route(waypoints, step_km=config.step_km)
+    samples = sample_hewson_at_route(
+        source, model,
+        [(la, lo) for la, lo, _ in dense],
+        hours=hour,
+        level_hPa=config.level_hPa,
+        terrain_mask=terrain_mask,
+    )
+    for s, (_, _, dist_km) in zip(samples, dense):
+        s["distance_km"] = dist_km
+    candidates = generate_front_candidates(
+        samples, airmass_window_km=config.airmass_window_km,
+    )
+    return apply_gate_config(candidates, config)
+
+
 def find_route_fronts(
-    case: Case,
+    source: HewsonFieldSource | Case,
     model: str,
     waypoints: Sequence[tuple[float, float]],
     hour: float,
@@ -523,17 +639,27 @@ def find_route_fronts(
     level_hPa: int | None = None,
     step_km: float = _DEFAULT_STEP_KM,
     terrain_mask: np.ndarray | None = None,
+    config: FrontGateConfig | None = None,
     **detect_kwargs,
 ) -> list[FrontCrossing]:
     """End-to-end: densify a route, sample Hewson fields, detect front crossings.
 
     Convenience orchestrator over :func:`densify_route`,
-    :func:`sample_hewson_at_route`, and :func:`detect_front_crossings`. Extra
-    keyword args are forwarded to the detector (gradient_min, etc.).
+    :func:`sample_hewson_at_route`, and the candidate/decision split. Accepts a
+    :class:`FrontGateConfig` (preferred) or the legacy individual keyword gates
+    (forwarded to :func:`detect_front_crossings` for backward compatibility).
     """
+    if config is not None:
+        return decisions_to_crossings(
+            evaluate_route_fronts(
+                source, model, waypoints, hour, config,
+                terrain_mask=terrain_mask,
+            ),
+            config.merge_km,
+        )
     dense = densify_route(waypoints, step_km=step_km)
     samples = sample_hewson_at_route(
-        case, model,
+        source, model,
         [(la, lo) for la, lo, _ in dense],
         hours=hour,
         level_hPa=level_hPa,
@@ -638,15 +764,24 @@ class FrontProximity:
 
 @dataclass(frozen=True)
 class RouteFrontAnalysis:
-    """Full per-route frontal picture for one model at one valid hour."""
+    """Full per-route frontal picture for one model at one valid hour.
+
+    ``decisions`` is the on-track candidate/decision trace (accepted *and*
+    rejected) and ``config`` is the gate recipe that produced this analysis —
+    both stamped in for reproducibility and so a calibrator can read why each
+    candidate passed or failed.
+    """
     model: str
     hour: float
     crossings: list[FrontCrossing]      # fronts the track crosses
     nearest: FrontProximity | None      # nearest front (may be on- or off-track)
+    level_hPa: int = 850
+    config: FrontGateConfig = field(default_factory=FrontGateConfig)
+    decisions: list[FrontDecision] = field(default_factory=list)
 
 
 def _hewson_grids_at(
-    case: Case,
+    source: HewsonFieldSource | Case,
     model: str,
     hour: float,
     *,
@@ -655,63 +790,52 @@ def _hewson_grids_at(
 ) -> dict | None:
     """Hewson diagnostic grids (gradient, tfp, dT_dx, dT_dy, theta_e) at a
     fractional hour, linearly interpolated between bounding available hours.
-    Returns None when the hour is outside the case range.
+    Returns None when the hour is outside the source range.
     """
-    avail = case.available_hours(model)
+    source = _as_source(source, terrain_mask)
+    avail = source.available_hours(model)
     lo, hi = _bracket(avail, hour)
     if lo is None or hi is None:
         return None
 
-    def _diag(h: int) -> dict:
-        f = case.fields(model, h, level_hPa)
-        d = compute_hewson_diagnostics(
-            f["theta_e"], case.lat, case.lon,
-            u=f["u850"], v=f["v850"], terrain_mask=terrain_mask,
-        )
+    def _diag(h: int) -> dict | None:
+        g = source.grids_at_hour(model, h, level_hPa)
+        if g is None:
+            return None
         return {
-            "gradient": d["gradient"], "tfp": d["tfp"],
-            "dT_dx": d["dT_dx"], "dT_dy": d["dT_dy"], "theta_e": f["theta_e"],
+            "gradient": g.gradient, "tfp": g.tfp,
+            "dT_dx": g.dT_dx, "dT_dy": g.dT_dy, "theta_e": g.theta_e,
         }
 
     if lo == hi:
         return _diag(lo)
-    w = (hour - lo) / (hi - lo)
     g0, g1 = _diag(lo), _diag(hi)
+    if g0 is None or g1 is None:
+        return None
+    w = (hour - lo) / (hi - lo)
     return {k: (1.0 - w) * g0[k] + w * g1[k] for k in g0}
 
 
 def compute_background_gradient(
-    case: Case,
+    source: HewsonFieldSource | Case,
     model: str,
     *,
     level_hPa: int | None = None,
     terrain_mask: np.ndarray | None = None,
     hour_stride: int = 6,
 ) -> np.ndarray:
-    """Time-mean |∇θe| over the case's forecast hours — the persistent
+    """Time-mean |∇θe| over the source's forecast hours — the persistent
     (orographic / sea-land) background used to anomaly-filter route fronts.
 
-    Sampled every ``hour_stride`` hours to bound cost; the mean is dominated by
-    persistent features either way (a front passing through for a few hours
-    barely moves a multi-day mean). The stride is in *hours*, not array indices,
-    so it behaves the same for hourly and 3-hourly models.
+    Delegates to :meth:`HewsonFieldSource.background_gradient`; kept as a
+    module-level function for the existing callers (and so a bare ``Case`` is
+    auto-wrapped). The stride is in *hours*, not array indices, so it behaves
+    the same for hourly and 3-hourly sources.
     """
-    hours = case.available_hours(model)
-    sampled = [h for h in hours if h % hour_stride == 0] or hours
-    acc: np.ndarray | None = None
-    n = 0
-    for h in sampled:
-        f = case.fields(model, h, level_hPa)
-        if f is None:
-            continue
-        g = compute_frontal_zones(
-            f["theta_e"], case.lat, case.lon, terrain_mask=terrain_mask,
-        )["gradient"]
-        acc = g if acc is None else acc + g
-        n += 1
-    if acc is None or n == 0:
-        return np.zeros((len(case.lat), len(case.lon)))
-    return acc / n
+    source = _as_source(source, terrain_mask)
+    return source.background_gradient(
+        model, level_hPa, hour_stride=hour_stride,
+    )
 
 
 def _route_bbox(
@@ -726,7 +850,7 @@ def _route_bbox(
 
 
 def extract_gated_fronts(
-    case: Case,
+    source: HewsonFieldSource | Case,
     model: str,
     hour: float,
     *,
@@ -749,14 +873,17 @@ def extract_gated_fronts(
     ``delta_theta_e_min``. Same gate philosophy as :func:`detect_front_crossings`,
     applied to the 2-D field instead of the 1-D route series.
     """
+    source = _as_source(source, terrain_mask)
+    if terrain_mask is None:
+        terrain_mask = source.terrain_mask
     grids = _hewson_grids_at(
-        case, model, hour, level_hPa=level_hPa, terrain_mask=terrain_mask,
+        source, model, hour, level_hPa=level_hPa, terrain_mask=terrain_mask,
     )
     if grids is None:
         return []
     grad, tfp = grids["gradient"], grids["tfp"]
     dtdx, dtdy, the = grids["dT_dx"], grids["dT_dy"], grids["theta_e"]
-    lat, lon = case.lat, case.lon
+    lat, lon = source.lat, source.lon
 
     if bbox is None:
         ila = range(len(lat))
@@ -824,7 +951,7 @@ def _nearest_front(
 
 
 def find_nearby_fronts(
-    case: Case,
+    source: HewsonFieldSource | Case,
     model: str,
     waypoints: Sequence[tuple[float, float]],
     hour: float,
@@ -851,18 +978,21 @@ def find_nearby_fronts(
     when no gated front exists within the bbox. Pass a precomputed
     ``background`` to avoid recomputing it across calls.
     """
+    source = _as_source(source, terrain_mask)
+    if terrain_mask is None:
+        terrain_mask = source.terrain_mask
     dense = densify_route(waypoints, step_km=step_km)
     if len(dense) < 1:
         return None
     bbox = _route_bbox(dense, proximity_km)
     if use_anomaly_filter and background is None:
         background = compute_background_gradient(
-            case, model, level_hPa=level_hPa, terrain_mask=terrain_mask,
+            source, model, level_hPa=level_hPa, terrain_mask=terrain_mask,
         )
 
     def _cells(h: float) -> list[GatedFrontPoint]:
         return extract_gated_fronts(
-            case, model, h, bbox=bbox, level_hPa=level_hPa,
+            source, model, h, bbox=bbox, level_hPa=level_hPa,
             terrain_mask=terrain_mask, background=background,
             gradient_min=gradient_min, delta_theta_e_min=delta_theta_e_min,
             anomaly_min=anomaly_min, airmass_window_km=airmass_window_km,
@@ -906,46 +1036,81 @@ def find_nearby_fronts(
 
 
 def analyze_route_fronts(
-    case: Case,
+    source: HewsonFieldSource | Case,
     model: str,
     waypoints: Sequence[tuple[float, float]],
     hour: float,
     *,
-    level_hPa: int | None = None,
+    config: FrontGateConfig | None = None,
     terrain_mask: np.ndarray | None = None,
-    step_km: float = _DEFAULT_STEP_KM,
-    proximity_km: float = _DEFAULT_PROXIMITY_KM,
-    approach_dh: float | None = _DEFAULT_APPROACH_DH,
-    gradient_min: float = _DEFAULT_GRADIENT_MIN,
-    delta_theta_e_min: float = _DEFAULT_DELTA_THETA_E_MIN,
-    advection_min: float = _DEFAULT_ADVECTION_MIN,
-    merge_km: float = _DEFAULT_MERGE_KM,
-    airmass_window_km: float = _DEFAULT_AIRMASS_WINDOW_KM,
-    anomaly_min: float = _DEFAULT_ANOMALY_MIN,
-    use_anomaly_filter: bool = True,
+    # Legacy per-gate overrides — used only when ``config`` is None, for the
+    # handful of callers/tests that still pass individual thresholds. Prefer
+    # building a FrontGateConfig.
+    level_hPa: int | None = None,
+    step_km: float | None = None,
+    proximity_km: float | None = None,
+    approach_dh: float | None = "__default__",  # sentinel: keep config value
+    gradient_min: float | None = None,
+    delta_theta_e_min: float | None = None,
+    advection_min: float | None = None,
+    merge_km: float | None = None,
+    airmass_window_km: float | None = None,
+    anomaly_min: float | None = None,
+    use_anomaly_filter: bool | None = None,
 ) -> RouteFrontAnalysis:
     """End-to-end per-route frontal analysis for one model at one valid hour.
 
-    Combines the on-track locator (:func:`find_route_fronts`) with the off-track
-    proximity scan (:func:`find_nearby_fronts`) into one structured result — the
-    "what fronts does this leg cross, and what front is it about to run into?"
-    answer that feeds route-SIGMET advisories (#168).
+    Source-agnostic and config-driven: takes a :class:`HewsonFieldSource`
+    (production passes a snapshot source; a bare :class:`Case` is auto-wrapped)
+    and a :class:`FrontGateConfig` *recipe*. Combines the on-track candidate/
+    decision locator with the off-track proximity scan into one structured
+    result — "what fronts does this leg cross, and what front is it about to run
+    into?" — and stamps the active config + full candidate trace into the
+    returned :class:`RouteFrontAnalysis` for reproducibility and calibration.
+
+    The legacy individual-gate keyword arguments are honoured only when
+    ``config`` is omitted (they build an ad-hoc config); ``config`` always wins.
     """
-    crossings = find_route_fronts(
-        case, model, waypoints, hour,
-        level_hPa=level_hPa, step_km=step_km, terrain_mask=terrain_mask,
-        gradient_min=gradient_min, delta_theta_e_min=delta_theta_e_min,
-        advection_min=advection_min, merge_km=merge_km,
-        airmass_window_km=airmass_window_km,
+    if config is None:
+        config = _build_config_from_legacy_kwargs(
+            level_hPa=level_hPa, step_km=step_km, proximity_km=proximity_km,
+            approach_dh=approach_dh, gradient_min=gradient_min,
+            delta_theta_e_min=delta_theta_e_min, advection_min=advection_min,
+            merge_km=merge_km, airmass_window_km=airmass_window_km,
+            anomaly_min=anomaly_min, use_anomaly_filter=use_anomaly_filter,
+        )
+
+    source = _as_source(source, terrain_mask)
+    decisions = evaluate_route_fronts(
+        source, model, waypoints, hour, config, terrain_mask=terrain_mask,
     )
+    crossings = decisions_to_crossings(decisions, config.merge_km)
     nearest = find_nearby_fronts(
-        case, model, waypoints, hour,
-        level_hPa=level_hPa, terrain_mask=terrain_mask,
-        proximity_km=proximity_km, step_km=step_km, gradient_min=gradient_min,
-        delta_theta_e_min=delta_theta_e_min, anomaly_min=anomaly_min,
-        airmass_window_km=airmass_window_km, use_anomaly_filter=use_anomaly_filter,
-        approach_dh=approach_dh,
+        source, model, waypoints, hour,
+        level_hPa=config.level_hPa, terrain_mask=terrain_mask,
+        proximity_km=config.proximity_km, step_km=config.step_km,
+        gradient_min=config.gradient_min,
+        delta_theta_e_min=config.delta_theta_e_min, anomaly_min=config.anomaly_min,
+        airmass_window_km=config.airmass_window_km,
+        use_anomaly_filter=config.use_anomaly_filter,
+        approach_dh=config.approach_dh,
     )
     return RouteFrontAnalysis(
         model=model, hour=float(hour), crossings=crossings, nearest=nearest,
+        level_hPa=config.level_hPa, config=config, decisions=decisions,
     )
+
+
+def _build_config_from_legacy_kwargs(**kw) -> FrontGateConfig:
+    """Build a :class:`FrontGateConfig` from the legacy per-gate keyword args,
+    dropping any left at their ``None`` sentinel so config defaults apply.
+    """
+    base = FrontGateConfig()
+    overrides: dict = {}
+    approach = kw.pop("approach_dh", "__default__")
+    if approach != "__default__":
+        overrides["approach_dh"] = approach
+    for name, value in kw.items():
+        if value is not None:
+            overrides[name] = value
+    return base.with_overrides(**overrides) if overrides else base

--- a/src/weatherbrief/frontal/route_sampling.py
+++ b/src/weatherbrief/frontal/route_sampling.py
@@ -1017,6 +1017,12 @@ def find_nearby_fronts(
     Pass a :class:`FrontGateConfig` as ``config`` to source every gate / geometry
     parameter from one recipe (preferred — avoids unpacking ~9 fields at the call
     site). When ``config`` is given it overrides the individual keyword gates.
+
+    ``background`` (when pre-supplied) MUST be the time-mean |∇θe| at the *same*
+    ``level_hPa`` as this scan — it is the level's own persistent baseline. In a
+    multi-level loop, compute one background per level (or leave it ``None`` to
+    let this function compute the matching one). The array carries no level tag,
+    so a mismatched background silently distorts the anomaly filter.
     """
     if config is not None:
         level_hPa = config.level_hPa

--- a/src/weatherbrief/frontal/sources.py
+++ b/src/weatherbrief/frontal/sources.py
@@ -1,0 +1,373 @@
+"""``HewsonFieldSource`` — one detection algorithm, swappable data source.
+
+Front detection needs, per ``(model, level, hour)``, the Hewson diagnostic
+grids (θe, |∇θe|, TFP, −∇²θe, advection, tendency) plus the gradient direction
+(``dT_dx``/``dT_dy``) and a time-mean background gradient for the anomaly
+filter. Two places can supply those:
+
+* :class:`SnapshotFieldSource` — reads a precomputed NPZ snapshot
+  (``weatherbrief.hewson.precompute`` output). **Production default.** Zero
+  fetch; the derivative fields were computed once on the full European grid
+  (cleaner 2nd derivatives than a route-corridor recompute); the 3 h temporal
+  stride is interpolated between frames by the route sampler. ``dT_dx``/
+  ``dT_dy`` are re-derived from the stored θe (the NPZ doesn't persist them).
+
+* :class:`CaseFieldSource` — recomputes diagnostics from a calibration
+  :class:`~weatherbrief.frontal.case.Case` via
+  :func:`~weatherbrief.frontal.detect.compute_hewson_diagnostics` (today's
+  path). For calibration, ERA5 historical studies, arbitrary-level/hourly work,
+  and as a fallback when no snapshot covers the route.
+
+The choice is made in code, **not** exposed as a user toggle — see
+``designs/future/hewson-fields-aviation-advisories.md`` §6.2/§6.3 (source-
+agnostic principle). A future native-GRIB stencil source slots in as a third
+implementation with no change to detection or gates.
+
+Hour reference frame: each source defines its own. ``CaseFieldSource`` hours are
+offsets from the case's first valid time (unchanged from the historical Case
+path); ``SnapshotFieldSource`` hours are offsets from the snapshot's model init.
+Callers pass hours in the source's frame and stay internally consistent.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+
+from weatherbrief.frontal.detect import (
+    compute_hewson_diagnostics,
+    theta_e_gradient_components,
+)
+
+
+@dataclass(frozen=True)
+class HewsonGrids:
+    """The diagnostic grids at one ``(model, level, integer hour)``.
+
+    All arrays share the source grid shape ``(n_lat, n_lon)``. ``dT_dx``/
+    ``dT_dy`` are in K/km (the unit gradient direction the front extractor
+    needs); every other field is in the unit the precompute NPZ stores
+    (gradient K/100 km, tfp & neg_laplacian K/(100 km)², advection & tendency
+    K/h). ``tendency`` may be all-NaN when neighbours aren't available.
+    """
+
+    theta_e: np.ndarray
+    gradient: np.ndarray
+    tfp: np.ndarray
+    neg_laplacian: np.ndarray
+    advection: np.ndarray
+    tendency: np.ndarray
+    dT_dx: np.ndarray
+    dT_dy: np.ndarray
+
+
+class HewsonFieldSource(ABC):
+    """Abstract "give me Hewson grids at (model, level, hour)" provider."""
+
+    # Subclasses set these in __init__.
+    lat: np.ndarray
+    lon: np.ndarray
+    terrain_mask: np.ndarray | None
+
+    @property
+    @abstractmethod
+    def models(self) -> list[str]:
+        """Model keys this source can answer for."""
+
+    @abstractmethod
+    def available_hours(self, model: str) -> list[int]:
+        """Sorted integer hour offsets available for ``model`` (source frame)."""
+
+    @abstractmethod
+    def available_levels(self, model: str) -> list[int]:
+        """Pressure levels (hPa) present for ``model``."""
+
+    @abstractmethod
+    def grids_at_hour(
+        self, model: str, hour: int, level_hPa: int | None = None,
+    ) -> HewsonGrids | None:
+        """Diagnostic grids at one integer ``hour``, or ``None`` if unavailable.
+
+        ``hour`` must be a member of :meth:`available_hours`.
+        """
+
+    def gradient_at_hour(
+        self, model: str, hour: int, level_hPa: int | None = None,
+    ) -> np.ndarray | None:
+        """Just the |∇θe| grid at ``hour`` — cheaper than the full grids.
+
+        Default pulls it out of :meth:`grids_at_hour`; sources override to avoid
+        computing the other diagnostics (the background-gradient mean only needs
+        this field, and computing tendency there would fetch neighbour hours).
+        """
+        grids = self.grids_at_hour(model, hour, level_hPa)
+        return None if grids is None else grids.gradient
+
+    # ------------------------------------------------------------------
+    # Shared helpers (default implementations)
+
+    def resolve_level(self, model: str, level_hPa: int | None) -> int:
+        """Default level is 850 hPa if present, else the lowest available."""
+        avail = self.available_levels(model)
+        if level_hPa is None:
+            return 850 if 850 in avail else avail[0]
+        if level_hPa not in avail:
+            raise ValueError(
+                f"level {level_hPa} hPa not in {avail} for model {model!r}"
+            )
+        return level_hPa
+
+    def background_gradient(
+        self,
+        model: str,
+        level_hPa: int | None = None,
+        *,
+        hour_stride: int = 6,
+    ) -> np.ndarray:
+        """Time-mean |∇θe| — the persistent (orographic / sea-land) background.
+
+        Used to anomaly-filter off-track fronts: a transient front passing
+        through for a few hours barely moves a multi-day mean, so subtracting
+        this leaves the synoptic signal. Sampled every ``hour_stride`` *hours*
+        (not array indices) so it behaves the same for hourly and 3-hourly
+        sources. Falls back to all available hours when the stride filters
+        everything out (short cases).
+        """
+        hours = self.available_hours(model)
+        sampled = [h for h in hours if h % hour_stride == 0] or hours
+        acc: np.ndarray | None = None
+        n = 0
+        for h in sampled:
+            grad = self.gradient_at_hour(model, h, level_hPa)
+            if grad is None:
+                continue
+            acc = grad if acc is None else acc + grad
+            n += 1
+        if acc is None or n == 0:
+            return np.zeros((len(self.lat), len(self.lon)))
+        return acc / n
+
+
+# ---------------------------------------------------------------------------
+# Case-backed source (recompute path — calibration / ERA5 / fallback)
+# ---------------------------------------------------------------------------
+
+
+class CaseFieldSource(HewsonFieldSource):
+    """Recompute diagnostics from a calibration :class:`Case` on demand.
+
+    This is the historical ``analyze_route_fronts`` path, now behind the source
+    interface. Diagnostics evaluate in well under a second on the 0.25° European
+    grid, so per-hour recompute is fine for a route that hits a handful of
+    forecast hours.
+    """
+
+    def __init__(self, case, *, terrain_mask: np.ndarray | None = None):
+        self._case = case
+        self.lat = case.lat
+        self.lon = case.lon
+        self.terrain_mask = terrain_mask
+
+    @property
+    def models(self) -> list[str]:
+        return list(self._case.models)
+
+    def available_hours(self, model: str) -> list[int]:
+        return sorted(self._case.available_hours(model))
+
+    def available_levels(self, model: str) -> list[int]:
+        return self._case.available_levels(model)
+
+    def resolve_level(self, model: str, level_hPa: int | None) -> int:
+        # Defer to the Case so its legacy single-level (850-only) handling and
+        # error messages stay authoritative.
+        return self._case._resolve_level(model, level_hPa)
+
+    def grids_at_hour(
+        self, model: str, hour: int, level_hPa: int | None = None,
+    ) -> HewsonGrids | None:
+        fields = self._case.fields(model, hour, level_hPa)
+        if fields is None:
+            return None
+        diag = compute_hewson_diagnostics(
+            fields["theta_e"], self.lat, self.lon,
+            u=fields["u850"], v=fields["v850"],
+            terrain_mask=self.terrain_mask,
+        )
+        return HewsonGrids(
+            theta_e=fields["theta_e"],
+            gradient=diag["gradient"],
+            tfp=diag["tfp"],
+            neg_laplacian=diag["neg_laplacian"],
+            advection=diag["advection"],
+            tendency=self._tendency(model, hour, level_hPa),
+            dT_dx=diag["dT_dx"],
+            dT_dy=diag["dT_dy"],
+        )
+
+    def gradient_at_hour(
+        self, model: str, hour: int, level_hPa: int | None = None,
+    ) -> np.ndarray | None:
+        # Compute only |∇θe| (via the zone detector's gradient, σ=0.5) — one
+        # field read, no neighbour fetch. Matches the historical
+        # ``compute_background_gradient`` numerics exactly so the validated
+        # anomaly-filter behaviour is preserved.
+        from weatherbrief.frontal.detect import compute_frontal_zones
+
+        fields = self._case.fields(model, hour, level_hPa)
+        if fields is None:
+            return None
+        return compute_frontal_zones(
+            fields["theta_e"], self.lat, self.lon, terrain_mask=self.terrain_mask,
+        )["gradient"]
+
+    def _tendency(self, model: str, hour: int, level_hPa: int | None) -> np.ndarray:
+        """∂θe/∂t via centred / one-sided difference across neighbouring hours."""
+        avail = self.available_hours(model)
+        prev_h = max((h for h in avail if h < hour), default=None)
+        next_h = min((h for h in avail if h > hour), default=None)
+
+        def _the(h: int) -> np.ndarray:
+            return self._case.fields(model, h, level_hPa)["theta_e"]
+
+        if prev_h is not None and next_h is not None:
+            return (_the(next_h) - _the(prev_h)) / (next_h - prev_h)
+        if next_h is not None:
+            return (_the(next_h) - _the(hour)) / (next_h - hour)
+        if prev_h is not None:
+            return (_the(hour) - _the(prev_h)) / (hour - prev_h)
+        return np.full((len(self.lat), len(self.lon)), np.nan, dtype=np.float64)
+
+
+# ---------------------------------------------------------------------------
+# Snapshot-backed source (production — reads the precompute NPZ)
+# ---------------------------------------------------------------------------
+
+
+class SnapshotFieldSource(HewsonFieldSource):
+    """Read Hewson grids straight from a precomputed NPZ snapshot.
+
+    One NPZ file holds one model's snapshot, so this source answers for a
+    single ``model_name`` (passed at construction). Metric stacks are pulled
+    lazily per level and cached, so a route that samples a few hours touches
+    only the levels it needs. ``dT_dx``/``dT_dy`` are re-derived from the stored
+    θe via :func:`theta_e_gradient_components` (the NPZ omits them by design).
+    """
+
+    def __init__(
+        self,
+        path: Path | str,
+        *,
+        model_name: str,
+        terrain_mask: np.ndarray | None = None,
+    ):
+        from weatherbrief.hewson.precompute import DEFAULT_STRIDE_HOURS
+
+        self._path = Path(path)
+        self._model_name = model_name
+        self.terrain_mask = terrain_mask
+        with np.load(self._path) as npz:
+            self.lat = npz["lat"].astype(np.float64)
+            self.lon = npz["lon"].astype(np.float64)
+            self._levels = sorted(int(L) for L in npz["levels"])
+            self._stride = (
+                int(npz["stride_hours"])
+                if "stride_hours" in npz.files
+                else DEFAULT_STRIDE_HOURS
+            )
+            self._init_unix = int(npz["init_time_unix"])
+            self._n_time = int(npz["valid_times"].shape[0])
+        # (level, metric) -> (n_time, n_lat, n_lon) stack, materialised on first use.
+        self._stack_cache: dict[tuple[int, str], np.ndarray] = {}
+
+    @property
+    def init_time_unix(self) -> int:
+        """Model init the snapshot's hour offsets are measured from."""
+        return self._init_unix
+
+    @property
+    def stride_hours(self) -> int:
+        return self._stride
+
+    @property
+    def models(self) -> list[str]:
+        return [self._model_name]
+
+    def available_levels(self, model: str) -> list[int]:
+        self._check_model(model)
+        return list(self._levels)
+
+    def available_hours(self, model: str) -> list[int]:
+        self._check_model(model)
+        return [i * self._stride for i in range(self._n_time)]
+
+    def grids_at_hour(
+        self, model: str, hour: int, level_hPa: int | None = None,
+    ) -> HewsonGrids | None:
+        self._check_model(model)
+        level = self.resolve_level(model, level_hPa)
+        if hour % self._stride != 0:
+            return None
+        idx = hour // self._stride
+        if idx < 0 or idx >= self._n_time:
+            return None
+        theta_e = self._slice(level, "theta_e", idx)
+        if theta_e is None:
+            return None
+        dT_dx, dT_dy = theta_e_gradient_components(
+            theta_e, self.lat, self.lon, terrain_mask=self.terrain_mask,
+        )
+        return HewsonGrids(
+            theta_e=theta_e,
+            gradient=self._slice(level, "gradient", idx),
+            tfp=self._slice(level, "tfp", idx),
+            neg_laplacian=self._slice(level, "neg_laplacian", idx),
+            advection=self._slice(level, "advection", idx),
+            tendency=self._slice(level, "tendency", idx),
+            dT_dx=dT_dx,
+            dT_dy=dT_dy,
+        )
+
+    def gradient_at_hour(
+        self, model: str, hour: int, level_hPa: int | None = None,
+    ) -> np.ndarray | None:
+        self._check_model(model)
+        level = self.resolve_level(model, level_hPa)
+        if hour % self._stride != 0:
+            return None
+        idx = hour // self._stride
+        if idx < 0 or idx >= self._n_time:
+            return None
+        return self._slice(level, "gradient", idx)
+
+    # ------------------------------------------------------------------
+    # Internals
+
+    def _check_model(self, model: str) -> None:
+        if model != self._model_name:
+            raise ValueError(
+                f"snapshot source holds {self._model_name!r}, asked for {model!r}"
+            )
+
+    def _slice(self, level: int, metric: str, idx: int) -> np.ndarray | None:
+        """One ``(n_lat, n_lon)`` grid for ``metric`` at ``level`` / time ``idx``.
+
+        Loads (and caches) the whole metric stack for the level the first time
+        it's touched — cheaper than reopening the NPZ per hour when several
+        hours of the same metric are read (background gradient, approach scan).
+        """
+        key = (level, metric)
+        stack = self._stack_cache.get(key)
+        if stack is None:
+            npz_key = f"{metric}_{level}"
+            with np.load(self._path) as npz:
+                if npz_key not in npz.files:
+                    return None
+                stack = npz[npz_key].astype(np.float64)
+            self._stack_cache[key] = stack
+        if idx >= stack.shape[0]:
+            return None
+        return stack[idx]

--- a/src/weatherbrief/hewson/precompute.py
+++ b/src/weatherbrief/hewson/precompute.py
@@ -103,6 +103,23 @@ def _terrain_mask_path(output_dir: Path | None = None) -> Path:
     return resolve_output_dir(output_dir) / "terrain_mask.npz"
 
 
+def latest_snapshot(
+    model: str, output_dir: Path | None = None,
+) -> Path | None:
+    """Most-recent snapshot file for ``model`` (by ISO-8601-Z filename), or None.
+
+    The front-detection stage reads the freshest snapshot per model; an init
+    mismatch between it and the briefing's forecast cycle is acceptable for the
+    smooth advective Hewson fields (see design §8). Filenames sort
+    chronologically so ``max`` over the glob is the latest.
+    """
+    subdir = resolve_output_dir(output_dir) / model
+    if not subdir.exists():
+        return None
+    snaps = sorted(subdir.glob("*.npz"))
+    return snaps[-1] if snaps else None
+
+
 # ---------------------------------------------------------------------------
 # Terrain-mask caching
 # ---------------------------------------------------------------------------

--- a/src/weatherbrief/models/__init__.py
+++ b/src/weatherbrief/models/__init__.py
@@ -81,6 +81,13 @@ from weatherbrief.models.advisories import (  # noqa: F401
     RouteAdvisoriesManifest,
     RouteAdvisoryResult,
 )
+from weatherbrief.models.fronts import (  # noqa: F401
+    FrontCrossingModel,
+    FrontDecisionModel,
+    FrontProximityModel,
+    RouteFrontAnalysisModel,
+    RouteFrontsManifest,
+)
 from weatherbrief.models.airport_conditions import (  # noqa: F401
     FLIGHT_CATEGORY_COLORS,
     AirportConditions,

--- a/src/weatherbrief/models/fronts.py
+++ b/src/weatherbrief/models/fronts.py
@@ -1,0 +1,99 @@
+"""Pydantic models for the per-briefing front-detection artifact.
+
+These are the serialization boundary for ``route_fronts.json`` — the data half
+of the Hewson front-detection feature (issue #195, Part 1). The compute layer
+(``weatherbrief.frontal.route_sampling``) works in frozen dataclasses; the
+``run_fronts`` stage projects those onto these models so the artifact has a
+validated, typed schema that the endpoint serves and Part 2 (#196) consumes.
+
+The active :class:`~weatherbrief.frontal.gates.FrontGateConfig` is stamped in as
+a plain dict (``gate_config``) so there is a single source of truth for the
+recipe — the dataclass — rather than a mirrored Pydantic copy that could drift.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+class FrontCrossingModel(BaseModel):
+    """A front the track crosses (accepted on-track candidate)."""
+
+    lat: float
+    lon: float
+    distance_km: float
+    gradient: float            # |∇θe|  K/100km
+    neg_laplacian: float       # −∇²θe  K/(100km)²  (diagnostic)
+    advection: float           # −V·∇θe  K/h
+    tfp_before: float
+    tfp_after: float
+    delta_theta_e: float       # θe jump across the window, K
+    kind: str                  # "cold" | "warm" | "quasi-stationary"
+    intensity: str             # "significant" | "classical" | "sharp"
+
+
+class FrontProximityModel(BaseModel):
+    """Nearest gated front to the route (on- or off-track) + approach sense."""
+
+    distance_km: float
+    lat: float
+    lon: float
+    gradient: float
+    delta_theta_e: float
+    on_track: bool
+    trend: str                 # "closing" | "receding" | "steady" | "unknown"
+    closing_km_per_h: float | None = None
+
+
+class FrontDecisionModel(BaseModel):
+    """One candidate's verdict — the rejection trace for calibration/debugging."""
+
+    lat: float
+    lon: float
+    distance_km: float
+    gradient: float
+    delta_theta_e: float
+    advection: float
+    accepted: bool
+    rejected_by: str | None = None     # "gradient" | "delta_theta_e" | None
+    kind: str
+    intensity: str
+    margins: dict[str, float] = Field(default_factory=dict)
+
+
+class RouteFrontAnalysisModel(BaseModel):
+    """Per-route frontal picture for one model at one level/valid hour."""
+
+    model: str
+    level_hPa: int
+    hour: float                # snapshot-relative forecast hour the off-track scan ran at
+    crossings: list[FrontCrossingModel] = Field(default_factory=list)
+    nearest: FrontProximityModel | None = None
+    decisions: list[FrontDecisionModel] = Field(default_factory=list)
+
+
+class RouteFrontsManifest(BaseModel):
+    """Top-level ``route_fronts.json`` container.
+
+    ``per_model`` maps each detected model to one
+    :class:`RouteFrontAnalysisModel` per stored pressure level (the level
+    nearest cruise is ``primary_level_hPa``; the others are kept so Part 2's
+    cross-section bands have data). ``gate_config`` is the active recipe stamp.
+    """
+
+    schema_version: int = 1
+    route_name: str = ""
+    generated_at: datetime
+    primary_level_hPa: int                       # level nearest cruise altitude
+    levels: list[int] = Field(default_factory=list)
+    gate_config: dict = Field(default_factory=dict)
+    models: list[str] = Field(default_factory=list)
+    # model → [analysis per level], ordered as ``levels``.
+    per_model: dict[str, list[RouteFrontAnalysisModel]] = Field(default_factory=dict)
+    # Models requested but with no precompute snapshot (degraded gracefully).
+    models_without_snapshot: list[str] = Field(default_factory=list)
+    # Snapshot init each model's detection read (model → ISO 8601 Z).
+    snapshot_inits: dict[str, str] = Field(default_factory=dict)
+    notes: list[str] = Field(default_factory=list)

--- a/src/weatherbrief/models/fronts.py
+++ b/src/weatherbrief/models/fronts.py
@@ -80,7 +80,17 @@ class RouteFrontsManifest(BaseModel):
     ``per_model`` maps each detected model to one
     :class:`RouteFrontAnalysisModel` per stored pressure level (the level
     nearest cruise is ``primary_level_hPa``; the others are kept so Part 2's
-    cross-section bands have data). ``gate_config`` is the active recipe stamp.
+    cross-section bands have data).
+
+    **Consumers must match each analysis by its ``level_hPa`` field, not by
+    position.** ``levels`` is the union across all models; a model whose
+    snapshot is partial may contribute fewer entries, so ``per_model[m]`` is
+    *not* guaranteed to align positionally with ``levels``.
+
+    ``gate_config`` is the active recipe stamp. Detection currently runs every
+    level with the same threshold gates (only ``level_hPa`` varies), so this
+    single dict describes all of them; if per-level presets land it would need
+    keying by level.
     """
 
     schema_version: int = 1
@@ -90,7 +100,7 @@ class RouteFrontsManifest(BaseModel):
     levels: list[int] = Field(default_factory=list)
     gate_config: dict = Field(default_factory=dict)
     models: list[str] = Field(default_factory=list)
-    # model → [analysis per level], ordered as ``levels``.
+    # model → analyses (one per level the model has; match by level_hPa).
     per_model: dict[str, list[RouteFrontAnalysisModel]] = Field(default_factory=dict)
     # Models requested but with no precompute snapshot (degraded gracefully).
     models_without_snapshot: list[str] = Field(default_factory=list)

--- a/src/weatherbrief/pipeline.py
+++ b/src/weatherbrief/pipeline.py
@@ -90,6 +90,7 @@ class BriefingOptions:
     advisory_aggregation: str | None = None  # "worst" or "majority"
     advisory_enabled: dict[str, bool] | None = None  # {advisory_id: enabled}
     advisory_params: dict[str, dict[str, float]] | None = None  # {advisory_id: {param: value}}
+    auto_front_detection: bool = False  # experimental: write route_fronts.json (#195)
     historical_mode: bool = False  # Use archived NWP data for past departure times
     as_of_time: datetime | None = None  # For historical: the date "as of" which to fetch data
     alt_departure_time: datetime | None = None  # optional same-day alt departure for lite advisory re-run
@@ -348,6 +349,25 @@ def execute_briefing(
     rss = _current_rss_mb()
     if rss is not None:
         rss_curve.append(("advisories", rss))
+
+    # === 3.0b Front detection (experimental, opt-in via auto_front_detection) ===
+    # Reads precomputed Hewson snapshots from ${DATA_DIR}/hewson — milliseconds,
+    # zero extra fetch. Skipped entirely unless the preference is enabled.
+    if options.auto_front_detection and analysis_result.route_analyses:
+        _t0 = perf_counter()
+        try:
+            from weatherbrief.tasks.fronts import run_fronts
+
+            run_fronts(
+                analysis_result.route_analyses,
+                route_name=route.name,
+                cruise_altitude_ft=route.cruise_altitude_ft,
+                advisory_models=options.advisory_models,
+                pack_dir=pack_dir,
+            )
+        except Exception:
+            logger.warning("Front detection stage failed", exc_info=True)
+        stage_timings["fronts"] = perf_counter() - _t0
 
     # cross_sections is no longer needed in memory after regular advisories:
     # save_fetch_artifacts persisted cross_section.json at end of fetch, alt

--- a/src/weatherbrief/tasks/artifacts.py
+++ b/src/weatherbrief/tasks/artifacts.py
@@ -17,6 +17,7 @@ from weatherbrief.models import (
     RouteAdvisoriesManifest,
     RouteAnalysesManifest,
     RouteCrossSection,
+    RouteFrontsManifest,
     RoutePoint,
 )
 
@@ -170,6 +171,25 @@ def save_advisory_artifacts(
     pack_dir.mkdir(parents=True, exist_ok=True)
     adv_path = pack_dir / "route_advisories.json"
     adv_path.write_text(manifest.model_dump_json(indent=2))
+
+
+def save_front_artifacts(
+    pack_dir: Path,
+    manifest: "RouteFrontsManifest",
+) -> None:
+    """Persist the front-detection artifact (``route_fronts.json``) to *pack_dir*."""
+    pack_dir.mkdir(parents=True, exist_ok=True)
+    (pack_dir / "route_fronts.json").write_text(manifest.model_dump_json(indent=2))
+
+
+def load_route_fronts(pack_dir: Path) -> "RouteFrontsManifest | None":
+    """Load the front-detection manifest, returning *None* if missing."""
+    from weatherbrief.models import RouteFrontsManifest
+
+    fr_path = pack_dir / "route_fronts.json"
+    if not fr_path.exists():
+        return None
+    return RouteFrontsManifest.model_validate_json(fr_path.read_text())
 
 
 # ---------------------------------------------------------------------------

--- a/src/weatherbrief/tasks/fronts.py
+++ b/src/weatherbrief/tasks/fronts.py
@@ -152,14 +152,7 @@ def _analyze_one(
     decisions = apply_gate_config(candidates, config)
     crossings = decisions_to_crossings(decisions, config.merge_km)
 
-    nearest = find_nearby_fronts(
-        source, model, waypoints, mid_hour,
-        level_hPa=config.level_hPa,
-        proximity_km=config.proximity_km, step_km=config.step_km,
-        gradient_min=config.gradient_min, delta_theta_e_min=config.delta_theta_e_min,
-        anomaly_min=config.anomaly_min, airmass_window_km=config.airmass_window_km,
-        use_anomaly_filter=config.use_anomaly_filter, approach_dh=config.approach_dh,
-    )
+    nearest = find_nearby_fronts(source, model, waypoints, mid_hour, config=config)
     return RouteFrontAnalysis(
         model=model, hour=float(mid_hour), crossings=crossings, nearest=nearest,
         level_hPa=config.level_hPa, config=config, decisions=decisions,
@@ -254,7 +247,20 @@ def compute_route_fronts(
                            exc_info=True)
             missing.append(model)
             continue
-        source.terrain_mask = terrain_mask
+        # Only apply the cached terrain mask if it matches this snapshot's grid
+        # — a stale mask (e.g. from a resolution change) would otherwise crash
+        # fill_terrain() on a shape mismatch. Mismatch → no masking (graceful).
+        if (
+            terrain_mask is not None
+            and terrain_mask.shape == (source.lat.size, source.lon.size)
+        ):
+            source.terrain_mask = terrain_mask
+        elif terrain_mask is not None:
+            logger.warning(
+                "Front detection: terrain mask %s mismatches %s grid %s — "
+                "skipping terrain masking",
+                terrain_mask.shape, model, (source.lat.size, source.lon.size),
+            )
         snapshot_inits[model] = _iso_z(source.init_time_unix)
 
         # ETAs → snapshot-relative forecast hours.
@@ -266,7 +272,9 @@ def compute_route_fronts(
         if not levels:
             missing.append(model)
             continue
-        levels_seen = levels
+        # Accumulate across models — a partial snapshot could expose a subset,
+        # and manifest.levels must describe everything actually in per_model.
+        levels_seen = sorted(set(levels_seen) | set(levels))
         primary_level = nearest_cruise_level(cruise_altitude_ft, levels)
 
         analyses: list[RouteFrontAnalysisModel] = []

--- a/src/weatherbrief/tasks/fronts.py
+++ b/src/weatherbrief/tasks/fronts.py
@@ -1,0 +1,425 @@
+"""Front-detection pipeline stage (issue #195, deliverable D).
+
+Produces the per-briefing ``route_fronts.json`` artifact: for each model that
+has a precompute snapshot, locate the fronts along the route — on-track
+crossings (sampled at each waypoint's ETA) and the nearest off-track front — at
+the level nearest cruise, **storing all three levels** so Part 2's cross-section
+bands have data.
+
+Two surfaces, one core (mirrors ``run_advisories`` / ``run_advisories_from_pack``):
+
+* :func:`run_fronts` — called inline by the pipeline when the experimental
+  ``auto_front_detection`` preference is on. Takes the in-memory route-point
+  analyses (which carry per-waypoint ETAs).
+* :func:`run_fronts_from_pack` — recompute twin that reads ``route_analyses.json``
+  from a pack, so toggling the preference re-runs cheaply with **zero re-fetch**
+  (the expensive grid already lives in the precompute snapshot).
+
+Reads the snapshot via :class:`SnapshotFieldSource` — milliseconds, no network.
+Degrades gracefully: models without a snapshot (ukmo / meteofrance / best_match,
+or a model whose precompute hasn't run) simply get no front data.
+
+Known limitations carried from the design doc: 850 hPa θe doesn't see low IMC /
+fog (§10a.2 — this is free-atmosphere weather); output is qualitative (§8); an
+init mismatch between the briefing forecast and the latest snapshot is
+acceptable for the smooth advective fields.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Sequence
+
+import numpy as np
+
+from weatherbrief.frontal.gates import FrontGateConfig
+from weatherbrief.frontal.route_sampling import (
+    RouteFrontAnalysis,
+    apply_gate_config,
+    decisions_to_crossings,
+    densify_route,
+    find_nearby_fronts,
+    generate_front_candidates,
+    haversine_km,
+    sample_hewson_at_route,
+)
+from weatherbrief.frontal.sources import SnapshotFieldSource
+from weatherbrief.hewson.precompute import (
+    DEFAULT_LEVELS,
+    latest_snapshot,
+    resolve_output_dir,
+)
+from weatherbrief.models import (
+    FrontCrossingModel,
+    FrontDecisionModel,
+    FrontProximityModel,
+    RouteFrontAnalysisModel,
+    RouteFrontsManifest,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# Only these models have precompute snapshots (design §6.1). Other advisory
+# models degrade gracefully (no front data).
+FRONT_MODELS: frozenset[str] = frozenset({"ecmwf", "gfs", "icon"})
+
+# Pressure level → representative MSL altitude (design §4.2 / §6.2).
+_LEVEL_FT: dict[int, int] = {925: 2_500, 850: 5_000, 700: 10_000}
+
+
+def nearest_cruise_level(cruise_altitude_ft: int, available: Sequence[int]) -> int:
+    """Pick the stored level whose representative altitude is nearest cruise."""
+    avail = [L for L in available if L in _LEVEL_FT] or list(available)
+    return min(avail, key=lambda L: abs(_LEVEL_FT.get(L, 5_000) - cruise_altitude_ft))
+
+
+# ---------------------------------------------------------------------------
+# Waypoint extraction
+# ---------------------------------------------------------------------------
+
+
+def _waypoints_with_eta(
+    analyses: Sequence,
+) -> tuple[list[tuple[float, float]], list[datetime]] | None:
+    """Pull ordered ``(lat, lon)`` + ETA datetimes from route-point analyses.
+
+    Requires ≥2 points with finite coords and a resolved ``interpolated_time``.
+    Returns ``None`` when the route is too short / lacks ETAs (front detection
+    is skipped — nothing to locate along).
+    """
+    pts: list[tuple[float, float]] = []
+    etas: list[datetime] = []
+    for a in analyses:
+        eta = getattr(a, "interpolated_time", None)
+        if eta is None or a.lat is None or a.lon is None:
+            continue
+        if eta.tzinfo is None:
+            eta = eta.replace(tzinfo=timezone.utc)
+        pts.append((float(a.lat), float(a.lon)))
+        etas.append(eta)
+    if len(pts) < 2:
+        return None
+    return pts, etas
+
+
+def _cumulative_km(waypoints: Sequence[tuple[float, float]]) -> list[float]:
+    cum = [0.0]
+    for (la0, lo0), (la1, lo1) in zip(waypoints[:-1], waypoints[1:]):
+        cum.append(cum[-1] + haversine_km(la0, lo0, la1, lo1))
+    return cum
+
+
+# ---------------------------------------------------------------------------
+# Detection for one (model, level)
+# ---------------------------------------------------------------------------
+
+
+def _analyze_one(
+    source: SnapshotFieldSource,
+    model: str,
+    waypoints: list[tuple[float, float]],
+    eta_hours: list[float],
+    mid_hour: float,
+    config: FrontGateConfig,
+) -> RouteFrontAnalysis:
+    """Detect fronts for one model/level.
+
+    On-track crossings sample each densified route point at its **own ETA**
+    (time advances along the route, so a moving front is crossed where/when the
+    aircraft actually meets it — design §6.3 temporal axis). The off-track
+    proximity scan needs one coherent grid, so it runs at the route-midpoint ETA.
+    """
+    dense = densify_route(waypoints, step_km=config.step_km)
+    wp_cum = _cumulative_km(waypoints)
+    dense_cum = [d[2] for d in dense]
+    dense_hours = np.interp(dense_cum, wp_cum, eta_hours).tolist()
+
+    samples = sample_hewson_at_route(
+        source, model,
+        [(la, lo) for la, lo, _ in dense],
+        hours=dense_hours,
+        level_hPa=config.level_hPa,
+    )
+    for s, (_, _, dist_km) in zip(samples, dense):
+        s["distance_km"] = dist_km
+
+    candidates = generate_front_candidates(
+        samples, airmass_window_km=config.airmass_window_km,
+    )
+    decisions = apply_gate_config(candidates, config)
+    crossings = decisions_to_crossings(decisions, config.merge_km)
+
+    nearest = find_nearby_fronts(
+        source, model, waypoints, mid_hour,
+        level_hPa=config.level_hPa,
+        proximity_km=config.proximity_km, step_km=config.step_km,
+        gradient_min=config.gradient_min, delta_theta_e_min=config.delta_theta_e_min,
+        anomaly_min=config.anomaly_min, airmass_window_km=config.airmass_window_km,
+        use_anomaly_filter=config.use_anomaly_filter, approach_dh=config.approach_dh,
+    )
+    return RouteFrontAnalysis(
+        model=model, hour=float(mid_hour), crossings=crossings, nearest=nearest,
+        level_hPa=config.level_hPa, config=config, decisions=decisions,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Dataclass → Pydantic projection
+# ---------------------------------------------------------------------------
+
+
+def _to_analysis_model(a: RouteFrontAnalysis) -> RouteFrontAnalysisModel:
+    return RouteFrontAnalysisModel(
+        model=a.model,
+        level_hPa=a.level_hPa,
+        hour=a.hour,
+        crossings=[
+            FrontCrossingModel(
+                lat=c.lat, lon=c.lon, distance_km=c.distance_km,
+                gradient=c.gradient, neg_laplacian=c.neg_laplacian,
+                advection=c.advection, tfp_before=c.tfp_before,
+                tfp_after=c.tfp_after, delta_theta_e=c.delta_theta_e,
+                kind=c.kind, intensity=c.intensity,
+            )
+            for c in a.crossings
+        ],
+        nearest=(
+            FrontProximityModel(
+                distance_km=a.nearest.distance_km, lat=a.nearest.lat,
+                lon=a.nearest.lon, gradient=a.nearest.gradient,
+                delta_theta_e=a.nearest.delta_theta_e, on_track=a.nearest.on_track,
+                trend=a.nearest.trend, closing_km_per_h=a.nearest.closing_km_per_h,
+            )
+            if a.nearest is not None else None
+        ),
+        decisions=[
+            FrontDecisionModel(
+                lat=d.candidate.lat, lon=d.candidate.lon,
+                distance_km=d.candidate.distance_km, gradient=d.candidate.gradient,
+                delta_theta_e=d.candidate.delta_theta_e,
+                advection=d.candidate.advection,
+                accepted=d.accepted, rejected_by=d.rejected_by,
+                kind=d.kind, intensity=d.intensity, margins=d.margins,
+            )
+            for d in a.decisions
+        ],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Core
+# ---------------------------------------------------------------------------
+
+
+def compute_route_fronts(
+    waypoints: list[tuple[float, float]],
+    etas: list[datetime],
+    *,
+    route_name: str,
+    cruise_altitude_ft: int,
+    advisory_models: Sequence[str] | None,
+    gate_preset: str = "default",
+    output_dir: Path | None = None,
+    now: datetime | None = None,
+) -> RouteFrontsManifest:
+    """Build the :class:`RouteFrontsManifest` (no I/O). Shared by both surfaces."""
+    from weatherbrief.frontal.gates import get_preset
+
+    now = now or datetime.now(timezone.utc)
+    models = [m for m in (advisory_models or list(FRONT_MODELS)) if m in FRONT_MODELS]
+    # Stable order: ecmwf, gfs, icon.
+    models = [m for m in ("ecmwf", "gfs", "icon") if m in models]
+
+    terrain_mask = _load_cached_terrain_mask(output_dir)
+
+    per_model: dict[str, list[RouteFrontAnalysisModel]] = {}
+    snapshot_inits: dict[str, str] = {}
+    missing: list[str] = []
+    levels_seen: list[int] = []
+    primary_level = 850
+    base_config = get_preset(gate_preset)
+
+    for model in models:
+        snap_path = latest_snapshot(model, output_dir)
+        if snap_path is None:
+            missing.append(model)
+            continue
+        try:
+            source = SnapshotFieldSource(snap_path, model_name=model)
+        except Exception:
+            logger.warning("Front detection: unreadable snapshot %s", snap_path,
+                           exc_info=True)
+            missing.append(model)
+            continue
+        source.terrain_mask = terrain_mask
+        snapshot_inits[model] = _iso_z(source.init_time_unix)
+
+        # ETAs → snapshot-relative forecast hours.
+        eta_hours = [(e.timestamp() - source.init_time_unix) / 3600.0 for e in etas]
+        wp_cum = _cumulative_km(waypoints)
+        mid_hour = float(np.interp(wp_cum[-1] / 2.0, wp_cum, eta_hours))
+
+        levels = [L for L in source.available_levels(model) if L in DEFAULT_LEVELS]
+        if not levels:
+            missing.append(model)
+            continue
+        levels_seen = levels
+        primary_level = nearest_cruise_level(cruise_altitude_ft, levels)
+
+        analyses: list[RouteFrontAnalysisModel] = []
+        for level in levels:
+            cfg = base_config.with_overrides(level_hPa=level)
+            try:
+                result = _analyze_one(
+                    source, model, waypoints, eta_hours, mid_hour, cfg,
+                )
+            except Exception:
+                logger.warning(
+                    "Front detection failed for %s @ %d hPa", model, level,
+                    exc_info=True,
+                )
+                continue
+            analyses.append(_to_analysis_model(result))
+        if analyses:
+            per_model[model] = analyses
+
+    notes: list[str] = []
+    if missing:
+        notes.append(
+            "No precompute snapshot for: " + ", ".join(missing)
+            + " — front data unavailable for those models."
+        )
+    notes.append(
+        "Free-atmosphere fronts only; 850 hPa θe does not see low IMC / fog. "
+        "Positions/timing are qualitative (±50–100 km, ±1–2 h)."
+    )
+
+    return RouteFrontsManifest(
+        schema_version=1,
+        route_name=route_name,
+        generated_at=now,
+        primary_level_hPa=primary_level,
+        levels=levels_seen,
+        gate_config=base_config.with_overrides(level_hPa=primary_level).to_dict(),
+        models=list(per_model.keys()),
+        per_model=per_model,
+        models_without_snapshot=missing,
+        snapshot_inits=snapshot_inits,
+        notes=notes,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public surfaces
+# ---------------------------------------------------------------------------
+
+
+def run_fronts(
+    route_point_analyses: Sequence,
+    *,
+    route_name: str,
+    cruise_altitude_ft: int,
+    advisory_models: Sequence[str] | None,
+    gate_preset: str = "default",
+    pack_dir: Path | None = None,
+    output_dir: Path | None = None,
+) -> RouteFrontsManifest | None:
+    """Detect fronts from in-memory route-point analyses; write the artifact.
+
+    Returns ``None`` (and writes nothing) when the route lacks ≥2 ETA-stamped
+    waypoints. ``output_dir`` overrides the snapshot root (defaults to
+    ``${DATA_DIR}/hewson``); ``pack_dir`` is where ``route_fronts.json`` lands.
+    """
+    extracted = _waypoints_with_eta(route_point_analyses)
+    if extracted is None:
+        logger.info("Front detection: route lacks ETA-stamped waypoints — skipping")
+        return None
+    waypoints, etas = extracted
+
+    manifest = compute_route_fronts(
+        waypoints, etas,
+        route_name=route_name, cruise_altitude_ft=cruise_altitude_ft,
+        advisory_models=advisory_models, gate_preset=gate_preset,
+        output_dir=output_dir,
+    )
+    if pack_dir is not None:
+        from weatherbrief.tasks.artifacts import save_front_artifacts
+
+        save_front_artifacts(pack_dir, manifest)
+    logger.info(
+        "Front detection: %d model(s) with snapshots, %d without; primary level %d hPa",
+        len(manifest.models), len(manifest.models_without_snapshot),
+        manifest.primary_level_hPa,
+    )
+    return manifest
+
+
+def run_fronts_from_pack(
+    pack_dir: Path,
+    *,
+    advisory_models: Sequence[str] | None = None,
+    cruise_altitude_ft: int | None = None,
+    gate_preset: str = "default",
+    output_dir: Path | None = None,
+) -> RouteFrontsManifest | None:
+    """Recompute fronts from a pack's persisted ``route_analyses.json``.
+
+    Lets the experimental preference be toggled on for an existing briefing
+    without re-fetching — the snapshot already holds the grid. Returns ``None``
+    if the route analyses are missing or lack ETA-stamped waypoints.
+    """
+    from weatherbrief.tasks.artifacts import load_route_analyses
+
+    try:
+        manifest_in = load_route_analyses(pack_dir)
+    except FileNotFoundError:
+        logger.info("Front detection (from pack): no route_analyses.json in %s", pack_dir)
+        return None
+
+    extracted = _waypoints_with_eta(manifest_in.analyses)
+    if extracted is None:
+        return None
+    waypoints, etas = extracted
+
+    cruise = (
+        cruise_altitude_ft
+        if cruise_altitude_ft is not None
+        else manifest_in.cruise_altitude_ft
+    )
+    models = advisory_models if advisory_models is not None else manifest_in.models
+
+    manifest = compute_route_fronts(
+        waypoints, etas,
+        route_name=manifest_in.route_name, cruise_altitude_ft=cruise,
+        advisory_models=models, gate_preset=gate_preset, output_dir=output_dir,
+    )
+    from weatherbrief.tasks.artifacts import save_front_artifacts
+
+    save_front_artifacts(pack_dir, manifest)
+    return manifest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _iso_z(unix_seconds: int) -> str:
+    dt = datetime.fromtimestamp(unix_seconds, tz=timezone.utc)
+    return dt.isoformat().replace("+00:00", "Z")
+
+
+def _load_cached_terrain_mask(output_dir: Path | None) -> np.ndarray | None:
+    """Load the precompute's cached terrain mask, or ``None`` if absent."""
+    path = resolve_output_dir(output_dir) / "terrain_mask.npz"
+    if not path.exists():
+        return None
+    try:
+        with np.load(path) as npz:
+            return npz["mask"]
+    except Exception:
+        logger.warning("Front detection: unreadable terrain mask %s", path)
+        return None

--- a/tests/test_api_hewson_map.py
+++ b/tests/test_api_hewson_map.py
@@ -546,3 +546,105 @@ def test_manifest_empty_when_no_data_dir(client):
 def test_manifest_requires_auth(client_anon):
     resp = client_anon.get("/api/hewson-map/manifest")
     assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Fronts endpoint (2-D TFP=0 gated polylines — §C2)
+# ---------------------------------------------------------------------------
+
+
+def _write_front_snapshot(out_dir: Path, model: str = "ecmwf") -> Path:
+    """Write a snapshot whose 850 hPa field holds a real meridional θe front.
+
+    All three levels are populated (the endpoint validates the level is present)
+    using the same front so the gate detects an axis at any level.
+    """
+    from weatherbrief.frontal.detect import compute_hewson_diagnostics
+    from weatherbrief.hewson.precompute import tendency_k_per_hour, write_snapshot
+
+    lat = np.linspace(45.0, 52.0, 29)   # 0.25°
+    lon = np.linspace(-2.0, 6.0, 33)
+    _, lon_grid = np.meshgrid(lat, lon, indexing="ij")
+    n_time = _N_TIME
+
+    per_level: dict[int, dict] = {}
+    for L in _LEVELS:
+        metrics = {
+            k: np.full((n_time, lat.size, lon.size), np.nan, dtype=np.float32)
+            for k in ("theta_e", "gradient", "neg_laplacian", "tfp", "advection")
+        }
+        for h in range(n_time):
+            axis = 2.0 + 0.05 * h * _STRIDE_HOURS
+            theta = 290.0 + 6.0 * np.tanh((lon_grid - axis) / 0.3)
+            u = np.full_like(theta, 30.0)   # eastward → cold advection
+            v = np.zeros_like(theta)
+            d = compute_hewson_diagnostics(theta, lat, lon, u, v)
+            metrics["theta_e"][h] = theta
+            metrics["gradient"][h] = d["gradient"]
+            metrics["neg_laplacian"][h] = d["neg_laplacian"]
+            metrics["tfp"][h] = d["tfp"]
+            metrics["advection"][h] = d["advection"]
+        metrics["tendency"] = tendency_k_per_hour(
+            metrics["theta_e"], step_hours=_STRIDE_HOURS,
+        )
+        per_level[L] = metrics
+
+    path = snapshot_path(model, _INIT_UNIX, output_dir=out_dir)
+    write_snapshot(
+        path, init_time_unix=_INIT_UNIX,
+        valid_times=np.array(
+            [np.datetime64(_INIT_DT.replace(tzinfo=None) + timedelta(hours=h * _STRIDE_HOURS))
+             for h in range(n_time)],
+            dtype="datetime64[ns]",
+        ),
+        lat=lat, lon=lon, levels=list(_LEVELS),
+        stride_hours=_STRIDE_HOURS, per_level=per_level,
+    )
+    return path
+
+
+def test_get_fronts_happy_path(client, hewson_data_dir):
+    _write_front_snapshot(hewson_data_dir / "hewson")
+    resp = client.get(
+        "/api/hewson-map/fronts",
+        params={"model": "ecmwf", "init": _INIT_ISO, "level": 850,
+                "hour": 6, "gate": "default"},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["gate"] == "default"
+    assert body["gate_config"]["level_hPa"] == 850
+    assert len(body["fronts"]) >= 1
+    front = body["fronts"][0]
+    assert front["kind"] == "cold"
+    assert front["length_km"] > 300.0
+    # GeoJSON [lon, lat] pairs, axis near the front longitude.
+    lons = [pt[0] for pt in front["coordinates"]]
+    assert min(lons) < 2.5 < max(lons) or abs(sum(lons) / len(lons) - 2.0) < 1.0
+
+
+def test_get_fronts_unknown_gate_400(client, hewson_data_dir):
+    _write_front_snapshot(hewson_data_dir / "hewson")
+    resp = client.get(
+        "/api/hewson-map/fronts",
+        params={"model": "ecmwf", "init": _INIT_ISO, "level": 850,
+                "hour": 0, "gate": "bogus"},
+    )
+    assert resp.status_code == 400
+    assert "unknown gate preset" in resp.json()["detail"]
+
+
+def test_get_fronts_missing_snapshot_404(client):
+    resp = client.get(
+        "/api/hewson-map/fronts",
+        params={"model": "ecmwf", "init": _INIT_ISO, "level": 850, "hour": 0},
+    )
+    assert resp.status_code == 404
+
+
+def test_get_fronts_requires_auth(client_anon):
+    resp = client_anon.get(
+        "/api/hewson-map/fronts",
+        params={"model": "ecmwf", "init": _INIT_ISO, "level": 850, "hour": 0},
+    )
+    assert resp.status_code == 401

--- a/tests/test_frontal_contour_fronts.py
+++ b/tests/test_frontal_contour_fronts.py
@@ -1,0 +1,67 @@
+"""Tests for weatherbrief.frontal.contour_fronts — 2-D TFP=0 gating."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from weatherbrief.frontal.contour_fronts import extract_front_lines
+from weatherbrief.frontal.detect import compute_hewson_diagnostics
+from weatherbrief.frontal.gates import FrontGateConfig
+from weatherbrief.frontal.sources import HewsonGrids
+
+
+def _front_grids(amp: float = 6.0, width: float = 0.3, u_kmh: float = 30.0):
+    """A meridional tanh θe front at lon=2.5 → a N-S TFP=0 axis."""
+    lat = np.linspace(45.0, 49.0, 17)
+    lon = np.linspace(0.0, 5.0, 21)
+    _, lon_grid = np.meshgrid(lat, lon, indexing="ij")
+    theta = 290.0 + amp * np.tanh((lon_grid - 2.5) / width)
+    u = np.full_like(theta, u_kmh)
+    v = np.zeros_like(theta)
+    d = compute_hewson_diagnostics(theta, lat, lon, u, v)
+    grids = HewsonGrids(
+        theta_e=theta, gradient=d["gradient"], tfp=d["tfp"],
+        neg_laplacian=d["neg_laplacian"], advection=d["advection"],
+        tendency=np.zeros_like(theta), dT_dx=d["dT_dx"], dT_dy=d["dT_dy"],
+    )
+    return grids, lat, lon
+
+
+class TestExtractFrontLines:
+    def test_detects_meridional_front(self):
+        grids, lat, lon = _front_grids()
+        lines = extract_front_lines(grids, lat, lon, FrontGateConfig(), min_length_km=200.0)
+        assert len(lines) == 1
+        ln = lines[0]
+        assert ln.kind == "cold"          # eastward wind into colder air east
+        assert ln.length_km > 300.0
+        # The axis sits on the front longitude.
+        assert np.mean([p[1] for p in ln.points]) == pytest.approx(2.5, abs=0.2)
+
+    def test_min_length_drops_short_axes(self):
+        grids, lat, lon = _front_grids()
+        # An absurd minimum length removes the (≈445 km) axis.
+        lines = extract_front_lines(grids, lat, lon, FrontGateConfig(), min_length_km=10_000.0)
+        assert lines == []
+
+    def test_strict_gate_can_reject(self):
+        # Weak front: amplitude 1.5 K → small gradient & Δθe, strict rejects.
+        grids, lat, lon = _front_grids(amp=1.5, width=0.6, u_kmh=5.0)
+        strict = FrontGateConfig(gradient_min=8.0, delta_theta_e_min=7.0)
+        assert extract_front_lines(grids, lat, lon, strict, min_length_km=200.0) == []
+
+    def test_no_front_no_lines(self):
+        lat = np.linspace(45.0, 49.0, 17)
+        lon = np.linspace(0.0, 5.0, 21)
+        lat_grid, _ = np.meshgrid(lat, lon, indexing="ij")
+        theta = 290.0 + 0.01 * lat_grid  # nearly uniform, no front
+        d = compute_hewson_diagnostics(
+            theta, lat, lon, np.zeros_like(theta), np.zeros_like(theta),
+        )
+        grids = HewsonGrids(
+            theta_e=theta, gradient=d["gradient"], tfp=d["tfp"],
+            neg_laplacian=d["neg_laplacian"], advection=d["advection"],
+            tendency=np.zeros_like(theta), dT_dx=d["dT_dx"], dT_dy=d["dT_dy"],
+        )
+        assert extract_front_lines(grids, lat, lon, FrontGateConfig()) == []

--- a/tests/test_frontal_decisions.py
+++ b/tests/test_frontal_decisions.py
@@ -1,0 +1,149 @@
+"""Tests for the candidate/decision split in route_sampling.
+
+Builds analytic ``samples`` series (one dict per dense route point) so the
+gate logic is exercised independently of the field sampling / smoothing.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from weatherbrief.frontal.gates import FrontGateConfig
+from weatherbrief.frontal.route_sampling import (
+    apply_gate_config,
+    decisions_to_crossings,
+    generate_front_candidates,
+)
+
+
+def _ramp_samples(
+    *,
+    theta_lo: float = 280.0,
+    theta_hi: float = 290.0,
+    gradient: float = 6.0,
+    n: int = 12,
+    span_km: float = 150.0,
+    advection: float = -1.0,
+):
+    """A straight route with a single TFP zero-crossing at mid-span.
+
+    θe ramps linearly ``theta_lo`` → ``theta_hi`` so the Δθe across a ±75 km
+    window centred on the crossing equals ``theta_hi − theta_lo``. TFP is
+    positive on the first half and negative on the second so exactly one
+    crossing exists at span/2.
+    """
+    dists = np.linspace(0.0, span_km, n)
+    samples = []
+    for d in dists:
+        frac = d / span_km
+        tfp = 1.0 - 2.0 * frac  # +1 → −1, zero at mid-span
+        samples.append({
+            "lat": 47.0,
+            "lon": frac * 2.0,
+            "distance_km": float(d),
+            "theta_e": theta_lo + frac * (theta_hi - theta_lo),
+            "gradient": gradient,
+            "neg_laplacian": 0.0,
+            "advection": advection,
+            "tfp": tfp,
+        })
+    return samples
+
+
+class TestGenerateCandidates:
+    def test_single_crossing_found(self):
+        cands = generate_front_candidates(_ramp_samples())
+        assert len(cands) == 1
+        c = cands[0]
+        assert c.distance_km == 75.0
+        # Δθe across ±75 km window = full ramp (290−280) = 10 K
+        assert c.delta_theta_e == 10.0
+        assert c.gradient == 6.0
+
+    def test_no_crossing_when_tfp_one_signed(self):
+        samples = _ramp_samples()
+        for s in samples:
+            s["tfp"] = 1.0  # never changes sign
+        assert generate_front_candidates(samples) == []
+
+    def test_nan_tfp_skipped(self):
+        samples = _ramp_samples()
+        samples[5]["tfp"] = float("nan")
+        samples[6]["tfp"] = float("nan")
+        # The crossing straddled those points; with them NaN no candidate forms.
+        cands = generate_front_candidates(samples)
+        assert all(np.isfinite(c.tfp_before) and np.isfinite(c.tfp_after) for c in cands)
+
+
+class TestApplyGateConfig:
+    def test_same_candidates_different_configs(self):
+        """One candidate set, three configs — zero re-sampling, different verdicts."""
+        cands = generate_front_candidates(
+            _ramp_samples(gradient=5.5, theta_lo=280.0, theta_hi=290.0)
+        )
+        assert len(cands) == 1
+
+        default = apply_gate_config(cands, FrontGateConfig())  # grad_min 6
+        sensitive = apply_gate_config(
+            cands, FrontGateConfig(gradient_min=4.0, delta_theta_e_min=3.0)
+        )
+        strict = apply_gate_config(
+            cands, FrontGateConfig(gradient_min=8.0, delta_theta_e_min=7.0)
+        )
+
+        assert default[0].accepted is False
+        assert default[0].rejected_by == "gradient"
+        assert sensitive[0].accepted is True
+        assert strict[0].accepted is False
+        assert strict[0].rejected_by == "gradient"
+
+    def test_rejected_by_delta_theta_e(self):
+        # Strong gradient, weak air-mass jump (Δθe = 2 K) → Δθe gate rejects.
+        cands = generate_front_candidates(
+            _ramp_samples(gradient=10.0, theta_lo=288.0, theta_hi=290.0)
+        )
+        decisions = apply_gate_config(cands, FrontGateConfig())  # Δθe_min 5
+        assert decisions[0].accepted is False
+        assert decisions[0].rejected_by == "delta_theta_e"
+
+    def test_margins_are_signed_slack(self):
+        cands = generate_front_candidates(
+            _ramp_samples(gradient=7.0, theta_lo=280.0, theta_hi=290.0)
+        )
+        d = apply_gate_config(cands, FrontGateConfig())[0]  # grad_min 6, Δθe_min 5
+        assert d.margins["gradient"] == 1.0          # 7 − 6
+        assert d.margins["delta_theta_e"] == 5.0     # |10| − 5
+        assert d.accepted is True
+
+    def test_classification_by_advection_sign(self):
+        cold = apply_gate_config(
+            generate_front_candidates(_ramp_samples(advection=-1.0)),
+            FrontGateConfig(),
+        )[0]
+        warm = apply_gate_config(
+            generate_front_candidates(_ramp_samples(advection=+1.0)),
+            FrontGateConfig(),
+        )[0]
+        stationary = apply_gate_config(
+            generate_front_candidates(_ramp_samples(advection=0.1)),
+            FrontGateConfig(advection_min=0.5),
+        )[0]
+        assert cold.kind == "cold"
+        assert warm.kind == "warm"
+        assert stationary.kind == "quasi-stationary"
+
+
+class TestDecisionsToCrossings:
+    def test_only_accepted_become_crossings(self):
+        cands = generate_front_candidates(_ramp_samples(gradient=5.5))
+        decisions = apply_gate_config(cands, FrontGateConfig())
+        assert decisions[0].accepted is False
+        assert decisions_to_crossings(decisions) == []
+
+    def test_accepted_projects_to_crossing(self):
+        cands = generate_front_candidates(_ramp_samples(gradient=7.0))
+        decisions = apply_gate_config(cands, FrontGateConfig())
+        crossings = decisions_to_crossings(decisions)
+        assert len(crossings) == 1
+        assert crossings[0].kind == "cold"
+        assert crossings[0].gradient == 7.0

--- a/tests/test_frontal_gates.py
+++ b/tests/test_frontal_gates.py
@@ -1,0 +1,96 @@
+"""Tests for weatherbrief.frontal.gates — FrontGateConfig + preset registry."""
+
+from __future__ import annotations
+
+import pytest
+
+from weatherbrief.frontal.gates import (
+    FrontGateConfig,
+    get_preset,
+    preset_names,
+)
+
+
+class TestSerialization:
+    def test_roundtrip_default(self):
+        cfg = FrontGateConfig()
+        assert FrontGateConfig.from_dict(cfg.to_dict()) == cfg
+
+    def test_roundtrip_custom(self):
+        cfg = FrontGateConfig(
+            name="custom", level_hPa=925, gradient_min=7.5,
+            delta_theta_e_min=6.0, approach_dh=None, use_anomaly_filter=False,
+        )
+        assert FrontGateConfig.from_dict(cfg.to_dict()) == cfg
+
+    def test_to_dict_is_json_friendly(self):
+        d = FrontGateConfig().to_dict()
+        # Every value is a primitive (None allowed for approach_dh).
+        assert all(
+            isinstance(v, (str, int, float, bool)) or v is None
+            for v in d.values()
+        )
+        assert d["name"] == "default"
+        assert d["level_hPa"] == 850
+
+    def test_from_dict_ignores_unknown_keys(self):
+        """A newer artifact with an extra gate still loads (forward-compat)."""
+        data = FrontGateConfig().to_dict()
+        data["some_future_gate"] = 42.0
+        cfg = FrontGateConfig.from_dict(data)
+        assert cfg == FrontGateConfig()
+
+    def test_from_dict_missing_keys_use_defaults(self):
+        cfg = FrontGateConfig.from_dict({"name": "partial", "gradient_min": 9.0})
+        assert cfg.name == "partial"
+        assert cfg.gradient_min == 9.0
+        assert cfg.delta_theta_e_min == FrontGateConfig().delta_theta_e_min
+
+
+class TestOverrides:
+    def test_with_overrides_is_pure(self):
+        base = FrontGateConfig()
+        derived = base.with_overrides(gradient_min=10.0, level_hPa=700)
+        assert derived.gradient_min == 10.0
+        assert derived.level_hPa == 700
+        # base untouched (frozen, copy semantics)
+        assert base.gradient_min == 6.0
+        assert base.level_hPa == 850
+
+    def test_frozen(self):
+        cfg = FrontGateConfig()
+        with pytest.raises(Exception):
+            cfg.gradient_min = 1.0  # type: ignore[misc]
+
+
+class TestPresets:
+    def test_known_presets_exist(self):
+        names = preset_names()
+        for expected in ("default", "strict", "sensitive", "gradient-only"):
+            assert expected in names
+
+    def test_strict_is_tighter_than_default(self):
+        d = get_preset("default")
+        s = get_preset("strict")
+        assert s.gradient_min > d.gradient_min
+        assert s.delta_theta_e_min > d.delta_theta_e_min
+
+    def test_sensitive_is_looser_than_default(self):
+        d = get_preset("default")
+        s = get_preset("sensitive")
+        assert s.gradient_min < d.gradient_min
+        assert s.delta_theta_e_min < d.delta_theta_e_min
+
+    def test_gradient_only_drops_airmass_gate(self):
+        assert get_preset("gradient-only").delta_theta_e_min == 0.0
+
+    def test_level_override(self):
+        cfg = get_preset("strict", level_hPa=925)
+        assert cfg.level_hPa == 925
+        assert cfg.name == "strict"
+        # preset registry entry itself is unchanged
+        assert get_preset("strict").level_hPa == 850
+
+    def test_unknown_preset_raises_with_names(self):
+        with pytest.raises(KeyError, match="unknown gate preset"):
+            get_preset("nope")

--- a/tests/test_frontal_route_sampling.py
+++ b/tests/test_frontal_route_sampling.py
@@ -182,7 +182,7 @@ class TestSampleHewsonAtRoute:
 
     def test_unknown_model_raises(self):
         case = _synthetic_case()
-        with pytest.raises(ValueError, match="not in case"):
+        with pytest.raises(ValueError, match="not in source"):
             sample_hewson_at_route(case, "nope", [(47.0, 2.0)])
 
     def test_hours_length_mismatch_raises(self):

--- a/tests/test_frontal_sources.py
+++ b/tests/test_frontal_sources.py
@@ -17,7 +17,10 @@ import pytest
 from weatherbrief.frontal.case import Case
 from weatherbrief.frontal.detect import compute_hewson_diagnostics
 from weatherbrief.frontal.gates import FrontGateConfig
-from weatherbrief.frontal.route_sampling import analyze_route_fronts
+from weatherbrief.frontal.route_sampling import (
+    analyze_route_fronts,
+    grids_at_fractional_hour,
+)
 from weatherbrief.frontal.sources import CaseFieldSource, SnapshotFieldSource
 from weatherbrief.hewson.precompute import (
     tendency_k_per_hour,
@@ -125,6 +128,22 @@ class TestCaseFieldSource:
         src = CaseFieldSource(_make_case(lat, lon, theta, u, v))
         assert src.available_hours("syn") == [0, 1, 2, 3, 4]
         assert src.models == ["syn"]
+
+
+class TestFractionalHour:
+    def test_interpolates_between_integer_hours(self):
+        lat, lon, theta, u, v = _build_field_stacks()
+        src = CaseFieldSource(_make_case(lat, lon, theta, u, v))
+        g0 = src.grids_at_hour("syn", 1, 850)
+        g1 = src.grids_at_hour("syn", 2, 850)
+        gm = grids_at_fractional_hour(src, "syn", 1.5, level_hPa=850)
+        assert gm is not None
+        np.testing.assert_allclose(gm.theta_e, 0.5 * (g0.theta_e + g1.theta_e))
+
+    def test_out_of_range_returns_none(self):
+        lat, lon, theta, u, v = _build_field_stacks()
+        src = CaseFieldSource(_make_case(lat, lon, theta, u, v))
+        assert grids_at_fractional_hour(src, "syn", 99.0, level_hPa=850) is None
 
 
 class TestSnapshotFieldSource:

--- a/tests/test_frontal_sources.py
+++ b/tests/test_frontal_sources.py
@@ -1,0 +1,225 @@
+"""Tests for weatherbrief.frontal.sources — the swappable field sources.
+
+Covers:
+  * CaseFieldSource recomputes the same diagnostics the legacy path did.
+  * SnapshotFieldSource reads a written precompute NPZ.
+  * The two sources agree (the abstraction is sound): a snapshot built from a
+    case yields the same grids the case recomputes.
+  * End-to-end front detection over a snapshot with an embedded θe front
+    (a self-contained regression for the production read path).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from weatherbrief.frontal.case import Case
+from weatherbrief.frontal.detect import compute_hewson_diagnostics
+from weatherbrief.frontal.gates import FrontGateConfig
+from weatherbrief.frontal.route_sampling import analyze_route_fronts
+from weatherbrief.frontal.sources import CaseFieldSource, SnapshotFieldSource
+from weatherbrief.hewson.precompute import (
+    tendency_k_per_hour,
+    write_snapshot,
+)
+
+
+# ---------------------------------------------------------------------------
+# Synthetic front: a tanh θe step in longitude (a meridional front).
+# ---------------------------------------------------------------------------
+
+LON0 = 2.5      # front axis longitude
+AMP = 6.0       # ± amplitude → 12 K total air-mass contrast
+WIDTH = 0.3     # deg, front sharpness
+
+
+def _theta_e(lat_grid, lon_grid, hour: int) -> np.ndarray:
+    # Front drifts slowly east with time so tendency is non-trivial.
+    axis = LON0 + 0.05 * hour
+    return 290.0 + AMP * np.tanh((lon_grid - axis) / WIDTH)
+
+
+def _build_field_stacks(n_hours: int = 5):
+    lat = np.linspace(45.0, 49.0, 17)   # 0.25°
+    lon = np.linspace(0.0, 5.0, 21)
+    lat_grid, lon_grid = np.meshgrid(lat, lon, indexing="ij")
+    nlat, nlon = lat.size, lon.size
+
+    theta = np.empty((n_hours, nlat, nlon), dtype=np.float64)
+    u = np.full((n_hours, nlat, nlon), 30.0)   # km/h eastward → cold advection
+    v = np.zeros((n_hours, nlat, nlon))
+    for h in range(n_hours):
+        theta[h] = _theta_e(lat_grid, lon_grid, h)
+    return lat, lon, theta, u, v
+
+
+def _make_case(lat, lon, theta, u, v) -> Case:
+    n_hours = theta.shape[0]
+    fields_by_hour = {
+        h: {
+            "T850": theta[h] - 40.0,
+            "Td850": theta[h] - 50.0,
+            "theta_e": theta[h],
+            "u850": u[h],
+            "v850": v[h],
+        }
+        for h in range(n_hours)
+    }
+    valid_times = np.array(
+        [np.datetime64("2026-05-31T00", "ns") + np.timedelta64(h, "h")
+         for h in range(n_hours)],
+        dtype="datetime64[ns]",
+    )
+    case = Case(
+        case_dir=None, case_name="front", source="synthetic",
+        resolution_deg=0.25, lat=lat, lon=lon, models=["syn"],
+        valid_times={"syn": valid_times}, init_times={"syn": 0},
+    )
+    case.fields = lambda model, hour, level_hPa=None, _s=fields_by_hour: _s.get(hour)  # type: ignore
+    case.available_hours = lambda model, _n=n_hours: list(range(_n))  # type: ignore
+    return case
+
+
+def _write_snapshot_from_case(path, lat, lon, theta, u, v, *, stride: int = 1):
+    """Mimic the precompute write (no Open-Meteo fetch) at one level (850)."""
+    n_hours = theta.shape[0]
+    metrics = {
+        k: np.full((n_hours, lat.size, lon.size), np.nan, dtype=np.float32)
+        for k in ("theta_e", "gradient", "neg_laplacian", "tfp", "advection")
+    }
+    for h in range(n_hours):
+        diag = compute_hewson_diagnostics(theta[h], lat, lon, u[h], v[h])
+        metrics["theta_e"][h] = theta[h]
+        metrics["gradient"][h] = diag["gradient"]
+        metrics["neg_laplacian"][h] = diag["neg_laplacian"]
+        metrics["tfp"][h] = diag["tfp"]
+        metrics["advection"][h] = diag["advection"]
+    metrics["tendency"] = tendency_k_per_hour(metrics["theta_e"], step_hours=stride)
+
+    valid_times = np.array(
+        [np.datetime64("2026-05-31T00", "ns") + np.timedelta64(h * stride, "h")
+         for h in range(n_hours)],
+        dtype="datetime64[ns]",
+    )
+    write_snapshot(
+        path, init_time_unix=int(np.datetime64("2026-05-31T00").astype("datetime64[s]").astype(int)),
+        valid_times=valid_times, lat=lat, lon=lon, levels=[850],
+        stride_hours=stride, per_level={850: metrics},
+    )
+
+
+class TestCaseFieldSource:
+    def test_grids_match_compute_hewson(self):
+        lat, lon, theta, u, v = _build_field_stacks()
+        case = _make_case(lat, lon, theta, u, v)
+        src = CaseFieldSource(case)
+        grids = src.grids_at_hour("syn", 1, 850)
+        diag = compute_hewson_diagnostics(theta[1], lat, lon, u[1], v[1])
+        np.testing.assert_allclose(grids.gradient, diag["gradient"])
+        np.testing.assert_allclose(grids.tfp, diag["tfp"])
+        np.testing.assert_allclose(grids.advection, diag["advection"])
+
+    def test_available_hours_and_levels(self):
+        lat, lon, theta, u, v = _build_field_stacks()
+        src = CaseFieldSource(_make_case(lat, lon, theta, u, v))
+        assert src.available_hours("syn") == [0, 1, 2, 3, 4]
+        assert src.models == ["syn"]
+
+
+class TestSnapshotFieldSource:
+    def test_reads_written_snapshot(self, tmp_path):
+        lat, lon, theta, u, v = _build_field_stacks()
+        snap = tmp_path / "snap.npz"
+        _write_snapshot_from_case(snap, lat, lon, theta, u, v)
+        src = SnapshotFieldSource(snap, model_name="ecmwf")
+        assert src.models == ["ecmwf"]
+        assert src.available_levels("ecmwf") == [850]
+        assert src.available_hours("ecmwf") == [0, 1, 2, 3, 4]
+        grids = src.grids_at_hour("ecmwf", 2, 850)
+        assert grids is not None
+        assert grids.theta_e.shape == (lat.size, lon.size)
+
+    def test_wrong_model_raises(self, tmp_path):
+        lat, lon, theta, u, v = _build_field_stacks()
+        snap = tmp_path / "snap.npz"
+        _write_snapshot_from_case(snap, lat, lon, theta, u, v)
+        src = SnapshotFieldSource(snap, model_name="ecmwf")
+        with pytest.raises(ValueError, match="snapshot source holds"):
+            src.grids_at_hour("gfs", 0, 850)
+
+    def test_out_of_range_hour_returns_none(self, tmp_path):
+        lat, lon, theta, u, v = _build_field_stacks()
+        snap = tmp_path / "snap.npz"
+        _write_snapshot_from_case(snap, lat, lon, theta, u, v)
+        src = SnapshotFieldSource(snap, model_name="ecmwf")
+        assert src.grids_at_hour("ecmwf", 99, 850) is None
+
+
+class TestSourceEquivalence:
+    """The whole point of the abstraction: snapshot ≡ case on the same fields."""
+
+    def test_grids_agree(self, tmp_path):
+        lat, lon, theta, u, v = _build_field_stacks()
+        case = _make_case(lat, lon, theta, u, v)
+        snap = tmp_path / "snap.npz"
+        _write_snapshot_from_case(snap, lat, lon, theta, u, v, stride=1)
+
+        case_src = CaseFieldSource(case)
+        snap_src = SnapshotFieldSource(snap, model_name="ecmwf")
+
+        for h in (1, 2, 3):  # interior hours (centred tendency on both sides)
+            cg = case_src.grids_at_hour("syn", h, 850)
+            sg = snap_src.grids_at_hour("ecmwf", h, 850)
+            # float32 storage in the NPZ → loosen tolerance vs float64 recompute
+            for fld in ("theta_e", "gradient", "tfp", "neg_laplacian",
+                        "advection", "tendency", "dT_dx", "dT_dy"):
+                np.testing.assert_allclose(
+                    getattr(cg, fld), getattr(sg, fld), atol=2e-3, rtol=1e-3,
+                    err_msg=f"hour={h} field={fld}",
+                )
+
+    def test_analysis_agrees(self, tmp_path):
+        """analyze_route_fronts gives the same crossing via either source."""
+        lat, lon, theta, u, v = _build_field_stacks()
+        case = _make_case(lat, lon, theta, u, v)
+        snap = tmp_path / "snap.npz"
+        _write_snapshot_from_case(snap, lat, lon, theta, u, v, stride=1)
+
+        # West→east route crossing the front axis at lon=2.5, 47°N.
+        wps = [(47.0, 0.5), (47.0, 4.5)]
+        cfg = FrontGateConfig(level_hPa=850)
+
+        res_case = analyze_route_fronts(case, "syn", wps, 2.0, config=cfg)
+        res_snap = analyze_route_fronts(
+            SnapshotFieldSource(snap, model_name="ecmwf"), "ecmwf", wps, 2.0, config=cfg,
+        )
+        assert len(res_case.crossings) == 1
+        assert len(res_snap.crossings) == 1
+        c, s = res_case.crossings[0], res_snap.crossings[0]
+        assert c.kind == s.kind == "cold"   # eastward wind into colder air (−AMP east)
+        assert c.distance_km == pytest.approx(s.distance_km, abs=20.0)
+
+
+class TestSnapshotFrontRegression:
+    """A front embedded in a snapshot is detected through the production path."""
+
+    def test_detects_embedded_cold_front(self, tmp_path):
+        lat, lon, theta, u, v = _build_field_stacks()
+        snap = tmp_path / "snap.npz"
+        _write_snapshot_from_case(snap, lat, lon, theta, u, v)
+        src = SnapshotFieldSource(snap, model_name="ecmwf")
+
+        wps = [(47.0, 0.5), (47.0, 4.5)]
+        res = analyze_route_fronts(src, "ecmwf", wps, 2.0, config=FrontGateConfig())
+
+        assert res.level_hPa == 850
+        assert res.config.name == "default"
+        assert len(res.crossings) == 1
+        xc = res.crossings[0]
+        assert xc.kind == "cold"
+        assert xc.gradient >= 6.0           # cleared the magnitude gate
+        assert abs(xc.delta_theta_e) >= 5.0  # cleared the air-mass-jump gate
+        # The full candidate/decision trace is stamped in.
+        assert res.decisions
+        assert any(d.accepted for d in res.decisions)

--- a/tests/test_route_fronts_api.py
+++ b/tests/test_route_fronts_api.py
@@ -1,0 +1,111 @@
+"""API test for GET /api/flights/{id}/packs/{ts}/route-fronts (#195)."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import sessionmaker
+
+from flyfun_common.db import current_user_id, get_db, DEV_USER_ID
+from flyfun_common.db.models import UserPreferencesRow, UserRow
+from weatherbrief.api.app import create_app
+from weatherbrief.models import BriefingPackMeta, Flight, RouteFrontsManifest
+from weatherbrief.storage.flights import pack_dir_for, save_flight, save_pack_meta
+from weatherbrief.tasks.artifacts import save_front_artifacts
+
+
+_NOW = datetime.now(timezone.utc)
+_DEP = (_NOW + timedelta(days=2)).replace(hour=9, minute=0, second=0, microsecond=0)
+
+
+@pytest.fixture
+def app_db():
+    from conftest import make_app_engine
+
+    engine = make_app_engine()
+    TestSession = sessionmaker(bind=engine)
+    session = TestSession()
+    session.add(UserRow(
+        id=DEV_USER_ID, provider="local", provider_sub="dev",
+        email="dev@localhost", display_name="Dev", approved=True,
+    ))
+    session.flush()
+    session.add(UserPreferencesRow(user_id=DEV_USER_ID))
+    session.commit()
+    session.close()
+    yield TestSession
+    engine.dispose()
+
+
+@pytest.fixture
+def client(app_db, tmp_path, monkeypatch):
+    monkeypatch.setenv("DATA_DIR", str(tmp_path / "data"))
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.setenv("JWT_SECRET", "test-secret")
+    app = create_app()
+
+    def _override_get_db():
+        session = app_db()
+        try:
+            yield session
+            session.commit()
+        finally:
+            session.close()
+
+    app.dependency_overrides[get_db] = _override_get_db
+    app.dependency_overrides[current_user_id] = lambda: DEV_USER_ID
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def _seed(app_db) -> tuple[Flight, BriefingPackMeta]:
+    fid = "egtk_lsgs-" + hashlib.sha256(b"x").hexdigest()[:4]
+    session = app_db()
+    flight = Flight(
+        id=fid, user_id=DEV_USER_ID, route_name="egtk_lsgs",
+        waypoints=["EGTK", "LSGS"], departure_time=_DEP,
+        cruise_altitude_ft=8000, flight_ceiling_ft=18000,
+        flight_duration_hours=4.5, created_at=_NOW - timedelta(days=1),
+    )
+    save_flight(session, flight, DEV_USER_ID)
+    meta = BriefingPackMeta(
+        flight_id=flight.id, fetch_timestamp=_NOW - timedelta(hours=1),
+        days_out=2, has_gramet=False, has_skewt=False, has_digest=False,
+        assessment="GREEN", assessment_reason="ok",
+    )
+    save_pack_meta(session, meta)
+    session.commit()
+    session.close()
+    return flight, meta
+
+
+def test_route_fronts_returns_artifact(client, app_db):
+    flight, meta = _seed(app_db)
+    ts = meta.fetch_timestamp.isoformat()
+    pack_dir = Path(pack_dir_for(DEV_USER_ID, flight.id, ts))
+    pack_dir.mkdir(parents=True, exist_ok=True)
+    save_front_artifacts(pack_dir, RouteFrontsManifest(
+        route_name="egtk_lsgs", generated_at=_NOW, primary_level_hPa=850,
+        levels=[925, 850, 700], models=["ecmwf"],
+    ))
+
+    resp = client.get(f"/api/flights/{flight.id}/packs/{ts}/route-fronts")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["primary_level_hPa"] == 850
+    assert body["models"] == ["ecmwf"]
+
+
+def test_route_fronts_404_when_absent(client, app_db):
+    """Default (preference off) → no artifact written → 404."""
+    flight, meta = _seed(app_db)
+    ts = meta.fetch_timestamp.isoformat()
+    pack_dir = Path(pack_dir_for(DEV_USER_ID, flight.id, ts))
+    pack_dir.mkdir(parents=True, exist_ok=True)  # pack exists, but no route_fronts.json
+
+    resp = client.get(f"/api/flights/{flight.id}/packs/{ts}/route-fronts")
+    assert resp.status_code == 404

--- a/tests/test_tasks_fronts.py
+++ b/tests/test_tasks_fronts.py
@@ -144,6 +144,28 @@ class TestComputeRouteFronts:
         assert manifest.models_without_snapshot == ["ecmwf"]
         assert manifest.per_model == {}
 
+    def test_stale_terrain_mask_does_not_crash(self, tmp_path):
+        """A wrong-shaped cached terrain mask is skipped, not fatal (#198 review)."""
+        out_dir = tmp_path / "hewson"
+        _write_front_snapshot(out_dir)
+        # Plant a terrain mask for a different (smaller) grid.
+        out_dir.mkdir(parents=True, exist_ok=True)
+        np.savez_compressed(
+            out_dir / "terrain_mask.npz",
+            mask=np.ones((3, 3), dtype=bool),
+            lat=np.linspace(45, 47, 3), lon=np.linspace(0, 2, 3),
+        )
+        analyses = _route_analyses()
+        manifest = compute_route_fronts(
+            [(a.lat, a.lon) for a in analyses],
+            [a.interpolated_time for a in analyses],
+            route_name="r", cruise_altitude_ft=5000,
+            advisory_models=["ecmwf"], output_dir=out_dir,
+        )
+        # Detection still runs (mask ignored) — no shape-mismatch crash.
+        assert manifest.models == ["ecmwf"]
+        assert manifest.per_model["ecmwf"]
+
 
 class TestRunFronts:
     def test_writes_artifact_and_roundtrips(self, tmp_path):

--- a/tests/test_tasks_fronts.py
+++ b/tests/test_tasks_fronts.py
@@ -1,0 +1,177 @@
+"""Tests for the front-detection pipeline stage (weatherbrief.tasks.fronts)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from weatherbrief.models import RoutePointAnalysis
+from weatherbrief.tasks.artifacts import load_route_fronts
+from weatherbrief.tasks.fronts import (
+    compute_route_fronts,
+    nearest_cruise_level,
+    run_fronts,
+)
+
+
+_INIT_DT = datetime(2026, 5, 31, 0, 0, 0, tzinfo=timezone.utc)
+_INIT_UNIX = int(_INIT_DT.timestamp())
+_LEVELS = (925, 850, 700)
+_STRIDE = 3
+_N_TIME = 9  # 0..24 h
+
+
+def _write_front_snapshot(out_dir: Path, model: str = "ecmwf") -> Path:
+    """A snapshot with a meridional θe front (cold front, eastward flow)."""
+    from weatherbrief.frontal.detect import compute_hewson_diagnostics
+    from weatherbrief.hewson.precompute import (
+        snapshot_path,
+        tendency_k_per_hour,
+        write_snapshot,
+    )
+
+    lat = np.linspace(45.0, 52.0, 29)
+    lon = np.linspace(-2.0, 6.0, 33)
+    _, lon_grid = np.meshgrid(lat, lon, indexing="ij")
+
+    per_level: dict[int, dict] = {}
+    for L in _LEVELS:
+        m = {
+            k: np.full((_N_TIME, lat.size, lon.size), np.nan, dtype=np.float32)
+            for k in ("theta_e", "gradient", "neg_laplacian", "tfp", "advection")
+        }
+        for h in range(_N_TIME):
+            axis = 2.0 + 0.03 * h * _STRIDE
+            theta = 290.0 + 6.0 * np.tanh((lon_grid - axis) / 0.3)
+            u = np.full_like(theta, 30.0)
+            v = np.zeros_like(theta)
+            d = compute_hewson_diagnostics(theta, lat, lon, u, v)
+            m["theta_e"][h] = theta
+            m["gradient"][h] = d["gradient"]
+            m["neg_laplacian"][h] = d["neg_laplacian"]
+            m["tfp"][h] = d["tfp"]
+            m["advection"][h] = d["advection"]
+        m["tendency"] = tendency_k_per_hour(m["theta_e"], step_hours=_STRIDE)
+        per_level[L] = m
+
+    valid_times = np.array(
+        [np.datetime64(_INIT_DT.replace(tzinfo=None) + timedelta(hours=h * _STRIDE))
+         for h in range(_N_TIME)],
+        dtype="datetime64[ns]",
+    )
+    path = snapshot_path(model, _INIT_UNIX, output_dir=out_dir)
+    write_snapshot(
+        path, init_time_unix=_INIT_UNIX, valid_times=valid_times,
+        lat=lat, lon=lon, levels=list(_LEVELS), stride_hours=_STRIDE,
+        per_level=per_level,
+    )
+    return path
+
+
+def _route_analyses():
+    """West→east route across the front axis, departing at init + 6 h."""
+    dep = _INIT_DT + timedelta(hours=6)
+    pts = [(47.0, -1.5), (47.0, 1.5), (47.0, 4.5)]
+    out = []
+    for i, (la, lo) in enumerate(pts):
+        out.append(RoutePointAnalysis(
+            point_index=i, lat=la, lon=lo,
+            distance_from_origin_nm=float(i * 80),
+            interpolated_time=dep + timedelta(minutes=40 * i),
+            forecast_hour=6 + i, track_deg=90.0,
+        ))
+    return out
+
+
+class TestNearestCruiseLevel:
+    def test_picks_closest_altitude(self):
+        assert nearest_cruise_level(2500, [925, 850, 700]) == 925
+        assert nearest_cruise_level(5500, [925, 850, 700]) == 850
+        assert nearest_cruise_level(11000, [925, 850, 700]) == 700
+
+
+class TestComputeRouteFronts:
+    def test_detects_front_all_levels(self, tmp_path):
+        out_dir = tmp_path / "hewson"
+        _write_front_snapshot(out_dir)
+        analyses = _route_analyses()
+        wps = [(a.lat, a.lon) for a in analyses]
+        etas = [a.interpolated_time for a in analyses]
+
+        manifest = compute_route_fronts(
+            wps, etas, route_name="EGKB-LFAT", cruise_altitude_ft=5000,
+            advisory_models=["ecmwf", "gfs"], output_dir=out_dir,
+        )
+        assert manifest.models == ["ecmwf"]            # only ecmwf has a snapshot
+        assert manifest.models_without_snapshot == ["gfs"]
+        assert manifest.primary_level_hPa == 850       # cruise 5000 ft
+        assert manifest.levels == [700, 850, 925]
+        assert "ecmwf" in manifest.snapshot_inits
+
+        analyses_850 = [
+            a for a in manifest.per_model["ecmwf"] if a.level_hPa == 850
+        ]
+        assert len(analyses_850) == 1
+        a = analyses_850[0]
+        assert len(a.crossings) >= 1
+        assert a.crossings[0].kind == "cold"
+        assert a.decisions  # candidate/decision trace stamped in
+
+    def test_gate_config_stamped(self, tmp_path):
+        out_dir = tmp_path / "hewson"
+        _write_front_snapshot(out_dir)
+        analyses = _route_analyses()
+        manifest = compute_route_fronts(
+            [(a.lat, a.lon) for a in analyses],
+            [a.interpolated_time for a in analyses],
+            route_name="r", cruise_altitude_ft=2500,
+            advisory_models=["ecmwf"], output_dir=out_dir,
+        )
+        assert manifest.gate_config["name"] == "default"
+        assert manifest.gate_config["level_hPa"] == 925  # cruise 2500 → primary 925
+
+    def test_no_models_when_no_snapshots(self, tmp_path):
+        manifest = compute_route_fronts(
+            [(47.0, -1.5), (47.0, 4.5)],
+            [_INIT_DT + timedelta(hours=6), _INIT_DT + timedelta(hours=7)],
+            route_name="r", cruise_altitude_ft=5000,
+            advisory_models=["ecmwf"], output_dir=tmp_path / "empty",
+        )
+        assert manifest.models == []
+        assert manifest.models_without_snapshot == ["ecmwf"]
+        assert manifest.per_model == {}
+
+
+class TestRunFronts:
+    def test_writes_artifact_and_roundtrips(self, tmp_path):
+        out_dir = tmp_path / "hewson"
+        _write_front_snapshot(out_dir)
+        pack_dir = tmp_path / "pack"
+        pack_dir.mkdir()
+
+        manifest = run_fronts(
+            _route_analyses(), route_name="r", cruise_altitude_ft=5000,
+            advisory_models=["ecmwf"], pack_dir=pack_dir, output_dir=out_dir,
+        )
+        assert manifest is not None
+        assert (pack_dir / "route_fronts.json").exists()
+        loaded = load_route_fronts(pack_dir)
+        assert loaded is not None
+        assert loaded.models == ["ecmwf"]
+        assert loaded.per_model["ecmwf"]
+
+    def test_skips_route_without_etas(self, tmp_path):
+        out_dir = tmp_path / "hewson"
+        _write_front_snapshot(out_dir)
+        pack_dir = tmp_path / "pack"
+        pack_dir.mkdir()
+        # Single point → fewer than 2 ETA-stamped waypoints.
+        one = _route_analyses()[:1]
+        assert run_fronts(
+            one, route_name="r", cruise_altitude_ft=5000,
+            advisory_models=["ecmwf"], pack_dir=pack_dir, output_dir=out_dir,
+        ) is None
+        assert not (pack_dir / "route_fronts.json").exists()

--- a/web/maps.html
+++ b/web/maps.html
@@ -503,6 +503,14 @@
           <input type="range" id="syn-opacity-slider" min="0" max="100" value="50" style="width:120px">
           <span class="range-value" id="syn-opacity-value">50%</span>
         </span>
+        <label title="Overlay gate-detected TFP=0 front axes. Pick a gate preset to compare against the raw field / official charts.">Fronts</label>
+        <select id="syn-fronts-picker" title="Overlay gate-detected front axes (calibration)">
+          <option value="off" selected>Off</option>
+          <option value="default">default gate</option>
+          <option value="strict">strict gate</option>
+          <option value="sensitive">sensitive gate</option>
+          <option value="gradient-only">gradient-only gate</option>
+        </select>
       </div>
 
       <div class="map-wrapper">

--- a/web/ts/adapters/hewson-map-adapter.ts
+++ b/web/ts/adapters/hewson-map-adapter.ts
@@ -112,3 +112,56 @@ export async function fetchHewsonAllMetrics(
   }
   return resp.json();
 }
+
+// --- Gated front polylines (the 2-D TFP=0 extractor, §C2) ---
+
+export interface HewsonFront {
+  kind: string;                       // "cold" | "warm" | "quasi-stationary"
+  length_km: number;
+  mean_gradient: number;
+  mean_delta_theta_e: number;
+  coordinates: [number, number][];    // GeoJSON [lon, lat] pairs
+}
+
+export interface HewsonFrontsResponse {
+  model: string;
+  init_time: string;
+  valid_time: string;
+  level: number;
+  hour: number;
+  stride_hours: number;
+  gate: string;
+  gate_config: Record<string, number | string | boolean | null>;
+  fronts: HewsonFront[];
+}
+
+export interface HewsonFrontsParams {
+  model: string;
+  init: string;
+  level: number;
+  hour: number;
+  gate: string;            // preset: default | strict | sensitive | gradient-only
+  minLengthKm?: number;
+}
+
+export async function fetchHewsonFronts(
+  p: HewsonFrontsParams,
+): Promise<HewsonFrontsResponse> {
+  const qs = new URLSearchParams({
+    model: p.model,
+    init: p.init,
+    level: String(p.level),
+    hour: String(p.hour),
+    gate: p.gate,
+  });
+  if (p.minLengthKm !== undefined) qs.set('min_length_km', String(p.minLengthKm));
+  const resp = await fetch(
+    `${apiBase}/hewson-map/fronts?${qs}`, { credentials: 'include' },
+  );
+  if (!resp.ok) {
+    let detail: string | undefined;
+    try { detail = (await resp.json())?.detail; } catch { /* ignore */ }
+    throw new Error(detail ?? `Hewson fronts: ${resp.status}`);
+  }
+  return resp.json();
+}

--- a/web/ts/maps-main.ts
+++ b/web/ts/maps-main.ts
@@ -6,7 +6,7 @@ import {
   type ForecastMapResponse,
 } from './adapters/maps-adapter';
 import {
-  fetchHewsonManifest, fetchHewsonSlice, fetchHewsonAllMetrics,
+  fetchHewsonManifest, fetchHewsonSlice, fetchHewsonAllMetrics, fetchHewsonFronts,
   type HewsonManifest, type HewsonManifestSnapshot,
   type HewsonAllMetricsSlice,
 } from './adapters/hewson-map-adapter';
@@ -40,6 +40,9 @@ let synMetric: HewsonMetric = 'tfp';
 let synHour = 0;
 let synOpacity = 0.5;
 let synScale: ColorScale = 'default';
+// Gate-detected front overlay: 'off' or a gate preset name. Dev/calibration —
+// draws TFP=0 axes on top of the grid for the current (model, init, level, hour).
+let synFrontsGate = 'off';
 // Cached multi-metric grid for the active (model, init, level, hour) — used
 // by the cursor tooltip and (when present) lets metric-change skip a
 // network call. Fetched in the background after the fast initial render.
@@ -456,6 +459,36 @@ async function loadSynoptic(): Promise<void> {
   //     the canvas is already rendered above; this just enables hover when
   //     it lands. Errors are non-fatal; map remains interactive without hover.
   fetchAllMetricsInBackground(myToken);
+
+  // --- 3. Optional front overlay (calibration). Independent of the canvas;
+  //     fetched only when a gate preset is selected.
+  loadFronts(myToken);
+}
+
+/** Fetch + render the gate-detected front axes for the current
+ * (model, init, level, hour, gate), or clear them when the gate is 'off'.
+ * Token-guarded so a stale response can't draw fronts for a since-changed
+ * selection; failures clear the overlay and leave the grid interactive. */
+function loadFronts(myToken: number): void {
+  if (!synopticMap) return;
+  if (synFrontsGate === 'off' || !synInit) {
+    synopticMap.clearFronts();
+    return;
+  }
+  fetchHewsonFronts({
+    model: synModel,
+    init: synInit,
+    level: synLevel,
+    hour: synHour,
+    gate: synFrontsGate,
+  }).then((resp) => {
+    if (myToken !== synLoadToken) return;  // stale — selection moved on
+    synopticMap?.setFronts(resp.fronts);
+  }).catch((err) => {
+    if (myToken !== synLoadToken) return;
+    console.warn('Hewson fronts fetch failed:', err);
+    synopticMap?.clearFronts();
+  });
 }
 
 /** Fire an /all-metrics fetch in the background and wire its response to
@@ -600,6 +633,14 @@ function wireSynopticControls(): void {
     synOpacity = pct / 100;
     if (opVal) opVal.textContent = `${pct}%`;
     synopticMap?.setOpacity(synOpacity);
+  });
+
+  const frontsSel = $('syn-fronts-picker') as HTMLSelectElement | null;
+  frontsSel?.addEventListener('change', () => {
+    synFrontsGate = frontsSel.value;
+    // No grid refetch — just (re)load or clear the front overlay for the
+    // current selection.
+    loadFronts(synLoadToken);
   });
 
   $('syn-info-btn')?.addEventListener('click', (e) => {

--- a/web/ts/visualization/synoptic-map.ts
+++ b/web/ts/visualization/synoptic-map.ts
@@ -6,9 +6,17 @@
  */
 
 import * as L from 'leaflet';
-import type { HewsonAllMetricsSlice, HewsonSlice } from '../adapters/hewson-map-adapter';
+import type { HewsonAllMetricsSlice, HewsonFront, HewsonSlice } from '../adapters/hewson-map-adapter';
 import { COLORMAPS, gradientCss, type HewsonMetric } from './hewson-colormaps';
 import { HewsonGridLayer } from './hewson-grid-layer';
+
+// Gate-detected front-axis colours (match the CLI DWD overlay: blue cold,
+// red warm, purple quasi-stationary).
+const FRONT_COLORS: Record<string, string> = {
+  cold: '#0a5adc',
+  warm: '#dc0000',
+  'quasi-stationary': '#960096',
+};
 
 const HEWSON_METRIC_ORDER: HewsonMetric[] = [
   'theta_e', 'gradient', 'neg_laplacian', 'tfp', 'advection', 'tendency',
@@ -31,6 +39,7 @@ export class SynopticMap {
   private map: L.Map | null = null;
   private tileLayer: L.TileLayer | null = null;
   private gridLayer: HewsonGridLayer | null = null;
+  private frontsLayer: L.LayerGroup | null = null;
   private legendEl: HTMLElement | null = null;
   // Hover state — populated via setHoverGrid(); cleared when no grid is loaded.
   private hoverGrid: HewsonAllMetricsSlice | null = null;
@@ -57,6 +66,9 @@ export class SynopticMap {
 
     this.gridLayer = new HewsonGridLayer();
     this.gridLayer.addTo(this.map);
+
+    // Front polylines draw on top of the grid overlay.
+    this.frontsLayer = L.layerGroup().addTo(this.map);
 
     // Cursor-following tooltip — wired once at init, hidden until hoverGrid
     // is populated by setHoverGrid().
@@ -110,9 +122,37 @@ export class SynopticMap {
 
   clear(): void {
     this.gridLayer?.clear();
+    this.clearFronts();
     this.removeLegend();
     this.hoverGrid = null;
     this.hideHover();
+  }
+
+  /** Draw gate-detected front polylines (replacing any already shown). Each
+   * front is a coloured Leaflet polyline with a tooltip summarising its
+   * kind / length / mean intensity. */
+  setFronts(fronts: HewsonFront[]): void {
+    if (!this.frontsLayer) return;
+    this.frontsLayer.clearLayers();
+    for (const f of fronts) {
+      // API gives GeoJSON [lon, lat]; Leaflet wants [lat, lon].
+      const latlngs = f.coordinates.map(([lon, lat]) => [lat, lon] as [number, number]);
+      if (latlngs.length < 2) continue;
+      const color = FRONT_COLORS[f.kind] ?? FRONT_COLORS['quasi-stationary'];
+      const line = L.polyline(latlngs, {
+        color, weight: 4, opacity: 0.9, lineJoin: 'round',
+      });
+      line.bindTooltip(
+        `${f.kind} front · ${Math.round(f.length_km)} km · ` +
+        `|∇θe| ${f.mean_gradient.toFixed(1)} · Δθe ${f.mean_delta_theta_e.toFixed(1)} K`,
+        { sticky: true },
+      );
+      line.addTo(this.frontsLayer);
+    }
+  }
+
+  clearFronts(): void {
+    this.frontsLayer?.clearLayers();
   }
 
   /** Cache the all-metrics grid for cursor-tooltip lookups. Pass null to


### PR DESCRIPTION
## Summary

Implements the complete front-detection pipeline for route briefings (issue #195, Part 1). Detects on-track front crossings and nearby off-track fronts along a flight route using Hewson diagnostics (θe, |∇θe|, TFP, advection, tendency) sampled from precomputed snapshots or calibration cases. Introduces a swappable field-source abstraction, gated decision logic, and a new pipeline stage that produces the `route_fronts.json` artifact.

## Key Changes

### Core Architecture
- **`weatherbrief.frontal.sources`** (new): Abstract `HewsonFieldSource` with two implementations:
  - `SnapshotFieldSource`: reads precomputed NPZ snapshots (production path, zero-fetch)
  - `CaseFieldSource`: recomputes diagnostics from calibration `Case` objects (legacy/calibration path)
  - Both expose the same interface; detection code is source-agnostic
  - Shared `HewsonGrids` dataclass carries all diagnostic fields (θe, gradient, TFP, advection, tendency, gradient components)

- **`weatherbrief.frontal.gates`** (new): `FrontGateConfig` — a frozen, serializable detection recipe
  - Consolidates ~10 acceptance/classification thresholds into one dataclass
  - Level-specific (gates vary by pressure level; 925 hPa has larger θe gradients than 700 hPa)
  - Includes preset registry (`get_preset`, `preset_names`) for reproducible calibration
  - Stamped into `route_fronts.json` so every briefing records which recipe produced it

### Route Sampling & Detection
- **`weatherbrief.frontal.route_sampling`** (refactored):
  - `sample_hewson_at_route()`: now accepts `HewsonFieldSource | Case` (auto-wraps bare `Case` via `_as_source()`)
  - Candidate/decision split: `generate_front_candidates()` → `apply_gate_config()` → `decisions_to_crossings()`
    - Enables zero-re-sampling calibration sweeps (apply many gate configs to same candidate set)
  - `find_nearby_fronts()`: locates nearest off-track front at route-midpoint ETA
  - `analyze_route_fronts()`: orchestrates full detection (on-track + off-track) for one model/level
  - Removed `_HourGrids` dataclass; now uses `HewsonGrids` from sources
  - Removed `_compute_hour_grids()` and `_tendency_grid()` (logic moved to sources)

- **`weatherbrief.frontal.contour_fronts`** (new): 2-D TFP=0 gated polyline extraction
  - Extracts front-axis contours from snapshot grids
  - Gates each vertex by the same `FrontGateConfig` (gradient, Δθe, anomaly filter)
  - Classifies cold/warm/quasi-stationary by advection sign
  - Primary calibration surface: overlay detected lines on official DWD analysis to validate gates

### Pipeline Integration
- **`weatherbrief.tasks.fronts`** (new): Front-detection pipeline stage
  - `run_fronts()`: called inline when `auto_front_detection` preference is on
  - `run_fronts_from_pack()`: recompute from `route_analyses.json` with zero re-fetch
  - `compute_route_fronts()`: orchestrates detection across all available models (ECMWF, GFS, ICON)
  - Graceful degradation: models without snapshots simply get no front data
  - Stores all three levels (925, 850, 700 hPa) so Part 2's cross-section bands have data

- **`weatherbrief.models.fronts`** (new): Pydantic models for serialization
  - `FrontCrossingModel`: on-track crossing (lat, lon, gradient, Δθe, advection, TFP before/after)
  - `F

https://claude.ai/code/session_01FFYMbimkjJ1uH3hhaXgoqx