### PR TITLE
Cross-section tooltip: add visual key (line + band swatches) and single-line point header

### DIFF
--- a/web/css/style.css
+++ b/web/css/style.css
@@ -2997,6 +2997,18 @@ label {
   border-radius: 1px;
 }
 
+/* Band/zone key: a small filled square matching a band's on-chart fill colour.
+   A faint border keeps low-opacity fills visible on the dark tooltip. */
+.viz-tooltip .tt-square-swatch {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  margin-right: 5px;
+  vertical-align: baseline;
+  border-radius: 2px;
+  border: 1px solid rgba(255, 255, 255, 0.35);
+}
+
 /* --- Layer info button --- */
 
 .viz-layer-info-btn {

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -2981,6 +2981,22 @@ label {
   word-break: break-word;
 }
 
+/* Point-identity header rendered on a single line. */
+.viz-tooltip .tt-header {
+  white-space: nowrap;
+}
+
+/* Line-style key: a short bar matching a reference line's colour + dash so the
+   tooltip row can be tied back to the line on the chart. */
+.viz-tooltip .tt-line-swatch {
+  display: inline-block;
+  width: 22px;
+  height: 3px;
+  margin-right: 5px;
+  vertical-align: middle;
+  border-radius: 1px;
+}
+
 /* --- Layer info button --- */
 
 .viz-layer-info-btn {

--- a/web/ts/visualization/cross-section/interaction.ts
+++ b/web/ts/visualization/cross-section/interaction.ts
@@ -8,6 +8,7 @@ import {
   fmtFL, altInBand, altNearLine,
 } from '../interaction-utils';
 import { LAYER_TOOLTIPS } from './tooltip-formatters';
+import { getActiveTheme, type LineStyle } from './theme';
 import { columnSpanNm, sigmetSpanNm, COLUMN_HEIGHT_FT } from './layers/current-conditions';
 import { formatVisibility } from '../../units';
 import { escapeHtml } from '../../utils';
@@ -119,18 +120,20 @@ export function attachInteraction(
     tooltip = ensureTooltipEl(canvas.parentElement!, tooltip);
     const sections: string[] = [];
     const en = (id: string) => renderer.isLayerEnabled(id);
+    const theme = getActiveTheme();
 
-    // --- Header (always) ---
-    const headerLines: string[] = [];
+    // --- Header (always) — point identity on a single line to save vertical
+    //     space (plenty of horizontal room beside the chart). ---
+    const headerParts: string[] = [];
     const wp = findNearbyWaypoint(currentData, point);
-    headerLines.push(wp ? `<strong>${wp.icao}</strong>` : `<strong>Point ${idx}</strong>`);
-    headerLines.push(`${point.distanceNm.toFixed(0)} nm`);
+    headerParts.push(wp ? `<strong>${wp.icao}</strong>` : `<strong>Point ${idx}</strong>`);
+    headerParts.push(`${point.distanceNm.toFixed(0)} nm`);
     try {
       const d = new Date(point.time);
-      headerLines.push(d.toISOString().slice(11, 16) + 'Z');
+      headerParts.push(d.toISOString().slice(11, 16) + 'Z');
     } catch { /* skip */ }
-    headerLines.push(`${fmtFL(hoverAltFt)}`);
-    sections.push(headerLines.join('<br>'));
+    headerParts.push(`${fmtFL(hoverAltFt)}`);
+    sections.push(`<span class="tt-header">${headerParts.join(' · ')}</span>`);
 
     // --- Terrain ---
     if (en('terrain')) {
@@ -156,26 +159,28 @@ export function attachInteraction(
     }
 
     // --- Temperature lines (proximity-based) ---
+    // Each row is prefixed with a swatch matching the rendered line's colour +
+    // dash so overlapping reference lines can be told apart at a glance.
     const alt = point.altitudeLines;
     if (en('freezing-level') && alt.freezingLevelFt !== null && altNearLine(hoverAltFt, alt.freezingLevelFt)) {
-      sections.push(`0°C: ${fmt(alt.freezingLevelFt)} ft`);
+      sections.push(`${lineSwatch(theme.temperature.freezingLevel)}0°C: ${fmt(alt.freezingLevelFt)} ft`);
     }
     if (en('minus-10c') && alt.minus10cLevelFt !== null && altNearLine(hoverAltFt, alt.minus10cLevelFt)) {
-      sections.push(`-10°C: ${fmt(alt.minus10cLevelFt)} ft`);
+      sections.push(`${lineSwatch(theme.temperature.minus10c)}-10°C: ${fmt(alt.minus10cLevelFt)} ft`);
     }
     if (en('minus-20c') && alt.minus20cLevelFt !== null && altNearLine(hoverAltFt, alt.minus20cLevelFt)) {
-      sections.push(`-20°C: ${fmt(alt.minus20cLevelFt)} ft`);
+      sections.push(`${lineSwatch(theme.temperature.minus20c)}-20°C: ${fmt(alt.minus20cLevelFt)} ft`);
     }
 
     // --- Stability lines (proximity-based) ---
     if (en('lcl') && alt.lclAltitudeFt !== null && altNearLine(hoverAltFt, alt.lclAltitudeFt)) {
-      sections.push(`LCL: ${fmt(alt.lclAltitudeFt)} ft`);
+      sections.push(`${lineSwatch(theme.stability.lcl)}LCL: ${fmt(alt.lclAltitudeFt)} ft`);
     }
     if (en('lfc') && alt.lfcAltitudeFt !== null && altNearLine(hoverAltFt, alt.lfcAltitudeFt)) {
-      sections.push(`LFC: ${fmt(alt.lfcAltitudeFt)} ft`);
+      sections.push(`${lineSwatch(theme.stability.lfc)}LFC: ${fmt(alt.lfcAltitudeFt)} ft`);
     }
     if (en('el') && alt.elAltitudeFt !== null && altNearLine(hoverAltFt, alt.elAltitudeFt)) {
-      sections.push(`EL: ${fmt(alt.elAltitudeFt)} ft`);
+      sections.push(`${lineSwatch(theme.stability.el)}EL: ${fmt(alt.elAltitudeFt)} ft`);
     }
 
     // --- Current conditions (route-global; matched by X span + Y band, not per-point) ---
@@ -242,6 +247,20 @@ export function attachInteraction(
 
 function fmt(n: number): string {
   return Math.round(n).toLocaleString();
+}
+
+/** Inline HTML swatch mimicking a reference line's colour + dash pattern, so a
+ *  tooltip row can be matched to the line drawn on the cross-section. */
+function lineSwatch(style: LineStyle): string {
+  const c = style.color;
+  let bg: string;
+  if (style.dash && style.dash.length >= 2) {
+    const [on, off] = style.dash;
+    bg = `repeating-linear-gradient(90deg, ${c} 0 ${on}px, transparent ${on}px ${on + off}px)`;
+  } else {
+    bg = c;
+  }
+  return `<span class="tt-line-swatch" style="background:${bg}"></span>`;
 }
 
 /** Interpolate terrain elevation at a given distance. */

--- a/web/ts/visualization/cross-section/interaction.ts
+++ b/web/ts/visualization/cross-section/interaction.ts
@@ -9,6 +9,7 @@ import {
 } from '../interaction-utils';
 import { LAYER_TOOLTIPS } from './tooltip-formatters';
 import { getActiveTheme, type LineStyle } from './theme';
+import { flightCategoryColor } from '../scales';
 import { columnSpanNm, sigmetSpanNm, COLUMN_HEIGHT_FT } from './layers/current-conditions';
 import { formatVisibility } from '../../units';
 import { escapeHtml } from '../../utils';
@@ -151,7 +152,9 @@ export function attachInteraction(
       for (const z of def.getZones(point)) {
         if (!altInBand(hoverAltFt, z.baseFt, z.topFt)) continue;
         const line = def.formatLine(z, hoverAltFt);
-        if (line !== null) lines.push(line);
+        if (line === null) continue;
+        const color = def.swatch?.(z) ?? null;
+        lines.push(color ? `${squareSwatch(color)}${line}` : line);
       }
       if (lines.length === 0) continue;
       const body = lines.join('<br>');
@@ -191,7 +194,7 @@ export function attachInteraction(
         const [d0, d1] = columnSpanNm(a.enrouteDistanceNm);
         if (distanceNm < d0 || distanceNm > d1) continue;
         if (hoverAltFt < a.baseFt || hoverAltFt > a.baseFt + COLUMN_HEIGHT_FT) continue;
-        const parts = [`<strong>${a.icao}</strong> ${a.flightCategory}`];
+        const parts = [`${squareSwatch(flightCategoryColor(a.flightCategory))}<strong>${a.icao}</strong> ${a.flightCategory}`];
         if (a.ceilingFt !== null) parts.push(`ceil ${fmtFL(a.ceilingFt)}`);
         if (a.visibilityM !== null) parts.push(`vis ${formatVisibility(a.visibilityM)}`);
         ccLines.push(parts.join(' · '));
@@ -261,6 +264,11 @@ function lineSwatch(style: LineStyle): string {
     bg = c;
   }
   return `<span class="tt-line-swatch" style="background:${bg}"></span>`;
+}
+
+/** Inline filled square mimicking a band/zone's on-chart fill colour. */
+function squareSwatch(color: string): string {
+  return `<span class="tt-square-swatch" style="background:${color}"></span>`;
 }
 
 /** Interpolate terrain elevation at a given distance. */

--- a/web/ts/visualization/cross-section/interaction.ts
+++ b/web/ts/visualization/cross-section/interaction.ts
@@ -154,7 +154,7 @@ export function attachInteraction(
         const line = def.formatLine(z, hoverAltFt);
         if (line === null) continue;
         const color = def.swatch?.(z) ?? null;
-        lines.push(color ? `${squareSwatch(color)}${line}` : line);
+        lines.push(color ? `${squareSwatch(color, theme.sky.background)}${line}` : line);
       }
       if (lines.length === 0) continue;
       const body = lines.join('<br>');
@@ -194,7 +194,7 @@ export function attachInteraction(
         const [d0, d1] = columnSpanNm(a.enrouteDistanceNm);
         if (distanceNm < d0 || distanceNm > d1) continue;
         if (hoverAltFt < a.baseFt || hoverAltFt > a.baseFt + COLUMN_HEIGHT_FT) continue;
-        const parts = [`${squareSwatch(flightCategoryColor(a.flightCategory))}<strong>${a.icao}</strong> ${a.flightCategory}`];
+        const parts = [`${squareSwatch(flightCategoryColor(a.flightCategory), theme.sky.background)}<strong>${a.icao}</strong> ${a.flightCategory}`];
         if (a.ceilingFt !== null) parts.push(`ceil ${fmtFL(a.ceilingFt)}`);
         if (a.visibilityM !== null) parts.push(`vis ${formatVisibility(a.visibilityM)}`);
         ccLines.push(parts.join(' · '));
@@ -266,9 +266,15 @@ function lineSwatch(style: LineStyle): string {
   return `<span class="tt-line-swatch" style="background:${bg}"></span>`;
 }
 
-/** Inline filled square mimicking a band/zone's on-chart fill colour. */
-function squareSwatch(color: string): string {
-  return `<span class="tt-square-swatch" style="background:${color}"></span>`;
+/** Inline filled square mimicking a band/zone's on-chart fill colour.
+ *  Band fills are semi-transparent and read on the chart as the fill
+ *  composited over the sky; we reproduce that by layering the (possibly
+ *  translucent) fill over the opaque theme sky colour, so the swatch shows
+ *  the perceived on-chart colour rather than the raw rgba dimmed over the
+ *  dark tooltip. */
+function squareSwatch(color: string, skyBg: string): string {
+  const bg = `linear-gradient(${color}, ${color}), ${skyBg}`;
+  return `<span class="tt-square-swatch" style="background:${bg}"></span>`;
 }
 
 /** Interpolate terrain elevation at a given distance. */

--- a/web/ts/visualization/cross-section/layers/cloud-bands-factory.ts
+++ b/web/ts/visualization/cross-section/layers/cloud-bands-factory.ts
@@ -58,7 +58,7 @@ function avgDD(a: VizCloudLayer, b: VizCloudLayer | null): number | undefined {
   return a.meanDewpointDepressionC ?? b.meanDewpointDepressionC;
 }
 
-function coverageToPct(coverage: string): number {
+export function coverageToPct(coverage: string): number {
   switch (coverage.toUpperCase()) {
     case 'OVC': return 90;
     case 'BKN': return 65;

--- a/web/ts/visualization/cross-section/tooltip-formatters.ts
+++ b/web/ts/visualization/cross-section/tooltip-formatters.ts
@@ -11,7 +11,8 @@ import type { VizPoint, VizCloudLayer, VizIcingZone, VizSfipZone, VizSldZone, Vi
 import { fmtFL } from '../interaction-utils';
 import { formatVisibility } from '../../units';
 import { getActiveTheme } from './theme';
-import { icingRiskColor, catRiskColor, convectiveRiskColor, cloudFillFromDD, nwpCloudFill, inversionOpacity } from '../scales';
+import { icingRiskColor, catRiskColor, cloudFillFromDD, nwpCloudFill, inversionOpacity } from '../scales';
+import { coverageToPct } from './layers/cloud-bands-factory';
 
 export interface LayerTooltipDef {
   /** Primary layer id (the toggle that owns the data). */
@@ -96,7 +97,7 @@ const cloudNWP: LayerTooltipDef = {
       + extras([fmtCC(cl.meanCloudCoverPct), fmtT(cl.meanTemperatureC)])
       + tag;
   },
-  swatch: (cl: VizCloudLayer) => nwpCloudFill(cl.meanCloudCoverPct ?? 0),
+  swatch: (cl: VizCloudLayer) => nwpCloudFill(cl.meanCloudCoverPct ?? coverageToPct(cl.coverage)),
 };
 
 const icingOgimetDD: LayerTooltipDef = {
@@ -217,7 +218,7 @@ const thermoConv: LayerTooltipDef = {
     }
     return line;
   },
-  swatch: (z: ThermoConvZone) => convectiveRiskColor(z.risk),
+  swatch: (z: ThermoConvZone) => getActiveTheme().convective.towerFill[z.risk] ?? null,
 };
 
 interface NwpConvZone {
@@ -249,7 +250,7 @@ const nwpConv: LayerTooltipDef = {
     line += `<br>Tower: ${fmtFL(z.baseFt)}–${fmtFL(z.topFt)}${tag}`;
     return line;
   },
-  swatch: (z: NwpConvZone) => convectiveRiskColor(z.risk),
+  swatch: (z: NwpConvZone) => getActiveTheme().convective.towerFill[z.risk] ?? null,
 };
 
 const inversion: LayerTooltipDef = {

--- a/web/ts/visualization/cross-section/tooltip-formatters.ts
+++ b/web/ts/visualization/cross-section/tooltip-formatters.ts
@@ -10,6 +10,8 @@
 import type { VizPoint, VizCloudLayer, VizIcingZone, VizSfipZone, VizSldZone, VizCATLayer, VizInversionLayer, VizSurfaceObscuration } from '../types';
 import { fmtFL } from '../interaction-utils';
 import { formatVisibility } from '../../units';
+import { getActiveTheme } from './theme';
+import { icingRiskColor, catRiskColor, convectiveRiskColor, cloudFillFromDD, nwpCloudFill, inversionOpacity } from '../scales';
 
 export interface LayerTooltipDef {
   /** Primary layer id (the toggle that owns the data). */
@@ -22,6 +24,28 @@ export interface LayerTooltipDef {
   getZones: (p: VizPoint) => Array<{ baseFt: number; topFt: number }>;
   /** Format one zone matched at hoverAltFt. Return null to skip. */
   formatLine: (zone: any, hoverAltFt: number) => string | null;
+  /** Optional fill colour for a small square swatch keyed to the band's
+   *  on-chart colour, so the row can be matched to the band on the canvas.
+   *  Return null/undefined to omit the swatch. */
+  swatch?: (zone: any) => string | null;
+}
+
+/** SLD fill colour, mirroring `sldRiskColor` in sld-bands.ts. */
+function sldSwatchColor(risk: string): string {
+  const sld = (getActiveTheme() as any).sld;
+  if (sld && sld[risk]) return sld[risk];
+  switch (risk) {
+    case 'light': return 'rgba(220, 53, 69, 0.25)';
+    case 'moderate': return 'rgba(220, 53, 69, 0.40)';
+    case 'severe': return 'rgba(220, 53, 69, 0.55)';
+    default: return 'transparent';
+  }
+}
+
+/** Inversion fill colour: theme base RGB at strength-scaled opacity. */
+function inversionSwatchColor(strengthC: number): string {
+  const [r, g, b] = getActiveTheme().inversion.baseRgb;
+  return `rgba(${r}, ${g}, ${b}, ${inversionOpacity(strengthC).toFixed(2)})`;
 }
 
 // ── format helpers ──────────────────────────────────────────────────
@@ -59,6 +83,7 @@ const cloudDD: LayerTooltipDef = {
     return `${fmtFL(cl.baseFt)}–${fmtFL(cl.topFt)} ${cl.coverage}`
       + extras([fmtDD(cl.meanDewpointDepressionC), fmtT(cl.meanTemperatureC)]);
   },
+  swatch: (cl: VizCloudLayer) => cloudFillFromDD(cl.meanDewpointDepressionC ?? undefined, cl.coverage),
 };
 
 const cloudNWP: LayerTooltipDef = {
@@ -71,6 +96,7 @@ const cloudNWP: LayerTooltipDef = {
       + extras([fmtCC(cl.meanCloudCoverPct), fmtT(cl.meanTemperatureC)])
       + tag;
   },
+  swatch: (cl: VizCloudLayer) => nwpCloudFill(cl.meanCloudCoverPct ?? 0),
 };
 
 const icingOgimetDD: LayerTooltipDef = {
@@ -82,6 +108,7 @@ const icingOgimetDD: LayerTooltipDef = {
       + extras([fmtIdx(z.meanIcingIndex), fmtT(z.meanTemperatureC)])
       + sldTag(z.sldRisk);
   },
+  swatch: (z: VizIcingZone) => icingRiskColor(z.risk),
 };
 
 const icingOgimetNWP: LayerTooltipDef = {
@@ -93,6 +120,7 @@ const icingOgimetNWP: LayerTooltipDef = {
       + extras([fmtIdx(z.meanIcingIndex), fmtT(z.meanTemperatureC)])
       + sldTag(z.sldRisk);
   },
+  swatch: (z: VizIcingZone) => icingRiskColor(z.risk),
 };
 
 const sfip: LayerTooltipDef = {
@@ -105,6 +133,7 @@ const sfip: LayerTooltipDef = {
       + extras([fmtT(z.meanTemperatureC)])
       + proxy;
   },
+  swatch: (z: VizSfipZone) => getActiveTheme().sfipIcing[z.risk] ?? 'transparent',
 };
 
 const ieng: LayerTooltipDef = {
@@ -116,6 +145,7 @@ const ieng: LayerTooltipDef = {
       + extras([fmtIdx(z.meanIcingIndex), fmtT(z.meanTemperatureC)])
       + sldTag(z.sldRisk);
   },
+  swatch: (z: VizIcingZone) => icingRiskColor(z.risk),
 };
 
 const sld: LayerTooltipDef = {
@@ -125,6 +155,7 @@ const sld: LayerTooltipDef = {
   formatLine: (z: VizSldZone) => {
     return `${fmtFL(z.baseFt)}–${fmtFL(z.topFt)} ${z.risk} ${z.mechanism}`;
   },
+  swatch: (z: VizSldZone) => sldSwatchColor(z.risk),
 };
 
 const cat: LayerTooltipDef = {
@@ -134,6 +165,7 @@ const cat: LayerTooltipDef = {
     return `${fmtFL(z.baseFt)}–${fmtFL(z.topFt)} CAT ${z.risk}`
       + extras([fmtRi(z.richardsonNumber)]);
   },
+  swatch: (z: VizCATLayer) => catRiskColor(z.risk),
 };
 
 const eShear: LayerTooltipDef = {
@@ -143,6 +175,7 @@ const eShear: LayerTooltipDef = {
     return `${fmtFL(z.baseFt)}–${fmtFL(z.topFt)} E-Shear ${z.risk}`
       + extras([fmtRi(z.richardsonNumber)]);
   },
+  swatch: (z: VizCATLayer) => catRiskColor(z.risk),
 };
 
 /** Convective layers are per-point, not per-zone; we synthesize a single
@@ -184,6 +217,7 @@ const thermoConv: LayerTooltipDef = {
     }
     return line;
   },
+  swatch: (z: ThermoConvZone) => convectiveRiskColor(z.risk),
 };
 
 interface NwpConvZone {
@@ -215,6 +249,7 @@ const nwpConv: LayerTooltipDef = {
     line += `<br>Tower: ${fmtFL(z.baseFt)}–${fmtFL(z.topFt)}${tag}`;
     return line;
   },
+  swatch: (z: NwpConvZone) => convectiveRiskColor(z.risk),
 };
 
 const inversion: LayerTooltipDef = {
@@ -225,6 +260,7 @@ const inversion: LayerTooltipDef = {
     const sfc = inv.surfaceBased ? ' (sfc)' : '';
     return `${fmtFL(inv.baseFt)}–${fmtFL(inv.topFt)} +${inv.strengthC.toFixed(1)}°C${sfc}`;
   },
+  swatch: (inv: VizInversionLayer) => inversionSwatchColor(inv.strengthC),
 };
 
 const surfaceObscuration: LayerTooltipDef = {
@@ -246,6 +282,7 @@ const surfaceObscuration: LayerTooltipDef = {
       + extras([vis, `T/Td ${t}/${td}`, `RH ${rh}`])
       + ` [${z.reason}]`;
   },
+  swatch: (z: VizSurfaceObscuration) => getActiveTheme().obscuration[z.severity],
 };
 
 /** All band/zone-style tooltip definitions, in display order. */


### PR DESCRIPTION
Closes #211

## What

Adds a visual **key** to the cross-section hover tooltip so rows can be tied back to the lines/bands drawn on the chart, and collapses the point-identity header onto one line.

### 1. Line-style key
Each reference-line row (0°C, -10°C, -20°C, LCL, LFC, EL) is prefixed with a short bar reproducing the line's colour + dash pattern, read from `getActiveTheme()`.

### 2. Band/zone colour key
Each band row (clouds DD + NWP, icing Ogimet-DD/NWP/IENG/SFIP, SLD, CAT, E-shear, convective thermo + NWP, **inversion**, **surface obscuration / IMC**) and the airport flight-category row gets a small filled square matching the band's on-chart fill. Each `LayerTooltipDef` gained an optional `swatch(zone)` that reuses the **same theme-aware scale function the renderer uses** (`icingRiskColor`, `catRiskColor`, `cloudFillFromDD`, `nwpCloudFill`, `theme.convective.towerFill`, inversion base RGB × `inversionOpacity`, `theme.obscuration[severity]`, …).

Because band fills are semi-transparent and read on the chart as the fill composited over the **sky**, the square layers the fill over the opaque `theme.sky.background` — so the swatch shows the *perceived* on-chart colour rather than the raw rgba dimmed over the dark tooltip. Theme-aware across standard / high-contrast / gramet / light.

### 3. Single-line header
`Point N · 94 nm · 07:39Z · FL102` instead of four stacked rows (waypoint ICAO substituted near a waypoint).

## Notes
- `coverageToPct` is now exported from `cloud-bands-factory.ts` so the NWP-cloud swatch can mirror the renderer's null-coverage fallback.
- During review I caught (and fixed) a real mismatch: convective initially used the route-map `riskColors` wash instead of the `towerFill` the cross-section actually draws — that's the "red swatch / yellow band" case.

## Verification
- `tsc --noEmit` clean
- `npm run build:briefing` builds
- `npm test` — 309/309 pass
- Manually ran on the dev server (`/devserver`, :8001); hovered overlapping reference lines and band layers across themes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)