### PR TITLE
feat(fetch): parse-time hour_filter for fetch_multi_point (#236)

### DIFF
--- a/designs/grib-decode-dispatcher.md
+++ b/designs/grib-decode-dispatcher.md
@@ -37,6 +37,7 @@ Propagation mirrors the existing `_GRIB_TIMER` pattern via a `ContextVar` `_DECO
   - `api/airport_profile.py`: `enrich_forecasts(priority=INTERACTIVE)`.
   - `scheduler.py` `_auto_refresh_one`: SCHEDULED. `_run_standalone_once`: BACKGROUND (runs in `asyncio.to_thread`, which copies the context).
   - `tasks/standalone_verification.py`: both `_dispatch_decode` calls pass `priority=BACKGROUND` explicitly (their decode runs off the standalone context).
+  - `tasks/standalone_grib.py`: the GFS/ICON cloud-diag adapter dispatches by cache path with `priority=BACKGROUND` (#236 — it previously called the decode functions directly in the orchestrating process, putting cfgrib/xarray full-grid decode on that process's heap). Note: scheduled standalone cycles now run in a subprocess with `GRIB_DECODE_WORKERS=0`, so these dispatches execute inline in the disposable child; the pool path still applies for in-process fallback (`STANDALONE_SUBPROCESS=0`) and manual CLI runs.
   - Precache (`scheduler.py`): download-only, no decode → nothing to prioritise.
 
 ## Dispatcher architecture

--- a/designs/metar-taf-accuracy.md
+++ b/designs/metar-taf-accuracy.md
@@ -242,6 +242,8 @@ During scoring (Phase D), `_build_sounding_proxy()` reconstructs a minimal `Soun
 
 Standalone fetches surface + pressure-level variables for ~830 airports per full cycle. Requests are chunked into batches of 100 airports per Open-Meteo call (`_OPEN_METEO_BATCH_SIZE`). Chunk-level retry: up to 3 attempts with exponential backoff.
 
+**Parse-time hour filtering (#236)**: the fetch passes `hour_filter=SAMPLE_HOURS_UTC` to `OpenMeteoClient.fetch_multi_point`, so only sample-hour slots are materialised as `HourlyForecast`/`PressureLevelData` objects. Without it, ~80% of the 4-day hourly response (28 pressure levels for GFS) was parsed into Pydantic objects only to be discarded — and stayed alive across the chunk's sounding analysis in up to 4 concurrent threads, dominating the fetch phase's transient memory. The wire payload still contains every hour; the filter bounds parse memory, not bandwidth.
+
 ### Scheduler Integration
 
 The standalone subsystem now runs as **three independent loops** (disable individually with the matching env flag):
@@ -251,6 +253,20 @@ The standalone subsystem now runs as **three independent loops** (disable indivi
 - **Verification** (`run_standalone_verification_loop`, `DISABLE_STANDALONE_VERIFICATION=1`) — fires at `VERIFICATION_HOURS_UTC = [6, 9, 12, 15, 18]`. Runs `run_standalone_cycle(fetch_forecasts=False, score_observations=True)`, scoring stored snapshots against whatever observations the ingest loop has persisted (most recent fetch wins).
 
 The hour-keyed loops compute the next fire hour and sleep until then (no polling), retry after 15 min on failure, use a 240 s startup delay, and trigger `cache_builder.rebuild_all` (after `rollup_today_and_pending`) on each successful verification cycle. The legacy combined cycle (`fetch_forecasts=True, score_observations=True`, cycle source `standalone_full`) is still callable from CLI/tests but is no longer scheduled.
+
+### Subprocess isolation (issue #236)
+
+Forecast and verification cycles run in a **short-lived child process**, not in the uvicorn process: `scheduler._run_standalone_cycle_supervised` spawns `python -m weatherbrief.verify standalone --forecast-only|--light --with-rollup --background` and waits on it. Why: the forecast cycle's transient working set (concurrent Open-Meteo chunk parsing + ~46K sounding analyses) ratcheted the uvicorn heap high-water mark; CPython/glibc never return that peak to the OS, so it became ~3 GB of permanent anon that the host swapped. The child returns the entire peak on exit.
+
+Mechanics worth knowing:
+
+- **Same code path as manual debugging** — the child *is* the CLI, so worktree reproduction is literally the production command.
+- `--with-rollup` runs `run_post_cycle_tasks` (daily-stats rollup + cache rebuild, shared with the in-process fallback) inside the child, keeping that memory out of the parent too.
+- `--background` renices the child and raises its `oom_score_adj`, so a cgroup OOM mid-cycle kills the disposable child, not the web process.
+- The child gets `GRIB_DECODE_WORKERS=0` (inline decode) — no second decode pool inside the cgroup; decode priority is moot since the child doesn't share a pool with interactive briefings.
+- Supervisor enforces a hard timeout (`STANDALONE_SUBPROCESS_TIMEOUT_S`, default 3 h) and records a failed `verification_cycles` row for children that die without writing one (SIGKILL/timeout never reach the in-cycle exception path); rows the child already wrote are not duplicated.
+- **Rollback switch**: `STANDALONE_SUBPROCESS=0` reverts to the old in-process `asyncio.to_thread` path.
+- `peak_rss_mb` on cycle rows now measures the child process (clean per-cycle attribution); `peak_cgroup_mb` semantics are unchanged. The 30-min METAR ingest stays in-process — too cheap to justify 48 spawns/day.
 
 ## Verification Stats & Digest
 

--- a/src/weatherbrief/fetch/open_meteo.py
+++ b/src/weatherbrief/fetch/open_meteo.py
@@ -389,8 +389,11 @@ class OpenMeteoClient:
                     endpoint.pressure_levels,
                 )
                 for i, ts in enumerate(timestamps)
-                if hour_filter is None
-                or datetime.fromisoformat(ts).hour in hour_filter
+                # Slice instead of fromisoformat: timestamps are always ISO
+                # "YYYY-MM-DDTHH:MM" (timezone=UTC is hardcoded above), and
+                # this runs per timestamp per point — no need to allocate a
+                # datetime just to read the hour.
+                if hour_filter is None or int(ts[11:13]) in hour_filter
             ]
 
             # Build a synthetic Waypoint for this route point

--- a/src/weatherbrief/fetch/open_meteo.py
+++ b/src/weatherbrief/fetch/open_meteo.py
@@ -284,6 +284,7 @@ class OpenMeteoClient:
         start_date: str | None = None,
         end_date: str | None = None,
         chunk_size: int | None = None,
+        hour_filter: set[int] | None = None,
     ) -> list[WaypointForecast]:
         """Fetch forecast for multiple points, chunking to avoid URL limits.
 
@@ -294,6 +295,14 @@ class OpenMeteoClient:
         ``chunk_size`` overrides the default max points per request.  Callers
         with short parameter lists (e.g. a single pressure level) can safely
         use larger chunks since URL length is the real constraint.
+
+        ``hour_filter`` keeps only hourly slots whose UTC hour is in the set,
+        applied *before* parsing — skipped hours never materialise as
+        ``HourlyForecast``/``PressureLevelData`` objects. The standalone
+        verification cycle samples 5 of every 24 hours, and parsing the full
+        response into Pydantic models was the dominant transient memory cost
+        of its fetch phase (issue #236). The wire payload still contains every
+        hour; this bounds parse memory, not bandwidth.
 
         Returns one ``WaypointForecast`` per input point, in the same order.
         """
