### PR TITLE
feat(flights): cruise speed as IAS → derive TAS for duration estimates (#224)

### DIFF
--- a/release-notes/issue-224-cruise-ias.json
+++ b/release-notes/issue-224-cruise-ias.json
@@ -1,0 +1,9 @@
+[
+  {
+    "date": "2026-06-08",
+    "title": "Cruise speed is now indicated airspeed (IAS)",
+    "category": "change",
+    "highlight": true,
+    "body": "The cruise **Speed** field on your aircraft and flight-default profiles is now labelled **Cruise Speed (IAS in kt)** and read as **indicated airspeed**. For time and distance estimates we convert it to **true airspeed (TAS)** at your selected cruise altitude using the ISA standard atmosphere — TAS is higher than IAS aloft (roughly +2% per 1,000 ft), so estimates now respond when you change altitude.\n\nBecause existing stored speeds are reinterpreted as IAS, **auto-calculated durations get a little shorter** at typical cruise altitudes (~13% shorter at 8,000 ft). Manually entered durations are untouched. Tap the new (i) button next to the speed field for the details."
+  }
+]

--- a/web/settings.html
+++ b/web/settings.html
@@ -63,7 +63,9 @@
           </div>
           <div class="form-row">
             <div class="form-group">
-              <label for="ac-speed">Cruise Speed (kt)</label>
+              <label for="ac-speed">Cruise Speed (IAS in kt)
+                <button class="metric-info-btn cruise-speed-info-btn" type="button" title="About cruise speed (IAS)" aria-label="About cruise speed (IAS)">i</button>
+              </label>
               <input type="number" id="ac-speed" placeholder="e.g. 170" min="10" max="500" class="input-narrow">
             </div>
             <div class="form-group">
@@ -285,7 +287,9 @@
               <input type="number" id="input-ceiling" value="18000" min="1000" max="45000" step="500" class="input-narrow">
             </div>
             <div class="form-group">
-              <label for="input-speed">Speed (kt)</label>
+              <label for="input-speed">Cruise Speed (IAS in kt)
+                <button class="metric-info-btn cruise-speed-info-btn" type="button" title="About cruise speed (IAS)" aria-label="About cruise speed (IAS)">i</button>
+              </label>
               <input type="number" id="input-speed" placeholder="e.g. 120" min="10" max="500" step="1" class="input-narrow">
             </div>
           </div>

--- a/web/tests/unit/atmo-utils.test.ts
+++ b/web/tests/unit/atmo-utils.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { iasToTasISA } from '../../ts/visualization/skewt/atmo-utils';
+
+describe('iasToTasISA', () => {
+  it('returns IAS unchanged at sea level (ISA datum)', () => {
+    expect(iasToTasISA(120, 0)).toBeCloseTo(120, 1);
+  });
+
+  it('matches the documented ~+13% TAS at 8000 ft', () => {
+    // 120 kt IAS @ 8000 ft → ~135 kt TAS (±1)
+    expect(iasToTasISA(120, 8000)).toBeCloseTo(135, 0);
+  });
+
+  it('increases monotonically with altitude', () => {
+    const ias = 120;
+    const tas0 = iasToTasISA(ias, 0);
+    const tas4k = iasToTasISA(ias, 4000);
+    const tas8k = iasToTasISA(ias, 8000);
+    const tas12k = iasToTasISA(ias, 12000);
+    expect(tas4k).toBeGreaterThan(tas0);
+    expect(tas8k).toBeGreaterThan(tas4k);
+    expect(tas12k).toBeGreaterThan(tas8k);
+  });
+
+  it('scales linearly with IAS at a fixed altitude', () => {
+    expect(iasToTasISA(200, 8000) / iasToTasISA(100, 8000)).toBeCloseTo(2, 5);
+  });
+
+  it('clamps negative altitudes to the sea-level datum', () => {
+    expect(iasToTasISA(120, -500)).toBeCloseTo(120, 5);
+  });
+});

--- a/web/tests/unit/atmo.test.ts
+++ b/web/tests/unit/atmo.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { iasToTasISA } from '../../ts/visualization/skewt/atmo-utils';
+import { iasToTasISA } from '../../ts/utils/atmo';
 
 describe('iasToTasISA', () => {
   it('returns IAS unchanged at sea level (ISA datum)', () => {

--- a/web/ts/flights-main.ts
+++ b/web/ts/flights-main.ts
@@ -22,6 +22,7 @@ import { showWelcomeWizard } from './components/welcome-wizard';
 import { initTheme } from './theme';
 import { initI18n, t } from './i18n/i18n';
 import { initInfoPopup } from './components/info-popup';
+import { iasToTasISA } from './visualization/skewt/atmo-utils';
 import {
   buildTimezoneOptions, localToUtc, utcToLocal, nearestMinuteOption,
 } from './utils/timezone';
@@ -41,6 +42,11 @@ let durationManuallyEdited = false;
 
 /** Cached waypoint info from the last route-distance response. */
 let lastWaypoints: WaypointInfo[] = [];
+
+/** Total route distance (nm) from the last route-distance response. Cached so the
+ *  duration estimate can be recomputed on altitude change without re-hitting the API
+ *  (distance is altitude-independent; only the IAS→TAS conversion is). */
+let lastTotalDistanceNm = 0;
 
 /** Build a reference Date from the currently selected date and UTC time selects. */
 function getRefDate(): Date {
@@ -126,22 +132,28 @@ async function fetchRouteAndUpdateUI(): Promise<void> {
 
     // Populate timezone dropdown from route waypoints
     populateTimezones(resp.waypoints);
+    lastTotalDistanceNm = resp.total_distance_nm;
 
-    // Auto-calculate duration from speed if not manually edited
-    if (!durationManuallyEdited) {
-      const profile = getSelectedProfile();
-      const speedKt = profile?.settings?.speed_kt;
-      if (speedKt && speedKt > 0) {
-        const durationHours = Math.ceil(resp.total_distance_nm / speedKt);
-        const durationInput = document.getElementById('input-duration') as HTMLInputElement;
-        if (durationInput) {
-          durationInput.value = String(durationHours);
-        }
-      }
-    }
+    recalcDurationEstimate();
   } catch (err) {
     console.error('Failed to fetch route distance:', err);
   }
+}
+
+/** Auto-calculate the duration field from the cached route distance and the
+ *  selected profile's cruise speed, unless the user has edited it manually.
+ *  speed_kt is the cruise IAS; we convert it to TAS at the selected cruise
+ *  altitude (ISA standard atmosphere) so distance ÷ TAS = still-air duration. */
+function recalcDurationEstimate(): void {
+  if (durationManuallyEdited || lastTotalDistanceNm <= 0) return;
+  const iasKt = getSelectedProfile()?.settings?.speed_kt;
+  if (!iasKt || iasKt <= 0) return;
+  const altFt = parseInt(
+    (document.getElementById('input-altitude') as HTMLInputElement)?.value || '8000', 10);
+  const tasKt = iasToTasISA(iasKt, altFt);
+  const durationHours = Math.ceil(lastTotalDistanceNm / tasKt);
+  const durationInput = document.getElementById('input-duration') as HTMLInputElement;
+  if (durationInput) durationInput.value = String(durationHours);
 }
 
 /** Populate the Recent Routes dropdown from the user's flight history.
@@ -765,6 +777,13 @@ async function init(): Promise<void> {
   durationInput?.addEventListener('input', () => {
     durationManuallyEdited = true;
   });
+
+  // --- Recompute the duration estimate when cruise altitude changes ---
+  // TAS (and therefore still-air duration) depends on altitude. Recompute from
+  // the cached route distance — no need to re-fetch (distance is altitude-independent).
+  // The recalc itself respects the durationManuallyEdited guard.
+  const altitudeInput = document.getElementById('input-altitude') as HTMLInputElement;
+  altitudeInput?.addEventListener('input', recalcDurationEstimate);
 
   // Update altitude/ceiling defaults and recalculate duration when profile changes
   const profileSelect = document.getElementById('input-profile') as HTMLSelectElement;

--- a/web/ts/flights-main.ts
+++ b/web/ts/flights-main.ts
@@ -22,7 +22,7 @@ import { showWelcomeWizard } from './components/welcome-wizard';
 import { initTheme } from './theme';
 import { initI18n, t } from './i18n/i18n';
 import { initInfoPopup } from './components/info-popup';
-import { iasToTasISA } from './visualization/skewt/atmo-utils';
+import { iasToTasISA } from './utils/atmo';
 import {
   buildTimezoneOptions, localToUtc, utcToLocal, nearestMinuteOption,
 } from './utils/timezone';

--- a/web/ts/i18n/locales/de.json
+++ b/web/ts/i18n/locales/de.json
@@ -621,6 +621,8 @@
   "page.settings.cruiseAltitude": "Reiseflughöhe (ft)",
   "page.settings.flightCeiling": "Gipfelhöhe (ft)",
   "page.settings.speed": "Reisegeschwindigkeit (IAS in kt)",
+  "settings.cruiseSpeedInfoTitle": "Reisegeschwindigkeit (IAS)",
+  "settings.cruiseSpeedInfoBody": "<p>Geben Sie Ihre Reisegeschwindigkeit als <strong>angezeigte Geschwindigkeit (IAS)</strong> in Knoten ein — den Wert, den Sie bei Reiseleistung am Fahrtmesser ablesen.</p><p>Für Zeit- und Streckenschätzungen rechnen wir die IAS in die <strong>wahre Geschwindigkeit (TAS)</strong> um, die in der Höhe größer ist (etwa +2 % je 1.000 ft). Wir verwenden die <strong>ISA-Standardatmosphäre</strong> in der gewählten Reisehöhe; eine Änderung der Höhe aktualisiert daher die Schätzung.</p>",
   "page.settings.forecastModels": "Vorhersagemodelle",
   "page.settings.forecastModelsHint": "Wählen Sie die NWP-Modelle für Briefings mit diesem Profil.",
   "page.settings.optionalServices": "Optionale Dienste",

--- a/web/ts/i18n/locales/de.json
+++ b/web/ts/i18n/locales/de.json
@@ -620,7 +620,7 @@
   "page.settings.vfrOnly": "Nur VFR",
   "page.settings.cruiseAltitude": "Reiseflughöhe (ft)",
   "page.settings.flightCeiling": "Gipfelhöhe (ft)",
-  "page.settings.speed": "Geschwindigkeit (kt)",
+  "page.settings.speed": "Reisegeschwindigkeit (IAS in kt)",
   "page.settings.forecastModels": "Vorhersagemodelle",
   "page.settings.forecastModelsHint": "Wählen Sie die NWP-Modelle für Briefings mit diesem Profil.",
   "page.settings.optionalServices": "Optionale Dienste",

--- a/web/ts/i18n/locales/en.json
+++ b/web/ts/i18n/locales/en.json
@@ -728,7 +728,7 @@
   "page.settings.vfrOnly": "VFR only",
   "page.settings.cruiseAltitude": "Cruise Altitude (ft)",
   "page.settings.flightCeiling": "Flight Ceiling (ft)",
-  "page.settings.speed": "Speed (kt)",
+  "page.settings.speed": "Cruise Speed (IAS in kt)",
   "page.settings.forecastModels": "Forecast Models",
   "page.settings.forecastModelsHint": "Select which NWP models to use for briefings with this profile.",
   "page.settings.optionalServices": "Optional Services",

--- a/web/ts/i18n/locales/en.json
+++ b/web/ts/i18n/locales/en.json
@@ -729,6 +729,8 @@
   "page.settings.cruiseAltitude": "Cruise Altitude (ft)",
   "page.settings.flightCeiling": "Flight Ceiling (ft)",
   "page.settings.speed": "Cruise Speed (IAS in kt)",
+  "settings.cruiseSpeedInfoTitle": "Cruise Speed (IAS)",
+  "settings.cruiseSpeedInfoBody": "<p>Enter your cruise speed as <strong>indicated airspeed (IAS)</strong> in knots — the number you read off the ASI at cruise power.</p><p>For time and distance estimates we convert IAS to <strong>true airspeed (TAS)</strong>, which is higher at altitude (roughly +2% per 1,000 ft). We use the <strong>ISA standard atmosphere</strong> at your selected cruise altitude, so changing the altitude updates the estimate.</p>",
   "page.settings.forecastModels": "Forecast Models",
   "page.settings.forecastModelsHint": "Select which NWP models to use for briefings with this profile.",
   "page.settings.optionalServices": "Optional Services",

--- a/web/ts/i18n/locales/es.json
+++ b/web/ts/i18n/locales/es.json
@@ -620,7 +620,7 @@
   "page.settings.vfrOnly": "Solo VFR",
   "page.settings.cruiseAltitude": "Altitud de crucero (ft)",
   "page.settings.flightCeiling": "Techo de vuelo (ft)",
-  "page.settings.speed": "Velocidad (kt)",
+  "page.settings.speed": "Velocidad de crucero (IAS en kt)",
   "page.settings.forecastModels": "Modelos de pronóstico",
   "page.settings.forecastModelsHint": "Seleccione qué modelos NWP usar para briefings con este perfil.",
   "page.settings.optionalServices": "Servicios opcionales",

--- a/web/ts/i18n/locales/es.json
+++ b/web/ts/i18n/locales/es.json
@@ -621,6 +621,8 @@
   "page.settings.cruiseAltitude": "Altitud de crucero (ft)",
   "page.settings.flightCeiling": "Techo de vuelo (ft)",
   "page.settings.speed": "Velocidad de crucero (IAS en kt)",
+  "settings.cruiseSpeedInfoTitle": "Velocidad de crucero (IAS)",
+  "settings.cruiseSpeedInfoBody": "<p>Introduzca su velocidad de crucero como <strong>velocidad indicada (IAS)</strong> en nudos — el valor que lee en el anemómetro a potencia de crucero.</p><p>Para las estimaciones de tiempo y distancia convertimos la IAS en <strong>velocidad verdadera (TAS)</strong>, que es mayor en altitud (aproximadamente +2 % por cada 1000 ft). Usamos la <strong>atmósfera estándar ISA</strong> a la altitud de crucero seleccionada, por lo que cambiar la altitud actualiza la estimación.</p>",
   "page.settings.forecastModels": "Modelos de pronóstico",
   "page.settings.forecastModelsHint": "Seleccione qué modelos NWP usar para briefings con este perfil.",
   "page.settings.optionalServices": "Servicios opcionales",

--- a/web/ts/i18n/locales/fr.json
+++ b/web/ts/i18n/locales/fr.json
@@ -621,6 +621,8 @@
   "page.settings.cruiseAltitude": "Altitude de croisière (ft)",
   "page.settings.flightCeiling": "Plafond de vol (ft)",
   "page.settings.speed": "Vitesse de croisière (IAS en kt)",
+  "settings.cruiseSpeedInfoTitle": "Vitesse de croisière (IAS)",
+  "settings.cruiseSpeedInfoBody": "<p>Saisissez votre vitesse de croisière en <strong>vitesse indiquée (IAS)</strong> en nœuds — la valeur lue sur l'anémomètre à la puissance de croisière.</p><p>Pour les estimations de temps et de distance, nous convertissons l'IAS en <strong>vitesse vraie (TAS)</strong>, plus élevée en altitude (environ +2 % par 1 000 ft). Nous utilisons l'<strong>atmosphère standard ISA</strong> à l'altitude de croisière choisie ; modifier l'altitude met donc à jour l'estimation.</p>",
   "page.settings.forecastModels": "Modèles de prévision",
   "page.settings.forecastModelsHint": "Sélectionnez les modèles NWP à utiliser pour les briefings avec ce profil.",
   "page.settings.optionalServices": "Services optionnels",

--- a/web/ts/i18n/locales/fr.json
+++ b/web/ts/i18n/locales/fr.json
@@ -620,7 +620,7 @@
   "page.settings.vfrOnly": "VFR uniquement",
   "page.settings.cruiseAltitude": "Altitude de croisière (ft)",
   "page.settings.flightCeiling": "Plafond de vol (ft)",
-  "page.settings.speed": "Vitesse (kt)",
+  "page.settings.speed": "Vitesse de croisière (IAS en kt)",
   "page.settings.forecastModels": "Modèles de prévision",
   "page.settings.forecastModelsHint": "Sélectionnez les modèles NWP à utiliser pour les briefings avec ce profil.",
   "page.settings.optionalServices": "Services optionnels",

--- a/web/ts/settings-main.ts
+++ b/web/ts/settings-main.ts
@@ -396,7 +396,13 @@ function translateStaticElements(): void {
   set('label[for="input-flight-rules"]', 'page.settings.flightRules');
   set('label[for="input-altitude"]', 'page.settings.cruiseAltitude');
   set('label[for="input-ceiling"]', 'page.settings.flightCeiling');
-  set('label[for="input-speed"]', 'page.settings.speed');
+  // Speed label carries an (i) info button child — set the text but keep the button.
+  const speedLabel = document.querySelector('label[for="input-speed"]');
+  if (speedLabel) {
+    const speedInfoBtn = speedLabel.querySelector('.cruise-speed-info-btn');
+    speedLabel.textContent = t('page.settings.speed') + ' ';
+    if (speedInfoBtn) speedLabel.appendChild(speedInfoBtn);
+  }
   // Forecast models section
   if (sections[2]) {
     const h3 = sections[2].querySelector('h3');
@@ -555,6 +561,18 @@ async function init(): Promise<void> {
   form?.addEventListener('submit', async (e) => {
     e.preventDefault();
     await handleSave();
+  });
+
+  // Cruise speed (IAS) info popup — wired on both the aircraft and flight-default speed labels
+  document.querySelectorAll('.cruise-speed-info-btn').forEach((btn) => {
+    btn.addEventListener('click', (e) => {
+      e.preventDefault();
+      showPopupContent(`
+        <h3 style="margin-top:0">Cruise Speed (IAS)</h3>
+        <p>Enter your cruise speed as <strong>indicated airspeed (IAS)</strong> in knots — the number you read off the ASI at cruise power.</p>
+        <p>For time and distance estimates we convert IAS to <strong>true airspeed (TAS)</strong>, which is higher at altitude (roughly +2% per 1,000 ft). We use the <strong>ISA standard atmosphere</strong> at your selected cruise altitude, so changing the altitude updates the estimate.</p>
+      `);
+    });
   });
 
   // Digest guidance info popup

--- a/web/ts/settings-main.ts
+++ b/web/ts/settings-main.ts
@@ -568,9 +568,8 @@ async function init(): Promise<void> {
     btn.addEventListener('click', (e) => {
       e.preventDefault();
       showPopupContent(`
-        <h3 style="margin-top:0">Cruise Speed (IAS)</h3>
-        <p>Enter your cruise speed as <strong>indicated airspeed (IAS)</strong> in knots — the number you read off the ASI at cruise power.</p>
-        <p>For time and distance estimates we convert IAS to <strong>true airspeed (TAS)</strong>, which is higher at altitude (roughly +2% per 1,000 ft). We use the <strong>ISA standard atmosphere</strong> at your selected cruise altitude, so changing the altitude updates the estimate.</p>
+        <h3 style="margin-top:0">${t('settings.cruiseSpeedInfoTitle')}</h3>
+        ${t('settings.cruiseSpeedInfoBody')}
       `);
     });
   });

--- a/web/ts/utils/atmo.ts
+++ b/web/ts/utils/atmo.ts
@@ -1,7 +1,8 @@
 /**
- * Standard atmosphere conversion utilities shared across Skew-T modules.
+ * ISA standard-atmosphere conversion utilities.
  *
- * Barometric formula (troposphere, T0=288.15K, L=0.0065K/m).
+ * Barometric formula (troposphere, T0=288.15K, L=0.0065K/m). General-purpose —
+ * consumed by the Skew-T modules and by the flights duration estimate.
  */
 
 /** Altitude (ft) → pressure (hPa). Returns null for negative altitudes. */

--- a/web/ts/visualization/skewt/atmo-utils.ts
+++ b/web/ts/visualization/skewt/atmo-utils.ts
@@ -16,3 +16,11 @@ export function pressureToAltitudeFt(pressureHPa: number): number {
   const altM = 288.15 / 0.0065 * (1 - Math.pow(pressureHPa / 1013.25, 1 / 5.2561));
   return altM * 3.28084;
 }
+
+/** Indicated airspeed (kt) → true airspeed (kt) under the ISA standard atmosphere at altFt.
+ *  TAS = IAS / √(ρ/ρ₀), where ρ/ρ₀ = (1 − L·altM/T0)^4.2561 in the ISA troposphere. */
+export function iasToTasISA(iasKt: number, altFt: number): number {
+  const altM = Math.max(0, altFt) / 3.28084;
+  const densityRatio = Math.pow(1 - 0.0065 * altM / 288.15, 4.2561);
+  return iasKt / Math.sqrt(densityRatio);
+}

--- a/web/ts/visualization/skewt/axes.ts
+++ b/web/ts/visualization/skewt/axes.ts
@@ -11,7 +11,7 @@
 import { SkewTTransform } from './skewt-transform';
 import { SoundingProfileData, PlotArea } from './types';
 import { isDarkTheme, cssVar } from '../interaction-utils';
-import { altitudeToPressure } from './atmo-utils';
+import { altitudeToPressure } from '../../utils/atmo';
 
 // Standard pressure levels to label on the Y-axis
 const PRESSURE_LABELS = [1000, 925, 850, 700, 500, 400, 300, 250];

--- a/web/ts/visualization/skewt/interaction.ts
+++ b/web/ts/visualization/skewt/interaction.ts
@@ -11,7 +11,7 @@ import type { SkewTTransform } from './skewt-transform';
 import type { SoundingProfileData, SoundingProfileLevel } from './types';
 import type { CompareModelDataset } from './compare-renderer';
 import { isDarkTheme } from '../interaction-utils';
-import { altitudeToPressure, pressureToAltitudeFt } from './atmo-utils';
+import { altitudeToPressure, pressureToAltitudeFt } from '../../utils/atmo';
 
 export interface SkewTInteractionCallbacks {
   /** Called with altitude in ft when hovering, undefined when leaving. */

--- a/web/ts/visualization/skewt/overlay-bands.ts
+++ b/web/ts/visualization/skewt/overlay-bands.ts
@@ -15,7 +15,7 @@ import type {
   IcingZone,
   InversionLayer,
 } from './types';
-import { altitudeToPressure } from './atmo-utils';
+import { altitudeToPressure } from '../../utils/atmo';
 
 // --- Cloud colors (matching cross-section theme) ---
 const CLOUD_DD_COLOR = 'rgba(140, 140, 150, ALPHA)';


### PR DESCRIPTION
Phase 1 of #224. The cruise **Speed** input is now treated as **indicated airspeed (IAS)** and converted to **true airspeed (TAS)** at the selected cruise altitude (ISA standard atmosphere) for the creation/edit-time duration auto-calc — instead of using the raw value as if it were already still-air TAS with no altitude correction.

Closes #224.

## What changed
- **Labels** → "Cruise Speed (IAS in kt)" in both places: the i18n key `page.settings.speed` (en/fr/de/es) and the two static `settings.html` labels (`input-speed`, `ac-speed`).
- **(i) info button** next to each speed label, reusing the existing `metric-info-btn` + `showPopupContent()` pattern, explaining the IAS→TAS conversion. The translate path preserves the button child (same approach as the aircraft-info label).
- **`iasToTasISA(iasKt, altFt)`** added to `web/ts/visualization/skewt/atmo-utils.ts` beside the existing ISA helpers — `TAS = IAS / √(ρ/ρ₀)` with the ISA troposphere density ratio.
- **Duration auto-calc** (`flights-main.ts`) now converts IAS→TAS at the current cruise altitude. Distance is cached so changing the altitude recomputes the estimate **without** re-fetching the route (distance is altitude-independent). The existing `durationManuallyEdited` guard is respected throughout.
- **Release note draft** (`release-notes/issue-224-cruise-ias.json`) for the one-time duration shift — existing stored speeds are reinterpreted as IAS, so auto-calc durations get ~13% shorter at 8,000 ft. No DB migration (label-only).

## Out of scope (Phase 2, deferred)
Real-atmosphere TAS (actual T/P at cruise level) and wind-corrected ground speed, once a briefing pack exists. The popup copy deliberately does **not** promise that behaviour yet.

## Testing
- `web/tests/unit/atmo-utils.test.ts`: `iasToTasISA(120,0)≈120`, `iasToTasISA(120,8000)≈135`, monotonic with altitude, linear in IAS, clamps negative altitude.
- Full frontend suite: 355 passed. `tsc --noEmit` clean. esbuild bundles build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)