### PR TITLE
fronts: on-track anomaly/terrain gate + cross-level vertical coherence

### DIFF
--- a/src/weatherbrief/analysis/advisories/fronts.py
+++ b/src/weatherbrief/analysis/advisories/fronts.py
@@ -92,15 +92,28 @@ def _grade_crossing(
         when deep (tops ≥ cruise + ``convective_deep_ft``); modest build-ups are
         AMBER. (Calibrated on the 2026-05-31 Dijon flight: a sharp 925 hPa cold
         front overflown at FL100 is AMBER, not RED.)
+
+    A third fact gates RED: **vertical coherence** — a RED needs a boundary seen
+    on ≥2 pressure levels (``c.vertical_levels``). A single-level detection is
+    shallow/suspect and caps at AMBER; convective towers are exempt (graded by
+    depth, not θe-level count).
     """
     # Flickering across the window → orographic / grid artifact, not a real front.
     if c.persistence is not None and c.persistence < persistence_min:
         return AdvisoryStatus.GREEN, "flicker"
+    # Vertical coherence: a RED demands a front that slopes through ≥2 levels.
+    # A single-level (shallow) detection is held at AMBER — it may be real but is
+    # not the deep, coherent boundary a RED implies. Unknown (None, older
+    # artifact) is treated as coherent so we never suppress on missing data.
+    # Convective towers are exempt: they're flagged by depth, not θe-level count.
+    coherent = c.vertical_levels is None or c.vertical_levels >= 2
     co = c.co_location
     if co is None:
         # No enrichment (older artifact / no analyses) → bare intensity grade,
         # rather than silently hiding the front.
-        return (AdvisoryStatus.RED, "sharp") if c.intensity == "sharp" else (AdvisoryStatus.AMBER, "classical")
+        if c.intensity == "sharp" and coherent:
+            return AdvisoryStatus.RED, "sharp"
+        return AdvisoryStatus.AMBER, "classical"
     if co == "dry":
         return AdvisoryStatus.GREEN, "dry"            # boundary aloft, clear → wind shift only
     # Unknown top (None) → assume it reaches: a "wet" boundary with no spanning
@@ -114,8 +127,8 @@ def _grade_crossing(
         deep = c.weather_top_ft is not None and c.weather_top_ft >= cruise_ft + convective_deep_ft
         return (AdvisoryStatus.RED, "convective") if deep else (AdvisoryStatus.AMBER, "convective")
     if co == "wet":
-        if c.intensity == "sharp" and not overflown:
-            return AdvisoryStatus.RED, "wet_sharp"    # sharp front at/above the flight level
+        if c.intensity == "sharp" and not overflown and coherent:
+            return AdvisoryStatus.RED, "wet_sharp"    # sharp, coherent front at/above the flight level
         return AdvisoryStatus.AMBER, "wet"
     return AdvisoryStatus.AMBER, "partly"             # few/sct cloud band
 

--- a/src/weatherbrief/frontal/gates.py
+++ b/src/weatherbrief/frontal/gates.py
@@ -43,13 +43,15 @@ class FrontGateConfig:
     * **acceptance gates** — decide IS-a-front. ``gradient_min`` (the air-mass
       boundary must be a real |∇θe| ridge) and ``delta_theta_e_min`` (the θe jump
       across the boundary must be a genuine change of air mass, not a col).
-      ``anomaly_min`` is the off-track-only gradient-above-background gate that
-      rejects persistent orographic / sea-land gradients.
+      ``anomaly_min`` is the gradient-above-background gate that rejects
+      persistent orographic / sea-land gradients — applied on the 2-D map, the
+      off-track scan, and (when a background + grid axes are supplied) the
+      on-track route locator.
     * **classification** — ``advection_min`` labels cold vs warm vs
       quasi-stationary; it *rejects nothing*.
     * **geometry / sampling** — route step, merge distance, the ±window the θe
       jump is measured across, the off-track proximity radius, the approach
-      look-ahead, and whether the off-track anomaly filter runs.
+      look-ahead, and whether the anomaly filter runs.
 
     All thresholds default to the values validated on the 2026-05-31 Channel
     cold front (the historical module constants). Construct presets with
@@ -62,7 +64,7 @@ class FrontGateConfig:
     # --- acceptance gates (decide IS-a-front) ---
     gradient_min: float = 6.0          # K/100km — significant (>4) .. classical (>8)
     delta_theta_e_min: float = 5.0     # K — |θe jump| across the ±window (air-mass contrast)
-    anomaly_min: float = 2.0           # K/100km — off-track gradient above background
+    anomaly_min: float = 2.0           # K/100km — gradient above time-mean background
 
     # --- classification (labels only, rejects nothing) ---
     advection_min: float = 0.5         # K/h — below this: quasi-stationary

--- a/src/weatherbrief/frontal/route_sampling.py
+++ b/src/weatherbrief/frontal/route_sampling.py
@@ -492,15 +492,19 @@ def _classify_kind(advection: float, advection_min: float) -> str:
 
 
 def _on_high_terrain(
-    terrain_mask: np.ndarray,
+    terrain_float: np.ndarray,
     lat_axis: np.ndarray,
     lon_axis: np.ndarray,
     lat: float,
     lon: float,
 ) -> bool:
     """True if (lat, lon) sits on a masked (high-terrain) cell — orographic θe,
-    not a synoptic front. Mirrors the 2-D map gate (:func:`_gate_vertex`)."""
-    valid = bilinear_sample(terrain_mask.astype(np.float64), lat_axis, lon_axis, lat, lon)
+    not a synoptic front. Mirrors the 2-D map gate (:func:`_gate_vertex`).
+
+    ``terrain_float`` is the boolean mask pre-cast to float (1.0 valid / 0.0
+    masked); the cast is hoisted to the caller so it happens once per gate run,
+    not once per candidate."""
+    valid = bilinear_sample(terrain_float, lat_axis, lon_axis, lat, lon)
     return bool(np.isfinite(valid) and valid < 0.5)
 
 
@@ -538,6 +542,12 @@ def apply_gate_config(
     candidate as a diagnostic.
     """
     can_sample = lat_axis is not None and lon_axis is not None
+    # Cast the boolean terrain mask to float ONCE (bilinear_sample needs float),
+    # not once per candidate — the copy is ~150 KB on the European grid.
+    terrain_float = (
+        terrain_mask.astype(np.float64)
+        if (terrain_mask is not None and can_sample) else None
+    )
     decisions: list[FrontDecision] = []
     for c in candidates:
         delta = c.delta_theta_e
@@ -562,8 +572,8 @@ def apply_gate_config(
         elif np.isfinite(anomaly) and anomaly < config.anomaly_min:
             rejected_by = "anomaly"
         elif (
-            terrain_mask is not None and can_sample
-            and _on_high_terrain(terrain_mask, lat_axis, lon_axis, c.lat, c.lon)
+            terrain_float is not None
+            and _on_high_terrain(terrain_float, lat_axis, lon_axis, c.lat, c.lon)
         ):
             rejected_by = "terrain"
         elif not np.isfinite(delta) or abs(delta) < config.delta_theta_e_min:

--- a/src/weatherbrief/frontal/route_sampling.py
+++ b/src/weatherbrief/frontal/route_sampling.py
@@ -401,7 +401,8 @@ class FrontDecision:
     """The verdict of one :class:`FrontGateConfig` on one :class:`FrontCandidate`.
 
     ``rejected_by`` is the *first* acceptance gate the candidate failed
-    (``"gradient"`` or ``"delta_theta_e"``), or ``None`` when accepted.
+    (``"gradient"``, ``"anomaly"``, ``"terrain"`` or ``"delta_theta_e"``), or
+    ``None`` when accepted.
     ``margins`` gives each gate's signed slack (value − threshold; ≥ 0 means
     the gate passed) so a calibrator can read "rejected: Δθe 4.2 K vs 5.0 gate"
     straight off the trace. ``kind`` / ``intensity`` are always populated (they
@@ -490,37 +491,81 @@ def _classify_kind(advection: float, advection_min: float) -> str:
     return "quasi-stationary"
 
 
+def _on_high_terrain(
+    terrain_mask: np.ndarray,
+    lat_axis: np.ndarray,
+    lon_axis: np.ndarray,
+    lat: float,
+    lon: float,
+) -> bool:
+    """True if (lat, lon) sits on a masked (high-terrain) cell — orographic θe,
+    not a synoptic front. Mirrors the 2-D map gate (:func:`_gate_vertex`)."""
+    valid = bilinear_sample(terrain_mask.astype(np.float64), lat_axis, lon_axis, lat, lon)
+    return bool(np.isfinite(valid) and valid < 0.5)
+
+
 def apply_gate_config(
     candidates: Sequence[FrontCandidate],
     config: FrontGateConfig,
+    *,
+    background: np.ndarray | None = None,
+    terrain_mask: np.ndarray | None = None,
+    lat_axis: np.ndarray | None = None,
+    lon_axis: np.ndarray | None = None,
 ) -> list[FrontDecision]:
     """Score each candidate against ``config`` → one :class:`FrontDecision` each.
 
-    Acceptance is the AND of the magnitude gate (|∇θe| ≥ ``gradient_min`` — a
-    significant air-mass boundary) and the air-mass-jump gate (|Δθe| ≥
-    ``delta_theta_e_min`` — a genuine change of air mass, not a gradient col).
-    The first failing gate is recorded in ``rejected_by``. Classification
-    (``advection_min``) and intensity (from |∇θe|) are labels only and reject
-    nothing.
+    Acceptance is the AND of: the magnitude gate (|∇θe| ≥ ``gradient_min`` — a
+    significant air-mass boundary); the gradient-anomaly gate (|∇θe| above the
+    time-mean ``background`` by ≥ ``anomaly_min`` — rejects *persistent*
+    orographic / sea-land gradients); the high-terrain gate (the cell is not
+    masked out); and the air-mass-jump gate (|Δθe| ≥ ``delta_theta_e_min`` — a
+    genuine change of air mass, not a gradient col). The first failing gate is
+    recorded in ``rejected_by``. Classification (``advection_min``) and intensity
+    (from |∇θe|) are labels only and reject nothing.
+
+    The anomaly and terrain gates only fire when ``background`` / ``terrain_mask``
+    (and the grid ``lat_axis`` / ``lon_axis`` to sample them) are supplied — the
+    same machinery the 2-D map and off-track paths use (:func:`_gate_vertex`,
+    :func:`extract_gated_fronts`). Without them this is the legacy magnitude-only
+    behaviour, so existing callers/tests are unaffected. Wiring them in lets the
+    on-track locator reject the orographic θe gradients the other surfaces
+    already reject (e.g. a shallow 925 hPa "boundary" pinned to a mountain range).
 
     The −∇²θe "sharpness" gate was deliberately *not* reinstated: −∇²θe ≈ 0 at
     the TFP zero by construction, so gating on it there suppresses real fronts
     (verified on the 2026-05-31 Channel front). It is still reported per
     candidate as a diagnostic.
     """
+    can_sample = lat_axis is not None and lon_axis is not None
     decisions: list[FrontDecision] = []
     for c in candidates:
         delta = c.delta_theta_e
+        anomaly = float("nan")
+        if config.use_anomaly_filter and background is not None and can_sample:
+            bg = bilinear_sample(background, lat_axis, lon_axis, c.lat, c.lon)
+            if np.isfinite(bg):
+                anomaly = c.gradient - bg
         margins = {
             "gradient": c.gradient - config.gradient_min,
             "delta_theta_e": (
                 abs(delta) - config.delta_theta_e_min
                 if np.isfinite(delta) else float("nan")
             ),
+            "anomaly": (
+                anomaly - config.anomaly_min if np.isfinite(anomaly) else float("nan")
+            ),
         }
         rejected_by: str | None = None
         if c.gradient < config.gradient_min:
             rejected_by = "gradient"
+        elif np.isfinite(anomaly) and anomaly < config.anomaly_min:
+            rejected_by = "anomaly"
+        elif (
+            terrain_mask is not None and can_sample
+            and _on_high_terrain(terrain_mask, lat_axis, lon_axis, c.lat, c.lon)
+        ):
+            rejected_by = "terrain"
         elif not np.isfinite(delta) or abs(delta) < config.delta_theta_e_min:
             rejected_by = "delta_theta_e"
         decisions.append(
@@ -559,6 +604,10 @@ def detect_front_crossings(
     merge_km: float = _DEFAULT_MERGE_KM,
     airmass_window_km: float = _DEFAULT_AIRMASS_WINDOW_KM,
     config: FrontGateConfig | None = None,
+    background: np.ndarray | None = None,
+    terrain_mask: np.ndarray | None = None,
+    lat_axis: np.ndarray | None = None,
+    lon_axis: np.ndarray | None = None,
 ) -> list[FrontCrossing]:
     """Locate accepted front crossings in a densely-sampled route series.
 
@@ -568,6 +617,10 @@ def detect_front_crossings(
     a named recipe, or rely on the individual keyword gates (kept for backward
     compatibility with existing callers/tests). When both are given the explicit
     ``config`` wins.
+
+    ``background`` / ``terrain_mask`` (+ ``lat_axis`` / ``lon_axis``) enable the
+    anomaly and high-terrain gates — see :func:`apply_gate_config`. Omit them for
+    the legacy magnitude-only gating.
     """
     if config is None:
         config = FrontGateConfig(
@@ -580,7 +633,11 @@ def detect_front_crossings(
     candidates = generate_front_candidates(
         samples, airmass_window_km=config.airmass_window_km,
     )
-    decisions = apply_gate_config(candidates, config)
+    decisions = apply_gate_config(
+        candidates, config,
+        background=background, terrain_mask=terrain_mask,
+        lat_axis=lat_axis, lon_axis=lon_axis,
+    )
     return decisions_to_crossings(decisions, config.merge_km)
 
 

--- a/src/weatherbrief/models/fronts.py
+++ b/src/weatherbrief/models/fronts.py
@@ -38,6 +38,11 @@ class FrontCrossingModel(BaseModel):
     co_location: str | None = None       # "dry"|"partly"|"wet"|"convective"
     weather_top_ft: float | None = None  # cloud/convective top at the crossing, ft
     persistence: float | None = None     # [0,1] fraction of ±window frames the gate holds
+    # Vertical coherence: how many of this model's stored levels (925/850/700)
+    # detect this same along-route feature. A real front slopes through several
+    # levels; a single-level (==1) detection is shallow/suspect. Stamped across
+    # levels by the pipeline (compute_route_fronts); None on the bare detector.
+    vertical_levels: int | None = None
 
 
 class FrontProximityModel(BaseModel):
@@ -63,7 +68,7 @@ class FrontDecisionModel(BaseModel):
     delta_theta_e: float
     advection: float
     accepted: bool
-    rejected_by: str | None = None     # "gradient" | "delta_theta_e" | None
+    rejected_by: str | None = None     # "gradient"|"anomaly"|"terrain"|"delta_theta_e"|None
     kind: str
     intensity: str
     margins: dict[str, float] = Field(default_factory=dict)

--- a/src/weatherbrief/tasks/fronts.py
+++ b/src/weatherbrief/tasks/fronts.py
@@ -207,6 +207,39 @@ def _colocate(analyses, model: str, dist_km: float, level_hpa: int):
     return category, weather_top_ft
 
 
+def _stamp_vertical_coherence(
+    analyses: list[RouteFrontAnalysisModel], tolerance_km: float
+) -> None:
+    """Mutate ``analyses`` (one per level, same model) so each crossing carries
+    ``vertical_levels`` — the count of distinct levels detecting that feature.
+
+    A genuine front slopes through several pressure levels, so the same crossing
+    appears at ~the same along-route distance on 850 *and* 925 (and maybe 700).
+    A shallow / artifactual boundary shows on one level only. We cluster all
+    crossings across levels by along-route distance (single-linkage within
+    ``tolerance_km`` — the same "same physical front" distance as ``merge_km``)
+    and stamp every member with how many distinct levels its cluster spans.
+    """
+    items = sorted(
+        ((a.level_hPa, c) for a in analyses for c in a.crossings),
+        key=lambda lc: lc[1].distance_km,
+    )
+    if not items:
+        return
+    cluster: list = [items[0]]
+    clusters: list[list] = [cluster]
+    for lvl_c in items[1:]:
+        if lvl_c[1].distance_km - cluster[-1][1].distance_km <= tolerance_km:
+            cluster.append(lvl_c)
+        else:
+            cluster = [lvl_c]
+            clusters.append(cluster)
+    for cl in clusters:
+        n_levels = len({lvl for lvl, _ in cl})
+        for _, c in cl:
+            c.vertical_levels = n_levels
+
+
 def _persistence(source, model, lat, lon, level_hpa, eta_hour, gradient_min):
     """Fraction of ±window frames where the gated gradient holds at the cell.
 
@@ -266,7 +299,21 @@ def _analyze_one(
     candidates = generate_front_candidates(
         samples, airmass_window_km=config.airmass_window_km,
     )
-    decisions = apply_gate_config(candidates, config)
+    # Reject orographic θe gradients on-track the same way the map / off-track
+    # paths do: a persistent gradient pinned to terrain has a high time-mean
+    # background (low anomaly) and/or sits on a masked cell. Needs ≥2 frames for
+    # a meaningful background — with one frame the mean equals the instant and
+    # every front would self-cancel, so skip the anomaly gate then (graceful).
+    background = None
+    if config.use_anomaly_filter and len(source.available_hours(model)) >= 2:
+        background = source.background_gradient(model, config.level_hPa)
+    decisions = apply_gate_config(
+        candidates, config,
+        background=background,
+        terrain_mask=source.terrain_mask,
+        lat_axis=source.lat,
+        lon_axis=source.lon,
+    )
     crossings = decisions_to_crossings(decisions, config.merge_km)
 
     # Attach relevance enrichment: each crossing is sampled at its own ETA
@@ -433,6 +480,10 @@ def compute_route_fronts(
                 )
                 continue
             analyses.append(_to_analysis_model(result))
+        # Cross-level coherence: stamp each crossing with how many levels see it,
+        # so the advisory / cross-section can down-weight single-level (shallow)
+        # detections. Per-model — vertical slope is a within-model property.
+        _stamp_vertical_coherence(analyses, base_config.merge_km)
         if analyses:
             per_model[model] = analyses
 

--- a/src/weatherbrief/tasks/fronts.py
+++ b/src/weatherbrief/tasks/fronts.py
@@ -216,9 +216,16 @@ def _stamp_vertical_coherence(
     A genuine front slopes through several pressure levels, so the same crossing
     appears at ~the same along-route distance on 850 *and* 925 (and maybe 700).
     A shallow / artifactual boundary shows on one level only. We cluster all
-    crossings across levels by along-route distance (single-linkage within
-    ``tolerance_km`` — the same "same physical front" distance as ``merge_km``)
-    and stamp every member with how many distinct levels its cluster spans.
+    crossings across levels by along-route distance and stamp every member with
+    how many distinct levels its cluster spans.
+
+    Clustering is **complete-linkage**: a crossing joins a cluster only if it is
+    within ``tolerance_km`` of the cluster's *first* (nearest) member, so the
+    whole cluster span stays ≤ ``tolerance_km``. Single-linkage (compare to the
+    last member) would let a shallow feature chain into a distant front through
+    intermediate crossings and inherit a multi-level count it doesn't deserve —
+    the false-positive this signal exists to suppress. ``tolerance_km`` is the
+    same "same physical front" distance as ``merge_km``.
     """
     items = sorted(
         ((a.level_hPa, c) for a in analyses for c in a.crossings),
@@ -229,7 +236,8 @@ def _stamp_vertical_coherence(
     cluster: list = [items[0]]
     clusters: list[list] = [cluster]
     for lvl_c in items[1:]:
-        if lvl_c[1].distance_km - cluster[-1][1].distance_km <= tolerance_km:
+        # vs cluster[0] (the nearest member) → bounds total span ≤ tolerance_km.
+        if lvl_c[1].distance_km - cluster[0][1].distance_km <= tolerance_km:
             cluster.append(lvl_c)
         else:
             cluster = [lvl_c]

--- a/tests/analysis/advisories/test_fronts_advisory.py
+++ b/tests/analysis/advisories/test_fronts_advisory.py
@@ -30,6 +30,7 @@ def _crossing(
     co_location: str | None = None,
     weather_top_ft: float | None = None,
     persistence: float | None = None,
+    vertical_levels: int | None = None,
 ) -> FrontCrossingModel:
     return FrontCrossingModel(
         lat=48.0, lon=2.0, distance_km=distance_km,
@@ -37,6 +38,7 @@ def _crossing(
         tfp_before=0.5, tfp_after=-0.5, delta_theta_e=8.0,
         kind=kind, intensity=intensity,
         co_location=co_location, weather_top_ft=weather_top_ft, persistence=persistence,
+        vertical_levels=vertical_levels,
     )
 
 
@@ -266,6 +268,40 @@ def test_wet_sharp_reaching_is_red_classical_is_amber():
         intensity="classical", co_location="wet", weather_top_ft=20000.0, persistence=0.8,
     )])
     assert FrontsEvaluator.evaluate(_ctx(amber), _PARAMS).aggregate_status == AdvisoryStatus.AMBER
+
+
+def test_single_level_wet_sharp_capped_to_amber():
+    """Vertical coherence: a sharp wet front seen on ONE level only is shallow →
+    AMBER, not RED. The same crossing on ≥2 levels stays RED."""
+    shallow = _manifest(crossings=[_crossing(
+        intensity="sharp", co_location="wet", weather_top_ft=20000.0,
+        persistence=0.8, vertical_levels=1,
+    )])
+    assert FrontsEvaluator.evaluate(_ctx(shallow), _PARAMS).aggregate_status == AdvisoryStatus.AMBER
+    coherent = _manifest(crossings=[_crossing(
+        intensity="sharp", co_location="wet", weather_top_ft=20000.0,
+        persistence=0.8, vertical_levels=2,
+    )])
+    assert FrontsEvaluator.evaluate(_ctx(coherent), _PARAMS).aggregate_status == AdvisoryStatus.RED
+
+
+def test_single_level_convective_still_red_when_deep():
+    """Vertical coherence does NOT suppress convection: deep towers on a single
+    θe level are graded by depth, not level count → still RED."""
+    deep = _manifest(crossings=[_crossing(
+        kind="warm", co_location="convective", weather_top_ft=33000.0,
+        persistence=0.8, vertical_levels=1,
+    )])
+    assert FrontsEvaluator.evaluate(_ctx(deep), _PARAMS).aggregate_status == AdvisoryStatus.RED
+
+
+def test_unknown_coherence_treated_as_coherent():
+    """vertical_levels None (older artifact) must not suppress — stays RED."""
+    m = _manifest(crossings=[_crossing(
+        intensity="sharp", co_location="wet", weather_top_ft=20000.0,
+        persistence=0.8, vertical_levels=None,
+    )])
+    assert FrontsEvaluator.evaluate(_ctx(m), _PARAMS).aggregate_status == AdvisoryStatus.RED
 
 
 def test_default_disabled_in_catalog():

--- a/tests/test_frontal_decisions.py
+++ b/tests/test_frontal_decisions.py
@@ -10,6 +10,7 @@ import numpy as np
 
 from weatherbrief.frontal.gates import FrontGateConfig
 from weatherbrief.frontal.route_sampling import (
+    FrontCandidate,
     apply_gate_config,
     decisions_to_crossings,
     generate_front_candidates,
@@ -147,3 +148,87 @@ class TestDecisionsToCrossings:
         assert len(crossings) == 1
         assert crossings[0].kind == "cold"
         assert crossings[0].gradient == 7.0
+
+
+class TestAnomalyTerrainGates:
+    """On-track anomaly + high-terrain gates (issue: route detector was gated
+    more loosely than the 2-D map / off-track paths, letting orographic θe
+    gradients through). Same machinery as :func:`_gate_vertex`."""
+
+    LAT = np.arange(45.0, 50.0, 0.25)
+    LON = np.arange(2.0, 9.0, 0.25)
+
+    @staticmethod
+    def _cand(lat, lon, gradient):
+        # delta_theta_e well above the 5 K gate so only anomaly/terrain decide.
+        return FrontCandidate(
+            lat=lat, lon=lon, distance_km=100.0, gradient=gradient,
+            neg_laplacian=0.0, advection=-1.0, tfp_before=1.0, tfp_after=-1.0,
+            delta_theta_e=10.0, airmass_window_km=75.0,
+        )
+
+    def _background(self):
+        # Broad persistent (orographic) high-gradient region east of 5.5° lon.
+        bg = np.full((self.LAT.size, self.LON.size), 2.0)
+        bg[:, self.LON >= 5.5] = 8.0
+        return bg
+
+    def _terrain(self):
+        # Valid everywhere except a broad high-terrain band south of 46.5° lat.
+        tm = np.ones((self.LAT.size, self.LON.size), dtype=bool)
+        tm[self.LAT <= 46.5, :] = False
+        return tm
+
+    def test_persistent_gradient_rejected_by_anomaly(self):
+        # grad 9 over background 8 → anomaly 1 < anomaly_min 2 → rejected.
+        cfg = FrontGateConfig(level_hPa=925)
+        d = apply_gate_config(
+            [self._cand(48.0, 6.5, 9.0)], cfg,
+            background=self._background(), lat_axis=self.LAT, lon_axis=self.LON,
+        )[0]
+        assert d.accepted is False
+        assert d.rejected_by == "anomaly"
+
+    def test_transient_front_passes_anomaly(self):
+        # grad 9 over background 2 → anomaly 7 → accepted.
+        cfg = FrontGateConfig(level_hPa=925)
+        d = apply_gate_config(
+            [self._cand(48.0, 3.5, 9.0)], cfg,
+            background=self._background(), lat_axis=self.LAT, lon_axis=self.LON,
+        )[0]
+        assert d.accepted is True
+
+    def test_high_terrain_rejected(self):
+        cfg = FrontGateConfig(level_hPa=925)
+        d = apply_gate_config(
+            [self._cand(45.5, 3.5, 12.0)], cfg,
+            terrain_mask=self._terrain(), lat_axis=self.LAT, lon_axis=self.LON,
+        )[0]
+        assert d.accepted is False
+        assert d.rejected_by == "terrain"
+
+    def test_gradient_gate_precedes_anomaly_and_terrain(self):
+        # A sub-threshold gradient is rejected by "gradient" first, regardless.
+        cfg = FrontGateConfig(level_hPa=925)
+        d = apply_gate_config(
+            [self._cand(45.5, 6.5, 4.0)], cfg,
+            background=self._background(), terrain_mask=self._terrain(),
+            lat_axis=self.LAT, lon_axis=self.LON,
+        )[0]
+        assert d.rejected_by == "gradient"
+
+    def test_no_inputs_is_legacy_magnitude_only(self):
+        # Without background/terrain/axes the gate is the old gradient+Δθe only,
+        # so a persistent-region candidate that the new gates would drop passes.
+        cfg = FrontGateConfig(level_hPa=925)
+        d = apply_gate_config([self._cand(48.0, 6.5, 9.0)], cfg)[0]
+        assert d.accepted is True
+        assert "anomaly" in d.margins  # margin still reported (NaN), no gate
+
+    def test_anomaly_disabled_by_config_flag(self):
+        cfg = FrontGateConfig(level_hPa=925, use_anomaly_filter=False)
+        d = apply_gate_config(
+            [self._cand(48.0, 6.5, 9.0)], cfg,
+            background=self._background(), lat_axis=self.LAT, lon_axis=self.LON,
+        )[0]
+        assert d.accepted is True  # anomaly gate skipped when flag off

--- a/tests/test_frontal_decisions.py
+++ b/tests/test_frontal_decisions.py
@@ -232,3 +232,14 @@ class TestAnomalyTerrainGates:
             background=self._background(), lat_axis=self.LAT, lon_axis=self.LON,
         )[0]
         assert d.accepted is True  # anomaly gate skipped when flag off
+
+    def test_terrain_gate_fires_independently_of_anomaly_flag(self):
+        # The terrain gate is not tied to use_anomaly_filter — a high-terrain
+        # candidate is rejected even with the anomaly filter off.
+        cfg = FrontGateConfig(level_hPa=925, use_anomaly_filter=False)
+        d = apply_gate_config(
+            [self._cand(45.5, 3.5, 12.0)], cfg,
+            terrain_mask=self._terrain(), lat_axis=self.LAT, lon_axis=self.LON,
+        )[0]
+        assert d.accepted is False
+        assert d.rejected_by == "terrain"

--- a/tests/test_tasks_fronts.py
+++ b/tests/test_tasks_fronts.py
@@ -10,9 +10,11 @@ import pytest
 
 from weatherbrief.models import RoutePointAnalysis
 from weatherbrief.tasks.artifacts import load_route_fronts
+from weatherbrief.models.fronts import FrontCrossingModel, RouteFrontAnalysisModel
 from weatherbrief.tasks.fronts import (
     _colocate,
     _persistence,
+    _stamp_vertical_coherence,
     compute_route_fronts,
     nearest_cruise_level,
     run_fronts,
@@ -183,6 +185,70 @@ class TestPersistence:
 
     def test_none_when_no_frames(self):
         assert _persistence(_StubSource({}), "ecmwf", 47.0, 0.0, 850, 3.0, 6.0) is None
+
+
+def _xing(distance_km: float, **kw) -> FrontCrossingModel:
+    base = dict(
+        lat=48.0, lon=4.0, distance_km=distance_km, gradient=10.0,
+        neg_laplacian=0.0, advection=-1.0, tfp_before=1.0, tfp_after=-1.0,
+        delta_theta_e=-12.0, kind="cold", intensity="classical",
+    )
+    base.update(kw)
+    return FrontCrossingModel(**base)
+
+
+def _analysis(level: int, *crossings: FrontCrossingModel) -> RouteFrontAnalysisModel:
+    return RouteFrontAnalysisModel(
+        model="ecmwf", level_hPa=level, hour=9.0, crossings=list(crossings),
+    )
+
+
+class TestVerticalCoherence:
+    """Cross-level stamping: a real front slopes through several levels; a
+    single-level detection is shallow/suspect (vertical_levels == 1)."""
+
+    def test_same_feature_across_two_levels_is_coherent(self):
+        # Cold front seen at 850 (387 km) and 925 (355 km) — 32 km apart, within
+        # merge_km (60) → one feature spanning 2 levels.
+        analyses = [_analysis(850, _xing(387.0)), _analysis(925, _xing(355.0))]
+        _stamp_vertical_coherence(analyses, tolerance_km=60.0)
+        assert analyses[0].crossings[0].vertical_levels == 2
+        assert analyses[1].crossings[0].vertical_levels == 2
+
+    def test_single_level_feature_is_shallow(self):
+        # A 925-only boundary far from any other-level crossing → vertical_levels 1.
+        analyses = [_analysis(925, _xing(84.0)), _analysis(850, _xing(387.0))]
+        _stamp_vertical_coherence(analyses, tolerance_km=60.0)
+        shallow = analyses[0].crossings[0]
+        deep = analyses[1].crossings[0]
+        assert shallow.vertical_levels == 1
+        assert deep.vertical_levels == 1  # 850 one is also alone here
+
+    def test_three_levels_cluster_together(self):
+        analyses = [
+            _analysis(925, _xing(350.0)),
+            _analysis(850, _xing(370.0)),
+            _analysis(700, _xing(390.0)),
+        ]
+        _stamp_vertical_coherence(analyses, tolerance_km=60.0)
+        assert all(a.crossings[0].vertical_levels == 3 for a in analyses)
+
+    def test_two_distinct_features_not_merged(self):
+        # An early 925 feature (84 km) and a late front on 850+925 (~355-387):
+        # early stays single-level, late spans 2.
+        analyses = [
+            _analysis(925, _xing(84.0), _xing(355.0)),
+            _analysis(850, _xing(387.0)),
+        ]
+        _stamp_vertical_coherence(analyses, tolerance_km=60.0)
+        early = analyses[0].crossings[0]
+        late_925 = analyses[0].crossings[1]
+        late_850 = analyses[1].crossings[0]
+        assert early.vertical_levels == 1
+        assert late_925.vertical_levels == 2 and late_850.vertical_levels == 2
+
+    def test_empty_is_noop(self):
+        _stamp_vertical_coherence([], tolerance_km=60.0)  # no crash
 
 
 class TestNearestCruiseLevel:

--- a/tests/test_tasks_fronts.py
+++ b/tests/test_tasks_fronts.py
@@ -247,6 +247,21 @@ class TestVerticalCoherence:
         assert early.vertical_levels == 1
         assert late_925.vertical_levels == 2 and late_850.vertical_levels == 2
 
+    def test_complete_linkage_prevents_chaining(self):
+        # 925@250, 850@300, 700@360: single-linkage would chain all three
+        # (gaps 50, 60) into one 110 km cluster → every crossing vlev=3, inflating
+        # a shallow 250 km feature. Complete-linkage caps the span at tolerance:
+        # {250, 300} cluster (span 50), and 360 splits off alone.
+        analyses = [
+            _analysis(925, _xing(250.0)),
+            _analysis(850, _xing(300.0)),
+            _analysis(700, _xing(360.0)),
+        ]
+        _stamp_vertical_coherence(analyses, tolerance_km=60.0)
+        assert analyses[0].crossings[0].vertical_levels == 2  # 925@250 with 850@300
+        assert analyses[1].crossings[0].vertical_levels == 2  # 850@300
+        assert analyses[2].crossings[0].vertical_levels == 1  # 700@360 not chained
+
     def test_empty_is_noop(self):
         _stamp_vertical_coherence([], tolerance_km=60.0)  # no crash
 

--- a/web/tests/unit/tooltip-formatters.test.ts
+++ b/web/tests/unit/tooltip-formatters.test.ts
@@ -48,6 +48,9 @@ describe('LAYER_TOOLTIPS registry — structural integrity', () => {
       'lcl', 'lfc', 'el',
       'cruise-altitude',
       'current-conditions',
+      // Discrete vertical markers at along-route distances, not per-VizPoint
+      // zones — the route map binds their tooltip (frontTooltip) directly.
+      'fronts-markers',
     ]);
 
     const layerIds = getAllLayers()

--- a/web/ts/types/fronts.ts
+++ b/web/ts/types/fronts.ts
@@ -25,6 +25,7 @@ export interface FrontCrossing {
   co_location?: FrontCoLocation | null;
   weather_top_ft?: number | null;   // cloud/convective top at the crossing, ft
   persistence?: number | null;      // [0,1] fraction of ±window frames the gate holds
+  vertical_levels?: number | null;  // # of this model's levels detecting the feature (1=shallow)
 }
 
 export type FrontCoLocation = 'dry' | 'partly' | 'wet' | 'convective';

--- a/web/ts/visualization/front-style.ts
+++ b/web/ts/visualization/front-style.ts
@@ -32,13 +32,17 @@ export function frontColor(kind: FrontKind): string {
   return FRONT_KIND_COLOR[kind] ?? FRONT_KIND_COLOR['quasi-stationary'];
 }
 
-/** Marker opacity from persistence: a front that holds across the time window
- *  draws solid; a flickering one (likely an orographic / grid artifact) draws
- *  faint, so the eye trusts it less. Unknown persistence → near-solid. */
+/** Marker opacity from confidence: a front that holds across the time window
+ *  (persistence) AND slopes through multiple levels (vertical_levels) draws
+ *  solid; a flickering one (likely an orographic / grid artifact) or a
+ *  single-level shallow one draws faint, so the eye trusts it less. Unknown →
+ *  near-solid. The two factors multiply: weak on either axis de-emphasizes. */
 export function frontAlpha(c: FrontCrossing): number {
   const p = c.persistence;
-  if (p == null) return 0.9;
-  return Math.max(0.35, Math.min(1, 0.35 + 0.65 * p));
+  const persistAlpha = p == null ? 0.9 : Math.max(0.35, Math.min(1, 0.35 + 0.65 * p));
+  // Single-level detections are shallow/suspect → dim; ≥2 levels → no penalty.
+  const coherenceFactor = c.vertical_levels != null && c.vertical_levels < 2 ? 0.6 : 1;
+  return Math.max(0.3, persistAlpha * coherenceFactor);
 }
 
 /** Dash from co-location: a boundary carrying real weather (wet / convective)


### PR DESCRIPTION
## Why

Reviewing the Dijon route (LSGS→LFQA) front detection: it reported **2–3 air-mass boundaries per model**, with the three models disagreeing on the *same* early low-level feature over the Jura — ECMWF called it quasi-stationary/dry, GFS didn't see it, ICON called it warm/convective. Tracing the derivation surfaced two real gaps.

## Root causes

1. **The on-track route detector was gated more loosely than the other two detectors.** The 2-D map (`_gate_vertex`) and off-track (`extract_gated_fronts`) paths both reject (a) gradients that don't exceed the **time-mean background** by ≥ `anomaly_min` (persistent orographic / sea-land gradients) and (b) cells on **high terrain**. The on-track path (`apply_gate_config`) applied only `gradient` + `Δθe`. The stamped gate config even carried `use_anomaly_filter` / `anomaly_min`, but the route locator never read them — so the config advertised orographic rejection the route crossings never got.

2. **No vertical-coherence signal.** A real front slopes through several pressure levels; a 925-only detection is shallow/suspect — but persistence *rewards* a stationary orographic feature, so it wasn't down-weighted.

(Cross-model agreement — the third lever — stays an **advisory** concern, not cross-section, as discussed; not in this PR.)

## Changes

**1. Anomaly + terrain gate on-track.** `apply_gate_config` gains optional `background` / `terrain_mask` (+ grid axes) and applies the same gates as `_gate_vertex` via the existing `bilinear_sample`. `_analyze_one` passes `source.background_gradient()` and `source.terrain_mask`. Omitting them = legacy magnitude-only behaviour (existing callers/tests unaffected). Needs ≥2 frames for a meaningful background, else skipped. `rejected_by` now also reports `"anomaly"` / `"terrain"`.

**2. Cross-level vertical coherence.** `compute_route_fronts` clusters crossings across levels by along-route distance (within `merge_km`) and stamps each with `vertical_levels`. The advisory caps a non-convective RED at AMBER when `vertical_levels == 1` (convective towers exempt — graded by depth, not θe-level count); the cross-section dims single-level markers (`frontAlpha`). Unknown (`None`) → treated as coherent, so older artifacts are never suppressed.

**Drive-by:** fixed a **pre-existing red** frontend test (red on `main` since #196/#200) — `fronts-markers` is a discrete X-span marker layer whose tooltip is bound on the route map, not a per-VizPoint zone; moved it to the structural test's exempt set.

## Validation

- New unit tests prove the gates fire: persistent gradient → `anomaly`, high terrain → `terrain`, transient front → accepted, no-inputs → legacy passthrough; vertical-coherence clustering (2/3-level + two-distinct-features); advisory single-level cap incl. convective exemption + `None`=coherent.
- End-to-end smoke run on the Dijon route with the retained 05-31 snapshots: pipeline runs clean, `vertical_levels` stamped, gates don't spuriously drop legitimate transient crossings.
- **Caveat:** the *exact* original case can't be replayed — the 05-31 **00z** snapshots that pack used are no longer retained (06z/12z give a different picture). Probing those: the Jura at 925 has an elevated time-mean background (4.2 vs 2.7 K/100km at the real Champagne front), confirming a partial orographic signature; and the user confirmed *real isolated convection* along that early area, which item 2 correctly preserves (multi-level convective stays) while demoting the single-level dry ECMWF detection.

506 backend + 309 frontend tests pass; `tsc --noEmit` clean.