@@ -320,6 +329,7 @@ class OpenMeteoClient:
             chunk_results = self._fetch_multi_point_chunk(
                 chunk, model, endpoint,
                 start_date=start_date, end_date=end_date,
+                hour_filter=hour_filter,
             )
             results.extend(chunk_results)
 
@@ -339,6 +349,7 @@ class OpenMeteoClient:
         *,
         start_date: str | None = None,
         end_date: str | None = None,
+        hour_filter: set[int] | None = None,
     ) -> list[WaypointForecast]:
         """Fetch forecast for a single chunk of points."""
         hourly_params = build_hourly_params(endpoint)
@@ -378,6 +389,8 @@ class OpenMeteoClient:
                     endpoint.pressure_levels,
                 )
                 for i, ts in enumerate(timestamps)
+                if hour_filter is None
+                or datetime.fromisoformat(ts).hour in hour_filter
             ]
 
             # Build a synthetic Waypoint for this route point

--- a/src/weatherbrief/scheduler.py
+++ b/src/weatherbrief/scheduler.py
@@ -17,6 +17,8 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import sys
+import time
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -885,10 +887,10 @@ async def run_forecast_fetch_loop(app_state) -> None:
             await asyncio.sleep(sleep_secs)
             await asyncio.sleep(_FORECAST_FETCH_HOUR_OFFSET_SECONDS)
             await _wait_for_marker_freshness(_FORECAST_FETCH_FRESHNESS_WAIT_MAX_SECONDS)
