### PR TITLE
feat(fronts): level-aware terrain masking + shared realized-convection gate (#216 Fix 3)

### DIFF
--- a/designs/meteorology-decisions.md
+++ b/designs/meteorology-decisions.md
@@ -729,6 +729,19 @@ The LI fallback (DD-derived → `nwp_lifted_index`) deliberately crosses the §4
 DD/NWP tier separation: here LI is a binary gate signal, not a tier input, so the
 mixing is acceptable.
 
+### Where the logic lives (refactor, PR for #216 Fix 3)
+
+The realized/potential decision is a public `convection_realized()` in
+`analysis/sounding/convective.py`, reusing `REGIME_CIN_CAP` (−50) and
+`REGIME_CAPE_LOW` (300) — the same anchors `classify_regime` uses — rather than
+duplicating constants. This keeps it next to the convective tier and shareable.
+The two answer different questions and must not be conflated: the **tier**
+(`risk_level`) deliberately keeps a moderate cap's risk at its potential level
+(WEAK_INSTABILITY only suppresses at CIN < −200), because a moderate-CAPE air mass
+is worth flagging on the route; the **realized predicate** uses the stricter −50
+cap, because using the parcel EL as a cloud top demands more confidence. Callers
+own data extraction (incl. the DD→NWP LI fallback); the module owns logic + thresholds.
+
 ### Real-world validation needed
 
 - A strong, genuinely active front (deep CAPE, weak cap) crossing the route at a
@@ -739,6 +752,72 @@ mixing is acceptable.
 ### Files changed
 
 `analysis/advisories/fronts.py` (`_grade_crossing`: overflown-convective
-coherence gate), `tasks/fronts.py` (`_colocate` + `_convection_realized`: realized
-gate, EL only on realized path). Tests: `tests/test_tasks_fronts.py`,
-`tests/analysis/advisories/test_fronts_advisory.py`.
+coherence gate), `tasks/fronts.py` (`_colocate`: realized gate via shared
+predicate, EL only on realized path), `analysis/sounding/convective.py`
+(`convection_realized`). Tests: `tests/test_tasks_fronts.py`,
+`tests/analysis/advisories/test_fronts_advisory.py`, `tests/test_convective.py`.
+
+
+---
+
+## 7. Level-aware terrain masking for front detection
+
+**Date:** 2026-06-06
+**Status:** Implemented (PR for #216 Fix 3).
+**Context:** Front detection masks grid cells where terrain generates orographic
+θe gradients. The mask used a single flat threshold — terrain > **1500 m**
+(≈ the 850 hPa surface) — applied to *every* detection level (925 / 850 / 700 hPa).
+That is two-sided wrong, because the pressure surfaces sit at very different
+heights:
+
+| level | ISA height | flat-1500 m behaviour |
+|-------|-----------|------------------------|
+| 925 hPa | ~762 m  | **under-masks**: terrain 762–1500 m lets near-ground crossings through |
+| 850 hPa | ~1457 m | ≈ correct (the threshold was calibrated here) |
+| 700 hPa | ~3012 m | **over-masks**: terrain 1500–3012 m wrongly rejects genuine *free-atmosphere* fronts |
+
+The 700 hPa over-masking is the worse failure — a **false negative** that hides a
+real front, against this codebase's "never silently hide a front" bias.
+
+### The decision
+
+Mask a cell at level *P* when terrain reaches *P*'s standard-atmosphere height:
+`terrain_m > pressure_hpa_to_altitude_m(P)`. The flat boolean mask is replaced by
+a cached **elevation grid** (`terrain_mask_for_level(elevation, level)`), so the
+*same* upstream change makes both `fill_terrain` (θe smoothing before gradients)
+and the per-crossing terrain gate level-aware with no change to their logic.
+925 hPa now masks terrain above ~762 m; 700 hPa only above ~3012 m.
+
+NaN elevation (ocean / no SRTM) is always valid. A `buffer_m` knob can lower the
+threshold if a sub-surface margin is ever wanted (default 0 = mask only at/above
+the surface).
+
+### Note on the triggering LSGS case
+
+This does **not** change the 2026-06-07 LSGS crossing: it sits over Lake Geneva
+(SRTM 370 m), where 925 hPa is *above* ground — a real shallow lake/pre-Alps θe
+boundary, already handled by §6 (dry co-location → green). Fix 3 is an independent
+detector-correctness improvement, not the fix for that bug. Its value is the
+general 925 under-masking / 700 over-masking correction above.
+
+### Migration
+
+The precompute cache (`{DATA_DIR}/hewson/terrain_mask.npz`) now also stores the
+elevation grid; a pre-elevation cache is treated as stale and rebuilt on next
+precompute. Until rebuilt, the route path falls back to the flat mask (current
+behaviour) — graceful, no manual wipe required.
+
+### Real-world validation needed
+
+- A genuine 700 hPa front over the Alps (terrain 1500–3000 m): confirm it now
+  surfaces instead of being smoothed/rejected.
+- Spot-check that low-level (925) detections over real high terrain (not lakes)
+  are suppressed as intended.
+
+### Files changed
+
+`frontal/grid.py` (`build_terrain_elevation`, `terrain_mask_for_level`),
+`hewson/precompute.py` (cache elevation, auto-rebuild pre-elevation caches),
+`tasks/fronts.py` (per-level mask in the detection loop), `api/hewson_map.py`
+(level-aware overlay). Tests: `tests/test_frontal_grid.py`,
+`tests/test_tasks_fronts.py`, `tests/test_hewson_precompute.py`.

--- a/src/weatherbrief/analysis/sounding/convective.py
+++ b/src/weatherbrief/analysis/sounding/convective.py
@@ -142,6 +142,48 @@ def classify_regime(cape: float | None, cin: float | None) -> ConvectiveRegime |
     return ConvectiveRegime.WEAK_INSTABILITY
 
 
+# Lifted-index threshold for the realized-vs-potential gate. LI ≤ −2 marks
+# moderate+ instability (0…−2 = stable/weak), the standard weak/moderate boundary.
+LI_REALIZED = -2.0
+
+
+def convection_realized(
+    *,
+    method: str | None,
+    cin_jkg: float | None,
+    ml_cape_jkg: float | None,
+    lifted_index: float | None,
+) -> bool:
+    """True when convection is *realized*, not just CIN-capped potential (#216).
+
+    Distinct from the convective *tier* (``risk_level`` / :func:`classify_regime`):
+    the tier deliberately keeps a moderate cap's risk at its potential level —
+    WEAK_INSTABILITY only suppresses at CIN < ``CIN_CAP_THRESHOLD`` (−200) — because
+    a moderate-CAPE air mass is worth flagging on the route. A consumer that must
+    know whether convection is *actually realized* — e.g. front co-location, which
+    would otherwise read the parcel equilibrium level as a real tower a pilot meets
+    — needs a stricter bar: realized unless strongly capped (CIN ≤
+    ``REGIME_CIN_CAP``, −50) with no countervailing instability (ML-CAPE ≥
+    ``REGIME_CAPE_LOW`` (300) or a lifted index ≤ ``LI_REALIZED`` (−2)).
+
+    NWP convective cloud (``method`` != "thermo") is realized by construction.
+    Unknown data defaults to realized — we downgrade only on *positive* evidence
+    the instability is weak, so a real signal is never silently hidden. Callers own
+    data extraction (and any DD→NWP lifted-index fallback); this owns the logic and
+    the shared thresholds. See ``meteorology-decisions.md`` §4 (tier) and §6 (gate).
+    """
+    if (method or "thermo") != "thermo":
+        return True
+    if not (cin_jkg is not None and cin_jkg <= REGIME_CIN_CAP):
+        return True
+    if ml_cape_jkg is None and lifted_index is None:
+        return True
+    return (
+        (ml_cape_jkg is not None and ml_cape_jkg >= REGIME_CAPE_LOW)
+        or (lifted_index is not None and lifted_index <= LI_REALIZED)
+    )
+
+
 _RISK_LEVELS = tuple(ConvectiveRisk)
 
 

--- a/src/weatherbrief/api/hewson_map.py
+++ b/src/weatherbrief/api/hewson_map.py
@@ -433,13 +433,17 @@ def get_all_metrics(
 # ---------------------------------------------------------------------------
 
 
-def _load_cached_terrain_mask(lat: np.ndarray, lon: np.ndarray) -> np.ndarray | None:
+def _load_cached_terrain_mask(
+    lat: np.ndarray, lon: np.ndarray, level_hPa: int | None = None,
+) -> np.ndarray | None:
     """Return the precompute's cached terrain mask if it matches this grid.
 
     The precompute loop writes ``${DATA_DIR}/hewson/terrain_mask.npz`` on first
-    run; reuse it so the front extractor rejects orographic θe ridges. Returns
-    ``None`` (no masking) when the cache is absent or grid-mismatched rather
-    than rebuilding from SRTM in the request path.
+    run; reuse it so the front extractor rejects orographic θe ridges. When the
+    cache carries an elevation grid and a ``level_hPa`` is given, return a
+    *level-aware* mask (#216) so the overlay matches the route detector; otherwise
+    fall back to the flat mask. Returns ``None`` (no masking) when the cache is
+    absent or grid-mismatched rather than rebuilding from SRTM in the request path.
     """
     path = resolve_output_dir() / "terrain_mask.npz"
     if not path.exists():
@@ -449,16 +453,20 @@ def _load_cached_terrain_mask(lat: np.ndarray, lon: np.ndarray) -> np.ndarray | 
             mask = npz["mask"]
             cached_lat = npz["lat"]
             cached_lon = npz["lon"]
+            elevation = npz["elevation"] if "elevation" in npz.files else None
     except (OSError, KeyError, ValueError, zipfile.BadZipFile, EOFError):
         logger.warning("Hewson fronts: unreadable terrain mask at %s", path)
         return None
-    if (
+    if not (
         mask.shape == (len(lat), len(lon))
         and np.allclose(cached_lat, lat)
         and np.allclose(cached_lon, lon)
     ):
-        return mask
-    return None
+        return None
+    if level_hPa is not None and elevation is not None and elevation.shape == mask.shape:
+        from weatherbrief.frontal.grid import terrain_mask_for_level
+        return terrain_mask_for_level(elevation, level_hPa)
+    return mask
 
 
 @router.get("/fronts")
@@ -504,7 +512,7 @@ def get_fronts(
     from weatherbrief.frontal.sources import SnapshotFieldSource
 
     source = SnapshotFieldSource(path, model_name=model)
-    terrain_mask = _load_cached_terrain_mask(source.lat, source.lon)
+    terrain_mask = _load_cached_terrain_mask(source.lat, source.lon, level)
     source.terrain_mask = terrain_mask
     grids = source.grids_at_hour(model, hour, level)
     if grids is None:

--- a/src/weatherbrief/frontal/grid.py
+++ b/src/weatherbrief/frontal/grid.py
@@ -183,6 +183,59 @@ def build_terrain_mask(lat: np.ndarray, lon: np.ndarray) -> np.ndarray:
     return mask
 
 
+def build_terrain_elevation(lat: np.ndarray, lon: np.ndarray) -> np.ndarray:
+    """Terrain elevation grid in metres (SRTM3 90 m); NaN where SRTM has no data.
+
+    The float counterpart of :func:`build_terrain_mask`: it retains the actual
+    heights so a *level-aware* mask can be derived per detection level (a 925 hPa
+    surface sits far lower than 850/700 hPa, so a single flat threshold both
+    under-masks low levels and over-masks high ones). Pair with
+    :func:`terrain_mask_for_level`. Static for a given grid — compute once, cache.
+    """
+    import srtm
+
+    from weatherbrief.fetch.elevation import SRTM_CACHE_DIR
+
+    elevation_data = srtm.get_data(
+        local_cache_dir=str(SRTM_CACHE_DIR), srtm3=True,
+    )
+    elev = np.full((len(lat), len(lon)), np.nan, dtype=np.float64)
+    for i, la in enumerate(lat):
+        for j, lo in enumerate(lon):
+            e = elevation_data.get_elevation(float(la), float(lo))
+            if e is not None:
+                elev[i, j] = float(e)
+
+    logger.info(
+        "Terrain elevation grid: %d of %d points have SRTM data",
+        int(np.isfinite(elev).sum()), elev.size,
+    )
+    return elev
+
+
+def terrain_mask_for_level(
+    elevation_m: np.ndarray, level_hPa: int, buffer_m: float = 0.0,
+) -> np.ndarray:
+    """Boolean mask (True = valid) for a detection level from an elevation grid.
+
+    A cell is masked (invalid) when terrain reaches the level's standard-atmosphere
+    height: the pressure surface is then at/below ground and its θe gradients are
+    orographic artefacts, not free-atmosphere fronts. This generalises the flat
+    1500 m (~850 hPa) threshold: 925 hPa masks terrain above ~762 m, 700 hPa only
+    above ~3012 m — so low-level Alpine artefacts are caught and genuine 700 hPa
+    fronts over moderate terrain are no longer wrongly hidden (#216 Fix 3).
+
+    NaN elevation (ocean / no SRTM) is treated as valid. ``buffer_m`` lowers the
+    threshold if a margin below the surface is wanted (0 = mask only at/above it).
+    """
+    from weatherbrief.models.analysis import pressure_hpa_to_altitude_m
+
+    threshold_m = pressure_hpa_to_altitude_m(level_hPa) - buffer_m
+    # NaN → -inf so unknown/ocean cells never exceed the threshold (stay valid).
+    elev = np.nan_to_num(elevation_m, nan=-np.inf)
+    return ~(elev > threshold_m)
+
+
 def fill_terrain(field: np.ndarray, terrain_mask: np.ndarray) -> np.ndarray:
     """Replace terrain-masked cells with values interpolated from valid neighbors.
 

--- a/src/weatherbrief/hewson/precompute.py
+++ b/src/weatherbrief/hewson/precompute.py
@@ -43,8 +43,9 @@ import numpy as np
 from weatherbrief.frontal.detect import compute_hewson_diagnostics
 from weatherbrief.process_rss import log_memory
 from weatherbrief.frontal.grid import (
+    _TERRAIN_MASK_THRESHOLD_M,
     build_grid_coords,
-    build_terrain_mask,
+    build_terrain_elevation,
     fetch_grid_fields,
     reshape_to_fields,
 )
@@ -188,11 +189,13 @@ def snapshot_for_window(
 def _load_or_build_terrain_mask(
     lat: np.ndarray, lon: np.ndarray, output_dir: Path | None,
 ) -> np.ndarray:
-    """Return the terrain mask for the current grid.
+    """Return the flat terrain mask for the current grid (back-compat).
 
-    First invocation per environment builds via SRTM3 (~seconds) and caches
-    to ``{DATA_DIR}/hewson/terrain_mask.npz``. Subsequent calls load from
-    disk and verify the shape matches the active grid.
+    First invocation per environment builds via SRTM3 (~seconds) and caches the
+    elevation grid + the derived flat mask to ``{DATA_DIR}/hewson/terrain_mask.npz``.
+    Subsequent calls load from disk and verify the shape matches the active grid.
+    A cache missing the ``elevation`` array (pre-#216) is treated as stale and
+    rebuilt, so level-aware masking gets its data without a manual cache wipe.
     """
     cache_path = _terrain_mask_path(output_dir)
     if cache_path.exists():
@@ -200,20 +203,25 @@ def _load_or_build_terrain_mask(
             mask = npz["mask"]
             cached_lat = npz["lat"]
             cached_lon = npz["lon"]
+            has_elevation = "elevation" in npz.files
         if (
-            mask.shape == (len(lat), len(lon))
+            has_elevation
+            and mask.shape == (len(lat), len(lon))
             and np.allclose(cached_lat, lat)
             and np.allclose(cached_lon, lon)
         ):
             return mask
         logger.info(
-            "Terrain-mask cache at %s stale (grid changed) — rebuilding",
-            cache_path,
+            "Terrain-mask cache at %s stale (grid changed or pre-elevation) — "
+            "rebuilding", cache_path,
         )
 
-    mask = build_terrain_mask(lat, lon)
+    elevation = build_terrain_elevation(lat, lon)
+    # Flat ≤1500 m (~850 hPa) mask, derived from the same scan so the two never
+    # drift; level-aware consumers use the elevation grid via terrain_mask_for_level.
+    mask = ~(np.nan_to_num(elevation, nan=-np.inf) > _TERRAIN_MASK_THRESHOLD_M)
     cache_path.parent.mkdir(parents=True, exist_ok=True)
-    np.savez_compressed(cache_path, mask=mask, lat=lat, lon=lon)
+    np.savez_compressed(cache_path, mask=mask, lat=lat, lon=lon, elevation=elevation)
     return mask
 
 

--- a/src/weatherbrief/tasks/fronts.py
+++ b/src/weatherbrief/tasks/fronts.py
@@ -36,7 +36,9 @@ from typing import Sequence
 
 import numpy as np
 
+from weatherbrief.analysis.sounding.convective import convection_realized
 from weatherbrief.frontal.gates import FrontGateConfig
+from weatherbrief.frontal.grid import terrain_mask_for_level
 from weatherbrief.frontal.route_sampling import (
     RouteFrontAnalysis,
     apply_gate_config,
@@ -135,17 +137,6 @@ _PARTLY_COVERAGE = {"few", "sct"}
 _CONVECTIVE_RISK = {"moderate", "high", "extreme"}
 _PERSIST_OFFSETS_H = (-6, -3, 0, 3, 6)
 
-# Realized-convection gate (#216). A thermo ``risk_level`` can be driven purely by
-# *potential* CAPE that a strong cap (CIN) never lets convect — and its ``top_ft``
-# is then the parcel equilibrium level, not a cloud a pilot meets. Treat
-# convection as realized unless it is strongly inhibited (CIN <= ``_CIN_CAP_JKG``)
-# with no countervailing instability (ML-CAPE >= ``_ML_CAPE_REALIZED_JKG`` or a
-# lifted index <= ``_LI_REALIZED``). Tuned to the 2026-06-07 LSGS false-RED
-# (CIN -59.5, ML-CAPE 147, LI -1) vs the realized Dijon front.
-_CIN_CAP_JKG = -50.0
-_ML_CAPE_REALIZED_JKG = 300.0
-_LI_REALIZED = -2.0
-
 
 def _attr(obj: object, name: str, default: object = None) -> object:
     """getattr/dict-get that tolerates pydantic objects or raw dicts (or None)."""
@@ -159,43 +150,6 @@ def _attr(obj: object, name: str, default: object = None) -> object:
 def _enum_val(x: object) -> object:
     """Unwrap an enum to its ``.value`` (passthrough for plain strings/None)."""
     return getattr(x, "value", x)
-
-
-def _convection_realized(conv, indices) -> bool:
-    """True when convection is *realized*, not just CIN-capped potential (#216).
-
-    A thermo ``risk_level`` can be driven by potential CAPE that a strong cap
-    (CIN) never lets convect; its ``top_ft`` is then the parcel equilibrium level,
-    not a cloud a pilot meets. Convection counts as realized when NWP convective
-    cloud is present (``method`` != "thermo"), the inhibition is weak, or there is
-    a countervailing instability signal (high ML-CAPE or a negative lifted index).
-    Unknown data defaults to realized so a real front is never silently hidden —
-    we downgrade only on *positive* evidence the instability is weak (caller
-    guarantees a non-None ``conv`` with a convective ``risk_level``).
-    """
-    if _attr(conv, "method", "thermo") != "thermo":
-        return True  # NWP convective-cloud diagnostics fired → realized weather
-    cin = _attr(conv, "cin_jkg", None)  # negative = inhibition
-    strong_cap = cin is not None and cin <= _CIN_CAP_JKG
-    if not strong_cap:
-        return True
-    # Strongly capped: downgrade to potential only with positive evidence the
-    # instability is weak. With CIN the sole available signal (ML-CAPE and LI both
-    # absent — e.g. ICON, which emits no lifted index), default to realized rather
-    # than silently hide a front. LI here is a binary gate signal, not a tier
-    # input, so falling back from the DD-derived to the NWP-native value is
-    # acceptable — the DD/NWP tier separation (meteorology-decisions.md §4) does
-    # not bind this realized/potential decision.
-    ml_cape = _attr(indices, "cape_mixed_layer_jkg", None)
-    li = _attr(conv, "lifted_index", None)
-    if li is None:
-        li = _attr(indices, "nwp_lifted_index", None)
-    if ml_cape is None and li is None:
-        return True
-    return (
-        (ml_cape is not None and ml_cape >= _ML_CAPE_REALIZED_JKG)
-        or (li is not None and li <= _LI_REALIZED)
-    )
 
 
 def _colocate(analyses, model: str, dist_km: float, level_hpa: int):
@@ -244,8 +198,21 @@ def _colocate(analyses, model: str, dist_km: float, level_hpa: int):
     # risk is not weather on the boundary, and its top_ft is the parcel EL — not a
     # tower a pilot meets. Realized convection keeps the EL as its tower-depth
     # proxy (the overflown-tower Dijon case); a potential-only risk falls through
-    # to the cloud-coverage category and the EL is never used as a top.
-    if risk in _CONVECTIVE_RISK and _convection_realized(conv, indices):
+    # to the cloud-coverage category and the EL is never used as a top. The
+    # realized/potential logic + thresholds live in the convective module (shared
+    # with the route convective tier); we own only the data extraction here,
+    # including the DD→NWP lifted-index fallback (LI is a binary gate signal, not a
+    # tier input, so the cross of the §4 DD/NWP boundary is acceptable).
+    li = _attr(conv, "lifted_index", None)
+    if li is None:
+        li = _attr(indices, "nwp_lifted_index", None)
+    realized = convection_realized(
+        method=_attr(conv, "method", "thermo"),
+        cin_jkg=_attr(conv, "cin_jkg", None),
+        ml_cape_jkg=_attr(indices, "cape_mixed_layer_jkg", None),
+        lifted_index=li,
+    )
+    if risk in _CONVECTIVE_RISK and realized:
         category = "convective"
         conv_top = _attr(conv, "top_ft", None) or _attr(conv, "el_altitude_ft", None)
         tops = [v for v in (cloud_top, conv_top) if v]
@@ -487,6 +454,9 @@ def compute_route_fronts(
     models = [m for m in ("ecmwf", "gfs", "icon") if m in models]
 
     terrain_mask = _load_cached_terrain_mask(output_dir)
+    # Elevation grid enables level-aware masking (a 925 hPa surface sits far below
+    # 850/700 hPa). Absent on pre-#216 caches → fall back to the flat mask.
+    terrain_elevation = _load_cached_terrain_elevation(output_dir)
 
     per_model: dict[str, list[RouteFrontAnalysisModel]] = {}
     per_model_primary: dict[str, int] = {}
@@ -524,17 +494,23 @@ def compute_route_fronts(
         # Only apply the cached terrain mask if it matches this snapshot's grid
         # — a stale mask (e.g. from a resolution change) would otherwise crash
         # fill_terrain() on a shape mismatch. Mismatch → no masking (graceful).
-        if (
-            terrain_mask is not None
-            and terrain_mask.shape == (source.lat.size, source.lon.size)
-        ):
+        grid_shape = (source.lat.size, source.lon.size)
+        if terrain_mask is not None and terrain_mask.shape == grid_shape:
             source.terrain_mask = terrain_mask
         elif terrain_mask is not None:
             logger.warning(
                 "Front detection: terrain mask %s mismatches %s grid %s — "
                 "skipping terrain masking",
-                terrain_mask.shape, model, (source.lat.size, source.lon.size),
+                terrain_mask.shape, model, grid_shape,
             )
+        # Level-aware masking (#216): when the elevation grid is available and
+        # matches the grid, derive a per-level mask inside the loop below instead
+        # of the flat one. Same shape-guard as the flat mask.
+        model_elevation = (
+            terrain_elevation
+            if (terrain_elevation is not None and terrain_elevation.shape == grid_shape)
+            else None
+        )
         snapshot_inits[model] = _iso_z(source.init_time_unix)
 
         # ETAs → snapshot-relative forecast hours.
@@ -557,6 +533,11 @@ def compute_route_fronts(
         analyses: list[RouteFrontAnalysisModel] = []
         for level in levels:
             cfg = base_config.with_overrides(level_hPa=level)
+            # Mask terrain against *this level's* standard-atmosphere height, so a
+            # 925 hPa surface masks far more terrain than 700 hPa — fixing both the
+            # low-level Alpine artefact and the high-level over-masking (#216).
+            if model_elevation is not None:
+                source.terrain_mask = terrain_mask_for_level(model_elevation, level)
             try:
                 result = _analyze_one(
                     source, model, waypoints, eta_hours, mid_hour, cfg,
@@ -730,4 +711,18 @@ def _load_cached_terrain_mask(output_dir: Path | None) -> np.ndarray | None:
             return npz["mask"]
     except Exception:
         logger.warning("Front detection: unreadable terrain mask %s", path)
+        return None
+
+
+def _load_cached_terrain_elevation(output_dir: Path | None) -> np.ndarray | None:
+    """Load the precompute's cached terrain elevation grid for level-aware masking,
+    or ``None`` if absent (pre-#216 cache) — callers fall back to the flat mask."""
+    path = resolve_output_dir(output_dir) / "terrain_mask.npz"
+    if not path.exists():
+        return None
+    try:
+        with np.load(path) as npz:
+            return npz["elevation"] if "elevation" in npz.files else None
+    except Exception:
+        logger.warning("Front detection: unreadable terrain elevation %s", path)
         return None

--- a/tests/test_convective.py
+++ b/tests/test_convective.py
@@ -6,6 +6,7 @@ from weatherbrief.analysis.sounding.convective import (
     assess_convective_nwp,
     assess_convective_thermo,
     classify_regime,
+    convection_realized,
     convective_cross_check,
     effective_cape,
 )
@@ -979,3 +980,76 @@ def test_cross_check_none_when_thermo_missing():
         risk_level=ConvectiveRisk.NONE, cover_pct=40.0, method="nwp"
     )
     assert convective_cross_check(None, nwp) is None
+
+
+# ---------------------------------------------------------------------------
+# convection_realized — the realized-vs-potential gate shared with front
+# co-location (#216). Tier-independent: stricter CIN bar than risk_level.
+# ---------------------------------------------------------------------------
+
+
+def test_realized_nwp_method_always_true():
+    """NWP convective cloud (method != thermo) is realized regardless of CIN."""
+    assert convection_realized(
+        method="nwp", cin_jkg=-300.0, ml_cape_jkg=10.0, lifted_index=5.0
+    ) is True
+
+
+def test_realized_weak_cap_is_true():
+    """Weak inhibition (CIN > -50) → realized even with low instability."""
+    assert convection_realized(
+        method="thermo", cin_jkg=-20.0, ml_cape_jkg=50.0, lifted_index=1.0
+    ) is True
+
+
+def test_potential_strong_cap_low_instability_is_false():
+    """The LSGS case: strong cap (CIN -59.5), ML-CAPE 147 < 300, LI -1 > -2 →
+    potential, not realized."""
+    assert convection_realized(
+        method="thermo", cin_jkg=-59.5, ml_cape_jkg=147.0, lifted_index=-1.0
+    ) is False
+
+
+def test_realized_strong_cap_high_ml_cape():
+    """Loaded gun: strong cap but ML-CAPE >= 300 → realized."""
+    assert convection_realized(
+        method="thermo", cin_jkg=-80.0, ml_cape_jkg=1200.0, lifted_index=None
+    ) is True
+
+
+def test_realized_strong_cap_negative_li():
+    """Strong cap but LI <= -2 → realized (symmetric to the ML-CAPE gate)."""
+    assert convection_realized(
+        method="thermo", cin_jkg=-80.0, ml_cape_jkg=120.0, lifted_index=-4.0
+    ) is True
+
+
+def test_strong_cap_no_instability_data_defaults_realized():
+    """Strong cap but ML-CAPE and LI both unknown (e.g. ICON, no lifted index) →
+    default to realized rather than silently hide a front."""
+    assert convection_realized(
+        method="thermo", cin_jkg=-90.0, ml_cape_jkg=None, lifted_index=None
+    ) is True
+
+
+def test_unknown_cin_is_realized():
+    """No CIN signal at all → not 'strongly capped' → realized."""
+    assert convection_realized(
+        method="thermo", cin_jkg=None, ml_cape_jkg=None, lifted_index=None
+    ) is True
+
+
+def test_threshold_boundaries_exclusive_inclusive():
+    """CIN == -50 is 'capped' (<=); ML-CAPE == 300 and LI == -2 are realized (>=/<=)."""
+    # CIN exactly at the cap, low instability → potential.
+    assert convection_realized(
+        method="thermo", cin_jkg=-50.0, ml_cape_jkg=299.0, lifted_index=-1.9
+    ) is False
+    # ML-CAPE exactly at the realized anchor → realized.
+    assert convection_realized(
+        method="thermo", cin_jkg=-50.0, ml_cape_jkg=300.0, lifted_index=None
+    ) is True
+    # LI exactly at the realized boundary → realized.
+    assert convection_realized(
+        method="thermo", cin_jkg=-50.0, ml_cape_jkg=None, lifted_index=-2.0
+    ) is True

--- a/tests/test_frontal_grid.py
+++ b/tests/test_frontal_grid.py
@@ -10,6 +10,7 @@ from weatherbrief.frontal.grid import (
     prepare_field,
     fill_terrain,
     compute_theta_e,
+    terrain_mask_for_level,
 )
 
 
@@ -136,6 +137,44 @@ class TestFillTerrain:
         result = fill_terrain(field, mask)
         # All valid cells should be unchanged
         np.testing.assert_array_equal(result[mask], field[mask])
+
+
+class TestTerrainMaskForLevel:
+    """Level-aware terrain masking (#216 Fix 3): mask a cell when terrain reaches
+    the level's standard-atmosphere height (925≈762m, 850≈1457m, 700≈3012m)."""
+
+    # lake (370m), pre-Alps (1102m), high Alps (2500m), ocean (NaN)
+    _ELEV = np.array([[370.0, 1102.0, 2500.0, np.nan]])
+
+    def test_925_masks_prealps_and_alps(self):
+        valid = terrain_mask_for_level(self._ELEV, 925)
+        np.testing.assert_array_equal(valid, [[True, False, False, True]])
+
+    def test_850_masks_only_high_alps(self):
+        valid = terrain_mask_for_level(self._ELEV, 850)
+        np.testing.assert_array_equal(valid, [[True, True, False, True]])
+
+    def test_700_keeps_all_terrain(self):
+        """700 hPa (~3012m) is above 2500m terrain → not masked (the over-masking
+        the flat 1500m threshold used to cause)."""
+        valid = terrain_mask_for_level(self._ELEV, 700)
+        np.testing.assert_array_equal(valid, [[True, True, True, True]])
+
+    def test_nan_elevation_is_valid(self):
+        """Ocean / no-SRTM cells (NaN) are always valid, never masked."""
+        valid = terrain_mask_for_level(np.array([[np.nan]]), 925)
+        assert valid.tolist() == [[True]]
+
+    def test_buffer_lowers_threshold(self):
+        """A positive buffer masks terrain a margin below the surface too."""
+        elev = np.array([[700.0]])  # below 925's ~762m → valid with no buffer
+        assert terrain_mask_for_level(elev, 925).tolist() == [[True]]
+        # 200m buffer → threshold ~562m → 700m now masked.
+        assert terrain_mask_for_level(elev, 925, buffer_m=200.0).tolist() == [[False]]
+
+    def test_shape_preserved(self):
+        elev = np.zeros((5, 7))
+        assert terrain_mask_for_level(elev, 850).shape == (5, 7)
 
 
 class TestComputeThetaE:

--- a/tests/test_hewson_precompute.py
+++ b/tests/test_hewson_precompute.py
@@ -256,13 +256,14 @@ def patched_metadata():
 
 @pytest.fixture
 def patched_terrain_mask():
-    """Replace build_terrain_mask with all-True to avoid SRTM lookups."""
-    def _all_true(lat, lon):
-        return np.ones((len(lat), len(lon)), dtype=bool)
+    """Replace build_terrain_elevation with a flat sea-level grid to avoid SRTM
+    lookups (0 m → all-valid mask; elevation also cached for level-aware masking)."""
+    def _zeros(lat, lon):
+        return np.zeros((len(lat), len(lon)), dtype=np.float64)
 
     with patch(
-        "weatherbrief.hewson.precompute.build_terrain_mask",
-        side_effect=_all_true,
+        "weatherbrief.hewson.precompute.build_terrain_elevation",
+        side_effect=_zeros,
     ):
         yield
 

--- a/tests/test_tasks_fronts.py
+++ b/tests/test_tasks_fronts.py
@@ -453,6 +453,40 @@ class TestComputeRouteFronts:
         assert manifest.models == ["ecmwf"]
         assert manifest.per_model["ecmwf"]
 
+    def test_level_aware_terrain_masks_low_level_only(self, tmp_path):
+        """#216 Fix 3: terrain reaching the 925 hPa surface (~762 m) masks the
+        925 crossing while leaving the 850/700 hPa fronts intact. A planted
+        elevation grid (1200 m over the route's front-crossing region) is below
+        the 850/700 surfaces but above 925's."""
+        out_dir = tmp_path / "hewson"
+        _write_front_snapshot(out_dir, levels=(925, 850, 700))
+        lat = np.linspace(45.0, 52.0, 29)
+        lon = np.linspace(-2.0, 6.0, 33)
+        la_grid, lo_grid = np.meshgrid(lat, lon, indexing="ij")
+        elev = np.zeros((lat.size, lon.size))
+        # High terrain over the crossing neighbourhood (route lat 47, front lon ~2).
+        elev[(np.abs(la_grid - 47.0) < 2.0) & (np.abs(lo_grid - 2.0) < 2.5)] = 1200.0
+        out_dir.mkdir(parents=True, exist_ok=True)
+        np.savez_compressed(
+            out_dir / "terrain_mask.npz",
+            mask=np.ones((lat.size, lon.size), dtype=bool),  # flat fallback (unused)
+            lat=lat, lon=lon, elevation=elev,
+        )
+        analyses = _route_analyses()
+        manifest = compute_route_fronts(
+            [(a.lat, a.lon) for a in analyses],
+            [a.interpolated_time for a in analyses],
+            route_name="r", cruise_altitude_ft=5000,
+            advisory_models=["ecmwf"], output_dir=out_dir,
+        )
+
+        def n_cross(level: int) -> int:
+            return sum(len(a.crossings) for a in manifest.per_model["ecmwf"]
+                       if a.level_hPa == level)
+
+        assert n_cross(700) >= 1   # free-atmosphere front intact (not over-masked)
+        assert n_cross(925) == 0   # low-level crossing suppressed by level-aware mask
+
 
 class TestRunFronts:
     def test_writes_artifact_and_roundtrips(self, tmp_path):


### PR DESCRIPTION
Follow-up to #216 / PR #217 — implements **Fix 3** (the deferred terrain-suppression item) plus a related DRY refactor of the realized-convection gate. Two cohesive changes to the front-detection pipeline.

## 1. Level-aware terrain masking (Fix 3)

The terrain gate masked grid cells where terrain generates orographic θe gradients, using a single **flat 1500 m** threshold (≈ the 850 hPa surface) for **every** detection level. Because the pressure surfaces sit at very different heights, that's two-sided wrong:

| level | ISA height | flat-1500 m behaviour |
|-------|-----------|------------------------|
| 925 hPa | ~762 m  | **under-masks**: terrain 762–1500 m leaks near-ground crossings |
| 850 hPa | ~1457 m | ≈ correct (where it was calibrated) |
| 700 hPa | ~3012 m | **over-masks**: terrain 1500–3012 m wrongly rejects genuine *free-atmosphere* fronts |

The 700 hPa over-masking is the worse failure — a **false negative** that hides a real front, against the codebase's "never silently hide a front" bias.

**Fix:** replace the flat boolean mask with a cached **elevation grid** and derive a per-level mask — `mask when terrain > pressure_hpa_to_altitude_m(level)`. The *same* upstream change makes both `fill_terrain` (θe smoothing before gradients) **and** the per-crossing gate level-aware, with **zero** change to their logic. The 2-D calibration overlay (`api/hewson_map.py`) is level-aware too.

**Migration:** the precompute cache (`terrain_mask.npz`) now also stores the elevation grid; a pre-elevation cache is treated as stale and rebuilt on next precompute. Until then the route path falls back to the flat mask (current behaviour) — graceful, no manual wipe.

> **Note:** this does **not** change the LSGS 2026-06-07 case that started #216 — its crossing is over **Lake Geneva (SRTM 370 m)**, where 925 hPa is *above* ground (a real shallow lake/pre-Alps boundary, already handled GREEN by #216 Fix 1/2). Fix 3 is an independent detector-correctness improvement; its value is the 925 under-masking / 700 over-masking correction.

## 2. Shared realized-convection gate (DRY, not duplication)

#216 added `_convection_realized` in `tasks/fronts.py` with constants (`-50`, `300`) that **already existed** as named anchors (`REGIME_CIN_CAP`, `REGIME_CAPE_LOW`) in `analysis/sounding/convective.py`. Per the project's "push complexity into the well-tested library" rule, I extracted a public **`convection_realized()`** into `convective.py`, reusing those anchors.

The convective **tier** (`risk_level`) and the **realized predicate** answer different questions and stay distinct: the tier deliberately keeps a moderate cap's risk at its potential level (WEAK_INSTABILITY suppresses only at CIN < −200, so a moderate-CAPE air mass is still flagged on the route), while the realized predicate uses the stricter −50 cap (using the parcel EL as a cloud top demands more confidence). Callers own data extraction (incl. the DD→NWP lifted-index fallback); the module owns logic + thresholds.

## Verification

- **Full suite: 2416 passed, 9 skipped** — no failures.
- New tests: `terrain_mask_for_level` (per-level matrix incl. NaN/buffer), a `compute_route_fronts` integration test (925 crossing suppressed over 1200 m terrain, 700 intact), and 7 `convection_realized` cases (the LSGS potential case, ML-CAPE/LI overrides, ICON no-LI default-realized, boundary values).
- Real-pack end-to-end re-checked: advisory still grades **GREEN** (the refactor is behavior-preserving).
- `test_hewson_precompute` fixture updated to patch `build_terrain_elevation` (the new SRTM entry point).

## Docs

`meteorology-decisions.md` §6 (shared-predicate note) + new **§7** (level-aware terrain: the ISA-height table, the LSGS-is-over-a-lake caveat, migration, validation needed).

Addresses #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)
