### PR TITLE
feat(briefing): opt-in sidebar layout with glance summary + section nav

### DIFF
--- a/web/css/style.css
+++ b/web/css/style.css
@@ -5516,3 +5516,202 @@ label {
   padding: 6px 14px;
   font-size: 0.9rem;
 }
+
+/* ====================================================================== */
+/* Optional sidebar briefing layout (opt-in via wb_layout=sidebar)         */
+/* Default 'classic' layout is unaffected — none of these rules apply      */
+/* unless .container has .layout-sidebar.                                   */
+/* ====================================================================== */
+.container.layout-sidebar {
+  max-width: 1440px;
+}
+.briefing-shell {
+  display: grid;
+  grid-template-columns: 320px minmax(0, 1fr);
+  gap: 1.5rem;
+  align-items: start;
+}
+.briefing-rail {
+  position: sticky;
+  top: 0.5rem;
+  align-self: start;
+  max-height: calc(100vh - 1rem);
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  padding: 0.25rem 0.5rem 0.5rem 0.25rem;
+}
+.briefing-main {
+  min-width: 0; /* allow canvases to shrink within the grid track */
+}
+
+/* The action toolbar becomes a slim top bar inside the main pane */
+.layout-sidebar .briefing-main .briefing-toolbar {
+  margin-bottom: 0.75rem;
+}
+
+.briefing-rail #briefing-header { font-size: 0.95rem; }
+.briefing-rail .freshness-bar { margin: 0; font-size: 0.78rem; }
+
+/* Rail glance summary: overall chip + what-to-watch (derived, not moved) */
+.rail-summary { display: flex; flex-direction: column; gap: 0.6rem; }
+.rail-overall {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  width: 100%;
+  text-align: left;
+  cursor: pointer;
+  padding: 0.5rem 0.6rem;
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--text);
+  font-weight: 600;
+}
+.rail-overall:hover { border-color: var(--text-muted); }
+.rail-overall-dot { width: 12px; height: 12px; border-radius: 50%; background: var(--border); flex: none; }
+.rail-overall-green .rail-overall-dot { background: var(--green); }
+.rail-overall-amber .rail-overall-dot { background: var(--amber); }
+.rail-overall-red .rail-overall-dot { background: var(--red); }
+.rail-overall-green { border-color: color-mix(in srgb, var(--green) 45%, var(--border)); }
+.rail-overall-amber { border-color: color-mix(in srgb, var(--amber) 45%, var(--border)); }
+.rail-overall-red { border-color: color-mix(in srgb, var(--red) 45%, var(--border)); }
+.rail-overall-level { flex: 1 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.rail-overall-hint { font-size: 0.72rem; font-weight: 400; color: var(--text-muted); flex: none; }
+
+.rail-watch { display: flex; flex-direction: column; gap: 2px; }
+.rail-watch-title {
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-muted);
+  margin-bottom: 0.15rem;
+}
+.rail-watch-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  width: 100%;
+  text-align: left;
+  cursor: pointer;
+  padding: 0.3rem 0.5rem;
+  border-radius: var(--radius);
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--text);
+  font-size: 0.88rem;
+  font-weight: 600;
+}
+.rail-watch-item:hover { background: color-mix(in srgb, var(--text-muted) 12%, transparent); }
+.rail-watch-dot { width: 8px; height: 8px; border-radius: 50%; flex: none; }
+.rail-watch-item.sev-red .rail-watch-dot { background: var(--red); }
+.rail-watch-item.sev-amber .rail-watch-dot { background: var(--amber); }
+.rail-watch-item.sev-red .rail-watch-name { color: var(--red); }
+.rail-watch-item.sev-amber .rail-watch-name { color: var(--amber); }
+.rail-watch-clear, .rail-watch-allclear { font-size: 0.78rem; color: var(--text-muted); padding: 0.2rem 0.5rem; }
+.rail-watch-allclear { color: var(--green); }
+
+/* Flash a main-pane target when jumped to from the rail */
+.rail-flash { animation: rail-flash-kf 1.3s ease-out; border-radius: var(--radius); }
+@keyframes rail-flash-kf {
+  0% { box-shadow: 0 0 0 3px color-mix(in srgb, var(--primary) 60%, transparent); }
+  100% { box-shadow: 0 0 0 3px transparent; }
+}
+
+/* SECTIONS nav */
+.rail-nav { display: flex; flex-direction: column; gap: 1px; }
+.rail-nav-title {
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-muted);
+  margin: 0.25rem 0 0.35rem;
+}
+.rail-group-title {
+  font-size: 0.68rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-muted);
+  opacity: 0.8;
+  margin: 0.6rem 0 0.15rem;
+}
+.rail-nav-item {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  width: 100%;
+  text-align: left;
+  padding: 0.35rem 0.5rem;
+  border: 1px solid transparent;
+  border-radius: var(--radius);
+  background: transparent;
+  color: var(--text);
+  font-size: 0.9rem;
+  cursor: pointer;
+}
+.rail-nav-item:hover { background: color-mix(in srgb, var(--text-muted) 12%, transparent); }
+.rail-nav-item.active {
+  background: color-mix(in srgb, var(--primary) 14%, transparent);
+  border-color: color-mix(in srgb, var(--primary) 30%, transparent);
+  font-weight: 600;
+}
+.rail-nav-dot {
+  width: 8px; height: 8px;
+  border-radius: 50%;
+  background: var(--border);
+  flex: none;
+}
+.rail-nav-item.active .rail-nav-dot { background: var(--primary); }
+.rail-nav-label { flex: 1 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.rail-nav-focus {
+  margin-left: auto;
+  flex: none;
+  opacity: 0;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+.rail-nav-item:hover .rail-nav-focus { opacity: 0.65; }
+.rail-nav-focus:hover { opacity: 1 !important; color: var(--primary); }
+
+/* Rail footer: history selector, depth toggle, layout switch */
+.rail-footer {
+  margin-top: auto;
+  padding-top: 0.75rem;
+  border-top: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+.rail-footer-row { display: flex; align-items: center; gap: 0.5rem; flex-wrap: wrap; }
+.rail-footer-label { font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.04em; color: var(--text-muted); }
+.rail-footer #history-select { flex: 1 1 auto; min-width: 0; }
+.layout-switch-btn { font-size: 0.78rem; }
+
+/* Focus mode: show only the focused section in the main pane */
+.rail-focus-bar {
+  display: none;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.4rem 0.5rem;
+  background: color-mix(in srgb, var(--primary) 12%, transparent);
+  border: 1px solid color-mix(in srgb, var(--primary) 30%, transparent);
+  border-radius: var(--radius);
+}
+.rail-focus-label { font-size: 0.82rem; font-weight: 600; }
+.briefing-shell[data-focus] .briefing-main > *:not([data-focus-target]) { display: none !important; }
+.briefing-shell[data-focus="cross-section"] .viz-canvas-container { height: min(62vh, 660px) !important; }
+.briefing-shell[data-focus="cross-section"] .map-container { height: min(62vh, 660px) !important; }
+
+/* Responsive: collapse to a single column on narrow viewports */
+@media (max-width: 980px) {
+  .briefing-shell { grid-template-columns: 1fr; }
+  .briefing-rail {
+    position: static;
+    max-height: none;
+    overflow: visible;
+    border-bottom: 1px solid var(--border);
+    padding-bottom: 0.75rem;
+  }
+}

--- a/web/ts/briefing-main.ts
+++ b/web/ts/briefing-main.ts
@@ -39,6 +39,7 @@ import { SkewTCompareRenderer, type CompareModelDataset as SkewtCompareModelData
 import { getActiveTheme } from './visualization/cross-section/theme';
 import { startBriefingTour, maybeAutoStartBriefingTour } from './tour/briefing-tour';
 import { maybeOfferTour } from './tour/tour-offer';
+import { initBriefingLayout } from './managers/sidebar-layout';
 
 
 async function loadFlightPireps(flightId: string): Promise<void> {
@@ -1383,6 +1384,11 @@ async function init(): Promise<void> {
       }
     }
   });
+
+  // --- Optional sidebar layout (opt-in, reversible) ---
+  // Reparents header/assessment/advisories/freshness into a rail and adds a
+  // scroll-spy section nav + focus mode. No-op in the default classic layout.
+  initBriefingLayout();
 
   // --- Wire image lightbox ---
   const lightbox = document.getElementById('lightbox');

--- a/web/ts/managers/sidebar-layout.ts
+++ b/web/ts/managers/sidebar-layout.ts
@@ -1,0 +1,417 @@
+/**
+ * Optional "sidebar" briefing layout — opt-in and fully reversible.
+ *
+ * Activated by `?layout=sidebar` or localStorage `wb_layout=sidebar`. The
+ * default ('classic') leaves the page exactly as before. In sidebar mode we
+ * build a two-column shell and REPARENT existing rendered nodes (route header,
+ * assessment, advisories, freshness, history, depth toggle) into a sticky left
+ * rail, generate a scroll-spy SECTIONS nav, and add a per-section focus mode.
+ *
+ * No section rendering logic is touched — this is a shell. Every node we move
+ * keeps its existing event listeners (direct or delegated), so refresh, the
+ * Standard/Details toggle, collapsibles, history, etc. all keep working.
+ */
+
+export type BriefingLayout = 'classic' | 'sidebar';
+const STORAGE_KEY = 'wb_layout';
+
+export function getBriefingLayout(): BriefingLayout {
+  const param = new URLSearchParams(location.search).get('layout');
+  if (param === 'sidebar' || param === 'classic') return param;
+  try {
+    if (localStorage.getItem(STORAGE_KEY) === 'sidebar') return 'sidebar';
+  } catch { /* ignore */ }
+  return 'classic';
+}
+
+function setBriefingLayout(layout: BriefingLayout): void {
+  try { localStorage.setItem(STORAGE_KEY, layout); } catch { /* ignore */ }
+}
+
+// Friendly labels + grouping for the SECTIONS nav. Keys are data-section values.
+const NAV_GROUPS: { title: string; keys: string[] }[] = [
+  { title: 'Explore', keys: ['cross-section', 'skewt'] },
+  { title: 'Observations', keys: ['observations', 'sigmets', 'pireps'] },
+  { title: 'Discussion', keys: ['synopsis', 'dwd-charts', 'dwd-overview', 'gramet'] },
+  { title: 'Detail', keys: ['sounding', 'comparison'] },
+];
+const NAV_LABELS: Record<string, string> = {
+  'cross-section': 'Cross-section & map',
+  'skewt': 'Skew-T soundings',
+  'observations': 'METAR / TAF',
+  'sigmets': 'SIGMETs',
+  'pireps': 'PIREPs',
+  'synopsis': 'Synopsis',
+  'dwd-charts': 'Surface pressure & fronts',
+  'dwd-overview': 'DWD overview',
+  'gramet': 'GRAMET',
+  'sounding': 'Sounding analysis',
+  'comparison': 'Model comparison',
+};
+
+function sectionEl(key: string): HTMLElement | null {
+  return document.querySelector(`[data-section="${key}"]`) as HTMLElement | null;
+}
+
+function appendIfPresent(parent: HTMLElement, selector: string): void {
+  const node = document.querySelector(selector);
+  if (node) parent.appendChild(node); // appendChild moves the node
+}
+
+function debounce(fn: () => void, ms: number): () => void {
+  let h: number | undefined;
+  return () => {
+    if (h) window.clearTimeout(h);
+    h = window.setTimeout(fn, ms);
+  };
+}
+
+let focusKey: string | null = null;
+
+function enterFocus(shell: HTMLElement, key: string): void {
+  const el = sectionEl(key);
+  if (!el) return;
+  el.classList.remove('collapsed');
+  document.querySelectorAll('[data-focus-target]').forEach((n) => n.removeAttribute('data-focus-target'));
+  el.setAttribute('data-focus-target', '');
+  shell.setAttribute('data-focus', key);
+  focusKey = key;
+  updateFocusBar(shell);
+  // Let ResizeObserver-driven renderers pick up the new size.
+  requestAnimationFrame(() => window.dispatchEvent(new Event('resize')));
+}
+
+function exitFocus(shell: HTMLElement): void {
+  shell.removeAttribute('data-focus');
+  document.querySelectorAll('[data-focus-target]').forEach((n) => n.removeAttribute('data-focus-target'));
+  focusKey = null;
+  updateFocusBar(shell);
+  requestAnimationFrame(() => window.dispatchEvent(new Event('resize')));
+}
+
+function buildFocusBar(shell: HTMLElement): HTMLElement {
+  const bar = document.createElement('div');
+  bar.className = 'rail-focus-bar';
+  bar.style.display = 'none';
+  const btn = document.createElement('button');
+  btn.type = 'button';
+  btn.className = 'btn btn-small rail-exit-focus';
+  btn.textContent = '✕ Exit focus';
+  btn.addEventListener('click', () => exitFocus(shell));
+  const label = document.createElement('span');
+  label.className = 'rail-focus-label';
+  bar.append(btn, label);
+  return bar;
+}
+
+function updateFocusBar(shell: HTMLElement): void {
+  const bar = shell.querySelector('.rail-focus-bar') as HTMLElement | null;
+  if (!bar) return;
+  if (focusKey) {
+    bar.style.display = 'flex';
+    const label = bar.querySelector('.rail-focus-label') as HTMLElement;
+    label.textContent = NAV_LABELS[focusKey] || focusKey;
+  } else {
+    bar.style.display = 'none';
+  }
+}
+
+let spyObserver: IntersectionObserver | null = null;
+
+function setupScrollSpy(nav: HTMLElement): void {
+  spyObserver?.disconnect();
+  const items = Array.from(nav.querySelectorAll('.rail-nav-item')) as HTMLElement[];
+  const recompute = (): void => {
+    let best: { key: string; top: number } | null = null;
+    for (const item of items) {
+      const key = item.dataset.navKey!;
+      const el = sectionEl(key);
+      if (!el) continue;
+      const r = el.getBoundingClientRect();
+      if (r.bottom > 80 && r.top < window.innerHeight * 0.5) {
+        if (!best || r.top < best.top) best = { key, top: r.top };
+      }
+    }
+    items.forEach((i) => i.classList.toggle('active', !!best && i.dataset.navKey === best.key));
+  };
+  spyObserver = new IntersectionObserver(recompute, { threshold: [0, 1] });
+  for (const item of items) {
+    const el = sectionEl(item.dataset.navKey!);
+    if (el) spyObserver.observe(el);
+  }
+  recompute();
+}
+
+function buildNav(nav: HTMLElement, shell: HTMLElement): void {
+  nav.innerHTML = '';
+  const title = document.createElement('div');
+  title.className = 'rail-nav-title';
+  title.textContent = 'Sections';
+  nav.appendChild(title);
+
+  for (const group of NAV_GROUPS) {
+    const visibleKeys = group.keys.filter((k) => {
+      const el = sectionEl(k);
+      return el && el.style.display !== 'none';
+    });
+    if (!visibleKeys.length) continue;
+
+    const gt = document.createElement('div');
+    gt.className = 'rail-group-title';
+    gt.textContent = group.title;
+    nav.appendChild(gt);
+
+    for (const key of visibleKeys) {
+      const el = sectionEl(key)!;
+      const label = NAV_LABELS[key] || el.querySelector('h3')?.textContent?.trim() || key;
+      const item = document.createElement('button');
+      item.type = 'button';
+      item.className = 'rail-nav-item';
+      item.dataset.navKey = key;
+
+      const dot = document.createElement('span');
+      dot.className = 'rail-nav-dot';
+      const lab = document.createElement('span');
+      lab.className = 'rail-nav-label';
+      lab.textContent = label;
+      const focus = document.createElement('span');
+      focus.className = 'rail-nav-focus';
+      focus.title = 'Focus this section';
+      focus.textContent = '⛶'; // ⛶
+      item.append(dot, lab, focus);
+
+      item.addEventListener('click', (e) => {
+        if ((e.target as HTMLElement).closest('.rail-nav-focus')) {
+          enterFocus(shell, key);
+          return;
+        }
+        el.classList.remove('collapsed');
+        el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      });
+      nav.appendChild(item);
+    }
+  }
+  setupScrollSpy(nav);
+}
+
+function buildRailFooter(): HTMLElement {
+  const footer = document.createElement('div');
+  footer.className = 'rail-footer';
+
+  const hist = document.getElementById('history-select');
+  if (hist) {
+    const row = document.createElement('div');
+    row.className = 'rail-footer-row';
+    const lab = document.createElement('span');
+    lab.className = 'rail-footer-label';
+    lab.textContent = 'Briefing';
+    row.append(lab, hist);
+    footer.appendChild(row);
+  }
+
+  const depth = document.getElementById('display-mode-toggle');
+  if (depth) {
+    const row = document.createElement('div');
+    row.className = 'rail-footer-row';
+    const lab = document.createElement('span');
+    lab.className = 'rail-footer-label';
+    lab.textContent = 'Detail';
+    row.append(lab, depth);
+    footer.appendChild(row);
+  }
+
+  const sw = document.createElement('button');
+  sw.type = 'button';
+  sw.className = 'btn btn-small layout-switch-btn';
+  sw.textContent = 'Switch to classic layout';
+  sw.addEventListener('click', () => {
+    setBriefingLayout('classic');
+    location.reload();
+  });
+  footer.appendChild(sw);
+  return footer;
+}
+
+function injectClassicOptIn(): void {
+  const group = document.querySelector('.toolbar-end-group');
+  if (!group || document.getElementById('layout-optin-btn')) return;
+  const btn = document.createElement('button');
+  btn.id = 'layout-optin-btn';
+  btn.type = 'button';
+  btn.className = 'btn btn-small layout-switch-btn';
+  btn.textContent = '▦ Try new layout';
+  btn.title = 'Preview the experimental sidebar layout';
+  btn.addEventListener('click', () => {
+    setBriefingLayout('sidebar');
+    location.reload();
+  });
+  group.insertBefore(btn, group.firstChild);
+}
+
+/**
+ * Entry point — call once after the page's sections and toolbar are wired.
+ * No-op (beyond injecting the opt-in button) when layout is 'classic'.
+ */
+export function initBriefingLayout(): void {
+  if (getBriefingLayout() !== 'sidebar') {
+    injectClassicOptIn();
+    return;
+  }
+
+  const container = document.querySelector('.container') as HTMLElement | null;
+  if (!container || container.classList.contains('layout-sidebar')) return;
+  container.classList.add('layout-sidebar');
+
+  const shell = document.createElement('div');
+  shell.className = 'briefing-shell';
+  const rail = document.createElement('aside');
+  rail.className = 'briefing-rail';
+  const main = document.createElement('main');
+  main.className = 'briefing-main';
+  shell.append(rail, main);
+
+  const pageHeader = container.querySelector('.page-header');
+  const loadingOverlay = document.getElementById('loading-overlay');
+  if (pageHeader && pageHeader.nextSibling) {
+    container.insertBefore(shell, pageHeader.nextSibling);
+  } else {
+    container.appendChild(shell);
+  }
+
+  // Move all briefing content into MAIN (preserve order), skipping the
+  // page-header, the shell itself, and the loading overlay.
+  const keep = new Set<Node | null>([pageHeader, shell, loadingOverlay]);
+  Array.from(container.childNodes).forEach((node) => {
+    if (keep.has(node)) return;
+    main.appendChild(node);
+  });
+
+  // Build the rail. The assessment + advisories stay in MAIN (rendered as
+  // before); the rail carries the route identity, a derived glance summary,
+  // section nav, freshness, and the footer controls.
+  rail.appendChild(buildFocusBar(shell));
+  appendIfPresent(rail, '#briefing-header'); // route identity
+
+  const summary = document.createElement('div');
+  summary.className = 'rail-summary';
+  rail.appendChild(summary);
+
+  const nav = document.createElement('nav');
+  nav.className = 'rail-nav';
+  rail.appendChild(nav);
+
+  appendIfPresent(rail, '#freshness-bar');
+  rail.appendChild(buildRailFooter());
+
+  buildNav(nav, shell);
+  buildSummary(summary);
+
+  // Rebuild nav as sections appear/disappear (empty ones toggle display:none).
+  const navMo = new MutationObserver(debounce(() => buildNav(nav, shell), 200));
+  navMo.observe(main, { attributes: true, attributeFilter: ['style'], subtree: true, childList: true });
+
+  // Rebuild the glance summary whenever the assessment or advisories re-render
+  // (initial load, model switch, Standard/Details toggle, recalc).
+  const sumMo = new MutationObserver(debounce(() => buildSummary(summary), 150));
+  const banner = document.getElementById('assessment-banner');
+  const advWrapper = document.getElementById('advisories-wrapper');
+  if (banner) sumMo.observe(banner, { childList: true, characterData: true, subtree: true, attributes: true, attributeFilter: ['class'] });
+  if (advWrapper) sumMo.observe(advWrapper, { childList: true, subtree: true, attributes: true, attributeFilter: ['style'] });
+
+  // Keep scroll-spy honest during scroll/resize.
+  const onScroll = debounce(() => setupScrollSpy(nav), 0);
+  window.addEventListener('scroll', onScroll, { passive: true });
+  window.addEventListener('resize', onScroll, { passive: true });
+}
+
+/** Scroll to a main-pane element, expanding its collapsible section and flashing it. */
+function scrollToEl(el: HTMLElement): void {
+  const section = el.closest('.section.collapsible') as HTMLElement | null;
+  if (section) section.classList.remove('collapsed');
+  el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  el.classList.add('rail-flash');
+  window.setTimeout(() => el.classList.remove('rail-flash'), 1300);
+}
+
+function readAssessmentLevel(banner: HTMLElement | null): 'green' | 'amber' | 'red' | null {
+  if (!banner) return null;
+  for (const lvl of ['red', 'amber', 'green'] as const) {
+    if (banner.classList.contains(`assessment-${lvl}`)) return lvl;
+  }
+  return null;
+}
+
+/**
+ * Derive the rail glance summary from the already-rendered main content:
+ *  - an overall amber/green/red chip → scrolls to the full assessment
+ *  - the titles of the non-green advisories → scroll to that advisory card
+ * Nothing is moved; this mirrors what's shown in the main pane.
+ */
+function buildSummary(container: HTMLElement): void {
+  container.innerHTML = '';
+
+  // Overall assessment chip
+  const banner = document.getElementById('assessment-banner');
+  const level = readAssessmentLevel(banner);
+  const overall = document.createElement('button');
+  overall.type = 'button';
+  overall.className = `rail-overall rail-overall-${level || 'none'}`;
+  const levelText = banner?.querySelector('strong')?.textContent?.trim() || (level ? level.toUpperCase() : '—');
+  const dot = document.createElement('span');
+  dot.className = 'rail-overall-dot';
+  const lvl = document.createElement('span');
+  lvl.className = 'rail-overall-level';
+  lvl.textContent = levelText;
+  const hint = document.createElement('span');
+  hint.className = 'rail-overall-hint';
+  hint.textContent = 'summary ›';
+  overall.append(dot, lvl, hint);
+  overall.addEventListener('click', () => { if (banner) scrollToEl(banner); });
+  container.appendChild(overall);
+
+  // What to watch: non-green advisory titles
+  const cards = Array.from(document.querySelectorAll('#advisories-section .advisory-card')) as HTMLElement[];
+  if (!cards.length) return;
+
+  const watch = document.createElement('div');
+  watch.className = 'rail-watch';
+  const wt = document.createElement('div');
+  wt.className = 'rail-watch-title';
+  wt.textContent = 'What to watch';
+  watch.appendChild(wt);
+
+  let nonGreen = 0;
+  let green = 0;
+  for (const card of cards) {
+    const status = card.classList.contains('advisory-red') ? 'red'
+      : card.classList.contains('advisory-amber') ? 'amber'
+        : card.classList.contains('advisory-green') ? 'green' : 'other';
+    if (status === 'green') { green++; continue; }
+    nonGreen++;
+    const name = card.querySelector('.advisory-name')?.textContent?.trim() || card.dataset.advisory || '';
+    const item = document.createElement('button');
+    item.type = 'button';
+    item.className = `rail-watch-item sev-${status}`;
+    const d = document.createElement('span');
+    d.className = 'rail-watch-dot';
+    const n = document.createElement('span');
+    n.className = 'rail-watch-name';
+    n.textContent = name;
+    item.append(d, n);
+    item.addEventListener('click', () => scrollToEl(card));
+    watch.appendChild(item);
+  }
+
+  if (nonGreen === 0) {
+    const allclear = document.createElement('div');
+    allclear.className = 'rail-watch-allclear';
+    allclear.textContent = green > 0 ? `✓ All clear (${green})` : '✓ All clear';
+    watch.appendChild(allclear);
+  } else if (green > 0) {
+    const clear = document.createElement('div');
+    clear.className = 'rail-watch-clear';
+    clear.textContent = `✓ ${green} clear`;
+    watch.appendChild(clear);
+  }
+  container.appendChild(watch);
+}


### PR DESCRIPTION
## What

An experimental **two-pane briefing layout**, opt-in and fully reversible, that runs alongside the current "classic" page as a setting. Default stays classic — **untouched**.

Toggle in via the **"▦ Try new layout"** toolbar button (classic mode), or `?layout=sidebar`; persisted to `localStorage` (`wb_layout`) so a subset of users can trial it and give feedback. "Switch to classic layout" in the rail flips back.

## Why

The briefing page has grown to ~13 sections in one long scroll. Two design goals drove this (discussed with @roznet):
- **Attention-director, not a verdict** — surface what to *understand / anticipate / mitigate*, with green quiet and amber/red raised. The rail makes that persistent and navigable.
- **Keep the full briefing intact** — the assessment + advisories stay rendered in full in the main pane, exactly as before. The rail only adds a *glance + navigation* layer on top; nothing is hidden.

## How

It's a **shell, not a rewrite** — reuses every existing rendered section. A new `sidebar-layout.ts` builds a sticky left rail and reparents only the route header + freshness bar; **no section rendering logic changes**.

**Rail:**
- Route identity (reparented `#briefing-header`)
- **Derived glance summary** — overall amber/green/red chip (→ scrolls to the full assessment) + the **titles of the non-green advisories** (→ scroll to that advisory card via its existing `data-advisory` anchor), plus an "N clear" count. Kept in sync with the main content via a `MutationObserver`.
- **Scroll-spy SECTIONS nav** grouped Explore / Observations / Discussion / Detail
- Footer: history selector, Standard/Details depth toggle, switch-to-classic
- **Per-section focus mode** — promote one section (e.g. the cross-section) to a hero, hiding the rest; reuses the existing `ResizeObserver` renderers.

## Verification

Headless-browser tested on a real flight (`EGTF→LSGS`):
- ✅ Classic mode **unregressed** (no shell, just adds the opt-in button)
- ✅ Assessment + advisories confirmed **in main**, not the rail
- ✅ Overall chip reads real level; non-green advisory titles surfaced; click scroll-and-flash to the full content
- ✅ Focus mode collapses main to a single section
- ✅ **Zero JS errors**; typecheck clean

## Mobile

Collapses to a single-column **summary-and-nav stack at the top** below 980px — clean. Note: a pre-existing horizontal overflow from the Skew-T / viz control rows exists at phone width **identically in classic** (same offenders) — out of scope here.

## Follow-ups (not in this PR)

- Visual polish of the "what to watch" chips (collapse green into a quiet expandable group)
- Promote the focus toggle into the section header UI (currently a hover ⛶ on the nav item)
- A real settings-page toggle (today it's the toolbar button + URL param)

🤖 Generated with [Claude Code](https://claude.com/claude-code)