### PR TITLE
fix(fronts): stop false RED from CIN-capped potential + terrain artifact (#216)

### DIFF
--- a/designs/meteorology-decisions.md
+++ b/designs/meteorology-decisions.md
@@ -673,3 +673,71 @@ Investigation only. Relevant code: `analysis/spatial_interpolation.py`
 `fetch/grib/fill.py` (time-axis interp + trailing forward-fill),
 `analysis/sounding/convective.py` (`assess_convective_nwp` vs
 `assess_convective_thermo`).
+
+---
+
+## 6. Front co-location: realized vs potential convection, and the parcel EL
+
+**Date:** 2026-06-06
+**Status:** Implemented (PR #217, #216).
+**Context:** The experimental `fronts` advisory red-flagged a stable
+high-pressure day (`lsgs_…_egtf-2026-06-07`) with "convective tops to FL272". A
+single GFS 925 hPa θe crossing over Alpine terrain was co-located as
+*convective* off a `risk_level="moderate"` that was CIN-capped potential CAPE
+(CIN −59.5, ML-CAPE 147 J/kg, NWP LI −1), and its `weather_top_ft` was taken as
+the **parcel equilibrium level** (27,233 ft) — clearing the deep-convection RED
+cutoff (cruise + 15,000 ft) by 233 ft. No convection existed; the EL is high
+simply because it's a deep summer troposphere.
+
+### The decision
+
+A front crossing is co-located as **convective only when convection is
+*realized***, and the parcel EL is used as a tower-depth proxy **only on that
+realized path**. Realized when:
+- NWP convective cloud is present (`method != "thermo"`), **or**
+- the cap is weak (CIN > −50 J/kg), **or**
+- there is positive evidence of usable instability — ML-CAPE ≥ 300 J/kg or a
+  lifted index ≤ −2.
+
+A strongly-capped (CIN ≤ −50) thermo risk with positive evidence of *weak*
+instability falls through to the cloud-coverage category (wet/partly/dry) and the
+EL is never used as a realized top. This mirrors §4's realizable-CAPE logic, one
+level down: §4 stops surface CAPE over-reading the *route* convective tier; this
+stops the same potential CAPE over-reading a *front's* relevance.
+
+### Thresholds (front realized-gate)
+
+- **CIN cap −50 J/kg** — moderate-cap boundary; ECMWF/GFS agree well at this scale.
+- **ML-CAPE 300 J/kg** — ESSL "appreciable convection" anchor (same value as §4's
+  MOD tier).
+- **LI −2** — weak/moderate instability boundary (0…−2 stable/weak; < −2 moderate+).
+
+Tuned on the single LSGS GFS case; revisit if a strong-front case disagrees.
+
+### Two conservative biases (don't silently hide a front)
+
+- **Unknown data → realized.** We downgrade only on *positive* evidence the
+  instability is weak. When CIN is the sole available signal (ML-CAPE and LI both
+  absent — e.g. ICON emits no lifted index), we keep the crossing convective.
+- **Vertical coherence for overflown convection.** A convective crossing seen
+  only on a single *below-cruise* θe level (the 925 hPa terrain case) needs a
+  second level to RED; a free-atmosphere detection at/above the primary level
+  still REDs single-level by depth.
+
+The LI fallback (DD-derived → `nwp_lifted_index`) deliberately crosses the §4
+DD/NWP tier separation: here LI is a binary gate signal, not a tier input, so the
+mixing is acceptable.
+
+### Real-world validation needed
+
+- A strong, genuinely active front (deep CAPE, weak cap) crossing the route at a
+  low level: confirm it still REDs and that the EL-as-top proxy isn't suppressed.
+- ICON / MeteoFrance partial-coverage points (CIN present, ML-CAPE/LI absent):
+  confirm the unknown-data-→-realized bias behaves as intended.
+
+### Files changed
+
+`analysis/advisories/fronts.py` (`_grade_crossing`: overflown-convective
+coherence gate), `tasks/fronts.py` (`_colocate` + `_convection_realized`: realized
+gate, EL only on realized path). Tests: `tests/test_tasks_fronts.py`,
+`tests/analysis/advisories/test_fronts_advisory.py`.

--- a/src/weatherbrief/analysis/advisories/fronts.py
+++ b/src/weatherbrief/analysis/advisories/fronts.py
@@ -95,8 +95,11 @@ def _grade_crossing(
 
     A third fact gates RED: **vertical coherence** — a RED needs a boundary seen
     on ≥2 pressure levels (``c.vertical_levels``). A single-level detection is
-    shallow/suspect and caps at AMBER; convective towers are exempt (graded by
-    depth, not θe-level count).
+    shallow/suspect and caps at AMBER. Convective towers at/above the flight's
+    free-atmosphere (primary) level are exempt (graded by depth, not θe-level
+    count); an *overflown* convective crossing seen on a single below-cruise level
+    (e.g. a 925 hPa boundary over high terrain) is held to the coherence rule too,
+    so a lone terrain-driven crossing cannot RED on its parcel EL alone (#216).
     """
     # Flickering across the window → orographic / grid artifact, not a real front.
     if c.persistence is not None and c.persistence < persistence_min:
@@ -105,7 +108,8 @@ def _grade_crossing(
     # A single-level (shallow) detection is held at AMBER — it may be real but is
     # not the deep, coherent boundary a RED implies. Unknown (None, older
     # artifact) is treated as coherent so we never suppress on missing data.
-    # Convective towers are exempt: they're flagged by depth, not θe-level count.
+    # Convective towers at/above the primary level are exempt (flagged by depth);
+    # overflown below-cruise convection is held to this rule too (#216, below).
     coherent = c.vertical_levels is None or c.vertical_levels >= 2
     co = c.co_location
     if co is None:
@@ -125,7 +129,14 @@ def _grade_crossing(
     overflown = level_hpa > primary_level             # boundary lower than cruise → you fly over its core
     if co == "convective":
         deep = c.weather_top_ft is not None and c.weather_top_ft >= cruise_ft + convective_deep_ft
-        return (AdvisoryStatus.RED, "convective") if deep else (AdvisoryStatus.AMBER, "convective")
+        # Overflown convection needs vertical coherence to RED: a single
+        # below-cruise θe crossing (a 925 hPa boundary over high terrain) is
+        # shallow/suspect and caps at AMBER even when its parcel EL is deep. A
+        # free-atmosphere detection (at/above the primary level) or a boundary
+        # spanning ≥2 levels can still RED on depth. (#216)
+        if deep and (not overflown or coherent):
+            return AdvisoryStatus.RED, "convective"
+        return AdvisoryStatus.AMBER, "convective"
     if co == "wet":
         if c.intensity == "sharp" and not overflown and coherent:
             return AdvisoryStatus.RED, "wet_sharp"    # sharp, coherent front at/above the flight level

--- a/src/weatherbrief/tasks/fronts.py
+++ b/src/weatherbrief/tasks/fronts.py
@@ -135,6 +135,17 @@ _PARTLY_COVERAGE = {"few", "sct"}
 _CONVECTIVE_RISK = {"moderate", "high", "extreme"}
 _PERSIST_OFFSETS_H = (-6, -3, 0, 3, 6)
 
+# Realized-convection gate (#216). A thermo ``risk_level`` can be driven purely by
+# *potential* CAPE that a strong cap (CIN) never lets convect — and its ``top_ft``
+# is then the parcel equilibrium level, not a cloud a pilot meets. Treat
+# convection as realized unless it is strongly inhibited (CIN <= ``_CIN_CAP_JKG``)
+# with no countervailing instability (ML-CAPE >= ``_ML_CAPE_REALIZED_JKG`` or a
+# lifted index <= ``_LI_REALIZED``). Tuned to the 2026-06-07 LSGS false-RED
+# (CIN -59.5, ML-CAPE 147, LI -1) vs the realized Dijon front.
+_CIN_CAP_JKG = -50.0
+_ML_CAPE_REALIZED_JKG = 300.0
+_LI_REALIZED = -2.0
+
 
 def _attr(obj: object, name: str, default: object = None) -> object:
     """getattr/dict-get that tolerates pydantic objects or raw dicts (or None)."""
@@ -148,6 +159,35 @@ def _attr(obj: object, name: str, default: object = None) -> object:
 def _enum_val(x: object) -> object:
     """Unwrap an enum to its ``.value`` (passthrough for plain strings/None)."""
     return getattr(x, "value", x)
+
+
+def _convection_realized(conv, indices) -> bool:
+    """True when convection is *realized*, not just CIN-capped potential (#216).
+
+    A thermo ``risk_level`` can be driven by potential CAPE that a strong cap
+    (CIN) never lets convect; its ``top_ft`` is then the parcel equilibrium level,
+    not a cloud a pilot meets. Convection counts as realized when NWP convective
+    cloud is present (``method`` != "thermo"), the inhibition is weak, or there is
+    a countervailing instability signal (high ML-CAPE or a negative lifted index).
+    Unknown data defaults to realized so a real front is never silently hidden.
+    """
+    if conv is None:
+        return False
+    if _attr(conv, "method", "thermo") != "thermo":
+        return True  # NWP convective-cloud diagnostics fired → realized weather
+    cin = _attr(conv, "cin_jkg", None)  # negative = inhibition
+    strong_cap = cin is not None and cin <= _CIN_CAP_JKG
+    if not strong_cap:
+        return True
+    # Strongly capped: realized only with a countervailing instability signal.
+    ml_cape = _attr(indices, "cape_mixed_layer_jkg", None)
+    li = _attr(conv, "lifted_index", None)
+    if li is None:
+        li = _attr(indices, "nwp_lifted_index", None)
+    return (
+        (ml_cape is not None and ml_cape >= _ML_CAPE_REALIZED_JKG)
+        or (li is not None and li <= _LI_REALIZED)
+    )
 
 
 def _colocate(analyses, model: str, dist_km: float, level_hpa: int):
@@ -166,6 +206,7 @@ def _colocate(analyses, model: str, dist_km: float, level_hpa: int):
         return None, None
     layers = _attr(s, "cloud_layers", None) or []
     conv = _attr(s, "convective", None)
+    indices = _attr(s, "indices", None)
     risk = _enum_val(_attr(conv, "risk_level", None)) if conv is not None else None
 
     def _spans(cl, level: int) -> bool:
@@ -179,12 +220,7 @@ def _colocate(analyses, model: str, dist_km: float, level_hpa: int):
     # Cloud top must come from layers spanning the frontal level, not the whole
     # column — else unrelated high cirrus inflates weather_top_ft and false-AMBERs
     # a low wet/partly front (the category is already level-gated via _covers).
-    cloud_top = max((_attr(cl, "top_ft", None) or 0.0 for cl in layers if _spans(cl, level_hpa)), default=0.0)
-    conv_top = None
-    if conv is not None:
-        conv_top = _attr(conv, "top_ft", None) or _attr(conv, "el_altitude_ft", None)
-    tops = [v for v in (cloud_top or None, conv_top) if v]
-    weather_top_ft = float(max(tops)) if tops else None
+    cloud_top = max((_attr(cl, "top_ft", None) or 0.0 for cl in layers if _spans(cl, level_hpa)), default=0.0) or None
 
     precip_obj = _attr(s, "precipitation", None)
     # surface_intensity is a column-wide surface reading, NOT level-gated like the
@@ -196,16 +232,28 @@ def _colocate(analyses, model: str, dist_km: float, level_hpa: int):
     # a real front. See test_drizzle_below_front_is_wet.
     precip = precip_obj is not None and _enum_val(_attr(precip_obj, "surface_intensity", "none")) != "none"
 
-    # Cloud must span the frontal level to count — a high cirrus deck unrelated
-    # to a low front is neither "wet" nor "partly" (it would otherwise false-AMBER).
-    if risk in _CONVECTIVE_RISK:
+    # Convective only when convection is *realized* (#216): a CIN-capped potential
+    # risk is not weather on the boundary, and its top_ft is the parcel EL — not a
+    # tower a pilot meets. Realized convection keeps the EL as its tower-depth
+    # proxy (the overflown-tower Dijon case); a potential-only risk falls through
+    # to the cloud-coverage category and the EL is never used as a top.
+    if risk in _CONVECTIVE_RISK and _convection_realized(conv, indices):
         category = "convective"
-    elif _covers(level_hpa, _SIGNIFICANT_COVERAGE) or precip:
-        category = "wet"
-    elif _covers(level_hpa, _PARTLY_COVERAGE):
-        category = "partly"
+        conv_top = _attr(conv, "top_ft", None) or _attr(conv, "el_altitude_ft", None)
+        tops = [v for v in (cloud_top, conv_top) if v]
+        weather_top_ft = float(max(tops)) if tops else None
     else:
-        category = "dry"
+        # Cloud must span the frontal level to count — a high cirrus deck unrelated
+        # to a low front is neither "wet" nor "partly" (it would otherwise
+        # false-AMBER). weather_top reflects the spanning cloud only; the parcel EL
+        # is never a realized top here.
+        weather_top_ft = cloud_top
+        if _covers(level_hpa, _SIGNIFICANT_COVERAGE) or precip:
+            category = "wet"
+        elif _covers(level_hpa, _PARTLY_COVERAGE):
+            category = "partly"
+        else:
+            category = "dry"
     return category, weather_top_ft
 
 

--- a/src/weatherbrief/tasks/fronts.py
+++ b/src/weatherbrief/tasks/fronts.py
@@ -169,21 +169,29 @@ def _convection_realized(conv, indices) -> bool:
     not a cloud a pilot meets. Convection counts as realized when NWP convective
     cloud is present (``method`` != "thermo"), the inhibition is weak, or there is
     a countervailing instability signal (high ML-CAPE or a negative lifted index).
-    Unknown data defaults to realized so a real front is never silently hidden.
+    Unknown data defaults to realized so a real front is never silently hidden —
+    we downgrade only on *positive* evidence the instability is weak (caller
+    guarantees a non-None ``conv`` with a convective ``risk_level``).
     """
-    if conv is None:
-        return False
     if _attr(conv, "method", "thermo") != "thermo":
         return True  # NWP convective-cloud diagnostics fired → realized weather
     cin = _attr(conv, "cin_jkg", None)  # negative = inhibition
     strong_cap = cin is not None and cin <= _CIN_CAP_JKG
     if not strong_cap:
         return True
-    # Strongly capped: realized only with a countervailing instability signal.
+    # Strongly capped: downgrade to potential only with positive evidence the
+    # instability is weak. With CIN the sole available signal (ML-CAPE and LI both
+    # absent — e.g. ICON, which emits no lifted index), default to realized rather
+    # than silently hide a front. LI here is a binary gate signal, not a tier
+    # input, so falling back from the DD-derived to the NWP-native value is
+    # acceptable — the DD/NWP tier separation (meteorology-decisions.md §4) does
+    # not bind this realized/potential decision.
     ml_cape = _attr(indices, "cape_mixed_layer_jkg", None)
     li = _attr(conv, "lifted_index", None)
     if li is None:
         li = _attr(indices, "nwp_lifted_index", None)
+    if ml_cape is None and li is None:
+        return True
     return (
         (ml_cape is not None and ml_cape >= _ML_CAPE_REALIZED_JKG)
         or (li is not None and li <= _LI_REALIZED)

--- a/tests/analysis/advisories/test_fronts_advisory.py
+++ b/tests/analysis/advisories/test_fronts_advisory.py
@@ -286,13 +286,53 @@ def test_single_level_wet_sharp_capped_to_amber():
 
 
 def test_single_level_convective_still_red_when_deep():
-    """Vertical coherence does NOT suppress convection: deep towers on a single
-    θe level are graded by depth, not level count → still RED."""
+    """A deep convective tower at/above the flight's free-atmosphere (primary)
+    level still REDs on a single θe level — graded by depth, not level count.
+    (The overflown below-cruise case is held to coherence: see
+    test_overflown_single_level_convective_capped_to_amber.)"""
     deep = _manifest(crossings=[_crossing(
         kind="warm", co_location="convective", weather_top_ft=33000.0,
         persistence=0.8, vertical_levels=1,
     )])
     assert FrontsEvaluator.evaluate(_ctx(deep), _PARAMS).aggregate_status == AdvisoryStatus.RED
+
+
+def _lsgs_ctx(*, vertical_levels: int) -> RouteContext:
+    """LSGS 2026-06-07 shape: convective θe crossing only at 925 hPa (below the
+    700 hPa free-atmosphere primary, which is empty), cruise FL120, weather_top
+    FL272 (the parcel EL). ``vertical_levels`` flips coherence."""
+    a925 = RouteFrontAnalysisModel(
+        model="gfs", level_hPa=925, hour=55.5,
+        crossings=[_crossing(
+            kind="quasi-stationary", co_location="convective",
+            weather_top_ft=27233.0, persistence=0.6, vertical_levels=vertical_levels,
+        )],
+    )
+    manifest = RouteFrontsManifest(
+        generated_at=datetime(2026, 6, 6, tzinfo=timezone.utc),
+        primary_level_hPa=700, levels=[700, 925], models=["gfs"],
+        per_model={"gfs": [a925]},
+    )
+    return RouteContext(
+        analyses=[], cross_sections=[], elevation=None, models=["gfs"],
+        cruise_altitude_ft=12000, flight_ceiling_ft=18000, total_distance_nm=486.0,
+        route_fronts=manifest,
+    )
+
+
+def test_overflown_single_level_convective_capped_to_amber():
+    """LSGS 2026-06-07 regression (#216): a convective θe crossing seen ONLY on a
+    single below-cruise level (925 hPa) over Alpine terrain must NOT RED on its
+    parcel EL alone — overflown convection needs vertical coherence. Caps AMBER."""
+    result = FrontsEvaluator.evaluate(_lsgs_ctx(vertical_levels=1), _PARAMS)
+    assert result.aggregate_status == AdvisoryStatus.AMBER
+
+
+def test_overflown_convective_reds_when_vertically_coherent():
+    """The same overflown 925 hPa convective crossing, but seen on ≥2 levels, is a
+    real sloping boundary → RED restored (coherence gate, not a blanket cap)."""
+    result = FrontsEvaluator.evaluate(_lsgs_ctx(vertical_levels=2), _PARAMS)
+    assert result.aggregate_status == AdvisoryStatus.RED
 
 
 def test_unknown_coherence_treated_as_coherent():

--- a/tests/test_tasks_fronts.py
+++ b/tests/test_tasks_fronts.py
@@ -179,6 +179,33 @@ class TestColocate:
         cat, top = _colocate(self._an_full(cl, conv, indices), "ecmwf", 0.0, 850)
         assert cat == "convective" and top == 36000.0
 
+    def test_cin_capped_but_negative_li_stays_convective(self):
+        # Symmetric to the ML-CAPE gate: a strong cap (CIN -80) with a negative
+        # lifted index (LI -4 <= -2) is realizable → still convective, EL kept.
+        cl = [{"top_ft": 9000.0, "base_pressure_hpa": 900, "top_pressure_hpa": 850, "coverage": "sct"}]
+        conv = {
+            "risk_level": "moderate", "method": "thermo",
+            "cin_jkg": -80.0, "el_altitude_ft": 34000.0, "top_ft": 34000.0,
+            "lifted_index": -4.0,
+        }
+        indices = {"cape_mixed_layer_jkg": 120.0, "nwp_lifted_index": None}
+        cat, top = _colocate(self._an_full(cl, conv, indices), "ecmwf", 0.0, 850)
+        assert cat == "convective" and top == 34000.0
+
+    def test_cin_capped_no_instability_data_defaults_realized(self):
+        # Item #1 (PR #217 review): strong CIN but NO countervailing data — both
+        # ML-CAPE and LI absent (e.g. ICON, which emits no lifted index). We must
+        # NOT silently downgrade a real front on CIN alone → default to realized.
+        cl = [{"top_ft": 9000.0, "base_pressure_hpa": 900, "top_pressure_hpa": 850, "coverage": "sct"}]
+        conv = {
+            "risk_level": "moderate", "method": "thermo",
+            "cin_jkg": -90.0, "el_altitude_ft": 30000.0, "top_ft": 30000.0,
+            "lifted_index": None,
+        }
+        indices = {"cape_mixed_layer_jkg": None, "nwp_lifted_index": None}
+        cat, top = _colocate(self._an_full(cl, conv, indices), "ecmwf", 0.0, 850)
+        assert cat == "convective" and top == 30000.0
+
     def test_nwp_convective_cloud_is_realized(self):
         # An NWP-method assessment (method != "thermo") reflects modeled
         # convective cloud → realized regardless of CIN; its NWP top is used.
@@ -189,6 +216,17 @@ class TestColocate:
         indices = {"cape_mixed_layer_jkg": 50.0, "nwp_lifted_index": 2.0}
         cat, top = _colocate(self._an_full([], conv, indices), "ecmwf", 0.0, 850)
         assert cat == "convective" and top == 25000.0
+
+    def test_wet_front_top_from_cloud_not_el(self):
+        # Item #5 (PR #217 review): a non-convective (wet) front must take its
+        # weather_top from the spanning cloud layer, never the parcel EL. Here a
+        # low OVC spans the 850 hPa front (top 11000) while the sounding still
+        # carries a high EL (28000); weather_top must be 11000, not the EL.
+        cl = [{"top_ft": 11000.0, "base_pressure_hpa": 900, "top_pressure_hpa": 700, "coverage": "ovc"}]
+        conv = {"risk_level": "low", "method": "thermo", "el_altitude_ft": 28000.0, "top_ft": 28000.0}
+        indices = {"cape_mixed_layer_jkg": 80.0, "nwp_lifted_index": 1.0}
+        cat, top = _colocate(self._an_full(cl, conv, indices), "ecmwf", 0.0, 850)
+        assert cat == "wet" and top == 11000.0
 
     def test_partly_cloud_at_level_is_partly(self):
         cl = [{"top_ft": 12000.0, "base_pressure_hpa": 900, "top_pressure_hpa": 700, "coverage": "sct"}]

--- a/tests/test_tasks_fronts.py
+++ b/tests/test_tasks_fronts.py
@@ -128,10 +128,67 @@ class TestColocate:
     def test_convective_uses_el_for_vertical_extent(self):
         # Overflown boundary but convective towers far above (the Dijon case):
         # weather_top must reflect the convective EL, not the shallow cloud layer.
+        # No CIN/ML-CAPE/LI in the fixture → convection defaults to realized.
         cl = [{"top_ft": 9000.0, "base_pressure_hpa": 900, "top_pressure_hpa": 850, "coverage": "sct"}]
         conv = {"risk_level": "moderate", "el_altitude_ft": 33000.0}
         cat, top = _colocate(self._an(cl, conv), "ecmwf", 0.0, 850)
         assert cat == "convective" and top == 33000.0
+
+    @staticmethod
+    def _an_full(cloud_layers, convective, indices, precip=None):
+        """Analysis fixture that also carries the sounding ``indices`` column
+        (ML-CAPE / NWP LI) needed by the realized-convection gate (#216)."""
+        return [{
+            "distance_from_origin_nm": 0.0,
+            "sounding": {"ecmwf": {
+                "cloud_layers": cloud_layers,
+                "convective": convective,
+                "indices": indices,
+                "precipitation": precip,
+            }},
+        }]
+
+    def test_cin_capped_potential_not_convective(self):
+        # LSGS 2026-06-07 regression (#216): GFS 925 hPa θe crossing over Alpine
+        # terrain. risk_level "moderate" is driven by CIN-capped potential CAPE
+        # (CIN -59.5, ML-CAPE 147, NWP LI -1) — convection is NOT realized. The
+        # only cloud is high cirrus (FL270+) that does NOT span 925, so the
+        # boundary is dry, and the parcel EL (27,233 ft) must NOT become a
+        # convective top. (Was the false-RED "convective tops to FL272".)
+        cl = [{"top_ft": 29298.0, "base_pressure_hpa": 400, "top_pressure_hpa": 300, "coverage": "ovc"}]
+        conv = {
+            "risk_level": "moderate", "method": "thermo",
+            "cin_jkg": -59.5, "el_altitude_ft": 27233.0, "top_ft": 27233.0,
+            "lifted_index": None,
+        }
+        indices = {"cape_mixed_layer_jkg": 147.3, "nwp_lifted_index": -1.0}
+        cat, top = _colocate(self._an_full(cl, conv, indices), "ecmwf", 0.0, 925)
+        assert cat == "dry"
+        assert top is None  # the parcel EL is never used as a realized top
+
+    def test_cin_capped_but_high_ml_cape_stays_convective(self):
+        # Guard the gate isn't over-aggressive: a strong cap (CIN -80) with a
+        # genuinely unstable air mass (ML-CAPE 1200) is realizable (loaded gun) →
+        # still convective, EL still its tower-depth proxy.
+        cl = [{"top_ft": 9000.0, "base_pressure_hpa": 900, "top_pressure_hpa": 850, "coverage": "sct"}]
+        conv = {
+            "risk_level": "high", "method": "thermo",
+            "cin_jkg": -80.0, "el_altitude_ft": 36000.0, "top_ft": 36000.0,
+        }
+        indices = {"cape_mixed_layer_jkg": 1200.0, "nwp_lifted_index": -1.0}
+        cat, top = _colocate(self._an_full(cl, conv, indices), "ecmwf", 0.0, 850)
+        assert cat == "convective" and top == 36000.0
+
+    def test_nwp_convective_cloud_is_realized(self):
+        # An NWP-method assessment (method != "thermo") reflects modeled
+        # convective cloud → realized regardless of CIN; its NWP top is used.
+        conv = {
+            "risk_level": "moderate", "method": "nwp",
+            "cin_jkg": -90.0, "top_ft": 25000.0,
+        }
+        indices = {"cape_mixed_layer_jkg": 50.0, "nwp_lifted_index": 2.0}
+        cat, top = _colocate(self._an_full([], conv, indices), "ecmwf", 0.0, 850)
+        assert cat == "convective" and top == 25000.0
 
     def test_partly_cloud_at_level_is_partly(self):
         cl = [{"top_ft": 12000.0, "base_pressure_hpa": 900, "top_pressure_hpa": 700, "coverage": "sct"}]


### PR DESCRIPTION
## Problem

The experimental `fronts` advisory produced a **false RED** on a stable, high-pressure day with no synoptic front and no deep convection (LSGS→EGTF, 2026-06-07):

> **RED** — "quasi-stationary front early on the route — convective tops to FL272, expect build-ups / deviation"

…while every other advisory on the route read benign (`convective` green "LOW 5%", `vmc_cruise` green "Clear at cruise") and DWD/Met Office charts showed no front anywhere near. Only **GFS** went red; ECMWF amber, ICON green ("air-mass boundary… little active weather on it").

### Root cause
The RED traced to a **single GFS θe crossing at 925 hPa** (~60 km out, over the Jura/Alps near LSGS):
- It was labelled `co_location="convective"` only because the nearest sounding's `convective.risk_level == "moderate"` — but that risk was **CIN-capped potential CAPE** (CIN −59.5, ML-CAPE 147 J/kg, NWP LI −1), not realized convection.
- Its `weather_top_ft` was taken as the **parcel equilibrium level** (`el_altitude_ft` = 27,233 ft) — high simply because it's a deep June troposphere, *not* an actual cloud top. The real cloud there is high cirrus (FL270+).
- That cleared the deep-convection RED cutoff (cruise FL120 + 15,000 = 27,000 ft) by **233 ft**.
- The vertical-coherence guard (RED needs ≥2 θe levels) was bypassed because convective crossings were exempt — so a single-level, terrain-driven crossing still RED'd.

Full investigation in #216.

## Fix

**Fix 1 — `_colocate` (`tasks/fronts.py`):** Only treat a crossing as `convective` — and only use the parcel EL as its tower-depth proxy — when convection is *realized*: NWP convective cloud present (`method != "thermo"`), weak inhibition, or a countervailing instability signal (ML-CAPE ≥ 300 or LI ≤ −2). CIN-capped potential falls through to the cloud-coverage category and the EL is never used as a realized top. Unknown data defaults to realized (never silently hides a front). Realized convection — including the overflown-tower Dijon case — is unchanged.

**Fix 2 — `_grade_crossing` (`advisories/fronts.py`):** An *overflown* convective crossing (below the free-atmosphere primary level) now needs vertical coherence (≥2 θe levels) to RED. A free-atmosphere detection at/above the primary level still REDs single-level by depth. A lone terrain-driven 925-hPa crossing can no longer RED on its parcel EL alone.

New thresholds (`tasks/fronts.py`): `_CIN_CAP_JKG = -50`, `_ML_CAPE_REALIZED_JKG = 300`, `_LI_REALIZED = -2`, tuned to this case vs the realized Dijon front.

## Verification

- **End-to-end on the real prod pack**: the GFS 925-hPa crossing flips `convective`/FL272 → `dry`/None, and the advisory aggregate goes **RED → GREEN** (GFS green, ICON green, ECMWF amber → majority green) — matching ICON and the benign day.
- The genuine **Dijon 2026-05-31 deep-convective front still REDs** (existing tests unchanged).
- **203 passed** across affected modules (front advisory, colocate, evaluators, advise-context, convective, route-fronts API).

## Regression fixtures
- `TestColocate::test_cin_capped_potential_not_convective` — the LSGS case → `dry`, EL not used as top.
- `TestColocate::test_cin_capped_but_high_ml_cape_stays_convective` — guards the gate isn't over-aggressive (loaded gun still convective).
- `TestColocate::test_nwp_convective_cloud_is_realized` — NWP-method convection realized regardless of CIN.
- `test_overflown_single_level_convective_capped_to_amber` / `test_overflown_convective_reds_when_vertically_coherent` — Fix 2 at the evaluator level.

## Follow-ups (out of scope)
- **Fix 3** from #216 — suppress 925/850-hPa fronts where the pressure level is below terrain (the broader Alpine-artifact class). The residual signal here would be addressed by it.
- Log the new convective-realization thresholds in `designs/future/meteorology-decisions.md` once that doc lands on main.

Closes #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)
