### PR TITLE
Add four advisory evaluators: precipitation, headwind, terminal convective, wave corroboration

### DIFF
--- a/designs/INDEX.md
+++ b/designs/INDEX.md
@@ -36,7 +36,7 @@ Dated log of explicit meteorological design decisions, each with context, reason
 → Full doc: meteorology-decisions.md
 
 ### advisories
-Route advisory system: 17 deterministic evaluators across 8 categories (icing incl. freezing precipitation, cloud, turbulence, convective, airport conditions incl. density altitude and LLWS, feasibility, model-quality, sun) with per-model severity grading, user-tunable params, registry auto-discovery, worst/majority aggregation, and recalculation without re-fetching.
+Route advisory system: 20 deterministic evaluators across 11 categories (icing incl. freezing precipitation, cloud, precipitation/en-route visibility, turbulence incl. wave-corroborated mountain wind, convective, winds-aloft trip impact, airport conditions incl. density altitude, LLWS and terminal convective, feasibility, model-quality, fronts, sun) with per-model severity grading, user-tunable params, registry auto-discovery, worst/majority aggregation, and recalculation without re-fetching.
 Key exports: `evaluate_all`, `get_catalog`, `RouteContext`, `RouteAdvisoriesManifest`
 → Full doc: advisories.md
 

--- a/designs/advisories.md
+++ b/designs/advisories.md
@@ -4,7 +4,7 @@
 
 ## Intent
 
-Provide actionable, severity-graded (GREEN/AMBER/RED) advisories from 17 hazard evaluators (grouped into icing, cloud, turbulence, convective, model, airport, feasibility, and sun categories) along the route. Evaluators analyze existing route analysis data — no additional data fetch. User-tunable parameters allow recalculation without re-running the pipeline. This is a **route-level** system (advisory per route), complementing the per-waypoint `AltitudeAdvisories` in the sounding subpackage.
+Provide actionable, severity-graded (GREEN/AMBER/RED) advisories from 20 hazard evaluators (grouped into icing, cloud, precipitation, turbulence, convective, wind, model, airport, feasibility, fronts, and sun categories) along the route. Evaluators analyze existing route analysis data — no additional data fetch. User-tunable parameters allow recalculation without re-running the pipeline. This is a **route-level** system (advisory per route), complementing the per-waypoint `AltitudeAdvisories` in the sounding subpackage.
 
 ## Architecture
 
@@ -22,17 +22,20 @@ Registry → evaluate_all(ctx, enabled_ids?, user_params?, aggregation?)
   ├── @register FreezingPrecipEvaluator
   ├── @register CloudTopEvaluator          # en-route cloud
   ├── @register VMCCruiseEvaluator
+  ├── @register EnroutePrecipEvaluator     # precipitation (en-route visibility proxy)
   ├── @register TurbulenceEvaluator        # en-route turbulence
   ├── @register MountainWindEvaluator
   ├── @register ConvectiveEvaluator        # convective
+  ├── @register HeadwindEvaluator          # wind (trip impact)
   ├── @register ModelAgreementEvaluator    # model quality (cross-model)
   ├── @register DDvsNWPAgreementEvaluator  # model quality (within-model)
-  ├── @register FlightCategoryEvaluator    # airport conditions
+  ├── @register FlightCategoryEvaluator    # airport conditions (+ terminal convective)
   ├── @register AirportWindEvaluator
   ├── @register DensityAltitudeEvaluator
   ├── @register LLWSEvaluator
   ├── @register VFRFeasibilityEvaluator    # composite go/no-go
   ├── @register IFRFeasibilityEvaluator
+  ├── @register FrontsEvaluator            # fronts (experimental, gated on artifact)
   └── @register SunEvaluator               # sun (glare + night-proximity + seating note)
       ↓
 RouteAdvisoriesManifest (advisories + catalog + aggregation mode)
@@ -77,7 +80,7 @@ Detail text comes from the worst-performing model. Shared classmethods on the mo
 
 `AdvisoryStatus.majority(statuses)` implements the majority logic: count each status (ignoring UNAVAILABLE), find max count, return worst among tied leaders. The registry re-aggregates after each evaluator returns if mode isn't WORST, so evaluator code is unchanged.
 
-## The 17 Evaluators
+## The 20 Evaluators
 
 ### Icing
 
@@ -94,18 +97,25 @@ Detail text comes from the worst-performing model. Shared classmethods on the mo
 | `CloudTopEvaluator` | cloud | Can we fly above the clouds? Only considers layers pilot would enter (base ≤ ceiling), ignores high cirrus | `margin_ft`, `pct_amber` |
 | `VMCCruiseEvaluator` | cloud | Cloud coverage at cruise altitude specifically (BKN/OVC percentage along route) | `bkn_pct_amber`, `ovc_pct_red` |
 
+### Precipitation
+
+| Evaluator | Category | Logic | Key Parameters |
+|-----------|----------|-------|----------------|
+| `EnroutePrecipEvaluator` | precipitation | Precipitation along the route as the en-route **visibility proxy** (no model forecasts visibility at altitude; surface phase/intensity from `PrecipitationAssessment` works for all 7 models). Snow is the VFR killer: any snow ≥ amber threshold → AMBER, widespread moderate+ snow → RED. Moderate+ rain → AMBER (capped — rain degrades, rarely prohibits). FZRA/PL count toward extent only; severity owned by `freezing_precip`. Shared classifier (`classify_enroute_precip`) feeds the VFR composite capped at AMBER | `snow_pct_amber` (5%), `snow_moderate_pct_red` (25%), `rain_pct_amber` (30%) |
+
 ### Turbulence
 
 | Evaluator | Category | Logic | Key Parameters |
 |-----------|----------|-------|----------------|
 | `TurbulenceEvaluator` | turbulence | CAT layers at cruise + strong vertical motion. SEVERE CAT anywhere → RED | `route_pct_amber`, `strong_w_fpm` |
-| `MountainWindEvaluator` | turbulence | Wind speed near significant terrain (orographic/rotor risk). Only evaluates where terrain > threshold | `terrain_threshold_ft`, `altitude_margin_ft`, `wind_amber_kt`, `wind_red_kt` |
+| `MountainWindEvaluator` | turbulence | Wind speed near significant terrain corroborated by wave signatures: an inversion overlapping ridge top (−1000/+4000ft band) or an OSCILLATING vertical-motion classification. Signature present → RED bar drops from `wind_red_kt` to `corroborated_red_kt` ("rotor day" vs "windy ridge"). Cross-ridge direction deliberately NOT assessed (1-D terrain profile — ridge orientation unknown). Only evaluates where terrain > threshold | `terrain_threshold_ft`, `altitude_margin_ft`, `wind_amber_kt`, `wind_red_kt` (40), `corroborated_red_kt` (30) |
 
 ### Other
 
 | Evaluator | Category | Logic | Key Parameters |
 |-----------|----------|-------|----------------|
 | `ConvectiveEvaluator` | convective | Route points with convective risk ≥ threshold. Altitude-aware: ignores convection whose tops are below `cruise_ft - top_clearance_ft`. HIGH/EXTREME → instant RED. LOW risk capped at AMBER (prevents false alarms for marginal instability) | `min_risk`, `affected_pct_amber`, `affected_pct_red`, `top_clearance_ft` (2000) |
+| `HeadwindEvaluator` | wind | Route-average cruise-level headwind + trip-time delta vs still air (TAS is an advisory **parameter**, not plumbed from the aircraft — keeps recalc-from-pack working). Altitude-aware (cross-section winds at the evaluated altitude → the altitude table shows the wind trade per level; falls back to precomputed `wind_components`). Informational bias: AMBER on mean ≥ 20kt, RED only ≥ 40kt; tailwinds report minutes saved | `cruise_tas_kt` (110), `mean_amber_kt` (20), `mean_red_kt` (40) |
 | `ModelAgreementEvaluator` | model | Cross-model divergence (POOR/MODERATE agreement). Evaluated once, not per-model. **Disabled by default** — user must enable via profile | `min_poor_vars` (3), `poor_pct_amber`, `poor_pct_red` |
 | `DDvsNWPAgreementEvaluator` | model | Within-model agreement: compares DD (thermodynamic) vs NWP tracks per model at each route point. Checks freezing-level delta, cloud layer Jaccard (only when NWP has real boundaries — `source="nwp_3d"` or `"grib"`, never `"synthesized"` which is circular), and convective risk category distance. Surfaces e.g. mid-level decks GFS sees that DD misses, or ECMWF cirrus ice-supersaturation that `cc` rejects. **Disabled by default** — dev/calibration signal, not pilot-facing | `freezing_delta_ft` (2000), `cloud_overlap_min` (30%), `amber_pct` (30), `red_pct` (60) |
 
@@ -113,7 +123,7 @@ Detail text comes from the worst-performing model. Shared classmethods on the mo
 
 | Evaluator | Category | Logic | Key Parameters |
 |-----------|----------|-------|----------------|
