### PR TITLE
Mobile-friendly web UI (issue #205)

### DIFF
--- a/web/admin.html
+++ b/web/admin.html
@@ -29,6 +29,15 @@
       text-align: center;
       font-variant-numeric: tabular-nums;
     }
+    /* Narrow screens: let wide admin tables scroll horizontally instead of
+       overflowing the viewport (issue #205). */
+    @media (max-width: 700px) {
+      .admin-table {
+        display: block;
+        overflow-x: auto;
+        white-space: nowrap;
+      }
+    }
     .summary-bar {
       display: grid;
       grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -2777,8 +2777,9 @@ label {
   display: flex;
   align-items: center;
   gap: 0.6rem;
-  flex-wrap: nowrap;
-  overflow: hidden;
+  /* Wrap instead of clipping — on narrow screens the layout-mode buttons,
+     model selector, and theme controls must stay reachable (issue #205). */
+  flex-wrap: wrap;
 }
 
 .viz-model-selector {

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -2084,6 +2084,80 @@ label {
   color: var(--text);
 }
 
+/* --- Mobile nav (hamburger) ---
+   Desktop: toggle hidden, .nav-menu is a normal flex row matching the prior
+   #user-info layout (gap 0.5rem) so the wide layout is unchanged. The mobile
+   dropdown lives in the @media block below (issue #205). */
+.nav-toggle {
+  display: none;
+  background: transparent;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 1.3rem;
+  line-height: 1;
+  border-radius: var(--radius);
+}
+
+.nav-menu {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+@media (max-width: 700px) {
+  .nav-toggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 44px;
+    min-height: 44px;
+  }
+
+  #user-info {
+    position: relative;
+  }
+
+  .nav-menu {
+    display: none;
+    position: absolute;
+    top: calc(100% + 0.25rem);
+    right: 0;
+    z-index: 100;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0;
+    min-width: 12rem;
+    padding: 0.25rem;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.18);
+  }
+
+  .nav-menu.open {
+    display: flex;
+  }
+
+  /* Roomy tap targets inside the dropdown. */
+  .nav-menu .btn-settings,
+  .nav-menu .btn-logout {
+    display: flex;
+    align-items: center;
+    min-height: 44px;
+    padding: 0.5rem 0.75rem;
+    font-size: 0.95rem;
+    text-align: left;
+    width: 100%;
+  }
+
+  .nav-menu .user-name {
+    padding: 0.5rem 0.75rem;
+    border-top: 1px solid var(--border);
+    margin-top: 0.25rem;
+  }
+}
+
 /* --- Nav notification dot --- */
 
 .nav-dot {

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -3950,6 +3950,51 @@ label {
   background: var(--bg);
 }
 
+/* --- Mobile touch targets (~44px, WCAG) — issue #205 ---
+   Inline icon badges keep their visual size but gain an invisible centered
+   44px hit overlay; standalone controls grow to a real 44px minimum. Scoped
+   to narrow screens so desktop renders identically. */
+@media (max-width: 700px) {
+  .freshness-info-btn,
+  .metric-info-btn {
+    position: relative;
+  }
+  .freshness-info-btn::after,
+  .metric-info-btn::after {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 44px;
+    height: 44px;
+    transform: translate(-50%, -50%);
+  }
+  /* Regime cells pack several info badges tightly — a 44px overlay there would
+     overlap neighbours and make taps ambiguous, so leave those at icon size. */
+  .regime-cell .metric-info-btn::after {
+    display: none;
+  }
+
+  .btn-chip {
+    min-height: 44px;
+    padding: 0.5rem 0.85rem;
+    font-size: 0.85rem;
+  }
+
+  .metric-popup-close {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 44px;
+    min-height: 44px;
+    padding: 0;
+  }
+
+  .section.collapsible > h3 {
+    min-height: 44px;
+  }
+}
+
 /* Compare layer selector inline with toolbar */
 .viz-compare-layer-selector {
   display: flex;

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -228,6 +228,15 @@ label {
 
 .form-group.grow { flex: 1; }
 
+/* Flight-creation field widths — previously inline on index.html; moved to CSS
+   so the mobile breakpoint can make them fluid while desktop stays identical
+   (issue #205). Scoped to .create-panel to avoid touching other forms. */
+.create-panel #input-aircraft { width: 160px; }
+.create-panel #input-profile { width: 140px; }
+.create-panel #input-altitude,
+.create-panel #input-ceiling { width: 100px; }
+.create-panel #input-duration { width: 80px; }
+
 .label-row {
   display: flex;
   align-items: baseline;
@@ -4163,6 +4172,27 @@ label {
 
 /* --- Responsive --- */
 
+/* Mobile form / panel / slider sweep (issue #205) — narrow-screen only. */
+@media (max-width: 700px) {
+  /* Flight form: stack each field full-width so nothing overflows at 375px. */
+  .create-panel .form-group { flex: 1 1 100%; }
+  .create-panel #input-aircraft,
+  .create-panel #input-profile,
+  .create-panel #input-altitude,
+  .create-panel #input-ceiling,
+  .create-panel #input-duration { width: 100%; }
+
+  /* Layer-toggle panel grows very tall when every group wraps — cap + scroll. */
+  .viz-layer-toggles { max-height: 45vh; overflow-y: auto; }
+
+  /* Altitude slider: wrap rather than compress label + range onto one line. */
+  .map-altitude-slider { flex-wrap: wrap; }
+  .map-altitude-slider input[type="range"] { max-width: none; }
+
+  /* Debrief accuracy rows: tighter fixed columns so the bar keeps room. */
+  .debrief-acc-row { grid-template-columns: 90px 1fr 64px; gap: 6px; }
+}
+
 @media (max-width: 800px) {
   .viz-layout-wrapper.layout-split {
     flex-direction: column;
@@ -4176,7 +4206,10 @@ label {
 @media (max-width: 640px) {
   .flight-header { flex-wrap: wrap; }
   .briefing-toolbar { flex-direction: column; align-items: stretch; }
-  .skewt-card { width: 220px; }
+  /* Fluid so a card fits the viewport instead of forcing horizontal scroll
+     at 375px; the large single card fills the width (issue #205). */
+  .skewt-card { width: min(88vw, 320px); }
+  .skewt-card-large { width: 100%; }
   .skewt-pair { flex-direction: column; }
   .skewt-pair .skewt-hodo-img { width: 60%; }
   .metric-popup { max-width: 95vw; padding: 1rem; }

--- a/web/index.html
+++ b/web/index.html
@@ -46,13 +46,13 @@
         <div class="form-row">
           <div class="form-group">
             <label for="input-aircraft">Aircraft <button type="button" class="metric-info-btn aircraft-info-btn" title="Aircraft info" aria-label="Aircraft info">i</button></label>
-            <select id="input-aircraft" style="width:160px">
+            <select id="input-aircraft">
               <option value="">None</option>
             </select>
           </div>
           <div class="form-group">
             <label for="input-profile">Profile</label>
-            <select id="input-profile" style="width:140px"></select>
+            <select id="input-profile"></select>
           </div>
         </div>
         <div class="form-row">
@@ -78,15 +78,15 @@
           </div>
           <div class="form-group">
             <label for="input-altitude">Altitude (ft)</label>
-            <input type="number" id="input-altitude" value="8000" min="1000" max="45000" step="500" style="width:100px">
+            <input type="number" id="input-altitude" value="8000" min="1000" max="45000" step="500">
           </div>
           <div class="form-group">
             <label for="input-ceiling">Ceiling (ft)</label>
-            <input type="number" id="input-ceiling" value="18000" min="1000" max="45000" step="500" style="width:100px">
+            <input type="number" id="input-ceiling" value="18000" min="1000" max="45000" step="500">
           </div>
           <div class="form-group">
             <label for="input-duration">Duration (hrs)</label>
-            <input type="number" id="input-duration" value="0" min="0" max="24" step="0.5" style="width:80px">
+            <input type="number" id="input-duration" value="0" min="0" max="24" step="0.5">
           </div>
           <div class="form-group">
             <label>&nbsp;</label>

--- a/web/ts/i18n/locales/de.json
+++ b/web/ts/i18n/locales/de.json
@@ -5,6 +5,7 @@
   "nav.admin": "Admin",
   "nav.signOut": "Abmelden",
   "nav.signIn": "Anmelden",
+  "nav.menu": "Menü",
   "theme.light": "Hell",
   "theme.system": "System",
   "theme.dark": "Dunkel",

--- a/web/ts/i18n/locales/en.json
+++ b/web/ts/i18n/locales/en.json
@@ -5,6 +5,7 @@
   "nav.admin": "Admin",
   "nav.signOut": "Sign out",
   "nav.signIn": "Sign in",
+  "nav.menu": "Menu",
 
   "theme.light": "Light",
   "theme.system": "System",

--- a/web/ts/i18n/locales/es.json
+++ b/web/ts/i18n/locales/es.json
@@ -5,6 +5,7 @@
   "nav.admin": "Administración",
   "nav.signOut": "Cerrar sesión",
   "nav.signIn": "Iniciar sesión",
+  "nav.menu": "Menú",
   "theme.light": "Claro",
   "theme.system": "Sistema",
   "theme.dark": "Oscuro",

--- a/web/ts/i18n/locales/fr.json
+++ b/web/ts/i18n/locales/fr.json
@@ -5,6 +5,7 @@
   "nav.admin": "Admin",
   "nav.signOut": "Déconnexion",
   "nav.signIn": "Connexion",
+  "nav.menu": "Menu",
   "theme.light": "Clair",
   "theme.system": "Système",
   "theme.dark": "Sombre",

--- a/web/ts/utils.ts
+++ b/web/ts/utils.ts
@@ -43,16 +43,36 @@ export function renderUserInfo(user: CurrentUser, currentPage?: string): void {
       })
       .join('\n');
 
+    // The hamburger toggle is desktop-hidden via CSS; under ~700px it reveals
+    // the .nav-menu as a dropdown. On desktop .nav-menu is a normal flex row,
+    // so the wide layout is unchanged (issue #205).
     container.innerHTML = `
-      ${links}
-      <span class="user-name">${escapeHtml(user.name)}</span>
-      <button class="btn-logout" id="logout-btn">${t('nav.signOut')}</button>
+      <button type="button" class="nav-toggle" id="nav-toggle"
+              aria-label="${t('nav.menu')}" aria-expanded="false" aria-controls="nav-menu">☰</button>
+      <div class="nav-menu" id="nav-menu">
+        ${links}
+        <span class="user-name">${escapeHtml(user.name)}</span>
+        <button class="btn-logout" id="logout-btn">${t('nav.signOut')}</button>
+      </div>
     `;
     document.getElementById('logout-btn')?.addEventListener('click', () => logout());
+
+    const toggle = document.getElementById('nav-toggle');
+    const menu = document.getElementById('nav-menu');
+    toggle?.addEventListener('click', (e) => {
+      e.stopPropagation();
+      const open = menu?.classList.toggle('open') ?? false;
+      toggle.setAttribute('aria-expanded', String(open));
+    });
   };
 
   // Initial render (no PIREP tab)
   renderNav(currentPage === 'pireps');
+
+  // Close the mobile menu on outside-click / Escape. Attached once per page;
+  // the handlers re-query the DOM so they survive nav re-renders. A no-op on
+  // desktop where the menu is never in the `.open` state.
+  setupNavDismiss();
 
   // Fire-and-forget: check pirep permission and re-render if enabled
   checkPirepNav(currentPage).then(enabled => {
@@ -61,6 +81,33 @@ export function renderUserInfo(user: CurrentUser, currentPage?: string): void {
 
   // Fire-and-forget: check for unseen messages and show badge
   checkMessagesBadge();
+}
+
+let _navDismissBound = false;
+
+/** Wire outside-click and Escape to close the mobile nav dropdown. Idempotent —
+ *  safe to call on every render; the listeners attach to `document` only once. */
+function setupNavDismiss(): void {
+  if (_navDismissBound) return;
+  _navDismissBound = true;
+
+  const close = () => {
+    const ui = document.getElementById('user-info');
+    const menu = ui?.querySelector('.nav-menu');
+    if (!menu || !menu.classList.contains('open')) return;
+    menu.classList.remove('open');
+    ui?.querySelector('.nav-toggle')?.setAttribute('aria-expanded', 'false');
+  };
+
+  document.addEventListener('click', (e) => {
+    const ui = document.getElementById('user-info');
+    // Clicks on the toggle (stopPropagation) and on links inside the menu
+    // (which navigate) are handled elsewhere; close only for clicks outside.
+    if (ui && !ui.contains(e.target as Node)) close();
+  });
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape') close();
+  });
 }
 
 /** Check if the user has PIREP viewing enabled. */

--- a/web/ts/visualization/cross-section/compare-interaction.ts
+++ b/web/ts/visualization/cross-section/compare-interaction.ts
@@ -72,10 +72,12 @@ export function attachCompareInteraction(
   }
 
   function handlePointerDown(e: PointerEvent): void {
+    if (e.button !== 0) return; // ignore right/middle on desktop; touch reports 0
     renderAt(e);
   }
 
   function handlePointerUp(e: PointerEvent): void {
+    if (e.button !== 0) return; // left-click / tap only, matching the old click handler
     const transform = renderer.createTransform();
     if (!transform || currentDatasets.length === 0) return;
 
@@ -93,6 +95,12 @@ export function attachCompareInteraction(
   function handlePointerLeave(e: PointerEvent): void {
     // On touch, leave the crosshair/tooltip pinned where the user tapped.
     if (e.pointerType === 'mouse') clearOverlay();
+  }
+
+  // OS-cancelled touch (notification shade, home-swipe) fires pointercancel
+  // instead of pointerleave — clear here too so the pin doesn't get stuck.
+  function handlePointerCancel(): void {
+    clearOverlay();
   }
 
   function showTooltip(
@@ -161,6 +169,7 @@ export function attachCompareInteraction(
   canvas.addEventListener('pointerdown', handlePointerDown);
   canvas.addEventListener('pointerup', handlePointerUp);
   canvas.addEventListener('pointerleave', handlePointerLeave);
+  canvas.addEventListener('pointercancel', handlePointerCancel);
 
   return {
     update(newDatasets, newLayer) {
@@ -172,6 +181,7 @@ export function attachCompareInteraction(
       canvas.removeEventListener('pointerdown', handlePointerDown);
       canvas.removeEventListener('pointerup', handlePointerUp);
       canvas.removeEventListener('pointerleave', handlePointerLeave);
+      canvas.removeEventListener('pointercancel', handlePointerCancel);
       if (tooltip) { tooltip.remove(); tooltip = null; }
       canvas.style.pointerEvents = '';
       canvas.style.cursor = '';

--- a/web/ts/visualization/cross-section/compare-interaction.ts
+++ b/web/ts/visualization/cross-section/compare-interaction.ts
@@ -30,12 +30,15 @@ export function attachCompareInteraction(
   const canvas = renderer.getCanvas();
   canvas.style.pointerEvents = 'auto';
   canvas.style.cursor = 'crosshair';
+  // Suppress browser scroll/zoom gestures so pointermove fires during touch drag.
+  canvas.style.touchAction = 'none';
 
   let currentDatasets = datasets;
   let currentLayer = layer;
   let tooltip: HTMLElement | null = null;
 
-  function handleMouseMove(e: MouseEvent): void {
+  /** Render crosshair + tooltip at the event position (shared by move/down). */
+  function renderAt(e: PointerEvent): void {
     const transform = renderer.createTransform();
     if (!transform || currentDatasets.length === 0) return;
 
@@ -44,9 +47,7 @@ export function attachCompareInteraction(
     const { plotArea } = transform;
 
     if (x < plotArea.left || x > plotArea.left + plotArea.width) {
-      renderer.renderOverlay();
-      hideTooltipEl(tooltip);
-      callbacks.onHover?.(undefined);
+      clearOverlay();
       return;
     }
 
@@ -60,7 +61,21 @@ export function attachCompareInteraction(
     showTooltip(e, idx, distanceNm, hoverAltFt);
   }
 
-  function handleClick(e: MouseEvent): void {
+  function clearOverlay(): void {
+    renderer.renderOverlay();
+    hideTooltipEl(tooltip);
+    callbacks.onHover?.(undefined);
+  }
+
+  function handlePointerMove(e: PointerEvent): void {
+    renderAt(e);
+  }
+
+  function handlePointerDown(e: PointerEvent): void {
+    renderAt(e);
+  }
+
+  function handlePointerUp(e: PointerEvent): void {
     const transform = renderer.createTransform();
     if (!transform || currentDatasets.length === 0) return;
 
@@ -75,14 +90,13 @@ export function attachCompareInteraction(
     callbacks.onSelectPoint(idx);
   }
 
-  function handleMouseLeave(): void {
-    renderer.renderOverlay();
-    hideTooltipEl(tooltip);
-    callbacks.onHover?.(undefined);
+  function handlePointerLeave(e: PointerEvent): void {
+    // On touch, leave the crosshair/tooltip pinned where the user tapped.
+    if (e.pointerType === 'mouse') clearOverlay();
   }
 
   function showTooltip(
-    e: MouseEvent, idx: number, distanceNm: number, hoverAltFt: number,
+    e: PointerEvent, idx: number, distanceNm: number, hoverAltFt: number,
   ): void {
     tooltip = ensureTooltipEl(canvas.parentElement!, tooltip);
     const sections: string[] = [];
@@ -143,9 +157,10 @@ export function attachCompareInteraction(
     positionTooltip(tooltip, e, canvas, canvas.parentElement!.clientWidth);
   }
 
-  canvas.addEventListener('mousemove', handleMouseMove);
-  canvas.addEventListener('click', handleClick);
-  canvas.addEventListener('mouseleave', handleMouseLeave);
+  canvas.addEventListener('pointermove', handlePointerMove);
+  canvas.addEventListener('pointerdown', handlePointerDown);
+  canvas.addEventListener('pointerup', handlePointerUp);
+  canvas.addEventListener('pointerleave', handlePointerLeave);
 
   return {
     update(newDatasets, newLayer) {
@@ -153,12 +168,14 @@ export function attachCompareInteraction(
       currentLayer = newLayer;
     },
     destroy() {
-      canvas.removeEventListener('mousemove', handleMouseMove);
-      canvas.removeEventListener('click', handleClick);
-      canvas.removeEventListener('mouseleave', handleMouseLeave);
+      canvas.removeEventListener('pointermove', handlePointerMove);
+      canvas.removeEventListener('pointerdown', handlePointerDown);
+      canvas.removeEventListener('pointerup', handlePointerUp);
+      canvas.removeEventListener('pointerleave', handlePointerLeave);
       if (tooltip) { tooltip.remove(); tooltip = null; }
       canvas.style.pointerEvents = '';
       canvas.style.cursor = '';
+      canvas.style.touchAction = '';
     },
   };
 }

--- a/web/ts/visualization/cross-section/interaction.ts
+++ b/web/ts/visualization/cross-section/interaction.ts
@@ -82,12 +82,14 @@ export function attachInteraction(
 
   // pointerdown gives instant feedback on a touch tap (no hover phase on touch).
   function handlePointerDown(e: PointerEvent): void {
+    if (e.button !== 0) return; // ignore right/middle on desktop; touch reports 0
     renderAt(e);
   }
 
   // pointerup selects the nearest point — equivalent to the old mouse click,
   // and the tap-to-select gesture on touch.
   function handlePointerUp(e: PointerEvent): void {
+    if (e.button !== 0) return; // left-click / tap only, matching the old click handler
     const transform = renderer.createTransform();
     if (!transform) return;
 
@@ -105,6 +107,13 @@ export function attachInteraction(
     // Mouse hover-out clears the crosshair. On touch, lifting the finger should
     // leave the crosshair/tooltip pinned where the user tapped.
     if (e.pointerType === 'mouse') clearOverlay();
+  }
+
+  // The OS can cancel a touch mid-gesture (notification shade, home-swipe, too
+  // many contacts) — pointercancel fires instead of pointerleave, so clear here
+  // too or the touch-pinned crosshair would stay stuck.
+  function handlePointerCancel(): void {
+    clearOverlay();
   }
 
   function showTooltip(
@@ -211,6 +220,7 @@ export function attachInteraction(
   canvas.addEventListener('pointerdown', handlePointerDown);
   canvas.addEventListener('pointerup', handlePointerUp);
   canvas.addEventListener('pointerleave', handlePointerLeave);
+  canvas.addEventListener('pointercancel', handlePointerCancel);
 
   return {
     update(newData) {
@@ -221,6 +231,7 @@ export function attachInteraction(
       canvas.removeEventListener('pointerdown', handlePointerDown);
       canvas.removeEventListener('pointerup', handlePointerUp);
       canvas.removeEventListener('pointerleave', handlePointerLeave);
+      canvas.removeEventListener('pointercancel', handlePointerCancel);
       if (tooltip) { tooltip.remove(); tooltip = null; }
       canvas.style.pointerEvents = '';
       canvas.style.cursor = '';

--- a/web/ts/visualization/cross-section/interaction.ts
+++ b/web/ts/visualization/cross-section/interaction.ts
@@ -36,12 +36,16 @@ export function attachInteraction(
   const canvas = renderer.getCanvas();
   canvas.style.pointerEvents = 'auto';
   canvas.style.cursor = 'crosshair';
+  // Suppress browser scroll/zoom gestures so pointermove fires during a touch
+  // drag — without this, touch panning eats the events and no crosshair shows.
+  canvas.style.touchAction = 'none';
 
   // Mutable state that can be swapped via update()
   let currentData = data;
   let tooltip: HTMLElement | null = null;
 
-  function handleMouseMove(e: MouseEvent): void {
+  /** Render crosshair + tooltip at the event position (shared by move/down). */
+  function renderAt(e: PointerEvent): void {
     const transform = renderer.createTransform();
     if (!transform) return;
 
@@ -50,10 +54,7 @@ export function attachInteraction(
     const { plotArea } = transform;
 
     if (x < plotArea.left || x > plotArea.left + plotArea.width) {
-      renderer.renderOverlay();
-      hideTooltipEl(tooltip);
-      callbacks.onHover?.(undefined);
-      callbacks.onHoverAltitude?.(undefined);
+      clearOverlay();
       return;
     }
 
@@ -68,7 +69,25 @@ export function attachInteraction(
     showTooltip(e, point, idx, distanceNm, hoverAltFt);
   }
 
-  function handleClick(e: MouseEvent): void {
+  function clearOverlay(): void {
+    renderer.renderOverlay();
+    hideTooltipEl(tooltip);
+    callbacks.onHover?.(undefined);
+    callbacks.onHoverAltitude?.(undefined);
+  }
+
+  function handlePointerMove(e: PointerEvent): void {
+    renderAt(e);
+  }
+
+  // pointerdown gives instant feedback on a touch tap (no hover phase on touch).
+  function handlePointerDown(e: PointerEvent): void {
+    renderAt(e);
+  }
+
+  // pointerup selects the nearest point — equivalent to the old mouse click,
+  // and the tap-to-select gesture on touch.
+  function handlePointerUp(e: PointerEvent): void {
     const transform = renderer.createTransform();
     if (!transform) return;
 
@@ -82,15 +101,14 @@ export function attachInteraction(
     callbacks.onSelectPoint(idx);
   }
 
-  function handleMouseLeave(): void {
-    renderer.renderOverlay();
-    hideTooltipEl(tooltip);
-    callbacks.onHover?.(undefined);
-    callbacks.onHoverAltitude?.(undefined);
+  function handlePointerLeave(e: PointerEvent): void {
+    // Mouse hover-out clears the crosshair. On touch, lifting the finger should
+    // leave the crosshair/tooltip pinned where the user tapped.
+    if (e.pointerType === 'mouse') clearOverlay();
   }
 
   function showTooltip(
-    e: MouseEvent, point: VizPoint, idx: number,
+    e: PointerEvent, point: VizPoint, idx: number,
     distanceNm: number, hoverAltFt: number,
   ): void {
     tooltip = ensureTooltipEl(canvas.parentElement!, tooltip);
@@ -189,21 +207,24 @@ export function attachInteraction(
     positionTooltip(tooltip, e, canvas, canvas.parentElement!.clientWidth);
   }
 
-  canvas.addEventListener('mousemove', handleMouseMove);
-  canvas.addEventListener('click', handleClick);
-  canvas.addEventListener('mouseleave', handleMouseLeave);
+  canvas.addEventListener('pointermove', handlePointerMove);
+  canvas.addEventListener('pointerdown', handlePointerDown);
+  canvas.addEventListener('pointerup', handlePointerUp);
+  canvas.addEventListener('pointerleave', handlePointerLeave);
 
   return {
     update(newData) {
       currentData = newData;
     },
     destroy() {
-      canvas.removeEventListener('mousemove', handleMouseMove);
-      canvas.removeEventListener('click', handleClick);
-      canvas.removeEventListener('mouseleave', handleMouseLeave);
+      canvas.removeEventListener('pointermove', handlePointerMove);
+      canvas.removeEventListener('pointerdown', handlePointerDown);
+      canvas.removeEventListener('pointerup', handlePointerUp);
+      canvas.removeEventListener('pointerleave', handlePointerLeave);
       if (tooltip) { tooltip.remove(); tooltip = null; }
       canvas.style.pointerEvents = '';
       canvas.style.cursor = '';
+      canvas.style.touchAction = '';
     },
   };
 }

--- a/web/ts/visualization/interaction-utils.ts
+++ b/web/ts/visualization/interaction-utils.ts
@@ -2,14 +2,18 @@
 
 import type { PlotArea, VizRouteData, VizPoint } from './types';
 
-/** Get the CSS-space X coordinate of a mouse event relative to an element. */
-export function getCanvasX(e: MouseEvent, el: HTMLElement): number {
+/** Minimal viewport-position shape shared by MouseEvent and PointerEvent.
+ *  Lets the canvas helpers work with either input source on one code path. */
+export type PointerPosition = Pick<MouseEvent, 'clientX' | 'clientY'>;
+
+/** Get the CSS-space X coordinate of a pointer/mouse event relative to an element. */
+export function getCanvasX(e: PointerPosition, el: HTMLElement): number {
   const rect = el.getBoundingClientRect();
   return e.clientX - rect.left;
 }
 
-/** Get the CSS-space Y coordinate of a mouse event relative to an element. */
-export function getCanvasY(e: MouseEvent, el: HTMLElement): number {
+/** Get the CSS-space Y coordinate of a pointer/mouse event relative to an element. */
+export function getCanvasY(e: PointerPosition, el: HTMLElement): number {
   const rect = el.getBoundingClientRect();
   return e.clientY - rect.top;
 }
@@ -49,10 +53,10 @@ export function ensureTooltip(
   return tip;
 }
 
-/** Position a tooltip relative to a mouse event within a container, flipping if near the right edge. */
+/** Position a tooltip relative to a pointer/mouse event within a container, flipping if near the right edge. */
 export function positionTooltip(
   tip: HTMLElement,
-  e: MouseEvent,
+  e: PointerPosition,
   canvas: HTMLElement,
   containerWidth: number,
 ): void {

--- a/web/ts/visualization/route-graph/interaction.ts
+++ b/web/ts/visualization/route-graph/interaction.ts
@@ -32,6 +32,8 @@ export function attachRouteGraphInteraction(
   const canvas = renderer.getCanvas();
   canvas.style.pointerEvents = 'auto';
   canvas.style.cursor = 'crosshair';
+  // Suppress browser scroll/zoom gestures so pointermove fires during touch drag.
+  canvas.style.touchAction = 'none';
 
   // Mutable state that can be swapped via update()
   let currentData = data;
@@ -45,16 +47,15 @@ export function attachRouteGraphInteraction(
     return ((x - plotArea.left) / plotArea.width) * currentData.totalDistanceNm;
   }
 
-  function handleMouseMove(e: MouseEvent): void {
+  /** Render crosshair + tooltip at the event position (shared by move/down). */
+  function renderAt(e: PointerEvent): void {
     const plotArea = renderer.getPlotArea();
     if (!plotArea) return;
 
     const x = getCanvasX(e, canvas);
 
     if (x < plotArea.left || x > plotArea.left + plotArea.width) {
-      renderer.renderOverlay();
-      hideTooltipEl(tooltip);
-      callbacks.onHover(undefined);
+      clearOverlay();
       return;
     }
 
@@ -67,7 +68,21 @@ export function attachRouteGraphInteraction(
     showTooltip(e, point, idx);
   }
 
-  function handleClick(e: MouseEvent): void {
+  function clearOverlay(): void {
+    renderer.renderOverlay();
+    hideTooltipEl(tooltip);
+    callbacks.onHover(undefined);
+  }
+
+  function handlePointerMove(e: PointerEvent): void {
+    renderAt(e);
+  }
+
+  function handlePointerDown(e: PointerEvent): void {
+    renderAt(e);
+  }
+
+  function handlePointerUp(e: PointerEvent): void {
     const plotArea = renderer.getPlotArea();
     if (!plotArea) return;
 
@@ -79,10 +94,9 @@ export function attachRouteGraphInteraction(
     callbacks.onSelectPoint(idx);
   }
 
-  function handleMouseLeave(): void {
-    renderer.renderOverlay();
-    hideTooltipEl(tooltip);
-    callbacks.onHover(undefined);
+  function handlePointerLeave(e: PointerEvent): void {
+    // On touch, leave the crosshair/tooltip pinned where the user tapped.
+    if (e.pointerType === 'mouse') clearOverlay();
   }
 
   function formatMetricLine(metric: RouteGraphMetric, point: VizPoint): string {
@@ -93,7 +107,7 @@ export function attachRouteGraphInteraction(
     return `<span style="color:${metric.color}">${getMetricLabel(metric.id)}: ${fmt}</span>`;
   }
 
-  function showTooltip(e: MouseEvent, point: VizPoint, idx: number): void {
+  function showTooltip(e: PointerEvent, point: VizPoint, idx: number): void {
     tooltip = ensureTooltipEl(canvas.parentElement!, tooltip);
     const lines: string[] = [];
 
@@ -109,9 +123,10 @@ export function attachRouteGraphInteraction(
     positionTooltip(tooltip, e, canvas, canvas.parentElement!.clientWidth);
   }
 
-  canvas.addEventListener('mousemove', handleMouseMove);
-  canvas.addEventListener('click', handleClick);
-  canvas.addEventListener('mouseleave', handleMouseLeave);
+  canvas.addEventListener('pointermove', handlePointerMove);
+  canvas.addEventListener('pointerdown', handlePointerDown);
+  canvas.addEventListener('pointerup', handlePointerUp);
+  canvas.addEventListener('pointerleave', handlePointerLeave);
 
   return {
     update(newData, newLeft, newRight) {
@@ -120,12 +135,14 @@ export function attachRouteGraphInteraction(
       currentRight = newRight;
     },
     destroy() {
-      canvas.removeEventListener('mousemove', handleMouseMove);
-      canvas.removeEventListener('click', handleClick);
-      canvas.removeEventListener('mouseleave', handleMouseLeave);
+      canvas.removeEventListener('pointermove', handlePointerMove);
+      canvas.removeEventListener('pointerdown', handlePointerDown);
+      canvas.removeEventListener('pointerup', handlePointerUp);
+      canvas.removeEventListener('pointerleave', handlePointerLeave);
       if (tooltip) { tooltip.remove(); tooltip = null; }
       canvas.style.pointerEvents = '';
       canvas.style.cursor = '';
+      canvas.style.touchAction = '';
     },
   };
 }

--- a/web/ts/visualization/route-graph/interaction.ts
+++ b/web/ts/visualization/route-graph/interaction.ts
@@ -79,10 +79,12 @@ export function attachRouteGraphInteraction(
   }
 
   function handlePointerDown(e: PointerEvent): void {
+    if (e.button !== 0) return; // ignore right/middle on desktop; touch reports 0
     renderAt(e);
   }
 
   function handlePointerUp(e: PointerEvent): void {
+    if (e.button !== 0) return; // left-click / tap only, matching the old click handler
     const plotArea = renderer.getPlotArea();
     if (!plotArea) return;
 
@@ -97,6 +99,12 @@ export function attachRouteGraphInteraction(
   function handlePointerLeave(e: PointerEvent): void {
     // On touch, leave the crosshair/tooltip pinned where the user tapped.
     if (e.pointerType === 'mouse') clearOverlay();
+  }
+
+  // OS-cancelled touch (notification shade, home-swipe) fires pointercancel
+  // instead of pointerleave — clear here too so the pin doesn't get stuck.
+  function handlePointerCancel(): void {
+    clearOverlay();
   }
 
   function formatMetricLine(metric: RouteGraphMetric, point: VizPoint): string {
@@ -127,6 +135,7 @@ export function attachRouteGraphInteraction(
   canvas.addEventListener('pointerdown', handlePointerDown);
   canvas.addEventListener('pointerup', handlePointerUp);
   canvas.addEventListener('pointerleave', handlePointerLeave);
+  canvas.addEventListener('pointercancel', handlePointerCancel);
 
   return {
     update(newData, newLeft, newRight) {
@@ -139,6 +148,7 @@ export function attachRouteGraphInteraction(
       canvas.removeEventListener('pointerdown', handlePointerDown);
       canvas.removeEventListener('pointerup', handlePointerUp);
       canvas.removeEventListener('pointerleave', handlePointerLeave);
+      canvas.removeEventListener('pointercancel', handlePointerCancel);
       if (tooltip) { tooltip.remove(); tooltip = null; }
       canvas.style.pointerEvents = '';
       canvas.style.cursor = '';

--- a/web/ts/visualization/route-map/interaction.ts
+++ b/web/ts/visualization/route-map/interaction.ts
@@ -34,15 +34,17 @@ export function attachMapInteraction(
     return { update() {}, destroy() {} };
   }
 
-  function onSegmentMouseOver(e: L.LeafletEvent): void {
-    const layer = e.target as any;
+  // The segment currently showing a tapped (touch) tooltip, so we can reset it
+  // when another segment is tapped — touch has no mouseout to clean up after.
+  let tappedLayer: any = null;
+
+  /** Highlight a segment and open its metric tooltip. Shared by hover + tap. */
+  function highlightSegment(layer: any): void {
     const idx: number | undefined = layer._segmentIndex;
     if (idx === undefined) return;
 
-    // Highlight the segment
     layer.setStyle({ weight: (layer.options.weight ?? 4) + 3, opacity: 1 });
 
-    // Show tooltip with metric values
     const p1 = currentData.points[idx];
     const p2 = currentData.points[idx + 1];
     if (!p1 || !p2) return;
@@ -66,25 +68,38 @@ export function attachMapInteraction(
     }
 
     layer.bindTooltip(lines.join('<br>'), { sticky: true, direction: 'top', offset: [0, -10] }).openTooltip();
-
     callbacks.onHover(idx);
   }
 
-  function onSegmentMouseOut(e: L.LeafletEvent): void {
-    const layer = e.target as any;
-    // Reset style
+  /** Reset a segment's style and tear down its tooltip. */
+  function resetSegment(layer: any): void {
     layer.setStyle({ weight: layer.options._originalWeight ?? 4, opacity: 0.9 });
     layer.closeTooltip();
     layer.unbindTooltip();
+  }
+
+  function onSegmentMouseOver(e: L.LeafletEvent): void {
+    highlightSegment(e.target as any);
+  }
+
+  function onSegmentMouseOut(e: L.LeafletEvent): void {
+    resetSegment(e.target as any);
     callbacks.onHover(undefined);
   }
 
   function onSegmentClick(e: L.LeafletEvent): void {
     const layer = e.target as any;
     const idx: number | undefined = layer._segmentIndex;
-    if (idx !== undefined) {
-      callbacks.onSelectPoint(idx);
-    }
+    if (idx === undefined) return;
+
+    // On touch there is no hover phase, so a tap must surface the segment's
+    // tooltip itself. Reset any previously-tapped segment first, then show this
+    // one. (On desktop mouseover already showed it — re-showing is harmless.)
+    if (tappedLayer && tappedLayer !== layer) resetSegment(tappedLayer);
+    highlightSegment(layer);
+    tappedLayer = layer;
+
+    callbacks.onSelectPoint(idx);
   }
 
   // Attach event listeners to all segment layers
@@ -100,6 +115,8 @@ export function attachMapInteraction(
   }
 
   function detachListeners(): void {
+    // Drop the tapped reference — segments are recreated on metric change.
+    tappedLayer = null;
     segmentGroup!.eachLayer((layer: any) => {
       layer.off('mouseover', onSegmentMouseOver);
       layer.off('mouseout', onSegmentMouseOut);

--- a/web/ts/visualization/route-map/interaction.ts
+++ b/web/ts/visualization/route-map/interaction.ts
@@ -115,8 +115,13 @@ export function attachMapInteraction(
   }
 
   function detachListeners(): void {
-    // Drop the tapped reference — segments are recreated on metric change.
-    tappedLayer = null;
+    // Reset the tapped segment's style before dropping the reference — if the
+    // caller updates data without recreating layers, it would otherwise stay
+    // highlighted permanently.
+    if (tappedLayer) {
+      resetSegment(tappedLayer);
+      tappedLayer = null;
+    }
     segmentGroup!.eachLayer((layer: any) => {
       layer.off('mouseover', onSegmentMouseOver);
       layer.off('mouseout', onSegmentMouseOut);


### PR DESCRIPTION
Makes the web UI usable on phone-sized screens (~375px) **without changing the desktop / wide-iPad layout**. All work is additive: new CSS lives in `@media (max-width: …)` blocks (or moves inline widths into CSS with identical desktop computed values), and the canvas input migration uses Pointer Events, which subsume mouse on one code path so desktop hover/click is preserved.

Closes #205.

## Commits (one per phase)

1. **Pointer Events migration + viz toolbar wrap** — the three canvas interaction modules (cross-section, compare, route-graph) + shared `interaction-utils` move from mouse-only to Pointer Events. Touch now works: `pointerdown` gives instant feedback, drag moves the crosshair, `pointerup` selects, and the crosshair/tooltip stay pinned after a touch (only mouse hover-out clears). `touch-action: none` on each interactive canvas stops the browser eating `pointermove` during a touch drag. Route map (Leaflet): tapping a segment now highlights + shows its tooltip (was `mouseover`-only). `.viz-toolbar-top` was `flex-wrap: nowrap; overflow: hidden` (silently clipped the layout/model/theme controls at 375px) → now wraps.
2. **Hamburger nav under 700px** — `renderUserInfo` wraps nav links + username + sign-out in a `.nav-menu` and prepends a `.nav-toggle`. Desktop: toggle hidden, menu is a normal flex row (unchanged). Mobile: 44px toggle reveals a right-anchored dropdown; outside-click / Escape close it. Adds `nav.menu` i18n key to all four locales.
3. **Touch targets (~44px)** — `freshness-info-btn` and `metric-info-btn` keep their visual size but gain a centered transparent 44px hit overlay (excluded in dense regime cells); `btn-chip`, the metric popup close, and collapsible headers grow to a real 44px min. Mobile-scoped.
4. **Fluid forms / cards / tables** — flight-creation field widths moved from inline `style="width:…"` into `.create-panel`-scoped CSS (identical on desktop) and stack full-width under 700px; Skew-T cards go fluid (`min(88vw, 320px)`); admin tables scroll horizontally; layer-toggle panel gets a 45vh max-height + scroll; map altitude slider wraps; debrief rows tighten.

## Verification

- `tsc --noEmit` clean; 309/309 vitest tests pass; all esbuild bundles build.
- Playwright at 390px and 1280px with a dev session:
  - Mobile: hamburger present and toggles open (dropdown shows links → divider → username → sign-out); flight form stacks full-width.
  - Desktop: `#nav-toggle` computed `display: none`; nav renders as the original horizontal row; form keeps original fixed widths.
  - Briefing page mobile: `.viz-toolbar-top` `flex-wrap: wrap` with `scrollWidth == clientWidth` (no clipping); all four layout buttons + selectors + layer toggles reachable; `touch-action: none` on the interactive overlay canvases; cross-section + route map render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)