### PR TITLE
feat(advisories): VFR feasibility climb-out/descent corridor check

### DIFF
--- a/designs/meteorology-decisions.md
+++ b/designs/meteorology-decisions.md
@@ -947,3 +947,76 @@ in FZRA has no descent escape.
 - Winter inversion days without precip — confirm the 5% primed threshold
   doesn't over-amber routine warm-nose-shaped dry profiles; raise the default
   if it does.
+
+---
+
+## 10. VFR feasibility: climb-out / descent corridor check (vertical column vs cruise line)
+
+**Date:** 2026-06-12
+**Status:** Implemented (`analysis/advisories/vfr_feasibility.py`,
+`_check_corridor_vfr`).
+**Context:** The VFR feasibility advisory combined two checks — departure/arrival
+flight category (METAR/TAF ceiling+visibility buckets) and en-route cloud
+clearance **at cruise altitude** along the route. A real flight
+(EGNE→GAM→OLNEY→EGTF, cruise 8000ft) read **GREEN "VFR conditions throughout"**
+on all three models while both GFS and ECMWF showed a BKN/OVC deck around
+3800–5350ft — below cruise. Cruise was genuinely clear and both airport ceilings
+were just above the 3000ft VFR floor, so neither existing check fired.
+
+### The gap
+
+VFR is a *whole-flight, surface-to-cruise* constraint, not a cruise-line one. The
+old model only ever inspected:
+
+1. the airport ceiling **category** (a ground-level ceiling/vis bucket), and
+2. cloud **at the cruise altitude** horizontally along the route.
+
+Nothing checked whether the aircraft can physically **climb from the surface up
+to cruise, and descend back down, in VMC**. A solid deck sitting between the
+field and a clear cruise is invisible to both checks: the ceiling can still grade
+VFR (lowest BKN base > 3000ft) while that same BKN/OVC deck blocks the climb-out.
+
+### Decision
+
+Add a third sub-check, folded into the existing worst-of aggregation. Within a
+**terminal corridor** (`terminal_corridor_nm`, default **5nm**) of departure and
+arrival, scan the full vertical column for a BKN/OVC layer whose **base is below
+cruise and top is above field elevation** — a deck the flight must transit on
+climb-out or descent. Grading:
+
+- **OVC deck in a corridor → RED.** Overcast is >7/8 by definition — no holes to
+  climb or descend through legally VMC. Categorical, like cruise-in-cloud.
+- **BKN deck in a corridor → AMBER.** Broken usually has gaps; transit is often
+  possible at pilot discretion, so it degrades rather than blocks.
+- **SCT and below → no flag.** Scattered is VMC-transitable.
+
+The field-elevation floor (nearest terrain sample from the elevation profile)
+prevents a layer buried below the airport from false-triggering. The corridor is
+deliberately **terminal-only**: a sub-cruise deck mid-route is irrelevant to VFR
+because the aircraft cruises above it — only the climb and descent ends matter.
+
+### Rejected / deferred
+
+- **Replacing the cruise-line check** — no. The two measure different phases
+  (cruise vs terminal transit); both are kept and aggregated worst-of.
+- **OVC → AMBER (softer)** — rejected. An overcast deck is a hard VMC stop for
+  climb/descent; calling it amber would under-warn the exact case that motivated
+  this. Chosen explicitly: OVC=red, BKN=amber.
+- **Treating SCT as a partial block** — deferred. SCT is legally transitable;
+  revisit only if real cases show SCT decks routinely trap VFR climbs.
+
+### Note
+
+This is a deliberate sharpening: a flight that read GREEN can now read RED. On the
+motivating flight, GFS and ECMWF both go RED (OVC in the EGNE climb-out; GFS also
+BKN in the EGTF descent) while ICON — which shows no significant low cloud —
+stays GREEN, preserving the model-disagreement signal.
+
+### Real-world validation needed
+
+- A day with a known low overcast deck under a clear cruise — confirm the route
+  grades RED for climb-out and the digest/advisory names the blocking airport.
+- A scattered-only terminal deck — confirm it stays GREEN (no over-flagging of
+  routine VMC-transitable cumulus).
+- Tune `terminal_corridor_nm` if 5nm proves too tight/loose against the real
+  climb/descent footprint of GA profiles.