-| `FlightCategoryEvaluator` | airport | Ceiling/visibility at departure + arrival. OR logic: either metric below threshold triggers. Defaults match MVFR/IFR boundaries | `amber_ceiling_ft` (3000), `amber_vis_sm` (5), `red_ceiling_ft` (1000), `red_vis_sm` (3) |
+| `FlightCategoryEvaluator` | airport | Ceiling/visibility at departure + arrival (OR logic: either metric below threshold triggers; defaults match MVFR/IFR boundaries) PLUS terminal-area convective risk within `conv_radius_nm` of each end with **no coverage dilution** (a deviation is not an option on climb-out/approach): MODERATE → AMBER, HIGH/EXTREME → RED, no altitude filter | `amber_ceiling_ft` (3000), `amber_vis_sm` (5), `red_ceiling_ft` (1000), `red_vis_sm` (3), `conv_radius_nm` (25) |
 | `AirportWindEvaluator` | airport | Crosswind on best runway + gust severity at departure + arrival. Worst of dep/arr becomes the status | `xwind_green_kt`, `xwind_red_kt`, `gust_green_kt`, `gust_red_kt` |
 | `DensityAltitudeEvaluator` | airport | Density altitude at departure + arrival from forecast T/QNH at the expected times + field elevation (terrain profile). Triggers on absolute DA OR DA-above-field (hot-day performance loss). UNAVAILABLE without temperature/terrain — never green-by-absence | `da_amber_ft` (5000), `da_red_ft` (8000), `delta_amber_ft` (3000), `delta_red_ft` (5000) |
 | `LLWSEvaluator` | airport | Low-level wind shear at departure + arrival: 0–1km bulk shear from the airport-point sounding (catches the nocturnal LLJ AirportWind can't see) OR gust factor (gust − sustained). Surface-based inversion reported alongside significant shear. Worst of dep/arr | `shear_amber_kt` (20), `shear_red_kt` (30), `gust_factor_amber_kt` (15) |
@@ -122,7 +132,7 @@ Detail text comes from the worst-performing model. Shared classmethods on the mo
 
 | Evaluator | Category | Logic | Key Parameters |
 |-----------|----------|-------|----------------|
-| `VFRFeasibilityEvaluator` | feasibility | Composite VFR go/no-go combining: airport flight category, en-route cloud clearance (base vs cruise), VMC compliance (BKN/OVC percentage). Worst of sub-assessments wins | `cloud_base_margin_ft`, `bkn_pct_amber`, `ovc_pct_red` |
+| `VFRFeasibilityEvaluator` | feasibility | Composite VFR go/no-go combining: airport flight category, en-route cloud clearance (base vs cruise), VMC compliance (BKN/OVC percentage), climb-out/descent corridor decks (BKN/OVC fully below cruise within `terminal_corridor_nm` of either end — OVC→RED, BKN→AMBER, see meteorology-decisions §10), and en-route precipitation (shared `classify_enroute_precip`, capped at AMBER in the composite). Worst of sub-assessments wins | `cloud_clearance_ft`, `imc_pct_amber`, `imc_pct_red`, `terminal_corridor_nm` (5) |
 | `IFRFeasibilityEvaluator` | feasibility | Composite IFR go/no-go combining: airport IFR viability (LIFR→amber, below minimums→red), en-route icing exposure (uses shared `has_relevant_icing()` helper aligned with FIKI advisory), convective risk along route | `min_dep_ceiling_ft`, `min_arr_ceiling_ft`, `icing_pct_amber`, `icing_pct_red`, `icing_altitude_buffer_ft` |
 
 ### Sun

--- a/designs/meteorology-decisions.md
+++ b/designs/meteorology-decisions.md
@@ -1020,3 +1020,86 @@ stays GREEN, preserving the model-disagreement signal.
   routine VMC-transitable cumulus).
 - Tune `terminal_corridor_nm` if 5nm proves too tight/loose against the real
   climb/descent footprint of GA profiles.
+
+---
+
+## 11. Four advisory additions: terminal convective, en-route precipitation, winds aloft, wave corroboration
+
+**Date:** 2026-06-12
+**Status:** Implemented.
+**Context:** Follow-ups from the second advisory review (after
+[meteorology-approach-review-2026-06.md](./meteorology-approach-review-2026-06.md)
+items landed): terminal-area convective dilution, the missing en-route
+visibility axis, no aggregation of the computed cruise headwind, and the
+speed-only mountain-wind grade.
+
+### (a) Terminal convective folded into Airport Weather, no coverage dilution
+
+The en-route `ConvectiveEvaluator` grades by %-of-route — right for "can I
+deviate around it", wrong at the airports where a deviation is not an option:
+one MODERATE cell over the destination is ~5% of a 20-point route → GREEN.
+`FlightCategoryEvaluator` now grades the worst convective risk within
+`conv_radius_nm` (default 25 nm) of each end with **no percentage
+threshold**: MODERATE → AMBER, HIGH/EXTREME → RED, no altitude filter (climb
+and approach traverse every level). Folded into the existing Airport Weather
+advisory (per product decision) rather than a separate card, so the airport
+line reads e.g. "Arr LSGS: VFR, convective MODERATE nearby". MARGINAL/LOW
+are ignored at the terminal — they amber half of summer otherwise.
+
+### (b) En-route precipitation as the visibility proxy (snow ≫ rain)
+
+No source provides visibility at altitude (parameterized vis is surface-only,
+3/7 models), so precipitation phase+intensity — available for **all** models
+via the existing per-sounding `PrecipitationAssessment` — is the honest
+en-route visibility signal. Grading reflects GA reality: any snow over ≥5%
+of the route → AMBER (vis collapses even in light snow showers; surface
+phase is column-representative below the melting layer), moderate+ snow over
+≥25% → RED, moderate+ rain over ≥30% → AMBER (rain capped at AMBER — it
+degrades but rarely prohibits). FZRA/PL count toward extent only; their
+severity stays owned by `freezing_precip` (§9) — no double-grading. The
+classifier is shared into the VFR feasibility composite **capped at AMBER**:
+a pilot VMC-on-top is not directly affected by surface rain, but widespread
+snow degrades every descent/divert option. UNAVAILABLE (never green) without
+precipitation data.
+
+### (c) Winds aloft / trip impact: informational, TAS as a parameter
+
+`RoutePointAnalysis.wind_components` (cruise headwind per point) fed only the
+route graph. New `HeadwindEvaluator` averages it route-wide and estimates the
+trip-time delta vs still air. Two deliberate choices:
+
+- **TAS is an advisory parameter** (default 110 kt), not plumbed from the
+  aircraft: keeps the advisory recalculable from a saved pack and tunable per
+  profile; the headwind numbers are model truth regardless of TAS.
+- **GREEN/AMBER-oriented** (AMBER at ≥20 kt mean, RED only ≥40 kt): wind is a
+  planning factor, not a hazard — the value is the number, not the colour.
+  Altitude-dependent (winds read from the cross-section at the evaluated
+  altitude), so the altitude table now shows the wind trade per level.
+
+### (d) Mountain wind: wave-signature corroboration, no fake cross-ridge term
+
+Speed-only grading cannot separate "windy ridge" from "rotor day". The
+evaluator now corroborates strong-wind mountain points with two signatures
+already computed per sounding: an **inversion overlapping ridge top**
+(−1000/+4000 ft band — the stable layer of the classical wave criteria) or an
+**OSCILLATING vertical-motion classification** (model resolving the wave).
+With a signature present, the RED bar drops from `wind_red_kt` (40) to
+`corroborated_red_kt` (default 30). Cross-ridge wind *direction* was
+considered and rejected: the elevation profile is 1-D along the route, ridge
+orientation is unknown, and inferring it from the along-track terrain
+gradient assumes perpendicular crossings — false precision. OSCILLATING
+finally feeds an advisory (was computed and unused).
+
+### Real-world validation needed
+
+- (a) A summer afternoon flight with an isolated MODERATE cell at the
+  destination ETA — confirm Airport Weather ambers while en-route convective
+  stays green; check 25 nm radius against typical cell spacing.
+- (b) A winter cold-sector day with scattered snow showers — confirm AMBER
+  and that the 5% threshold doesn't flicker on a single mixed-phase point; a
+  warm-sector stratiform rain day — confirm rain stays AMBER-bounded.
+- (c) A strong jet day — sanity-check the minutes-delta against a flight
+  planner for the same route/TAS.
+- (d) A documented Alpine föhn/wave day (e.g. strong S flow over the main
+  ridge) — confirm RED at 30-39 kt with the inversion signature, and that
+  ordinary windy-but-neutral days stay AMBER.

