### PR TITLE
Only show "no flights" empty state after the list has loaded

### DIFF
--- a/web/ts/flights-main.ts
+++ b/web/ts/flights-main.ts
@@ -560,13 +560,15 @@ async function init(): Promise<void> {
       state.pastTotal !== prev.pastTotal ||
       state.activeRefreshes !== prev.activeRefreshes ||
       state.selectedIds !== prev.selectedIds ||
-      state.debriefStats !== prev.debriefStats
+      state.debriefStats !== prev.debriefStats ||
+      state.loaded !== prev.loaded
     ) {
       ui.renderFlightList(
         state.flights,
         state.activeRefreshes,
         state.selectedIds,
         state.pastTotal,
+        state.loaded,
         (id) => navigateToBriefing(id),
         (id) => navigateToFlight(id),
         (id) => store.getState().deleteFlight(id),

--- a/web/ts/managers/flights-ui.ts
+++ b/web/ts/managers/flights-ui.ts
@@ -144,6 +144,7 @@ export function renderFlightList(
   activeRefreshes: Record<string, RefreshEntry>,
   selectedIds: Set<string>,
   pastTotal: number,
+  loaded: boolean,
   onBriefing: (id: string) => void,
   onEdit: (id: string) => void,
   onDelete: (id: string) => void,
@@ -157,6 +158,14 @@ export function renderFlightList(
   if (!container) return;
 
   if (flights.length === 0) {
+    // Don't claim "no flights" until the list has actually been fetched —
+    // otherwise the empty-state flashes while the user's flights are still
+    // downloading. The loading spinner covers the pre-fetch window.
+    if (!loaded) {
+      container.innerHTML = '';
+      renderSelectionBar(0, [], [], selection);
+      return;
+    }
     container.innerHTML = `
       <div class="empty-state">
         <p>${t('flights.empty')}</p>

--- a/web/ts/store/flights-store.ts
+++ b/web/ts/store/flights-store.ts
@@ -19,6 +19,7 @@ export interface FlightsState {
 
   // UI state
   loading: boolean;
+  loaded: boolean;  // a flights fetch has completed at least once
   loadingMore: boolean;  // a "Show more" past-page fetch is in flight
   error: string | null;
   selectedIds: Set<string>;  // flights ticked for bulk actions
@@ -53,6 +54,7 @@ export const flightsStore = createStore<FlightsState>((set, get) => ({
   activeRefreshes: {},
   debriefStats: null,
   loading: false,
+  loaded: false,
   loadingMore: false,
   error: null,
   selectedIds: new Set(),
@@ -65,7 +67,7 @@ export const flightsStore = createStore<FlightsState>((set, get) => ({
       // page — no per-flight /packs/latest round-trips. Only the past section
       // is paginated; future + recent always come back in full.
       const { flights, pastTotal } = await api.fetchFlights({ pastLimit: PAST_PAGE_SIZE });
-      set({ flights, pastTotal, loading: false });
+      set({ flights, pastTotal, loading: false, loaded: true });
     } catch (err) {
       set({ loading: false, error: `Failed to load flights: ${err}` });
     }


### PR DESCRIPTION
The flights list painted "No flights yet. Create one to get started."
whenever the store held an empty array, including before/while the
user's flights were still being fetched. That was confusing for users
who actually have flights — the empty-state could flash before the
download completed.

Track a `loaded` flag in the flights store (set once a fetch
completes) and gate the empty-state render on it. While not yet
loaded, the flight list stays blank and the loading spinner covers
the pre-fetch window.

https://claude.ai/code/session_01SreEoJmXUFkNnBFYNL5iwx