--- a/src/weatherbrief/analysis/advisories/strings.py
+++ b/src/weatherbrief/analysis/advisories/strings.py
@@ -282,6 +282,18 @@ _STRINGS: dict[str, dict[str, str]] = {
         "de": "Flughäfen VFR, keine Streckendaten",
         "es": "Aeropuertos VFR, sin datos en ruta",
     },
+    "vfr.corridor_climb": {
+        "en": "{cov} deck in climb-out at {icao}",
+        "fr": "Couche {cov} en montée à {icao}",
+        "de": "{cov}-Schicht im Steigflug bei {icao}",
+        "es": "Capa {cov} en ascenso en {icao}",
+    },
+    "vfr.corridor_descent": {
+        "en": "{cov} deck in descent at {icao}",
+        "fr": "Couche {cov} en descente à {icao}",
+        "de": "{cov}-Schicht im Sinkflug bei {icao}",
+        "es": "Capa {cov} en descenso en {icao}",
+    },
 
     # --- ifr_feasibility ---
     "ifr.lifr_below_min": {

--- a/src/weatherbrief/analysis/advisories/vfr_feasibility.py
+++ b/src/weatherbrief/analysis/advisories/vfr_feasibility.py
@@ -115,6 +115,82 @@ def _check_enroute_vfr(
     return total, imc_count, marginal_count, clear_count
 
 
+def _field_elevation_ft(ctx: RouteContext, distance_nm: float) -> float:
+    """Terrain elevation (ft MSL) at an along-track distance, 0.0 if unknown.
+
+    Used as the floor for the climb/descent corridor check so a cloud layer
+    buried below the field (base above cruise is already excluded) is not
+    mistaken for a deck the aircraft must transit.
+    """
+    if ctx.elevation is None or not ctx.elevation.points:
+        return 0.0
+    nearest = min(ctx.elevation.points, key=lambda p: abs(p.distance_nm - distance_nm))
+    return nearest.elevation_ft
+
+
+def _check_corridor_vfr(
+    ctx: RouteContext,
+    model: str,
+    corridor_nm: float,
+) -> tuple[AdvisoryStatus, list[str]]:
+    """Check the climb-out and descent corridors for transitable cloud decks.
+
+    Cruise altitude can be clear (handled by ``_check_enroute_vfr``) while a
+    BKN/OVC deck still sits between the surface and cruise near an airport — a
+    layer the flight must climb up through or descend down through to remain
+    VMC. Within ``corridor_nm`` of the origin (climb-out) and destination
+    (descent), a BKN/OVC layer whose base is below cruise and whose top is
+    above field elevation is such a deck. OVC -> RED (no holes to climb/descend
+    through), BKN -> AMBER (likely gaps, pilot judgement).
+
+    Returns (worst_status, detail_fragments).
+    """
+    cruise = ctx.cruise_altitude_ft
+    total = ctx.total_distance_nm
+    worst = AdvisoryStatus.GREEN
+    parts: list[str] = []
+    loc = ctx.locale
+
+    dep_icao = ctx.airport_conditions.departure.icao if ctx.airport_conditions else None
+    arr_icao = ctx.airport_conditions.arrival.icao if ctx.airport_conditions else None
+
+    phases = (
+        ("climb", "vfr.corridor_climb", dep_icao, adv_t("airport.dep", loc)),
+        ("descent", "vfr.corridor_descent", arr_icao, adv_t("airport.arr", loc)),
+    )
+
+    for phase, key, icao, fallback in phases:
+        has_ovc = False
+        has_bkn = False
+        for rpa in ctx.analyses:
+            d = rpa.distance_from_origin_nm or 0.0
+            in_corridor = d <= corridor_nm if phase == "climb" else d >= total - corridor_nm
+            if not in_corridor:
+                continue
+            sounding = rpa.sounding.get(model)
+            if sounding is None:
+                continue
+            floor = _field_elevation_ft(ctx, d)
+            for cl in sounding.cloud_layers:
+                if cl.coverage not in (CloudCoverage.BKN, CloudCoverage.OVC):
+                    continue
+                # A deck we must transit: base below cruise AND top above the field.
+                if cl.base_ft < cruise and cl.top_ft > floor:
+                    if cl.coverage == CloudCoverage.OVC:
+                        has_ovc = True
+                    else:
+                        has_bkn = True
+
+        if has_ovc:
+            worst = _worst_status(worst, AdvisoryStatus.RED)
+            parts.append(adv_t(key, loc, cov="OVC", icao=icao or fallback))
+        elif has_bkn:
+            worst = _worst_status(worst, AdvisoryStatus.AMBER)
+            parts.append(adv_t(key, loc, cov="BKN", icao=icao or fallback))
+
+    return worst, parts
+
+
 @register
 class VFRFeasibilityEvaluator:
     """Evaluates overall feasibility of VFR flight along the route.
@@ -133,9 +209,11 @@ class VFRFeasibilityEvaluator:
             description=(
                 "Composite assessment of VFR flight feasibility. Checks airport "
                 "conditions (VFR/MVFR/IFR), en-route cloud clearance relative to "
-                "cruise altitude, and minimum cloud separation. RED indicates IFR "
-                "conditions or inadequate cloud clearance along a significant "
-                "portion of the route."
+                "cruise altitude, minimum cloud separation, and whether the "
+                "climb-out and descent corridors near the airports are clear of "
+                "BKN/OVC decks the flight would have to transit. RED indicates IFR "
+                "conditions, IMC at cruise, or an OVC deck blocking climb/descent; "
+                "AMBER flags marginal conditions or a BKN deck in a corridor."
             ),
             category="flight_rules",
             altitude_dependent=True,
@@ -173,6 +251,17 @@ class VFRFeasibilityEvaluator:
                     max=80,
                     step=5,
                 ),
+                AdvisoryParameterDef(
+                    key="terminal_corridor_nm",
+                    label="Terminal corridor",
+                    description="Distance from departure/arrival to check for BKN/OVC decks in the climb-out and descent path",
+                    type="distance",
+                    unit="nm",
+                    default=5,
+                    min=0,
+                    max=20,
+                    step=1,
+                ),
             ],
         )
 
@@ -181,6 +270,7 @@ class VFRFeasibilityEvaluator:
         cloud_clearance_ft = params.get("cloud_clearance_ft", 1000)
         imc_pct_amber = params.get("imc_pct_amber", 15)
         imc_pct_red = params.get("imc_pct_red", 30)
+        corridor_nm = params.get("terminal_corridor_nm", 5)
 
         per_model: list[ModelAdvisoryResult] = []
 
@@ -193,8 +283,18 @@ class VFRFeasibilityEvaluator:
                 ctx, model, cloud_clearance_ft
             )
 
+            # 3. Climb-out / descent corridor decks (BKN/OVC below cruise near airports)
+            corridor_status, corridor_parts = _check_corridor_vfr(
+                ctx, model, corridor_nm
+            )
+
             loc = ctx.locale
-            if total == 0 and airport_status == AdvisoryStatus.GREEN and not airport_detail:
+            if (
+                total == 0
+                and airport_status == AdvisoryStatus.GREEN
+                and not airport_detail
+                and corridor_status == AdvisoryStatus.GREEN
+            ):
                 per_model.append(ModelAdvisoryResult.build(
                     model=model, status=AdvisoryStatus.UNAVAILABLE,
                     detail=adv_t("no_data", loc), affected=0, total=0,
@@ -202,7 +302,7 @@ class VFRFeasibilityEvaluator:
                 ))
                 continue
 
-            # 3. Determine en-route status
+            # 4. Determine en-route status
             affected = imc_count + marginal_count
             enroute_status = AdvisoryStatus.GREEN
             enroute_detail = ""
@@ -227,14 +327,15 @@ class VFRFeasibilityEvaluator:
                 elif affected > 0:
                     enroute_detail = adv_t("vfr.minor", loc, extent=format_extent(affected, total, ctx.total_distance_nm))
 
-            # 4. Combine airport + en-route
-            status = _worst_status(airport_status, enroute_status)
+            # 5. Combine airport + en-route + corridor
+            status = _worst_status(airport_status, enroute_status, corridor_status)
 
             detail_parts = []
             if airport_detail:
                 detail_parts.append(airport_detail)
             if enroute_detail:
                 detail_parts.append(enroute_detail)
+            detail_parts.extend(corridor_parts)
 
             if not detail_parts:
                 if total > 0:

--- a/tests/analysis/advisories/conftest.py
+++ b/tests/analysis/advisories/conftest.py
@@ -636,6 +636,87 @@ def vfr_imc_enroute_context() -> RouteContext:
 
 
 @pytest.fixture
+def vfr_bkn_corridor_context() -> RouteContext:
+    """VFR at airports + clear cruise, but a BKN deck below cruise in the
+    climb-out corridor (within 5nm of origin) — should be AMBER.
+
+    Mirrors the real EGNE→EGTF case: cruise 8000ft is clear, ceilings report
+    VFR, but a BKN 3500-5000ft deck sits in the surface-to-cruise climb path.
+    """
+    deck = EnhancedCloudLayer(base_ft=3500, top_ft=5000, coverage=CloudCoverage.BKN)
+    # Point 0 at 0nm is in the origin corridor; later points (20nm+) are clear.
+    analyses = [
+        _make_rpa(0, 0.0, sounding={"gfs": _make_sounding(cloud_layers=[deck])}),
+        *[
+            _make_rpa(i, i * 20.0, sounding={"gfs": _make_sounding()})
+            for i in range(1, 10)
+        ],
+    ]
+    return RouteContext(
+        analyses=analyses,
+        cross_sections=[],
+        elevation=_make_elevation(),
+        models=["gfs"],
+        cruise_altitude_ft=8000,
+        flight_ceiling_ft=18000,
+        total_distance_nm=180,
+        airport_conditions=_make_airport_conditions(models=["gfs"]),
+    )
+
+
+@pytest.fixture
+def vfr_ovc_corridor_context() -> RouteContext:
+    """VFR at airports + clear cruise, but an OVC deck below cruise in the
+    climb-out corridor — should be RED (no holes to climb through)."""
+    deck = EnhancedCloudLayer(base_ft=3500, top_ft=5000, coverage=CloudCoverage.OVC)
+    analyses = [
+        _make_rpa(0, 0.0, sounding={"gfs": _make_sounding(cloud_layers=[deck])}),
+        *[
+            _make_rpa(i, i * 20.0, sounding={"gfs": _make_sounding()})
+            for i in range(1, 10)
+        ],
+    ]
+    return RouteContext(
+        analyses=analyses,
+        cross_sections=[],
+        elevation=_make_elevation(),
+        models=["gfs"],
+        cruise_altitude_ft=8000,
+        flight_ceiling_ft=18000,
+        total_distance_nm=180,
+        airport_conditions=_make_airport_conditions(models=["gfs"]),
+    )
+
+
+@pytest.fixture
+def vfr_midroute_deck_context() -> RouteContext:
+    """OVC deck below cruise in the middle of the route, clear at both ends.
+
+    Cruise (8000ft) is above the deck and both corridors are clear, so VFR is
+    feasible — the corridor check must NOT flag a mid-route sub-cruise deck.
+    """
+    deck = EnhancedCloudLayer(base_ft=3500, top_ft=5000, coverage=CloudCoverage.OVC)
+    # Deck only at mid-route points (80-100nm); ends (0nm, 180nm) are clear.
+    analyses = [
+        _make_rpa(
+            i, i * 20.0,
+            sounding={"gfs": _make_sounding(cloud_layers=[deck] if 4 <= i <= 5 else [])},
+        )
+        for i in range(10)
+    ]
+    return RouteContext(
+        analyses=analyses,
+        cross_sections=[],
+        elevation=_make_elevation(),
+        models=["gfs"],
+        cruise_altitude_ft=8000,
+        flight_ceiling_ft=18000,
+        total_distance_nm=180,
+        airport_conditions=_make_airport_conditions(models=["gfs"]),
+    )
+
+
+@pytest.fixture
 def ifr_normal_context() -> RouteContext:
     """IFR-normal: IFR at airports, no icing or convective issues."""
     n_points = 10

--- a/tests/analysis/advisories/test_evaluators.py
+++ b/tests/analysis/advisories/test_evaluators.py
@@ -385,13 +385,37 @@ class TestVFRFeasibility:
         entry = VFRFeasibilityEvaluator.catalog_entry()
         assert entry.id == "vfr_feasibility"
         assert entry.category == "flight_rules"
-        assert len(entry.parameters) == 3
+        assert len(entry.parameters) == 4
 
     def test_tunable_clearance(self, vfr_marginal_clearance_context: RouteContext):
         """With 500ft clearance threshold, 800ft gap is comfortable → GREEN."""
         params = {**_VFR_DEFAULTS, "cloud_clearance_ft": 500}
         result = VFRFeasibilityEvaluator.evaluate(
             vfr_marginal_clearance_context, params,
+        )
+        assert result.aggregate_status == AdvisoryStatus.GREEN
+
+    def test_amber_bkn_climb_corridor(self, vfr_bkn_corridor_context: RouteContext):
+        """Clear cruise + VFR airports but a BKN deck in the climb-out → AMBER."""
+        result = VFRFeasibilityEvaluator.evaluate(
+            vfr_bkn_corridor_context, _VFR_DEFAULTS,
+        )
+        assert result.aggregate_status == AdvisoryStatus.AMBER
+        assert "BKN" in result.aggregate_detail
+
+    def test_red_ovc_climb_corridor(self, vfr_ovc_corridor_context: RouteContext):
+        """Clear cruise + VFR airports but an OVC deck in the climb-out → RED."""
+        result = VFRFeasibilityEvaluator.evaluate(
+            vfr_ovc_corridor_context, _VFR_DEFAULTS,
+        )
+        assert result.aggregate_status == AdvisoryStatus.RED
+        assert "OVC" in result.aggregate_detail
+
+    def test_midroute_subcruise_deck_stays_green(self, vfr_midroute_deck_context: RouteContext):
+        """An OVC deck below cruise in the MIDDLE of the route (not near either
+        airport) is irrelevant to VFR — you cruise above it → GREEN."""
+        result = VFRFeasibilityEvaluator.evaluate(
+            vfr_midroute_deck_context, _VFR_DEFAULTS,
         )
         assert result.aggregate_status == AdvisoryStatus.GREEN
 


### PR DESCRIPTION
## What

Adds a **climb-out / descent corridor** check to the VFR feasibility advisory, folded into the existing worst-of aggregation alongside the airport-category and cruise-line checks. Nothing is replaced.

## Why

VFR is a whole-flight, surface-to-cruise constraint, but the advisory only ever inspected (1) the airport ceiling **category** and (2) cloud **at cruise altitude** along the route. A BKN/OVC deck sitting between the surface and a clear cruise was invisible to both.

Motivating case — `briefing.html?flight=egne_gam_olney_egtf-2026-06-14-89e5`, cruise 8000ft — read **GREEN "VFR conditions throughout"** on all three models, while GFS/ECMWF both showed a BKN/OVC deck at ~3800–5350ft (below cruise) that you'd have to climb up through. Cruise was genuinely clear and both ceilings sat just above the 3000ft VFR floor, so neither existing check fired.

## How

`_check_corridor_vfr`: within `terminal_corridor_nm` (default **5nm**) of departure/arrival, scan the full vertical column for a BKN/OVC layer whose **base is below cruise and top is above field elevation** — a deck the flight must transit.

- **OVC deck in corridor → RED** (overcast is >7/8 — no holes to climb/descend through VMC)
- **BKN deck in corridor → AMBER** (usually has gaps; pilot judgement)
- **SCT and below → no flag** (VMC-transitable)

Design choices: terminal-only (mid-route sub-cruise decks are irrelevant — you cruise above them); field-elevation floor prevents below-airport layers from false-triggering; new param named `terminal_corridor_nm` to avoid confusion with the unrelated route-weather observation `corridor_nm` (30–50nm).

## Effect on the motivating flight

| model | before | after |
|---|---|---|
| GFS | green | **RED** — OVC deck in climb-out at EGNE \| BKN deck in descent at EGTF |
| ECMWF | green | **RED** — OVC deck in climb-out at EGNE |
| ICON | green | **GREEN** — VFR conditions throughout |
| **aggregate** | **GREEN** | **RED** |

ICON's disagreement (no significant low cloud) is preserved.

## Notes for review

- This is a deliberate sharpening — a flight that read GREEN can now read RED. Documented as a weather-calibration decision in `designs/meteorology-decisions.md` §10 (with rejected alternatives).
- Registry-driven: the new `terminal_corridor_nm` slider surfaces in the tunable-params UI automatically; detail strings flow into the advisory card + LLM digest with no extra wiring.
- Tests: 3 new fixtures + 3 tests (BKN→amber, OVC→red, mid-route deck→green/scoping). Existing VFR tests unchanged (their BKN base 8800 is above cruise; OVC-at-cruise is already red). Full `tests/analysis/` tree + `test_advisory_priority_sync.py` pass.

## Validation still wanted (post-merge)

- A known low-overcast-under-clear-cruise day → confirm RED climb-out.
- A scattered-only terminal deck → confirm it stays GREEN.
- Tune `terminal_corridor_nm` against the real GA climb/descent footprint if 5nm proves too tight/loose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)