### PR TITLE
fronts: fix recompute-from-pack path (#201, #202, #203)

### DIFF
--- a/src/weatherbrief/analysis/advisories/fronts.py
+++ b/src/weatherbrief/analysis/advisories/fronts.py
@@ -285,12 +285,19 @@ class FrontsEvaluator:
             if not analyses:
                 continue
 
+            # Grade against *this* model's nearest-cruise level, not a single
+            # manifest-wide value — a partial snapshot may expose different
+            # levels per model, so a shared primary would mis-grade overflown
+            # vs. crossed (#203). Falls back to the representative level on
+            # pre-#203 packs that lack the per-model map.
+            model_primary = manifest.per_model_primary_hPa.get(model, primary)
+
             # Grade every crossing at every stored level — the boundary may sit
             # below cruise yet loft weather through it (the Dijon case) — and keep
             # the worst. Nearest off-track closing front handled separately.
             graded = [
                 (*_grade_crossing(
-                    c, a.level_hPa, primary, cruise_ft,
+                    c, a.level_hPa, model_primary, cruise_ft,
                     persistence_min, buffer_ft, convective_deep_ft,
                 ), c)
                 for a in analyses for c in a.crossings

--- a/src/weatherbrief/analysis/comparison.py
+++ b/src/weatherbrief/analysis/comparison.py
@@ -63,13 +63,26 @@ def circular_spread(values: list[float]) -> tuple[float, float]:
 
 
 def compare_models(
-    variable: str, model_values: dict[str, float]
+    variable: str, model_values: dict[str, float | None]
 ) -> ModelDivergence:
     """Compare a variable across models and score agreement.
 
     model_values: e.g. {'gfs': 12.3, 'ecmwf': 11.8, 'icon': 12.1}
+
+    A model may be absent at a point (``None``); those are skipped rather than
+    averaged in. With no values left the divergence is empty (``mean=None``,
+    spread 0, good agreement) so the metric reads as "absent", not divergent.
     """
-    values = list(model_values.values())
+    values = [v for v in model_values.values() if v is not None]
+
+    if not values:
+        return ModelDivergence(
+            variable=variable,
+            model_values=model_values,
+            mean=None,
+            spread=0.0,
+            agreement=AgreementLevel.GOOD,
+        )
 
     if variable in CIRCULAR_VARIABLES:
         mean, spread = circular_spread(values)

--- a/src/weatherbrief/digest/text.py
+++ b/src/weatherbrief/digest/text.py
@@ -404,7 +404,12 @@ def _format_model_agreement(snapshot: ForecastSnapshot) -> list[str]:
         lines.append(f"  {analysis.waypoint.icao}:")
         if poor:
             for d in poor:
-                models_str = ", ".join(f"{k}={v:.1f}" for k, v in d.model_values.items())
+                # A model absent at the point reads back as None on pack
+                # round-trips (#202) — render "N/A", don't format None as float.
+                models_str = ", ".join(
+                    f"{k}={v:.1f}" if v is not None else f"{k}=N/A"
+                    for k, v in d.model_values.items()
+                )
                 lines.append(f"    POOR {d.variable}: spread {d.spread:.1f} ({models_str})")
         if moderate:
             names = ", ".join(d.variable for d in moderate)

--- a/src/weatherbrief/hewson/precompute.py
+++ b/src/weatherbrief/hewson/precompute.py
@@ -32,6 +32,8 @@ from __future__ import annotations
 import logging
 import os
 import time
+import zipfile
+import zlib
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -123,9 +125,10 @@ def latest_snapshot(
 def _snapshot_valid_window(path: Path) -> tuple[int, int] | None:
     """``(init_unix, last_valid_unix)`` a snapshot covers, or None if unreadable.
 
-    Reads only the lightweight scalars (``init_time_unix``, ``valid_times`` shape,
-    ``stride_hours``) — np.load is lazy over the zip members, so this does not
-    materialise the metric stacks.
+    Touches only the small header members — ``init_time_unix``, ``valid_times``
+    (a tiny 1-D timestamp array, read to count steps), and ``stride_hours``. The
+    large per-level metric stacks are never materialised, since np.load loads
+    zip members lazily on access.
     """
     try:
         with np.load(path) as npz:
@@ -136,7 +139,9 @@ def _snapshot_valid_window(path: Path) -> tuple[int, int] | None:
                 if "stride_hours" in npz.files
                 else DEFAULT_STRIDE_HOURS
             )
-    except Exception:
+    except (OSError, ValueError, KeyError, EOFError, zipfile.BadZipFile, zlib.error):
+        # Missing/corrupt/partially-written snapshot during a filesystem scan —
+        # skip it, but don't swallow unrelated bugs (e.g. a programming error).
         return None
     if n_time <= 0:
         return None

--- a/src/weatherbrief/hewson/precompute.py
+++ b/src/weatherbrief/hewson/precompute.py
@@ -120,6 +120,63 @@ def latest_snapshot(
     return snaps[-1] if snaps else None
 
 
+def _snapshot_valid_window(path: Path) -> tuple[int, int] | None:
+    """``(init_unix, last_valid_unix)`` a snapshot covers, or None if unreadable.
+
+    Reads only the lightweight scalars (``init_time_unix``, ``valid_times`` shape,
+    ``stride_hours``) — np.load is lazy over the zip members, so this does not
+    materialise the metric stacks.
+    """
+    try:
+        with np.load(path) as npz:
+            init = int(npz["init_time_unix"])
+            n_time = int(npz["valid_times"].shape[0])
+            stride = (
+                int(npz["stride_hours"])
+                if "stride_hours" in npz.files
+                else DEFAULT_STRIDE_HOURS
+            )
+    except Exception:
+        return None
+    if n_time <= 0:
+        return None
+    last = init + (n_time - 1) * stride * 3600
+    return init, last
+
+
+def snapshot_for_window(
+    model: str,
+    start: datetime,
+    end: datetime,
+    output_dir: Path | None = None,
+) -> Path | None:
+    """Latest snapshot whose forecast hours bracket ``[start, end]``, else None.
+
+    The front stage samples a flight at snapshot-relative hours; the *newest*
+    init (:func:`latest_snapshot`) is wrong when the flight window falls outside
+    it — a past flight lands at negative offsets and a far-future one past the
+    horizon. This scans available snapshots newest-first and returns the most
+    recent init whose valid-time span fully contains ``[start, end]``.
+
+    Returns ``None`` when no retained snapshot brackets the window (the caller
+    falls back to :func:`latest_snapshot` and notes the approximation).
+    """
+    subdir = resolve_output_dir(output_dir) / model
+    if not subdir.exists():
+        return None
+    start_u = int(start.timestamp())
+    end_u = int(end.timestamp())
+    # ISO-8601-Z filenames sort chronologically; reverse → newest init first.
+    for path in sorted(subdir.glob("*.npz"), reverse=True):
+        window = _snapshot_valid_window(path)
+        if window is None:
+            continue
+        init_u, last_u = window
+        if init_u <= start_u and end_u <= last_u:
+            return path
+    return None
+
+
 # ---------------------------------------------------------------------------
 # Terrain-mask caching
 # ---------------------------------------------------------------------------

--- a/src/weatherbrief/models/analysis.py
+++ b/src/weatherbrief/models/analysis.py
@@ -729,11 +729,17 @@ class AgreementLevel(str, Enum):
 
 
 class ModelDivergence(BaseModel):
-    """Comparison of a single variable across models."""
+    """Comparison of a single variable across models.
+
+    ``model_values`` may carry ``None`` for a model that lacks the metric at a
+    point, and ``mean`` is ``None`` when no model supplied a value. The artifact
+    is *written* with these nulls, so the schema must read them back — consumers
+    treat ``None`` as "metric absent for that model" (skip, don't average).
+    """
 
     variable: str
-    model_values: dict[str, float]
-    mean: float
+    model_values: dict[str, float | None]
+    mean: float | None = None
     spread: float
     agreement: AgreementLevel
 

--- a/src/weatherbrief/models/fronts.py
+++ b/src/weatherbrief/models/fronts.py
@@ -107,7 +107,15 @@ class RouteFrontsManifest(BaseModel):
     schema_version: int = 1
     route_name: str = ""
     generated_at: datetime
-    primary_level_hPa: int                       # level nearest cruise altitude
+    # Representative (modal) nearest-cruise level across models — kept for
+    # display / back-compat. Per-model grading must use ``per_model_primary_hPa``
+    # instead: a partial snapshot may expose different levels per model, so a
+    # single manifest-wide value would mis-grade a model whose cruise level
+    # differs (e.g. GFS 850 judged "overflown" against ECMWF's 700).
+    primary_level_hPa: int                       # representative level nearest cruise
+    # model → that model's own nearest-cruise level. Empty on pre-#203 packs;
+    # consumers fall back to ``primary_level_hPa`` then.
+    per_model_primary_hPa: dict[str, int] = Field(default_factory=dict)
     levels: list[int] = Field(default_factory=list)
     gate_config: dict = Field(default_factory=dict)
     models: list[str] = Field(default_factory=list)

--- a/src/weatherbrief/tasks/fronts.py
+++ b/src/weatherbrief/tasks/fronts.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 
 import dataclasses
 import logging
+from collections import Counter
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Sequence
@@ -51,6 +52,7 @@ from weatherbrief.hewson.precompute import (
     DEFAULT_LEVELS,
     latest_snapshot,
     resolve_output_dir,
+    snapshot_for_window,
 )
 from weatherbrief.models import (
     FrontCrossingModel,
@@ -431,14 +433,28 @@ def compute_route_fronts(
     terrain_mask = _load_cached_terrain_mask(output_dir)
 
     per_model: dict[str, list[RouteFrontAnalysisModel]] = {}
+    per_model_primary: dict[str, int] = {}
     snapshot_inits: dict[str, str] = {}
     missing: list[str] = []
+    fell_back: list[str] = []
     levels_seen: list[int] = []
     primary_level = 850
     base_config = get_preset(gate_preset)
 
+    # The flight's valid-time window — pick each model's snapshot to bracket it
+    # rather than always the newest init, so past/far-future flights sample at
+    # real (non-negative, in-horizon) forecast hours (#201).
+    win_start = min(etas) if etas else now
+    win_end = max(etas) if etas else now
+
     for model in models:
-        snap_path = latest_snapshot(model, output_dir)
+        snap_path = snapshot_for_window(model, win_start, win_end, output_dir)
+        if snap_path is None:
+            # No retained snapshot brackets the window — fall back to the latest
+            # init (timing may be off for past/far-future flights; noted below).
+            snap_path = latest_snapshot(model, output_dir)
+            if snap_path is not None:
+                fell_back.append(model)
         if snap_path is None:
             missing.append(model)
             continue
@@ -477,7 +493,10 @@ def compute_route_fronts(
         # Accumulate across models — a partial snapshot could expose a subset,
         # and manifest.levels must describe everything actually in per_model.
         levels_seen = sorted(set(levels_seen) | set(levels))
-        primary_level = nearest_cruise_level(cruise_altitude_ft, levels)
+        # Per-model nearest-cruise level — a partial snapshot may expose a
+        # different level set per model, so the advisory must grade each model's
+        # crossings against *its own* primary, not one manifest-wide value (#203).
+        model_primary = nearest_cruise_level(cruise_altitude_ft, levels)
 
         analyses: list[RouteFrontAnalysisModel] = []
         for level in levels:
@@ -500,12 +519,24 @@ def compute_route_fronts(
         _stamp_vertical_coherence(analyses, base_config.merge_km)
         if analyses:
             per_model[model] = analyses
+            per_model_primary[model] = model_primary
+
+    # Representative manifest-wide primary (display / back-compat): the modal
+    # per-model value, falling back to the legacy default when nothing detected.
+    if per_model_primary:
+        primary_level = Counter(per_model_primary.values()).most_common(1)[0][0]
 
     notes: list[str] = []
     if missing:
         notes.append(
             "No precompute snapshot for: " + ", ".join(missing)
             + " — front data unavailable for those models."
+        )
+    if fell_back:
+        notes.append(
+            "No snapshot brackets the flight window for: " + ", ".join(fell_back)
+            + " — used the latest available init (timing may be approximate for "
+            "past or far-future flights)."
         )
     notes.append(
         "Free-atmosphere fronts only; 850 hPa θe does not see low IMC / fog. "
@@ -517,6 +548,7 @@ def compute_route_fronts(
         route_name=route_name,
         generated_at=now,
         primary_level_hPa=primary_level,
+        per_model_primary_hPa=per_model_primary,
         levels=levels_seen,
         gate_config=base_config.with_overrides(level_hPa=primary_level).to_dict(),
         models=list(per_model.keys()),

--- a/tests/analysis/advisories/test_fronts_advisory.py
+++ b/tests/analysis/advisories/test_fronts_advisory.py
@@ -307,3 +307,38 @@ def test_unknown_coherence_treated_as_coherent():
 def test_default_disabled_in_catalog():
     """Front advisory must not run by default — gated by artifact presence."""
     assert FrontsEvaluator.catalog_entry().default_enabled is False
+
+
+def test_per_model_primary_level_not_flattened():
+    """A model's own cruise-level crossing must grade against *its* primary (#203).
+
+    GFS exposes only 850 hPa (its nearest-cruise level) while the manifest-wide
+    ``primary_level_hPa`` reflects another model's 700. A sharp, coherent wet GFS
+    crossing at 850 reaches the flight: graded against 850 it is at-cruise → RED;
+    graded against the wrong manifest-wide 700 it would read as overflown →
+    capped AMBER. ``per_model_primary_hPa`` keeps it RED.
+    """
+    xing = _crossing(
+        kind="cold", intensity="sharp", co_location="wet",
+        weather_top_ft=None, persistence=1.0, vertical_levels=2,
+    )
+    analysis = RouteFrontAnalysisModel(
+        model="gfs", level_hPa=850, hour=12.0, crossings=[xing],
+    )
+    manifest = RouteFrontsManifest(
+        generated_at=datetime(2026, 5, 31, tzinfo=timezone.utc),
+        primary_level_hPa=700,                       # another model's level
+        per_model_primary_hPa={"gfs": 850},          # gfs's own nearest-cruise
+        levels=[700, 850],
+        models=["gfs"],
+        per_model={"gfs": [analysis]},
+    )
+    result = FrontsEvaluator.evaluate(_ctx(manifest), _PARAMS)
+    assert result.aggregate_status == AdvisoryStatus.RED
+
+    # Without the per-model map (pre-#203 pack), the same crossing falls back to
+    # the manifest-wide 700 → 850 reads as overflown → capped AMBER. This is the
+    # latent mis-grade the field fixes.
+    manifest_old = manifest.model_copy(update={"per_model_primary_hPa": {}})
+    result_old = FrontsEvaluator.evaluate(_ctx(manifest_old), _PARAMS)
+    assert result_old.aggregate_status == AdvisoryStatus.AMBER

--- a/tests/test_comparison.py
+++ b/tests/test_comparison.py
@@ -66,3 +66,20 @@ def test_three_models():
     assert result.mean == 35.0
     assert result.spread == 10.0
     assert result.agreement == AgreementLevel.GOOD  # <15% spread
+
+
+def test_skips_none_value_not_averaged():
+    """A model absent at a point (None) is skipped, not averaged in (#202)."""
+    result = compare_models("temperature_c", {"gfs": 10.0, "ecmwf": 12.0, "icon": None})
+    assert result.model_values == {"gfs": 10.0, "ecmwf": 12.0, "icon": None}
+    assert result.mean == 11.0          # icon=None excluded from the mean
+    assert result.spread == 2.0
+
+
+def test_all_none_reads_as_absent():
+    """No model supplied a value → mean None, not a crash (#202)."""
+    result = compare_models("temperature_c", {"gfs": None, "ecmwf": None})
+    assert result.mean is None
+    assert result.spread == 0.0
+    assert result.agreement == AgreementLevel.GOOD
+    assert result.model_values == {"gfs": None, "ecmwf": None}

--- a/tests/test_digest_text_null_divergence.py
+++ b/tests/test_digest_text_null_divergence.py
@@ -1,0 +1,40 @@
+"""Regression: digest model-agreement text tolerates None model values (#202 review).
+
+Relaxing ``ModelDivergence.model_values`` to ``dict[str, float | None]`` so packs
+round-trip (#202) opened a latent crash in ``_format_model_agreement``: a POOR
+divergence with an absent model (``None``) hit ``f"{None:.1f}"`` →
+``ValueError``. The formatter now renders absent models as ``N/A``.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from weatherbrief.digest.text import _format_model_agreement
+from weatherbrief.models import AgreementLevel, ModelDivergence
+
+
+def _snapshot_with_poor_null_divergence():
+    div = ModelDivergence(
+        variable="temperature_c",
+        # icon absent at this point → None; the others diverge widely → POOR.
+        model_values={"ecmwf": 4.0, "gfs": 12.0, "icon": None},
+        mean=8.0,
+        spread=8.0,
+        agreement=AgreementLevel.POOR,
+    )
+    analysis = SimpleNamespace(
+        waypoint=SimpleNamespace(icao="LFAT"),
+        model_divergence=[div],
+    )
+    return SimpleNamespace(analyses=[analysis])
+
+
+def test_format_model_agreement_renders_none_as_na():
+    # Must not raise ValueError on the None value.
+    lines = _format_model_agreement(_snapshot_with_poor_null_divergence())
+    text = "\n".join(lines)
+    assert "POOR temperature_c" in text
+    assert "icon=N/A" in text
+    assert "ecmwf=4.0" in text
+    assert "gfs=12.0" in text

--- a/tests/test_route_analyses_null_divergence.py
+++ b/tests/test_route_analyses_null_divergence.py
@@ -1,0 +1,74 @@
+"""Regression: route_analyses.json with null model_divergence must read back (#202).
+
+The artifact is *written* with ``null`` for a model that lacks a divergence
+metric at a point (and a null ``mean`` when all models are absent). Before #202
+``load_route_analyses`` raised a Pydantic ``ValidationError`` on read-back, which
+broke every recompute-from-pack path (advisory recalculate, alt-departure,
+scoring, and front recompute).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from weatherbrief.tasks.artifacts import load_route_analyses
+
+
+def _pack_with_null_divergence(pack_dir: Path) -> None:
+    """Write a minimal route_analyses.json whose one point has a null divergence."""
+    manifest = {
+        "route_name": "EGKB-LFAT",
+        "target_date": "2026-05-31",
+        "departure_time": "2026-05-31T06:00:00+00:00",
+        "flight_duration_hours": 2.0,
+        "total_distance_nm": 160.0,
+        "cruise_altitude_ft": 5000,
+        "models": ["ecmwf", "gfs", "icon"],
+        "analyses": [
+            {
+                "point_index": 0,
+                "lat": 47.0,
+                "lon": -1.5,
+                "distance_from_origin_nm": 0.0,
+                "interpolated_time": "2026-05-31T06:00:00+00:00",
+                "forecast_hour": "2026-05-31T06:00:00+00:00",
+                "track_deg": 90.0,
+                "model_divergence": [
+                    {
+                        # icon absent at this point → null; mean still numeric.
+                        "variable": "temperature_c",
+                        "model_values": {"ecmwf": 11.8, "gfs": 12.3, "icon": None},
+                        "mean": 12.05,
+                        "spread": 0.5,
+                        "agreement": "good",
+                    },
+                    {
+                        # all models absent → null mean (the case that crashed).
+                        "variable": "cape_jkg",
+                        "model_values": {"ecmwf": None, "gfs": None, "icon": None},
+                        "mean": None,
+                        "spread": 0.0,
+                        "agreement": "good",
+                    },
+                ],
+            }
+        ],
+    }
+    (pack_dir / "route_analyses.json").write_text(json.dumps(manifest))
+
+
+def test_load_route_analyses_tolerates_null_divergence(tmp_path):
+    pack_dir = tmp_path / "pack"
+    pack_dir.mkdir()
+    _pack_with_null_divergence(pack_dir)
+
+    # Must not raise ValidationError.
+    manifest = load_route_analyses(pack_dir)
+
+    rpa = manifest.analyses[0]
+    by_var = {d.variable: d for d in rpa.model_divergence}
+    assert by_var["temperature_c"].model_values["icon"] is None
+    assert by_var["temperature_c"].mean == 12.05
+    assert by_var["cape_jkg"].mean is None
+    assert all(v is None for v in by_var["cape_jkg"].model_values.values())

--- a/tests/test_tasks_fronts.py
+++ b/tests/test_tasks_fronts.py
@@ -28,8 +28,19 @@ _STRIDE = 3
 _N_TIME = 9  # 0..24 h
 
 
-def _write_front_snapshot(out_dir: Path, model: str = "ecmwf") -> Path:
-    """A snapshot with a meridional θe front (cold front, eastward flow)."""
+def _write_front_snapshot(
+    out_dir: Path,
+    model: str = "ecmwf",
+    *,
+    init_dt: datetime = _INIT_DT,
+    levels: tuple[int, ...] = _LEVELS,
+) -> Path:
+    """A snapshot with a meridional θe front (cold front, eastward flow).
+
+    ``init_dt`` lets a test plant snapshots at several model inits (#201); the
+    ``levels`` override lets it plant a partial snapshot — fewer pressure levels
+    for one model — to exercise the per-model primary level (#203).
+    """
     from weatherbrief.frontal.detect import compute_hewson_diagnostics
     from weatherbrief.hewson.precompute import (
         snapshot_path,
@@ -37,12 +48,13 @@ def _write_front_snapshot(out_dir: Path, model: str = "ecmwf") -> Path:
         write_snapshot,
     )
 
+    init_unix = int(init_dt.timestamp())
     lat = np.linspace(45.0, 52.0, 29)
     lon = np.linspace(-2.0, 6.0, 33)
     _, lon_grid = np.meshgrid(lat, lon, indexing="ij")
 
     per_level: dict[int, dict] = {}
-    for L in _LEVELS:
+    for L in levels:
         m = {
             k: np.full((_N_TIME, lat.size, lon.size), np.nan, dtype=np.float32)
             for k in ("theta_e", "gradient", "neg_laplacian", "tfp", "advection")
@@ -62,14 +74,14 @@ def _write_front_snapshot(out_dir: Path, model: str = "ecmwf") -> Path:
         per_level[L] = m
 
     valid_times = np.array(
-        [np.datetime64(_INIT_DT.replace(tzinfo=None) + timedelta(hours=h * _STRIDE))
+        [np.datetime64(init_dt.replace(tzinfo=None) + timedelta(hours=h * _STRIDE))
          for h in range(_N_TIME)],
         dtype="datetime64[ns]",
     )
-    path = snapshot_path(model, _INIT_UNIX, output_dir=out_dir)
+    path = snapshot_path(model, init_unix, output_dir=out_dir)
     write_snapshot(
-        path, init_time_unix=_INIT_UNIX, valid_times=valid_times,
-        lat=lat, lon=lon, levels=list(_LEVELS), stride_hours=_STRIDE,
+        path, init_time_unix=init_unix, valid_times=valid_times,
+        lat=lat, lon=lon, levels=list(levels), stride_hours=_STRIDE,
         per_level=per_level,
     )
     return path
@@ -396,3 +408,102 @@ class TestRunFronts:
             advisory_models=["ecmwf"], pack_dir=pack_dir, output_dir=out_dir,
         ) is None
         assert not (pack_dir / "route_fronts.json").exists()
+
+
+class TestSnapshotForWindow:
+    """Valid-time snapshot selection (#201) — pick the init that brackets the
+    flight window, not merely the newest."""
+
+    def test_prefers_latest_init_that_brackets(self, tmp_path):
+        from weatherbrief.hewson.precompute import snapshot_for_window
+        out_dir = tmp_path / "hewson"
+        # Two inits 12 h apart; both cover [15Z, 18Z]. Expect the newer (12Z).
+        _write_front_snapshot(out_dir, init_dt=_INIT_DT)
+        _write_front_snapshot(out_dir, init_dt=_INIT_DT + timedelta(hours=12))
+        sel = snapshot_for_window(
+            "ecmwf", _INIT_DT + timedelta(hours=15), _INIT_DT + timedelta(hours=18),
+            output_dir=out_dir,
+        )
+        assert sel is not None
+        assert sel.stem == "2026-05-31T12:00:00Z"
+
+    def test_none_when_window_before_all_inits(self, tmp_path):
+        from weatherbrief.hewson.precompute import snapshot_for_window
+        out_dir = tmp_path / "hewson"
+        _write_front_snapshot(out_dir, init_dt=_INIT_DT)
+        # A past flight: window precedes the only init → no bracketing snapshot.
+        assert snapshot_for_window(
+            "ecmwf", _INIT_DT - timedelta(hours=6), _INIT_DT - timedelta(hours=3),
+            output_dir=out_dir,
+        ) is None
+
+    def test_none_when_window_past_horizon(self, tmp_path):
+        from weatherbrief.hewson.precompute import snapshot_for_window
+        out_dir = tmp_path / "hewson"
+        _write_front_snapshot(out_dir, init_dt=_INIT_DT)  # covers 0..24 h
+        assert snapshot_for_window(
+            "ecmwf", _INIT_DT + timedelta(hours=30), _INIT_DT + timedelta(hours=33),
+            output_dir=out_dir,
+        ) is None
+
+    def test_missing_model_dir(self, tmp_path):
+        from weatherbrief.hewson.precompute import snapshot_for_window
+        assert snapshot_for_window(
+            "ecmwf", _INIT_DT, _INIT_DT + timedelta(hours=1),
+            output_dir=tmp_path / "empty",
+        ) is None
+
+
+class TestWindowSelectionInCompute:
+    """compute_route_fronts wires snapshot-by-window with a logged fallback (#201)."""
+
+    def test_picks_bracketing_init_over_newest(self, tmp_path):
+        out_dir = tmp_path / "hewson"
+        # Older init brackets the flight; a much newer init does NOT (starts +48h).
+        _write_front_snapshot(out_dir, init_dt=_INIT_DT)
+        _write_front_snapshot(out_dir, init_dt=_INIT_DT + timedelta(hours=48))
+        analyses = _route_analyses()  # flight at init + 6 h
+        manifest = compute_route_fronts(
+            [(a.lat, a.lon) for a in analyses],
+            [a.interpolated_time for a in analyses],
+            route_name="r", cruise_altitude_ft=5000,
+            advisory_models=["ecmwf"], output_dir=out_dir,
+        )
+        # latest_snapshot would have picked the +48h init; window selection
+        # picks the older init that actually brackets the flight.
+        assert manifest.snapshot_inits["ecmwf"] == "2026-05-31T00:00:00Z"
+
+    def test_falls_back_to_latest_with_note(self, tmp_path):
+        out_dir = tmp_path / "hewson"
+        # Only a future init exists; the flight precedes it → no bracket → fall
+        # back to the latest available init and note the approximation.
+        _write_front_snapshot(out_dir, init_dt=_INIT_DT + timedelta(hours=48))
+        analyses = _route_analyses()  # flight at _INIT_DT + 6 h (before the init)
+        manifest = compute_route_fronts(
+            [(a.lat, a.lon) for a in analyses],
+            [a.interpolated_time for a in analyses],
+            route_name="r", cruise_altitude_ft=5000,
+            advisory_models=["ecmwf"], output_dir=out_dir,
+        )
+        assert manifest.snapshot_inits["ecmwf"] == "2026-06-02T00:00:00Z"
+        assert any("latest available init" in n for n in manifest.notes)
+
+
+class TestPerModelPrimaryLevel:
+    """primary_level_hPa is tracked per model, not last-model-wins (#203)."""
+
+    def test_partial_snapshot_gets_own_primary(self, tmp_path):
+        out_dir = tmp_path / "hewson"
+        # ecmwf carries all three levels; gfs is a partial snapshot (850 only).
+        _write_front_snapshot(out_dir, model="ecmwf", levels=(925, 850, 700))
+        _write_front_snapshot(out_dir, model="gfs", levels=(850,))
+        analyses = _route_analyses()
+        manifest = compute_route_fronts(
+            [(a.lat, a.lon) for a in analyses],
+            [a.interpolated_time for a in analyses],
+            route_name="r", cruise_altitude_ft=11000,  # nearest cruise → 700
+            advisory_models=["ecmwf", "gfs"], output_dir=out_dir,
+        )
+        # ecmwf has 700 (nearest to FL110); gfs only exposes 850, so its own
+        # nearest-cruise primary is 850 — not flattened to ecmwf's 700.
+        assert manifest.per_model_primary_hPa == {"ecmwf": 700, "gfs": 850}


### PR DESCRIPTION
Bundles three small, related front-detection fixes that all surfaced from the #200 Dijon work and live in the same recompute-from-pack path. Ordered by dependency — #202 unblocks the others (and was a prerequisite for testing them on a real pack).

## #202 — null `model_divergence` blocks recompute-from-pack (bug)
`ModelDivergence.model_values`/`mean` were non-optional, so `load_route_analyses` raised a `ValidationError` on any pack written with a `null` divergence entry. That broke **every** recompute-from-pack path: advisory recalculate, alt-departure, scoring, and front recompute.

- `model_values: dict[str, float | None]`, `mean: float | None = None` — read back what we write.
- `compare_models` now skips `None` (doesn't average it in); all-`None` reads as "metric absent" (`mean=None`), not a crash.
- Regression test loads a manifest with both a per-model null and an all-null divergence.

## #201 — select snapshot by flight valid-time, not just latest init (enhancement)
`compute_route_fronts` always read the **newest** Hewson snapshot, so past/far-future flights sampled at out-of-range forecast hours (negative offsets / beyond horizon).

- New `snapshot_for_window(model, start, end)` — most recent init whose valid-time span brackets the flight window.
- `compute_route_fronts` uses it with a **logged fallback** to `latest_snapshot` when nothing brackets (note added to the manifest).
- **Scope:** core selection only. On-demand historical regen for genuinely past flights (on-demand precompute / `CaseFieldSource`) is intentionally deferred to a follow-up.

## #203 — per-model primary level, not last-model-wins (enhancement)
The nearest-cruise primary was set inside the per-model loop, so `manifest.primary_level_hPa` was whatever the **last** model produced. Under a partial snapshot (models exposing different levels), that mis-grades a model's own cruise-level crossing as "overflown" — flipping its severity given #200's altitude-relative grading.

- Track `per_model_primary_hPa: dict[str, int]`; the advisory grades each model against **its own** primary (falls back to `primary_level_hPa` on pre-#203 packs).
- `primary_level_hPa` kept as the representative (modal) value for display/back-compat.
- Harmless today (all three precompute models share 925/850/700) — this prevents the latent mis-grade if that invariant ever breaks.

## Tests
Full suite green (2362 passed, 9 skipped). Added: `compare_models` None handling, null-divergence pack round-trip, `snapshot_for_window` selection/fallback, window selection + fallback note in `compute_route_fronts`, per-model primary tracking, and an advisory test proving a GFS-850 crossing stays RED against its own primary instead of being capped to AMBER against another model's 700.

Closes #201
Closes #202
Closes #203

🤖 Generated with [Claude Code](https://claude.com/claude-code)