### PR TITLE
feat(alternates): weather-based alternate airports (#210)

### DIFF
--- a/src/weatherbrief/analysis/airport_consensus.py
+++ b/src/weatherbrief/analysis/airport_consensus.py
@@ -1,0 +1,172 @@
+"""Shared airport forecast-snapshot consensus math.
+
+Pure functions that turn per-model forecast-snapshot dicts (keys == the
+``AirportForecastSnapshotRow`` column names) into a flight category,
+runway-relative wind, and a cross-model consensus.
+
+Used by BOTH the pan-European forecast map (``tasks/map_queries.py``) and the
+route-alternates stage (``tasks/alternates.py``) so the SAME airport yields the
+SAME category / crosswind / consensus in both views. The forecast map feeds an
+ORM-row→dict adapter; the alternates stage feeds the snapshot dicts produced by
+``tasks/standalone_verification`` directly (same column keys).
+
+Nothing here touches the database or the ORM — it operates on plain dicts so
+both callers can share one code path. See ``designs/future/alternates.md``
+("Seam 2") for the rationale.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from typing import Any
+
+from weatherbrief.analysis.airport_conditions import (
+    classify_flight_category,
+    compute_runway_winds,
+)
+from weatherbrief.analysis.comparison import (
+    circular_spread,
+    compare_models,
+)
+from weatherbrief.analysis.wind import compute_wind_components
+from weatherbrief.models.airport_conditions import FlightCategory, RunwayEnd
+
+_M_PER_SM = 1609.34
+
+# Ceiling estimate priority — read from the snapshot dict's column-name keys.
+_CEILING_FIELDS = ("sounding_ceiling_ft", "nwp_ceiling_ft", "cloud_base_ft", "lcl_ft")
+
+
+def best_ceiling(snap: dict[str, Any]) -> float | None:
+    """Pick the best ceiling estimate from a snapshot dict.
+
+    ``snap`` keys are the ``AirportForecastSnapshotRow`` column names.
+    """
+    for field in _CEILING_FIELDS:
+        val = snap.get(field)
+        if val is not None:
+            return val
+    return None
+
+
+def flight_category(snap: dict[str, Any]) -> str:
+    """Derive flight category from a snapshot dict.
+
+    Visibility is always converted from metres to statute miles before
+    classification (the map and alternates must agree on units).
+    """
+    ceiling = best_ceiling(snap)
+    vis_m = snap.get("visibility_m")
+    vis_sm = vis_m / _M_PER_SM if vis_m is not None else None
+    return classify_flight_category(ceiling, vis_sm).value
+
+
+def snap_to_dict(snap: dict[str, Any]) -> dict[str, Any]:
+    """Convert a column-keyed snapshot dict into the lightweight per-model dict.
+
+    The output is the per-model shape consumed by :func:`enrich_wind` and
+    :func:`consensus` (and surfaced verbatim in the forecast-map API response).
+    """
+    return {
+        "ceiling_ft": best_ceiling(snap),
+        "visibility_m": snap.get("visibility_m"),
+        "wind_speed_kt": snap.get("wind_speed_10m_kt"),
+        "wind_dir_deg": snap.get("wind_direction_10m_deg"),
+        "wind_gust_kt": snap.get("wind_gusts_10m_kt"),
+        "cloud_cover_pct": snap.get("cloud_cover_pct"),
+        "cape_jkg": snap.get("cape_jkg"),
+        "convective_risk": snap.get("sounding_convective_risk") or "none",
+        "temperature_c": snap.get("temperature_2m_c"),
+        "flight_category": flight_category(snap),
+    }
+
+
+def enrich_wind(d: dict, runway_ends: list[RunwayEnd]) -> None:
+    """Add crosswind/headwind for the best runway to a per-model dict, in place."""
+    ws, wd = d.get("wind_speed_kt"), d.get("wind_dir_deg")
+    if not runway_ends or ws is None or wd is None:
+        return
+    all_rwy = compute_runway_winds(runway_ends, ws, wd)
+    if not all_rwy:
+        return
+    best = min(all_rwy, key=lambda r: (r.crosswind_kt, -r.headwind_kt))
+    d["crosswind_kt"] = best.crosswind_kt
+    d["headwind_kt"] = round(best.headwind_kt, 1)
+    d["best_runway_id"] = best.runway_id
+    # Gust components on the same best runway
+    gust = d.get("wind_gust_kt")
+    if gust is not None:
+        wc = compute_wind_components(gust, wd, best.heading_deg)
+        d["gust_crosswind_kt"] = round(abs(wc.crosswind_kt), 1)
+        d["gust_headwind_kt"] = round(wc.headwind_kt, 1)
+
+
+_AGREEMENT_LABELS = {"good": "consistent", "moderate": "mixed", "poor": "divergent"}
+
+
+def agreement_label(level: str) -> str:
+    """Map internal agreement level to user-facing label."""
+    return _AGREEMENT_LABELS.get(level, level)
+
+
+def consensus(per_model: dict[str, dict], mode: str = "worst") -> dict[str, Any]:
+    """Compute consensus across models for key variables.
+
+    mode: "worst" = most restrictive category, "majority" = most common (worst as tiebreaker)
+    Returns per-variable agreement labels alongside consensus values.
+    """
+    models_with_data = list(per_model.keys())
+    if not models_with_data:
+        return {"flight_category": "VFR", "agreement": {}}
+
+    cats = [FlightCategory(m["flight_category"]) for m in per_model.values()]
+
+    if mode == "majority":
+        counts = Counter(cats)
+        max_count = max(counts.values())
+        tied = [c for c, n in counts.items() if n == max_count]
+        consensus_cat = FlightCategory.worst(tied).value
+    else:
+        consensus_cat = FlightCategory.worst(cats).value
+
+    # Per-variable agreement
+    agreement: dict[str, str] = {}
+    # Flight category agreement: based on whether models agree on the category
+    unique_cats = set(c.value for c in cats)
+    if len(unique_cats) == 1:
+        agreement["flight_category"] = agreement_label("good")
+    elif len(unique_cats) == len(cats):
+        agreement["flight_category"] = agreement_label("poor")
+    else:
+        agreement["flight_category"] = agreement_label("moderate")
+
+    for var in ("wind_speed_kt", "ceiling_ft", "cape_jkg", "visibility_m", "cloud_cover_pct"):
+        vals = {m: per_model[m].get(var) for m in models_with_data}
+        vals = {m: v for m, v in vals.items() if v is not None}
+        if len(vals) >= 2:
+            div = compare_models(var, vals)
+            agreement[var] = agreement_label(div.agreement.value)
+
+    # Means for numeric fields
+    result: dict[str, Any] = {
+        "flight_category": consensus_cat,
+        "agreement": agreement,
+    }
+    for field in ("wind_speed_kt", "wind_dir_deg", "ceiling_ft", "cape_jkg", "visibility_m"):
+        vals = [per_model[m].get(field) for m in models_with_data]
+        vals = [v for v in vals if v is not None]
+        if vals:
+            if field == "wind_dir_deg":
+                mean, _ = circular_spread(vals)
+                result[field] = round(mean, 1)
+            else:
+                result[field] = round(sum(vals) / len(vals), 1)
+
+    # Crosswind/headwind consensus: worst (max) across models
+    for field in ("crosswind_kt", "headwind_kt"):
+        vals = [per_model[m].get(field) for m in models_with_data]
+        vals = [v for v in vals if v is not None]
+        if vals:
+            result[field] = round(max(vals), 1)
+
+    return result

--- a/src/weatherbrief/api/packs.py
+++ b/src/weatherbrief/api/packs.py
@@ -910,6 +910,7 @@ def _prepare_refresh(flight, db_path, user_id, flight_id, db=None, *, is_privile
     do_llm_digest = True
     do_icing_enhance = True
     auto_front_detection = False  # experimental front-detection artifact (#195)
+    compute_alternates = False  # weather-based divert candidates, D-2 inward (#210)
     icing_method = None
     cloud_method = None
     convective_method = None
@@ -944,6 +945,7 @@ def _prepare_refresh(flight, db_path, user_id, flight_id, db=None, *, is_privile
         do_llm_digest = profile_settings.get("llm_digest_enabled", True)
         do_icing_enhance = profile_settings.get("icing_severity_enhance", False)
         auto_front_detection = profile_settings.get("auto_front_detection", False)
+        compute_alternates = profile_settings.get("compute_alternates", False)
         icing_method = profile_settings.get("icing_method")
         cloud_method = profile_settings.get("cloud_method")
         convective_method = profile_settings.get("convective_method")
@@ -983,6 +985,7 @@ def _prepare_refresh(flight, db_path, user_id, flight_id, db=None, *, is_privile
         airports_db_path=db_path,
         icing_severity_enhance=do_icing_enhance,
         auto_front_detection=auto_front_detection,
+        compute_alternates=compute_alternates,
         historical_mode=is_historical,
     )
     if as_of_time:

--- a/src/weatherbrief/api/profiles.py
+++ b/src/weatherbrief/api/profiles.py
@@ -40,6 +40,7 @@ class ProfileSettings(BaseModel):
     llm_digest_enabled: bool | None = None
     icing_severity_enhance: bool | None = None
     auto_front_detection: bool | None = None  # experimental front detection (#196)
+    compute_alternates: bool | None = None  # weather-based divert candidates, D-2 inward (#210)
     icing_method: str | None = None  # "ogimet_dd", "ogimet_nwp", or "sfip_nwp"
     cloud_method: str | None = None  # "dd" or "nwp"
     convective_method: str | None = None  # "thermo" or "nwp"

--- a/src/weatherbrief/digest/prompt_builder.py
+++ b/src/weatherbrief/digest/prompt_builder.py
@@ -15,6 +15,7 @@ from weatherbrief.models import (
     ModelDivergence,
     PrecipPhase,
     RouteAdvisoriesManifest,
+    RouteAlternates,
     RouteObservations,
     RouteSigmets,
     SoundingAnalysis,
@@ -192,6 +193,10 @@ def build_digest_context(
     # --- Route SIGMETs (D-0 only) ---
     if snapshot.route_sigmets and snapshot.route_sigmets.count:
         sections.append(_format_sigmets_context(snapshot.route_sigmets))
+
+    # NOTE: Weather alternates are intentionally NOT fed to the LLM prompt for
+    # now (#210) — they surface in the briefing UI only. Re-enable by appending
+    # _format_alternates_context(snapshot.alternates) here.
 
     # --- Text forecasts ---
     if dwd_translated:
@@ -442,6 +447,64 @@ def _format_sigmets_context(sig: RouteSigmets) -> str:
         lines.append("  " + ", ".join(parts))
         if s.raw_text:
             lines.append(f"    {s.raw_text}")
+
+    return "\n".join(lines)
+
+
+_ALT_AXIS_LABELS = {
+    "category": "better flight category",
+    "wind": "lower wind",
+    "crosswind": "lower crosswind",
+}
+
+
+def _format_alternates_context(alt: RouteAlternates) -> str:
+    """Format weather alternates into a compact LLM context section.
+
+    Leads with the nearest-improving pick per deficient axis (the actionable
+    "where to go instead") so the LLM can mention it in prose, then a short
+    ranked list. Advisory-grade: approach presence is a minima proxy, not a
+    guarantee.
+    """
+    lines: list[str] = [
+        "=== WEATHER ALTERNATES ===",
+        "(Weather-driven divert candidates that fix the destination's weather "
+        "problem — call these \"weather alternates\", NOT operational alternates: "
+        "no fuel, minima, NOTAM, customs or PPR has been checked.)",
+    ]
+    dest_xw = (
+        f", {alt.destination_crosswind_kt:.0f}kt crosswind"
+        if alt.destination_crosswind_kt is not None else ""
+    )
+    lines.append(
+        f"Destination {alt.destination_icao}: {alt.destination_category}{dest_xw} "
+        f"({alt.candidates_evaluated} candidates evaluated"
+        f"{', IFR approach required' if alt.require_approach else ''})"
+    )
+
+    improving = [p for p in alt.nearest_improving if p.icao]
+    if improving:
+        lines.append("Nearest improving alternate per axis:")
+        for p in improving:
+            label = _ALT_AXIS_LABELS.get(p.axis, p.axis)
+            pos = f" ({p.position})" if p.position else ""
+            dist = f" {p.distance_from_dest_nm:.0f}nm from dest" if p.distance_from_dest_nm is not None else ""
+            lines.append(f"  {label}: {p.icao}{dist}{pos}")
+    else:
+        lines.append("No alternate improves on the destination across the evaluated candidates.")
+
+    # Short ranked list (closest-first); cap to keep the prompt compact.
+    for a in alt.alternates[:8]:
+        bits = [f"{a.distance_from_dest_nm:.0f}nm", a.position, a.flight_category]
+        if a.wind_speed_kt is not None:
+            bits.append(f"wind {a.wind_speed_kt:.0f}kt")
+        if a.crosswind_kt is not None:
+            bits.append(f"xwind {a.crosswind_kt:.0f}kt")
+        if a.has_instrument_approach:
+            bits.append(a.best_approach_type or "approach")
+        if a.dominates_destination:
+            bits.append("dominates dest")
+        lines.append(f"  {a.icao}: " + ", ".join(str(b) for b in bits if b))
 
     return "\n".join(lines)
 

--- a/src/weatherbrief/digest/prompt_builder.py
+++ b/src/weatherbrief/digest/prompt_builder.py
@@ -470,12 +470,7 @@ def _format_alternates_context(alt: RouteAlternates) -> str:
         f", {alt.destination_crosswind_kt:.0f}kt crosswind"
         if alt.destination_crosswind_kt is not None else ""
     )
-    approach_note = ""
-    if alt.require_approach:
-        approach_note = (
-            ", approach data unavailable" if alt.approach_filter_relaxed
-            else ", IFR approach required"
-        )
+    approach_note = ", approach data unavailable" if alt.approach_filter_relaxed else ""
     lines.append(
         f"Destination {alt.destination_icao}: {alt.destination_category}{dest_xw} "
         f"({alt.candidates_evaluated} candidates evaluated{approach_note})"

--- a/src/weatherbrief/digest/prompt_builder.py
+++ b/src/weatherbrief/digest/prompt_builder.py
@@ -9,6 +9,7 @@ from weatherbrief.analysis.sounding.convective import convective_cross_check
 from weatherbrief.digest.format_utils import format_flight_level
 from weatherbrief.units import format_visibility
 from weatherbrief.models import (
+    ALT_AXIS_LABELS,
     AgreementLevel,
     ConvectiveRisk,
     ForecastSnapshot,
@@ -451,13 +452,6 @@ def _format_sigmets_context(sig: RouteSigmets) -> str:
     return "\n".join(lines)
 
 
-_ALT_AXIS_LABELS = {
-    "category": "better flight category",
-    "wind": "lower wind",
-    "crosswind": "lower crosswind",
-}
-
-
 def _format_alternates_context(alt: RouteAlternates) -> str:
     """Format weather alternates into a compact LLM context section.
 
@@ -476,17 +470,22 @@ def _format_alternates_context(alt: RouteAlternates) -> str:
         f", {alt.destination_crosswind_kt:.0f}kt crosswind"
         if alt.destination_crosswind_kt is not None else ""
     )