--- a/src/weatherbrief/analysis/advisories/enroute_precip.py
+++ b/src/weatherbrief/analysis/advisories/enroute_precip.py
@@ -1,0 +1,217 @@
+"""En-route precipitation advisory — precipitation along the route as a
+visibility proxy.
+
+No model provides visibility at altitude — parameterized visibility is a
+surface-only diagnostic, and only three of seven models deliver even that.
+What every model does deliver is hourly precipitation split by phase
+(rain/showers/snowfall), already assessed per sounding into a surface phase +
+intensity (``PrecipitationAssessment``). Precipitation is the dominant driver
+of en-route visibility loss for VFR:
+
+- **Snow** collapses visibility at any intensity (often below 1500 m in a
+  shower, near zero in moderate snow) and falls through the whole column, so
+  the surface phase is representative of flight levels below the melting
+  layer. Wet snow also adheres to the airframe.
+- **Moderate+ rain** reduces visibility and ceilings and makes a windscreen
+  view marginal; light rain is mostly a comfort issue.
+- **Freezing rain / ice pellets** are counted here as significant
+  precipitation for visibility extent, but their icing severity is owned by
+  the dedicated freezing-precipitation advisory (which REDs independently).
+
+The classifier is shared with the VFR feasibility composite via
+:func:`enroute_precip_check` (capped at AMBER there — a pilot VMC-on-top is
+not directly affected by surface rain below, but widespread snow degrades
+every divert/descent option, which is worth a composite caution).
+"""
+
+from __future__ import annotations
+
+from weatherbrief.analysis.advisories import RouteContext
+from weatherbrief.analysis.advisories._helpers import format_extent
+from weatherbrief.analysis.advisories.registry import register
+from weatherbrief.analysis.advisories.strings import adv_t
+from weatherbrief.models import (
+    AdvisoryCatalogEntry,
+    AdvisoryParameterDef,
+    AdvisoryStatus,
+    ModelAdvisoryResult,
+    PrecipIntensity,
+    PrecipPhase,
+    RouteAdvisoryResult,
+)
+
+_SNOW_PHASES = (PrecipPhase.SNOW, PrecipPhase.MIXED)
+_FREEZING_PHASES = (PrecipPhase.FREEZING_RAIN, PrecipPhase.ICE_PELLETS)
+_SIGNIFICANT = (PrecipIntensity.MODERATE, PrecipIntensity.HEAVY)
+
+_DEFAULTS = {
+    "snow_pct_amber": 5.0,
+    "snow_moderate_pct_red": 25.0,
+    "rain_pct_amber": 30.0,
+}
+
+
+def classify_enroute_precip(
+    ctx: RouteContext,
+    model: str,
+    params: dict[str, float] | None = None,
+) -> tuple[AdvisoryStatus, str, int, int, bool]:
+    """Classify en-route precipitation for one model.
+
+    Returns ``(status, detail, affected, total, has_signal)``.
+    ``has_signal`` is False when no point carries a precipitation assessment
+    (old pack) — callers must treat that as UNAVAILABLE, not GREEN.
+    """
+    p = {**_DEFAULTS, **(params or {})}
+    snow_pct_amber = p["snow_pct_amber"]
+    snow_moderate_pct_red = p["snow_moderate_pct_red"]
+    rain_pct_amber = p["rain_pct_amber"]
+    loc = ctx.locale
+
+    total = 0
+    snow_pts = 0           # any snow/mixed, any intensity
+    snow_moderate_pts = 0  # snow/mixed at moderate+
+    sig_rain_pts = 0       # rain moderate+ — and FZRA/PL (vis extent only)
+    light_pts = 0          # light rain — comfort, not a hazard
+    has_signal = False
+
+    for rpa in ctx.analyses:
+        sounding = rpa.sounding.get(model)
+        if sounding is None:
+            continue
+        total += 1
+        precip = sounding.precipitation
+        if precip is None:
+            continue
+        has_signal = True
+        phase = precip.surface_phase
+        intensity = precip.surface_intensity
+        if phase == PrecipPhase.DRY or intensity == PrecipIntensity.NONE:
+            continue
+        if phase in _SNOW_PHASES:
+            snow_pts += 1
+            if intensity in _SIGNIFICANT:
+                snow_moderate_pts += 1
+        elif phase in _FREEZING_PHASES:
+            # Visibility extent only — severity owned by freezing_precip.
+            sig_rain_pts += 1
+        elif intensity in _SIGNIFICANT:
+            sig_rain_pts += 1
+        else:
+            light_pts += 1
+
+    if total == 0 or not has_signal:
+        return AdvisoryStatus.UNAVAILABLE, adv_t("no_data", loc), 0, total, has_signal
+
+    affected = snow_pts + sig_rain_pts + light_pts
+    snow_pct = 100.0 * snow_pts / total
+    snow_moderate_pct = 100.0 * snow_moderate_pts / total
+    sig_rain_pct = 100.0 * sig_rain_pts / total
+
+    parts: list[str] = []
+    if snow_pts:
+        parts.append(adv_t(
+            "enroute_precip.snow", loc,
+            extent=format_extent(snow_pts, total, ctx.total_distance_nm),
+        ))
+    if sig_rain_pts:
+        parts.append(adv_t(
+            "enroute_precip.rain", loc,
+            extent=format_extent(sig_rain_pts, total, ctx.total_distance_nm),
+        ))
+
+    if snow_moderate_pct >= snow_moderate_pct_red:
+        status = AdvisoryStatus.RED
+    elif snow_pct >= snow_pct_amber or sig_rain_pct >= rain_pct_amber:
+        status = AdvisoryStatus.AMBER
+    else:
+        status = AdvisoryStatus.GREEN
+        if not parts and light_pts:
+            parts.append(adv_t(
+                "enroute_precip.light", loc,
+                extent=format_extent(light_pts, total, ctx.total_distance_nm),
+            ))
+        if not parts:
+            parts.append(adv_t("enroute_precip.clear", loc))
+
+    return status, " | ".join(parts), affected, total, has_signal
+
+
+@register
+class EnroutePrecipEvaluator:
+    """Evaluates precipitation along the route as a visibility hazard."""
+
+    @staticmethod
+    def catalog_entry() -> AdvisoryCatalogEntry:
+        return AdvisoryCatalogEntry(
+            id="enroute_precip",
+            name="En-route Precipitation",
+            short_description="Precipitation along the route (visibility)",
+            description=(
+                "Grades precipitation along the route as a visibility hazard — "
+                "no model forecasts visibility at altitude, so precipitation "
+                "phase and intensity are the honest proxy. Snow is the VFR "
+                "killer: visibility collapses in even light snow showers and "
+                "the surface phase is representative of the whole column below "
+                "the melting layer, so any snow over more than a small fraction "
+                "of the route is amber and widespread moderate snow is red. "
+                "Moderate-or-heavier rain over a large fraction of the route is "
+                "amber (reduced visibility and ceilings); light rain is noted "
+                "but stays green. Freezing rain / ice pellets count toward the "
+                "extent here, but their icing severity is graded by the "
+                "dedicated Freezing Precipitation advisory. Unavailable (not "
+                "green) on packs without precipitation data."
+            ),
+            category="precipitation",
+            parameters=[
+                AdvisoryParameterDef(
+                    key="snow_pct_amber",
+                    label="Snow % (amber)",
+                    description="Route percentage with any snow for amber",
+                    type="percent",
+                    unit="%",
+                    default=5,
+                    min=0,
+                    max=50,
+                    step=5,
+                ),
+                AdvisoryParameterDef(
+                    key="snow_moderate_pct_red",
+                    label="Moderate snow % (red)",
+                    description="Route percentage with moderate+ snow for red",
+                    type="percent",
+                    unit="%",
+                    default=25,
+                    min=5,
+                    max=80,
+                    step=5,
+                ),
+                AdvisoryParameterDef(
+                    key="rain_pct_amber",
+                    label="Rain % (amber)",
+                    description="Route percentage with moderate+ rain for amber",
+                    type="percent",
+                    unit="%",
+                    default=30,
+                    min=5,
+                    max=80,
+                    step=5,
+                ),
+            ],
+        )
+
+    @staticmethod
+    def evaluate(ctx: RouteContext, params: dict[str, float]) -> RouteAdvisoryResult:
+        per_model: list[ModelAdvisoryResult] = []
+
+        for model in ctx.models:
+            status, detail, affected, total, _ = classify_enroute_precip(
+                ctx, model, params,
+            )
+            per_model.append(ModelAdvisoryResult.build(
+                model=model, status=status, detail=detail,
+                affected=affected, total=total,
+                total_distance_nm=ctx.total_distance_nm,
+            ))
+
+        return RouteAdvisoryResult.from_per_model("enroute_precip", per_model, params)

--- a/src/weatherbrief/analysis/advisories/flight_category.py
+++ b/src/weatherbrief/analysis/advisories/flight_category.py
@@ -1,4 +1,14 @@
-"""Airport weather (flight category) advisory evaluator."""
+"""Airport weather (flight category + terminal convective) advisory evaluator.
+
+Besides ceiling/visibility category, this grades convective risk in the
+terminal area: the en-route convective advisory dilutes a single cell by
+percentage-of-route (one MODERATE cell over the destination is ~5% of a
+20-point route → GREEN), but at the airports a deviation is not an option —
+the cell must not be there at ETD/ETA. Terminal convection is therefore
+graded per airport with no coverage threshold: MODERATE within the terminal
+radius is AMBER, HIGH/EXTREME is RED, and no altitude filter applies (climb
+and approach traverse every level).
+"""
 
 from __future__ import annotations
 
@@ -9,10 +19,54 @@ from weatherbrief.models import (
     AdvisoryCatalogEntry,
     AdvisoryParameterDef,
     AdvisoryStatus,
+    ConvectiveRisk,
     ModelAdvisoryResult,
     RouteAdvisoryResult,
 )
 from weatherbrief.models.airport_conditions import AirportModelCondition
+
+_CONV_ORDER = [
+    ConvectiveRisk.NONE,
+    ConvectiveRisk.MARGINAL,
+    ConvectiveRisk.LOW,
+    ConvectiveRisk.MODERATE,
+    ConvectiveRisk.HIGH,
+    ConvectiveRisk.EXTREME,
+]
+
+
+def _terminal_convective_risk(
+    ctx: RouteContext,
+    model: str,
+    end: str,
+    radius_nm: float,
+) -> ConvectiveRisk:
+    """Worst convective risk within *radius_nm* of one route end ("dep"/"arr")."""
+    worst = ConvectiveRisk.NONE
+    for rpa in ctx.analyses:
+        dist = rpa.distance_from_origin_nm
+        in_terminal = (
+            dist <= radius_nm if end == "dep"
+            else dist >= ctx.total_distance_nm - radius_nm
+        )
+        if not in_terminal:
+            continue
+        sounding = rpa.sounding.get(model)
+        conv = sounding.convective if sounding is not None else None
+        if conv is None:
+            continue
+        if _CONV_ORDER.index(conv.risk_level) > _CONV_ORDER.index(worst):
+            worst = conv.risk_level
+    return worst
+
+
+def _terminal_convective_status(risk: ConvectiveRisk) -> AdvisoryStatus:
+    """No coverage threshold at the terminal: MODERATE→AMBER, HIGH+→RED."""
+    if risk in (ConvectiveRisk.HIGH, ConvectiveRisk.EXTREME):
+        return AdvisoryStatus.RED
+    if risk == ConvectiveRisk.MODERATE:
+        return AdvisoryStatus.AMBER
+    return AdvisoryStatus.GREEN
 
 
 def _classify_conditions(
@@ -50,12 +104,17 @@ class FlightCategoryEvaluator:
         return AdvisoryCatalogEntry(
             id="flight_category",
             name="Airport Weather",
-            short_description="Flight category at departure and arrival",
+            short_description="Flight category and convective risk at departure and arrival",
             description=(
                 "Checks visibility and ceiling at departure and arrival airports "
                 "against configurable thresholds. Defaults match standard MVFR/IFR "
                 "boundaries: amber when ceiling < 3000ft or visibility < 5sm, "
-                "red when ceiling < 1000ft or visibility < 3sm."
+                "red when ceiling < 1000ft or visibility < 3sm. Also grades "
+                "convective risk within the terminal radius of each airport with "
+                "no coverage dilution — a deviation is not an option on climb-out "
+                "or approach, so MODERATE convective risk near either airport is "
+                "amber and HIGH or above is red, regardless of how small a "
+                "fraction of the route it covers."
             ),
             category="airport",
             parameters=[
@@ -103,6 +162,20 @@ class FlightCategoryEvaluator:
                     max=5,
                     step=0.5,
                 ),
+                AdvisoryParameterDef(
+                    key="conv_radius_nm",
+                    label="Terminal radius",
+                    description=(
+                        "Convective risk is checked within this distance of "
+                        "departure and arrival (MODERATE = amber, HIGH+ = red)"
+                    ),
+                    type="number",
+                    unit="nm",
+                    default=25,
+                    min=10,
+                    max=50,
+                    step=5,
+                ),
             ],
         )
 
@@ -112,6 +185,7 @@ class FlightCategoryEvaluator:
         amber_vis_sm = params.get("amber_vis_sm", 5)
         red_ceiling_ft = params.get("red_ceiling_ft", 1000)
         red_vis_sm = params.get("red_vis_sm", 3)
+        conv_radius_nm = params.get("conv_radius_nm", 25)
 
         per_model: list[ModelAdvisoryResult] = []
 
@@ -136,9 +210,9 @@ class FlightCategoryEvaluator:
 
             parts = []
             worst = AdvisoryStatus.GREEN
-            for label_key, icao, cond in [
-                ("airport.dep", dep.icao, dep_cond),
-                ("airport.arr", arr.icao, arr_cond),
+            for label_key, icao, cond, end in [
+                ("airport.dep", dep.icao, dep_cond, "dep"),
+                ("airport.arr", arr.icao, arr_cond, "arr"),
             ]:
                 if cond is None:
                     continue
@@ -148,7 +222,18 @@ class FlightCategoryEvaluator:
                 )
                 cat_label = cond.flight_category.value
                 label = adv_t(label_key, loc)
