### PR TITLE
Front relevance gating: weather-on-boundary + altitude-aware severity, cross-section styling

### DIFF
--- a/src/weatherbrief/analysis/advisories/fronts.py
+++ b/src/weatherbrief/analysis/advisories/fronts.py
@@ -72,14 +72,27 @@ _STATUS_RANK = {
 
 def _grade_crossing(
     c: FrontCrossingModel,
+    level_hpa: int,
+    primary_level: int,
     cruise_ft: int,
     persistence_min: float,
     buffer_ft: float,
+    convective_deep_ft: float,
 ) -> tuple[AdvisoryStatus, str]:
-    """Grade one crossing → (status, reason), gating on persistence + co-located
-    weather. The θe boundary's *level* is not the weather's *level*: relevance is
-    judged by whether the front's cloud/convective top reaches the flight band,
-    not by which pressure level the gradient sits at."""
+    """Grade one crossing → (status, reason).
+
+    Two altitude facts matter, not just the gradient:
+      * **does the weather reach the flight?** — judged by the cloud/convective
+        top vs the flight band, since the θe boundary's level is not the
+        weather's level;
+      * **is the sharp part at the flight level?** — a sharp boundary *below*
+        cruise (``level_hpa > primary_level``) is one you overfly: its core
+        never touches you, so it caps at AMBER. Only convective towers, which
+        grow up through your level, can still RED from below — and then only
+        when deep (tops ≥ cruise + ``convective_deep_ft``); modest build-ups are
+        AMBER. (Calibrated on the 2026-05-31 Dijon flight: a sharp 925 hPa cold
+        front overflown at FL100 is AMBER, not RED.)
+    """
     # Flickering across the window → orographic / grid artifact, not a real front.
     if c.persistence is not None and c.persistence < persistence_min:
         return AdvisoryStatus.GREEN, "flicker"
@@ -93,10 +106,14 @@ def _grade_crossing(
     reaches = c.weather_top_ft is None or c.weather_top_ft >= cruise_ft - buffer_ft
     if not reaches:
         return AdvisoryStatus.GREEN, "below"          # weather stays below cruise — overflown
+    overflown = level_hpa > primary_level             # boundary lower than cruise → you fly over its core
     if co == "convective":
-        return AdvisoryStatus.RED, "convective"       # towers through / above the flight level
+        deep = c.weather_top_ft is not None and c.weather_top_ft >= cruise_ft + convective_deep_ft
+        return (AdvisoryStatus.RED, "convective") if deep else (AdvisoryStatus.AMBER, "convective")
     if co == "wet":
-        return (AdvisoryStatus.RED, "wet_sharp") if c.intensity == "sharp" else (AdvisoryStatus.AMBER, "wet")
+        if c.intensity == "sharp" and not overflown:
+            return AdvisoryStatus.RED, "wet_sharp"    # sharp front at/above the flight level
+        return AdvisoryStatus.AMBER, "wet"
     return AdvisoryStatus.AMBER, "partly"             # few/sct cloud band
 
 
@@ -204,6 +221,21 @@ class FrontsEvaluator:
                     max=10000,
                     step=500,
                 ),
+                AdvisoryParameterDef(
+                    key="convective_deep_ft",
+                    label="Deep-convection height",
+                    description=(
+                        "A convective front reaching the flight is RED only when its "
+                        "tops are at least this far above cruise (deep towers); "
+                        "shallower build-ups are AMBER"
+                    ),
+                    type="number",
+                    unit="ft",
+                    default=15000,
+                    min=5000,
+                    max=30000,
+                    step=1000,
+                ),
             ],
         )
 
@@ -214,6 +246,7 @@ class FrontsEvaluator:
         closing_within_km = params.get("closing_within_km", 300)
         persistence_min = params.get("persistence_min", 0.5)
         buffer_ft = params.get("altitude_buffer_ft", 2000)
+        convective_deep_ft = params.get("convective_deep_ft", 15000)
         cruise_ft = ctx.cruise_altitude_ft
 
         # Gating: no artifact → experimental feature was off → UNAVAILABLE.
@@ -224,6 +257,7 @@ class FrontsEvaluator:
             return _unavailable(params, loc)
 
         total_km = ctx.total_distance_nm * _KM_PER_NM
+        primary = manifest.primary_level_hPa
 
         # Honor the user's advisory model selection; fall back to whatever the
         # artifact carries (front models are always a subset of ecmwf/gfs/icon).
@@ -239,7 +273,10 @@ class FrontsEvaluator:
             # below cruise yet loft weather through it (the Dijon case) — and keep
             # the worst. Nearest off-track closing front handled separately.
             graded = [
-                (*_grade_crossing(c, cruise_ft, persistence_min, buffer_ft), c)
+                (*_grade_crossing(
+                    c, a.level_hPa, primary, cruise_ft,
+                    persistence_min, buffer_ft, convective_deep_ft,
+                ), c)
                 for a in analyses for c in a.crossings
             ]
             closing = min(

--- a/src/weatherbrief/analysis/advisories/fronts.py
+++ b/src/weatherbrief/analysis/advisories/fronts.py
@@ -13,11 +13,21 @@ is the master (data + overlays) and this advisory toggle independently gates the
 grade, so a pilot can keep the overlays without letting the experimental signal
 move the overall assessment.
 
-Grading (design doc §2–3, qualitative per §8):
-  * a **sharp** crossing (|∇θe| > 12, SIGMET-worthy) → RED
-  * a **classical / significant** crossing → AMBER
-  * the nearest off-track front **closing** within ``closing_within_km`` → AMBER
-  * otherwise → GREEN
+Grading is gated by the weather *on* the boundary, not the θe gradient alone —
+so a dry orographic ribbon doesn't false-RED and a front you overfly whose cloud
+lofts through your level doesn't false-GREEN. Each crossing (at every stored
+level) is graded:
+  * **flickering** (low persistence across the time window) → demote: likely an
+    orographic / grid artifact, not a front you'll meet.
+  * **dry** boundary (clear air on it) → GREEN: a wind shift only.
+  * weather **below** the flight (top doesn't reach cruise − buffer) → GREEN:
+    overflown cleanly.
+  * **convective** boundary reaching the flight band → RED: towers through / above
+    your level (deviation / turbulence).
+  * **wet** boundary reaching the flight: sharp → RED, else AMBER.
+  * nearest off-track front **closing** within ``closing_within_km`` → AMBER.
+The per-model status is the worst graded crossing. (No co-location enrichment →
+falls back to the bare intensity grade so fronts are never silently hidden.)
 
 Free-atmosphere only: 850 hPa θe does not see low IMC / fog (§10a.2). Positions
 are described qualitatively (early / mid / late route), never as exact
@@ -53,6 +63,41 @@ _KIND_KEY = {
 
 # Intensity → severity rank (higher = worse) so we can pick the "worst" crossing.
 _INTENSITY_RANK = {"significant": 1, "classical": 2, "sharp": 3}
+_STATUS_RANK = {
+    AdvisoryStatus.GREEN: 0,
+    AdvisoryStatus.AMBER: 1,
+    AdvisoryStatus.RED: 2,
+}
+
+
+def _grade_crossing(
+    c: FrontCrossingModel,
+    cruise_ft: int,
+    persistence_min: float,
+    buffer_ft: float,
+) -> tuple[AdvisoryStatus, str]:
+    """Grade one crossing → (status, reason), gating on persistence + co-located
+    weather. The θe boundary's *level* is not the weather's *level*: relevance is
+    judged by whether the front's cloud/convective top reaches the flight band,
+    not by which pressure level the gradient sits at."""
+    # Flickering across the window → orographic / grid artifact, not a real front.
+    if c.persistence is not None and c.persistence < persistence_min:
+        return AdvisoryStatus.GREEN, "flicker"
+    co = c.co_location
+    if co is None:
+        # No enrichment (older artifact / no analyses) → bare intensity grade,
+        # rather than silently hiding the front.
+        return (AdvisoryStatus.RED, "sharp") if c.intensity == "sharp" else (AdvisoryStatus.AMBER, "classical")
+    if co == "dry":
+        return AdvisoryStatus.GREEN, "dry"            # boundary aloft, clear → wind shift only
+    reaches = c.weather_top_ft is None or c.weather_top_ft >= cruise_ft - buffer_ft
+    if not reaches:
+        return AdvisoryStatus.GREEN, "below"          # weather stays below cruise — overflown
+    if co == "convective":
+        return AdvisoryStatus.RED, "convective"       # towers through / above the flight level
+    if co == "wet":
+        return (AdvisoryStatus.RED, "wet_sharp") if c.intensity == "sharp" else (AdvisoryStatus.AMBER, "wet")
+    return AdvisoryStatus.AMBER, "partly"             # few/sct cloud band
 
 
 def _where_key(distance_km: float, total_km: float) -> str:
@@ -67,11 +112,12 @@ def _where_key(distance_km: float, total_km: float) -> str:
 
 def _describe(
     worst: FrontCrossingModel,
+    reason: str,
     n_crossings: int,
     total_km: float,
     loc: str | None,
 ) -> str:
-    """Build the localized detail for the worst on-track crossing."""
+    """Build the localized detail for the worst graded crossing."""
     prefix = adv_t("fronts.sharp", loc) if worst.intensity == "sharp" else ""
     kind = adv_t(_KIND_KEY.get(worst.kind, "fronts.kind.quasi"), loc)
     where = adv_t(_where_key(worst.distance_km, total_km), loc)
@@ -82,8 +128,11 @@ def _describe(
         )
     else:
         detail = adv_t("fronts.crossing", loc, prefix=prefix, kind=kind, where=where)
-    # Warm/cold advection tail (§2.5) — the most flight-relevant nuance.
-    if worst.advection > 1.0:
+    # Tail: convective tops (most flight-relevant for an overflown front) take
+    # priority, else the warm/cold advection tendency (§2.5).
+    if reason == "convective" and worst.weather_top_ft:
+        detail += adv_t("fronts.tail.convective", loc, top=int(round(worst.weather_top_ft / 100)))
+    elif worst.advection > 1.0:
         detail += adv_t("fronts.tail.deteriorating", loc)
     elif worst.advection < -1.0:
         detail += adv_t("fronts.tail.improving", loc)
@@ -125,6 +174,36 @@ class FrontsEvaluator:
                     max=600,
                     step=50,
                 ),
+                AdvisoryParameterDef(
+                    key="persistence_min",
+                    label="Min front persistence",
+                    description=(
+                        "Demote a crossing to GREEN when the gradient holds in fewer "
+                        "than this fraction of the time-window frames (flickering = "
+                        "likely orographic / grid artifact, not a real front)"
+                    ),
+                    type="number",
+                    unit="",
+                    default=0.5,
+                    min=0.0,
+                    max=1.0,
+                    step=0.1,
+                ),
+                AdvisoryParameterDef(
+                    key="altitude_buffer_ft",
+                    label="Flight-band buffer",
+                    description=(
+                        "A front's weather is 'relevant' when its cloud/convective "
+                        "top reaches cruise minus this buffer (so weather entirely "
+                        "below the aircraft is overflown, not graded)"
+                    ),
+                    type="number",
+                    unit="ft",
+                    default=2000,
+                    min=0,
+                    max=10000,
+                    step=500,
+                ),
             ],
         )
 
