### PR TITLE
feat(turbulence): EDR scale v0 — Sharman & Pearson remap + calibration accumulator (#221)

### DIFF
--- a/alembic/versions/063_edr_calibration_accumulator.py
+++ b/alembic/versions/063_edr_calibration_accumulator.py
@@ -34,7 +34,7 @@ def upgrade() -> None:
         sa.Column("n", sa.BigInteger, nullable=False, server_default="0"),
         sa.Column("sum_ln", sa.Double, nullable=False, server_default="0"),
         sa.Column("sum_ln2", sa.Double, nullable=False, server_default="0"),
-        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
         sa.UniqueConstraint("model", "diagnostic", "band", name="uq_edr_calib_key"),
     )
 

--- a/alembic/versions/063_edr_calibration_accumulator.py
+++ b/alembic/versions/063_edr_calibration_accumulator.py
@@ -1,0 +1,43 @@
+"""Add edr_calibration_accumulator table.
+
+Streaming ln-moment accumulator for the Sharman & Pearson (2017) EDR remap
+(issue #221). One row per (model, diagnostic, band) holding running sums of
+ln(D); coefficients are derived offline, samples are never stored.
+
+Revision ID: 063
+Revises: 062
+Create Date: 2026-06-08
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "063"
+down_revision: Union[str, None] = "062"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # create_table works on both SQLite and MySQL without batch mode.
+    # sum_ln / sum_ln2 are DOUBLE — they accumulate indefinitely across cycles
+    # and would lose precision in MySQL's single-precision FLOAT.
+    op.create_table(
+        "edr_calibration_accumulator",
+        sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),
+        sa.Column("model", sa.String(20), nullable=False),
+        sa.Column("diagnostic", sa.String(20), nullable=False),
+        sa.Column("band", sa.String(16), nullable=False),
+        sa.Column("n", sa.BigInteger, nullable=False, server_default="0"),
+        sa.Column("sum_ln", sa.Double, nullable=False, server_default="0"),
+        sa.Column("sum_ln2", sa.Double, nullable=False, server_default="0"),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.UniqueConstraint("model", "diagnostic", "band", name="uq_edr_calib_key"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("edr_calibration_accumulator")

--- a/src/weatherbrief/analysis/sounding/edr.py
+++ b/src/weatherbrief/analysis/sounding/edr.py
@@ -80,7 +80,8 @@ ALTITUDE_BANDS = ("0_10kft", "10_20kft", "20_45kft")
 ALL_BAND = "all"
 
 # Lower-bound on variance so SD never collapses to 0 (and b never explodes).
-_VAR_EPS = 1e-12
+# Public so the CLI readout can floor its display SD identically.
+VAR_EPS = 1e-12
 
 
 def band_for_altitude_ft(altitude_ft: float | None) -> str | None:
@@ -123,13 +124,13 @@ def coefficients_from_accumulator(
         return None
     mean = sum_ln / n
     var = sum_ln2 / n - mean * mean
-    sd = math.sqrt(max(var, _VAR_EPS))
+    sd = math.sqrt(max(var, VAR_EPS))
     b = c2 / sd
     a = c1 - b * mean
     return a, b
 
 
-def diagnostic_to_edr(d: float, a: float, b: float) -> float | None:
+def diagnostic_to_edr(d: float | None, a: float, b: float) -> float | None:
     """Apply the frozen remap: ``EDR = exp(a + b·ln D)``, clipped to [0, 1].
 
     Returns ``None`` for non-positive / non-finite ``D``.