-                parts.append(f"{label} {icao}: {cat_label}")
+                part = f"{label} {icao}: {cat_label}"
+
+                conv_risk = _terminal_convective_risk(ctx, model, end, conv_radius_nm)
+                conv_status = _terminal_convective_status(conv_risk)
+                if conv_status != AdvisoryStatus.GREEN:
+                    part += adv_t(
+                        "flight_category.conv", loc,
+                        risk=conv_risk.value.upper(),
+                    )
+                    status = AdvisoryStatus.worst([status, conv_status])
+
+                parts.append(part)
                 worst = AdvisoryStatus.worst([worst, status])
 
             detail = " | ".join(parts)

--- a/src/weatherbrief/analysis/advisories/headwind.py
+++ b/src/weatherbrief/analysis/advisories/headwind.py
@@ -1,0 +1,191 @@
+"""Headwind / trip-impact advisory — winds aloft at cruise along the route.
+
+The cruise-level headwind component is computed at every route point
+(``RoutePointAnalysis.wind_components``) and drawn on the route graph, but
+nothing aggregated it into the briefing. For GA fuel planning the question is
+simple: how much longer does this trip take than still air, and is today a
+day to reconsider altitude or add a fuel stop?
+
+Informational by design — wind is a planning factor, not a hazard — so the
+grade is GREEN/AMBER on the route-average headwind (RED only for genuinely
+brutal days). Tailwinds report the time gained and stay GREEN.
+
+Altitude-aware: winds are read from the cross-section at the context's cruise
+altitude (so the altitude slider and altitude table show how winds change
+with level — often the actual decision being made), falling back to the
+precomputed cruise wind components on packs without cross-section winds.
+
+The time estimate uses a per-profile TAS *parameter* rather than plumbing the
+aircraft through the pipeline: it keeps the advisory recalculable from a
+saved pack, and the headwind numbers themselves are model truth regardless of
+the TAS chosen.
+"""
+
+from __future__ import annotations
+
+import math
+
+from weatherbrief.analysis.advisories import RouteContext
+from weatherbrief.analysis.advisories._helpers import wind_at_altitude
+from weatherbrief.analysis.advisories.registry import register
+from weatherbrief.analysis.advisories.strings import adv_t
+from weatherbrief.models import (
+    AdvisoryCatalogEntry,
+    AdvisoryParameterDef,
+    AdvisoryStatus,
+    ModelAdvisoryResult,
+    RouteAdvisoryResult,
+)
+
+# Floor on per-point groundspeed for the time integral — keeps the estimate
+# finite if a parameter combination puts headwind near TAS.
+_MIN_GS_KT = 30.0
+
+
+def _headwind_component(speed_kt: float, direction_deg: float, track_deg: float) -> float:
+    """Along-track wind component: positive = headwind, negative = tailwind."""
+    return speed_kt * math.cos(math.radians(direction_deg - track_deg))
+
+
+@register
+class HeadwindEvaluator:
+    """Aggregates cruise-level headwind into a trip-impact advisory."""
+
+    @staticmethod
+    def catalog_entry() -> AdvisoryCatalogEntry:
+        return AdvisoryCatalogEntry(
+            id="headwind",
+            name="Winds Aloft",
+            short_description="Headwind at cruise and trip-time impact",
+            description=(
+                "Averages the cruise-level headwind component along the route "
+                "and estimates the trip-time impact versus still air using the "
+                "cruise TAS parameter (set it to your aircraft's). Mostly "
+                "informational: amber when the average headwind exceeds the "
+                "threshold (fuel-planning attention), red only for extreme "
+                "days. Tailwinds report the time gained. Reads winds at the "
+                "evaluated cruise altitude, so the altitude table shows how "
+                "the wind trade changes with level."
+            ),
+            category="wind",
+            altitude_dependent=True,
+            parameters=[
+                AdvisoryParameterDef(
+                    key="cruise_tas_kt",
+                    label="Cruise TAS",
+                    description="True airspeed used for the trip-time estimate",
+                    type="speed",
+                    unit="kt",
+                    default=110,
+                    min=60,
+                    max=250,
+                    step=5,
+                ),
+                AdvisoryParameterDef(
+                    key="mean_amber_kt",
+                    label="Avg headwind (amber)",
+                    description="Route-average headwind above this triggers amber",
+                    type="speed",
+                    unit="kt",
+                    default=20,
+                    min=5,
+                    max=50,
+                    step=5,
+                ),
+                AdvisoryParameterDef(
+                    key="mean_red_kt",
+                    label="Avg headwind (red)",
+                    description="Route-average headwind above this triggers red",
+                    type="speed",
+                    unit="kt",
+                    default=40,
+                    min=20,
+                    max=80,
+                    step=5,
+                ),
+            ],
+        )
+
+    @staticmethod
+    def evaluate(ctx: RouteContext, params: dict[str, float]) -> RouteAdvisoryResult:
+        tas_kt = params.get("cruise_tas_kt", 110)
+        mean_amber_kt = params.get("mean_amber_kt", 20)
+        mean_red_kt = params.get("mean_red_kt", 40)
+
+        per_model: list[ModelAdvisoryResult] = []
+
+        for model in ctx.models:
+            headwinds: list[float] = []
+            affected = 0
+
+            for rpa in ctx.analyses:
+                hw: float | None = None
+                wind = wind_at_altitude(
+                    ctx.cross_sections, model, rpa.point_index,
+                    ctx.cruise_altitude_ft, rpa.forecast_hour,
+                )
+                if wind is not None:
+                    speed_kt, direction_deg = wind
+                    hw = _headwind_component(speed_kt, direction_deg, rpa.track_deg)
+                else:
+                    # Pack without cross-section winds: precomputed component
+                    # at the pack's original cruise level.
+                    wc = rpa.wind_components.get(model)
+                    if wc is not None:
+                        hw = wc.headwind_kt
+                if hw is None:
+                    continue
+                headwinds.append(hw)
+                if hw >= mean_amber_kt:
+                    affected += 1
+
+            loc = ctx.locale
+            total = len(headwinds)
+            if total == 0:
+                per_model.append(ModelAdvisoryResult.build(
+                    model=model, status=AdvisoryStatus.UNAVAILABLE,
+                    detail=adv_t("no_data", loc), affected=0, total=0,
+                    total_distance_nm=ctx.total_distance_nm,
+                ))
+                continue
+
+            mean_hw = sum(headwinds) / total
+            max_hw = max(headwinds)
+
+            # Trip time vs still air: equal-weight segments at per-point GS.
+            seg_nm = ctx.total_distance_nm / total
+            still_min = 60.0 * ctx.total_distance_nm / tas_kt
+            wind_min = sum(
+                60.0 * seg_nm / max(tas_kt - hw, _MIN_GS_KT) for hw in headwinds
+            )
+            delta_min = wind_min - still_min
+            delta_pct = 100.0 * delta_min / still_min if still_min > 0 else 0.0
+
+            if mean_hw >= mean_red_kt:
+                status = AdvisoryStatus.RED
+            elif mean_hw >= mean_amber_kt:
+                status = AdvisoryStatus.AMBER
+            else:
+                status = AdvisoryStatus.GREEN
+
+            if mean_hw <= -3:
+                detail = adv_t(
+                    "headwind.tailwind", loc,
+                    mean=round(-mean_hw), delta=round(-delta_min),
+                )
+            elif abs(mean_hw) < 3 and abs(delta_min) < 3:
+                detail = adv_t("headwind.neutral", loc)
+            else:
+                detail = adv_t(
+                    "headwind.summary", loc,
+                    mean=round(mean_hw), max=round(max_hw),
+                    delta=round(delta_min), pct=round(delta_pct),
+                )
+
+            per_model.append(ModelAdvisoryResult.build(
+                model=model, status=status, detail=detail,
+                affected=affected, total=total,
+                total_distance_nm=ctx.total_distance_nm,
+            ))
+
+        return RouteAdvisoryResult.from_per_model("headwind", per_model, params)

--- a/src/weatherbrief/analysis/advisories/mountain_wind.py
+++ b/src/weatherbrief/analysis/advisories/mountain_wind.py
@@ -1,4 +1,25 @@
-"""Mountain wind advisory — wind near terrain safe."""
+"""Mountain wind advisory — wind near terrain, with wave-signature corroboration.
+
+Wind speed near ridge level is a necessary but not sufficient condition for
+mountain wave / rotor: the classical ingredients are strong cross-barrier
+flow AND a stable layer near ridge top (Scorer parameter decreasing with
+height). Speed alone cannot separate "windy ridge" from "rotor day", so this
+evaluator corroborates the wind grade with two signatures already computed
+per sounding:
+
+- an **inversion layer near ridge top** (the stable layer that supports
+  trapped lee waves and rotors beneath them);
+- an **OSCILLATING vertical-motion classification** (alternating ascent /
+  descent couplets in the omega profile — the model resolving the wave
+  itself).
+
+When either signature is present at a strong-wind mountain point, the RED
+threshold drops from ``wind_red_kt`` (speed so high it's hazardous
+regardless) to ``corroborated_red_kt``. Cross-ridge wind *direction* is
+deliberately not assessed: the elevation profile is one-dimensional along
+the route, so ridge orientation is unknown — pretending otherwise would be
+false precision.
+"""
 
 from __future__ import annotations
 
@@ -16,7 +37,34 @@ from weatherbrief.models import (
     AdvisoryStatus,
     ModelAdvisoryResult,
     RouteAdvisoryResult,
+    SoundingAnalysis,
+    VerticalMotionClass,
 )
+
+# Stable-layer search band around ridge top: an inversion this far below to
+# this far above the local peak counts as the wave-supporting layer.
+_INV_BELOW_FT = 1000.0
+_INV_ABOVE_FT = 4000.0
+
+
+def _wave_signatures(
+    sounding: SoundingAnalysis | None,
+    terrain_ft: float,
+) -> set[str]:
+    """Wave-supporting signatures at one point: 'inversion' and/or 'oscillating'."""
+    sigs: set[str] = set()
+    if sounding is None:
+        return sigs
+    vm = sounding.vertical_motion
+    if vm is not None and vm.classification == VerticalMotionClass.OSCILLATING:
+        sigs.add("oscillating")
+    lo = terrain_ft - _INV_BELOW_FT
+    hi = terrain_ft + _INV_ABOVE_FT
+    for inv in sounding.inversion_layers:
+        if inv.top_ft > lo and inv.base_ft < hi:
+            sigs.add("inversion")
+            break
+    return sigs
 
 
 @register
