### PR TITLE
feat(export): FlightExchange JSON export endpoint (#197)

### DIFF
--- a/src/weatherbrief/airports.py
+++ b/src/weatherbrief/airports.py
@@ -133,15 +133,10 @@ def resolve_waypoints(
             on the map — those are mandatory. Missing middles go into
             ``rejected`` instead.
     """
-    from euro_aip.models.route_resolver import RouteResolver
-
-    model = _load_airport_model(db_path)
-    resolver = RouteResolver(model)
-
-    # Use the full route resolver which disambiguates by proximity and
-    # filters points whose detour from the route is too large.
-    route_string = " ".join(codes)
-    route = resolver.resolve(route_string)
+    # resolve_route handles the resolver setup (proximity disambiguation +
+    # detour filtering) and the departure/destination coord guards, raising
+    # KeyError if an endpoint can't be placed on the map.
+    route = resolve_route(codes, db_path)
 
     # euro_aip emits detour-rejected entries as dicts: {"name", "reason",
     # "detour_nm", "leg_nm", "threshold_nm"}. Older releases lack the field
@@ -150,11 +145,6 @@ def resolve_waypoints(
         RejectedWaypoint(name=str(r["name"]), reason="detour")
         for r in getattr(route, "rejected_waypoints", [])
     ]
-
-    if not route.departure_coords:
-        raise KeyError(f"We did not find in our database: {codes[0]}")
-    if not route.destination_coords:
-        raise KeyError(f"We did not find in our database: {codes[-1]}")
 
     # Middle tokens that the resolver neither placed nor rejected: the
     # resolver silently dropped them because no DB entry matched under

--- a/src/weatherbrief/airports.py
+++ b/src/weatherbrief/airports.py
@@ -64,6 +64,42 @@ def is_known_waypoint(code: str, db_path: str) -> bool:
     return resolver.resolve_point(code.upper()) is not None
 
 
+def resolve_route(codes: list[str], db_path: str):
+    """Resolve waypoint codes to a euro_aip ``Route`` with coordinates.
+
+    Unlike :func:`resolve_waypoints` (which flattens to a single ``Waypoint``
+    list), this returns the richer ``euro_aip.briefing.models.route.Route``
+    object the resolver builds: explicit ``departure``/``destination`` endpoints,
+    intermediate ``waypoints`` (middle tokens only), resolved coordinates, and
+    ``rejected_waypoints``. That ``Route`` is the type ``FlightExchange`` wraps,
+    so this is the entry point for emitting a cross-app flight payload.
+
+    Args:
+        codes: Ordered waypoint codes (min 2); ``codes[0]`` is the departure,
+            ``codes[-1]`` the destination.
+        db_path: Path to the euro_aip SQLite database.
+
+    Returns:
+        The resolved ``Route``. Timing/altitude/aircraft are NOT set here —
+        those live on weather's ``Flight`` and are layered on by the caller.
+
+    Raises:
+        KeyError: If the departure or destination can't be placed on the map.
+    """
+    from euro_aip.models.route_resolver import RouteResolver
+
+    model = _load_airport_model(db_path)
+    resolver = RouteResolver(model)
+    route = resolver.resolve(" ".join(codes))
+
+    if not route.departure_coords:
+        raise KeyError(f"We did not find in our database: {codes[0]}")
+    if not route.destination_coords:
+        raise KeyError(f"We did not find in our database: {codes[-1]}")
+
+    return route
+
+
 def resolve_waypoints(
     codes: list[str], db_path: str
 ) -> tuple[list[Waypoint], list[RejectedWaypoint]]:

--- a/src/weatherbrief/airports.py
+++ b/src/weatherbrief/airports.py
@@ -5,12 +5,15 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from functools import lru_cache
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
 from euro_aip.storage.database_storage import DatabaseStorage
 from timezonefinder import TimezoneFinder
 
 from weatherbrief.models import RunwayEnd, Waypoint
+
+if TYPE_CHECKING:
+    from euro_aip.briefing.models.route import Route
 
 
 RejectReason = Literal["detour", "unknown"]
@@ -64,7 +67,7 @@ def is_known_waypoint(code: str, db_path: str) -> bool:
     return resolver.resolve_point(code.upper()) is not None
 
 
-def resolve_route(codes: list[str], db_path: str):
+def resolve_route(codes: list[str], db_path: str) -> Route:
     """Resolve waypoint codes to a euro_aip ``Route`` with coordinates.
 
     Unlike :func:`resolve_waypoints` (which flattens to a single ``Waypoint``

--- a/src/weatherbrief/api/flights.py
+++ b/src/weatherbrief/api/flights.py
@@ -7,7 +7,7 @@ import json
 import logging
 import re
 from datetime import datetime, timedelta, timezone
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
 from pydantic import BaseModel, Field, field_validator
@@ -41,6 +41,9 @@ router = APIRouter(prefix="/flights", tags=["flights"])
 logger = logging.getLogger(__name__)
 
 from weatherbrief.api.validation import WAYPOINT_RE, is_valid_waypoint
+
+if TYPE_CHECKING:
+    from euro_aip.briefing.models.flight_exchange import FlightExchange
 
 
 class CreateFlightRequest(BaseModel):
@@ -247,7 +250,7 @@ def _resolve_aircraft_info(
 
 def flight_to_exchange(
     flight: Flight, db: Session, db_path: str, *, viewer_id: str
-):
+) -> FlightExchange:
     """Map a weather ``Flight`` to a cross-app ``FlightExchange`` envelope.
 
     Weather stores a route as a single ``waypoints`` list with implicit
@@ -1447,7 +1450,8 @@ def export_flight(
     try:
         exchange = flight_to_exchange(flight, db, db_path, viewer_id=user_id)
     except KeyError as exc:
-        raise HTTPException(status_code=422, detail=exc.args[0])
+        detail = exc.args[0] if exc.args else "Route could not be resolved"
+        raise HTTPException(status_code=422, detail=detail)
 
     return exchange.to_dict()
 

--- a/src/weatherbrief/api/flights.py
+++ b/src/weatherbrief/api/flights.py
@@ -245,6 +245,60 @@ def _resolve_aircraft_info(
     )
 
 
+def flight_to_exchange(
+    flight: Flight, db: Session, db_path: str, *, viewer_id: str
+):
+    """Map a weather ``Flight`` to a cross-app ``FlightExchange`` envelope.
+
+    Weather stores a route as a single ``waypoints`` list with implicit
+    endpoints, and keeps timing/altitude/aircraft alongside it on the flight
+    row. The shared ``FlightExchange`` format (and the ``Route`` it wraps) uses
+    explicit endpoints, so weather is the side that adapts on emit:
+
+    - resolve ``waypoints`` → a ``Route`` with split endpoints + coordinates
+    - layer on ``departure_time``, derived ``arrival_time``, cruise altitude
+    - resolve ``aircraft_id`` → ICAO type + registration
+    - wrap with provenance (``source`` = weather, native id, share code)
+
+    The aircraft registration is only emitted to the aircraft's owner — it is
+    semi-personal, the same privacy gate :func:`_resolve_aircraft_info` applies
+    to ``tail_number``.
+
+    Raises:
+        KeyError: If the departure or destination can't be resolved (caller
+            maps this to a 422). Callers should pre-check ``len(waypoints) >= 2``.
+    """
+    from euro_aip.briefing.models.flight_exchange import FlightExchange
+    from weatherbrief.airports import resolve_route
+    from weatherbrief.db.models import UserAircraftRow
+
+    route = resolve_route(flight.waypoints, db_path)
+
+    route.departure_time = flight.departure_time
+    if flight.flight_duration_hours:
+        route.arrival_time = flight.departure_time + timedelta(
+            hours=flight.flight_duration_hours
+        )
+    route.cruise_altitude_ft = flight.cruise_altitude_ft
+
+    registration = None
+    if flight.aircraft_id is not None:
+        ac = db.get(UserAircraftRow, flight.aircraft_id)
+        if ac is not None:
+            route.aircraft_type = ac.icao_type
+            if ac.user_id == viewer_id:
+                registration = ac.tail_number
+
+    return FlightExchange(
+        route=route,
+        name=flight.route_name or None,
+        aircraft_registration=registration,
+        source_app="weather",
+        source_flight_id=flight.id,
+        source_share_code=flight.share_code,
+    )
+
+
 def _resolve_owner_display_name(db: Session, owner_id: str) -> str | None:
     """Look up a flight owner's display name for the subscriber/non-owner view.
 
@@ -1361,6 +1415,41 @@ def get_flight(
     """Get flight details. Any authenticated user can view public flights."""
     flight = _load_flight_or_404(db, flight_id, viewer_id=user_id)
     return _flight_to_response(flight, db, viewer_id=user_id)
+
+
+@router.get("/{flight_id}/export")
+def export_flight(
+    flight_id: str,
+    request: Request,
+    user_id: str = Depends(current_user_id),
+    db: Session = Depends(get_db),
+):
+    """Export a flight as a cross-app ``FlightExchange`` JSON payload.
+
+    The shared interchange format other flyfun apps (forms, brief) consume to
+    import a flight's route/time/aircraft — see euro_aip's ``FlightExchange``.
+    Authenticated, and respects the same visibility as ``GET /{flight_id}``:
+    the owner always, plus any viewer for a non-private flight. Distinct from
+    the public ``/s/{code}`` share link, which redirects humans to the briefing
+    page and stays unchanged.
+    """
+    flight = _load_flight_or_404(db, flight_id, viewer_id=user_id)
+
+    if len(flight.waypoints) < 2:
+        raise HTTPException(
+            status_code=422, detail=f"Flight '{flight_id}' has no route to export"
+        )
+
+    db_path = getattr(request.app.state, "db_path", "")
+    if not db_path:
+        raise HTTPException(status_code=503, detail="Airport database unavailable")
+
+    try:
+        exchange = flight_to_exchange(flight, db, db_path, viewer_id=user_id)
+    except KeyError as exc:
+        raise HTTPException(status_code=422, detail=exc.args[0])
+
+    return exchange.to_dict()
 
 
 class SubscribeResponse(BaseModel):

--- a/tests/test_flight_export.py
+++ b/tests/test_flight_export.py
@@ -1,0 +1,311 @@
+"""Tests for the FlightExchange export feature (issue #197).
+
+Covers the ``Flight`` → ``FlightExchange`` emit adapter
+(:func:`weatherbrief.api.flights.flight_to_exchange`) and the
+``GET /api/flights/{flight_id}/export`` endpoint that serves the shared
+cross-app interchange payload other flyfun apps (forms, brief) import.
+
+The adapter splits weather's single ``waypoints`` list into the explicit
+endpoints the shared ``Route`` uses, so we test both with a real airport DB
+(end-to-end coordinate resolution) and with a stubbed resolver (deterministic
+envelope logic: derived arrival, aircraft registration owner-gating, source).
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import sessionmaker
+
+from flyfun_common.db import DEV_USER_ID, current_user_id, get_db
+from flyfun_common.db.models import UserPreferencesRow, UserRow
+from weatherbrief.api import flights as flights_api
+from weatherbrief.api.app import create_app
+from weatherbrief.db.models import UserAircraftRow
+from weatherbrief.models import Flight
+from weatherbrief.storage.flights import save_flight
+
+
+def _find_nav_db() -> str | None:
+    """Locate the euro_aip airport DB, or return None so DB tests can skip.
+
+    Worktrees share ``nav.db`` from the ``main`` worktree's data dir (see
+    project CLAUDE.md), so prefer an explicit ``AIRPORTS_DB`` then fall back
+    to the conventional ``<repo>/main/data/nav.db``.
+    """
+    env = os.environ.get("AIRPORTS_DB")
+    candidates = [os.path.expandvars(env)] if env else []
+    here = Path(__file__).resolve()
+    candidates.append(str(here.parents[2] / "main" / "data" / "nav.db"))
+    candidates.append(str(here.parents[1] / "data" / "nav.db"))
+    for c in candidates:
+        if c and "$" not in c and Path(c).exists():
+            return c
+    return None
+
+
+NAV_DB = _find_nav_db()
+needs_nav_db = pytest.mark.skipif(NAV_DB is None, reason="nav.db not available")
+
+DEP = datetime(2026, 6, 1, 9, 0, tzinfo=timezone.utc)
+
+
+def _make_flight(
+    idx: int,
+    *,
+    waypoints: list[str] | None = None,
+    aircraft_id: int | None = None,
+    private: bool = False,
+    share_code: str | None = None,
+) -> Flight:
+    return Flight(
+        id=f"egtk-lfat-2026-06-01-{idx:04d}",
+        user_id=DEV_USER_ID,
+        route_name="egtk_lfat",
+        waypoints=waypoints if waypoints is not None else ["EGTK", "LFAT"],
+        departure_time=DEP,
+        cruise_altitude_ft=8000,
+        flight_ceiling_ft=18000,
+        flight_duration_hours=1.5,
+        aircraft_id=aircraft_id,
+        private=private,
+        share_code=share_code,
+        created_at=DEP,
+    )
+
+
+# --- Adapter: deterministic envelope logic (stubbed resolver) ---
+
+
+class TestExchangeEnvelope:
+    """Envelope mapping that does not depend on airport geography.
+
+    Stubs :func:`resolve_route` so the route is fixed and we can assert the
+    timing / aircraft / provenance logic the adapter layers on top.
+    """
+
+    @pytest.fixture
+    def stub_route(self, monkeypatch):
+        from euro_aip.briefing.models.route import Route
+
+        def _fake_resolve_route(codes, db_path):
+            return Route(
+                departure=codes[0],
+                destination=codes[-1],
+                waypoints=list(codes[1:-1]),
+                departure_coords=(51.83, -1.32),
+                destination_coords=(43.18, 0.0),
+            )
+
+        monkeypatch.setattr(flights_api, "resolve_route", _fake_resolve_route, raising=False)
+        # The adapter imports resolve_route from weatherbrief.airports at call
+        # time, so patch it at the source module too.
+        import weatherbrief.airports as airports_mod
+
+        monkeypatch.setattr(airports_mod, "resolve_route", _fake_resolve_route)
+
+    def test_basic_envelope_and_source(self, stub_route, db_session, dev_user):
+        flight = _make_flight(1, share_code="aB3xy7Q9")
+        fx = flights_api.flight_to_exchange(
+            flight, db_session, "unused-db", viewer_id=DEV_USER_ID
+        )
+        d = fx.to_dict()
+        assert d["schema_version"] == 1
+        assert d["route"]["departure"] == "EGTK"
+        assert d["route"]["destination"] == "LFAT"
+        assert d["name"] == "egtk_lfat"
+        assert d["source"] == {
+            "app": "weather",
+            "flight_id": flight.id,
+            "share_code": "aB3xy7Q9",
+        }
+
+    def test_arrival_derived_from_duration(self, stub_route, db_session, dev_user):
+        flight = _make_flight(2)  # duration 1.5h
+        fx = flights_api.flight_to_exchange(
+            flight, db_session, "unused-db", viewer_id=DEV_USER_ID
+        )
+        route = fx.route
+        assert route.departure_time == DEP
+        assert route.arrival_time == DEP + timedelta(hours=1.5)
+
+    def test_no_arrival_when_duration_zero(self, stub_route, db_session, dev_user):
+        flight = _make_flight(3)
+        flight.flight_duration_hours = 0.0
+        fx = flights_api.flight_to_exchange(
+            flight, db_session, "unused-db", viewer_id=DEV_USER_ID
+        )
+        assert fx.route.arrival_time is None
+
+    def test_intermediate_waypoints_kept(self, stub_route, db_session, dev_user):
+        flight = _make_flight(4, waypoints=["EGTK", "BILGO", "LFAT"])
+        fx = flights_api.flight_to_exchange(
+            flight, db_session, "unused-db", viewer_id=DEV_USER_ID
+        )
+        # waypoints carries the middle tokens only; endpoints are split out.
+        assert fx.route.waypoints == ["BILGO"]
+        assert fx.route.departure == "EGTK"
+        assert fx.route.destination == "LFAT"
+
+    def test_aircraft_registration_for_owner(self, stub_route, db_session, dev_user):
+        ac = UserAircraftRow(
+            user_id=DEV_USER_ID, icao_type="P28A", tail_number="G-ABCD",
+        )
+        db_session.add(ac)
+        db_session.flush()
+        flight = _make_flight(5, aircraft_id=ac.id)
+        fx = flights_api.flight_to_exchange(
+            flight, db_session, "unused-db", viewer_id=DEV_USER_ID
+        )
+        d = fx.to_dict()
+        assert d["aircraft"]["registration"] == "G-ABCD"
+        assert d["aircraft"]["type"] == "P28A"
+        assert d["route"]["aircraft_type"] == "P28A"
+
+    def test_aircraft_registration_hidden_from_non_owner(
+        self, stub_route, db_session, dev_user
+    ):
+        ac = UserAircraftRow(
+            user_id=DEV_USER_ID, icao_type="P28A", tail_number="G-ABCD",
+        )
+        db_session.add(ac)
+        db_session.flush()
+        flight = _make_flight(6, aircraft_id=ac.id)
+        fx = flights_api.flight_to_exchange(
+            flight, db_session, "unused-db", viewer_id="someone-else"
+        )
+        d = fx.to_dict()
+        # Type still travels (it's not personal); the registration does not.
+        assert d["route"]["aircraft_type"] == "P28A"
+        assert "registration" not in d.get("aircraft", {})
+
+
+# --- Adapter: real airport-DB resolution ---
+
+
+@needs_nav_db
+class TestExchangeRealResolution:
+    def test_resolves_endpoints_and_coords(self, db_session, dev_user):
+        flight = _make_flight(20)
+        fx = flights_api.flight_to_exchange(
+            flight, db_session, NAV_DB, viewer_id=DEV_USER_ID
+        )
+        route = fx.route
+        assert route.departure == "EGTK"
+        assert route.destination == "LFAT"
+        assert route.departure_coords is not None
+        assert route.destination_coords is not None
+        # EGTK (Oxford) sits around 51.8N / -1.3E — sanity, not exactness.
+        assert 50 < route.departure_coords[0] < 53
+
+
+# --- Endpoint: GET /api/flights/{id}/export ---
+
+
+@pytest.fixture
+def app_db():
+    from conftest import make_app_engine
+
+    engine = make_app_engine()
+    TestSession = sessionmaker(bind=engine)
+    s = TestSession()
+    s.add(UserRow(
+        id=DEV_USER_ID, provider="local", provider_sub="dev",
+        email="d@l", display_name="D", approved=True,
+    ))
+    s.flush()
+    s.add(UserPreferencesRow(user_id=DEV_USER_ID))
+    s.commit()
+    s.close()
+    yield TestSession
+    engine.dispose()
+
+
+@pytest.fixture
+def client(app_db, tmp_path, monkeypatch):
+    monkeypatch.setenv("DATA_DIR", str(tmp_path / "data"))
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.setenv("JWT_SECRET", "test")
+    if NAV_DB:
+        monkeypatch.setenv("AIRPORTS_DB", NAV_DB)
+    app = create_app()
+    if NAV_DB:
+        app.state.db_path = NAV_DB
+
+    def _override_get_db():
+        s = app_db()
+        try:
+            yield s
+            s.commit()
+        except Exception:
+            s.rollback()
+            raise
+        finally:
+            s.close()
+
+    app.dependency_overrides[get_db] = _override_get_db
+    app.dependency_overrides[current_user_id] = lambda: DEV_USER_ID
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def _seed(app_db, flight: Flight) -> Flight:
+    s = app_db()
+    save_flight(s, flight, flight.user_id)
+    s.commit()
+    s.close()
+    return flight
+
+
+@needs_nav_db
+class TestExportEndpoint:
+    def test_export_returns_flightexchange(self, client, app_db):
+        f = _seed(app_db, _make_flight(30, share_code="Exp0rtAA"))
+        resp = client.get(f"/api/flights/{f.id}/export")
+        assert resp.status_code == 200, resp.text
+        d = resp.json()
+        assert d["schema_version"] == 1
+        assert d["route"]["departure"] == "EGTK"
+        assert d["route"]["destination"] == "LFAT"
+        assert d["route"]["departure_coords"] is not None
+        assert d["source"] == {
+            "app": "weather",
+            "flight_id": f.id,
+            "share_code": "Exp0rtAA",
+        }
+
+    def test_export_includes_owned_aircraft_registration(self, client, app_db):
+        s = app_db()
+        ac = UserAircraftRow(
+            user_id=DEV_USER_ID, icao_type="C172", tail_number="G-TEST",
+        )
+        s.add(ac)
+        s.commit()
+        ac_id = ac.id
+        s.close()
+        f = _seed(app_db, _make_flight(31, aircraft_id=ac_id))
+        resp = client.get(f"/api/flights/{f.id}/export")
+        assert resp.status_code == 200, resp.text
+        d = resp.json()
+        assert d["aircraft"]["registration"] == "G-TEST"
+        assert d["aircraft"]["type"] == "C172"
+
+    def test_export_unknown_flight_404(self, client):
+        resp = client.get("/api/flights/does-not-exist/export")
+        assert resp.status_code == 404
+
+    def test_export_flight_without_route_422(self, client, app_db):
+        f = _seed(app_db, _make_flight(32, waypoints=["EGTK"]))
+        resp = client.get(f"/api/flights/{f.id}/export")
+        assert resp.status_code == 422
+
+    def test_export_private_flight_hidden_from_non_owner(self, client, app_db):
+        f = _seed(app_db, _make_flight(33, private=True))
+        # Re-point auth at a different user: a private flight they don't own
+        # must 404, exactly like GET /{flight_id}.
+        client.app.dependency_overrides[current_user_id] = lambda: "intruder"
+        resp = client.get(f"/api/flights/{f.id}/export")
+        assert resp.status_code == 404

--- a/tests/test_flight_export.py
+++ b/tests/test_flight_export.py
@@ -101,9 +101,8 @@ class TestExchangeEnvelope:
                 destination_coords=(43.18, 0.0),
             )
 
-        monkeypatch.setattr(flights_api, "resolve_route", _fake_resolve_route, raising=False)
-        # The adapter imports resolve_route from weatherbrief.airports at call
-        # time, so patch it at the source module too.
+        # flight_to_exchange imports resolve_route from weatherbrief.airports
+        # at call time, so patching the source module is what takes effect.
         import weatherbrief.airports as airports_mod
 
         monkeypatch.setattr(airports_mod, "resolve_route", _fake_resolve_route)
@@ -260,8 +259,11 @@ def _seed(app_db, flight: Flight) -> Flight:
     return flight
 
 
-@needs_nav_db
 class TestExportEndpoint:
+    # Only the two tests that resolve coordinates need nav.db; the 404/422
+    # cases exit before the resolver, so they run in any CI environment.
+
+    @needs_nav_db
     def test_export_returns_flightexchange(self, client, app_db):
         f = _seed(app_db, _make_flight(30, share_code="Exp0rtAA"))
         resp = client.get(f"/api/flights/{f.id}/export")
@@ -277,6 +279,7 @@ class TestExportEndpoint:
             "share_code": "Exp0rtAA",
         }
 
+    @needs_nav_db
     def test_export_includes_owned_aircraft_registration(self, client, app_db):
         s = app_db()
         ac = UserAircraftRow(


### PR DESCRIPTION
## What

Adds a cross-app flight **export** endpoint so other flyfun apps (forms, brief) can import a weather flight's route/time/aircraft via the shared **FlightExchange** interchange format (rzflight#14, euro_aip 0.11.0).

Part of the FlightExchange initiative. The first consumer is flyfun-forms' "Import from Weather" (roznet/flyfun-forms#13, PR linked below).

## Changes

- **`airports.resolve_route()`** — returns the euro_aip `Route` the resolver already builds (explicit endpoints + resolved coords + `rejected_waypoints`). This is the type `FlightExchange` wraps, so it's the natural emit entry point. Sits alongside `resolve_waypoints()` (which flattens to `Waypoint`s).
- **`flights.flight_to_exchange()`** — maps weather's single-list `waypoints` + flight-level timing/altitude/aircraft onto that `Route` and wraps it: `arrival_time = departure + flight_duration_hours`; `aircraft_id` → ICAO type + registration. The **registration is owner-gated** (same privacy gate as `_resolve_aircraft_info`'s `tail_number`).
- **`GET /api/flights/{flight_id}/export`** — authenticated, same visibility as `GET /{flight_id}` (owner always; any viewer for a non-private flight). Returns the `FlightExchange` JSON.

## Not changed

The public, human-facing **`/s/{code}` share link is untouched** — it still 302-redirects to the briefing page. Export is a distinct, authed JSON endpoint. (Transport decided as authed — forms lists the user's *own* flights — rather than the design doc's tentative public `/api/s/{share_code}`.)

## Tests

`tests/test_flight_export.py` — 12 tests, all green:
- envelope logic with a stubbed resolver (derived arrival, intermediate-waypoint split, aircraft registration owner-gating, source/provenance fields)
- real `nav.db` coordinate resolution (EGTK→LFAT)
- the endpoint (success, owned-aircraft registration, 404 unknown, 422 no-route, private-flight visibility)

Existing `tests/test_flight_share_code.py` (10) still pass — no regression to the share link.

Addresses #197

🤖 Generated with [Claude Code](https://claude.com/claude-code)