@@ -133,6 +212,9 @@ class FrontsEvaluator:
         loc = ctx.locale
         manifest = ctx.route_fronts
         closing_within_km = params.get("closing_within_km", 300)
+        persistence_min = params.get("persistence_min", 0.5)
+        buffer_ft = params.get("altitude_buffer_ft", 2000)
+        cruise_ft = ctx.cruise_altitude_ft
 
         # Gating: no artifact → experimental feature was off → UNAVAILABLE.
         # Build the result directly (not via from_per_model): the aggregation
@@ -141,7 +223,6 @@ class FrontsEvaluator:
         if manifest is None or not manifest.per_model:
             return _unavailable(params, loc)
 
-        primary = manifest.primary_level_hPa
         total_km = ctx.total_distance_nm * _KM_PER_NM
 
         # Honor the user's advisory model selection; fall back to whatever the
@@ -153,28 +234,39 @@ class FrontsEvaluator:
             analyses = manifest.per_model.get(model)
             if not analyses:
                 continue
-            # Match the analysis at the primary (nearest-cruise) level by its
-            # level_hPa field, not by position (manifest contract).
-            analysis = next((a for a in analyses if a.level_hPa == primary), analyses[0])
 
-            crossings = list(analysis.crossings)
-            nearest = analysis.nearest
+            # Grade every crossing at every stored level — the boundary may sit
+            # below cruise yet loft weather through it (the Dijon case) — and keep
+            # the worst. Nearest off-track closing front handled separately.
+            graded = [
+                (*_grade_crossing(c, cruise_ft, persistence_min, buffer_ft), c)
+                for a in analyses for c in a.crossings
+            ]
+            closing = min(
+                (a.nearest for a in analyses
+                 if a.nearest is not None and not a.nearest.on_track
+                 and a.nearest.trend == "closing" and a.nearest.distance_km <= closing_within_km),
+                key=lambda nf: nf.distance_km, default=None,
+            )
 