@@ -28,11 +76,16 @@ class MountainWindEvaluator:
         return AdvisoryCatalogEntry(
             id="mountain_wind",
             name="Mountain Wind",
-            short_description="Wind near terrain safe",
+            short_description="Wind and wave signatures near terrain",
             description=(
                 "Evaluates wind speed near terrain tops at points where terrain "
-                "exceeds a threshold. High winds near mountains indicate mountain "
-                "wave and rotor risk."
+                "exceeds a threshold, corroborated by the classical wave "
+                "ingredients: a stable layer (inversion) near ridge top or a "
+                "wave-like oscillating vertical-motion profile in the model. "
+                "Strong wind alone is amber; very strong wind is red; and "
+                "moderately strong wind WITH a wave signature is also red at a "
+                "lower threshold — that combination is the rotor-day setup, "
+                "not just a windy ridge."
             ),
             category="turbulence",
             parameters=[
@@ -80,6 +133,21 @@ class MountainWindEvaluator:
                     max=60,
                     step=5,
                 ),
+                AdvisoryParameterDef(
+                    key="corroborated_red_kt",
+                    label="Wind red w/ signature",
+                    description=(
+                        "Red threshold when a wave signature (ridge-top "
+                        "inversion or oscillating vertical motion) is present "
+                        "at the same point"
+                    ),
+                    type="speed",
+                    unit="kt",
+                    default=30,
+                    min=15,
+                    max=50,
+                    step=5,
+                ),
             ],
         )
 
@@ -89,6 +157,7 @@ class MountainWindEvaluator:
         altitude_margin = params.get("altitude_margin_ft", 2000)
         wind_amber = params.get("wind_amber_kt", 20)
         wind_red = params.get("wind_red_kt", 40)
+        corroborated_red = params.get("corroborated_red_kt", 30)
 
         per_model: list[ModelAdvisoryResult] = []
 
@@ -96,6 +165,8 @@ class MountainWindEvaluator:
             total = 0  # mountain points only
             affected = 0
             max_wind = 0.0