--- a/src/weatherbrief/analysis/sounding/edr.py
+++ b/src/weatherbrief/analysis/sounding/edr.py
@@ -1,0 +1,211 @@
+"""EDR (Eddy Dissipation Rate) scale via the Sharman & Pearson (2017) remap.
+
+EDR (ε^1/3) is the ICAO-standard, aircraft-independent turbulence intensity
+that pilots see in tools like ForeFlight, banded roughly: <0.1 smooth,
+0.1–0.2 light, 0.2–0.45 moderate, 0.45–0.75 severe, >0.75 extreme.
+
+Rather than compute EDR from scratch (a GTG-style ensemble), we use the
+published **statistical remapping** of Sharman & Pearson (2017): any
+turbulence diagnostic ``D`` that is positive and *increases* with turbulence
+is mapped onto the lognormal EDR climatology with a log-linear fit::
+
+    ln(EDR) = a + b·ln(D)
+        b = C2 / SD[ln D]
+        a = C1 − b·⟨ln D⟩
+
+- ``⟨ln D⟩`` and ``SD[ln D]`` are the climatological mean and std of ``ln(D)``
+  computed from *our own* model output (pure moment-matching — no turbulence
+  ground truth / PIREPs needed). These are accumulated offline by
+  :class:`EdrAccumulator` as standalone soundings stream past, and persisted
+  as running sums in the ``edr_calibration_accumulator`` table.
+- ``C1``, ``C2`` are the published universal climatology of EDR (mean and std
+  of ``ln(EDR)`` from in-situ aircraft, 2009–2014); they are altitude-band
+  dependent. Values below are primary-source-verified from Kim et al. 2020
+  (AMT 13, 1373–1385), reproducing the Sharman & Pearson 2017 table.
+
+The calibration is a one-time / periodic *offline* exercise over a large
+multi-day, multi-airport sample — NOT recomputed per briefing. At runtime the
+coefficients ``a, b`` are fixed and we just apply
+``EDR = exp(a + b·ln D)``, clipped to ~[0, 1].
+
+Diagnostic for Richardson number
+--------------------------------
+Richardson number is the *inverse* of turbulence intensity (low Ri ⇒ turbulent)
+and ``compute_stability_indicators`` only assigns Ri when ``N² >= 0`` (so
+Ri ≥ 0). We therefore define the positive, turbulence-increasing diagnostic::
+
+    D_ri = 1 / max(Ri, RI_FLOOR)
+
+``RI_FLOOR`` caps ``D`` so a near-zero Ri does not blow up to infinity.
+
+Scope
+-----
+v0 covers the calibration accumulator + the Richardson remap. The C1/C2
+lognormal climatology is only valid down to 10 kft; below that (boundary
+layer) the operational method (Pearson & Sharman 2018) switches to a
+log-Weibull distribution for daytime/convective conditions. That regime is
+**out of scope** for v0 — the lowest band (0–10 kft) here uses the lognormal
+pair below and is therefore *approximate* for the convective boundary layer.
+
+References
+----------
+- Sharman & Pearson 2017, J. Appl. Meteor. Climatol. 56, 229–243.
+- Kim et al. 2020, AMT 13, 1373–1385 (open-access reproduction of C1/C2).
+- Pearson & Sharman 2018, JAMC 57(6) (boundary-layer log-Weibull, follow-up).
+"""
+
+from __future__ import annotations
+
+import math
+import threading
+
+# Diagnostic identifiers (room for "e_shear" in a follow-up).
+DIAGNOSTIC_RICHARDSON = "richardson"
+
+# Floor applied to Ri before inverting, so D = 1/max(Ri, RI_FLOOR) stays bounded.
+RI_FLOOR = 0.01
+
+# Published universal EDR climatology (mean, SD of ln EDR), per altitude band.
+# Kim et al. 2020 / Sharman & Pearson 2017. The ">45 kft" regime is clipped to
+# the 20–45 kft constants for now (see band_for_altitude_ft).
+C1_C2_BY_BAND: dict[str, tuple[float, float]] = {
+    "0_10kft": (-2.248, 0.4235),   # NOTE: approximate — convective BL wants log-Weibull (out of scope v0)
+    "10_20kft": (-2.578, 0.557),
+    "20_45kft": (-2.953, 0.602),
+    "all": (-2.572, 0.5067),       # all-altitude (>0 ft), sanity cross-check band
+}
+
+# Ordered list of altitude bands (excludes the "all" cross-check band).
+ALTITUDE_BANDS = ("0_10kft", "10_20kft", "20_45kft")
+ALL_BAND = "all"
+
+# Lower-bound on variance so SD never collapses to 0 (and b never explodes).
+_VAR_EPS = 1e-12
+
+
+def band_for_altitude_ft(altitude_ft: float | None) -> str | None:
+    """Return the altitude-band key for a level's geometric altitude (ft).
+
+    Bands: 0–10 kft, 10–20 kft, 20–45 kft. Levels above 45 kft are clipped
+    into the 20–45 kft band (its constants are the closest published pair).
+    Returns ``None`` only when altitude is unknown.
+    """
+    if altitude_ft is None or not math.isfinite(altitude_ft):
+        return None
+    kft = altitude_ft / 1000.0
+    if kft < 10.0:
+        return "0_10kft"
+    if kft < 20.0:
+        return "10_20kft"
+    return "20_45kft"  # includes >45 kft, clipped per v0 scope
+
+
+def richardson_to_d(ri: float | None) -> float | None:
+    """Map a Richardson number to the positive turbulence diagnostic ``D``.
+
+    ``D = 1 / max(Ri, RI_FLOOR)``. Returns ``None`` for missing/non-finite Ri
+    so the caller skips the level (no ``ln(D)`` is taken).
+    """
+    if ri is None or not math.isfinite(ri):
+        return None
+    return 1.0 / max(ri, RI_FLOOR)
+
+
+def coefficients_from_accumulator(
+    n: int, sum_ln: float, sum_ln2: float, c1: float, c2: float,
+) -> tuple[float, float] | None:
+    """Derive the remap coefficients ``(a, b)`` from accumulated ln-moments.
+
+    ``b = C2 / SD[ln D]``, ``a = C1 − b·⟨ln D⟩``. Returns ``None`` when there
+    are too few samples to estimate a variance (``n < 2``).
+    """
+    if n < 2:
+        return None
+    mean = sum_ln / n
+    var = sum_ln2 / n - mean * mean
+    sd = math.sqrt(max(var, _VAR_EPS))
+    b = c2 / sd
+    a = c1 - b * mean
+    return a, b
+
+
+def diagnostic_to_edr(d: float, a: float, b: float) -> float | None:
+    """Apply the frozen remap: ``EDR = exp(a + b·ln D)``, clipped to [0, 1].
+
+    Returns ``None`` for non-positive / non-finite ``D``.
+    """
+    if d is None or not math.isfinite(d) or d <= 0.0:
+        return None
+    edr = math.exp(a + b * math.log(d))
+    return min(max(edr, 0.0), 1.0)
+
+
+class EdrAccumulator:
+    """Thread-safe streaming accumulator of ``ln(D)`` moments for EDR calibration.
+
+    Holds running ``(n, Σ ln D, Σ (ln D)²)`` keyed by
+    ``(model, diagnostic, band)`` — constant memory, no per-sample archive.
+    The accumulated moments are independent of ``C1/C2``: if the target
+    climatology is later refined (e.g. log-Weibull low band), ``a, b`` are
+    re-derived from the *same* stored moments without re-accumulation.
+
+    Designed to be fed concurrently from the standalone fetch thread pool:
+    :meth:`observe_richardson_levels` computes one snapshot's partial sums
+    lock-free, then merges them under a single lock acquisition.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        # key -> [n, sum_ln, sum_ln2]
+        self._data: dict[tuple[str, str, str], list[float]] = {}
+
+    def observe_richardson_levels(self, model: str, derived_levels) -> None:
+        """Accumulate ln(D_ri) moments for every valid level of one sounding.
+
+        Samples the *full* distribution — every adjacent-level Ri, not only
+        layers flagged as turbulent — so the climatological mean is unbiased.
+        Each valid level contributes to both its altitude band and the ``all``
+        cross-check band. Non-finite / non-positive ``D`` levels are dropped.
+        """
+        partials: dict[tuple[str, str, str], list[float]] = {}
+        for lv in derived_levels:
+            ri = getattr(lv, "richardson_number", None)
+            d = richardson_to_d(ri)
+            if d is None or d <= 0.0:
+                continue
+            ln_d = math.log(d)
+            if not math.isfinite(ln_d):
+                continue
+            ln_d2 = ln_d * ln_d
+            band = band_for_altitude_ft(getattr(lv, "altitude_ft", None))
+            for key_band in (band, ALL_BAND):
+                if key_band is None:
+                    continue
+                key = (model, DIAGNOSTIC_RICHARDSON, key_band)
+                slot = partials.get(key)
+                if slot is None:
+                    partials[key] = [1.0, ln_d, ln_d2]
+                else:
+                    slot[0] += 1.0
+                    slot[1] += ln_d
+                    slot[2] += ln_d2
+
+        if not partials:
+            return
+        with self._lock:
+            for key, (n, s1, s2) in partials.items():
+                tot = self._data.get(key)
+                if tot is None:
+                    self._data[key] = [n, s1, s2]
+                else:
+                    tot[0] += n
+                    tot[1] += s1
+                    tot[2] += s2
+
+    def rows(self) -> list[tuple[str, str, str, int, float, float]]:
+        """Snapshot the accumulated moments as ``(model, diagnostic, band, n, sum_ln, sum_ln2)``."""
+        with self._lock:
+            return [
+                (model, diag, band, int(vals[0]), vals[1], vals[2])
+                for (model, diag, band), vals in self._data.items()
+            ]

--- a/src/weatherbrief/db/models.py
+++ b/src/weatherbrief/db/models.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from datetime import date as date_t, datetime, timezone
 
-from sqlalchemy import Boolean, Date, DateTime, Float, ForeignKey, Index, Integer, String, Text, UniqueConstraint
+from sqlalchemy import BigInteger, Boolean, Date, DateTime, Double, Float, ForeignKey, Index, Integer, String, Text, UniqueConstraint
 from sqlalchemy.dialects.mysql import MEDIUMTEXT
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -1027,5 +1027,40 @@ class VerificationCycleRow(Base):
     peak_rss_mb: Mapped[int | None] = mapped_column(Integer, nullable=True)
     # Peak total cgroup memory (parent + GRIB decode workers). Same caveat.
     peak_cgroup_mb: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
+
+class EdrCalibrationAccumulatorRow(Base):
+    """Streaming ln-moment accumulator for the Sharman & Pearson (2017) EDR remap.
+
+    One row per ``(model, diagnostic, band)``. Holds running Welford-style sums
+    of ``ln(D)`` for a turbulence diagnostic ``D`` (for ``diagnostic=richardson``,
+    ``D = 1/max(Ri, RI_FLOOR)``), accumulated over standalone-verification
+    soundings. The remap coefficients ``a, b`` for ``EDR = exp(a + b·ln D)`` are
+    derived offline from these moments plus the published C1/C2 climatology;
+    individual samples are never stored. See
+    :mod:`weatherbrief.analysis.sounding.edr`.
+
+    ``sum_ln`` / ``sum_ln2`` are DOUBLE (not single-precision FLOAT): these sums
+    accumulate across every cycle indefinitely, so they outgrow FLOAT's ~7
+    significant digits on MySQL.
+    """
+
+    __tablename__ = "edr_calibration_accumulator"
+    __table_args__ = (
+        UniqueConstraint("model", "diagnostic", "band", name="uq_edr_calib_key"),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    model: Mapped[str] = mapped_column(String(20), nullable=False)  # gfs / icon / ecmwf
+    diagnostic: Mapped[str] = mapped_column(String(20), nullable=False)  # richardson (room for e_shear)
+    band: Mapped[str] = mapped_column(String(16), nullable=False)  # 0_10kft / 10_20kft / 20_45kft / all
+    n: Mapped[int] = mapped_column(BigInteger, nullable=False, default=0)
+    sum_ln: Mapped[float] = mapped_column(Double, nullable=False, default=0.0)
+    sum_ln2: Mapped[float] = mapped_column(Double, nullable=False, default=0.0)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+    )
 
 

--- a/src/weatherbrief/tasks/edr_calibration.py
+++ b/src/weatherbrief/tasks/edr_calibration.py
@@ -1,0 +1,219 @@
+"""EDR calibration persistence + readout (issue #221).
+
+DB-facing companion to :mod:`weatherbrief.analysis.sounding.edr`:
+
+- :func:`flush_accumulator` — additively upsert one standalone run's
+  accumulated ln-moments into ``edr_calibration_accumulator``.
+- :func:`load_coefficients` — load the frozen remap coefficients ``(a, b)``
+  for a ``(model, band)`` at runtime.
+- a small CLI (``python -m weatherbrief.tasks.edr_calibration``) that dumps the
+  current moments, derived ``a, b``, and sample EDR at p50/p90/p99 of ``D`` so
+  a maintainer can eyeball whether the remap lands in sane severity bands.
+
+**v0 coefficient source.** Coefficients are derived *live from the table*
+(stored moments + the published C1/C2 climatology) via :func:`load_coefficients`.
+Hard-freezing them as committed constants is deliberately deferred: the
+accumulators need ~1–2 weeks of runs to converge, so frozen constants would be
+meaningless today. Once converged, a maintainer reads them off the CLI and may
+populate :data:`weatherbrief.analysis.sounding.edr` — but no display surface
+consumes EDR in v0, so nothing depends on the choice yet.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import math
+import sys
+from datetime import datetime, timezone
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from weatherbrief.analysis.sounding.edr import (
+    C1_C2_BY_BAND,
+    DIAGNOSTIC_RICHARDSON,
+    EdrAccumulator,
+    coefficients_from_accumulator,
+    diagnostic_to_edr,
+)
+from weatherbrief.db.models import EdrCalibrationAccumulatorRow
+
+logger = logging.getLogger(__name__)
+
+
+def flush_accumulator(db: Session, acc: EdrAccumulator) -> int:
+    """Additively upsert an accumulator's moments into the calibration table.
+
+    One UPDATE-add (or INSERT) per ``(model, diagnostic, band)`` key, committed
+    once. Additive so repeated cycles compose; the standalone cycle is a single
+    server-side process so there is no cross-process write race on a key.
+
+    Fails silent: calibration must never break a forecast run. Returns the
+    number of keys written (0 on empty accumulator or on error).
+    """
+    rows = acc.rows()
+    if not rows:
+        return 0
+    now = datetime.now(timezone.utc)
+    written = 0
+    try:
+        for model, diagnostic, band, n, sum_ln, sum_ln2 in rows:
+            if n <= 0:
+                continue
+            existing = db.execute(
+                select(EdrCalibrationAccumulatorRow)
+                .where(EdrCalibrationAccumulatorRow.model == model)
+                .where(EdrCalibrationAccumulatorRow.diagnostic == diagnostic)
+                .where(EdrCalibrationAccumulatorRow.band == band)
+            ).scalar_one_or_none()
+            if existing is not None:
+                existing.n += n
+                existing.sum_ln += sum_ln
+                existing.sum_ln2 += sum_ln2
+                existing.updated_at = now
+            else:
+                db.add(EdrCalibrationAccumulatorRow(
+                    model=model,
+                    diagnostic=diagnostic,
+                    band=band,
+                    n=n,
+                    sum_ln=sum_ln,
+                    sum_ln2=sum_ln2,
+                    updated_at=now,
+                ))
+            written += 1
+        db.commit()
+    except Exception:
+        logger.warning("EDR calibration flush failed, rolling back", exc_info=True)
+        db.rollback()
+        return 0
+    logger.info("EDR calibration: flushed %d (model, diagnostic, band) keys", written)
+    return written
+
+
+def load_coefficients(
+    db: Session, model: str, band: str, diagnostic: str = DIAGNOSTIC_RICHARDSON,
+) -> tuple[float, float] | None:
+    """Load the frozen remap coefficients ``(a, b)`` for one (model, band).
+
+    Reads the accumulated moments and derives ``a, b`` from them plus the
+    published C1/C2 climatology for the band. Returns ``None`` if the band is
+    unknown, the accumulator row is missing, or there are too few samples.
+    """
+    c1_c2 = C1_C2_BY_BAND.get(band)
+    if c1_c2 is None:
+        return None
+    row = db.execute(
+        select(EdrCalibrationAccumulatorRow)
+        .where(EdrCalibrationAccumulatorRow.model == model)
+        .where(EdrCalibrationAccumulatorRow.diagnostic == diagnostic)
+        .where(EdrCalibrationAccumulatorRow.band == band)
+    ).scalar_one_or_none()
+    if row is None:
+        return None
+    return coefficients_from_accumulator(row.n, row.sum_ln, row.sum_ln2, *c1_c2)
+
+
+# Standard-normal quantiles for the percentile readout.
+_Z = {"p50": 0.0, "p90": 1.2815515594, "p99": 2.3263478740}
+
+
+def _readout_rows(db: Session) -> list[dict]:
+    """Build the CLI readout: moments, derived a/b, and sample EDR percentiles.
+
+    Because ln(D) is modelled as Gaussian (that is the remap's own assumption),
+    the p50/p90/p99 of D follow directly from the moments — no sample archive
+    needed: ``ln(D_p) = ⟨ln D⟩ + z_p·SD[ln D]``.
+    """
+    rows = db.execute(
+        select(EdrCalibrationAccumulatorRow).order_by(
+            EdrCalibrationAccumulatorRow.model,
+            EdrCalibrationAccumulatorRow.diagnostic,
+            EdrCalibrationAccumulatorRow.band,
+        )
+    ).scalars().all()
+
+    out: list[dict] = []
+    for r in rows:
+        c1_c2 = C1_C2_BY_BAND.get(r.band)
+        mean = r.sum_ln / r.n if r.n else float("nan")
+        sd = float("nan")
+        if r.n >= 2:
+            var = r.sum_ln2 / r.n - mean * mean
+            sd = math.sqrt(max(var, 0.0))
+        coeffs = (
+            coefficients_from_accumulator(r.n, r.sum_ln, r.sum_ln2, *c1_c2)
+            if c1_c2 else None
+        )
+        entry = {
+            "model": r.model,
+            "diagnostic": r.diagnostic,
+            "band": r.band,
+            "n": r.n,
+            "mean_ln_d": mean,
+            "sd_ln_d": sd,
+            "a": coeffs[0] if coeffs else None,
+            "b": coeffs[1] if coeffs else None,
+            "edr": {},
+        }
+        if coeffs and math.isfinite(sd):
+            a, b = coeffs
+            for label, z in _Z.items():
+                d_p = math.exp(mean + z * sd)
+                entry["edr"][label] = diagnostic_to_edr(d_p, a, b)
+        out.append(entry)
+    return out
+
+
+def _format_readout(rows: list[dict]) -> str:
+    if not rows:
+        return "No EDR calibration data accumulated yet."
+    header = (
+        f"{'model':<8}{'diag':<12}{'band':<10}{'n':>12}"
+        f"{'<lnD>':>10}{'SD lnD':>10}{'a':>10}{'b':>10}"
+        f"{'EDR p50':>10}{'EDR p90':>10}{'EDR p99':>10}"
+    )
+    lines = [header, "-" * len(header)]
+
+    def fmt(v, prec=3):
+        return f"{v:.{prec}f}" if isinstance(v, (int, float)) and v == v else "—"
+
+    for r in rows:
+        edr = r["edr"]
+        lines.append(
+            f"{r['model']:<8}{r['diagnostic']:<12}{r['band']:<10}{r['n']:>12}"
+            f"{fmt(r['mean_ln_d']):>10}{fmt(r['sd_ln_d']):>10}"
+            f"{fmt(r['a']):>10}{fmt(r['b']):>10}"
+            f"{fmt(edr.get('p50')):>10}{fmt(edr.get('p90')):>10}{fmt(edr.get('p99')):>10}"
+        )
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m weatherbrief.tasks.edr_calibration",
+        description="Dump EDR calibration moments + derived remap coefficients.",
+    )
+    parser.add_argument(
+        "command", nargs="?", default="show", choices=["show"],
+        help="show: print current moments, a/b, and sample EDR percentiles.",
+    )
+    args = parser.parse_args(argv)
+
+    from flyfun_common.db import SessionLocal, get_engine
+
+    get_engine()  # configures SessionLocal's bind for standalone CLI use
+    db = SessionLocal()
+    try:
+        rows = _readout_rows(db)
+    finally:
+        db.close()
+
+    if args.command == "show":
+        print(_format_readout(rows))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/weatherbrief/tasks/edr_calibration.py
+++ b/src/weatherbrief/tasks/edr_calibration.py
@@ -33,6 +33,7 @@ from sqlalchemy.orm import Session
 from weatherbrief.analysis.sounding.edr import (
     C1_C2_BY_BAND,
     DIAGNOSTIC_RICHARDSON,
+    VAR_EPS,
     EdrAccumulator,
     coefficients_from_accumulator,
     diagnostic_to_edr,
@@ -141,7 +142,10 @@ def _readout_rows(db: Session) -> list[dict]:
         sd = float("nan")
         if r.n >= 2:
             var = r.sum_ln2 / r.n - mean * mean
-            sd = math.sqrt(max(var, 0.0))
+            # Floor at VAR_EPS to match coefficients_from_accumulator, so the
+            # percentile readout below uses the same SD the a/b math does (else
+            # near-zero variance collapses p50/p90/p99 to equal values).
+            sd = math.sqrt(max(var, VAR_EPS))
         coeffs = (
             coefficients_from_accumulator(r.n, r.sum_ln, r.sum_ln2, *c1_c2)
             if c1_c2 else None

--- a/src/weatherbrief/tasks/standalone_verification.py
+++ b/src/weatherbrief/tasks/standalone_verification.py
@@ -27,9 +27,11 @@ from weatherbrief.db.models import (
     VerificationObservationRow,
     VerificationScoreRow,
 )
+from weatherbrief.analysis.sounding.edr import EdrAccumulator
 from weatherbrief.process_memory_sampler import MemorySampler, MemoryPeaks
 from weatherbrief.process_rss import current_rss_mb, log_memory
 from weatherbrief.tasks.airport_watchlist import WatchlistAirport
+from weatherbrief.tasks.edr_calibration import flush_accumulator
 
 logger = logging.getLogger(__name__)
 
@@ -278,6 +280,7 @@ def _fetch_forecasts_for_model(
     airports: list[WatchlistAirport],
     session: requests.Session,
     sample_hours: list[int] | None = None,
+    edr_acc: "EdrAccumulator | None" = None,
 ) -> tuple[list[dict], int]:
     """Fetch Open-Meteo surface forecasts for all airports for one model.
 
@@ -399,7 +402,7 @@ def _fetch_forecasts_for_model(
                 }
 
                 # Run sounding analysis on pressure levels (already fetched)
-                _enrich_with_sounding(snap, hourly, model)
+                _enrich_with_sounding(snap, hourly, model, edr_acc=edr_acc)
 
                 chunk_results.append(snap)
         return chunk_results, client._thread_call_count()
@@ -444,10 +447,17 @@ def _fetch_forecasts_for_model(
     return all_results, client.call_count
 
 
-def _enrich_with_sounding(snap: dict, hourly, model: str) -> None:
+def _enrich_with_sounding(
+    snap: dict, hourly, model: str, edr_acc: "EdrAccumulator | None" = None,
+) -> None:
     """Run sounding analysis on pressure-level data and store results in snap dict.
 
     Fails silently — surface data is preserved even if sounding analysis fails.
+
+    When ``edr_acc`` is supplied (standalone calibration path only), the full
+    per-level Richardson distribution is fed into the EDR calibration
+    accumulator (issue #221). The accumulation shares this function's
+    fail-silent try, so it can never break a forecast run.
     """
     if not getattr(hourly, "pressure_levels", None):
         return
@@ -482,6 +492,12 @@ def _enrich_with_sounding(snap: dict, hourly, model: str) -> None:
         # Convective risk
         if sounding.convective and sounding.convective.risk_level is not None:
             snap["sounding_convective_risk"] = sounding.convective.risk_level.value
+
+        # EDR calibration: harvest the full per-level Richardson distribution
+        # (already computed, otherwise discarded) into the streaming
+        # accumulator. Standalone-only — None on the per-user briefing path.
+        if edr_acc is not None and sounding.derived_levels:
+            edr_acc.observe_richardson_levels(model, sounding.derived_levels)
 
     except Exception:
         logger.warning(
@@ -605,6 +621,7 @@ def fetch_ecmwf_grib_snapshots(
     airports: list[WatchlistAirport],
     sample_hours: list[int],
     days: int,
+    edr_acc: "EdrAccumulator | None" = None,
 ) -> list[dict]:
     """Decode an ECMWF run on disk into standalone-snapshot dicts.
 
@@ -781,7 +798,7 @@ def fetch_ecmwf_grib_snapshots(
                             cloud_cover_low_pct=snap_fields.get("cloud_cover_low_pct"),
                             pressure_levels=levels,
                         )
-                        _enrich_with_sounding(snap, hourly, "ecmwf")
+                        _enrich_with_sounding(snap, hourly, "ecmwf", edr_acc=edr_acc)
 
                 snapshots.append(snap)
 
@@ -1188,6 +1205,12 @@ def run_standalone_cycle(
         _rss_log(f"start ({cycle_type})")
 
         if fetch_forecasts:
+            # EDR calibration accumulator (issue #221): harvests the per-level
+            # Richardson distribution already computed during sounding analysis
+            # into running ln-moments, flushed once after the fetch loop. Cheap
+            # (a few float ops per level) and fail-silent.
+            edr_acc = EdrAccumulator()
+
             # Phase A+B: Fetch and store forecasts per model. One model at a
             # time to bound memory — each model's snapshots are stored and
             # freed before the next fetch.
@@ -1237,6 +1260,7 @@ def run_standalone_cycle(
                         grib_run_files, airports,
                         SAMPLE_HOURS_UTC,
                         MODEL_FORECAST_DAYS.get(model, 4),
+                        edr_acc=edr_acc,
                     )
                     api_calls = 0
                     logger.info(
@@ -1247,7 +1271,7 @@ def run_standalone_cycle(
                     logger.info("Fetching %s forecasts (init %s) for %d airports",
                                 model, init_time, len(airports))
                     snapshots, api_calls = _fetch_forecasts_for_model(
-                        model, init_time, airports, session,
+                        model, init_time, airports, session, edr_acc=edr_acc,
                     )
                     total_api_calls += api_calls
                     logger.info("Model %s: %d snapshot values from Open-Meteo (%d API calls)",
@@ -1262,6 +1286,10 @@ def run_standalone_cycle(
                 del snapshots
                 models_fetched += 1
                 _rss_log(f"after {model}")
+
+            # Single batched, additive upsert of this run's EDR ln-moments.
+            # Fail-silent inside flush_accumulator — never aborts the cycle.
+            flush_accumulator(db, edr_acc)
         else:
             logger.info("Skipping forecast fetch (score-only cycle)")
 

--- a/tests/test_edr.py
+++ b/tests/test_edr.py
@@ -1,0 +1,172 @@
+"""Tests for the EDR (Sharman & Pearson 2017) remap + calibration (issue #221)."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from weatherbrief.analysis.sounding.edr import (
+    ALL_BAND,
+    C1_C2_BY_BAND,
+    DIAGNOSTIC_RICHARDSON,
+    RI_FLOOR,
+    EdrAccumulator,
+    band_for_altitude_ft,
+    coefficients_from_accumulator,
+    diagnostic_to_edr,
+    richardson_to_d,
+)
+
+
+class _Level:
+    """Minimal stand-in for DerivedLevel (only the fields edr.py reads)."""
+
+    def __init__(self, richardson_number=None, altitude_ft=None):
+        self.richardson_number = richardson_number
+        self.altitude_ft = altitude_ft
+
+
+# --------------------------------------------------------------------------
+# band_for_altitude_ft
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize("alt,expected", [
+    (0, "0_10kft"),
+    (9_999, "0_10kft"),
+    (10_000, "10_20kft"),
+    (19_999, "10_20kft"),
+    (20_000, "20_45kft"),
+    (45_000, "20_45kft"),
+    (60_000, "20_45kft"),  # >45 kft clipped into the top band (v0 scope)
+])
+def test_band_for_altitude_ft_boundaries(alt, expected):
+    assert band_for_altitude_ft(alt) == expected
+
+
+def test_band_for_altitude_ft_unknown():
+    assert band_for_altitude_ft(None) is None
+    assert band_for_altitude_ft(float("nan")) is None
+
+
+# --------------------------------------------------------------------------
+# richardson_to_d
+# --------------------------------------------------------------------------
+
+def test_richardson_to_d_inverse():
+    assert richardson_to_d(1.0) == pytest.approx(1.0)
+    assert richardson_to_d(2.0) == pytest.approx(0.5)
+
+
+def test_richardson_to_d_floor_caps_small_ri():
+    # Ri below the floor is clamped so D doesn't blow up.
+    assert richardson_to_d(0.0) == pytest.approx(1.0 / RI_FLOOR)
+    assert richardson_to_d(1e-9) == pytest.approx(1.0 / RI_FLOOR)
+
+
+def test_richardson_to_d_rejects_missing_or_nonfinite():
+    assert richardson_to_d(None) is None
+    assert richardson_to_d(float("nan")) is None
+    assert richardson_to_d(float("inf")) is None
+
+
+# --------------------------------------------------------------------------
+# coefficients_from_accumulator + diagnostic_to_edr
+# --------------------------------------------------------------------------
+
+def test_coefficients_need_two_samples():
+    assert coefficients_from_accumulator(0, 0.0, 0.0, -2.5, 0.5) is None
+    assert coefficients_from_accumulator(1, 1.0, 1.0, -2.5, 0.5) is None
+
+
+def test_coefficients_match_moment_formula():
+    # Construct moments for a known ln(D): mean=1.0, var=4.0 (sd=2.0).
+    n, mean, sd = 100, 1.0, 2.0
+    sum_ln = n * mean
+    sum_ln2 = n * (sd * sd + mean * mean)
+    c1, c2 = -2.5, 0.6
+    a, b = coefficients_from_accumulator(n, sum_ln, sum_ln2, c1, c2)
+    assert b == pytest.approx(c2 / sd)
+    assert a == pytest.approx(c1 - b * mean)
+
+
+def test_remap_maps_geometric_mean_to_exp_c1():
+    # At D = exp(<lnD>), the remap gives exactly exp(C1) (the climatological
+    # median EDR) regardless of spread — the core invariant of the method.
+    n, mean, sd = 1000, 0.7, 1.3
+    sum_ln = n * mean
+    sum_ln2 = n * (sd * sd + mean * mean)
+    c1, c2 = -2.578, 0.557
+    a, b = coefficients_from_accumulator(n, sum_ln, sum_ln2, c1, c2)
+    edr_at_median = diagnostic_to_edr(math.exp(mean), a, b)
+    assert edr_at_median == pytest.approx(math.exp(c1), rel=1e-9)
+
+
+def test_diagnostic_to_edr_clips_and_filters():
+    a, b = -2.5, 0.5
+    # Huge D would exceed 1.0 → clipped.
+    assert diagnostic_to_edr(1e9, a, b) == 1.0
+    # Non-positive / non-finite D rejected.
+    assert diagnostic_to_edr(0.0, a, b) is None
+    assert diagnostic_to_edr(-1.0, a, b) is None
+    assert diagnostic_to_edr(float("inf"), a, b) is None
+
+
+def test_remap_monotonic_increasing_in_d():
+    a, b = coefficients_from_accumulator(
+        500, 500 * 0.5, 500 * (1.0 + 0.25), *C1_C2_BY_BAND["all"]
+    )
+    vals = [diagnostic_to_edr(d, a, b) for d in (0.5, 1.0, 5.0, 50.0)]
+    assert all(x < y for x, y in zip(vals, vals[1:]))
+
+
+# --------------------------------------------------------------------------
+# EdrAccumulator
+# --------------------------------------------------------------------------
+
+def test_accumulator_counts_band_and_all():
+    acc = EdrAccumulator()
+    # Two valid levels in the 10-20 kft band, plus one invalid (None Ri).
+    acc.observe_richardson_levels("gfs", [
+        _Level(richardson_number=1.0, altitude_ft=12_000),
+        _Level(richardson_number=4.0, altitude_ft=15_000),
+        _Level(richardson_number=None, altitude_ft=14_000),
+    ])
+    rows = {(m, diag, band): (n, s1, s2) for m, diag, band, n, s1, s2 in acc.rows()}
+
+    band_key = ("gfs", DIAGNOSTIC_RICHARDSON, "10_20kft")
+    all_key = ("gfs", DIAGNOSTIC_RICHARDSON, ALL_BAND)
+    assert band_key in rows and all_key in rows
+    # Each valid level counted once in its band and once in "all".
+    assert rows[band_key][0] == 2
+    assert rows[all_key][0] == 2
+
+    # ln(D): D=1/1=1 → ln 0; D=1/4=0.25 → ln(0.25).
+    expected_sum = math.log(1.0) + math.log(0.25)
+    assert rows[band_key][1] == pytest.approx(expected_sum)
+    assert rows[band_key][2] == pytest.approx(math.log(0.25) ** 2)
+
+
+def test_accumulator_separates_models():
+    acc = EdrAccumulator()
+    acc.observe_richardson_levels("gfs", [_Level(2.0, 12_000)])
+    acc.observe_richardson_levels("icon", [_Level(2.0, 12_000)])
+    models = {m for m, _, _, _, _, _ in acc.rows()}
+    assert models == {"gfs", "icon"}
+
+
+def test_accumulator_level_without_altitude_still_counts_all():
+    acc = EdrAccumulator()
+    acc.observe_richardson_levels("gfs", [_Level(richardson_number=1.0, altitude_ft=None)])
+    rows = {(m, diag, band): n for m, diag, band, n, *_ in acc.rows()}
+    # No altitude band, but the "all" cross-check band still gets the sample.
+    assert rows.get(("gfs", DIAGNOSTIC_RICHARDSON, ALL_BAND)) == 1
+    assert all(band == ALL_BAND for _, _, band in rows)
+
+
+def test_accumulator_additive_across_calls():
+    acc = EdrAccumulator()
+    acc.observe_richardson_levels("gfs", [_Level(1.0, 5_000)])
+    acc.observe_richardson_levels("gfs", [_Level(1.0, 5_000)])
+    rows = {(m, diag, band): n for m, diag, band, n, *_ in acc.rows()}
+    assert rows[("gfs", DIAGNOSTIC_RICHARDSON, "0_10kft")] == 2

--- a/tests/test_edr_calibration.py
+++ b/tests/test_edr_calibration.py
@@ -1,0 +1,99 @@
+"""Tests for EDR calibration persistence + readout (issue #221)."""
+
+from __future__ import annotations
+
+import pytest
+
+from weatherbrief.analysis.sounding.edr import DIAGNOSTIC_RICHARDSON, EdrAccumulator
+from weatherbrief.db.models import EdrCalibrationAccumulatorRow
+from weatherbrief.tasks.edr_calibration import (
+    _readout_rows,
+    flush_accumulator,
+    load_coefficients,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_edr_table(db_session):
+    # flush_accumulator commits (the real table accumulates indefinitely), so
+    # committed rows survive db_session's rollback on the shared in-memory
+    # engine. Wipe the table before each test for isolation.
+    db_session.query(EdrCalibrationAccumulatorRow).delete()
+    db_session.commit()
+    yield
+
+
+class _Level:
+    def __init__(self, richardson_number=None, altitude_ft=None):
+        self.richardson_number = richardson_number
+        self.altitude_ft = altitude_ft
+
+
+def _seed(acc, model="gfs"):
+    # Spread of Ri values across one band so variance is non-zero.
+    acc.observe_richardson_levels(model, [
+        _Level(0.5, 12_000),
+        _Level(1.0, 13_000),
+        _Level(2.0, 14_000),
+        _Level(5.0, 15_000),
+    ])
+
+
+def test_flush_inserts_then_adds_idempotently(db_session):
+    acc = EdrAccumulator()
+    _seed(acc)
+    written = flush_accumulator(db_session, acc)
+    assert written >= 1
+
+    rows = db_session.query(EdrCalibrationAccumulatorRow).all()
+    by_band = {r.band: r for r in rows}
+    assert "10_20kft" in by_band and "all" in by_band
+    n_first = by_band["10_20kft"].n
+    s1_first = by_band["10_20kft"].sum_ln
+
+    # A second run's moments must ADD to the existing row, not replace it.
+    acc2 = EdrAccumulator()
+    _seed(acc2)
+    flush_accumulator(db_session, acc2)
+
+    row = (
+        db_session.query(EdrCalibrationAccumulatorRow)
+        .filter_by(model="gfs", diagnostic=DIAGNOSTIC_RICHARDSON, band="10_20kft")
+        .one()
+    )
+    assert row.n == n_first * 2
+    assert row.sum_ln == pytest.approx(s1_first * 2)
+
+
+def test_flush_empty_accumulator_is_noop(db_session):
+    assert flush_accumulator(db_session, EdrAccumulator()) == 0
+    assert db_session.query(EdrCalibrationAccumulatorRow).count() == 0
+
+
+def test_load_coefficients_roundtrip(db_session):
+    acc = EdrAccumulator()
+    _seed(acc)
+    flush_accumulator(db_session, acc)
+
+    coeffs = load_coefficients(db_session, "gfs", "10_20kft")
+    assert coeffs is not None
+    a, b = coeffs
+    assert b > 0  # diagnostic increases with turbulence → positive slope
+
+    # Unknown band / missing row → None.
+    assert load_coefficients(db_session, "gfs", "not_a_band") is None
+    assert load_coefficients(db_session, "icon", "10_20kft") is None
+
+
+def test_readout_reports_edr_percentiles(db_session):
+    acc = EdrAccumulator()
+    _seed(acc)
+    flush_accumulator(db_session, acc)
+
+    readout = _readout_rows(db_session)
+    assert readout
+    entry = next(r for r in readout if r["band"] == "10_20kft")
+    assert entry["a"] is not None and entry["b"] is not None
+    # Percentiles present and monotonically non-decreasing p50 ≤ p90 ≤ p99.
+    p50, p90, p99 = entry["edr"]["p50"], entry["edr"]["p90"], entry["edr"]["p99"]
+    assert 0.0 <= p50 <= p90 <= p99 <= 1.0


### PR DESCRIPTION
Implements **issue #221 v0**: the EDR (Eddy Dissipation Rate) calibration accumulator + the Richardson remap. No user-facing output yet (display/advisory/E-Shear are explicit follow-ups in the issue).

## Why this is cheap (verified before building)
The standalone verification pipeline **already** computes a Richardson number for every adjacent pressure-level pair on every run (`vertical_motion.py:122`), inside `analyze_sounding_lite` → `_enrich_with_sounding`. Today those per-level `Ri` values are used for the thermodynamic summary then **discarded**. This PR harvests that existing distribution into streaming `ln(D)` moments.

- **No new data fetch** — reads values already in memory.
- **No new heavy calc** — per level: `D = 1/max(Ri, 0.01)`, one `ln`, three running sums.
- **No storage growth** — Welford accumulators → ~12 rows total, **one** batched additive upsert per cycle.
- **Standalone-only** — the per-user briefing/alternates path (which calls the same fetch fns) passes no accumulator, so it's untouched.

## What's here
- `analysis/sounding/edr.py` — per-band C₁/C₂ climatology (Kim et al. 2020), `band_for_altitude_ft`, `richardson_to_d`, `coefficients_from_accumulator`, `diagnostic_to_edr`, and a thread-safe `EdrAccumulator`.
- `db/models.py` + **migration 063** — `edr_calibration_accumulator (model, diagnostic, band) → n/sum_ln/sum_ln2`. `sum_ln*` are **DOUBLE** (they accumulate indefinitely → single-precision MySQL FLOAT would lose precision). Verified upgrade+downgrade on SQLite and DDL render on MySQL.
- `tasks/standalone_verification.py` — fail-silent accumulation in `_enrich_with_sounding` (optional `edr_acc`), single flush after the fetch loop. Skipped-because-already-stored models are never re-accumulated (no double-counting).
- `tasks/edr_calibration.py` — additive `flush_accumulator`, `load_coefficients` (derived **live** from stored moments + published C₁/C₂), and `python -m weatherbrief.tasks.edr_calibration show` readout (moments, a/b, sample EDR at p50/p90/p99 — derived analytically from the lognormal moments, no sample archive).
- Tests: `test_edr.py` (math + accumulator), `test_edr_calibration.py` (DB flush/load/readout).

## v0 coefficient source
Coefficients are derived **live from the table**, not hard-frozen. The accumulators need ~1–2 weeks of runs to converge, so committing constants today would be meaningless. Once converged, a maintainer reads them off the CLI and may freeze them — but nothing consumes EDR in v0, so the choice has no downstream dependency yet.

## Acceptance criteria
- [x] `edr_calibration_accumulator` table + migration 063 (SQLite + MySQL)
- [x] Standalone runs accumulate per-`(model, band)` ln-moments, fail-silent, single batched upsert
- [x] `edr.py` with C₁/C₂ table, `coefficients_from_accumulator`, `diagnostic_to_edr`, unit-tested
- [x] CLI readout of moments + a/b + sample EDR percentiles
- [x] No user-facing change; no standalone-pipeline regression (existing standalone/ECMWF/alternates tests green)

## Out of scope (follow-ups, per issue)
Display/advisory/digest integration · E-Shear remap · boundary-layer (<10 kft) log-Weibull · validation vs observed turbulence.

Closes #221

🤖 Generated with [Claude Code](https://claude.com/claude-code)