+    approach_note = ""
+    if alt.require_approach:
+        approach_note = (
+            ", approach data unavailable" if alt.approach_filter_relaxed
+            else ", IFR approach required"
+        )
     lines.append(
         f"Destination {alt.destination_icao}: {alt.destination_category}{dest_xw} "
-        f"({alt.candidates_evaluated} candidates evaluated"
-        f"{', IFR approach required' if alt.require_approach else ''})"
+        f"({alt.candidates_evaluated} candidates evaluated{approach_note})"
     )
 
     improving = [p for p in alt.nearest_improving if p.icao]
     if improving:
         lines.append("Nearest improving alternate per axis:")
         for p in improving:
-            label = _ALT_AXIS_LABELS.get(p.axis, p.axis)
+            label = ALT_AXIS_LABELS.get(p.axis, p.axis)
             pos = f" ({p.position})" if p.position else ""
             dist = f" {p.distance_from_dest_nm:.0f}nm from dest" if p.distance_from_dest_nm is not None else ""
             lines.append(f"  {label}: {p.icao}{dist}{pos}")

--- a/src/weatherbrief/digest/text.py
+++ b/src/weatherbrief/digest/text.py
@@ -12,6 +12,7 @@ from weatherbrief.models import (
     ForecastSnapshot,
     IcingRisk,
     PrecipPhase,
+    RouteAlternates,
     RouteObservations,
     RouteSigmets,
     SoundingAnalysis,
@@ -69,6 +70,10 @@ def format_digest(
     # Route SIGMETs (D-0 only)
     if snapshot.route_sigmets and snapshot.route_sigmets.count:
         lines.extend(_format_route_sigmets(snapshot.route_sigmets))
+
+    # Weather-based alternates (D-2 inward, opt-in)
+    if snapshot.alternates and snapshot.alternates.alternates:
+        lines.extend(_format_route_alternates(snapshot.alternates))
 
     # Model agreement summary
     lines.extend(_format_model_agreement(snapshot))
@@ -383,6 +388,54 @@ def _format_route_sigmets(sig: RouteSigmets) -> list[str]:
         lines.append(f"  [{head}]{fir_str}{band_str}{span}")
         if s.raw_text:
             lines.append(f"    {s.raw_text}")
+
+    lines.append("")
+    return lines
+
+
+_ALT_AXIS_LABELS = {
+    "category": "better category",
+    "wind": "lower wind",
+    "crosswind": "lower crosswind",
+}
+
+
+def _format_route_alternates(alt: RouteAlternates) -> list[str]:
+    """Format weather alternates for plain-text digest."""
+    lines: list[str] = ["--- Weather Alternates ---"]
+    dest_xw = (
+        f", {alt.destination_crosswind_kt:.0f}kt xwind"
+        if alt.destination_crosswind_kt is not None else ""
+    )
+    approach_note = ""
+    if alt.require_approach:
+        approach_note = (
+            ", approach data unavailable" if alt.approach_filter_relaxed
+            else ", IFR approach required"
+        )
+    lines.append(
+        f"  Destination {alt.destination_icao}: {alt.destination_category}{dest_xw} "
+        f"({alt.candidates_evaluated} candidates{approach_note})"
+    )
+
+    for p in alt.nearest_improving:
+        if not p.icao:
+            continue
+        label = _ALT_AXIS_LABELS.get(p.axis, p.axis)
+        pos = f" {p.position}" if p.position else ""
+        dist = f" {p.distance_from_dest_nm:.0f}nm" if p.distance_from_dest_nm is not None else ""
+        lines.append(f"  Nearest weather alternate ({label}): {p.icao}{dist}{pos}")
+
+    lines.append("")
+    for a in alt.alternates[:8]:
+        bits = [f"{a.distance_from_dest_nm:.0f}nm", a.position, a.flight_category]
+        if a.crosswind_kt is not None:
+            bits.append(f"xwind {a.crosswind_kt:.0f}kt")
+        if a.has_instrument_approach and a.best_approach_type:
+            bits.append(a.best_approach_type)
+        if a.dominates_destination:
+            bits.append("dominates")
+        lines.append(f"  {a.icao}: " + ", ".join(str(b) for b in bits if b))
 
     lines.append("")
     return lines

--- a/src/weatherbrief/digest/text.py
+++ b/src/weatherbrief/digest/text.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from weatherbrief.digest.format_utils import format_flight_level
 from weatherbrief.models import (
     AgreementLevel,
+    ALT_AXIS_LABELS,
     AltitudeAdvisories,
     ConvectiveRisk,
     ForecastSnapshot,
@@ -393,13 +394,6 @@ def _format_route_sigmets(sig: RouteSigmets) -> list[str]:
     return lines
 
 
-_ALT_AXIS_LABELS = {
-    "category": "better category",
-    "wind": "lower wind",
-    "crosswind": "lower crosswind",
-}
-
-
 def _format_route_alternates(alt: RouteAlternates) -> list[str]:
     """Format weather alternates for plain-text digest."""
     lines: list[str] = ["--- Weather Alternates ---"]
@@ -421,7 +415,7 @@ def _format_route_alternates(alt: RouteAlternates) -> list[str]:
     for p in alt.nearest_improving:
         if not p.icao:
             continue
-        label = _ALT_AXIS_LABELS.get(p.axis, p.axis)
+        label = ALT_AXIS_LABELS.get(p.axis, p.axis)
         pos = f" {p.position}" if p.position else ""
         dist = f" {p.distance_from_dest_nm:.0f}nm" if p.distance_from_dest_nm is not None else ""
         lines.append(f"  Nearest weather alternate ({label}): {p.icao}{dist}{pos}")

--- a/src/weatherbrief/digest/text.py
+++ b/src/weatherbrief/digest/text.py
@@ -401,12 +401,7 @@ def _format_route_alternates(alt: RouteAlternates) -> list[str]:
         f", {alt.destination_crosswind_kt:.0f}kt xwind"
         if alt.destination_crosswind_kt is not None else ""
     )
-    approach_note = ""
-    if alt.require_approach:
-        approach_note = (
-            ", approach data unavailable" if alt.approach_filter_relaxed
-            else ", IFR approach required"
-        )
+    approach_note = ", approach data unavailable" if alt.approach_filter_relaxed else ""
     lines.append(
         f"  Destination {alt.destination_icao}: {alt.destination_category}{dest_xw} "
         f"({alt.candidates_evaluated} candidates{approach_note})"

--- a/src/weatherbrief/models/__init__.py
+++ b/src/weatherbrief/models/__init__.py
@@ -98,6 +98,7 @@ from weatherbrief.models.airport_conditions import (  # noqa: F401
     RunwayWind,
 )
 from weatherbrief.models.alternates import (  # noqa: F401
+    ALT_AXIS_LABELS,
     AlternateAirport,
     AlternateAxisPick,
     RouteAlternates,

--- a/src/weatherbrief/models/__init__.py
+++ b/src/weatherbrief/models/__init__.py
@@ -97,6 +97,11 @@ from weatherbrief.models.airport_conditions import (  # noqa: F401
     RunwayEnd,
     RunwayWind,
 )
+from weatherbrief.models.alternates import (  # noqa: F401
+    AlternateAirport,
+    AlternateAxisPick,
+    RouteAlternates,
+)
 from weatherbrief.models.observations import (  # noqa: F401
     AirportObservation,
     ObservationComparison,

--- a/src/weatherbrief/models/alternates.py
+++ b/src/weatherbrief/models/alternates.py
@@ -17,6 +17,14 @@ from datetime import datetime
 
 from pydantic import BaseModel, Field
 
+# Canonical per-axis labels for the nearest-improving picks, shared by the web
+# UI / text digest / LLM prompt so the wording can't drift between surfaces.
+ALT_AXIS_LABELS = {
+    "category": "better category",
+    "wind": "lower wind",
+    "crosswind": "lower crosswind",
+}
+
 
 class AlternateAirport(BaseModel):
     """One candidate divert airport with geometry, assessment and suitability."""

--- a/src/weatherbrief/models/alternates.py
+++ b/src/weatherbrief/models/alternates.py
@@ -1,0 +1,85 @@
+"""Weather-based alternate-airport models (issue #210).
+
+When a destination forecast is marginal, the alternates stage surfaces the
+closest airports a pilot could divert to that *fix the specific problem*
+(flight category, wind, crosswind), classified as reachable **before** or
+**after** the destination along the route. Each alternate's assessment is
+computed by the same shared code path as the pan-European forecast map
+(``analysis.airport_consensus``), so the same airport reads the same
+category / crosswind / consensus in both views.
+
+See ``designs/future/alternates.md`` for the full design.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+class AlternateAirport(BaseModel):
+    """One candidate divert airport with geometry, assessment and suitability."""
+
+    icao: str
+    name: str | None = None
+    lat: float
+    lon: float
+
+    # --- geometry (relative to route + destination) ---
+    distance_from_dest_nm: float
+    enroute_distance_nm: float | None = None  # along-track position
+    segment_distance_nm: float | None = None  # cross-track distance from route
+    position: str  # "before" | "after"
+    detour_early_nm: float | None = None  # extra miles if you divert from the start
+    detour_late_nm: float | None = None  # extra miles if you fly to the dest area then divert
+
+    # --- consensus assessment (same shape as the forecast-map consensus) ---
+    flight_category: str
+    wind_speed_kt: float | None = None
+    crosswind_kt: float | None = None
+    headwind_kt: float | None = None
+    best_runway_id: str | None = None
+    ceiling_ft: float | None = None
+    visibility_m: float | None = None
+    agreement: dict[str, str] = Field(default_factory=dict)
+    per_model: dict[str, dict] = Field(default_factory=dict)  # raw per-model dicts (like map "models")
+
+    # --- suitability ---
+    has_instrument_approach: bool = False
+    best_approach_type: str | None = None  # ILS/RNP/RNAV/... precision tier (minima proxy)
+    longest_runway_ft: int | None = None
+    has_hard_runway: bool = False
+    point_of_entry: bool = False  # customs/border crossing
+
+    # --- vs-destination flags ---
+    better_category: bool = False
+    better_wind: bool = False
+    better_crosswind: bool = False
+    dominates_destination: bool = False  # better-or-equal on all axes (Pareto)
+
+
+class AlternateAxisPick(BaseModel):
+    """The nearest improving alternate for one deficient axis."""
+
+    axis: str  # "category" | "wind" | "crosswind"
+    icao: str | None = None  # nearest improving alternate (None if none qualifies)
+    distance_from_dest_nm: float | None = None
+    position: str | None = None  # "before" | "after"
+
+
+class RouteAlternates(BaseModel):
+    """Weather-based alternates for a route's destination (D-2 inward)."""
+
+    destination_icao: str
+    destination_category: str
+    destination_crosswind_kt: float | None = None
+    eta: datetime | None = None
+    corridor_nm: float
+    radius_nm: float
+    require_approach: bool = False  # whether the IAP filter was applied
+    approach_filter_relaxed: bool = False  # IAP filter dropped (no candidate had approach data)
+    candidates_evaluated: int = 0
+    alternates: list[AlternateAirport] = Field(default_factory=list)  # ranked, closest-first
+    nearest_improving: list[AlternateAxisPick] = Field(default_factory=list)
+    computed_at: datetime | None = None

--- a/src/weatherbrief/models/alternates.py
+++ b/src/weatherbrief/models/alternates.py
@@ -85,8 +85,8 @@ class RouteAlternates(BaseModel):
     eta: datetime | None = None
     corridor_nm: float
     radius_nm: float
-    require_approach: bool = False  # whether the IAP filter was applied
-    approach_filter_relaxed: bool = False  # IAP filter dropped (no candidate had approach data)
+    require_approach: bool = False  # informational: destination itself is MVFR/IFR/LIFR
+    approach_filter_relaxed: bool = False  # per-candidate IAP gate skipped (no procedure data present)
     candidates_evaluated: int = 0
     alternates: list[AlternateAirport] = Field(default_factory=list)  # ranked, closest-first
     nearest_improving: list[AlternateAxisPick] = Field(default_factory=list)

--- a/src/weatherbrief/models/analysis.py
+++ b/src/weatherbrief/models/analysis.py
@@ -9,6 +9,7 @@ from typing import Optional
 
 from pydantic import BaseModel, Field, model_validator
 
+from weatherbrief.models.alternates import RouteAlternates
 from weatherbrief.models.observations import RefreshDelta, RouteObservations, RouteSigmets
 
 
@@ -850,6 +851,9 @@ class ForecastSnapshot(BaseModel):
     cross_sections: list[RouteCrossSection] = Field(default_factory=list)
     route_observations: RouteObservations | None = None
     route_sigmets: RouteSigmets | None = None
+    # Weather-based divert candidates (D-2 inward, opt-in via compute_alternates).
+    # None outside that window so the web section stays hidden (#210).
+    alternates: RouteAlternates | None = None
     # Worsening summary from the last cheap real-time refresh (no digest re-run);
     # None after a full pipeline run (clean slate — the digest covers changes).
     last_refresh_delta: RefreshDelta | None = None

--- a/src/weatherbrief/pipeline.py
+++ b/src/weatherbrief/pipeline.py
@@ -91,6 +91,7 @@ class BriefingOptions:
     advisory_enabled: dict[str, bool] | None = None  # {advisory_id: enabled}
     advisory_params: dict[str, dict[str, float]] | None = None  # {advisory_id: {param: value}}
     auto_front_detection: bool = False  # experimental: write route_fronts.json (#195)
+    compute_alternates: bool = False  # opt-in: weather-based divert candidates, D-2 inward (#210)
     historical_mode: bool = False  # Use archived NWP data for past departure times
     as_of_time: datetime | None = None  # For historical: the date "as of" which to fetch data
     alt_departure_time: datetime | None = None  # optional same-day alt departure for lite advisory re-run
@@ -118,6 +119,9 @@ class BriefingUsage:
     metar_taf_airports: int = 0
     sigmet_fetched: bool = False
     sigmet_count: int = 0
+    alternates_computed: bool = False
+    alternates_count: int = 0
+    alternates_candidates: int = 0
     elapsed_seconds: float | None = None
     queue_wait_seconds: float | None = None
     triggered_by: str | None = None
@@ -513,6 +517,32 @@ def execute_briefing(
         result_usage_metar = False
         result_usage_metar_airports = 0
 
+    # === 3.6 Weather-based alternates (D-2 inward, opt-in) ===
+    # Surfaces the closest divert candidates that fix the destination's
+    # specific problem (category/wind/crosswind), via the SAME shared assembly
+    # as the forecast map. Gated on the medium-range window (`days_out <= 2`)
+    # and the `compute_alternates` preference — a "fast brief" skips it.
+    alternates = None
+    if (
+        days_out <= 2
+        and options.compute_alternates
+        and options.airports_db_path
+        and not options.historical_mode
+    ):
+        _notify("alternates")
+        _t0 = perf_counter()
+        try:
+            from weatherbrief.tasks.alternates import run_alternates
+
+            alternates = run_alternates(
+                route=route,
+                target_time=target_dt,
+                airports_db_path=options.airports_db_path,
+            )
+        except Exception:
+            logger.warning("Alternates stage failed", exc_info=True)
+        stage_timings["alternates"] = perf_counter() - _t0
+
     # === 4. Build & save snapshot ===
     _t0 = perf_counter()
     snapshot = ForecastSnapshot(
@@ -526,6 +556,7 @@ def execute_briefing(
         cross_sections=fetch_result.cross_sections,
         route_observations=route_observations,
         route_sigmets=route_sigmets,
+        alternates=alternates,
     )
 
     if pack_dir:
@@ -557,6 +588,9 @@ def execute_briefing(
     result.usage.metar_taf_airports = result_usage_metar_airports
     result.usage.sigmet_fetched = result_usage_sigmet
     result.usage.sigmet_count = result_usage_sigmet_count
+    result.usage.alternates_computed = alternates is not None
+    result.usage.alternates_count = len(alternates.alternates) if alternates else 0
+    result.usage.alternates_candidates = alternates.candidates_evaluated if alternates else 0
     if fetch_result.elevation_profile and pack_dir:
         result.elevation_profile_path = pack_dir / "elevation_profile.json"
     if route_advisories_manifest and pack_dir:

--- a/src/weatherbrief/tasks/alternates.py
+++ b/src/weatherbrief/tasks/alternates.py
@@ -1,0 +1,475 @@
+"""Weather-based alternate airports (issue #210).
+
+When a destination forecast is marginal, surface the closest airports a pilot
+could divert to that *fix the specific problem* (flight category, wind speed,
+best-runway crosswind), classify each as reachable **before** or **after** the
+destination along the route, and rank them closest-first.
+
+Consistency is the point of this module: each alternate's assessment is
+computed by the SAME shared code path as the pan-European forecast map
+(``analysis.airport_consensus``) fed from the SAME per-model fetchers the
+standalone verification cycle uses (GFS/ICON via Open-Meteo + GRIB ceiling,
+ECMWF via local GRIB for visibility). So the same airport reads the same
+category / crosswind / consensus in both views.
+
+See ``designs/future/alternates.md`` for the full design and rationale.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta, timezone
+
+from weatherbrief.analysis.airport_consensus import consensus, enrich_wind, snap_to_dict
+from weatherbrief.models.alternates import (
+    AlternateAirport,
+    AlternateAxisPick,
+    RouteAlternates,
+)
+from weatherbrief.models.analysis import RouteConfig
+from weatherbrief.tasks.airport_watchlist import WatchlistAirport
+
+logger = logging.getLogger(__name__)
+
+# Candidate-selection geometry defaults (NM).
+ALT_CORRIDOR_NM = 40.0  # near-route corridor half-width
+ALT_DEST_RADIUS_NM = 50.0  # great-circle radius around the destination
+ALT_MAX_CANDIDATES = 30  # cap fetched candidates (the N×3 lite-sounding cost)
+ALT_POSITION_MARGIN_NM = 10.0  # along-track slack before calling an airport "before"
+ALT_DEFAULT_MIN_RUNWAY_FT = 2000  # conservative default when no aircraft profile is known
+
+# Flight category severity: higher index = worse conditions.
+_CATEGORY_ORDER = {"VFR": 0, "MVFR": 1, "IFR": 2, "LIFR": 3}
+# Destination at/worse than MVFR triggers the instrument-approach requirement.
+_REQUIRE_APPROACH_FROM = _CATEGORY_ORDER["MVFR"]
+
+# Per-model split mirrors the forecast map exactly (STANDALONE_MODELS).
+_MODELS = ["gfs", "icon", "ecmwf"]
+
+
+def _cat_idx(category: str | None) -> int:
+    """Severity index for a flight category (unknown → best/VFR)."""
+    if category is None:
+        return 0
+    return _CATEGORY_ORDER.get(category.upper(), 0)
+
+
+def _haversine_nm(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
+    """Great-circle distance in NM via euro_aip's NavPoint (single source of truth)."""
+    from euro_aip.models.navpoint import NavPoint
+
+    _, dist_nm = NavPoint(latitude=lat1, longitude=lon1).haversine_distance(
+        NavPoint(latitude=lat2, longitude=lon2)
+    )
+    return dist_nm
+
+
+def _is_scheduled_service(value) -> bool:
+    """True when an airport advertises scheduled commercial service."""
+    return str(value).strip().lower() == "yes"
+
+
+def _eta_hour(target_time: datetime, duration_hours: float) -> datetime:
+    """Destination ETA rounded to the nearest whole UTC hour (the fetch sample hour)."""
+    eta = target_time
+    if eta.tzinfo is None:
+        eta = eta.replace(tzinfo=timezone.utc)
+    eta = eta.astimezone(timezone.utc) + timedelta(hours=max(0.0, duration_hours))
+    # Round to nearest hour so we hit an integer sample hour the fetchers emit.
+    rounded = (eta + timedelta(minutes=30)).replace(minute=0, second=0, microsecond=0)
+    return rounded
+
+
+def _same_hour(a: datetime, b: datetime) -> bool:
+    """True when two aware datetimes fall on the same UTC calendar hour."""
+    if a.tzinfo is None:
+        a = a.replace(tzinfo=timezone.utc)
+    if b.tzinfo is None:
+        b = b.replace(tzinfo=timezone.utc)
+    a = a.astimezone(timezone.utc)
+    b = b.astimezone(timezone.utc)
+    return (a.year, a.month, a.day, a.hour) == (b.year, b.month, b.day, b.hour)
+
+
+def _fetch_eta_snapshots(
+    airports: list[WatchlistAirport],
+    eta_dt: datetime,
+) -> dict[str, dict[str, dict]]:
+    """Fetch per-model snapshot dicts for ``airports`` at the ETA hour.
+
+    Returns ``{icao: {model: snapshot_dict}}`` keeping only the snapshot whose
+    ``forecast_hour`` matches ``eta_dt``. Per-model split mirrors the forecast
+    map: GFS/ICON via Open-Meteo + GRIB ceiling, ECMWF via local GRIB (the only
+    source of ECMWF visibility), with an Open-Meteo fallback when no local GRIB
+    run is available (degraded — ECMWF visibility absent — but consensus still
+    works). Each model's failure is non-fatal.
+    """
+    import requests
+
+    from weatherbrief.fetch.model_status import fetch_model_metadata
+    from weatherbrief.tasks.standalone_verification import (
+        MODEL_FORECAST_DAYS,
+        _enrich_with_grib,
+        _fetch_forecasts_for_model,
+        _select_ecmwf_grib_run,
+        fetch_ecmwf_grib_snapshots,
+    )
+
+    sample_hours = [eta_dt.hour]
+    by_icao: dict[str, dict[str, dict]] = {}
+    session = requests.Session()
+    metadata = fetch_model_metadata(_MODELS)
+
+    for model in _MODELS:
+        meta = metadata.get(model)
+        if meta is None:
+            logger.warning("Alternates: no model metadata for %s, skipping", model)
+            continue
+        om_init_time = datetime.fromtimestamp(meta.last_init_time, tz=timezone.utc)
+        days = MODEL_FORECAST_DAYS.get(model, 4)
+
+        snaps: list[dict] = []
+        try:
+            if model == "ecmwf":
+                run_files = _select_ecmwf_grib_run(om_init_time, days)
+                if run_files is not None:
+                    snaps = fetch_ecmwf_grib_snapshots(
+                        run_files, airports, sample_hours, days,
+                    )
+                else:
+                    logger.info(
+                        "Alternates: no local ECMWF GRIB run; falling back to "
+                        "Open-Meteo (no ECMWF visibility)"
+                    )
+                    snaps, _ = _fetch_forecasts_for_model(
+                        model, om_init_time, airports, session, sample_hours,
+                    )
+                    _enrich_with_grib(snaps, model, om_init_time, airports, session)
+            else:
+                snaps, _ = _fetch_forecasts_for_model(
+                    model, om_init_time, airports, session, sample_hours,
+                )
+                _enrich_with_grib(snaps, model, om_init_time, airports, session)
+        except Exception:
+            logger.warning("Alternates: %s fetch failed", model, exc_info=True)
+            continue
+
+        for snap in snaps:
+            if _same_hour(snap["forecast_hour"], eta_dt):
+                by_icao.setdefault(snap["icao"], {})[model] = snap
+
+    return by_icao
+
+
+def _assess(
+    icao: str,
+    by_icao: dict[str, dict[str, dict]],
+    runways: dict,
+) -> tuple[dict[str, dict], dict] | None:
+    """Build (per_model, consensus) for one airport via the shared assembly.
+
+    Returns None when no model produced a snapshot for the airport.
+    """
+    models_raw = by_icao.get(icao)
+    if not models_raw:
+        return None
+    per_model = {m: snap_to_dict(s) for m, s in models_raw.items()}
+    rwy_ends = runways.get(icao, [])
+    for d in per_model.values():
+        enrich_wind(d, rwy_ends)
+    return per_model, consensus(per_model, mode="worst")
+
+
+def run_alternates(
+    route: RouteConfig,
+    target_time: datetime,
+    airports_db_path: str,
+    *,
+    corridor_nm: float = ALT_CORRIDOR_NM,
+    radius_nm: float = ALT_DEST_RADIUS_NM,
+    max_candidates: int = ALT_MAX_CANDIDATES,
+    require_hard_runway: bool = True,
+    min_runway_ft: int | None = ALT_DEFAULT_MIN_RUNWAY_FT,
+    now: datetime | None = None,
+) -> RouteAlternates | None:
+    """Compute weather-based divert candidates for a route's destination.
+
+    Args:
+        route: Flight route (destination = last waypoint).
+        target_time: Flight departure time (aware UTC); ETA = departure + duration.
+        airports_db_path: euro_aip SQLite database path.
+        corridor_nm: Near-route corridor half-width for candidate geometry.
+        radius_nm: Great-circle radius around the destination for laterally-offset fields.
+        max_candidates: Cap on fetched candidates (nearest-to-destination first).
+        require_hard_runway: Drop airports without a hard runway.
+        min_runway_ft: Drop airports whose longest runway is shorter (when known).
+        now: Override for "now" (testing); defaults to current UTC time.
+
+    Returns:
+        A populated ``RouteAlternates``, or ``None`` if the destination
+        assessment could not be computed (caller degrades gracefully).
+    """
+    from weatherbrief.airports import _load_airport_model, get_runway_ends
+    from weatherbrief.tasks.route_weather import _compute_route_distances
+
+    now = now or datetime.now(timezone.utc)
+    eta_dt = _eta_hour(target_time, route.flight_duration_hours)
+
+    model = _load_airport_model(airports_db_path)
+    route_icaos = [wp.icao for wp in route.waypoints]
+    dest = route.destination
+    origin = route.origin
+
+    route_distances = _compute_route_distances(route)
+    dest_enroute_nm = route_distances[-1] if route_distances else 0.0
+    gc_dep_dest = _haversine_nm(origin.lat, origin.lon, dest.lat, dest.lon)
+
+    # --- 1. Candidate geometry: near-route corridor ∪ destination radius ---
+    candidates: dict[str, dict] = {}
+    try:
+        near = model.find_airports_near_route(route_icaos, distance_nm=corridor_nm)
+    except Exception:
+        logger.warning("Alternates: find_airports_near_route failed", exc_info=True)
+        near = []
+    for item in near:
+        ap = item.get("airport")
+        if ap is None or ap.ident is None:
+            continue
+        candidates[ap.ident] = {
+            "airport": ap,
+            "enroute_distance_nm": item.get("enroute_distance_nm"),
+            "segment_distance_nm": item.get("segment_distance_nm"),
+        }
+
+    try:
+        all_airports = model.airports.all()
+    except Exception:
+        all_airports = []
+    for ap in all_airports:
+        if ap.ident in candidates:
+            continue
+        if ap.latitude_deg is None or ap.longitude_deg is None:
+            continue
+        d = _haversine_nm(dest.lat, dest.lon, ap.latitude_deg, ap.longitude_deg)
+        if d <= radius_nm:
+            candidates[ap.ident] = {
+                "airport": ap,
+                "enroute_distance_nm": None,
+                "segment_distance_nm": None,
+            }
+
+    # --- 2. Drop the destination and departure themselves ---
+    candidates.pop(dest.icao, None)
+    candidates.pop(origin.icao, None)
+
+    # --- 3+4. GA-appropriateness + runway suitability ---
+    filtered: list[dict] = []
+    for c in candidates.values():
+        ap = c["airport"]
+        if ap.type == "large_airport":
+            continue
+        if _is_scheduled_service(ap.scheduled_service):
+            continue
+        if require_hard_runway and not ap.has_hard_runway:
+            continue
+        if (
+            min_runway_ft is not None
+            and ap.longest_runway_length_ft is not None
+            and ap.longest_runway_length_ft < min_runway_ft
+        ):
+            continue
+        if ap.latitude_deg is None or ap.longitude_deg is None:
+            continue
+        c["distance_from_dest_nm"] = _haversine_nm(
+            dest.lat, dest.lon, ap.latitude_deg, ap.longitude_deg,
+        )
+        filtered.append(c)
+
+    # --- 6. Cap to the nearest N by destination distance (log the cap) ---
+    filtered.sort(key=lambda c: c["distance_from_dest_nm"])
+    capped = filtered[:max_candidates]
+    if len(filtered) > max_candidates:
+        logger.info(
+            "Alternates: capped candidates %d → %d (nearest-to-destination)",
+            len(filtered), max_candidates,
+        )
+
+    # --- 5. Fetch destination + candidates at ETA (shared per-model split) ---
+    fetch_airports = [WatchlistAirport(icao=dest.icao, lat=dest.lat, lon=dest.lon)]
+    for c in capped:
+        ap = c["airport"]
+        fetch_airports.append(
+            WatchlistAirport(icao=ap.ident, lat=ap.latitude_deg, lon=ap.longitude_deg)
+        )
+
+    by_icao = _fetch_eta_snapshots(fetch_airports, eta_dt)
+    fetch_icaos = [a.icao for a in fetch_airports]
+    try:
+        runways = get_runway_ends(fetch_icaos, airports_db_path)
+    except Exception:
+        logger.warning("Alternates: runway lookup failed", exc_info=True)
+        runways = {}
+
+    # --- Destination assessment (drives axes + the instrument-approach gate) ---
+    dest_assessed = _assess(dest.icao, by_icao, runways)
+    if dest_assessed is None:
+        logger.info("Alternates: no destination snapshot at ETA; skipping stage")
+        return None
+    _, dest_cons = dest_assessed
+    dest_category = dest_cons["flight_category"]
+    dest_wind = dest_cons.get("wind_speed_kt")
+    dest_crosswind = dest_cons.get("crosswind_kt")
+    dest_idx = _cat_idx(dest_category)
+    require_approach = dest_idx >= _REQUIRE_APPROACH_FROM
+
+    # --- Build each alternate ---
+    alternates: list[AlternateAirport] = []
+    for c in capped:
+        ap = c["airport"]
+        assessed = _assess(ap.ident, by_icao, runways)
+        if assessed is None:
+            continue
+        per_model, cons = assessed
+
+        # Suitability: instrument approach + best precision tier (minima proxy).
+        # The gate itself is applied *after* the loop so we can detect when the
+        # airport DB simply has no procedure data and degrade gracefully.
+        has_iap = False
+        best_approach_type = None
+        try:
+            approaches = ap.procedures_query.approaches()
+            has_iap = approaches.exists()
+            if has_iap:
+                best = approaches.most_precise()
+                best_approach_type = best.approach_type if best is not None else None
+        except Exception:
+            logger.debug("Alternates: approach query failed for %s", ap.ident, exc_info=True)
+
+        # Geometry: before/after + detour pair.
+        enroute = c.get("enroute_distance_nm")
+        if enroute is not None and enroute < dest_enroute_nm - ALT_POSITION_MARGIN_NM:
+            position = "before"
+        else:
+            position = "after"
+        dist_from_dest = c["distance_from_dest_nm"]
+        gc_dep_alt = _haversine_nm(origin.lat, origin.lon, ap.latitude_deg, ap.longitude_deg)
+        detour_early_nm = round(gc_dep_alt - gc_dep_dest, 1)
+        detour_late_nm = round(dist_from_dest, 1)
+
+        # Assessment vs destination, per axis.
+        alt_cat = cons["flight_category"]
+        alt_idx = _cat_idx(alt_cat)
+        alt_wind = cons.get("wind_speed_kt")
+        alt_xw = cons.get("crosswind_kt")
+
+        better_category = alt_idx < dest_idx
+        better_wind = (
+            alt_wind is not None and dest_wind is not None and alt_wind < dest_wind
+        )
+        better_crosswind = (
+            alt_xw is not None and dest_crosswind is not None and alt_xw < dest_crosswind
+        )
+        not_worse_cat = alt_idx <= dest_idx
+        not_worse_wind = alt_wind is None or dest_wind is None or alt_wind <= dest_wind
+        not_worse_xw = (
+            alt_xw is None or dest_crosswind is None or alt_xw <= dest_crosswind
+        )
+        dominates = (
+            not_worse_cat
+            and not_worse_wind
+            and not_worse_xw
+            and (better_category or better_wind or better_crosswind)
+        )
+
+        alternates.append(AlternateAirport(
+            icao=ap.ident,
+            name=ap.name,
+            lat=ap.latitude_deg,
+            lon=ap.longitude_deg,
+            distance_from_dest_nm=round(dist_from_dest, 1),
+            enroute_distance_nm=enroute,
+            segment_distance_nm=c.get("segment_distance_nm"),
+            position=position,
+            detour_early_nm=detour_early_nm,
+            detour_late_nm=detour_late_nm,
+            flight_category=alt_cat,
+            wind_speed_kt=cons.get("wind_speed_kt"),
+            crosswind_kt=cons.get("crosswind_kt"),
+            headwind_kt=cons.get("headwind_kt"),
+            best_runway_id=next(
+                (d.get("best_runway_id") for d in per_model.values() if d.get("best_runway_id")),
+                None,
+            ),
+            ceiling_ft=cons.get("ceiling_ft"),
+            visibility_m=cons.get("visibility_m"),
+            agreement=cons.get("agreement", {}),
+            per_model=per_model,
+            has_instrument_approach=has_iap,
+            best_approach_type=best_approach_type,
+            longest_runway_ft=ap.longest_runway_length_ft,
+            has_hard_runway=bool(ap.has_hard_runway),
+            point_of_entry=bool(ap.point_of_entry),
+            better_category=better_category,
+            better_wind=better_wind,
+            better_crosswind=better_crosswind,
+            dominates_destination=dominates,
+        ))
+
+    # Instrument-approach gate (applied here, not per-row, so it can degrade
+    # gracefully). When the destination is MVFR/IFR/LIFR, a field with no
+    # published approach is not a planning-grade IFR alternate — drop it. BUT if
+    # *no* candidate has approach data, the airport DB almost certainly lacks
+    # procedure data (the dev nav.db has zero procedure rows); going dark in that
+    # case is worse than showing weather-better fields with the approach column
+    # blank, so relax the gate and flag it.
+    approach_filter_relaxed = False
+    if require_approach:
+        with_iap = [a for a in alternates if a.has_instrument_approach]
+        if with_iap:
+            alternates = with_iap
+        elif alternates:
+            approach_filter_relaxed = True
+            logger.info(
+                "Alternates: destination %s is %s but no candidate has approach "
+                "data (procedure data likely absent) — showing %d unfiltered, flagged",
+                dest.icao, dest_category, len(alternates),
+            )
+
+    # Rank closest-first.
+    alternates.sort(key=lambda a: a.distance_from_dest_nm)
+
+    # Nearest-improving alternate per deficient axis.
+    def _nearest(pred) -> AlternateAirport | None:
+        matching = [a for a in alternates if pred(a)]
+        if not matching:
+            return None
+        return min(matching, key=lambda a: a.distance_from_dest_nm)
+
+    nearest_improving: list[AlternateAxisPick] = []
+    for axis, pred in (
+        ("category", lambda a: a.better_category),
+        ("wind", lambda a: a.better_wind),
+        ("crosswind", lambda a: a.better_crosswind),
+    ):
+        pick = _nearest(pred)
+        nearest_improving.append(AlternateAxisPick(
+            axis=axis,
+            icao=pick.icao if pick else None,
+            distance_from_dest_nm=pick.distance_from_dest_nm if pick else None,
+            position=pick.position if pick else None,
+        ))
+
+    return RouteAlternates(
+        destination_icao=dest.icao,
+        destination_category=dest_category,
+        destination_crosswind_kt=dest_crosswind,
+        eta=eta_dt,
+        corridor_nm=corridor_nm,
+        radius_nm=radius_nm,
+        require_approach=require_approach,
+        approach_filter_relaxed=approach_filter_relaxed,
+        candidates_evaluated=len(capped),
+        alternates=alternates,
+        nearest_improving=nearest_improving,
+        computed_at=now,
+    )

--- a/src/weatherbrief/tasks/alternates.py
+++ b/src/weatherbrief/tasks/alternates.py
@@ -18,6 +18,7 @@ See ``designs/future/alternates.md`` for the full design and rationale.
 from __future__ import annotations
 
 import logging
+import math
 from datetime import datetime, timedelta, timezone
 
 from weatherbrief.analysis.airport_consensus import consensus, enrich_wind, snap_to_dict
@@ -241,6 +242,16 @@ def run_alternates(
             "segment_distance_nm": item.get("segment_distance_nm"),
         }
 
+    # euro_aip loads the whole airport set into memory (no spatial index), so
+    # the radius query is a scan. Cheap bounding-box pre-filter first — skip the
+    # haversine for airports that can't possibly be within radius_nm. 1° lat ≈
+    # 60 NM; longitude degrees shrink by cos(lat) toward the poles.
+    lat_margin = radius_nm / 60.0
+    # Use cos at the worst-case (highest-|lat|) edge of the box so the longitude
+    # margin is never too tight — the box must not exclude a true in-radius
+    # airport; the haversine below still does the exact gating.
+    cos_lat = max(0.01, math.cos(math.radians(min(89.0, abs(dest.lat) + lat_margin))))
+    lon_margin = radius_nm / (60.0 * cos_lat)
     try:
         all_airports = model.airports.all()
     except Exception:
@@ -249,6 +260,10 @@ def run_alternates(
         if ap.ident in candidates:
             continue
         if ap.latitude_deg is None or ap.longitude_deg is None:
+            continue
+        if abs(ap.latitude_deg - dest.lat) > lat_margin:
+            continue
+        if abs(ap.longitude_deg - dest.lon) > lon_margin:
             continue
         d = _haversine_nm(dest.lat, dest.lon, ap.latitude_deg, ap.longitude_deg)
         if d <= radius_nm:

--- a/src/weatherbrief/tasks/alternates.py
+++ b/src/weatherbrief/tasks/alternates.py
@@ -335,6 +335,9 @@ def run_alternates(
     dest_wind = dest_cons.get("wind_speed_kt")
     dest_crosswind = dest_cons.get("crosswind_kt")
     dest_idx = _cat_idx(dest_category)
+    # Informational only: is the destination itself MVFR/IFR/LIFR (i.e. you'd
+    # need an instrument approach to get into the *destination*). The candidate
+    # approach gate below is per-candidate and does NOT key off this.
     require_approach = dest_idx >= _REQUIRE_APPROACH_FROM
 
     # --- Build each alternate ---
@@ -430,25 +433,32 @@ def run_alternates(
             dominates_destination=dominates,
         ))
 
-    # Instrument-approach gate (applied here, not per-row, so it can degrade
-    # gracefully). When the destination is MVFR/IFR/LIFR, a field with no
-    # published approach is not a planning-grade IFR alternate — drop it. BUT if
-    # *no* candidate has approach data, the airport DB almost certainly lacks
-    # procedure data (the dev nav.db has zero procedure rows); going dark in that
-    # case is worse than showing weather-better fields with the approach column
-    # blank, so relax the gate and flag it.
+    # Per-candidate instrument-approach gate (always applied, by the
+    # candidate's *own* weather — not the destination's). A field that is
+    # itself MVFR/IFR/LIFR with no published approach can't be reached in those
+    # conditions, so drop it. A field forecast VFR is always kept: you divert
+    # there visually, no approach needed. Graceful degradation: if procedure
+    # data is absent entirely (no candidate has any approach) yet there are
+    # sub-VFR fields the gate *would* drop, going dark on missing reference
+    # data is worse than showing them flagged — so relax + flag instead.
+    def _needs_approach(a: AlternateAirport) -> bool:
+        return _cat_idx(a.flight_category) >= _REQUIRE_APPROACH_FROM
+
+    gated_out = [a for a in alternates if _needs_approach(a) and not a.has_instrument_approach]
+    any_approach_data = any(a.has_instrument_approach for a in alternates)
     approach_filter_relaxed = False
-    if require_approach:
-        with_iap = [a for a in alternates if a.has_instrument_approach]
-        if with_iap:
-            alternates = with_iap
-        elif alternates:
-            approach_filter_relaxed = True
-            logger.info(
-                "Alternates: destination %s is %s but no candidate has approach "
-                "data (procedure data likely absent) — showing %d unfiltered, flagged",
-                dest.icao, dest_category, len(alternates),
-            )
+    if gated_out and not any_approach_data:
+        approach_filter_relaxed = True
+        logger.info(
+            "Alternates: %d sub-VFR candidate(s) lack an approach but no procedure "
+            "data is present (likely absent from the airport DB) — showing unfiltered, flagged",
+            len(gated_out),
+        )
+    else:
+        alternates = [
+            a for a in alternates
+            if a.has_instrument_approach or not _needs_approach(a)
+        ]
 
     # Rank closest-first.
     alternates.sort(key=lambda a: a.distance_from_dest_nm)

--- a/src/weatherbrief/tasks/map_queries.py
+++ b/src/weatherbrief/tasks/map_queries.py
@@ -8,28 +8,25 @@ Two query types:
 from __future__ import annotations
 
 import logging
-from collections import Counter
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
 from sqlalchemy import func, or_, select
 from sqlalchemy.orm import Session
 
-from weatherbrief.analysis.airport_conditions import (
-    classify_flight_category,
-    compute_runway_winds,
+from weatherbrief.analysis.airport_consensus import (
+    best_ceiling as _shared_best_ceiling,
+    consensus as _shared_consensus,
+    enrich_wind as _shared_enrich_wind,
+    flight_category as _shared_flight_category,
+    snap_to_dict as _shared_snap_to_dict,
 )
-from weatherbrief.analysis.comparison import (
-    circular_spread,
-    compare_models,
-)
-from weatherbrief.analysis.wind import compute_wind_components
 from weatherbrief.db.models import (
     AirportForecastSnapshotRow,
     VerificationObservationRow,
     VerificationScoreRow,
 )
-from weatherbrief.models.airport_conditions import FlightCategory, RunwayEnd
+from weatherbrief.models.airport_conditions import RunwayEnd
 from weatherbrief.tasks.airport_watchlist import (
     WatchlistAirport,
     get_configs_dir,
@@ -37,8 +34,6 @@ from weatherbrief.tasks.airport_watchlist import (
 )
 
 logger = logging.getLogger(__name__)
-
-_M_PER_SM = 1609.34
 
 # Models used in standalone verification
 _MODELS = ["gfs", "icon", "ecmwf"]
@@ -80,127 +75,61 @@ def _get_runways(airports_db_path: str) -> dict[str, list[RunwayEnd]]:
 # ---------------------------------------------------------------------------
 
 
+# Snapshot → category/wind/consensus assembly now lives in the shared,
+# dict-based ``analysis.airport_consensus`` so the forecast map and the
+# route-alternates stage compute identical results (issue #210, "Seam 2").
+# These module-level wrappers preserve the original row/attribute-access
+# signatures (the forecast map reads ORM rows; tests pass SimpleNamespace).
+
+# Snapshot columns the shared assembly reads, copied off the ORM row.
+_SNAPSHOT_DICT_FIELDS = (
+    "sounding_ceiling_ft",
+    "nwp_ceiling_ft",
+    "cloud_base_ft",
+    "lcl_ft",
+    "visibility_m",
+    "wind_speed_10m_kt",
+    "wind_direction_10m_deg",
+    "wind_gusts_10m_kt",
+    "cloud_cover_pct",
+    "cape_jkg",
+    "sounding_convective_risk",
+    "temperature_2m_c",
+)
+
+
+def _row_to_snapshot_dict(snap: AirportForecastSnapshotRow) -> dict[str, Any]:
+    """Adapt an ORM snapshot row to the plain dict the shared assembly reads.
+
+    ``getattr(..., None)`` keeps the adapter tolerant of partial test doubles
+    (e.g. ``SimpleNamespace``) that only set the fields a given test exercises.
+    """
+    return {field: getattr(snap, field, None) for field in _SNAPSHOT_DICT_FIELDS}
+
+
 def _best_ceiling(snap: AirportForecastSnapshotRow) -> float | None:
-    """Pick the best ceiling estimate from a snapshot."""
-    for field in ("sounding_ceiling_ft", "nwp_ceiling_ft", "cloud_base_ft", "lcl_ft"):
-        val = getattr(snap, field, None)
-        if val is not None:
-            return val
-    return None
+    """Pick the best ceiling estimate from a snapshot (row→dict adapter)."""
+    return _shared_best_ceiling(_row_to_snapshot_dict(snap))
 
 
 def _flight_category(snap: AirportForecastSnapshotRow) -> str:
-    """Derive flight category from snapshot fields."""
-    ceiling = _best_ceiling(snap)
-    vis_sm = snap.visibility_m / _M_PER_SM if snap.visibility_m is not None else None
-    return classify_flight_category(ceiling, vis_sm).value
+    """Derive flight category from snapshot fields (row→dict adapter)."""
+    return _shared_flight_category(_row_to_snapshot_dict(snap))
 
 
 def _snap_to_dict(snap: AirportForecastSnapshotRow) -> dict[str, Any]:
     """Convert a forecast snapshot to a lightweight dict for the API response."""
-    return {
-        "ceiling_ft": _best_ceiling(snap),
-        "visibility_m": snap.visibility_m,
-        "wind_speed_kt": snap.wind_speed_10m_kt,
-        "wind_dir_deg": snap.wind_direction_10m_deg,
-        "wind_gust_kt": snap.wind_gusts_10m_kt,
-        "cloud_cover_pct": snap.cloud_cover_pct,
-        "cape_jkg": snap.cape_jkg,
-        "convective_risk": snap.sounding_convective_risk or "none",
-        "temperature_c": snap.temperature_2m_c,
-        "flight_category": _flight_category(snap),
-    }
+    return _shared_snap_to_dict(_row_to_snapshot_dict(snap))
 
 
 def _enrich_wind(d: dict, runway_ends: list[RunwayEnd]) -> None:
     """Add crosswind/headwind for best runway to a snapshot dict."""
-    ws, wd = d.get("wind_speed_kt"), d.get("wind_dir_deg")
-    if not runway_ends or ws is None or wd is None:
-        return
-    all_rwy = compute_runway_winds(runway_ends, ws, wd)
-    if not all_rwy:
-        return
-    best = min(all_rwy, key=lambda r: (r.crosswind_kt, -r.headwind_kt))
-    d["crosswind_kt"] = best.crosswind_kt
-    d["headwind_kt"] = round(best.headwind_kt, 1)
-    d["best_runway_id"] = best.runway_id
-    # Gust components on the same best runway
-    gust = d.get("wind_gust_kt")
-    if gust is not None:
-        wc = compute_wind_components(gust, wd, best.heading_deg)
-        d["gust_crosswind_kt"] = round(abs(wc.crosswind_kt), 1)
-        d["gust_headwind_kt"] = round(wc.headwind_kt, 1)
-
-
-_AGREEMENT_LABELS = {"good": "consistent", "moderate": "mixed", "poor": "divergent"}
-
-
-def _agreement_label(level: str) -> str:
-    """Map internal agreement level to user-facing label."""
-    return _AGREEMENT_LABELS.get(level, level)
+    _shared_enrich_wind(d, runway_ends)
 
 
 def _consensus(per_model: dict[str, dict], mode: str = "worst") -> dict[str, Any]:
-    """Compute consensus across models for key variables.
-
-    mode: "worst" = most restrictive category, "majority" = most common (worst as tiebreaker)
-    Returns per-variable agreement labels alongside consensus values.
-    """
-    models_with_data = list(per_model.keys())
-    if not models_with_data:
-        return {"flight_category": "VFR", "agreement": {}}
-
-    cats = [FlightCategory(m["flight_category"]) for m in per_model.values()]
-
-    if mode == "majority":
-        counts = Counter(cats)
-        max_count = max(counts.values())
-        tied = [c for c, n in counts.items() if n == max_count]
-        consensus_cat = FlightCategory.worst(tied).value
-    else:
-        consensus_cat = FlightCategory.worst(cats).value
-
-    # Per-variable agreement
-    agreement: dict[str, str] = {}
-    # Flight category agreement: based on whether models agree on the category
-    unique_cats = set(c.value for c in cats)
-    if len(unique_cats) == 1:
-        agreement["flight_category"] = _agreement_label("good")
-    elif len(unique_cats) == len(cats):
-        agreement["flight_category"] = _agreement_label("poor")
-    else:
-        agreement["flight_category"] = _agreement_label("moderate")
-
-    for var in ("wind_speed_kt", "ceiling_ft", "cape_jkg", "visibility_m", "cloud_cover_pct"):
-        vals = {m: per_model[m].get(var) for m in models_with_data}
-        vals = {m: v for m, v in vals.items() if v is not None}
-        if len(vals) >= 2:
-            div = compare_models(var, vals)
-            agreement[var] = _agreement_label(div.agreement.value)
-
-    # Means for numeric fields
-    result: dict[str, Any] = {
-        "flight_category": consensus_cat,
-        "agreement": agreement,
-    }
-    for field in ("wind_speed_kt", "wind_dir_deg", "ceiling_ft", "cape_jkg", "visibility_m"):
-        vals = [per_model[m].get(field) for m in models_with_data]
-        vals = [v for v in vals if v is not None]
-        if vals:
-            if field == "wind_dir_deg":
-                mean, _ = circular_spread(vals)
-                result[field] = round(mean, 1)
-            else:
-                result[field] = round(sum(vals) / len(vals), 1)
-
-    # Crosswind/headwind consensus: worst (max) across models
-    for field in ("crosswind_kt", "headwind_kt"):
-        vals = [per_model[m].get(field) for m in models_with_data]
-        vals = [v for v in vals if v is not None]
-        if vals:
-            result[field] = round(max(vals), 1)
-
-    return result
+    """Compute consensus across models for key variables."""
+    return _shared_consensus(per_model, mode)
 
 
 def get_forecast_map_data(

--- a/src/weatherbrief/tasks/standalone_verification.py
+++ b/src/weatherbrief/tasks/standalone_verification.py
@@ -277,15 +277,25 @@ def _fetch_forecasts_for_model(
     init_time: datetime,
     airports: list[WatchlistAirport],
     session: requests.Session,
+    sample_hours: list[int] | None = None,
 ) -> tuple[list[dict], int]:
     """Fetch Open-Meteo surface forecasts for all airports for one model.
 
     Returns (snapshots, api_call_count) — list of dicts with airport ICAO
-    and per-sample-hour values filtered to SAMPLE_HOURS_UTC, plus the number
+    and per-sample-hour values filtered to ``sample_hours``, plus the number
     of actual HTTP requests made.
+
+    ``sample_hours`` defaults to the module-level ``SAMPLE_HOURS_UTC`` so the
+    standalone verification cycle keeps its current behaviour; the route
+    alternates stage passes the flight's ETA hour to fetch off-grid hours
+    (issue #210, "Seam 1"). ``fetch_ecmwf_grib_snapshots`` already takes a
+    ``sample_hours`` argument, so this brings the GFS/ICON path in line.
     """
     from weatherbrief.models.analysis import ModelSource, RoutePoint
     from weatherbrief.fetch.open_meteo import OpenMeteoClient
+
+    if sample_hours is None:
+        sample_hours = SAMPLE_HOURS_UTC
 
     model_source = ModelSource(model)
     forecast_days = MODEL_FORECAST_DAYS.get(model, 7)
@@ -359,7 +369,7 @@ def _fetch_forecasts_for_model(
             # Filter to sample hours only
             for hourly in wpf.hourly:
                 utc_hour = hourly.time.hour if hasattr(hourly.time, 'hour') else None
-                if utc_hour not in SAMPLE_HOURS_UTC:
+                if utc_hour not in sample_hours:
                     continue
 
                 # Compute LCL from T-Td

--- a/tests/test_alternates.py
+++ b/tests/test_alternates.py
@@ -1,0 +1,355 @@
+"""Tests for weather-based alternate airports (issue #210).
+
+Covers:
+- geometry: before/after classification + the detour pair
+- candidate filters: instrument-approach gate, large_airport / scheduled exclusion
+- consistency: the shared assembly yields the same category/crosswind as the
+  forecast map's ``map_queries`` wrappers for a fixed snapshot ("Seam 2").
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from weatherbrief.models.analysis import RouteConfig, Waypoint
+from weatherbrief.tasks import alternates as alt_mod
+from weatherbrief.tasks.alternates import run_alternates
+
+NOW = datetime(2026, 6, 5, 6, 0, 0, tzinfo=timezone.utc)
+DEPARTURE = datetime(2026, 6, 6, 8, 0, 0, tzinfo=timezone.utc)  # D-1 → stage gate ok
+
+
+# ---------------------------------------------------------------------------
+# Fake euro_aip model
+# ---------------------------------------------------------------------------
+
+
+class _FakeApproaches:
+    def __init__(self, exists: bool, best_type: str | None):
+        self._exists = exists
+        self._best_type = best_type
+
+    def exists(self) -> bool:
+        return self._exists
+
+    def most_precise(self):
+        if not self._exists:
+            return None
+        return SimpleNamespace(approach_type=self._best_type)
+
+
+class _FakeProceduresQuery:
+    def __init__(self, exists: bool, best_type: str | None):
+        self._approaches = _FakeApproaches(exists, best_type)
+
+    def approaches(self):
+        return self._approaches
+
+
+class _FakeAirport:
+    def __init__(
+        self, ident, lat, lon, *,
+        type="small_airport", scheduled_service="no",
+        has_hard_runway=True, longest_runway_length_ft=4000,
+        point_of_entry=False, has_approach=True, best_approach="ILS", name=None,
+    ):
+        self.ident = ident
+        self.latitude_deg = lat
+        self.longitude_deg = lon
+        self.type = type
+        self.scheduled_service = scheduled_service
+        self.has_hard_runway = has_hard_runway
+        self.longest_runway_length_ft = longest_runway_length_ft
+        self.point_of_entry = point_of_entry
+        self.name = name or ident
+        self._pq = _FakeProceduresQuery(has_approach, best_approach)
+
+    @property
+    def procedures_query(self):
+        return self._pq
+
+
+class _FakeAirportCollection:
+    def __init__(self, airports):
+        self._airports = airports
+
+    def all(self):
+        return self._airports
+
+    def get(self, icao):
+        return next((a for a in self._airports if a.ident == icao), None)
+
+
+class _FakeModel:
+    def __init__(self, near_results, all_airports=None):
+        self._near = near_results
+        self.airports = _FakeAirportCollection(all_airports or [])
+
+    def find_airports_near_route(self, route_icaos, distance_nm=50.0):
+        return self._near
+
+
+def _route():
+    return RouteConfig(
+        name="EGKK-EGPF",
+        waypoints=[
+            Waypoint(icao="EGKK", name="Gatwick", lat=51.15, lon=-0.18),
+            Waypoint(icao="EGPF", name="Glasgow", lat=55.87, lon=-4.43),
+        ],
+        flight_duration_hours=2.0,
+    )
+
+
+def _snap(icao, model, *, ceiling=5000.0, vis_m=9999.0, ws=8.0, wd=270.0):
+    """A column-keyed snapshot dict (keys == AirportForecastSnapshotRow columns)."""
+    return {
+        "icao": icao,
+        "model": model,
+        "model_init_time": NOW,
+        "forecast_hour": NOW,
+        "sounding_ceiling_ft": ceiling,
+        "nwp_ceiling_ft": None,
+        "cloud_base_ft": None,
+        "lcl_ft": None,
+        "visibility_m": vis_m,
+        "wind_speed_10m_kt": ws,
+        "wind_direction_10m_deg": wd,
+        "wind_gusts_10m_kt": None,
+        "cloud_cover_pct": 20.0,
+        "cape_jkg": 10.0,
+        "sounding_convective_risk": "none",
+        "temperature_2m_c": 14.0,
+    }
+
+
+def _all_models(icao, **kw):
+    return {m: _snap(icao, m, **kw) for m in ("gfs", "icon", "ecmwf")}
+
+
+def _run(route, near_results, snapshots_by_icao, *, all_airports=None, runways=None):
+    """Drive run_alternates with euro_aip + fetch fully mocked."""
+    model = _FakeModel(near_results, all_airports=all_airports)
+    with patch("weatherbrief.airports._load_airport_model", return_value=model), \
+         patch("weatherbrief.airports.get_runway_ends", return_value=runways or {}), \
+         patch.object(alt_mod, "_fetch_eta_snapshots", return_value=snapshots_by_icao):
+        return run_alternates(
+            route=route,
+            target_time=DEPARTURE,
+            airports_db_path="/fake/nav.db",
+            now=NOW,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Geometry: before / after + detour pair
+# ---------------------------------------------------------------------------
+
+
+def test_before_after_and_detour_pair():
+    route = _route()
+    # A "before" field near the departure, an "after" field near the destination.
+    before = _FakeAirport("EGTC", 51.50, -0.50)
+    after = _FakeAirport("EGPN", 55.50, -3.40)
+    near = [
+        {"airport": before, "enroute_distance_nm": 30.0, "segment_distance_nm": 8.0},
+        {"airport": after, "enroute_distance_nm": None, "segment_distance_nm": 12.0},
+    ]
+    snaps = {
+        "EGPF": _all_models("EGPF"),
+        "EGTC": _all_models("EGTC"),
+        "EGPN": _all_models("EGPN"),
+    }
+    result = _run(route, near, snaps)
+    assert result is not None
+    by_icao = {a.icao: a for a in result.alternates}
+
+    assert by_icao["EGTC"].position == "before"
+    assert by_icao["EGPN"].position == "after"
+
+    # The whole point of the detour pair: a "before" field is cheap to divert to
+    # early but expensive late (you'd backtrack from the destination).
+    egtc = by_icao["EGTC"]
+    assert egtc.detour_early_nm < egtc.detour_late_nm
+
+    # Closest-first ranking.
+    dists = [a.distance_from_dest_nm for a in result.alternates]
+    assert dists == sorted(dists)
+
+
+# ---------------------------------------------------------------------------
+# Instrument-approach gate (destination IFR/MVFR)
+# ---------------------------------------------------------------------------
+
+
+def test_iap_gate_excludes_no_approach_when_dest_ifr():
+    route = _route()
+    with_iap = _FakeAirport("EGAA", 54.66, -6.22, has_approach=True, best_approach="ILS")
+    no_iap = _FakeAirport("EGAE", 55.04, -7.16, has_approach=False, best_approach=None)
+    near = [
+        {"airport": with_iap, "enroute_distance_nm": 120.0, "segment_distance_nm": 10.0},
+        {"airport": no_iap, "enroute_distance_nm": 130.0, "segment_distance_nm": 15.0},
+    ]
+    snaps = {
+        # Destination IFR (low ceiling) → require_approach should trip.
+        "EGPF": _all_models("EGPF", ceiling=600.0),
+        "EGAA": _all_models("EGAA"),
+        "EGAE": _all_models("EGAE"),
+    }
+    result = _run(route, near, snaps)
+    assert result is not None
+    assert result.require_approach is True
+    icaos = {a.icao for a in result.alternates}
+    assert "EGAA" in icaos
+    assert "EGAE" not in icaos  # no published approach → dropped when dest is IFR
+
+    egaa = next(a for a in result.alternates if a.icao == "EGAA")
+    assert egaa.has_instrument_approach is True
+    assert egaa.best_approach_type == "ILS"
+
+
+def test_iap_gate_relaxed_when_no_candidate_has_approach_data():
+    # Destination IFR, but NO candidate has approach data (e.g. nav DB lacks
+    # procedure rows). Rather than going dark, the gate relaxes and flags it.
+    route = _route()
+    a = _FakeAirport("EGKE", 51.10, -0.20, has_approach=False, best_approach=None)
+    b = _FakeAirport("EGKH", 51.05, -0.30, has_approach=False, best_approach=None)
+    near = [
+        {"airport": a, "enroute_distance_nm": 200.0, "segment_distance_nm": 8.0},
+        {"airport": b, "enroute_distance_nm": 205.0, "segment_distance_nm": 9.0},
+    ]
+    snaps = {
+        "EGPF": _all_models("EGPF", ceiling=600.0),  # IFR
+        "EGKE": _all_models("EGKE"),
+        "EGKH": _all_models("EGKH"),
+    }
+    result = _run(route, near, snaps)
+    assert result is not None
+    assert result.require_approach is True
+    assert result.approach_filter_relaxed is True
+    # Candidates are still shown (flagged), not dropped.
+    assert {a.icao for a in result.alternates} == {"EGKE", "EGKH"}
+
+
+def test_iap_gate_not_applied_when_dest_vfr():
+    route = _route()
+    no_iap = _FakeAirport("EGAE", 55.04, -7.16, has_approach=False, best_approach=None)
+    near = [
+        {"airport": no_iap, "enroute_distance_nm": 130.0, "segment_distance_nm": 15.0},
+    ]
+    snaps = {
+        "EGPF": _all_models("EGPF", ceiling=5000.0),  # VFR
+        "EGAE": _all_models("EGAE"),
+    }
+    result = _run(route, near, snaps)
+    assert result is not None
+    assert result.require_approach is False
+    assert {a.icao for a in result.alternates} == {"EGAE"}
+
+
+# ---------------------------------------------------------------------------
+# GA-appropriateness filters
+# ---------------------------------------------------------------------------
+
+
+def test_large_airport_and_scheduled_service_excluded():
+    route = _route()
+    ok = _FakeAirport("EGPN", 55.50, -3.40)
+    large = _FakeAirport("EGPK", 55.51, -4.59, type="large_airport")
+    scheduled = _FakeAirport("EGPH", 55.95, -3.37, scheduled_service="yes")
+    near = [
+        {"airport": ok, "enroute_distance_nm": 200.0, "segment_distance_nm": 5.0},
+        {"airport": large, "enroute_distance_nm": 205.0, "segment_distance_nm": 6.0},
+        {"airport": scheduled, "enroute_distance_nm": 210.0, "segment_distance_nm": 7.0},
+    ]
+    snaps = {
+        "EGPF": _all_models("EGPF"),
+        "EGPN": _all_models("EGPN"),
+        "EGPK": _all_models("EGPK"),
+        "EGPH": _all_models("EGPH"),
+    }
+    result = _run(route, near, snaps)
+    assert result is not None
+    assert {a.icao for a in result.alternates} == {"EGPN"}
+
+
+def test_short_runway_excluded():
+    route = _route()
+    short = _FakeAirport("EGPN", 55.50, -3.40, longest_runway_length_ft=1200)
+    ok = _FakeAirport("EGPT", 55.40, -3.50, longest_runway_length_ft=4000)
+    near = [
+        {"airport": short, "enroute_distance_nm": 200.0, "segment_distance_nm": 5.0},
+        {"airport": ok, "enroute_distance_nm": 195.0, "segment_distance_nm": 5.0},
+    ]
+    snaps = {
+        "EGPF": _all_models("EGPF"),
+        "EGPN": _all_models("EGPN"),
+        "EGPT": _all_models("EGPT"),
+    }
+    result = _run(route, near, snaps)
+    assert result is not None
+    assert {a.icao for a in result.alternates} == {"EGPT"}
+
+
+# ---------------------------------------------------------------------------
+# Nearest-improving picks
+# ---------------------------------------------------------------------------
+
+
+def test_nearest_improving_category_pick():
+    route = _route()
+    # Destination IFR; a nearer VFR field and a farther VFR field.
+    near_vfr = _FakeAirport("EGPN", 55.60, -3.80)
+    far_vfr = _FakeAirport("EGAA", 54.66, -6.22)
+    near = [
+        {"airport": near_vfr, "enroute_distance_nm": 220.0, "segment_distance_nm": 5.0},
+        {"airport": far_vfr, "enroute_distance_nm": 150.0, "segment_distance_nm": 10.0},
+    ]
+    snaps = {
+        "EGPF": _all_models("EGPF", ceiling=600.0),  # IFR
+        "EGPN": _all_models("EGPN", ceiling=5000.0),  # VFR
+        "EGAA": _all_models("EGAA", ceiling=5000.0),  # VFR
+    }
+    result = _run(route, near, snaps)
+    assert result is not None
+    picks = {p.axis: p for p in result.nearest_improving}
+    cat_pick = picks["category"]
+    # The geographically nearer VFR field wins the category axis.
+    assert cat_pick.icao == "EGPN"
+    egpn = next(a for a in result.alternates if a.icao == "EGPN")
+    assert egpn.better_category is True
+
+
+# ---------------------------------------------------------------------------
+# Consistency: shared assembly == map_queries wrappers (Seam 2)
+# ---------------------------------------------------------------------------
+
+
+def test_shared_assembly_matches_map_queries():
+    from weatherbrief.analysis import airport_consensus as ac
+    from weatherbrief.models.airport_conditions import RunwayEnd
+    from weatherbrief.tasks import map_queries as mq
+
+    snap_dict = _snap("EGPF", "gfs", ceiling=800.0, vis_m=5000.0, ws=18.0, wd=240.0)
+    row = SimpleNamespace(**snap_dict)
+
+    # snap_to_dict: same lightweight per-model dict from a dict and from a row.
+    shared = ac.snap_to_dict(snap_dict)
+    via_row = mq._snap_to_dict(row)
+    assert shared == via_row
+
+    # enrich_wind: identical crosswind/headwind on the best runway.
+    runways = [RunwayEnd(id="05", heading_deg=50.0), RunwayEnd(id="23", heading_deg=230.0)]
+    d_shared = dict(shared)
+    d_row = dict(via_row)
+    ac.enrich_wind(d_shared, runways)
+    mq._enrich_wind(d_row, runways)
+    assert d_shared == d_row
+    assert d_shared["crosswind_kt"] == pytest.approx(d_row["crosswind_kt"])
+
+    # consensus: identical category + worst crosswind across models.
+    per_model = {"gfs": d_shared, "icon": dict(d_shared)}
+    assert ac.consensus(per_model) == mq._consensus(per_model)

--- a/tests/test_alternates.py
+++ b/tests/test_alternates.py
@@ -181,39 +181,67 @@ def test_before_after_and_detour_pair():
 
 
 # ---------------------------------------------------------------------------
-# Instrument-approach gate (destination IFR/MVFR)
+# Per-candidate instrument-approach gate
 # ---------------------------------------------------------------------------
 
 
-def test_iap_gate_excludes_no_approach_when_dest_ifr():
+def test_per_candidate_approach_gate():
+    # The gate is per-candidate, by the candidate's OWN weather (not the
+    # destination's): a sub-VFR field with no approach is dropped; a VFR field
+    # with no approach is kept (visual divert); a sub-VFR field WITH an approach
+    # is kept.
     route = _route()
-    with_iap = _FakeAirport("EGAA", 54.66, -6.22, has_approach=True, best_approach="ILS")
-    no_iap = _FakeAirport("EGAE", 55.04, -7.16, has_approach=False, best_approach=None)
+    ifr_iap = _FakeAirport("EGAA", 54.66, -6.22, has_approach=True, best_approach="ILS")
+    ifr_no_iap = _FakeAirport("EGAE", 55.04, -7.16, has_approach=False, best_approach=None)
+    vfr_no_iap = _FakeAirport("EGAC", 54.62, -5.87, has_approach=False, best_approach=None)
     near = [
-        {"airport": with_iap, "enroute_distance_nm": 120.0, "segment_distance_nm": 10.0},
-        {"airport": no_iap, "enroute_distance_nm": 130.0, "segment_distance_nm": 15.0},
+        {"airport": ifr_iap, "enroute_distance_nm": 120.0, "segment_distance_nm": 10.0},
+        {"airport": ifr_no_iap, "enroute_distance_nm": 130.0, "segment_distance_nm": 15.0},
+        {"airport": vfr_no_iap, "enroute_distance_nm": 125.0, "segment_distance_nm": 12.0},
     ]
     snaps = {
-        # Destination IFR (low ceiling) → require_approach should trip.
-        "EGPF": _all_models("EGPF", ceiling=600.0),
-        "EGAA": _all_models("EGAA"),
-        "EGAE": _all_models("EGAE"),
+        "EGPF": _all_models("EGPF", ceiling=600.0),   # destination IFR (irrelevant to the gate)
+        "EGAA": _all_models("EGAA", ceiling=600.0),   # IFR + approach  → kept
+        "EGAE": _all_models("EGAE", ceiling=600.0),   # IFR + no approach → dropped
+        "EGAC": _all_models("EGAC", ceiling=5000.0),  # VFR + no approach → kept (visual divert)
     }
     result = _run(route, near, snaps)
     assert result is not None
-    assert result.require_approach is True
+    assert result.approach_filter_relaxed is False
     icaos = {a.icao for a in result.alternates}
-    assert "EGAA" in icaos
-    assert "EGAE" not in icaos  # no published approach → dropped when dest is IFR
-
-    egaa = next(a for a in result.alternates if a.icao == "EGAA")
-    assert egaa.has_instrument_approach is True
-    assert egaa.best_approach_type == "ILS"
+    assert icaos == {"EGAA", "EGAC"}  # IFR-no-approach dropped; VFR-no-approach kept
 
 
-def test_iap_gate_relaxed_when_no_candidate_has_approach_data():
-    # Destination IFR, but NO candidate has approach data (e.g. nav DB lacks
-    # procedure rows). Rather than going dark, the gate relaxes and flags it.
+def test_approach_gate_independent_of_destination_vfr():
+    # Even when the destination is VFR, a sub-VFR candidate with no approach is
+    # still unusable in its own conditions → dropped. A VFR candidate is kept.
+    # (An approach-bearing candidate is present so procedure data exists and the
+    # relaxation safety net does not trigger.)
+    route = _route()
+    ifr_iap = _FakeAirport("EGAA", 54.66, -6.22, has_approach=True, best_approach="ILS")
+    ifr_no_iap = _FakeAirport("EGAE", 55.04, -7.16, has_approach=False, best_approach=None)
+    vfr_no_iap = _FakeAirport("EGAC", 54.62, -5.87, has_approach=False, best_approach=None)
+    near = [
+        {"airport": ifr_iap, "enroute_distance_nm": 120.0, "segment_distance_nm": 10.0},
+        {"airport": ifr_no_iap, "enroute_distance_nm": 130.0, "segment_distance_nm": 15.0},
+        {"airport": vfr_no_iap, "enroute_distance_nm": 125.0, "segment_distance_nm": 12.0},
+    ]
+    snaps = {
+        "EGPF": _all_models("EGPF", ceiling=5000.0),  # destination VFR
+        "EGAA": _all_models("EGAA", ceiling=600.0),   # IFR + approach → kept
+        "EGAE": _all_models("EGAE", ceiling=600.0),   # IFR + no approach → dropped
+        "EGAC": _all_models("EGAC", ceiling=5000.0),  # VFR + no approach → kept
+    }
+    result = _run(route, near, snaps)
+    assert result is not None
+    assert result.require_approach is False  # informational: destination is VFR
+    assert result.approach_filter_relaxed is False
+    assert {a.icao for a in result.alternates} == {"EGAA", "EGAC"}
+
+
+def test_approach_gate_relaxed_when_no_procedure_data():
+    # Sub-VFR candidates lack an approach AND no candidate has any approach data
+    # (procedure data absent from the airport DB) → don't go dark; keep them flagged.
     route = _route()
     a = _FakeAirport("EGKE", 51.10, -0.20, has_approach=False, best_approach=None)
     b = _FakeAirport("EGKH", 51.05, -0.30, has_approach=False, best_approach=None)
@@ -222,32 +250,15 @@ def test_iap_gate_relaxed_when_no_candidate_has_approach_data():
         {"airport": b, "enroute_distance_nm": 205.0, "segment_distance_nm": 9.0},
     ]
     snaps = {
-        "EGPF": _all_models("EGPF", ceiling=600.0),  # IFR
-        "EGKE": _all_models("EGKE"),
-        "EGKH": _all_models("EGKH"),
+        "EGPF": _all_models("EGPF", ceiling=600.0),
+        "EGKE": _all_models("EGKE", ceiling=600.0),  # IFR + no approach
+        "EGKH": _all_models("EGKH", ceiling=600.0),  # IFR + no approach
     }
     result = _run(route, near, snaps)
     assert result is not None
-    assert result.require_approach is True
     assert result.approach_filter_relaxed is True
-    # Candidates are still shown (flagged), not dropped.
+    # Both shown (flagged), not dropped — missing reference data, not a real gate.
     assert {a.icao for a in result.alternates} == {"EGKE", "EGKH"}
-
-
-def test_iap_gate_not_applied_when_dest_vfr():
-    route = _route()
-    no_iap = _FakeAirport("EGAE", 55.04, -7.16, has_approach=False, best_approach=None)
-    near = [
-        {"airport": no_iap, "enroute_distance_nm": 130.0, "segment_distance_nm": 15.0},
-    ]
-    snaps = {
-        "EGPF": _all_models("EGPF", ceiling=5000.0),  # VFR
-        "EGAE": _all_models("EGAE"),
-    }
-    result = _run(route, near, snaps)
-    assert result is not None
-    assert result.require_approach is False
-    assert {a.icao for a in result.alternates} == {"EGAE"}
 
 
 # ---------------------------------------------------------------------------

--- a/web/briefing.html
+++ b/web/briefing.html
@@ -115,6 +115,16 @@
       </div>
     </div>
 
+    <!-- Weather alternates (D-2 inward — hidden when not populated) -->
+    <div id="alternates-wrapper" class="section collapsible" data-section="alternates" style="display: none;">
+      <h3>Weather Alternates</h3>
+      <div class="section-body">
+        <div id="alternates-section">
+          <p class="muted">Loading...</p>
+        </div>
+      </div>
+    </div>
+
     <!-- Cross-Section & Route Map Visualization -->
     <div id="viz-section" class="section collapsible" data-section="cross-section" style="display: none;">
       <h3>Cross-Section</h3>

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -3612,6 +3612,49 @@ label {
   cursor: pointer;
 }
 
+/* --- Weather-based alternates (#210) --- */
+.alt-picks {
+  margin: 0.25rem 0 0.5rem;
+  padding-left: 1.1rem;
+  font-size: 0.85rem;
+}
+
+.alt-info-btn {
+  margin-left: 0.25rem;
+  padding: 0 0.35rem;
+  font-size: 0.72rem;
+  line-height: 1.3;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--surface);
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+
+.alt-tag {
+  display: inline-block;
+  padding: 0.05rem 0.35rem;
+  margin-right: 0.15rem;
+  font-size: 0.7rem;
+  border-radius: var(--radius, 4px);
+  background: rgba(46, 125, 50, 0.15);
+  color: var(--text-secondary);
+}
+
+.alt-tag-dom {
+  background: rgba(46, 125, 50, 0.3);
+  font-weight: 600;
+}
+
+.alt-agree {
+  font-size: 0.7rem;
+  color: var(--text-tertiary, #888);
+}
+
+.alt-agree-divergent {
+  color: var(--danger, #b8860b);
+}
+
 .obs-refresh-btn:hover {
   background: var(--surface-hover, #f0f0f0);
 }

--- a/web/settings.html
+++ b/web/settings.html
@@ -370,6 +370,12 @@
               <span class="muted" style="font-size:0.85em; display:block; margin-top:2px;">⚠️ Experimental. Adds a front advisory plus map &amp; cross-section overlays from Hewson θe diagnostics (ECMWF / GFS / ICON only). These are <em>free-atmosphere air-mass boundaries</em> — advisory-only, not official SIGWX, and blind to low IMC / fog. Adds some compute and rendering per briefing.</span>
             </label>
           </div>
+          <div class="form-row model-checkboxes">
+            <label class="checkbox-label">
+              <input type="checkbox" id="toggle-compute-alternates"> Weather alternates (D-2 inward)
+              <span class="muted" style="font-size:0.85em; display:block; margin-top:2px;">⚠️ Experimental. On day-of and the two days before, finds the closest airports that improve on the destination's weather (flight category, wind, crosswind) and shows them on the briefing. <em>Planning-grade weather candidates only</em> — not operational alternates (no fuel, minima, NOTAM, customs or PPR check). Adds some compute per briefing.</span>
+            </label>
+          </div>
           <div class="subsection">
             <h4 class="subsection-heading">Models</h4>
             <p class="muted section-hint">Select which briefing models are evaluated for advisories. Unchecked models are still available for cross-section and Skew-T.</p>

--- a/web/ts/adapters/profiles-adapter.ts
+++ b/web/ts/adapters/profiles-adapter.ts
@@ -13,6 +13,7 @@ export interface ProfileSettings {
   llm_digest_enabled: boolean | null;
   icing_severity_enhance: boolean | null;
   auto_front_detection: boolean | null;
+  compute_alternates: boolean | null;
   icing_method: string | null;
   cloud_method: string | null;
   convective_method: string | null;

--- a/web/ts/briefing-main.ts
+++ b/web/ts/briefing-main.ts
@@ -1019,6 +1019,7 @@ async function init(): Promise<void> {
       ui.renderRefreshDelta(state.snapshot);
       ui.renderRouteSigmets(state.snapshot);
       ui.renderRouteObservations(state.snapshot, () => store.getState().refreshObservations());
+      ui.renderRouteAlternates(state.snapshot);
       ui.renderSynopsis(state.flight, state.currentPack, state.digest, state.displayMode, state.digestPending);
       ui.renderDwdCharts(state.flight, state.currentPack, user.is_admin || !!state.currentPack?.metoffice_charts_public);
       ui.renderDWDOverview(state.flight, state.currentPack, user.is_admin);
@@ -1431,6 +1432,7 @@ async function init(): Promise<void> {
     ui.renderRefreshDelta(s.snapshot);
     ui.renderRouteSigmets(s.snapshot);
     ui.renderRouteObservations(s.snapshot, () => store.getState().refreshObservations());
+    ui.renderRouteAlternates(s.snapshot);
     ui.renderSynopsis(s.flight, s.currentPack, s.digest, s.displayMode, s.digestPending);
     ui.renderDwdCharts(s.flight, s.currentPack, user.is_admin || !!s.currentPack?.metoffice_charts_public);
     ui.renderDWDOverview(s.flight, s.currentPack, user.is_admin);

--- a/web/ts/managers/briefing-ui.ts
+++ b/web/ts/managers/briefing-ui.ts
@@ -1187,7 +1187,9 @@ export function renderRouteAlternates(snapshot: ForecastSnapshot | null): void {
     </div>
   `;
 
-  el.addEventListener('click', (e) => {
+  // Assign (not addEventListener) so repeated renders from the store
+  // subscription replace the handler rather than stacking duplicates.
+  el.onclick = (e) => {
     const target = e.target as HTMLElement;
     const infoBtn = target.closest('.alt-info-btn') as HTMLElement | null;
     if (infoBtn) {
@@ -1196,7 +1198,7 @@ export function renderRouteAlternates(snapshot: ForecastSnapshot | null): void {
       const apt = alt.alternates.find((a) => a.icao === icao);
       if (apt) showPopupContent(renderAltPopup(apt));
     }
-  });
+  };
 }
 
 // --- Route SIGMETs (area hazards) ---

--- a/web/ts/managers/briefing-ui.ts
+++ b/web/ts/managers/briefing-ui.ts
@@ -6,6 +6,7 @@
 
 import type {
   AirportObservation,
+  AlternateAirport,
   AltitudeAdvisories,
   ConvectiveAssessment,
   DataStatus,
@@ -15,6 +16,7 @@ import type {
   ModelSourceDetail,
   ObservationComparison,
   PackMeta,
+  RouteAlternates,
   RouteAnalysesManifest,
   RouteObservations,
   RoutePointAnalysis,
@@ -1051,6 +1053,148 @@ export function renderRouteObservations(
         refreshBtn.disabled = false;
         refreshBtn.textContent = t('observations.refresh');
       });
+    }
+  });
+}
+
+// --- Weather-based alternates (D-2 inward) ---
+
+function detourLabel(apt: AlternateAirport): string {
+  if (apt.detour_early_nm == null && apt.detour_late_nm == null) return '—';
+  const early = apt.detour_early_nm != null ? `${apt.detour_early_nm >= 0 ? '+' : ''}${Math.round(apt.detour_early_nm)}` : '?';
+  const late = apt.detour_late_nm != null ? `+${Math.round(apt.detour_late_nm)}` : '?';
+  return `${early} / ${late}nm`;
+}
+
+function deltaTags(apt: AlternateAirport): string {
+  const tags: string[] = [];
+  if (apt.better_category) tags.push('<span class="alt-tag alt-tag-cat">cat</span>');
+  if (apt.better_wind) tags.push('<span class="alt-tag alt-tag-wind">wind</span>');
+  if (apt.better_crosswind) tags.push('<span class="alt-tag alt-tag-xw">xwind</span>');
+  if (apt.dominates_destination) tags.push('<span class="alt-tag alt-tag-dom" title="Better-or-equal on every axis">dominates</span>');
+  return tags.join(' ') || '—';
+}
+
+function renderAltPopup(apt: AlternateAirport): string {
+  const rows = Object.entries(apt.per_model).map(([model, d]) => {
+    const cat = (d['flight_category'] as string) ?? '—';
+    const wind = d['wind_speed_kt'] != null ? `${Math.round(d['wind_speed_kt'] as number)}kt` : '—';
+    const xw = d['crosswind_kt'] != null ? `${Math.round(d['crosswind_kt'] as number)}kt` : '—';
+    return `<tr><td>${escapeHtml(model.toUpperCase())}</td><td>${flightCatBadge(cat)}</td><td>${wind}</td><td>${xw}</td></tr>`;
+  }).join('');
+  const approach = apt.has_instrument_approach
+    ? (apt.best_approach_type ? escapeHtml(apt.best_approach_type) : 'yes')
+    : 'none';
+  const rwy = apt.longest_runway_ft != null ? `${apt.longest_runway_ft}ft${apt.has_hard_runway ? ' hard' : ''}` : '—';
+  const meta = [
+    `Distance from dest: ${Math.round(apt.distance_from_dest_nm)}nm (${escapeHtml(apt.position)})`,
+    `Detour early/late: ${detourLabel(apt)}`,
+    `Approach: ${approach}`,
+    `Longest runway: ${rwy}`,
+  ].join('\n');
+  return `
+    <div class="popup-header"><h3>${escapeHtml(apt.icao)}${apt.name ? ' — ' + escapeHtml(apt.name) : ''}</h3></div>
+    <pre class="obs-wind-summary">${meta}</pre>
+    <h4>Per-model</h4>
+    <table class="band-table"><thead><tr><th>Model</th><th>Cat</th><th>Wind</th><th>Xwind</th></tr></thead><tbody>${rows}</tbody></table>
+  `;
+}
+
+export function renderRouteAlternates(snapshot: ForecastSnapshot | null): void {
+  const el = $('alternates-section');
+  const wrapper = $('alternates-wrapper');
+  if (!el) return;
+
+  const alt: RouteAlternates | null | undefined = snapshot?.alternates;
+  // Hidden unless populated — only appears D-2 inward (the stage gate).
+  if (!alt) {
+    if (wrapper) wrapper.style.display = 'none';
+    return;
+  }
+  if (wrapper) wrapper.style.display = '';
+
+  const destXw = alt.destination_crosswind_kt != null
+    ? `, ${Math.round(alt.destination_crosswind_kt)}kt xwind` : '';
+  const header = `Destination ${escapeHtml(alt.destination_icao)}: ${flightCatBadge(alt.destination_category)}${destXw}`;
+
+  // Nearest-improving picks ("nearest VFR: EGyy 22nm before")
+  const axisLabel: Record<string, string> = {
+    category: 'better category', wind: 'lower wind', crosswind: 'lower crosswind',
+  };
+  const picks = alt.nearest_improving
+    .filter((p) => p.icao)
+    .map((p) => {
+      const pos = p.position ? ` ${escapeHtml(p.position)}` : '';
+      return `<li>Nearest ${axisLabel[p.axis] ?? escapeHtml(p.axis)}: <strong>${escapeHtml(p.icao as string)}</strong> ${Math.round(p.distance_from_dest_nm as number)}nm${pos}</li>`;
+    })
+    .join('');
+  const picksHtml = picks
+    ? `<ul class="alt-picks">${picks}</ul>`
+    : `<p class="muted">No weather alternate improves on the destination across the evaluated candidates.</p>`;
+
+  const approachNote = alt.require_approach
+    ? (alt.approach_filter_relaxed ? ', approach data unavailable' : ', IFR approach required')
+    : '';
+  const summaryHtml = `<p class="obs-summary">${header} <span class="obs-fetch-time">${alt.candidates_evaluated} candidates within ${Math.round(alt.radius_nm)}nm${approachNote}</span></p>`;
+  const relaxedHtml = alt.approach_filter_relaxed
+    ? `<p class="muted alt-caption">⚠️ The destination is ${escapeHtml(alt.destination_category)} but no published-approach data is available for the candidates, so the instrument-approach filter was skipped — confirm an approach independently.</p>`
+    : '';
+
+  const rows = alt.alternates.map((apt) => {
+    const tip = windTooltip(apt.best_runway_id, apt.crosswind_kt);
+    const windStr = apt.wind_speed_kt != null ? `${Math.round(apt.wind_speed_kt)}kt` : '—';
+    const xwStr = apt.crosswind_kt != null
+      ? `<span${tip ? ` title="${escapeHtml(tip)}"` : ''}>${Math.round(apt.crosswind_kt)}kt</span>` : '—';
+    const approach = apt.has_instrument_approach
+      ? (apt.best_approach_type ? escapeHtml(apt.best_approach_type) : '✓') : '—';
+    const agreeCat = apt.agreement?.['flight_category'];
+    const agreeBadge = agreeCat ? ` <span class="alt-agree alt-agree-${agreeCat}">${escapeHtml(agreeCat)}</span>` : '';
+    return `
+      <tr>
+        <td class="obs-icao">${escapeHtml(apt.icao)} <button class="alt-info-btn" data-icao="${escapeHtml(apt.icao)}" title="Details" aria-label="info">i</button></td>
+        <td>${Math.round(apt.distance_from_dest_nm)}nm</td>
+        <td>${escapeHtml(apt.position)} <span class="muted">(${detourLabel(apt)})</span></td>
+        <td>${flightCatBadge(apt.flight_category)}${agreeBadge}</td>
+        <td>${windStr}</td>
+        <td>${xwStr}</td>
+        <td>${approach}</td>
+        <td>${deltaTags(apt)}</td>
+      </tr>
+    `;
+  }).join('');
+
+  el.innerHTML = `
+    ${summaryHtml}
+    <p class="muted alt-caption">Planning-grade divert candidates that improve on the destination weather — not an operational alternate (no fuel, minima, NOTAM, customs or PPR check).</p>
+    ${relaxedHtml}
+    ${picksHtml}
+    <div class="table-scroll">
+      <table class="band-table obs-table">
+        <thead>
+          <tr>
+            <th style="text-align:left;">Weather alternate</th>
+            <th>From dest</th>
+            <th>Before/after (detour)</th>
+            <th>Category</th>
+            <th>Wind</th>
+            <th>Xwind</th>
+            <th>Approach</th>
+            <th>vs dest</th>
+          </tr>
+        </thead>
+        <tbody>${rows}</tbody>
+      </table>
+    </div>
+  `;
+
+  el.addEventListener('click', (e) => {
+    const target = e.target as HTMLElement;
+    const infoBtn = target.closest('.alt-info-btn') as HTMLElement | null;
+    if (infoBtn) {
+      const icao = infoBtn.dataset.icao;
+      if (!icao) return;
+      const apt = alt.alternates.find((a) => a.icao === icao);
+      if (apt) showPopupContent(renderAltPopup(apt));
     }
   });
 }

--- a/web/ts/managers/briefing-ui.ts
+++ b/web/ts/managers/briefing-ui.ts
@@ -1071,7 +1071,7 @@ function deltaTags(apt: AlternateAirport): string {
   if (apt.better_category) tags.push('<span class="alt-tag alt-tag-cat">cat</span>');
   if (apt.better_wind) tags.push('<span class="alt-tag alt-tag-wind">wind</span>');
   if (apt.better_crosswind) tags.push('<span class="alt-tag alt-tag-xw">xwind</span>');
-  if (apt.dominates_destination) tags.push('<span class="alt-tag alt-tag-dom" title="Better-or-equal on every axis">dominates</span>');
+  if (apt.dominates_destination) tags.push('<span class="alt-tag alt-tag-dom" title="Better than the destination on at least one weather axis, and no worse on any">Better</span>');
   return tags.join(' ') || '—';
 }
 
@@ -1132,12 +1132,10 @@ export function renderRouteAlternates(snapshot: ForecastSnapshot | null): void {
     ? `<ul class="alt-picks">${picks}</ul>`
     : `<p class="muted">No weather alternate improves on the destination across the evaluated candidates.</p>`;
 
-  const approachNote = alt.require_approach
-    ? (alt.approach_filter_relaxed ? ', approach data unavailable' : ', IFR approach required')
-    : '';
+  const approachNote = alt.approach_filter_relaxed ? ', approach data unavailable' : '';
   const summaryHtml = `<p class="obs-summary">${header} <span class="obs-fetch-time">${alt.candidates_evaluated} candidates within ${Math.round(alt.radius_nm)}nm${approachNote}</span></p>`;
   const relaxedHtml = alt.approach_filter_relaxed
-    ? `<p class="muted alt-caption">⚠️ The destination is ${escapeHtml(alt.destination_category)} but no published-approach data is available for the candidates, so the instrument-approach filter was skipped — confirm an approach independently.</p>`
+    ? `<p class="muted alt-caption">⚠️ No published-approach data is available for the candidates, so non-VFR fields could not be filtered by approach — confirm an approach independently.</p>`
     : '';
 
   const rows = alt.alternates.map((apt) => {
@@ -1165,7 +1163,7 @@ export function renderRouteAlternates(snapshot: ForecastSnapshot | null): void {
 
   el.innerHTML = `
     ${summaryHtml}
-    <p class="muted alt-caption">Planning-grade divert candidates that improve on the destination weather — not an operational alternate (no fuel, minima, NOTAM, customs or PPR check).</p>
+    <p class="muted alt-caption">Planning-grade divert candidates that improve on the destination weather — not an operational alternate (no fuel, minima, NOTAM, customs or PPR check). Non-VFR fields are shown only with a published instrument approach.</p>
     ${relaxedHtml}
     ${picksHtml}
     <div class="table-scroll">

--- a/web/ts/managers/sidebar-layout.ts
+++ b/web/ts/managers/sidebar-layout.ts
@@ -31,7 +31,7 @@ function setBriefingLayout(layout: BriefingLayout): void {
 // Friendly labels + grouping for the SECTIONS nav. Keys are data-section values.
 const NAV_GROUPS: { title: string; keys: string[] }[] = [
   { title: 'Explore', keys: ['cross-section', 'skewt'] },
-  { title: 'Observations', keys: ['observations', 'sigmets', 'pireps'] },
+  { title: 'Observations', keys: ['observations', 'sigmets', 'pireps', 'alternates'] },
   { title: 'Discussion', keys: ['synopsis', 'dwd-charts', 'dwd-overview', 'gramet'] },
   { title: 'Detail', keys: ['sounding', 'comparison'] },
 ];
@@ -41,6 +41,7 @@ const NAV_LABELS: Record<string, string> = {
   'observations': 'METAR / TAF',
   'sigmets': 'SIGMETs',
   'pireps': 'PIREPs',
+  'alternates': 'Weather alternates',
   'synopsis': 'Synopsis',
   'dwd-charts': 'Surface pressure & fronts',
   'dwd-overview': 'DWD overview',

--- a/web/ts/settings-main.ts
+++ b/web/ts/settings-main.ts
@@ -214,6 +214,8 @@ function populateProfileForm(profile: ProfileResponse): void {
   if (icingEnhanceToggle) icingEnhanceToggle.checked = s.icing_severity_enhance ?? false;
   const autoFrontToggle = document.getElementById('toggle-auto-front-detection') as HTMLInputElement;
   if (autoFrontToggle) autoFrontToggle.checked = s.auto_front_detection ?? false;
+  const computeAlternatesToggle = document.getElementById('toggle-compute-alternates') as HTMLInputElement;
+  if (computeAlternatesToggle) computeAlternatesToggle.checked = s.compute_alternates ?? false;
 
   // Icing method selector
   const icingMethodSelect = document.getElementById('input-icing-method') as HTMLSelectElement;
@@ -899,6 +901,7 @@ async function handleSave(): Promise<void> {
   const llmDigestEnabled = (document.getElementById('toggle-llm-digest') as HTMLInputElement)?.checked ?? true;
   const icingSeverityEnhance = (document.getElementById('toggle-icing-enhance') as HTMLInputElement)?.checked ?? false;
   const autoFrontDetection = (document.getElementById('toggle-auto-front-detection') as HTMLInputElement)?.checked ?? false;
+  const computeAlternates = (document.getElementById('toggle-compute-alternates') as HTMLInputElement)?.checked ?? false;
   const icingMethod = (document.getElementById('input-icing-method') as HTMLSelectElement)?.value || 'ogimet_dd';
   const cloudSourceValue = (document.getElementById('input-cloud-source') as HTMLSelectElement)?.value || 'nwp';
   const cloudStyleValue = (document.getElementById('input-cloud-style') as HTMLSelectElement)?.value || 'square';
@@ -926,6 +929,7 @@ async function handleSave(): Promise<void> {
     llm_digest_enabled: llmDigestEnabled,
     icing_severity_enhance: icingSeverityEnhance,
     auto_front_detection: autoFrontDetection,
+    compute_alternates: computeAlternates,
     icing_method: icingMethod,
     cloud_method: cloudMethod,
     convective_method: convectiveMethod,

--- a/web/ts/store/types.ts
+++ b/web/ts/store/types.ts
@@ -568,6 +568,62 @@ export interface RealtimeRefreshResult {
   delta?: RefreshDelta | null;
 }
 
+/** One weather-based divert candidate (issue #210). */
+export interface AlternateAirport {
+  icao: string;
+  name: string | null;
+  lat: number;
+  lon: number;
+  distance_from_dest_nm: number;
+  enroute_distance_nm: number | null;
+  segment_distance_nm: number | null;
+  position: string; // "before" | "after"
+  detour_early_nm: number | null;
+  detour_late_nm: number | null;
+  flight_category: string;
+  wind_speed_kt: number | null;
+  crosswind_kt: number | null;
+  headwind_kt: number | null;
+  best_runway_id: string | null;
+  ceiling_ft: number | null;
+  visibility_m: number | null;
+  agreement: Record<string, string>;
+  per_model: Record<string, Record<string, unknown>>;
+  has_instrument_approach: boolean;
+  best_approach_type: string | null;
+  longest_runway_ft: number | null;
+  has_hard_runway: boolean;
+  point_of_entry: boolean;
+  better_category: boolean;
+  better_wind: boolean;
+  better_crosswind: boolean;
+  dominates_destination: boolean;
+}
+
+/** The nearest improving alternate for one deficient axis. */
+export interface AlternateAxisPick {
+  axis: string; // "category" | "wind" | "crosswind"
+  icao: string | null;
+  distance_from_dest_nm: number | null;
+  position: string | null;
+}
+
+/** Weather-based alternates for a route's destination (D-2 inward). */
+export interface RouteAlternates {
+  destination_icao: string;
+  destination_category: string;
+  destination_crosswind_kt: number | null;
+  eta: string | null;
+  corridor_nm: number;
+  radius_nm: number;
+  require_approach: boolean;
+  approach_filter_relaxed: boolean;
+  candidates_evaluated: number;
+  alternates: AlternateAirport[];
+  nearest_improving: AlternateAxisPick[];
+  computed_at: string | null;
+}
+
 export interface ForecastSnapshot {
   route: {
     name: string;
@@ -580,6 +636,7 @@ export interface ForecastSnapshot {
   analyses: WaypointAnalysis[];
   route_observations?: RouteObservations | null;
   route_sigmets?: RouteSigmets | null;
+  alternates?: RouteAlternates | null;
   last_refresh_delta?: RefreshDelta | null;
 }
 


### PR DESCRIPTION
Implements issue #210 — weather-based alternate airports.

When a destination forecast is marginal (D-2 inward, opt-in), surface the closest airports a pilot could divert to that **fix the specific problem** (flight category, wind, best-runway crosswind), classified **before**/**after** along the route with a quantitative detour pair, ranked closest-first. Each alternate is assessed by the **same shared code path** as the pan-European forecast map, so an airport reads the same category/crosswind/consensus in both views.

## What's in it
- **Seam 2 (consistency core):** new `analysis/airport_consensus.py` — pure, dict-based `best_ceiling`/`flight_category`/`snap_to_dict`/`enrich_wind`/`consensus`. `tasks/map_queries.py` now delegates via a row→dict adapter, **no behavior change** for the forecast map (its 21 tests still pass).
- **Seam 1:** `_fetch_forecasts_for_model` gains a `sample_hours` param (default preserves current behavior) so GFS/ICON can be fetched at an arbitrary ETA hour.
- **Models:** `AlternateAirport` / `AlternateAxisPick` / `RouteAlternates`, attached to `ForecastSnapshot`.
- **Stage:** `tasks/alternates.run_alternates` — candidate geometry (near-route corridor ∪ destination radius via euro_aip), GA/runway/instrument-approach filters, per-model fresh fetch at ETA (GFS/ICON Open-Meteo+GRIB, ECMWF local GRIB), before/after + detour + nearest-improving-per-axis. Wired as a gated optional pipeline stage (`days_out <= 2` **and** `compute_alternates`), with `stage_timings["alternates"]` and `BriefingUsage` fields.
- **Preference:** `compute_alternates`, **per-profile, OFF by default** — `profiles.py`/`packs.py`/`BriefingOptions` + a settings-page checkbox.
- **Web UI:** "Weather Alternates" section (hidden unless populated, i.e. D-2 inward) — nearest-improving picks, closest-first table (before/after + detour, category, wind, crosswind, approach tier, vs-dest tags), per-row per-model popup.
- **Graceful approach-gate fallback:** nav.db currently ships **without procedure data**, so the instrument-approach filter would otherwise empty the section for every IFR/MVFR destination. When no candidate has approach data the gate **relaxes and flags** `approach_filter_relaxed` instead of going dark. Once procedures are added to nav.db, real IFR filtering + the `best_approach_type` minima-proxy light up with no code change.

## Decisions worth flagging
- **Not fed to the LLM prompt for now** — alternates surface in the briefing UI (and deterministic text digest) only; the formatter is left in place for easy re-enable.
- **Single fetch round** — destination + candidates fetched together, IAP filter applied post-hoc (avoids decoding the ECMWF GRIB twice). `candidates_evaluated` reflects what was fetched.
- **Timing:** measured ~20s on a long route locally (dominated by N×3 lite soundings + GRIB cloud-diag enrichment, inflated here by dev-network retries and an Open-Meteo ECMWF fallback). Instrumentation is in place so we can later decide whether reusing forecast-map snapshots is worth it (the design's stated v2 lever).

## Out of scope (per design v2)
Route-map markers, realtime-refresh wiring, convective/icing-at-field axis, across-time consistency window, AIP-based suitability (PPR/customs).

## Verified
Validated end-to-end against a real D-1 EGMD (IFR) briefing: 17 candidates ranked closest-first, nearest-improving picks resolved, detour pairs and Pareto "dominates" flags correct, relaxation flag set as expected. Full suite green (2392 passed, 9 skipped); `tsc` clean; bundles build.

Closes #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)