-            if crossings:
-                worst = max(crossings, key=lambda c: _INTENSITY_RANK.get(c.intensity, 0))
-                status = (
-                    AdvisoryStatus.RED if worst.intensity == "sharp"
-                    else AdvisoryStatus.AMBER
+            if graded:
+                status, reason, worst = max(
+                    graded, key=lambda g: (_STATUS_RANK[g[0]], _INTENSITY_RANK.get(g[2].intensity, 0)),
                 )
-                detail = _describe(worst, len(crossings), total_km, loc)
-            elif (
-                nearest is not None
-                and not nearest.on_track
-                and nearest.trend == "closing"
-                and nearest.distance_km <= closing_within_km
-            ):
+                if status != AdvisoryStatus.GREEN:
+                    # Distinct relevant crossings (dedup the same front seen at
+                    # multiple levels into ~50 km bins).
+                    n = len({round(c.distance_km / 50.0) for st, _r, c in graded if st != AdvisoryStatus.GREEN})
+                    detail = _describe(worst, reason, n, total_km, loc)
+                elif closing is not None:
+                    status = AdvisoryStatus.AMBER
+                    detail = adv_t("fronts.closing", loc, dist=int(round(closing.distance_km)))
+                else:
+                    # Crossings existed but all demoted (dry / below / flicker).
+                    detail = adv_t("fronts.benign", loc)
+            elif closing is not None:
                 status = AdvisoryStatus.AMBER
-                detail = adv_t("fronts.closing", loc, dist=int(round(nearest.distance_km)))
+                detail = adv_t("fronts.closing", loc, dist=int(round(closing.distance_km)))
             else:
                 status = AdvisoryStatus.GREEN
                 detail = adv_t("fronts.none", loc)

--- a/src/weatherbrief/analysis/advisories/strings.py
+++ b/src/weatherbrief/analysis/advisories/strings.py
@@ -398,6 +398,18 @@ _STRINGS: dict[str, dict[str, str]] = {
         "de": "Front {dist} km abseits der Strecke und näher kommend",
         "es": "Frente a {dist} km fuera de ruta y acercándose",
     },
+    "fronts.tail.convective": {
+        "en": " — convective tops to FL{top}, expect build-ups / deviation",
+        "fr": " — sommets convectifs au FL{top}, prévoir des développements / déroutements",
+        "de": " — konvektive Obergrenzen bis FL{top}, mit Aufbauten / Ausweichen rechnen",
+        "es": " — topes convectivos a FL{top}, prever desarrollos / desvíos",
+    },
+    "fronts.benign": {
+        "en": "Air-mass boundary on route, but little active weather on it",
+        "fr": "Limite de masse d'air sur la route, mais peu de météo active",
+        "de": "Luftmassengrenze auf der Strecke, aber kaum aktives Wetter",
+        "es": "Límite de masa de aire en la ruta, pero con poco tiempo activo",
+    },
 
     # --- shared airport labels ---
     "airport.dep": {

--- a/src/weatherbrief/frontal/route_sampling.py
+++ b/src/weatherbrief/frontal/route_sampling.py
@@ -318,6 +318,11 @@ class FrontCrossing:
     delta_theta_e: float   # θe(after) − θe(before) across the window, K
     kind: str              # "cold" | "warm" | "quasi-stationary"
     intensity: str         # "significant" | "classical" | "sharp"
+    # Relevance enrichment (attached post-detection by the pipeline stage; the
+    # bare detector leaves these None). See tasks/fronts.py:_colocate / _persistence.
+    co_location: str | None = None      # "dry" | "partly" | "wet" | "convective" — weather on the boundary
+    weather_top_ft: float | None = None # vertical extent of that weather (cloud/convective top), ft
+    persistence: float | None = None    # fraction [0,1] of ±window frames the gated gradient holds
 
 
 def _intensity_label(gradient: float) -> str:

--- a/src/weatherbrief/models/fronts.py
+++ b/src/weatherbrief/models/fronts.py
@@ -32,6 +32,12 @@ class FrontCrossingModel(BaseModel):
     delta_theta_e: float       # θe jump across the window, K
     kind: str                  # "cold" | "warm" | "quasi-stationary"
     intensity: str             # "significant" | "classical" | "sharp"
+    # Relevance enrichment (None until the pipeline stage attaches it). The θe
+    # boundary's level is not the weather's level — ``weather_top_ft`` is what a
+    # pilot actually encounters (e.g. convective towers above an overflown front).
+    co_location: str | None = None       # "dry"|"partly"|"wet"|"convective"
+    weather_top_ft: float | None = None  # cloud/convective top at the crossing, ft
+    persistence: float | None = None     # [0,1] fraction of ±window frames the gate holds
 
 
 class FrontProximityModel(BaseModel):

--- a/src/weatherbrief/tasks/fronts.py
+++ b/src/weatherbrief/tasks/fronts.py
@@ -165,20 +165,23 @@ def _colocate(analyses, model: str, dist_km: float, level_hpa: int):
     conv = _attr(s, "convective", None)
     risk = _enum_val(_attr(conv, "risk_level", None)) if conv is not None else None
 
-    cloud_top = max((_attr(cl, "top_ft", None) or 0.0 for cl in layers), default=0.0)
+    def _spans(cl, level: int) -> bool:
+        bp, tp = _attr(cl, "base_pressure_hpa", None), _attr(cl, "top_pressure_hpa", None)
+        return bool(bp and tp and tp <= level <= bp)
+
+    def _covers(level: int, coverages: set[str]) -> bool:
+        """True if a cloud layer of one of ``coverages`` physically spans ``level``."""
+        return any(_spans(cl, level) and _enum_val(_attr(cl, "coverage", None)) in coverages for cl in layers)
+
+    # Cloud top must come from layers spanning the frontal level, not the whole
+    # column — else unrelated high cirrus inflates weather_top_ft and false-AMBERs
+    # a low wet/partly front (the category is already level-gated via _covers).
+    cloud_top = max((_attr(cl, "top_ft", None) or 0.0 for cl in layers if _spans(cl, level_hpa)), default=0.0)
     conv_top = None
     if conv is not None:
         conv_top = _attr(conv, "top_ft", None) or _attr(conv, "el_altitude_ft", None)
     tops = [v for v in (cloud_top or None, conv_top) if v]
     weather_top_ft = float(max(tops)) if tops else None
-
-    def _covers(level: int, coverages: set[str]) -> bool:
-        """True if a cloud layer of one of ``coverages`` physically spans ``level``."""
-        for cl in layers:
-            bp, tp = _attr(cl, "base_pressure_hpa", None), _attr(cl, "top_pressure_hpa", None)
-            if bp and tp and tp <= level <= bp and _enum_val(_attr(cl, "coverage", None)) in coverages:
-                return True
-        return False
 
     precip_obj = _attr(s, "precipitation", None)
     precip = precip_obj is not None and _enum_val(_attr(precip_obj, "surface_intensity", "none")) != "none"
@@ -207,11 +210,11 @@ def _persistence(source, model, lat, lon, level_hpa, eta_hour, gradient_min):
     stride = getattr(source, "stride_hours", None) or 3
     li = int(np.argmin(np.abs(source.lat - lat)))
     lj = int(np.argmin(np.abs(source.lon - lon)))
+    # Dedupe snapped hours: with stride > 3 h several offsets round to the same
+    # frame (banker's rounding), which would triple-count that frame in tot.
+    hours = sorted({int(round((eta_hour + dh) / stride) * stride) for dh in _PERSIST_OFFSETS_H} & avail)
     hits = tot = 0
-    for dh in _PERSIST_OFFSETS_H:
-        h = int(round((eta_hour + dh) / stride) * stride)
-        if h not in avail:
-            continue
+    for h in hours:
         g = source.gradient_at_hour(model, h, level_hpa)
         if g is None:
             continue

--- a/src/weatherbrief/tasks/fronts.py
+++ b/src/weatherbrief/tasks/fronts.py
@@ -172,21 +172,24 @@ def _colocate(analyses, model: str, dist_km: float, level_hpa: int):
     tops = [v for v in (cloud_top or None, conv_top) if v]
     weather_top_ft = float(max(tops)) if tops else None
 
-    def _covers(level: int) -> bool:
+    def _covers(level: int, coverages: set[str]) -> bool:
+        """True if a cloud layer of one of ``coverages`` physically spans ``level``."""
         for cl in layers:
             bp, tp = _attr(cl, "base_pressure_hpa", None), _attr(cl, "top_pressure_hpa", None)
-            if bp and tp and tp <= level <= bp and _enum_val(_attr(cl, "coverage", None)) in _SIGNIFICANT_COVERAGE:
+            if bp and tp and tp <= level <= bp and _enum_val(_attr(cl, "coverage", None)) in coverages:
                 return True
         return False
 
     precip_obj = _attr(s, "precipitation", None)
     precip = precip_obj is not None and _enum_val(_attr(precip_obj, "surface_intensity", "none")) != "none"
 
+    # Cloud must span the frontal level to count — a high cirrus deck unrelated
+    # to a low front is neither "wet" nor "partly" (it would otherwise false-AMBER).
     if risk in _CONVECTIVE_RISK:
         category = "convective"
-    elif _covers(level_hpa) or precip:
+    elif _covers(level_hpa, _SIGNIFICANT_COVERAGE) or precip:
         category = "wet"
-    elif any(_enum_val(_attr(cl, "coverage", None)) in _PARTLY_COVERAGE for cl in layers):
+    elif _covers(level_hpa, _PARTLY_COVERAGE):
         category = "partly"
     else:
         category = "dry"
@@ -201,7 +204,7 @@ def _persistence(source, model, lat, lon, level_hpa, eta_hour, gradient_min):
     avail = set(source.available_hours(model))
     if not avail:
         return None
-    stride = source.stride_hours or 3
+    stride = getattr(source, "stride_hours", None) or 3
     li = int(np.argmin(np.abs(source.lat - lat)))
     lj = int(np.argmin(np.abs(source.lon - lon)))
     hits = tot = 0

--- a/src/weatherbrief/tasks/fronts.py
+++ b/src/weatherbrief/tasks/fronts.py
@@ -27,6 +27,7 @@ acceptable for the smooth advective fields.
 
 from __future__ import annotations
 
+import dataclasses
 import logging
 from datetime import datetime, timezone
 from pathlib import Path
@@ -117,6 +118,107 @@ def _cumulative_km(waypoints: Sequence[tuple[float, float]]) -> list[float]:
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# Relevance enrichment — co-location (is the boundary "wet"?) + persistence
+# (does the gate hold over time, or flicker?). These turn a bare θe zero-crossing
+# into something gradeable: a dry, flickering crossing (orographic artifact, e.g.
+# the 2026-05-31 Alpine case) is demoted; a wet/convective, persistent one (the
+# Dijon cold front the same day) is kept. The θe boundary's *level* is not the
+# weather's *level* — weather_top_ft is the cloud/convective top a pilot meets,
+# so an overflown front with towering convection still reads as relevant.
+# ---------------------------------------------------------------------------
+
+_SIGNIFICANT_COVERAGE = {"bkn", "ovc"}
+_PARTLY_COVERAGE = {"few", "sct"}
+_CONVECTIVE_RISK = {"moderate", "high", "extreme"}
+_PERSIST_OFFSETS_H = (-6, -3, 0, 3, 6)
+
+
+def _attr(obj, name, default=None):
+    """getattr/dict-get that tolerates pydantic objects or raw dicts (or None)."""
+    if obj is None:
+        return default
+    if isinstance(obj, dict):
+        return obj.get(name, default)
+    return getattr(obj, name, default)
+
+
+def _enum_val(x):
+    return getattr(x, "value", x)
+
+
+def _colocate(analyses, model: str, dist_km: float, level_hpa: int):
+    """Weather co-located with a crossing → (category, weather_top_ft).
+
+    category ∈ {"dry","partly","wet","convective"}; ``(None, None)`` when the
+    per-model column for this point/model isn't available (degrade gracefully).
+    """
+    if not analyses:
+        return None, None
+    nm = dist_km / 1.852
+    a = min(analyses, key=lambda x: abs((_attr(x, "distance_from_origin_nm", 0.0) or 0.0) - nm))
+    sounding = _attr(a, "sounding", None) or {}
+    s = sounding.get(model) if hasattr(sounding, "get") else None
+    if s is None:
+        return None, None
+    layers = _attr(s, "cloud_layers", None) or []
+    conv = _attr(s, "convective", None)
+    risk = _enum_val(_attr(conv, "risk_level", None)) if conv is not None else None
+
+    cloud_top = max((_attr(cl, "top_ft", None) or 0.0 for cl in layers), default=0.0)
+    conv_top = None
+    if conv is not None:
+        conv_top = _attr(conv, "top_ft", None) or _attr(conv, "el_altitude_ft", None)
+    tops = [v for v in (cloud_top or None, conv_top) if v]
+    weather_top_ft = float(max(tops)) if tops else None
+
+    def _covers(level: int) -> bool:
+        for cl in layers:
+            bp, tp = _attr(cl, "base_pressure_hpa", None), _attr(cl, "top_pressure_hpa", None)
+            if bp and tp and tp <= level <= bp and _enum_val(_attr(cl, "coverage", None)) in _SIGNIFICANT_COVERAGE:
+                return True
+        return False
+
+    precip_obj = _attr(s, "precipitation", None)
+    precip = precip_obj is not None and _enum_val(_attr(precip_obj, "surface_intensity", "none")) != "none"
+
+    if risk in _CONVECTIVE_RISK:
+        category = "convective"
+    elif _covers(level_hpa) or precip:
+        category = "wet"
+    elif any(_enum_val(_attr(cl, "coverage", None)) in _PARTLY_COVERAGE for cl in layers):
+        category = "partly"
+    else:
+        category = "dry"
+    return category, weather_top_ft
+
+
+def _persistence(source, model, lat, lon, level_hpa, eta_hour, gradient_min):
+    """Fraction of ±window frames where the gated gradient holds at the cell.
+
+    A real front persists; an orographic/grid artifact flickers. ``None`` when
+    no frames are samplable (e.g. single-timestep historical snapshot)."""
+    avail = set(source.available_hours(model))
+    if not avail:
+        return None
+    stride = source.stride_hours or 3
+    li = int(np.argmin(np.abs(source.lat - lat)))
+    lj = int(np.argmin(np.abs(source.lon - lon)))
+    hits = tot = 0
+    for dh in _PERSIST_OFFSETS_H:
+        h = int(round((eta_hour + dh) / stride) * stride)
+        if h not in avail:
+            continue
+        g = source.gradient_at_hour(model, h, level_hpa)
+        if g is None:
+            continue
+        tot += 1
+        v = g[li, lj]
+        if np.isfinite(v) and v >= gradient_min:
+            hits += 1
+    return (hits / tot) if tot else None
+
+
 def _analyze_one(
     source: SnapshotFieldSource,
     model: str,
@@ -124,6 +226,7 @@ def _analyze_one(
     eta_hours: list[float],
     mid_hour: float,
     config: FrontGateConfig,
+    analyses=None,
 ) -> RouteFrontAnalysis:
     """Detect fronts for one model/level.
 
@@ -152,6 +255,21 @@ def _analyze_one(
     decisions = apply_gate_config(candidates, config)
     crossings = decisions_to_crossings(decisions, config.merge_km)
 
+    # Attach relevance enrichment: each crossing is sampled at its own ETA
+    # (consistent with the per-point time-march above).
+    if crossings:
+        enriched = []
+        for c in crossings:
+            eta_h = float(np.interp(c.distance_km, dense_cum, dense_hours))
+            co_loc, weather_top = _colocate(analyses, model, c.distance_km, config.level_hPa)
+            pers = _persistence(
+                source, model, c.lat, c.lon, config.level_hPa, eta_h, config.gradient_min,
+            )
+            enriched.append(dataclasses.replace(
+                c, co_location=co_loc, weather_top_ft=weather_top, persistence=pers,
+            ))
+        crossings = enriched
+
     nearest = find_nearby_fronts(source, model, waypoints, mid_hour, config=config)
     return RouteFrontAnalysis(
         model=model, hour=float(mid_hour), crossings=crossings, nearest=nearest,
@@ -176,6 +294,8 @@ def _to_analysis_model(a: RouteFrontAnalysis) -> RouteFrontAnalysisModel:
                 advection=c.advection, tfp_before=c.tfp_before,
                 tfp_after=c.tfp_after, delta_theta_e=c.delta_theta_e,
                 kind=c.kind, intensity=c.intensity,
+                co_location=c.co_location, weather_top_ft=c.weather_top_ft,
+                persistence=c.persistence,
             )
             for c in a.crossings
         ],
@@ -217,8 +337,15 @@ def compute_route_fronts(
     gate_preset: str = "default",
     output_dir: Path | None = None,
     now: datetime | None = None,
+    route_point_analyses=None,
 ) -> RouteFrontsManifest:
-    """Build the :class:`RouteFrontsManifest` (no I/O). Shared by both surfaces."""
+    """Build the :class:`RouteFrontsManifest` (no I/O). Shared by both surfaces.
+
+    ``route_point_analyses`` (the per-model sounding column along the route) is
+    optional; when present, crossings are enriched with cloud/convection
+    co-location so the advisory and cross-section can gate on weather, not just
+    the θe gradient.
+    """
     from weatherbrief.frontal.gates import get_preset
 
     now = now or datetime.now(timezone.utc)
@@ -283,6 +410,7 @@ def compute_route_fronts(
             try:
                 result = _analyze_one(
                     source, model, waypoints, eta_hours, mid_hour, cfg,
+                    analyses=route_point_analyses,
                 )
             except Exception:
                 logger.warning(
@@ -355,7 +483,7 @@ def run_fronts(
         waypoints, etas,
         route_name=route_name, cruise_altitude_ft=cruise_altitude_ft,
         advisory_models=advisory_models, gate_preset=gate_preset,
-        output_dir=output_dir,
+        output_dir=output_dir, route_point_analyses=route_point_analyses,
     )
     if pack_dir is not None:
         from weatherbrief.tasks.artifacts import save_front_artifacts
@@ -407,6 +535,7 @@ def run_fronts_from_pack(
         waypoints, etas,
         route_name=manifest_in.route_name, cruise_altitude_ft=cruise,
         advisory_models=models, gate_preset=gate_preset, output_dir=output_dir,
+        route_point_analyses=manifest_in.analyses,
     )
     from weatherbrief.tasks.artifacts import save_front_artifacts
 

--- a/tests/analysis/advisories/test_fronts_advisory.py
+++ b/tests/analysis/advisories/test_fronts_advisory.py
@@ -157,8 +157,10 @@ def test_multiple_crossings_picks_worst_and_counts():
 
 
 def test_grades_fronts_at_non_primary_level():
-    """A front below cruise (non-primary level) still grades — the Dijon
-    false-GREEN fix. Primary 850 is empty; a sharp 700 crossing must still RED."""
+    """A front at a NON-PRIMARY level still grades — the Dijon false-GREEN fix.
+    Here the primary 850 hPa is empty and the sharp crossing is at 700 hPa
+    (~10,000 ft, ABOVE 850); it must still RED. The below-cruise case (a 925 hPa
+    front overflown) is covered by test_sharp_front_below_flight_capped_to_amber."""
     a700 = RouteFrontAnalysisModel(
         model="gfs", level_hPa=700, hour=12.0,
         crossings=[_crossing(intensity="sharp", gradient=14.0)],

--- a/tests/analysis/advisories/test_fronts_advisory.py
+++ b/tests/analysis/advisories/test_fronts_advisory.py
@@ -220,6 +220,41 @@ def test_convective_reaching_flight_is_red_with_tail():
     assert "fl330" in result.aggregate_detail.lower()
 
 
+def test_sharp_front_below_flight_capped_to_amber():
+    """A sharp wet front whose core sits BELOW cruise is overflown → AMBER, not
+    RED (the Dijon FL100-over-a-925-hPa-front fix). Flight high (primary 700),
+    sharp crossing at 925."""
+    a925 = RouteFrontAnalysisModel(
+        model="gfs", level_hPa=925, hour=12.0,
+        crossings=[_crossing(intensity="sharp", gradient=14.0, co_location="wet",
+                             weather_top_ft=30000.0, persistence=0.8)],
+    )
+    manifest = RouteFrontsManifest(
+        generated_at=datetime(2026, 5, 31, tzinfo=timezone.utc),
+        primary_level_hPa=700, levels=[700, 925], models=["gfs"],
+        per_model={"gfs": [a925]},
+    )
+    ctx = RouteContext(
+        analyses=[], cross_sections=[], elevation=None, models=["gfs"],
+        cruise_altitude_ft=10000, flight_ceiling_ft=18000, total_distance_nm=200.0,
+        route_fronts=manifest,
+    )
+    assert FrontsEvaluator.evaluate(ctx, _PARAMS).aggregate_status == AdvisoryStatus.AMBER
+
+
+def test_shallow_convective_is_amber_deep_is_red():
+    """Convective tops just above cruise → AMBER (isolated build-ups); deep
+    towers → RED. cruise=8000, convective_deep_ft=15000 → RED at >= FL230."""
+    shallow = _manifest(crossings=[_crossing(
+        kind="warm", co_location="convective", weather_top_ft=18000.0, persistence=0.8,
+    )])
+    assert FrontsEvaluator.evaluate(_ctx(shallow), _PARAMS).aggregate_status == AdvisoryStatus.AMBER
+    deep = _manifest(crossings=[_crossing(
+        kind="warm", co_location="convective", weather_top_ft=33000.0, persistence=0.8,
+    )])
+    assert FrontsEvaluator.evaluate(_ctx(deep), _PARAMS).aggregate_status == AdvisoryStatus.RED
+
+
 def test_wet_sharp_reaching_is_red_classical_is_amber():
     red = _manifest(crossings=[_crossing(
         intensity="sharp", co_location="wet", weather_top_ft=20000.0, persistence=0.8,

--- a/tests/analysis/advisories/test_fronts_advisory.py
+++ b/tests/analysis/advisories/test_fronts_advisory.py
@@ -27,12 +27,16 @@ def _crossing(
     intensity: str = "classical",
     advection: float = 0.0,
     gradient: float = 9.0,
+    co_location: str | None = None,
+    weather_top_ft: float | None = None,
+    persistence: float | None = None,
 ) -> FrontCrossingModel:
     return FrontCrossingModel(
         lat=48.0, lon=2.0, distance_km=distance_km,
         gradient=gradient, neg_laplacian=1.0, advection=advection,
         tfp_before=0.5, tfp_after=-0.5, delta_theta_e=8.0,
         kind=kind, intensity=intensity,
+        co_location=co_location, weather_top_ft=weather_top_ft, persistence=persistence,
     )
 
 
@@ -152,8 +156,9 @@ def test_multiple_crossings_picks_worst_and_counts():
     assert "2" in result.aggregate_detail  # count surfaced
 
 
-def test_matches_primary_level_not_position():
-    """Analyses are matched by level_hPa, not list order."""
+def test_grades_fronts_at_non_primary_level():
+    """A front below cruise (non-primary level) still grades — the Dijon
+    false-GREEN fix. Primary 850 is empty; a sharp 700 crossing must still RED."""
     a700 = RouteFrontAnalysisModel(
         model="gfs", level_hPa=700, hour=12.0,
         crossings=[_crossing(intensity="sharp", gradient=14.0)],
@@ -164,11 +169,66 @@ def test_matches_primary_level_not_position():
     manifest = RouteFrontsManifest(
         generated_at=datetime(2026, 5, 31, tzinfo=timezone.utc),
         primary_level_hPa=850, levels=[700, 850], models=["gfs"],
-        per_model={"gfs": [a700, a850]},  # 700 first on purpose
+        per_model={"gfs": [a700, a850]},
     )
     result = FrontsEvaluator.evaluate(_ctx(manifest), _PARAMS)
-    # Must grade the 850 (primary) analysis → GREEN, ignoring the sharp 700.
+    assert result.aggregate_status == AdvisoryStatus.RED
+
+
+# --- Relevance gating: co-location + persistence + flight-band (the Alpine
+# false-RED / Dijon false-GREEN fixes). cruise=8000 ft, buffer=2000 → weather
+# is "relevant" when its top reaches >= 6000 ft.
+
+def test_dry_boundary_demoted_to_green():
+    """A sharp but DRY boundary (clear air) is a wind-shift only → GREEN
+    (the Alpine orographic false-RED fix)."""
+    manifest = _manifest(crossings=[_crossing(
+        intensity="sharp", gradient=18.0, co_location="dry", weather_top_ft=None,
+    )])
+    result = FrontsEvaluator.evaluate(_ctx(manifest), _PARAMS)
     assert result.aggregate_status == AdvisoryStatus.GREEN
+    assert "boundary" in result.aggregate_detail.lower()
+
+
+def test_flickering_crossing_demoted_to_green():
+    """Low persistence → likely artifact → GREEN even if wet+sharp."""
+    manifest = _manifest(crossings=[_crossing(
+        intensity="sharp", gradient=18.0, co_location="wet",
+        weather_top_ft=30000.0, persistence=0.2,
+    )])
+    result = FrontsEvaluator.evaluate(_ctx(manifest), _PARAMS)
+    assert result.aggregate_status == AdvisoryStatus.GREEN
+
+
+def test_weather_below_flight_is_green():
+    """Wet boundary but its cloud tops out below cruise → overflown → GREEN."""
+    manifest = _manifest(crossings=[_crossing(
+        intensity="sharp", co_location="wet", weather_top_ft=3000.0, persistence=0.8,
+    )])
+    result = FrontsEvaluator.evaluate(_ctx(manifest), _PARAMS)
+    assert result.aggregate_status == AdvisoryStatus.GREEN
+
+
+def test_convective_reaching_flight_is_red_with_tail():
+    """Convective tops through/above the flight band → RED + towers tail."""
+    manifest = _manifest(crossings=[_crossing(
+        kind="warm", intensity="classical", co_location="convective",
+        weather_top_ft=33000.0, persistence=0.8,
+    )])
+    result = FrontsEvaluator.evaluate(_ctx(manifest), _PARAMS)
+    assert result.aggregate_status == AdvisoryStatus.RED
+    assert "fl330" in result.aggregate_detail.lower()
+
+
+def test_wet_sharp_reaching_is_red_classical_is_amber():
+    red = _manifest(crossings=[_crossing(
+        intensity="sharp", co_location="wet", weather_top_ft=20000.0, persistence=0.8,
+    )])
+    assert FrontsEvaluator.evaluate(_ctx(red), _PARAMS).aggregate_status == AdvisoryStatus.RED
+    amber = _manifest(crossings=[_crossing(
+        intensity="classical", co_location="wet", weather_top_ft=20000.0, persistence=0.8,
+    )])
+    assert FrontsEvaluator.evaluate(_ctx(amber), _PARAMS).aggregate_status == AdvisoryStatus.AMBER
 
 
 def test_default_disabled_in_catalog():

--- a/tests/test_tasks_fronts.py
+++ b/tests/test_tasks_fronts.py
@@ -11,6 +11,8 @@ import pytest
 from weatherbrief.models import RoutePointAnalysis
 from weatherbrief.tasks.artifacts import load_route_fronts
 from weatherbrief.tasks.fronts import (
+    _colocate,
+    _persistence,
     compute_route_fronts,
     nearest_cruise_level,
     run_fronts,
@@ -84,6 +86,68 @@ def _route_analyses():
             forecast_hour=6 + i, track_deg=90.0,
         ))
     return out
+
+
+class TestColocate:
+    """Cloud/convection co-location classification (the wet/dry/convective gate)."""
+
+    @staticmethod
+    def _an(cloud_layers, convective, precip=None):
+        return [{
+            "distance_from_origin_nm": 0.0,
+            "sounding": {"ecmwf": {
+                "cloud_layers": cloud_layers,
+                "convective": convective,
+                "precipitation": precip,
+            }},
+        }]
+
+    def test_dry_blue_sky(self):
+        # No cloud, low convection → demote (the Alpine-artifact case).
+        assert _colocate(self._an([], {"risk_level": "low"}), "ecmwf", 0.0, 850) == ("dry", None)
+
+    def test_wet_cloud_spans_level(self):
+        cl = [{"top_ft": 18000.0, "base_pressure_hpa": 900, "top_pressure_hpa": 700, "coverage": "ovc"}]
+        cat, top = _colocate(self._an(cl, {"risk_level": "none"}), "ecmwf", 0.0, 850)
+        assert cat == "wet" and top == 18000.0
+
+    def test_convective_uses_el_for_vertical_extent(self):
+        # Overflown boundary but convective towers far above (the Dijon case):
+        # weather_top must reflect the convective EL, not the shallow cloud layer.
+        cl = [{"top_ft": 9000.0, "base_pressure_hpa": 900, "top_pressure_hpa": 850, "coverage": "sct"}]
+        conv = {"risk_level": "moderate", "el_altitude_ft": 33000.0}
+        cat, top = _colocate(self._an(cl, conv), "ecmwf", 0.0, 850)
+        assert cat == "convective" and top == 33000.0
+
+    def test_missing_model_degrades_gracefully(self):
+        assert _colocate(self._an([], {"risk_level": "low"}), "gfs", 0.0, 850) == (None, None)
+
+
+class _StubSource:
+    """Minimal SnapshotFieldSource stand-in for persistence testing."""
+
+    def __init__(self, grid_by_hour, stride=3):
+        self.lat = np.array([47.0])
+        self.lon = np.array([0.0])
+        self.stride_hours = stride
+        self._g = grid_by_hour
+
+    def available_hours(self, model):
+        return sorted(self._g)
+
+    def gradient_at_hour(self, model, hour, level):
+        return self._g.get(hour)
+
+
+class TestPersistence:
+    def test_fraction_over_window(self):
+        # eta_hour=3, offsets ±6/3/0 → hours -3,0,3,6,9; only {0,3,6} exist.
+        g = {0: np.array([[10.0]]), 3: np.array([[2.0]]), 6: np.array([[10.0]])}
+        p = _persistence(_StubSource(g), "ecmwf", 47.0, 0.0, 850, eta_hour=3.0, gradient_min=6.0)
+        assert abs(p - 2 / 3) < 1e-6  # 0h & 6h hold (10≥6), 3h does not (2<6)
+
+    def test_none_when_no_frames(self):
+        assert _persistence(_StubSource({}), "ecmwf", 47.0, 0.0, 850, 3.0, 6.0) is None
 
 
 class TestNearestCruiseLevel:

--- a/tests/test_tasks_fronts.py
+++ b/tests/test_tasks_fronts.py
@@ -119,6 +119,18 @@ class TestColocate:
         cat, top = _colocate(self._an(cl, conv), "ecmwf", 0.0, 850)
         assert cat == "convective" and top == 33000.0
 
+    def test_partly_cloud_at_level_is_partly(self):
+        cl = [{"top_ft": 12000.0, "base_pressure_hpa": 900, "top_pressure_hpa": 700, "coverage": "sct"}]
+        cat, _ = _colocate(self._an(cl, {"risk_level": "none"}), "ecmwf", 0.0, 850)
+        assert cat == "partly"
+
+    def test_high_cirrus_unrelated_to_front_is_dry(self):
+        # few/sct cirrus at 300 hPa does NOT span an 850 hPa front → dry, not
+        # "partly" (the false-AMBER the level-gate prevents).
+        cl = [{"top_ft": 38000.0, "base_pressure_hpa": 300, "top_pressure_hpa": 250, "coverage": "sct"}]
+        cat, _ = _colocate(self._an(cl, {"risk_level": "none"}), "ecmwf", 0.0, 850)
+        assert cat == "dry"
+
     def test_missing_model_degrades_gracefully(self):
         assert _colocate(self._an([], {"risk_level": "low"}), "gfs", 0.0, 850) == (None, None)
 

--- a/tests/test_tasks_fronts.py
+++ b/tests/test_tasks_fronts.py
@@ -131,6 +131,18 @@ class TestColocate:
         cat, _ = _colocate(self._an(cl, {"risk_level": "none"}), "ecmwf", 0.0, 850)
         assert cat == "dry"
 
+    def test_weather_top_excludes_unrelated_cirrus(self):
+        # Low OVC spanning an 850 hPa front (top 12000) + unrelated cirrus at
+        # 300 hPa (top 38000). Category is "wet" from the OVC; weather_top must
+        # come from the spanning layer only — else the cirrus false-AMBERs a
+        # front that's well below cruise (PR #200 review finding #1).
+        cl = [
+            {"top_ft": 12000.0, "base_pressure_hpa": 900, "top_pressure_hpa": 700, "coverage": "ovc"},
+            {"top_ft": 38000.0, "base_pressure_hpa": 300, "top_pressure_hpa": 250, "coverage": "sct"},
+        ]
+        cat, top = _colocate(self._an(cl, {"risk_level": "none"}), "ecmwf", 0.0, 850)
+        assert cat == "wet" and top == 12000.0
+
     def test_missing_model_degrades_gracefully(self):
         assert _colocate(self._an([], {"risk_level": "low"}), "gfs", 0.0, 850) == (None, None)
 

--- a/web/tests/unit/layer-registry.test.ts
+++ b/web/tests/unit/layer-registry.test.ts
@@ -154,6 +154,18 @@ describe('getLayerGroups', () => {
       expect(g.layers.length).toBeGreaterThan(0);
     }
   });
+
+  it("'fronts' and 'conditions' stay single-layer (HIDE_GROUP_WHEN_UNAVAILABLE assumption)", () => {
+    // panel.ts hides these whole groups when their lone layer is unavailable,
+    // assuming each has exactly ONE layer. If a second layer is added here it
+    // would be silently hidden — gate per-layer in panel.ts instead.
+    const groups = getLayerGroups();
+    for (const id of ['fronts', 'conditions'] as const) {
+      const grp = groups.find((g) => g.group === id);
+      expect(grp, `group ${id} not registered`).toBeDefined();
+      expect(grp!.layers.length, `group ${id} must stay single-layer`).toBe(1);
+    }
+  });
 });
 
 describe('presets', () => {

--- a/web/ts/helpers/fronts-info.ts
+++ b/web/ts/helpers/fronts-info.ts
@@ -1,0 +1,102 @@
+/** Info-popup content for the experimental cross-section "Fronts" layer.
+ *
+ * Fronts are a hard concept, so this is layered: a plain-language explanation
+ * first, then how relevance is judged, then the actual Hewson maths for advanced
+ * users — plus references and an AI-discussion seed. Returned as an HTML string
+ * for showPopupContent() (components/info-popup.ts), reusing the same popup CSS
+ * classes as the metric / synoptic-Hewson popups. English-only, matching the
+ * other rich info catalogs (data/hewson-metrics-catalog.ts, metrics-helper.ts).
+ */
+
+function escapeAttr(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/"/g, '&quot;');
+}
+
+const NAME = 'Front detection (experimental)';
+
+// Fits the "… In particular, {llm_prompt}." template in info-popup.ts.
+const LLM_PROMPT =
+  'explain in practical flying terms what an equivalent-potential-temperature '
+  + '(θe) front is and what crossing one means for a light aircraft; how to read '
+  + 'cold vs warm vs quasi-stationary crossings; why ECMWF, GFS and ICON can '
+  + 'disagree about the same boundary; and the method’s blind spots — orographic '
+  + 'θe gradients over mountains that masquerade as fronts, dry boundaries that '
+  + 'carry no weather, and that an 850 hPa θe field cannot see low cloud or fog';
+
+export function renderFrontsInfo(): string {
+  return `
+    <div class="popup-header">
+      <h3>${NAME}</h3>
+      <p class="popup-vibe">Where your route crosses the boundary between two different air masses — and whether that boundary actually carries weather.</p>
+    </div>
+    <div class="popup-body">
+
+      <div class="popup-section">
+        <h4>In plain terms</h4>
+        <p>A front is the edge between two air masses — say warm, humid air ahead and cooler, drier air behind. Crossing one you might meet a wind shift, a band of cloud or showers, some turbulence, or — if the air is unstable — towering build-ups. This overlay marks, for each model, the point along your route where your track crosses such a boundary.</p>
+      </div>
+
+      <div class="popup-section">
+        <h4>Reading the markers</h4>
+        <p>A vertical line on the cross-section sits at the crossing point along the route, drawn at the level nearest your cruise. Its colour is the type:</p>
+        <ul>
+          <li><strong>Cold</strong> — colder air advancing; often a sharper, showery, gusty transition that clears behind.</li>
+          <li><strong>Warm</strong> — warmer, moister air overrunning; lowering cloud and more persistent rain ahead of it.</li>
+          <li><strong>Quasi-stationary</strong> — little movement; weather lingers near the boundary.</li>
+        </ul>
+      </div>
+
+      <div class="popup-section">
+        <h4>How we judge whether it matters</h4>
+        <p>Not every air-mass boundary brings weather, so a bare crossing isn’t graded on its own. We read the same model’s cloud and convection <em>at the crossing</em>, shown in the cross-section beneath the line:</p>
+        <ul>
+          <li><strong>Dry</strong> boundary (clear air) → essentially just a wind shift.</li>
+          <li><strong>Wet</strong> boundary (cloud / precipitation) → expect a band of IMC, rain, and shear.</li>
+          <li><strong>Convective</strong> boundary → build-ups that can tower <em>far above</em> the boundary, so a front you overfly can still matter.</li>
+        </ul>
+        <p>We also check the boundary <strong>persists</strong> over a few hours and whether the models <strong>agree</strong>: a flickering, single-model boundary sitting over high terrain is usually an orographic artifact, not a real front.</p>
+      </div>
+
+      <div class="popup-section">
+        <h4>How it’s calculated <span class="popup-unit">(for the curious)</span></h4>
+        <p>This is the <strong>Hewson (1998) objective-front</strong> method restricted to your route. It works on <strong>equivalent potential temperature θe</strong> — a single quantity that bundles temperature and humidity, so it tracks air masses better than temperature alone.</p>
+        <ul>
+          <li>The <strong>front axis</strong> is the zero line of the <strong>Thermal Front Parameter (TFP)</strong> — the locus where the θe gradient is sharpest (a <em>position</em> indicator, not a tendency).</li>
+          <li>A crossing is kept only if both the gradient magnitude <code>|∇θe|</code> <em>and</em> the air-mass jump <code>Δθe</code> across it are strong enough — weak or dry gradients, and gradient “cols”, are rejected.</li>
+          <li>Cold vs warm comes from the <strong>advection</strong> sign <code>−V·∇θe</code>; intensity (significant / classical / sharp) from <code>|∇θe|</code>.</li>
+          <li>Fields are precomputed at <strong>925 / 850 / 700 hPa</strong> from ECMWF, GFS and ICON, then sampled along your route <em>at each waypoint’s ETA</em> — so a moving front is placed where and when you actually meet it.</li>
+        </ul>
+      </div>
+
+      <div class="popup-section popup-limitations">
+        <h4>Limitations</h4>
+        <ul>
+          <li>A <strong>free-atmosphere</strong> signal: an 850 hPa θe field does not see low stratus or fog — that stays METAR/TAF territory.</li>
+          <li>Position ±50–100 km, timing ±1–2 h; treat it qualitatively.</li>
+          <li>Models disagree, and <strong>orographic</strong> θe gradients over mountains can masquerade as quasi-stationary “fronts”.</li>
+          <li><strong>Advisory only</strong> — not an official SIGWX / SIGMET product.</li>
+        </ul>
+      </div>
+
+      <div class="popup-section popup-learn-more">
+        <a href="https://en.wikipedia.org/wiki/Weather_front" target="_blank" rel="noopener noreferrer">Weather fronts on Wikipedia ↗</a>
+        &nbsp;·&nbsp;
+        <a href="https://en.wikipedia.org/wiki/Equivalent_potential_temperature" target="_blank" rel="noopener noreferrer">Equivalent potential temperature ↗</a>
+        <p style="margin:0.4rem 0 0;font-size:0.85em;opacity:0.8">Method: Hewson, T. D. (1998), “Objective fronts”, <em>Meteorological Applications</em> 5(1), 37–65. There is no dedicated Wikipedia page for the Hewson method; the links above cover the underlying concepts.</p>
+      </div>
+
+      <div class="popup-section popup-discuss-ai" data-metric-name="${escapeAttr(NAME)}" data-llm-prompt="${escapeAttr(LLM_PROMPT)}">
+        <div class="popup-discuss-header">
+          <span class="popup-discuss-label">Discuss with AI</span>
+          <span class="popup-discuss-hint">A prompt is copied to clipboard — just paste it in the new chat</span>
+        </div>
+        <div class="popup-discuss-buttons">
+          <a href="https://claude.ai/new" target="_blank" rel="noopener noreferrer" class="popup-ai-btn popup-ai-claude" data-ai="claude">Claude</a>
+          <a href="https://chatgpt.com/" target="_blank" rel="noopener noreferrer" class="popup-ai-btn popup-ai-chatgpt" data-ai="chatgpt">ChatGPT</a>
+          <a href="https://gemini.google.com/app" target="_blank" rel="noopener noreferrer" class="popup-ai-btn popup-ai-gemini" data-ai="gemini">Gemini</a>
+        </div>
+        <div class="popup-discuss-toast" hidden>Prompt copied! Paste it into the chat.</div>
+      </div>
+    </div>
+  `;
+}

--- a/web/ts/helpers/fronts-info.ts
+++ b/web/ts/helpers/fronts-info.ts
@@ -14,14 +14,22 @@ function escapeAttr(s: string): string {
 
 const NAME = 'Front detection (experimental)';
 
-// Fits the "… In particular, {llm_prompt}." template in info-popup.ts.
+// The AI-discussion subject is the *meteorological method*, not our feature
+// label — "(experimental)" is about our code, irrelevant to the chat. Naming
+// Hewson + TFP + θe points the model straight at the right technique. This
+// fills the "Tell me more about {metric} …" slot in info-popup.ts.
+const AI_TOPIC =
+  'the Hewson Thermal Front Parameter (TFP) method for locating fronts from '
+  + 'equivalent potential temperature (θe)';
+
+// Fits the "… In particular, {llm_prompt}." continuation.
 const LLM_PROMPT =
-  'explain in practical flying terms what an equivalent-potential-temperature '
-  + '(θe) front is and what crossing one means for a light aircraft; how to read '
-  + 'cold vs warm vs quasi-stationary crossings; why ECMWF, GFS and ICON can '
-  + 'disagree about the same boundary; and the method’s blind spots — orographic '
-  + 'θe gradients over mountains that masquerade as fronts, dry boundaries that '
-  + 'carry no weather, and that an 850 hPa θe field cannot see low cloud or fog';
+  'explain in practical flying terms what crossing such a front means for a '
+  + 'light aircraft; how to read cold vs warm vs quasi-stationary crossings; '
+  + 'why ECMWF, GFS and ICON can disagree about the same boundary; and the '
+  + 'method’s blind spots — orographic θe gradients over mountains that '
+  + 'masquerade as fronts, dry boundaries that carry no weather, and that an '
+  + '850 hPa θe field cannot see low cloud or fog';
 
 export function renderFrontsInfo(): string {
   return `
@@ -85,7 +93,7 @@ export function renderFrontsInfo(): string {
         <p style="margin:0.4rem 0 0;font-size:0.85em;opacity:0.8">Method: Hewson, T. D. (1998), “Objective fronts”, <em>Meteorological Applications</em> 5(1), 37–65. There is no dedicated Wikipedia page for the Hewson method; the links above cover the underlying concepts.</p>
       </div>
 
-      <div class="popup-section popup-discuss-ai" data-metric-name="${escapeAttr(NAME)}" data-llm-prompt="${escapeAttr(LLM_PROMPT)}">
+      <div class="popup-section popup-discuss-ai" data-metric-name="${escapeAttr(AI_TOPIC)}" data-llm-prompt="${escapeAttr(LLM_PROMPT)}">
         <div class="popup-discuss-header">
           <span class="popup-discuss-label">Discuss with AI</span>
           <span class="popup-discuss-hint">A prompt is copied to clipboard — just paste it in the new chat</span>

--- a/web/ts/helpers/fronts-info.ts
+++ b/web/ts/helpers/fronts-info.ts
@@ -9,7 +9,7 @@
  */
 
 function escapeAttr(s: string): string {
-  return s.replace(/&/g, '&amp;').replace(/"/g, '&quot;');
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
 }
 
 const NAME = 'Front detection (experimental)';

--- a/web/ts/i18n/locales/de.json
+++ b/web/ts/i18n/locales/de.json
@@ -441,6 +441,8 @@
   "viz.layer.cruise-altitude": "Reiseflughöhe / Gipfelhöhe",
   "viz.layer.surface-obscuration-bands": "Bodensichttrübung",
   "viz.layer.current-conditions": "Aktuelle Bedingungen",
+  "viz.layer.fronts-markers": "Fronten (experimentell)",
+  "viz.frontsInfo": "<strong>Fronten (experimentell)</strong><br>Luftmassengrenzen (Hewson \u03b8e), die Ihre Route kreuzt \u2014 eine Markierung pro Modell dort, wo Sie eine Front \u00fcberqueren; die Farbe zeigt den Typ (Kalt- / Warm- / quasistation\u00e4re Front).<br><br>Die Relevanz ergibt sich aus dem Wetter an der Grenze, unten im Querschnitt dargestellt: eine trockene Grenze ist nur ein Winddreher, w\u00e4hrend feuchte oder konvektive Grenzen Wolken, Niederschlag und Scherung bringen k\u00f6nnen \u2014 und konvektive Fronten k\u00f6nnen Aufbauten weit \u00fcber die Grenze hinaus erzeugen, sodass eine \u00fcberflogene Front trotzdem relevant sein kann.<br><br>Nur als Hinweis \u2014 kein offizielles SIGWX und ein Signal der freien Atmosph\u00e4re, das tiefe Bew\u00f6lkung oder Nebel nicht erfasst.",
   "viz.group.terrain": "Gelände",
   "viz.group.temperature": "Temperatur",
   "viz.group.clouds": "Wolken",

--- a/web/ts/i18n/locales/de.json
+++ b/web/ts/i18n/locales/de.json
@@ -441,7 +441,7 @@
   "viz.layer.cruise-altitude": "Reiseflughöhe / Gipfelhöhe",
   "viz.layer.surface-obscuration-bands": "Bodensichttrübung",
   "viz.layer.current-conditions": "Aktuelle Bedingungen",
-  "viz.layer.fronts-markers": "Fronten (experimentell)",
+  "viz.layer.fronts-markers": "Luftmassengrenze",
   "viz.group.terrain": "Gelände",
   "viz.group.temperature": "Temperatur",
   "viz.group.clouds": "Wolken",

--- a/web/ts/i18n/locales/de.json
+++ b/web/ts/i18n/locales/de.json
@@ -442,7 +442,6 @@
   "viz.layer.surface-obscuration-bands": "Bodensichttrübung",
   "viz.layer.current-conditions": "Aktuelle Bedingungen",
   "viz.layer.fronts-markers": "Fronten (experimentell)",
-  "viz.frontsInfo": "<strong>Fronten (experimentell)</strong><br>Luftmassengrenzen (Hewson \u03b8e), die Ihre Route kreuzt \u2014 eine Markierung pro Modell dort, wo Sie eine Front \u00fcberqueren; die Farbe zeigt den Typ (Kalt- / Warm- / quasistation\u00e4re Front).<br><br>Die Relevanz ergibt sich aus dem Wetter an der Grenze, unten im Querschnitt dargestellt: eine trockene Grenze ist nur ein Winddreher, w\u00e4hrend feuchte oder konvektive Grenzen Wolken, Niederschlag und Scherung bringen k\u00f6nnen \u2014 und konvektive Fronten k\u00f6nnen Aufbauten weit \u00fcber die Grenze hinaus erzeugen, sodass eine \u00fcberflogene Front trotzdem relevant sein kann.<br><br>Nur als Hinweis \u2014 kein offizielles SIGWX und ein Signal der freien Atmosph\u00e4re, das tiefe Bew\u00f6lkung oder Nebel nicht erfasst.",
   "viz.group.terrain": "Gelände",
   "viz.group.temperature": "Temperatur",
   "viz.group.clouds": "Wolken",

--- a/web/ts/i18n/locales/en.json
+++ b/web/ts/i18n/locales/en.json
@@ -526,7 +526,7 @@
   "viz.layer.cruise-altitude": "Cruise / Ceiling",
   "viz.layer.surface-obscuration-bands": "Surface obscuration",
   "viz.layer.current-conditions": "Current conditions",
-  "viz.layer.fronts-markers": "Fronts (experimental)",
+  "viz.layer.fronts-markers": "Air-mass boundary",
 
   "viz.group.terrain": "Terrain",
   "viz.group.temperature": "Temperature",

--- a/web/ts/i18n/locales/en.json
+++ b/web/ts/i18n/locales/en.json
@@ -527,7 +527,6 @@
   "viz.layer.surface-obscuration-bands": "Surface obscuration",
   "viz.layer.current-conditions": "Current conditions",
   "viz.layer.fronts-markers": "Fronts (experimental)",
-  "viz.frontsInfo": "<strong>Fronts (experimental)</strong><br>Air-mass boundaries (Hewson \u03b8e) your route crosses \u2014 one marker per model where you cross a front; colour shows type (cold / warm / quasi-stationary).<br><br>Relevance is read from the weather on the boundary in the cross-section below it: a dry boundary is a wind-shift only, while wet or convective boundaries can bring cloud, precipitation and shear \u2014 and convective fronts can throw towers far above the boundary, so a front you overfly may still matter.<br><br>Advisory only \u2014 not official SIGWX, and a free-atmosphere signal that does not capture low cloud or fog.",
 
   "viz.group.terrain": "Terrain",
   "viz.group.temperature": "Temperature",

--- a/web/ts/i18n/locales/en.json
+++ b/web/ts/i18n/locales/en.json
@@ -526,6 +526,8 @@
   "viz.layer.cruise-altitude": "Cruise / Ceiling",
   "viz.layer.surface-obscuration-bands": "Surface obscuration",
   "viz.layer.current-conditions": "Current conditions",
+  "viz.layer.fronts-markers": "Fronts (experimental)",
+  "viz.frontsInfo": "<strong>Fronts (experimental)</strong><br>Air-mass boundaries (Hewson \u03b8e) your route crosses \u2014 one marker per model where you cross a front; colour shows type (cold / warm / quasi-stationary).<br><br>Relevance is read from the weather on the boundary in the cross-section below it: a dry boundary is a wind-shift only, while wet or convective boundaries can bring cloud, precipitation and shear \u2014 and convective fronts can throw towers far above the boundary, so a front you overfly may still matter.<br><br>Advisory only \u2014 not official SIGWX, and a free-atmosphere signal that does not capture low cloud or fog.",
 
   "viz.group.terrain": "Terrain",
   "viz.group.temperature": "Temperature",

--- a/web/ts/i18n/locales/es.json
+++ b/web/ts/i18n/locales/es.json
@@ -441,6 +441,8 @@
   "viz.layer.cruise-altitude": "Crucero / Techo",
   "viz.layer.surface-obscuration-bands": "Oscurecimiento de superficie",
   "viz.layer.current-conditions": "Condiciones actuales",
+  "viz.layer.fronts-markers": "Frentes (experimental)",
+  "viz.frontsInfo": "<strong>Frentes (experimental)</strong><br>L\u00edmites de masas de aire (\u03b8e de Hewson) que cruza su ruta \u2014 una marca por modelo donde cruza un frente; el color indica el tipo (fr\u00edo / c\u00e1lido / cuasiestacionario).<br><br>La relevancia se lee del tiempo en el l\u00edmite, mostrado en el corte inferior: un l\u00edmite seco es solo un cambio de viento, mientras que los l\u00edmites h\u00famedos o convectivos pueden traer nubes, precipitaci\u00f3n y cizalladura \u2014 y los frentes convectivos pueden generar desarrollos muy por encima del l\u00edmite, por lo que un frente sobrevolado puede importar igualmente.<br><br>Solo orientativo \u2014 no es un SIGWX oficial, y es una se\u00f1al de la atm\u00f3sfera libre que no capta nubes bajas ni niebla.",
   "viz.group.terrain": "Terreno",
   "viz.group.temperature": "Temperatura",
   "viz.group.clouds": "Nubes",

--- a/web/ts/i18n/locales/es.json
+++ b/web/ts/i18n/locales/es.json
@@ -442,7 +442,6 @@
   "viz.layer.surface-obscuration-bands": "Oscurecimiento de superficie",
   "viz.layer.current-conditions": "Condiciones actuales",
   "viz.layer.fronts-markers": "Frentes (experimental)",
-  "viz.frontsInfo": "<strong>Frentes (experimental)</strong><br>L\u00edmites de masas de aire (\u03b8e de Hewson) que cruza su ruta \u2014 una marca por modelo donde cruza un frente; el color indica el tipo (fr\u00edo / c\u00e1lido / cuasiestacionario).<br><br>La relevancia se lee del tiempo en el l\u00edmite, mostrado en el corte inferior: un l\u00edmite seco es solo un cambio de viento, mientras que los l\u00edmites h\u00famedos o convectivos pueden traer nubes, precipitaci\u00f3n y cizalladura \u2014 y los frentes convectivos pueden generar desarrollos muy por encima del l\u00edmite, por lo que un frente sobrevolado puede importar igualmente.<br><br>Solo orientativo \u2014 no es un SIGWX oficial, y es una se\u00f1al de la atm\u00f3sfera libre que no capta nubes bajas ni niebla.",
   "viz.group.terrain": "Terreno",
   "viz.group.temperature": "Temperatura",
   "viz.group.clouds": "Nubes",

--- a/web/ts/i18n/locales/es.json
+++ b/web/ts/i18n/locales/es.json
@@ -441,7 +441,7 @@
   "viz.layer.cruise-altitude": "Crucero / Techo",
   "viz.layer.surface-obscuration-bands": "Oscurecimiento de superficie",
   "viz.layer.current-conditions": "Condiciones actuales",
-  "viz.layer.fronts-markers": "Frentes (experimental)",
+  "viz.layer.fronts-markers": "L\u00edmite de masa de aire",
   "viz.group.terrain": "Terreno",
   "viz.group.temperature": "Temperatura",
   "viz.group.clouds": "Nubes",

--- a/web/ts/i18n/locales/fr.json
+++ b/web/ts/i18n/locales/fr.json
@@ -441,6 +441,8 @@
   "viz.layer.cruise-altitude": "Croisière / Plafond",
   "viz.layer.surface-obscuration-bands": "Obscurcissement de surface",
   "viz.layer.current-conditions": "Conditions actuelles",
+  "viz.layer.fronts-markers": "Fronts (exp\u00e9rimental)",
+  "viz.frontsInfo": "<strong>Fronts (exp\u00e9rimental)</strong><br>Limites de masses d'air (\u03b8e de Hewson) que votre route traverse \u2014 un rep\u00e8re par mod\u00e8le l\u00e0 o\u00f9 vous franchissez un front ; la couleur indique le type (froid / chaud / quasi-stationnaire).<br><br>La pertinence se lit d'apr\u00e8s la m\u00e9t\u00e9o sur la limite, affich\u00e9e dans la coupe en dessous : une limite s\u00e8che n'est qu'un changement de vent, tandis qu'une limite humide ou convective peut apporter nuages, pr\u00e9cipitations et cisaillement \u2014 et les fronts convectifs peuvent g\u00e9n\u00e9rer des d\u00e9veloppements bien au-dessus de la limite, donc un front survol\u00e9 peut tout de m\u00eame compter.<br><br>\u00c0 titre indicatif seulement \u2014 ce n'est pas un SIGWX officiel, et c'est un signal de l'atmosph\u00e8re libre qui ne capte pas les nuages bas ni le brouillard.",
   "viz.group.terrain": "Terrain",
   "viz.group.temperature": "Température",
   "viz.group.clouds": "Nuages",

--- a/web/ts/i18n/locales/fr.json
+++ b/web/ts/i18n/locales/fr.json
@@ -442,7 +442,6 @@
   "viz.layer.surface-obscuration-bands": "Obscurcissement de surface",
   "viz.layer.current-conditions": "Conditions actuelles",
   "viz.layer.fronts-markers": "Fronts (exp\u00e9rimental)",
-  "viz.frontsInfo": "<strong>Fronts (exp\u00e9rimental)</strong><br>Limites de masses d'air (\u03b8e de Hewson) que votre route traverse \u2014 un rep\u00e8re par mod\u00e8le l\u00e0 o\u00f9 vous franchissez un front ; la couleur indique le type (froid / chaud / quasi-stationnaire).<br><br>La pertinence se lit d'apr\u00e8s la m\u00e9t\u00e9o sur la limite, affich\u00e9e dans la coupe en dessous : une limite s\u00e8che n'est qu'un changement de vent, tandis qu'une limite humide ou convective peut apporter nuages, pr\u00e9cipitations et cisaillement \u2014 et les fronts convectifs peuvent g\u00e9n\u00e9rer des d\u00e9veloppements bien au-dessus de la limite, donc un front survol\u00e9 peut tout de m\u00eame compter.<br><br>\u00c0 titre indicatif seulement \u2014 ce n'est pas un SIGWX officiel, et c'est un signal de l'atmosph\u00e8re libre qui ne capte pas les nuages bas ni le brouillard.",
   "viz.group.terrain": "Terrain",
   "viz.group.temperature": "Température",
   "viz.group.clouds": "Nuages",

--- a/web/ts/i18n/locales/fr.json
+++ b/web/ts/i18n/locales/fr.json
@@ -441,7 +441,7 @@
   "viz.layer.cruise-altitude": "Croisière / Plafond",
   "viz.layer.surface-obscuration-bands": "Obscurcissement de surface",
   "viz.layer.current-conditions": "Conditions actuelles",
-  "viz.layer.fronts-markers": "Fronts (exp\u00e9rimental)",
+  "viz.layer.fronts-markers": "Limite de masse d'air",
   "viz.group.terrain": "Terrain",
   "viz.group.temperature": "Température",
   "viz.group.clouds": "Nuages",

--- a/web/ts/types/fronts.ts
+++ b/web/ts/types/fronts.ts
@@ -21,7 +21,13 @@ export interface FrontCrossing {
   delta_theta_e: number;     // θe jump across the window, K
   kind: FrontKind;
   intensity: FrontIntensity;
+  // Relevance enrichment (present on current artifacts; optional for back-compat).
+  co_location?: FrontCoLocation | null;
+  weather_top_ft?: number | null;   // cloud/convective top at the crossing, ft
+  persistence?: number | null;      // [0,1] fraction of ±window frames the gate holds
 }
+
+export type FrontCoLocation = 'dry' | 'partly' | 'wet' | 'convective';
 
 export interface FrontProximity {
   distance_km: number;

--- a/web/ts/visualization/controls/panel.ts
+++ b/web/ts/visualization/controls/panel.ts
@@ -132,10 +132,23 @@ function layerTogglesHtml(
   opts: LayerTogglesOptions = {},
 ): string {
   const { displayMode, preferredMethods, unavailableLayers, cloudStyle, substitutedLayers, hiddenGroups } = opts;
+  // Single-layer "feature/context" groups hide entirely when their lone layer is
+  // unavailable — front detection off or no on-track crossing for this model;
+  // current conditions on a non-D-0 flight. A disabled solitary checkbox is just
+  // noise. (Other groups keep their layers visible-but-dimmed so alternative
+  // methods stay discoverable.)
+  const HIDE_GROUP_WHEN_UNAVAILABLE: Partial<Record<LayerGroup, string>> = {
+    fronts: 'fronts-markers',
+    conditions: 'current-conditions',
+  };
+  const effectiveHidden = new Set<LayerGroup>(hiddenGroups ?? []);
+  for (const [grp, layerId] of Object.entries(HIDE_GROUP_WHEN_UNAVAILABLE)) {
+    if (unavailableLayers?.has(layerId)) effectiveHidden.add(grp as LayerGroup);
+  }
   const groups = getLayerGroups();
   let html = '<div class="viz-layer-toggles">';
   for (const group of groups) {
-    if (hiddenGroups?.has(group.group)) continue;
+    if (effectiveHidden.has(group.group)) continue;
     const isCompactCollapse = displayMode === 'compact' && COMPACT_GROUPS.has(group.group);
     const layersToRender = isCompactCollapse
       ? [getPreferredLayerForGroup(group.group, group.layers, preferredMethods?.[group.group])]
@@ -175,6 +188,10 @@ function layerTogglesHtml(
       html += `</label>`;
       if (layer.metricId) {
         html += `<button class="viz-layer-info-btn" data-layer-info="${layer.id}" data-metric-id="${layer.metricId}" title="${t('viz.moreInfo')}" aria-label="${t('viz.moreInfo')}">ⓘ</button>`;
+      } else if (layer.id === 'fronts-markers') {
+        // Fronts have no metric registry entry — show the experimental-feature
+        // explainer instead of metric info.
+        html += `<button class="viz-layer-info-btn" data-front-info="1" title="${t('viz.moreInfo')}" aria-label="${t('viz.moreInfo')}">ⓘ</button>`;
       }
     }
     html += '</div>';
@@ -263,6 +280,13 @@ function wireLayerInfoButtons(container: HTMLElement): void {
       const groupKey = (btn as HTMLElement).dataset.groupInfo!;
       const infoFn = GROUP_INFO[groupKey];
       if (infoFn) showPopupContent(infoFn());
+    });
+  });
+  container.querySelectorAll('[data-front-info]').forEach((btn) => {
+    btn.addEventListener('click', (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      showPopupContent(t('viz.frontsInfo'));
     });
   });
 }

--- a/web/ts/visualization/controls/panel.ts
+++ b/web/ts/visualization/controls/panel.ts
@@ -11,6 +11,7 @@ import {
 import { getDdSubstituteId } from '../cross-section/nwp-fallback';
 import { getComparableLayerGroups, getComparableLayer } from '../cross-section/compare-layers';
 import { showLayerInfo, showPopupContent } from '../../components/info-popup';
+import { renderFrontsInfo } from '../../helpers/fronts-info';
 import { modelLabel } from '../../utils';
 import { getMetricOptions } from '../route-graph/metrics';
 import { getMapMetricOptions, MAP_METRIC_NONE } from '../route-map/metrics';
@@ -286,7 +287,7 @@ function wireLayerInfoButtons(container: HTMLElement): void {
     btn.addEventListener('click', (e) => {
       e.preventDefault();
       e.stopPropagation();
-      showPopupContent(t('viz.frontsInfo'));
+      showPopupContent(renderFrontsInfo());
     });
   });
 }

--- a/web/ts/visualization/controls/panel.ts
+++ b/web/ts/visualization/controls/panel.ts
@@ -138,6 +138,9 @@ function layerTogglesHtml(
   // current conditions on a non-D-0 flight. A disabled solitary checkbox is just
   // noise. (Other groups keep their layers visible-but-dimmed so alternative
   // methods stay discoverable.)
+  // NB: assumes each listed group has exactly ONE layer (the named id) — hiding
+  // the group hides that layer. If a second layer is ever added to 'fronts' or
+  // 'conditions', gate per-layer instead, or it would be silently hidden too.
   const HIDE_GROUP_WHEN_UNAVAILABLE: Partial<Record<LayerGroup, string>> = {
     fronts: 'fronts-markers',
     conditions: 'current-conditions',

--- a/web/ts/visualization/cross-section/layers/fronts-markers.ts
+++ b/web/ts/visualization/cross-section/layers/fronts-markers.ts
@@ -40,6 +40,7 @@ export const frontsMarkersLayer: CrossSectionLayer = {
     for (const c of fronts.crossings) {
       const x = transform.distanceToX(c.distance_km / KM_PER_NM);
       const color = frontColor(c.kind);
+      const savedAlpha = ctx.globalAlpha;
       ctx.globalAlpha = frontAlpha(c);
 
       ctx.strokeStyle = color;
@@ -76,7 +77,7 @@ export const frontsMarkersLayer: CrossSectionLayer = {
         ctx.closePath();
         ctx.fill();
       }
-      ctx.globalAlpha = 1;
+      ctx.globalAlpha = savedAlpha;
     }
     ctx.restore();
   },

--- a/web/ts/visualization/cross-section/layers/fronts-markers.ts
+++ b/web/ts/visualization/cross-section/layers/fronts-markers.ts
@@ -9,7 +9,10 @@
  *  altitude θe bands; this layer is the discrete-marker precursor. */
 
 import type { CrossSectionLayer, CoordTransform, VizRouteData } from '../../types';
-import { frontColor, frontKindLabel, FRONT_INTENSITY_DASH, FRONT_INTENSITY_WEIGHT } from '../../front-style';
+import {
+  frontColor, frontKindLabel, frontAlpha, frontDash, frontIsConvective,
+  FRONT_INTENSITY_WEIGHT,
+} from '../../front-style';
 
 const KM_PER_NM = 1.852;
 
@@ -30,13 +33,18 @@ export const frontsMarkersLayer: CrossSectionLayer = {
     const yBottom = top + height;
 
     ctx.save();
+    // Visual encoding (matches the advisory gate so the picture reads like the
+    // grade): colour = kind, line weight = intensity, SOLID vs DASHED = wet/dry
+    // co-location, OPACITY = persistence (faint = flickering/uncertain), and a
+    // small triangle flags convective boundaries (towers above an overflown front).
     for (const c of fronts.crossings) {
       const x = transform.distanceToX(c.distance_km / KM_PER_NM);
       const color = frontColor(c.kind);
+      ctx.globalAlpha = frontAlpha(c);
 
       ctx.strokeStyle = color;
       ctx.lineWidth = FRONT_INTENSITY_WEIGHT[c.intensity] ?? 2;
-      ctx.setLineDash(FRONT_INTENSITY_DASH[c.intensity] ?? []);
+      ctx.setLineDash(frontDash(c));
       ctx.beginPath();
       ctx.moveTo(x, yTop);
       ctx.lineTo(x, yBottom);
@@ -56,6 +64,19 @@ export const frontsMarkersLayer: CrossSectionLayer = {
       ctx.textBaseline = 'middle';
       ctx.textAlign = 'center';
       ctx.fillText(label, x, yTop + chipH / 2);
+
+      // Convective glyph: a small upward triangle below the chip = towers.
+      if (frontIsConvective(c)) {
+        const ty = yTop + chipH + 2;
+        ctx.fillStyle = color;
+        ctx.beginPath();
+        ctx.moveTo(x, ty);
+        ctx.lineTo(x - 5, ty + 8);
+        ctx.lineTo(x + 5, ty + 8);
+        ctx.closePath();
+        ctx.fill();
+      }
+      ctx.globalAlpha = 1;
     }
     ctx.restore();
   },

--- a/web/ts/visualization/data-extract.ts
+++ b/web/ts/visualization/data-extract.ts
@@ -114,10 +114,12 @@ function buildFronts(
   const INTENSITY: Record<string, number> = { sharp: 3, classical: 2, significant: 1 };
   const score = (c: FrontCrossing): number =>
     (RELEVANCE[c.co_location ?? ''] ?? 0) * 10 + (INTENSITY[c.intensity] ?? 0);
+  // 50 km bins — same width the advisory uses to count distinct crossings
+  // (analysis/advisories/fronts.py), so marker count and "N fronts" text agree.
   const byBin = new Map<number, FrontCrossing>();
   for (const a of analyses) {
     for (const c of a.crossings) {
-      const bin = Math.round(c.distance_km / 25);
+      const bin = Math.round(c.distance_km / 50);
       const cur = byBin.get(bin);
       if (!cur || score(c) > score(cur)) byBin.set(bin, c);
     }

--- a/web/ts/visualization/data-extract.ts
+++ b/web/ts/visualization/data-extract.ts
@@ -3,7 +3,7 @@
 import type { ElevationProfile, RouteAnalysesManifest, RoutePointAnalysis, SoundingAnalysis, RouteObservations, RouteSigmets } from '../store/types';
 import type { RouteWindOverlay } from '../adapters/api-adapter';
 import type { TerrainPoint, VizRouteData, VizPoint, WaypointMarker, AltitudeLines, VizCloudLayer, VizIcingZone, VizSfipZone, VizSldZone, VizCATLayer, VizInversionLayer, VizCloudDiag, VizCurrentConditions, VizMetarColumn, VizSigmetZone, VizFronts } from './types';
-import type { RouteFrontsManifest } from '../types/fronts';
+import type { FrontCrossing, FrontProximity, RouteFrontsManifest } from '../types/fronts';
 import { computeSurfaceObscurationFromCloudLayers } from './surface-obscuration';
 import { randomOverlapPct } from './scales';
 
@@ -103,14 +103,41 @@ function buildFronts(
   if (!manifest) return null;
   const analyses = manifest.per_model[model];
   if (!analyses || analyses.length === 0) return null;
-  const primary = manifest.primary_level_hPa;
-  const analysis = analyses.find((a) => a.level_hPa === primary) ?? analyses[0];
-  if (analysis.crossings.length === 0 && !analysis.nearest) return null;
-  return {
-    crossings: analysis.crossings,
-    nearest: analysis.nearest ?? null,
-    primaryLevelHpa: analysis.level_hPa,
-  };
+
+  // Merge crossings across ALL stored levels, not just the nearest-cruise one:
+  // a front can sit below cruise (so the primary level has none) yet still
+  // matter — its cloud/convection lofts through the flight (the Dijon case).
+  // Dedupe the same front seen at multiple levels into ~25 km bins, keeping the
+  // most relevant version (convective > wet > partly > dry, then by intensity)
+  // so the marker reflects the worst the column carries.
+  const RELEVANCE: Record<string, number> = { convective: 3, wet: 2, partly: 1, dry: 0 };
+  const INTENSITY: Record<string, number> = { sharp: 3, classical: 2, significant: 1 };
+  const score = (c: FrontCrossing): number =>
+    (RELEVANCE[c.co_location ?? ''] ?? 0) * 10 + (INTENSITY[c.intensity] ?? 0);
+  const byBin = new Map<number, FrontCrossing>();
+  for (const a of analyses) {
+    for (const c of a.crossings) {
+      const bin = Math.round(c.distance_km / 25);
+      const cur = byBin.get(bin);
+      if (!cur || score(c) > score(cur)) byBin.set(bin, c);
+    }
+  }
+  const crossings = [...byBin.values()].sort((a, b) => a.distance_km - b.distance_km);
+
+  // Nearest: prefer an on-track gated front, else the closest off-track one,
+  // across levels.
+  let nearest: FrontProximity | null = null;
+  for (const a of analyses) {
+    const nf = a.nearest;
+    if (!nf) continue;
+    const better = !nearest
+      || (nf.on_track && !nearest.on_track)
+      || (nf.on_track === nearest.on_track && nf.distance_km < nearest.distance_km);
+    if (better) nearest = nf;
+  }
+
+  if (crossings.length === 0 && !nearest) return null;
+  return { crossings, nearest, primaryLevelHpa: manifest.primary_level_hPa };
 }
 
 /**

--- a/web/ts/visualization/front-style.ts
+++ b/web/ts/visualization/front-style.ts
@@ -39,6 +39,29 @@ export function frontColor(kind: FrontKind): string {
   return FRONT_KIND_COLOR[kind] ?? FRONT_KIND_COLOR['quasi-stationary'];
 }
 
+/** Marker opacity from persistence: a front that holds across the time window
+ *  draws solid; a flickering one (likely an orographic / grid artifact) draws
+ *  faint, so the eye trusts it less. Unknown persistence → near-solid. */
+export function frontAlpha(c: FrontCrossing): number {
+  const p = c.persistence;
+  if (p == null) return 0.9;
+  return Math.max(0.35, Math.min(1, 0.35 + 0.65 * p));
+}
+
+/** Dash from co-location: a boundary carrying real weather (wet / convective)
+ *  draws solid; a dry or partly one — a wind shift more than a weather event —
+ *  draws dashed and de-emphasized. Mirrors the advisory's wet/dry gate. */
+export function frontDash(c: FrontCrossing): number[] {
+  return c.co_location === 'wet' || c.co_location === 'convective' ? [] : [6, 4];
+}
+
+/** Convective boundaries get an extra glyph — towers can punch through / above
+ *  an overflown front, so the cross-section flags them even when the line reads
+ *  benign at the crossing level. */
+export function frontIsConvective(c: FrontCrossing): boolean {
+  return c.co_location === 'convective';
+}
+
 export function frontKindLabel(kind: FrontKind): string {
   return t(FRONT_KIND_I18N[kind] ?? FRONT_KIND_I18N['quasi-stationary']);
 }

--- a/web/ts/visualization/front-style.ts
+++ b/web/ts/visualization/front-style.ts
@@ -22,13 +22,6 @@ export const FRONT_INTENSITY_WEIGHT: Record<FrontIntensity, number> = {
   sharp: 4.5,
 };
 
-/** Dash pattern by intensity; sharp is solid, weaker boundaries dashed. */
-export const FRONT_INTENSITY_DASH: Record<FrontIntensity, number[]> = {
-  significant: [4, 4],
-  classical: [8, 4],
-  sharp: [],
-};
-
 const FRONT_KIND_I18N: Record<FrontKind, string> = {
   cold: 'fronts.kind.cold',
   warm: 'fronts.kind.warm',


### PR DESCRIPTION
## Summary

Makes the experimental front feature (#195/#196) **judge a front by the weather on it, relative to the flight**, rather than by the raw θe gradient — and shows that judgement on the cross-section. Fixes two miscalibrations found flying real routes:

- **Alpine false-RED** — a sharp but *dry*, flickering θe ribbon over the Alps (orographic artifact) was REDing. Now demoted.
- **Dijon false-GREEN → then false-RED → AMBER** — a real front sitting at 925/850 hPa *below* a FL100 cruise: first missed (graded only at the nearest-cruise level), then over-graded RED off its low-level sharpness. Now AMBER — a weak front you overfly, with convective tops noted.

All gated by the existing `auto_front_detection` pref (default off); the advisory stays `default_enabled=False`.

## What changed

**Detection enrichment** (`tasks/fronts.py`, `frontal/route_sampling.py`, `models/fronts.py`)
Each on-track crossing now carries, computed from the same model's column + snapshot:
- `co_location` — `dry / partly / wet / convective`
- `weather_top_ft` — cloud top, or **convective EL** (the θe boundary's level ≠ the weather's level)
- `persistence` — fraction of ±window frames the gate holds

**Advisory severity** (`analysis/advisories/fronts.py`) — grades every stored level, worst wins:
- flickering → GREEN (artifact); dry → GREEN (wind shift); weather below cruise → GREEN (overflown)
- sharp **wet** front *at/above* the flight level → RED; **below** cruise (overflown core) → AMBER
- **convective** by tower depth: tops ≥ cruise + `convective_deep_ft` → RED, else AMBER
- no enrichment → falls back to bare intensity grade (never hides a front)
- new tunables: `persistence_min`, `altitude_buffer_ft`, `convective_deep_ft`
- the AI digest picks the graded card up via the existing generic advisory loop

**Frontend**
- Layer panel: single-layer feature/context groups (fronts, conditions) **hide when irrelevant** instead of showing a disabled checkbox
- Fronts toggle: a **rich layered info popup** (plain terms → relevance gating → Hewson/TFP/θe maths → limitations → Wikipedia + paper → AI-discuss prompt), label fixed (`viz.layer.fronts-markers`) and de-duplicated to **"Air-mass boundary"**
- Cross-section markers **styled to match the grade**: colour = kind, weight = intensity, solid/dashed = wet/dry, opacity = persistence, triangle = convective

## Validation

End-to-end on the real **2026-05-31 Dijon** pack (LSGS→…→LFQA, FL100): aggregate **AMBER** (was RED), with the sharp 925 hPa front correctly treated as overflown and ICON's convection surfaced. Pilot-confirmed: weak, flyable front with isolated towers above. **213 tests pass** (incl. new co-location / persistence / altitude-relative / gating tests).

## Notes
- Free-atmosphere only (no low cloud/fog), advisory-only — wording reflects this.
- Calibration knobs are exposed as advisory params for further tuning as more cases are flown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
