### PR TITLE
refactor(xsection): reuse sldRiskColor for SLD tooltip swatch

### DIFF
--- a/web/ts/visualization/cross-section/layers/sld-bands.ts
+++ b/web/ts/visualization/cross-section/layers/sld-bands.ts
@@ -4,7 +4,7 @@ import type { CrossSectionLayer, CoordTransform, VizRouteData } from '../../type
 import { getActiveTheme } from '../theme';
 import { renderMatchedZones, maxRisk } from './zone-matching';
 
-function sldRiskColor(risk: string): string {
+export function sldRiskColor(risk: string): string {
   const theme = getActiveTheme();
   const sldColors = (theme as any).sld;
   if (sldColors && sldColors[risk]) return sldColors[risk];

--- a/web/ts/visualization/cross-section/tooltip-formatters.ts
+++ b/web/ts/visualization/cross-section/tooltip-formatters.ts
@@ -13,6 +13,7 @@ import { formatVisibility } from '../../units';
 import { getActiveTheme } from './theme';
 import { icingRiskColor, catRiskColor, cloudFillFromDD, nwpCloudFill, inversionOpacity } from '../scales';
 import { coverageToPct } from './layers/cloud-bands-factory';
+import { sldRiskColor } from './layers/sld-bands';
 
 export interface LayerTooltipDef {
   /** Primary layer id (the toggle that owns the data). */
@@ -29,18 +30,6 @@ export interface LayerTooltipDef {
    *  on-chart colour, so the row can be matched to the band on the canvas.
    *  Return null/undefined to omit the swatch. */
   swatch?: (zone: any) => string | null;
-}
-
-/** SLD fill colour, mirroring `sldRiskColor` in sld-bands.ts. */
-function sldSwatchColor(risk: string): string {
-  const sld = (getActiveTheme() as any).sld;
-  if (sld && sld[risk]) return sld[risk];
-  switch (risk) {
-    case 'light': return 'rgba(220, 53, 69, 0.25)';
-    case 'moderate': return 'rgba(220, 53, 69, 0.40)';
-    case 'severe': return 'rgba(220, 53, 69, 0.55)';
-    default: return 'transparent';
-  }
 }
 
 /** Inversion fill colour: theme base RGB at strength-scaled opacity. */
@@ -156,7 +145,7 @@ const sld: LayerTooltipDef = {
   formatLine: (z: VizSldZone) => {
     return `${fmtFL(z.baseFt)}–${fmtFL(z.topFt)} ${z.risk} ${z.mechanism}`;
   },
-  swatch: (z: VizSldZone) => sldSwatchColor(z.risk),
+  swatch: (z: VizSldZone) => sldRiskColor(z.risk),
 };
 
 const cat: LayerTooltipDef = {


### PR DESCRIPTION
Follow-up to the #212 code review (merged).

Addresses the one actionable Minor finding: the SLD tooltip swatch duplicated `sldRiskColor` (same theme lookup + identical `0.25/0.40/0.55` fallbacks). Exports `sldRiskColor` from `sld-bands.ts` and reuses it, deleting the copy — same single-source precedent as the exported `coverageToPct`.

The review's second finding (scattered `getActiveTheme()` calls vs the cached theme in `interaction.ts`) is moot: the scale functions (`icingRiskColor`, `cloudFillFromDD`, etc.) re-read `getActiveTheme()` internally regardless, so threading a cached theme into the swatch closures wouldn't remove the re-fetch. The cost is a module-variable read and the only theoretical risk (mid-render theme switch on a transient hover tooltip) is not reachable in practice.

## Verification
- `tsc --noEmit` clean
- `npm run build:briefing` builds
- `npm test` — 309/309 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)