+            wave_red = False          # corroborated point above the lower red bar
+            wave_sigs: set[str] = set()  # signatures seen at strong-wind points
 
             for rpa in ctx.analyses:
                 terrain_ft = max_terrain_near_point(
@@ -116,21 +187,39 @@ class MountainWindEvaluator:
                 if speed_kt > max_wind:
                     max_wind = speed_kt
 
-                if speed_kt >= wind_red or speed_kt >= wind_amber:
+                if speed_kt >= wind_amber:
                     affected += 1
+                    sigs = _wave_signatures(rpa.sounding.get(model), terrain_ft)
+                    if sigs:
+                        wave_sigs |= sigs
+                        if speed_kt >= corroborated_red:
+                            wave_red = True
 
             loc = ctx.locale
+            ext = format_extent(affected, total, ctx.total_distance_nm)
+            sig_text = " + ".join(
+                adv_t(f"mountain_wind.sig_{s}", loc)
+                for s in sorted(wave_sigs)
+            )
             if total == 0:
                 status = AdvisoryStatus.GREEN
                 detail = adv_t("mountain_wind.no_terrain", loc)
             elif max_wind >= wind_red:
                 status = AdvisoryStatus.RED
-                ext = format_extent(affected, total, ctx.total_distance_nm)
                 detail = adv_t("mountain_wind.severe", loc, speed=f"{max_wind:.0f}", extent=ext)
+                if sig_text:
+                    detail += adv_t("mountain_wind.sig_suffix", loc, signature=sig_text)
+            elif wave_red:
+                status = AdvisoryStatus.RED
+                detail = adv_t(
+                    "mountain_wind.wave_confirmed", loc,
+                    speed=f"{max_wind:.0f}", signature=sig_text, extent=ext,
+                )
             elif max_wind >= wind_amber:
                 status = AdvisoryStatus.AMBER
-                ext = format_extent(affected, total, ctx.total_distance_nm)
                 detail = adv_t("mountain_wind.wave_risk", loc, speed=f"{max_wind:.0f}", extent=ext)
+                if sig_text:
+                    detail += adv_t("mountain_wind.sig_suffix", loc, signature=sig_text)
             else:
                 status = AdvisoryStatus.GREEN
                 detail = adv_t("mountain_wind.light", loc, speed=f"{max_wind:.0f}")

--- a/src/weatherbrief/analysis/advisories/strings.py
+++ b/src/weatherbrief/analysis/advisories/strings.py
@@ -48,6 +48,14 @@ _STRINGS: dict[str, dict[str, str]] = {
 
     # --- flight_category ---
     # Uses "Dep {icao}: {cat}" pattern — Dep/Arr kept as compact labels
+    # Inline suffix appended to the per-airport part when terminal-area
+    # convective risk is MODERATE or worse.
+    "flight_category.conv": {
+        "en": ", convective {risk} nearby",
+        "fr": ", convectif {risk} à proximité",
+        "de": ", Konvektion {risk} in der Nähe",
+        "es": ", convectivo {risk} cercano",
+    },
 
     # --- convective ---
     "convective.risk_over": {
@@ -101,6 +109,31 @@ _STRINGS: dict[str, dict[str, str]] = {
         "fr": "Vents faibles près du relief ({speed}kt)",
         "de": "Schwache Winde nahe Gelände ({speed}kt)",
         "es": "Vientos débiles cerca del terreno ({speed}kt)",
+    },
+    "mountain_wind.wave_confirmed": {
+        "en": "Mountain wave conditions ({speed}kt near terrain, {signature}) over {extent}",
+        "fr": "Conditions d'onde de montagne ({speed}kt près du relief, {signature}) sur {extent}",
+        "de": "Gebirgswellenbedingungen ({speed}kt nahe Gelände, {signature}) über {extent}",
+        "es": "Condiciones de onda de montaña ({speed}kt cerca del terreno, {signature}) sobre {extent}",
+    },
+    # Inline suffix listing the wave signature(s) seen at strong-wind points.
+    "mountain_wind.sig_suffix": {
+        "en": " — {signature}",
+        "fr": " — {signature}",
+        "de": " — {signature}",
+        "es": " — {signature}",
+    },
+    "mountain_wind.sig_inversion": {
+        "en": "stable layer at ridge top",
+        "fr": "couche stable au sommet des crêtes",
+        "de": "stabile Schicht am Kammniveau",
+        "es": "capa estable en la cima",
+    },
+    "mountain_wind.sig_oscillating": {
+        "en": "wave-like vertical motion",
+        "fr": "mouvement vertical ondulatoire",
+        "de": "wellenartige Vertikalbewegung",
+        "es": "movimiento vertical ondulatorio",
     },
 
     # --- cloud_top ---
@@ -421,6 +454,52 @@ _STRINGS: dict[str, dict[str, str]] = {
         "fr": "Limite de masse d'air sur la route, mais peu de météo active",
         "de": "Luftmassengrenze auf der Strecke, aber kaum aktives Wetter",
         "es": "Límite de masa de aire en la ruta, pero con poco tiempo activo",
+    },
+
+    # --- enroute_precip ---
+    "enroute_precip.clear": {
+        "en": "No precipitation along route",
+        "fr": "Pas de précipitations le long de la route",
+        "de": "Kein Niederschlag entlang der Route",
+        "es": "Sin precipitación a lo largo de la ruta",
+    },
+    "enroute_precip.snow": {
+        "en": "Snow over {extent} — expect visibility to collapse in showers",
+        "fr": "Neige sur {extent} — visibilité s'effondrant dans les averses",
+        "de": "Schnee über {extent} — Sicht bricht in Schauern zusammen",
+        "es": "Nieve sobre {extent} — visibilidad colapsa en chubascos",
+    },
+    "enroute_precip.rain": {
+        "en": "Moderate+ rain over {extent}",
+        "fr": "Pluie modérée ou plus sur {extent}",
+        "de": "Mäßiger+ Regen über {extent}",
+        "es": "Lluvia moderada o más sobre {extent}",
+    },
+    "enroute_precip.light": {
+        "en": "Light precipitation over {extent}",
+        "fr": "Précipitations faibles sur {extent}",
+        "de": "Leichter Niederschlag über {extent}",
+        "es": "Precipitación ligera sobre {extent}",
+    },
+
+    # --- headwind ---
+    "headwind.summary": {
+        "en": "Avg {mean}kt headwind (max {max}kt) — about +{delta} min vs still air ({pct}%)",
+        "fr": "Vent de face moyen {mean}kt (max {max}kt) — environ +{delta} min vs air calme ({pct}%)",
+        "de": "Mittlerer Gegenwind {mean}kt (max {max}kt) — etwa +{delta} Min. ggü. ruhiger Luft ({pct}%)",
+        "es": "Viento en contra medio {mean}kt (máx {max}kt) — aprox +{delta} min vs aire en calma ({pct}%)",
+    },
+    "headwind.tailwind": {
+        "en": "Avg {mean}kt tailwind — about {delta} min saved",
+        "fr": "Vent arrière moyen {mean}kt — environ {delta} min gagnées",
+        "de": "Mittlerer Rückenwind {mean}kt — etwa {delta} Min. gespart",
+        "es": "Viento en cola medio {mean}kt — aprox {delta} min ahorrados",
+    },
+    "headwind.neutral": {
+        "en": "Light winds aloft — negligible trip impact",
+        "fr": "Vents faibles en altitude — impact négligeable sur le trajet",
+        "de": "Schwache Höhenwinde — vernachlässigbarer Einfluss",
+        "es": "Vientos débiles en altura — impacto insignificante",
     },
 
     # --- shared airport labels ---

--- a/src/weatherbrief/analysis/advisories/vfr_feasibility.py
+++ b/src/weatherbrief/analysis/advisories/vfr_feasibility.py
@@ -1,13 +1,21 @@
 """VFR feasibility advisory — overall VFR flight viability assessment.
 
 Composite advisory combining airport conditions, en-route cloud clearance,
-and VMC compliance into a single go/no-go style assessment for VFR flights.
+VMC compliance, climb-out/descent corridor decks, and en-route precipitation
+into a single go/no-go style assessment for VFR flights.
+
+The precipitation axis (shared classifier with the en-route precipitation
+advisory) is capped at AMBER here: a pilot VMC-on-top is not directly
+affected by surface rain below, but widespread snow or heavy rain degrades
+visibility and every descent/divert option, which deserves a composite
+caution. The standalone advisory still grades it fully (snow can RED).
 """
 
 from __future__ import annotations
 
 from weatherbrief.analysis.advisories import RouteContext
 from weatherbrief.analysis.advisories._helpers import format_extent
+from weatherbrief.analysis.advisories.enroute_precip import classify_enroute_precip
 from weatherbrief.analysis.advisories.registry import register
 from weatherbrief.analysis.advisories.strings import adv_t
 from weatherbrief.models import (
@@ -338,8 +346,20 @@ class VFRFeasibilityEvaluator:
                 elif affected > 0:
                     enroute_detail = adv_t("vfr.minor", loc, extent=format_extent(affected, total, ctx.total_distance_nm))
 
-            # 5. Combine airport + en-route + corridor
-            status = _worst_status(airport_status, enroute_status, corridor_status)
+            # 5. En-route precipitation (visibility proxy) — capped at AMBER
+            # in the composite; the standalone advisory grades it fully.
+            precip_status, precip_detail, _, _, precip_signal = (
+                classify_enroute_precip(ctx, model)
+            )
+            if not precip_signal or precip_status == AdvisoryStatus.UNAVAILABLE:
+                precip_status, precip_detail = AdvisoryStatus.GREEN, ""
+            elif precip_status == AdvisoryStatus.RED:
+                precip_status = AdvisoryStatus.AMBER
+
+            # 6. Combine airport + en-route + corridor + precipitation
+            status = _worst_status(
+                airport_status, enroute_status, corridor_status, precip_status,
+            )
 
             detail_parts = []
             if airport_detail:
@@ -347,6 +367,8 @@ class VFRFeasibilityEvaluator:
             if enroute_detail:
                 detail_parts.append(enroute_detail)
             detail_parts.extend(corridor_parts)
+            if precip_status != AdvisoryStatus.GREEN and precip_detail:
+                detail_parts.append(precip_detail)
 
             if not detail_parts:
                 if total > 0:

--- a/tests/analysis/advisories/test_airport_advisories.py
+++ b/tests/analysis/advisories/test_airport_advisories.py
@@ -116,7 +116,7 @@ class TestFlightCategoryEvaluator:
         entry = FlightCategoryEvaluator.catalog_entry()
         assert entry.id == "flight_category"
         assert entry.category == "airport"
-        assert len(entry.parameters) == 4
+        assert len(entry.parameters) == 5
 
     def test_vfr_both_airports(self):
         ac = _make_airport_conditions(
@@ -366,3 +366,97 @@ def test_density_altitude_unavailable_without_elevation():
         _da_ctx(temperature_c=30.0, elevation=None), {},
     )
     assert result.per_model[0].status == AdvisoryStatus.UNAVAILABLE
+
+
+# --- FlightCategoryEvaluator: terminal convective aspect ---
+
+def _conv_rpa(i: int, distance_nm: float, risk) -> RoutePointAnalysis:
+    from weatherbrief.models import ConvectiveAssessment, SoundingAnalysis, ThermodynamicIndices
+
+    conv = ConvectiveAssessment(risk_level=risk) if risk is not None else None
+    return RoutePointAnalysis(
+        point_index=i,
+        lat=48.0,
+        lon=2.0 + i * 0.5,
+        distance_from_origin_nm=distance_nm,
+        interpolated_time=datetime(2026, 6, 1, 12, 0),
+        forecast_hour=datetime(2026, 6, 1, 12, 0),
+        track_deg=90.0,
+        sounding={"gfs": SoundingAnalysis(indices=ThermodynamicIndices(), convective=conv)},
+    )
+
+
+def _terminal_conv_ctx(dep_risk, arr_risk, mid_risk=None) -> RouteContext:
+    """200nm route, 10 points: convective risk at the endpoints and optionally mid-route."""
+    from weatherbrief.models import ConvectiveRisk
+
+    analyses = []
+    for i in range(10):
+        d = i * 200.0 / 9
+        if d <= 25:
+            risk = dep_risk
+        elif d >= 175:
+            risk = arr_risk
+        else:
+            risk = mid_risk
+        analyses.append(_conv_rpa(i, d, risk))
+    conditions = _make_airport_conditions(
+        {"gfs": FlightCategory.VFR}, {"gfs": FlightCategory.VFR},
+    )
+    return RouteContext(
+        analyses=analyses,
+        cross_sections=[],
+        elevation=None,
+        models=["gfs"],
+        cruise_altitude_ft=8000,
+        flight_ceiling_ft=18000,
+        total_distance_nm=200,
+        airport_conditions=conditions,
+    )
+
+
+class TestTerminalConvective:
+
+    def test_quiet_terminals_green(self):
+        from weatherbrief.models import ConvectiveRisk
+
+        ctx = _terminal_conv_ctx(ConvectiveRisk.LOW, ConvectiveRisk.NONE)
+        result = FlightCategoryEvaluator.evaluate(ctx, {})
+        assert result.aggregate_status == AdvisoryStatus.GREEN
+
+    def test_moderate_at_arrival_amber_despite_low_route_coverage(self):
+        from weatherbrief.models import ConvectiveRisk
+
+        # One MODERATE zone only at the arrival end — % -of-route dilution must
+        # not apply at the terminal.
+        ctx = _terminal_conv_ctx(ConvectiveRisk.NONE, ConvectiveRisk.MODERATE)
+        result = FlightCategoryEvaluator.evaluate(ctx, {})
+        assert result.aggregate_status == AdvisoryStatus.AMBER
+        assert "convective MODERATE" in result.per_model[0].detail
+
+    def test_high_at_departure_red(self):
+        from weatherbrief.models import ConvectiveRisk
+
+        ctx = _terminal_conv_ctx(ConvectiveRisk.HIGH, ConvectiveRisk.NONE)
+        result = FlightCategoryEvaluator.evaluate(ctx, {})
+        assert result.aggregate_status == AdvisoryStatus.RED
+
+    def test_mid_route_convection_not_attributed_to_terminals(self):
+        from weatherbrief.models import ConvectiveRisk
+
+        ctx = _terminal_conv_ctx(
+            ConvectiveRisk.NONE, ConvectiveRisk.NONE, mid_risk=ConvectiveRisk.HIGH,
+        )
+        result = FlightCategoryEvaluator.evaluate(ctx, {})
+        assert result.aggregate_status == AdvisoryStatus.GREEN
+
+    def test_radius_parameter_widens_terminal(self):
+        from weatherbrief.models import ConvectiveRisk
+
+        # HIGH at ~89nm (mid-route point 4) is outside default 25nm radius but
+        # inside a 120nm one.
+        ctx = _terminal_conv_ctx(
+            ConvectiveRisk.NONE, ConvectiveRisk.NONE, mid_risk=ConvectiveRisk.HIGH,
+        )
+        result = FlightCategoryEvaluator.evaluate(ctx, {"conv_radius_nm": 120})
+        assert result.aggregate_status == AdvisoryStatus.RED

--- a/tests/analysis/advisories/test_enroute_precip.py
+++ b/tests/analysis/advisories/test_enroute_precip.py
@@ -1,0 +1,160 @@
+"""Tests for the en-route precipitation advisory and its VFR composite feed."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from weatherbrief.analysis.advisories import RouteContext
+from weatherbrief.analysis.advisories.enroute_precip import (
+    EnroutePrecipEvaluator,
+    classify_enroute_precip,
+)
+from weatherbrief.analysis.advisories.vfr_feasibility import VFRFeasibilityEvaluator
+from weatherbrief.models import (
+    AdvisoryStatus,
+    PrecipIntensity,
+    PrecipPhase,
+    PrecipitationAssessment,
+    RoutePointAnalysis,
+    SoundingAnalysis,
+    ThermodynamicIndices,
+)
+
+
+def _make_rpa(i: int, sounding: dict[str, SoundingAnalysis]) -> RoutePointAnalysis:
+    return RoutePointAnalysis(
+        point_index=i,
+        lat=48.0 + i * 0.5,
+        lon=2.0 + i * 0.5,
+        distance_from_origin_nm=i * 20.0,
+        interpolated_time=datetime(2026, 3, 1, 10, 0),
+        forecast_hour=datetime(2026, 3, 1, 9, 0),
+        track_deg=90.0,
+        sounding=sounding,
+    )
+
+
+def _sounding(
+    phase: PrecipPhase = PrecipPhase.DRY,
+    intensity: PrecipIntensity = PrecipIntensity.NONE,
+    with_precip: bool = True,
+) -> SoundingAnalysis:
+    return SoundingAnalysis(
+        indices=ThermodynamicIndices(),
+        precipitation=(
+            PrecipitationAssessment(surface_phase=phase, surface_intensity=intensity)
+            if with_precip else None
+        ),
+    )
+
+
+def _ctx(per_point: list[SoundingAnalysis]) -> RouteContext:
+    analyses = [_make_rpa(i, {"gfs": s}) for i, s in enumerate(per_point)]
+    return RouteContext(
+        analyses=analyses,
+        cross_sections=[],
+        elevation=None,
+        models=["gfs"],
+        cruise_altitude_ft=8000,
+        flight_ceiling_ft=18000,
+        total_distance_nm=200,
+    )
+
+
+def _evaluate(ctx: RouteContext, params: dict | None = None):
+    entry = EnroutePrecipEvaluator.catalog_entry()
+    defaults = {p.key: p.default for p in entry.parameters}
+    return EnroutePrecipEvaluator.evaluate(ctx, {**defaults, **(params or {})})
+
+
+class TestEnroutePrecipEvaluator:
+
+    def test_dry_route_is_green(self):
+        ctx = _ctx([_sounding() for _ in range(10)])
+        result = _evaluate(ctx)
+        assert result.aggregate_status == AdvisoryStatus.GREEN
+
+    def test_no_precip_data_is_unavailable(self):
+        ctx = _ctx([_sounding(with_precip=False) for _ in range(10)])
+        result = _evaluate(ctx)
+        assert result.per_model[0].status == AdvisoryStatus.UNAVAILABLE
+
+    def test_light_rain_stays_green(self):
+        per_point = [
+            _sounding(PrecipPhase.RAIN, PrecipIntensity.LIGHT) if i < 4 else _sounding()
+            for i in range(10)
+        ]
+        result = _evaluate(_ctx(per_point))
+        assert result.aggregate_status == AdvisoryStatus.GREEN
+
+    def test_light_snow_is_amber(self):
+        # 2/10 points with light snow > 5% default amber threshold
+        per_point = [
+            _sounding(PrecipPhase.SNOW, PrecipIntensity.LIGHT) if i < 2 else _sounding()
+            for i in range(10)
+        ]
+        result = _evaluate(_ctx(per_point))
+        assert result.aggregate_status == AdvisoryStatus.AMBER
+        assert "Snow" in result.per_model[0].detail
+
+    def test_widespread_moderate_snow_is_red(self):
+        per_point = [
+            _sounding(PrecipPhase.SNOW, PrecipIntensity.MODERATE) if i < 4 else _sounding()
+            for i in range(10)
+        ]
+        result = _evaluate(_ctx(per_point))
+        assert result.aggregate_status == AdvisoryStatus.RED
+
+    def test_widespread_moderate_rain_is_amber(self):
+        per_point = [
+            _sounding(PrecipPhase.RAIN, PrecipIntensity.MODERATE) if i < 4 else _sounding()
+            for i in range(10)
+        ]
+        result = _evaluate(_ctx(per_point))
+        assert result.aggregate_status == AdvisoryStatus.AMBER
+
+    def test_freezing_rain_counts_as_significant_extent(self):
+        # FZRA over 40% of the route exceeds the rain amber threshold (30%).
+        # Severity (RED) is owned by the freezing_precip advisory.
+        per_point = [
+            _sounding(PrecipPhase.FREEZING_RAIN, PrecipIntensity.LIGHT) if i < 4 else _sounding()
+            for i in range(10)
+        ]
+        result = _evaluate(_ctx(per_point))
+        assert result.aggregate_status == AdvisoryStatus.AMBER
+
+    def test_tunable_snow_threshold(self):
+        per_point = [
+            _sounding(PrecipPhase.SNOW, PrecipIntensity.LIGHT) if i < 2 else _sounding()
+            for i in range(10)
+        ]
+        result = _evaluate(_ctx(per_point), params={"snow_pct_amber": 30})
+        assert result.aggregate_status == AdvisoryStatus.GREEN
+
+
+class TestVFRPrecipFeed:
+
+    def test_vfr_composite_capped_at_amber_on_snow(self):
+        # Widespread moderate snow REDs the standalone advisory but only
+        # AMBERs the VFR composite.
+        per_point = [
+            _sounding(PrecipPhase.SNOW, PrecipIntensity.MODERATE) if i < 4 else _sounding()
+            for i in range(10)
+        ]
+        ctx = _ctx(per_point)
+
+        status, _, _, _, signal = classify_enroute_precip(ctx, "gfs")
+        assert signal and status == AdvisoryStatus.RED
+
+        entry = VFRFeasibilityEvaluator.catalog_entry()
+        defaults = {p.key: p.default for p in entry.parameters}
+        result = VFRFeasibilityEvaluator.evaluate(ctx, defaults)
+        assert result.aggregate_status == AdvisoryStatus.AMBER
+        assert "Snow" in result.per_model[0].detail
+
+    def test_vfr_composite_unaffected_by_missing_precip_data(self):
+        ctx = _ctx([_sounding(with_precip=False) for _ in range(10)])
+        entry = VFRFeasibilityEvaluator.catalog_entry()
+        defaults = {p.key: p.default for p in entry.parameters}
+        result = VFRFeasibilityEvaluator.evaluate(ctx, defaults)
+        assert result.per_model[0].status == AdvisoryStatus.GREEN

--- a/tests/analysis/advisories/test_headwind.py
+++ b/tests/analysis/advisories/test_headwind.py
@@ -1,0 +1,102 @@
+"""Tests for the winds-aloft / trip-impact advisory."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from weatherbrief.analysis.advisories import RouteContext
+from weatherbrief.analysis.advisories.headwind import HeadwindEvaluator
+from weatherbrief.models import (
+    AdvisoryStatus,
+    RoutePointAnalysis,
+    SoundingAnalysis,
+    ThermodynamicIndices,
+    WindComponent,
+)
+
+
+def _make_rpa(i: int, headwind_kt: float | None) -> RoutePointAnalysis:
+    wind_components = {}
+    if headwind_kt is not None:
+        # Track 90°, wind FROM 90° at |headwind| kt → pure headwind (or FROM
+        # 270° for a tailwind). The evaluator's cross-section path is not
+        # exercised here (empty cross_sections → fallback to wind_components).
+        wind_components["gfs"] = WindComponent(
+            wind_speed_kt=abs(headwind_kt),
+            wind_direction_deg=90.0 if headwind_kt >= 0 else 270.0,
+            track_deg=90.0,
+            headwind_kt=headwind_kt,
+            crosswind_kt=0.0,
+        )
+    return RoutePointAnalysis(
+        point_index=i,
+        lat=48.0,
+        lon=2.0 + i * 0.5,
+        distance_from_origin_nm=i * 20.0,
+        interpolated_time=datetime(2026, 3, 1, 10, 0),
+        forecast_hour=datetime(2026, 3, 1, 9, 0),
+        track_deg=90.0,
+        wind_components=wind_components,
+        sounding={"gfs": SoundingAnalysis(indices=ThermodynamicIndices())},
+    )
+
+
+def _ctx(headwinds: list[float | None]) -> RouteContext:
+    return RouteContext(
+        analyses=[_make_rpa(i, hw) for i, hw in enumerate(headwinds)],
+        cross_sections=[],
+        elevation=None,
+        models=["gfs"],
+        cruise_altitude_ft=8000,
+        flight_ceiling_ft=18000,
+        total_distance_nm=200,
+    )
+
+
+def _evaluate(ctx: RouteContext, params: dict | None = None):
+    entry = HeadwindEvaluator.catalog_entry()
+    defaults = {p.key: p.default for p in entry.parameters}
+    return HeadwindEvaluator.evaluate(ctx, {**defaults, **(params or {})})
+
+
+class TestHeadwindEvaluator:
+
+    def test_catalog_entry(self):
+        entry = HeadwindEvaluator.catalog_entry()
+        assert entry.id == "headwind"
+        assert entry.altitude_dependent is True
+
+    def test_light_winds_green(self):
+        result = _evaluate(_ctx([5.0] * 10))
+        assert result.aggregate_status == AdvisoryStatus.GREEN
+
+    def test_strong_headwind_amber_with_time_impact(self):
+        result = _evaluate(_ctx([25.0] * 10))
+        assert result.aggregate_status == AdvisoryStatus.AMBER
+        detail = result.per_model[0].detail
+        assert "25kt" in detail
+        # 200nm at 110 TAS: still 109.1 min, at GS 85 → 141.2 min → +32 min
+        assert "+32 min" in detail
+
+    def test_extreme_headwind_red(self):
+        result = _evaluate(_ctx([45.0] * 10))
+        assert result.aggregate_status == AdvisoryStatus.RED
+
+    def test_tailwind_green_with_gain(self):
+        result = _evaluate(_ctx([-20.0] * 10))
+        assert result.aggregate_status == AdvisoryStatus.GREEN
+        assert "tailwind" in result.per_model[0].detail.lower()
+
+    def test_no_wind_data_unavailable(self):
+        result = _evaluate(_ctx([None] * 10))
+        assert result.per_model[0].status == AdvisoryStatus.UNAVAILABLE
+
+    def test_tunable_thresholds(self):
+        result = _evaluate(_ctx([25.0] * 10), params={"mean_amber_kt": 30})
+        assert result.aggregate_status == AdvisoryStatus.GREEN
+
+    def test_tas_changes_time_estimate(self):
+        slow = _evaluate(_ctx([25.0] * 10), params={"cruise_tas_kt": 80})
+        fast = _evaluate(_ctx([25.0] * 10), params={"cruise_tas_kt": 160})
+        # Same wind, slower aircraft → larger time penalty in the detail.
+        assert slow.per_model[0].detail != fast.per_model[0].detail

--- a/tests/analysis/advisories/test_mountain_wind.py
+++ b/tests/analysis/advisories/test_mountain_wind.py
@@ -1,0 +1,179 @@
+"""Tests for the mountain wind advisory's wave-signature corroboration."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from weatherbrief.analysis.advisories import RouteContext
+from weatherbrief.analysis.advisories.mountain_wind import MountainWindEvaluator
+from weatherbrief.models import (
+    AdvisoryStatus,
+    ElevationPoint,
+    ElevationProfile,
+    HourlyForecast,
+    InversionLayer,
+    ModelSource,
+    PressureLevelData,
+    RouteCrossSection,
+    RoutePoint,
+    RoutePointAnalysis,
+    SoundingAnalysis,
+    ThermodynamicIndices,
+    VerticalMotionAssessment,
+    VerticalMotionClass,
+    Waypoint,
+    WaypointForecast,
+)
+
+_T0 = datetime(2026, 3, 1, 12, 0)
+_N = 10
+_TOTAL_NM = 200.0
+
+
+def _mountain_elevation() -> ElevationProfile:
+    """Flat 500ft profile with a 5000ft plateau mid-route (points 4-6)."""
+    points = []
+    for i in range(_N):
+        d = i * _TOTAL_NM / (_N - 1)
+        elev = 5000.0 if 4 <= i <= 6 else 500.0
+        points.append(ElevationPoint(distance_nm=d, elevation_ft=elev, lat=46.0, lon=6.0 + i * 0.2))
+    return ElevationProfile(
+        route_name="test", points=points,
+        max_elevation_ft=5000, total_distance_nm=_TOTAL_NM,
+    )
+
+
+def _cross_section(wind_speed_kt: float) -> RouteCrossSection:
+    """One-model cross-section with uniform wind at a single 800hPa level."""
+    route_points = [
+        RoutePoint(lat=46.0, lon=6.0 + i * 0.2, distance_from_origin_nm=i * _TOTAL_NM / (_N - 1))
+        for i in range(_N)
+    ]
+    forecasts = [
+        WaypointForecast(
+            waypoint=Waypoint(icao=f"P{i}", name=f"P{i}", lat=46.0, lon=6.0 + i * 0.2),
+            model=ModelSource.GFS,
+            fetched_at=_T0,
+            hourly=[HourlyForecast(
+                time=_T0,
+                pressure_levels=[PressureLevelData(
+                    pressure_hpa=800,
+                    wind_speed_kt=wind_speed_kt,
+                    wind_direction_deg=270.0,
+                )],
+            )],
+        )
+        for i in range(_N)
+    ]
+    return RouteCrossSection(
+        model=ModelSource.GFS, route_points=route_points,
+        fetched_at=_T0, point_forecasts=forecasts,
+    )
+
+
+def _sounding(
+    ridge_inversion: bool = False,
+    oscillating: bool = False,
+) -> SoundingAnalysis:
+    inversions = (
+        [InversionLayer(base_ft=5500, top_ft=6500, strength_c=3.0)]
+        if ridge_inversion else []
+    )
+    vm = VerticalMotionAssessment(
+        classification=(
+            VerticalMotionClass.OSCILLATING if oscillating
+            else VerticalMotionClass.QUIESCENT
+        ),
+    )
+    return SoundingAnalysis(
+        indices=ThermodynamicIndices(),
+        inversion_layers=inversions,
+        vertical_motion=vm,
+    )
+
+
+def _ctx(
+    wind_speed_kt: float,
+    ridge_inversion: bool = False,
+    oscillating: bool = False,
+) -> RouteContext:
+    analyses = [
+        RoutePointAnalysis(
+            point_index=i,
+            lat=46.0,
+            lon=6.0 + i * 0.2,
+            distance_from_origin_nm=i * _TOTAL_NM / (_N - 1),
+            interpolated_time=_T0,
+            forecast_hour=_T0,
+            track_deg=90.0,
+            sounding={"gfs": _sounding(ridge_inversion, oscillating)},
+        )
+        for i in range(_N)
+    ]
+    return RouteContext(
+        analyses=analyses,
+        cross_sections=[_cross_section(wind_speed_kt)],
+        elevation=_mountain_elevation(),
+        models=["gfs"],
+        cruise_altitude_ft=8000,
+        flight_ceiling_ft=18000,
+        total_distance_nm=_TOTAL_NM,
+    )
+
+
+def _evaluate(ctx: RouteContext, params: dict | None = None):
+    entry = MountainWindEvaluator.catalog_entry()
+    defaults = {p.key: p.default for p in entry.parameters}
+    return MountainWindEvaluator.evaluate(ctx, {**defaults, **(params or {})})
+
+
+class TestMountainWindWaveCorroboration:
+
+    def test_light_wind_green(self):
+        result = _evaluate(_ctx(10.0))
+        assert result.aggregate_status == AdvisoryStatus.GREEN
+
+    def test_strong_wind_no_signature_amber(self):
+        # 32kt is above the corroborated red bar (30) but with no wave
+        # signature it stays AMBER until the plain red bar (40).
+        result = _evaluate(_ctx(32.0))
+        assert result.aggregate_status == AdvisoryStatus.AMBER
+
+    def test_strong_wind_with_ridge_inversion_red(self):
+        result = _evaluate(_ctx(32.0, ridge_inversion=True))
+        assert result.aggregate_status == AdvisoryStatus.RED
+        assert "stable layer" in result.per_model[0].detail
+
+    def test_strong_wind_with_oscillating_motion_red(self):
+        result = _evaluate(_ctx(32.0, oscillating=True))
+        assert result.aggregate_status == AdvisoryStatus.RED
+        assert "wave-like" in result.per_model[0].detail
+
+    def test_moderate_wind_with_signature_stays_amber(self):
+        # 25kt + signature: below the corroborated red bar — wave possible
+        # but flow too weak for an automatic RED.
+        result = _evaluate(_ctx(25.0, ridge_inversion=True))
+        assert result.aggregate_status == AdvisoryStatus.AMBER
+
+    def test_very_strong_wind_red_regardless(self):
+        result = _evaluate(_ctx(45.0))
+        assert result.aggregate_status == AdvisoryStatus.RED
+
+    def test_no_mountains_green(self):
+        ctx = _ctx(45.0)
+        flat = ElevationProfile(
+            route_name="test",
+            points=[ElevationPoint(distance_nm=p.distance_nm, elevation_ft=500, lat=p.lat, lon=p.lon)
+                    for p in ctx.elevation.points],
+            max_elevation_ft=500, total_distance_nm=_TOTAL_NM,
+        )
+        from dataclasses import replace
+        result = _evaluate(replace(ctx, elevation=flat))
+        assert result.aggregate_status == AdvisoryStatus.GREEN
+
+    def test_corroborated_threshold_tunable(self):
+        result = _evaluate(
+            _ctx(32.0, ridge_inversion=True),
+            params={"corroborated_red_kt": 35},
+        )
+        assert result.aggregate_status == AdvisoryStatus.AMBER

--- a/web/ts/helpers/advisory-order.ts
+++ b/web/ts/helpers/advisory-order.ts
@@ -33,6 +33,7 @@ export const ADVISORY_PRIORITY: string[] = [
   'airport_wind',
   'cloud_top',
   'vmc_cruise',
+  'enroute_precip',      // En-route Precipitation (visibility)
   'convective',
   'fronts',
   'fiki_icing',
@@ -42,6 +43,7 @@ export const ADVISORY_PRIORITY: string[] = [
   'mountain_wind',
   'llws',                // Low-Level Wind Shear
   'density_altitude',
+  'headwind',            // Winds Aloft / trip impact
   'sun',
   'model_agreement',     // Forecast Confidence
   'dd_nwp_agreement',

--- a/web/ts/i18n/locales/de.json
+++ b/web/ts/i18n/locales/de.json
@@ -386,6 +386,8 @@
   "settings.cat.turbulence": "Turbulenz",
   "settings.cat.convective": "Konvektiv",
   "settings.cat.airport": "Flugplatz",
+  "settings.cat.precipitation": "Niederschlag",
+  "settings.cat.wind": "Winde",
   "settings.cat.model": "Vorhersage",
   "settings.selectOneModel": "Wählen Sie mindestens ein Vorhersagemodell aus.",
   "settings.profileCreated": "Profil „{name}“ erstellt.",

--- a/web/ts/i18n/locales/en.json
+++ b/web/ts/i18n/locales/en.json
@@ -462,6 +462,8 @@
   "settings.cat.turbulence": "Turbulence",
   "settings.cat.convective": "Convective",
   "settings.cat.airport": "Airport",
+  "settings.cat.precipitation": "Precipitation",
+  "settings.cat.wind": "Winds",
   "settings.cat.model": "Forecast",
   "settings.selectOneModel": "Select at least one forecast model.",
   "settings.profileCreated": "Profile \"{name}\" created.",

--- a/web/ts/i18n/locales/es.json
+++ b/web/ts/i18n/locales/es.json
@@ -386,6 +386,8 @@
   "settings.cat.turbulence": "Turbulencia",
   "settings.cat.convective": "Convectivo",
   "settings.cat.airport": "Aeropuerto",
+  "settings.cat.precipitation": "Precipitación",
+  "settings.cat.wind": "Vientos",
   "settings.cat.model": "Pronóstico",
   "settings.selectOneModel": "Seleccione al menos un modelo de pronóstico.",
   "settings.profileCreated": "Perfil \"{name}\" creado.",

--- a/web/ts/i18n/locales/fr.json
+++ b/web/ts/i18n/locales/fr.json
@@ -386,6 +386,8 @@
   "settings.cat.turbulence": "Turbulence",
   "settings.cat.convective": "Convectif",
   "settings.cat.airport": "Aérodrome",
+  "settings.cat.precipitation": "Précipitations",
+  "settings.cat.wind": "Vents",
   "settings.cat.model": "Prévision",
   "settings.selectOneModel": "Sélectionnez au moins un modèle de prévision.",
   "settings.profileCreated": "Profil « {name} » créé.",

--- a/web/ts/settings-main.ts
+++ b/web/ts/settings-main.ts
@@ -53,8 +53,10 @@ import { renderAdvisoryPopup } from './helpers/advisory-popup';
 const CATEGORY_KEYS: [string, string][] = [
   ['icing', 'settings.cat.icing'],
   ['cloud', 'settings.cat.cloud'],
+  ['precipitation', 'settings.cat.precipitation'],
   ['turbulence', 'settings.cat.turbulence'],
   ['convective', 'settings.cat.convective'],
+  ['wind', 'settings.cat.wind'],
   ['airport', 'settings.cat.airport'],
   ['model', 'settings.cat.model'],
 ];


### PR DESCRIPTION
## Summary

Implements four new advisory evaluators and enhances one existing evaluator to complete the second advisory review cycle:

1. **En-route Precipitation** — Uses precipitation phase/intensity (available from all models via `PrecipitationAssessment`) as the visibility proxy since no model provides altitude visibility. Snow over ≥5% of route → AMBER; moderate+ snow over ≥25% → RED; moderate+ rain over ≥30% → AMBER. Shared classifier feeds VFR feasibility composite capped at AMBER.

2. **Winds Aloft / Headwind** — Aggregates cruise-level headwind along the route and estimates trip-time impact using a tunable TAS parameter. Informational by design (GREEN/AMBER on route-average headwind, RED only for extreme days). Altitude-aware: reads from cross-section at evaluated cruise level.

3. **Terminal Convective Risk** — Folded into `FlightCategoryEvaluator` to grade worst convective risk within terminal radius (default 25 nm) of each airport with **no coverage dilution** (deviation not an option on climb/approach). MODERATE → AMBER, HIGH/EXTREME → RED.

4. **Mountain Wind Wave Corroboration** — Enhanced `MountainWindEvaluator` to corroborate strong-wind grades with classical wave signatures: inversion layer near ridge top or oscillating vertical-motion profile. When either signature is present, RED threshold drops from `wind_red_kt` to `corroborated_red_kt`.

## Key Changes

- **New files:**
  - `src/weatherbrief/analysis/advisories/enroute_precip.py` — Precipitation visibility evaluator with shared `classify_enroute_precip()` classifier
  - `src/weatherbrief/analysis/advisories/headwind.py` — Cruise headwind and trip-impact evaluator
  - `tests/analysis/advisories/test_enroute_precip.py` — Comprehensive tests for precipitation grading and VFR composite feed
  - `tests/analysis/advisories/test_headwind.py` — Headwind evaluator tests
  - `tests/analysis/advisories/test_mountain_wind.py` — Wave-signature corroboration tests

- **Modified files:**
  - `src/weatherbrief/analysis/advisories/mountain_wind.py` — Added `_wave_signatures()` helper and wave-signature corroboration logic; updated catalog entry and grading thresholds
  - `src/weatherbrief/analysis/advisories/flight_category.py` — Added `_terminal_convective_risk()` and `_terminal_convective_status()` helpers; integrated terminal convective grading into airport evaluation
  - `src/weatherbrief/analysis/advisories/vfr_feasibility.py` — Integrated precipitation classifier (capped at AMBER) into composite assessment
  - `src/weatherbrief/analysis/advisories/strings.py` — Added localized strings for all four advisories and wave signatures
  - `designs/meteorology-decisions.md` — Documented design rationale for all four additions
  - `designs/advisories.md` — Updated evaluator count (17 → 20) and category list
  - Web UI files — Added new advisory categories ("Precipitation", "Winds") and priority ordering

## Implementation Details

- **Precipitation classifier** is shared between standalone advisory and VFR composite via `classify_enroute_precip()` function, allowing consistent grading with different caps per context.
- **Headwind evaluator** reads winds from cross-section at evaluated cruise altitude (altitude-dependent), falling back to precomputed `wind_components` on older packs without cross-section data.
- **Terminal convective** uses worst-case risk within radius with no percentage threshold — reflects GA reality that a cell at the destination cannot be deviated around.
- **Wave signatures** search for inversion layers within ±1000/4000 ft of terrain and oscillating vertical-motion classification; both are already computed per sounding, no new analysis required.
- All four evaluators follow existing patterns: `@register` decorator, `catalog_entry()` static method, `evaluate

https://claude.ai/code/session_014FhsuBDWhMoDC72TYPVF3W