-            await asyncio.to_thread(
-                _run_standalone_once, app_state,
-                True,   # fetch_forecasts
-                False,  # score_observations
+            await _run_standalone_cycle_supervised(
+                app_state,
+                fetch_forecasts=True,
+                score_observations=False,
             )
             await asyncio.sleep(60)  # advance past the current hour
         except Exception:
@@ -960,10 +962,10 @@ async def run_standalone_verification_loop(app_state) -> None:
             # Offset by 15 min so the HH:00 METAR ingest (~30-60s fetch) has
             # fully landed before scoring picks the nearest obs.
             await asyncio.sleep(_VERIFICATION_HOUR_OFFSET_SECONDS)
-            await asyncio.to_thread(
-                _run_standalone_once, app_state,
-                False,  # fetch_forecasts
-                True,   # score_observations
+            await _run_standalone_cycle_supervised(
+                app_state,
+                fetch_forecasts=False,
+                score_observations=True,
             )
             await asyncio.sleep(60)  # advance past the current offset
         except Exception:
@@ -989,6 +991,172 @@ def _seconds_until_next_sample_hour(sample_hours: list[int]) -> float:
     return (candidate - now).total_seconds()
 
 
+# Hard ceiling on a standalone cycle subprocess. Generous — forecast cycles
+# run ~70 min in production — but finite: an in-process cycle that hung used
+# to wedge its thread invisibly forever; the subprocess gets killed and logged.
+_STANDALONE_SUBPROCESS_TIMEOUT_S = int(
+    os.environ.get("STANDALONE_SUBPROCESS_TIMEOUT_S", str(3 * 3600))
+)
+
+
+def _standalone_subprocess_enabled() -> bool:
+    """Rollback switch for subprocess cycle isolation (issue #236).
+
+    ``STANDALONE_SUBPROCESS=0`` reverts to running cycles in-process via
+    ``asyncio.to_thread`` — same pattern as ``GRIB_DECODE_PRIORITY_ENABLED``.
+    """
+    return os.environ.get("STANDALONE_SUBPROCESS", "").strip() not in ("0", "false")
+
+
+async def _run_standalone_cycle_supervised(
+    app_state,
+    *,
+    fetch_forecasts: bool,
+    score_observations: bool,
+) -> None:
+    """Run one standalone cycle, isolated in a child process when enabled.
+
+    Why a subprocess (issue #236): the forecast cycle's transient working set
+    (concurrent Open-Meteo chunk parsing + 46K sounding analyses) ratchets the
+    long-lived uvicorn process's heap high-water mark. CPython/glibc never
+    return that peak to the OS, so it became permanent anon memory (~3 GB)
+    that the host pushed to swap. A short-lived child returns the entire peak
+    on exit. Side benefits: a hung cycle is killable, and an OOM mid-cycle
+    kills the disposable child (which raises its own oom_score_adj via
+    ``--background``) instead of the web process.
+
+    The child is the existing CLI — ``python -m weatherbrief.verify
+    standalone`` — so the production code path and manual/worktree debugging
+    are literally the same command. Results flow through the DB exactly as
+    before; ``--with-rollup`` moves the post-cycle rollup + cache rebuild
+    into the child too, keeping their memory out of the parent as well.
+    """
+    db_path = getattr(app_state, "db_path", "")
+    if not db_path:
+        logger.warning("Standalone cycle: no AIRPORTS_DB configured")
+        return
+
+    if not _standalone_subprocess_enabled():
+        await asyncio.to_thread(
+            _run_standalone_once, app_state, fetch_forecasts, score_observations,
+        )
+        return
+
+    if fetch_forecasts and score_observations:
+        cycle_type, mode_flag = "full", None
+    elif fetch_forecasts:
+        cycle_type, mode_flag = "forecast", "--forecast-only"
+    else:
+        cycle_type, mode_flag = "light", "--light"
+
+    cmd = [
+        sys.executable, "-m", "weatherbrief.verify", "standalone",
+        "--with-rollup", "--background",
+    ]
+    if mode_flag:
+        cmd.append(mode_flag)
+
+    # The child needs no decode parallelism: it has a whole process to itself
+    # and exits after one cycle. Inline decode (workers=0) avoids spawning a
+    # second decode pool inside the cgroup next to the parent's.
+    env = {**os.environ, "GRIB_DECODE_WORKERS": "0"}
+
+    launched_at = datetime.now(timezone.utc)
+    t_start = time.monotonic()
+    logger.info(
+        "Standalone %s cycle: launching subprocess (%s)",
+        cycle_type, " ".join(cmd[2:]),
+    )
+    # stdout/stderr inherited — the child's log lines flow straight to the
+    # container's log stream alongside the parent's.
+    proc = await asyncio.create_subprocess_exec(*cmd, env=env)
+
+    error_message: str | None = None
+    try:
+        returncode = await asyncio.wait_for(
+            proc.wait(), timeout=_STANDALONE_SUBPROCESS_TIMEOUT_S,
+        )
+    except asyncio.TimeoutError:
+        error_message = (
+            f"standalone {cycle_type} subprocess exceeded "
+            f"{_STANDALONE_SUBPROCESS_TIMEOUT_S}s, killed"
+        )
+        logger.error(error_message)
+        await _terminate_subprocess(proc)
+        returncode = proc.returncode
+    except asyncio.CancelledError:
+        # App shutdown: don't leave the cycle running against a stopping
+        # container. The cycle is idempotent end-to-end (UPSERT/dup-check),
+        # so the next fire simply re-does the truncated work.
+        await _terminate_subprocess(proc)
+        raise
+
+    if returncode == 0:
+        return
+
+    if error_message is None:
+        error_message = (
+            f"standalone {cycle_type} subprocess exited with code {returncode}"
+        )
+        logger.error(error_message)
+    _ensure_failed_cycle_recorded(cycle_type, launched_at, t_start, error_message)
+
+
+async def _terminate_subprocess(proc: asyncio.subprocess.Process) -> None:
+    """Terminate a child, escalating to SIGKILL after a 30 s grace period."""
+    if proc.returncode is not None:
+        return
+    proc.terminate()
+    try:
+        await asyncio.wait_for(proc.wait(), timeout=30)
+    except asyncio.TimeoutError:
+        proc.kill()
+        await proc.wait()
+
+
+def _ensure_failed_cycle_recorded(
+    cycle_type: str,
+    launched_at: datetime,
+    t_start: float,
+    error_message: str,
+) -> None:
+    """Record a failed VerificationCycleRow unless the child already wrote one.
+
+    The cycle records its own failures from inside the child
+    (``_record_failed_cycle`` on the exception path), but a child killed by a
+    signal — OOM kill, supervisor timeout — never reaches that path. Without
+    this, such cycles would vanish from the ``verification_cycles`` audit
+    trail, which the memory-anomaly baseline and admin dashboard rely on.
+    """
+    from weatherbrief.db.models import VerificationCycleRow
+    from weatherbrief.tasks.standalone_verification import _record_failed_cycle
+
+    source = f"standalone_{cycle_type}"
+    try:
+        db = SessionLocal()
+        try:
+            # Aware-UTC comparison param — same convention as the
+            # _check_memory_anomaly baseline query on this table.
+            existing = db.execute(
+                select(VerificationCycleRow.id)
+                .where(VerificationCycleRow.source == source)
+                .where(VerificationCycleRow.started_at >= launched_at)
+                .limit(1)
+            ).scalar_one_or_none()
+        finally:
+            db.close()
+    except Exception:
+        logger.warning(
+            "Could not check for existing %s cycle row", source, exc_info=True,
+        )
+        return
+    if existing is not None:
+        return
+    _record_failed_cycle(
+        launched_at, t_start, cycle_type, 0, error_message=error_message,
+    )
+
+
 def _run_standalone_once(
     app_state,
     fetch_forecasts: bool,
@@ -996,8 +1164,9 @@ def _run_standalone_once(
 ) -> None:
     """Execute a single standalone cycle (called in a thread).
 
-    Used by both the forecast-fetch loop (fetch=True, score=False) and the
-    verification loop (fetch=False, score=True).
+    In-process fallback path (``STANDALONE_SUBPROCESS=0``) for
+    :func:`_run_standalone_cycle_supervised`; the scheduled default runs the
+    cycle in a subprocess instead.
     """
     db_path = getattr(app_state, "db_path", "")
     if not db_path:
@@ -1017,7 +1186,10 @@ def _run_standalone_once(
         get_configs_dir,
         load_watchlist_with_coords,
     )
-    from weatherbrief.tasks.standalone_verification import run_standalone_cycle
+    from weatherbrief.tasks.standalone_verification import (
+        run_post_cycle_tasks,
+        run_standalone_cycle,
+    )
 
     try:
         airports = load_watchlist_with_coords(get_configs_dir(), db_path)
@@ -1046,55 +1218,9 @@ def _run_standalone_once(
         result["duration_ms"],
     )
 
-    # Roll up freshly-scored days into verification_daily_stats BEFORE the
-    # cache rebuild so the cache reflects today's scores. Idempotent — re-
-    # rolls "yesterday" once per cycle, plus any older missing days (first-
-    # deploy backfill of ~43 days). Cheap (~12K rows/day, pure SQL).
-    try:
-        from flyfun_common.db import SessionLocal
-        from weatherbrief.tasks.verification_daily_rollup import (
-            rollup_today_and_pending,
-        )
-
-        rollup_db = SessionLocal()
-        try:
-            n_rows = rollup_today_and_pending(rollup_db)
-            rollup_db.commit()
-            if n_rows:
-                logger.info(
-                    "Standalone %s cycle: %d daily-stats rows rolled up",
-                    result["cycle_type"], n_rows,
-                )
-        except Exception:
-            rollup_db.rollback()
-            raise
-        finally:
-            rollup_db.close()
-    except Exception:
-        logger.error("verification_daily_stats rollup failed", exc_info=True)
-
-    # Rebuild dashboard + map caches after cycle completes. Light (score-only)
-    # cycles don't touch forecast snapshots, so the forecast_map cache would be
-    # regenerated to identical content — skip it to halve the rebuild cost on
-    # the four hourly light cycles.
-    try:
-        from flyfun_common.db import SessionLocal
-        from weatherbrief.tasks.cache_builder import rebuild_all
-
-        cache_db = SessionLocal()
-        try:
-            cache_result = rebuild_all(
-                cache_db, db_path,
-                include_forecast_map=(result["cycle_type"] != "light"),
-            )
-            logger.info(
-                "Standalone %s cycle: cache rebuilt (%dms)",
-                result["cycle_type"], cache_result["duration_ms"],
-            )
-        finally:
-            cache_db.close()
-    except Exception:
-        logger.error("Cache rebuild failed", exc_info=True)
+    # Daily-stats rollup + dashboard cache rebuild. Shared with the CLI's
+    # --with-rollup so the subprocess path behaves identically.
+    run_post_cycle_tasks(db_path, result["cycle_type"])
 
 
 # ---------------------------------------------------------------------------

--- a/src/weatherbrief/scheduler.py
+++ b/src/weatherbrief/scheduler.py
@@ -1082,13 +1082,26 @@ async def _run_standalone_cycle_supervised(
             f"{_STANDALONE_SUBPROCESS_TIMEOUT_S}s, killed"
         )
         logger.error(error_message)
-        await _terminate_subprocess(proc)
+        try:
+            await _terminate_subprocess(proc)
+        except asyncio.CancelledError:
+            # Cancelled (app shutdown) while waiting out the SIGTERM grace
+            # period. A sibling `except CancelledError` would not catch this
+            # (each try matches once), and another awaiting cleanup would
+            # just re-open the race — escalate synchronously and re-raise.
+            if proc.returncode is None:
+                proc.kill()
+            raise
         returncode = proc.returncode
     except asyncio.CancelledError:
         # App shutdown: don't leave the cycle running against a stopping
-        # container. The cycle is idempotent end-to-end (UPSERT/dup-check),
-        # so the next fire simply re-does the truncated work.
-        await _terminate_subprocess(proc)
+        # container. terminate() is synchronous, so there is no window for a
+        # second cancellation; the child exits on SIGTERM unreaped (the OS /
+        # container teardown collects it), and the cycle is idempotent
+        # end-to-end (UPSERT/dup-check) so the next fire re-does the
+        # truncated work.
+        if proc.returncode is None:
+            proc.terminate()
         raise
 
     if returncode == 0:

--- a/src/weatherbrief/tasks/standalone_grib.py
+++ b/src/weatherbrief/tasks/standalone_grib.py
@@ -80,6 +80,12 @@ def fetch_gfs_cloud_diag(
                 logger.warning("GFS cloud diag fetch failed f%03d", fhour, exc_info=True)
                 continue
 
+        # TOCTOU: the decode worker re-reads the path, so a TTL expiry
+        # between is_cached and dispatch surfaces as FileNotFoundError here
+        # and skips this fhour (snapshot just lacks nwp_ceiling — same
+        # graceful degradation as any decode failure). TTLs are 12-24h, the
+        # window is milliseconds, and the briefing path
+        # (_fetch_cloud_diag_for_fhour) accepts the identical race.
         try:
             decoded = _dispatch_decode(
                 "decode_gfs_cloud_diag", str(run_dir / ck), lats, lons,
@@ -151,6 +157,7 @@ def fetch_icon_cloud_diag(
                 logger.warning("ICON cloud diag fetch failed f%03d", fhour, exc_info=True)
                 continue
 
+        # TOCTOU window accepted — see the GFS branch above.
         try:
             decoded = _dispatch_decode(
                 "decode_icon_cloud_diag", str(run_dir / ck), lats, lons,

--- a/src/weatherbrief/tasks/standalone_grib.py
+++ b/src/weatherbrief/tasks/standalone_grib.py
@@ -2,6 +2,13 @@
 
 Thin wrapper around existing GRIB fetch/decode to extract ceiling and cloud base
 at airport coordinates. Reuses the shared GRIB cache — no duplicate downloads.
+
+Decode goes through ``_dispatch_decode`` by cache path, same as the briefing
+path (``_fetch_cloud_diag_for_fhour``) — never in this process. cfgrib/xarray
+decode of full-domain grids in the orchestrating process was a parent-RSS
+contributor before issue #236 (the dispatcher exists precisely to keep that
+out of the parent). With ``GRIB_DECODE_WORKERS=0`` (the subprocess cycle's
+setting) the dispatch runs inline, which is fine — that process is disposable.
 """
 
 from __future__ import annotations
@@ -14,7 +21,7 @@ from pathlib import Path
 
 import requests
 
-from weatherbrief.fetch.grib.cache import cache_dir_for_run, cache_key, get_cached, put_cached
+from weatherbrief.fetch.grib.cache import cache_dir_for_run, cache_key, is_cached, put_cached
 
 logger = logging.getLogger(__name__)
 
@@ -42,7 +49,8 @@ def fetch_gfs_cloud_diag(
         Dict mapping forecast_hour → list of AirportCeilingData (same order as lats/lons).
         Missing hours are omitted from the dict.
     """
-    from weatherbrief.fetch.grib.decode import build_cloud_diagnostics, decode_cloud_diag_per_point
+    from weatherbrief.fetch.grib import DecodePriority, _dispatch_decode
+    from weatherbrief.fetch.grib.decode import build_cloud_diagnostics
     from weatherbrief.fetch.grib.gfs_idx import plan_cloud_diag_byte_ranges
     from weatherbrief.fetch.grib.grib_fetch import fetch_cloud_diag_ranges, fetch_idx
 
@@ -56,9 +64,8 @@ def fetch_gfs_cloud_diag(
 
     for fhour in forecast_hours:
         ck = cache_key(fhour, "CLOUD_DIAG")
-        grib_bytes = get_cached(run_dir, ck)
 
-        if grib_bytes is None:
+        if not is_cached(run_dir, ck):
             try:
                 idx_text = fetch_idx(init_date, init_hour, fhour, session=session)
                 ranges = plan_cloud_diag_byte_ranges(idx_text)
@@ -68,17 +75,19 @@ def fetch_gfs_cloud_diag(
                     init_date, init_hour, fhour, ranges, session=session,
                 )
                 put_cached(run_dir, ck, grib_bytes)
+                del grib_bytes
             except Exception:
                 logger.warning("GFS cloud diag fetch failed f%03d", fhour, exc_info=True)
                 continue
 
         try:
-            decoded = decode_cloud_diag_per_point(grib_bytes, lats, lons)
+            decoded = _dispatch_decode(
+                "decode_gfs_cloud_diag", str(run_dir / ck), lats, lons,
+                priority=DecodePriority.BACKGROUND,
+            )
         except Exception:
             logger.warning("GFS cloud diag decode failed f%03d", fhour, exc_info=True)
             continue
-        finally:
-            del grib_bytes
 
         if not decoded:
             continue
@@ -113,10 +122,8 @@ def fetch_icon_cloud_diag(
 
     Same interface as fetch_gfs_cloud_diag but uses DWD ICON-EU data source.
     """
-    from weatherbrief.fetch.grib.decode import (
-        build_icon_cloud_diagnostics,
-        decode_icon_eu_cloud_diag_per_point,
-    )
+    from weatherbrief.fetch.grib import DecodePriority, _dispatch_decode
+    from weatherbrief.fetch.grib.decode import build_icon_cloud_diagnostics
     from weatherbrief.fetch.grib.icon_eu_fetch import fetch_icon_eu_single_level
 
     if data_dir is None:
@@ -129,30 +136,29 @@ def fetch_icon_cloud_diag(
 
     for fhour in forecast_hours:
         ck = cache_key(fhour, "ICON_EU_CLOUD_DIAG")
-        grib_bytes = get_cached(run_dir, ck)
 
-        if grib_bytes is None:
+        if not is_cached(run_dir, ck):
             try:
                 fetched = fetch_icon_eu_single_level(
                     init_date, init_hour, [fhour], session=session,
                 )
                 grib_bytes = fetched.get(fhour)
-                if grib_bytes:
-                    put_cached(run_dir, ck, grib_bytes)
+                if not grib_bytes:
+                    continue
+                put_cached(run_dir, ck, grib_bytes)
+                del grib_bytes
             except Exception:
                 logger.warning("ICON cloud diag fetch failed f%03d", fhour, exc_info=True)
                 continue
 
-        if not grib_bytes:
-            continue
-
         try:
-            decoded = decode_icon_eu_cloud_diag_per_point(grib_bytes, lats, lons)
+            decoded = _dispatch_decode(
+                "decode_icon_cloud_diag", str(run_dir / ck), lats, lons,
+                priority=DecodePriority.BACKGROUND,
+            )
         except Exception:
             logger.warning("ICON cloud diag decode failed f%03d", fhour, exc_info=True)
             continue
-        finally:
-            del grib_bytes
 
         if not decoded:
             continue

--- a/src/weatherbrief/tasks/standalone_verification.py
+++ b/src/weatherbrief/tasks/standalone_verification.py
@@ -339,9 +339,16 @@ def _fetch_forecasts_for_model(
         forecasts = None
         for attempt in range(3):
             try:
+                # hour_filter drops non-sample hours at parse time — without
+                # it, ~80% of the response (a 4-day hourly horizon at up to
+                # 28 pressure levels) was materialised as Pydantic objects
+                # only to be discarded by the loop below, and those objects
+                # stayed alive across the chunk's sounding analysis in up to
+                # _OPEN_METEO_CONCURRENCY threads at once (issue #236).
                 forecasts = client.fetch_multi_point(
                     points, model_source,
                     start_date=start_date, end_date=end_date,
+                    hour_filter=set(sample_hours),
                 )
                 break
             except Exception:
@@ -1459,19 +1466,85 @@ def run_metar_ingest_cycle(
         db.close()
 
 
+def run_post_cycle_tasks(airports_db_path: str, cycle_type: str) -> None:
+    """Daily-stats rollup + dashboard cache rebuild after a standalone cycle.
+
+    Shared by the scheduler's in-process fallback path and the CLI
+    (``--with-rollup``) so the subprocess path (#236) keeps post-cycle
+    behaviour identical. Each step is independently fail-safe — a rollup
+    failure must not block the cache rebuild, and neither failure marks
+    the cycle itself as failed.
+    """
+    from flyfun_common.db import SessionLocal
+
+    # Roll up freshly-scored days into verification_daily_stats BEFORE the
+    # cache rebuild so the cache reflects today's scores. Idempotent — re-
+    # rolls "yesterday" once per cycle, plus any older missing days. Cheap
+    # (~12K rows/day, pure SQL).
+    try:
+        from weatherbrief.tasks.verification_daily_rollup import (
+            rollup_today_and_pending,
+        )
+
+        rollup_db = SessionLocal()
+        try:
+            n_rows = rollup_today_and_pending(rollup_db)
+            rollup_db.commit()
+            if n_rows:
+                logger.info(
+                    "Standalone %s cycle: %d daily-stats rows rolled up",
+                    cycle_type, n_rows,
+                )
+        except Exception:
+            rollup_db.rollback()
+            raise
+        finally:
+            rollup_db.close()
+    except Exception:
+        logger.error("verification_daily_stats rollup failed", exc_info=True)
+
+    # Light (score-only) cycles don't touch forecast snapshots, so the
+    # forecast_map cache would be regenerated to identical content — skip it
+    # to halve the rebuild cost on the hourly light cycles.
+    try:
+        from weatherbrief.tasks.cache_builder import rebuild_all
+
+        cache_db = SessionLocal()
+        try:
+            cache_result = rebuild_all(
+                cache_db, airports_db_path,
+                include_forecast_map=(cycle_type != "light"),
+            )
+            logger.info(
+                "Standalone %s cycle: cache rebuilt (%dms)",
+                cycle_type, cache_result["duration_ms"],
+            )
+        finally:
+            cache_db.close()
+    except Exception:
+        logger.error("Cache rebuild failed", exc_info=True)
+
+
 def _record_failed_cycle(
     started_at: datetime,
     t_start: float,
     cycle_type: str,
     airport_count: int,
+    error_message: str | None = None,
 ) -> None:
-    """Commit a VerificationCycleRow with error info using a fresh session."""
+    """Commit a VerificationCycleRow with error info using a fresh session.
+
+    ``error_message`` overrides the default traceback capture — used by the
+    scheduler's subprocess supervisor (#236), which records failures for
+    child cycles that died without reaching their own exception path (e.g.
+    SIGKILL from the OOM killer, or a supervisor timeout).
+    """
     import traceback
 
     from flyfun_common.db import SessionLocal
 
     duration_ms = int((time.monotonic() - t_start) * 1000)
-    error_msg = traceback.format_exc()[-500:]  # last 500 chars
+    error_msg = (error_message or traceback.format_exc())[-500:]  # last 500 chars
 
     # New metar_ingest cycle keeps its bare source name; the legacy
     # standalone cycles prefix it for backward-compat with existing queries.

--- a/src/weatherbrief/tasks/standalone_verification.py
+++ b/src/weatherbrief/tasks/standalone_verification.py
@@ -299,6 +299,7 @@ def _fetch_forecasts_for_model(
 
     if sample_hours is None:
         sample_hours = SAMPLE_HOURS_UTC
+    hour_filter = set(sample_hours)
 
     model_source = ModelSource(model)
     forecast_days = MODEL_FORECAST_DAYS.get(model, 7)
@@ -348,7 +349,7 @@ def _fetch_forecasts_for_model(
                 forecasts = client.fetch_multi_point(
                     points, model_source,
                     start_date=start_date, end_date=end_date,
-                    hour_filter=set(sample_hours),
+                    hour_filter=hour_filter,
                 )
                 break
             except Exception:

--- a/src/weatherbrief/verify/__main__.py
+++ b/src/weatherbrief/verify/__main__.py
@@ -296,8 +296,32 @@ def cmd_discover(args):
     print(f"\nSaved to {path}")
 
 
+def _enter_background_mode() -> None:
+    """Lower scheduling priority and prefer this process as the OOM victim.
+
+    Used by scheduler-spawned standalone cycles (issue #236): the cycle
+    competes less with interactive requests for CPU, and if the cgroup ever
+    OOMs mid-cycle the kernel kills this disposable child instead of the
+    uvicorn parent (the OOM killer favours higher oom_score_adj). Both are
+    best-effort — a restricted environment just runs at normal priority.
+    """
+    log = logging.getLogger(__name__)
+    try:
+        os.nice(10)
+    except OSError:
+        log.warning("Could not renice background cycle", exc_info=True)
+    try:
+        with open("/proc/self/oom_score_adj", "w") as f:
+            f.write("500")
+    except OSError:
+        log.warning("Could not set oom_score_adj", exc_info=True)
+
+
 def cmd_standalone(args):
     """Run a standalone verification cycle."""
+    if args.background:
+        _enter_background_mode()
+
     _init_db()
     load_dotenv()
 
@@ -315,15 +339,25 @@ def cmd_standalone(args):
         print(f"ERROR: {e}", file=sys.stderr)
         sys.exit(1)
 
-    from weatherbrief.tasks.standalone_verification import run_standalone_cycle
+    from weatherbrief.tasks.standalone_verification import (
+        run_post_cycle_tasks,
+        run_standalone_cycle,
+    )
 
-    result = run_standalone_cycle(watchlist, airports_db, fetch_forecasts=not args.light)
+    result = run_standalone_cycle(
+        watchlist, airports_db,
+        fetch_forecasts=not args.light,
+        score_observations=not args.forecast_only,
+    )
     print(f"\nStandalone verification cycle complete:")
     print(f"  Models fetched: {result.get('models_fetched', 0)}")
     print(f"  Snapshots stored: {result.get('snapshots_stored', 0)}")
     print(f"  Observations stored: {result.get('observations_stored', 0)}")
     print(f"  Scores created: {result.get('scores_created', 0)}")
     print(f"  Duration: {result.get('duration_ms', 0)}ms")
+
+    if args.with_rollup:
+        run_post_cycle_tasks(airports_db, result["cycle_type"])
 
 
 def cmd_rebuild_cache(args):
@@ -564,9 +598,25 @@ def main():
         "--once", action="store_true", default=True,
         help="Run a single cycle (default)",
     )
-    p_standalone.add_argument(
+    standalone_mode = p_standalone.add_mutually_exclusive_group()
+    standalone_mode.add_argument(
         "--light", action="store_true",
         help="Light cycle: observations + scoring only, skip forecast fetch",
+    )
+    standalone_mode.add_argument(
+        "--forecast-only", action="store_true",
+        help="Forecast cycle: fetch + store snapshots only, skip scoring "
+             "(what the scheduler's 07/19 UTC fetch loop runs)",
+    )
+    p_standalone.add_argument(
+        "--with-rollup", action="store_true",
+        help="After the cycle, run the daily-stats rollup + dashboard cache "
+             "rebuild (the scheduler loops' post-cycle work)",
+    )
+    p_standalone.add_argument(
+        "--background", action="store_true",
+        help="Renice and raise oom_score_adj — set by the scheduler when it "
+             "runs the cycle as an isolated subprocess",
     )
 
     # rebuild-cache

--- a/tests/test_open_meteo.py
+++ b/tests/test_open_meteo.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from unittest.mock import patch
 
+import pytest
 import responses
 
 from weatherbrief.fetch.open_meteo import (
@@ -301,13 +302,10 @@ def test_fetch_multi_point_hour_filter_all_null_still_raises():
     )
 
     client = OpenMeteoClient()
-    try:
+    with pytest.raises(EmptyForecastError):
         client.fetch_multi_point(
             _make_route_points(), ModelSource.GFS, hour_filter={6, 9},
         )
-        assert False, "expected EmptyForecastError"
-    except EmptyForecastError:
-        pass
 
 
 @responses.activate

--- a/tests/test_open_meteo.py
+++ b/tests/test_open_meteo.py
@@ -234,6 +234,83 @@ def test_fetch_multi_point_parses_list_response():
 
 
 @responses.activate
+def test_fetch_multi_point_hour_filter_skips_parsing_other_hours():
+    """hour_filter keeps only hourly slots whose UTC hour is in the set.
+
+    Issue #236: the standalone cycle samples 5 of every 24 hours; parsing
+    the rest into Pydantic objects only to discard them dominated the fetch
+    phase's transient memory.
+    """
+    hourly = {
+        "time": ["2026-02-21T06:00", "2026-02-21T07:00",
+                 "2026-02-21T09:00", "2026-02-21T12:00"],
+        "temperature_2m": [5.0, 6.0, 7.0, 8.0],
+    }
+    responses.add(
+        responses.GET,
+        "https://api.open-meteo.com/v1/gfs",
+        json=[{"hourly": hourly}, {"hourly": hourly}, {"hourly": hourly}],
+        status=200,
+    )
+
+    client = OpenMeteoClient()
+    results = client.fetch_multi_point(
+        _make_route_points(), ModelSource.GFS, hour_filter={6, 9},
+    )
+
+    assert len(results) == 3
+    for r in results:
+        assert [h.time.hour for h in r.hourly] == [6, 9]
+    assert results[0].hourly[0].temperature_2m_c == 5.0
+    assert results[0].hourly[1].temperature_2m_c == 7.0
+
+
+@responses.activate
+def test_fetch_multi_point_hour_filter_none_keeps_all_hours():
+    """Default behaviour (no filter) is unchanged."""
+    hourly = {
+        "time": ["2026-02-21T06:00", "2026-02-21T07:00"],
+        "temperature_2m": [5.0, 6.0],
+    }
+    responses.add(
+        responses.GET,
+        "https://api.open-meteo.com/v1/gfs",
+        json=[{"hourly": hourly}, {"hourly": hourly}, {"hourly": hourly}],
+        status=200,
+    )
+
+    client = OpenMeteoClient()
+    results = client.fetch_multi_point(_make_route_points(), ModelSource.GFS)
+
+    assert all(len(r.hourly) == 2 for r in results)
+
+
+@responses.activate
+def test_fetch_multi_point_hour_filter_all_null_still_raises():
+    """The empty-forecast guard operates on the filtered slots."""
+    hourly = {
+        "time": ["2026-02-21T06:00", "2026-02-21T09:00"],
+        "temperature_2m": [None, None],
+        "wind_speed_10m": [None, None],
+    }
+    responses.add(
+        responses.GET,
+        "https://api.open-meteo.com/v1/gfs",
+        json=[{"hourly": hourly}, {"hourly": hourly}, {"hourly": hourly}],
+        status=200,
+    )
+
+    client = OpenMeteoClient()
+    try:
+        client.fetch_multi_point(
+            _make_route_points(), ModelSource.GFS, hour_filter={6, 9},
+        )
+        assert False, "expected EmptyForecastError"
+    except EmptyForecastError:
+        pass
+
+
+@responses.activate
 def test_fetch_multi_point_raises_when_all_values_null():
     """Open-Meteo answers requests past a run's actual data_end_time with a
     structurally-valid response (correct timestamps) where every value is

--- a/tests/test_standalone_fetch_parallel.py
+++ b/tests/test_standalone_fetch_parallel.py
@@ -74,7 +74,7 @@ def test_chunks_dispatch_concurrently(small_chunk_size, monkeypatch):
     monkeypatch.setattr(sv, "_OPEN_METEO_CONCURRENCY", 4)
     barrier = threading.Barrier(len(airports), timeout=15.0)
 
-    def fake_fetch_multi_point(self, points, model, *, start_date=None, end_date=None, chunk_size=None):
+    def fake_fetch_multi_point(self, points, model, *, start_date=None, end_date=None, chunk_size=None, hour_filter=None):
         barrier.wait()  # raises BrokenBarrierError on timeout
         self._record_call()
         return [_empty_forecast(p.waypoint_icao) for p in points]
@@ -102,7 +102,7 @@ def test_aggregated_snapshot_count_matches_sequential(small_chunk_size, monkeypa
     airports = _airports(4)
     monkeypatch.setattr(sv, "_OPEN_METEO_CONCURRENCY", 4)
 
-    def fake_fetch_multi_point(self, points, model, *, start_date=None, end_date=None, chunk_size=None):
+    def fake_fetch_multi_point(self, points, model, *, start_date=None, end_date=None, chunk_size=None, hour_filter=None):
         self._record_call()
         return [_forecast_with_one_sample(p.waypoint_icao) for p in points]
 
@@ -131,7 +131,7 @@ def test_partial_chunk_failure_does_not_abort_others(small_chunk_size, monkeypat
     # Don't actually wait between retries.
     monkeypatch.setattr(sv.time, "sleep", lambda _: None)
 
-    def fake_fetch_multi_point(self, points, model, *, start_date=None, end_date=None, chunk_size=None):
+    def fake_fetch_multi_point(self, points, model, *, start_date=None, end_date=None, chunk_size=None, hour_filter=None):
         if any(p.waypoint_icao == "EG02" for p in points):
             self._record_call()
             raise RuntimeError("simulated 500")
@@ -172,7 +172,7 @@ def test_concurrency_capped_to_chunk_count(small_chunk_size, monkeypatch):
         sv.concurrent.futures, "ThreadPoolExecutor", CapturingExecutor,
     )
 
-    def fake_fetch_multi_point(self, points, model, *, start_date=None, end_date=None, chunk_size=None):
+    def fake_fetch_multi_point(self, points, model, *, start_date=None, end_date=None, chunk_size=None, hour_filter=None):
         return [_empty_forecast(p.waypoint_icao) for p in points]
 
     with patch(
@@ -195,7 +195,7 @@ def test_empty_airport_list_returns_no_snapshots(monkeypatch):
     """Empty input must short-circuit cleanly without spinning up an executor."""
     monkeypatch.setattr(sv, "_OPEN_METEO_CONCURRENCY", 4)
 
-    def fake_fetch_multi_point(self, points, model, *, start_date=None, end_date=None, chunk_size=None):
+    def fake_fetch_multi_point(self, points, model, *, start_date=None, end_date=None, chunk_size=None, hour_filter=None):
         raise AssertionError("fetch_multi_point must not be called for empty input")
 
     with patch(

--- a/tests/test_standalone_subprocess.py
+++ b/tests/test_standalone_subprocess.py
@@ -1,0 +1,353 @@
+"""Tests for subprocess isolation of standalone cycles (issue #236).
+
+The scheduler runs standalone forecast/verification cycles in a short-lived
+child process so the cycle's transient heap peak is returned to the OS on
+exit instead of ratcheting the uvicorn parent's anon working set. These
+tests cover the supervisor: command construction, the rollback switch, and
+failure recording for children that die without writing their own cycle row
+(SIGKILL/timeout never reach the in-cycle exception path).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy.orm import sessionmaker
+
+import weatherbrief.scheduler as scheduler
+from weatherbrief.db.models import VerificationCycleRow
+from weatherbrief.scheduler import (
+    _ensure_failed_cycle_recorded,
+    _run_standalone_cycle_supervised,
+    _standalone_subprocess_enabled,
+)
+
+
+class FakeProc:
+    """Stand-in for asyncio.subprocess.Process."""
+
+    def __init__(self, returncode: int = 0, hang: bool = False):
+        self.returncode = None
+        self._rc = returncode
+        self.terminated = False
+        self.killed = False
+        self._done = asyncio.Event()
+        if not hang:
+            self._done.set()
+
+    async def wait(self):
+        await self._done.wait()
+        self.returncode = self._rc
+        return self._rc
+
+    def terminate(self):
+        self.terminated = True
+        self._rc = -15
+        self._done.set()
+
+    def kill(self):
+        self.killed = True
+        self._rc = -9
+        self._done.set()
+
+
+def _app_state(db_path: str = "/tmp/airports.db"):
+    return SimpleNamespace(db_path=db_path)
+
+
+def _patch_exec(monkeypatch, proc: FakeProc) -> dict:
+    """Patch asyncio.create_subprocess_exec, capturing cmd and env."""
+    captured: dict = {}
+
+    async def fake_exec(*cmd, env=None, **kwargs):
+        captured["cmd"] = list(cmd)
+        captured["env"] = env
+        return proc
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+    return captured
+
+
+# ---------------------------------------------------------------------------
+# Rollback switch
+# ---------------------------------------------------------------------------
+
+
+def test_subprocess_enabled_by_default(monkeypatch):
+    monkeypatch.delenv("STANDALONE_SUBPROCESS", raising=False)
+    assert _standalone_subprocess_enabled() is True
+
+
+@pytest.mark.parametrize("value", ["0", "false", " 0 "])
+def test_subprocess_disabled_via_env(monkeypatch, value):
+    monkeypatch.setenv("STANDALONE_SUBPROCESS", value)
+    assert _standalone_subprocess_enabled() is False
+
+
+@pytest.mark.asyncio
+async def test_fallback_runs_in_process(monkeypatch):
+    """STANDALONE_SUBPROCESS=0 reverts to the in-process thread path."""
+    monkeypatch.setenv("STANDALONE_SUBPROCESS", "0")
+    calls = []
+
+    def fake_once(app_state, fetch, score):
+        calls.append((fetch, score))
+
+    monkeypatch.setattr(scheduler, "_run_standalone_once", fake_once)
+
+    async def fail_exec(*a, **k):  # pragma: no cover - must not run
+        raise AssertionError("subprocess must not be spawned when disabled")
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fail_exec)
+
+    await _run_standalone_cycle_supervised(
+        _app_state(), fetch_forecasts=True, score_observations=False,
+    )
+    assert calls == [(True, False)]
+
+
+# ---------------------------------------------------------------------------
+# Command construction
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_forecast_cycle_command(monkeypatch):
+    monkeypatch.delenv("STANDALONE_SUBPROCESS", raising=False)
+    captured = _patch_exec(monkeypatch, FakeProc(returncode=0))
+
+    await _run_standalone_cycle_supervised(
+        _app_state(), fetch_forecasts=True, score_observations=False,
+    )
+
+    cmd = captured["cmd"]
+    assert cmd[1:4] == ["-m", "weatherbrief.verify", "standalone"]
+    assert "--forecast-only" in cmd
+    assert "--light" not in cmd
+    assert "--with-rollup" in cmd
+    assert "--background" in cmd
+    # The child decodes inline — no second decode pool inside the cgroup.
+    assert captured["env"]["GRIB_DECODE_WORKERS"] == "0"
+
+
+@pytest.mark.asyncio
+async def test_light_cycle_command(monkeypatch):
+    monkeypatch.delenv("STANDALONE_SUBPROCESS", raising=False)
+    captured = _patch_exec(monkeypatch, FakeProc(returncode=0))
+
+    await _run_standalone_cycle_supervised(
+        _app_state(), fetch_forecasts=False, score_observations=True,
+    )
+
+    assert "--light" in captured["cmd"]
+    assert "--forecast-only" not in captured["cmd"]
+
+
+@pytest.mark.asyncio
+async def test_no_db_path_skips_spawn(monkeypatch):
+    monkeypatch.delenv("STANDALONE_SUBPROCESS", raising=False)
+
+    async def fail_exec(*a, **k):  # pragma: no cover - must not run
+        raise AssertionError("must not spawn without AIRPORTS_DB")
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fail_exec)
+    await _run_standalone_cycle_supervised(
+        _app_state(db_path=""), fetch_forecasts=True, score_observations=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Failure recording
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_success_records_no_failure(monkeypatch):
+    monkeypatch.delenv("STANDALONE_SUBPROCESS", raising=False)
+    _patch_exec(monkeypatch, FakeProc(returncode=0))
+
+    with patch.object(scheduler, "_ensure_failed_cycle_recorded") as rec:
+        await _run_standalone_cycle_supervised(
+            _app_state(), fetch_forecasts=True, score_observations=False,
+        )
+    rec.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_nonzero_exit_records_failure(monkeypatch):
+    monkeypatch.delenv("STANDALONE_SUBPROCESS", raising=False)
+    _patch_exec(monkeypatch, FakeProc(returncode=1))
+
+    with patch.object(scheduler, "_ensure_failed_cycle_recorded") as rec:
+        await _run_standalone_cycle_supervised(
+            _app_state(), fetch_forecasts=True, score_observations=False,
+        )
+    rec.assert_called_once()
+    cycle_type, _launched_at, _t_start, error_message = rec.call_args[0]
+    assert cycle_type == "forecast"
+    assert "exited with code 1" in error_message
+
+
+@pytest.mark.asyncio
+async def test_timeout_kills_child_and_records_failure(monkeypatch):
+    monkeypatch.delenv("STANDALONE_SUBPROCESS", raising=False)
+    monkeypatch.setattr(scheduler, "_STANDALONE_SUBPROCESS_TIMEOUT_S", 0.05)
+    proc = FakeProc(hang=True)
+    _patch_exec(monkeypatch, proc)
+
+    with patch.object(scheduler, "_ensure_failed_cycle_recorded") as rec:
+        await _run_standalone_cycle_supervised(
+            _app_state(), fetch_forecasts=False, score_observations=True,
+        )
+
+    assert proc.terminated
+    rec.assert_called_once()
+    assert "exceeded" in rec.call_args[0][3]
+
+
+# ---------------------------------------------------------------------------
+# _ensure_failed_cycle_recorded — dedup against child-written rows
+# ---------------------------------------------------------------------------
+
+
+def _seed_cycle_row(session, source: str, started_at: datetime) -> None:
+    session.add(VerificationCycleRow(
+        started_at=started_at,
+        duration_ms=1000,
+        source=source,
+        airports=0,
+        observations_stored=0,
+        scored=0,
+    ))
+    session.commit()
+
+
+def test_failed_cycle_recorded_when_no_child_row(db_engine, monkeypatch):
+    monkeypatch.setattr(scheduler, "SessionLocal", sessionmaker(bind=db_engine))
+    launched_at = datetime.now(timezone.utc)
+
+    with patch(
+        "weatherbrief.tasks.standalone_verification._record_failed_cycle"
+    ) as rec:
+        _ensure_failed_cycle_recorded(
+            "forecast", launched_at, 0.0, "subprocess exited with code -9",
+        )
+    rec.assert_called_once()
+    assert rec.call_args.kwargs["error_message"] == "subprocess exited with code -9"
+
+
+def test_failed_cycle_not_duplicated_when_child_recorded(db_engine, monkeypatch):
+    """A child that failed via its own exception path already wrote a cycle
+    row — the parent must not add a second one."""
+    session_factory = sessionmaker(bind=db_engine)
+    monkeypatch.setattr(scheduler, "SessionLocal", session_factory)
+    launched_at = datetime.now(timezone.utc)
+
+    session = session_factory()
+    try:
+        _seed_cycle_row(
+            session, "standalone_forecast",
+            launched_at + timedelta(seconds=5),
+        )
+
+        with patch(
+            "weatherbrief.tasks.standalone_verification._record_failed_cycle"
+        ) as rec:
+            _ensure_failed_cycle_recorded(
+                "forecast", launched_at, 0.0, "subprocess exited with code 1",
+            )
+        rec.assert_not_called()
+    finally:
+        session.query(VerificationCycleRow).delete()
+        session.commit()
+        session.close()
+
+
+# ---------------------------------------------------------------------------
+# CLI flag wiring — the subprocess command must reproduce the scheduler's
+# in-process flag combinations exactly
+# ---------------------------------------------------------------------------
+
+
+def _run_cli_standalone(monkeypatch, args):
+    import weatherbrief.verify.__main__ as vmain
+
+    monkeypatch.setenv("AIRPORTS_DB", "/tmp/airports.db")
+    monkeypatch.setattr(vmain, "_init_db", lambda: None)
+    monkeypatch.setattr(vmain, "load_dotenv", lambda: None)
+
+    calls: dict = {}
+
+    def fake_cycle(watchlist, db, *, fetch_forecasts, score_observations):
+        calls["flags"] = (fetch_forecasts, score_observations)
+        return {
+            "cycle_type": "forecast" if not score_observations else "light",
+            "models_fetched": 0, "snapshots_stored": 0,
+            "observations_stored": 0, "scores_created": 0,
+            "pruned": 0, "duration_ms": 1,
+        }
+
+    with patch(
+        "weatherbrief.tasks.standalone_verification.run_standalone_cycle",
+        new=fake_cycle,
+    ), patch(
+        "weatherbrief.tasks.standalone_verification.run_post_cycle_tasks"
+    ) as post, patch(
+        "weatherbrief.tasks.airport_watchlist.load_watchlist_with_coords",
+        return_value=[object()],
+    ), patch(
+        "weatherbrief.tasks.airport_watchlist.get_configs_dir",
+        return_value=".",
+    ):
+        vmain.cmd_standalone(args)
+    calls["post"] = post
+    return calls
+
+
+def test_cli_forecast_only_maps_to_fetch_no_score(monkeypatch):
+    args = SimpleNamespace(
+        light=False, forecast_only=True, with_rollup=True, background=False,
+    )
+    calls = _run_cli_standalone(monkeypatch, args)
+    assert calls["flags"] == (True, False)
+    calls["post"].assert_called_once_with("/tmp/airports.db", "forecast")
+
+
+def test_cli_light_maps_to_score_no_fetch(monkeypatch):
+    args = SimpleNamespace(
+        light=True, forecast_only=False, with_rollup=False, background=False,
+    )
+    calls = _run_cli_standalone(monkeypatch, args)
+    assert calls["flags"] == (False, True)
+    calls["post"].assert_not_called()
+
+
+def test_failed_cycle_ignores_rows_from_before_launch(db_engine, monkeypatch):
+    """Old cycle rows (previous fires) must not mask a missing row for the
+    current launch."""
+    session_factory = sessionmaker(bind=db_engine)
+    monkeypatch.setattr(scheduler, "SessionLocal", session_factory)
+    launched_at = datetime.now(timezone.utc)
+
+    session = session_factory()
+    try:
+        _seed_cycle_row(
+            session, "standalone_forecast",
+            launched_at - timedelta(hours=12),
+        )
+
+        with patch(
+            "weatherbrief.tasks.standalone_verification._record_failed_cycle"
+        ) as rec:
+            _ensure_failed_cycle_recorded(
+                "forecast", launched_at, 0.0, "subprocess exited with code 1",
+            )
+        rec.assert_called_once()
+    finally:
+        session.query(VerificationCycleRow).delete()
+        session.commit()
+        session.close()

--- a/tests/test_standalone_subprocess.py
+++ b/tests/test_standalone_subprocess.py
@@ -209,6 +209,51 @@ async def test_timeout_kills_child_and_records_failure(monkeypatch):
     assert "exceeded" in rec.call_args[0][3]
 
 
+@pytest.mark.asyncio
+async def test_cancellation_terminates_child(monkeypatch):
+    """App shutdown mid-cycle must signal the child and propagate the cancel."""
+    monkeypatch.delenv("STANDALONE_SUBPROCESS", raising=False)
+    proc = FakeProc(hang=True)
+    _patch_exec(monkeypatch, proc)
+
+    task = asyncio.ensure_future(_run_standalone_cycle_supervised(
+        _app_state(), fetch_forecasts=True, score_observations=False,
+    ))
+    await asyncio.sleep(0.05)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert proc.terminated
+
+
+@pytest.mark.asyncio
+async def test_cancellation_during_timeout_grace_kills_child(monkeypatch):
+    """Cancellation arriving while the TimeoutError handler waits out the
+    SIGTERM grace period escapes that handler (a sibling `except
+    CancelledError` only matches the same try once) — the supervisor must
+    still escalate to SIGKILL synchronously and propagate the cancel."""
+    monkeypatch.delenv("STANDALONE_SUBPROCESS", raising=False)
+    monkeypatch.setattr(scheduler, "_STANDALONE_SUBPROCESS_TIMEOUT_S", 0.05)
+
+    class StubbornProc(FakeProc):
+        def terminate(self):
+            self.terminated = True  # ignores SIGTERM — never completes wait()
+
+    proc = StubbornProc(hang=True)
+    _patch_exec(monkeypatch, proc)
+
+    task = asyncio.ensure_future(_run_standalone_cycle_supervised(
+        _app_state(), fetch_forecasts=True, score_observations=False,
+    ))
+    # Let the supervisor hit the timeout and enter the SIGTERM grace wait.
+    await asyncio.sleep(0.2)
+    assert proc.terminated
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert proc.killed
+
+
 # ---------------------------------------------------------------------------
 # _ensure_failed_cycle_recorded — dedup against child-written rows
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Open-Meteo multi-point responses are parsed in full into
HourlyForecast/PressureLevelData Pydantic objects before callers can
filter. The standalone verification cycle keeps only ~5 of every 24
hours, so ~80% of a 4-day, 28-pressure-level response was materialised
just to be discarded — the dominant transient memory cost of its fetch
phase. hour_filter skips non-matching timestamps before parsing; the
empty-forecast guard now operates on the filtered slots.

https://claude.ai/code/session_01XowPLnSBpQFFvpAF54M5TK