### PR TITLE
fix(maps): align forecast-map day labels with actual forecast dates

### DIFF
--- a/src/weatherbrief/api/maps.py
+++ b/src/weatherbrief/api/maps.py
@@ -32,6 +32,21 @@ from weatherbrief.tasks.standalone_verification import SAMPLE_HOURS_UTC as _SAMP
 from weatherbrief.api.deps import airports_db as _airports_db
 
 
+def _forecast_hour(day: int, hour: int) -> datetime:
+    """Absolute UTC datetime for a relative ``(day, hour)`` selection.
+
+    ``day`` is days from today (0 = today). This mirrors the client's date
+    labelling (``now + day``) so cache and live queries resolve to the same
+    calendar date the UI displays — the relative-day cache key alone is
+    ambiguous across a UTC-midnight rollover.
+    """
+    target_date = (datetime.now(timezone.utc) + timedelta(days=day)).date()
+    return datetime(
+        target_date.year, target_date.month, target_date.day,
+        hour, 0, 0, tzinfo=timezone.utc,
+    )
+
+
 @router.get("/forecast")
 def get_forecast_map(
     day: int = Query(default=0, ge=0, le=3),
@@ -61,13 +76,7 @@ def get_forecast_map(
         if cached is not None:
             return cached
 
-    now = datetime.now(timezone.utc)
-    target_date = (now + timedelta(days=day)).date()
-    forecast_hour = datetime(
-        target_date.year, target_date.month, target_date.day,
-        hour, 0, 0, tzinfo=timezone.utc,
-    )
-
+    forecast_hour = _forecast_hour(day, hour)
     return get_forecast_map_data(db, forecast_hour, airports_db)
 
 
@@ -104,6 +113,52 @@ def get_available_hours(
     available = sorted(int(h) for h in hour_rows if int(h) in _SAMPLE_HOURS)
 
     return {"day": day, "date": target_date.isoformat(), "hours": available}
+
+
+def compute_day_availability(db: Session) -> list[dict[str, Any]]:
+    """Per-relative-day (D-0..D-3) flag for whether any forecast data exists.
+
+    Pure logic (no ``Depends`` defaults) so it can be unit-tested directly and
+    reused. The far day (today+3) has no snapshots until the next twice-daily
+    model run extends the horizon.
+    """
+    from sqlalchemy import select
+
+    from weatherbrief.db.models import AirportForecastSnapshotRow
+
+    days = []
+    for day in (0, 1, 2, 3):
+        forecast_date = (datetime.now(timezone.utc) + timedelta(days=day)).date()
+        start = datetime(
+            forecast_date.year, forecast_date.month, forecast_date.day,
+            0, 0, 0, tzinfo=timezone.utc,
+        )
+        end = start + timedelta(days=1)
+        has_data = db.execute(
+            select(AirportForecastSnapshotRow.id)
+            .where(AirportForecastSnapshotRow.forecast_hour >= start)
+            .where(AirportForecastSnapshotRow.forecast_hour < end)
+            .limit(1)
+        ).scalar()
+        days.append({
+            "day": day,
+            "date": forecast_date.isoformat(),
+            "available": has_data is not None,
+        })
+    return days
+
+
+@router.get("/forecast/days")
+def get_available_days(
+    _user_id: str = Depends(current_user_id),
+    db: Session = Depends(get_db),
+):
+    """Return which relative days (D-0..D-3) have any forecast data.
+
+    The frontend disables days beyond the current model horizon rather than
+    showing an empty or mislabelled map.
+    """
+    return {"days": compute_day_availability(db)}
 
 
 # ---------------------------------------------------------------------------
@@ -228,23 +283,38 @@ def get_airport_weather(
             "note": "No supported European airports found. Coverage: Western, Central, and Eastern Europe.",
         }
 
-    # Serve from pre-built cache only — the cache is rebuilt frequently
-    # by the background scheduler. Avoids expensive full-map queries
-    # when only a few airports are needed.
-    from weatherbrief.tasks.cache_builder import get_cached
+    # Prefer the pre-built cache (rebuilt frequently by the background
+    # scheduler) to avoid expensive full-map queries when only a few airports
+    # are needed. ``is_stale`` also rejects an entry whose relative-day index
+    # no longer maps to today's date (post-midnight, before the next model
+    # run); in that case compute live for the correct absolute date so the
+    # response date stays consistent with the requested day/hour.
+    from weatherbrief.tasks.cache_builder import get_cached, is_stale
+    from weatherbrief.tasks.map_queries import (
+        enrich_with_observations,
+        get_forecast_map_data,
+    )
 
     if hour not in _SAMPLE_HOURS:
         hour = min(_SAMPLE_HOURS, key=lambda h: abs(h - hour))
 
     cache_key = f"forecast_map:{day}:{hour}"
-    data = get_cached(db, cache_key)
+    data = None
+    if not is_stale(db, cache_key, "snapshot"):
+        data = get_cached(db, cache_key)
 
     if data is None:
-        raise HTTPException(
-            status_code=503,
-            detail=f"Forecast data for day={day} hour={hour} is not yet available. "
-            "The cache is rebuilt every ~30 minutes — try again shortly.",
-        )
+        forecast_hour = _forecast_hour(day, hour)
+        data = get_forecast_map_data(db, forecast_hour, airports_db)
+        if day == 0:
+            data = enrich_with_observations(db, forecast_hour, data)
+        if not data.get("airports"):
+            raise HTTPException(
+                status_code=503,
+                detail=f"Forecast data for day={day} hour={hour} is not yet "
+                "available — the day may be beyond the current model horizon. "
+                "The next model run extends it; try again shortly.",
+            )
 
     # Filter to requested airports
     resolution_map = {r["icao"]: r for r in resolved if "requested_icao" in r}

--- a/src/weatherbrief/tasks/cache_builder.py
+++ b/src/weatherbrief/tasks/cache_builder.py
@@ -99,11 +99,25 @@ def is_stale(db: Session, cache_key: str, source: str) -> bool:
 
     For forecast map keys, compares against snapshot fetched_at instead of
     verification scores.
+
+    Forecast-map keys (``source == "snapshot"``) are *relative-day* indexed
+    (``forecast_map:{day}:{hour}``) but the cached payload holds an *absolute*
+    forecast date. Snapshots only refresh on the twice-daily fetch cycles, so
+    after a UTC-midnight rollover the snapshot max-time is unchanged yet the
+    relative day now maps to a new calendar date. Without a date check the
+    stale entry would be served — e.g. D-0 showing yesterday's data labelled
+    today. So an entry computed on an earlier UTC day is always stale, forcing
+    the live path (which re-derives the correct absolute hour). See
+    designs/forecast-page.md.
     """
-    _, cached_max = get_cache_meta(db, cache_key)
+    computed_at, cached_max = get_cache_meta(db, cache_key)
     if cached_max is None:
         return True
     if source == "snapshot":
+        if computed_at is not None:
+            ca = computed_at.astimezone(timezone.utc) if computed_at.tzinfo else computed_at
+            if ca.date() < datetime.now(timezone.utc).date():
+                return True
         live_max = get_snapshot_max_time(db)
     else:
         live_max = get_source_max_time(db, source)

--- a/tests/test_cache_builder.py
+++ b/tests/test_cache_builder.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from datetime import datetime, timedelta, timezone
 
 import pytest
@@ -17,6 +18,7 @@ def db_engine():
 
 
 from weatherbrief.db.models import (
+    AirportForecastSnapshotRow,
     VerificationCacheRow,
     VerificationObservationRow,
     VerificationScoreRow,
@@ -116,6 +118,41 @@ class TestStalenessCheck:
         # SQLite drops tzinfo, so compare naive
         assert flight_max.replace(tzinfo=None) == NOW.replace(tzinfo=None)
         assert standalone_max.replace(tzinfo=None) == (NOW - timedelta(hours=1)).replace(tzinfo=None)
+
+
+class TestForecastMapRolloverStaleness:
+    """forecast_map cache keys are relative-day indexed but hold absolute
+    dates, so an entry built on an earlier UTC day is stale even when no new
+    snapshot has arrived (otherwise D-0 would show yesterday's data)."""
+
+    def _seed(self, db_session, computed_at: datetime):
+        # Snapshot whose fetched_at equals the cache's stored source_max, so
+        # the snapshot-freshness branch alone would report "not stale".
+        snap_time = datetime(2026, 4, 8, 7, 0, tzinfo=timezone.utc)
+        db_session.add(AirportForecastSnapshotRow(
+            icao="LFPG", model="gfs",
+            model_init_time=snap_time - timedelta(hours=1),
+            forecast_hour=datetime(2026, 4, 8, 12, 0, tzinfo=timezone.utc),
+            fetched_at=snap_time,
+        ))
+        db_session.add(VerificationCacheRow(
+            cache_key="forecast_map:0:12",
+            computed_at=computed_at,
+            source_max_time=snap_time,
+            data_json=json.dumps({"airports": []}),
+        ))
+        db_session.flush()
+
+    def test_stale_when_computed_yesterday(self, db_session):
+        # Built two days ago but snapshot unchanged → relative day now maps to
+        # a different calendar date → must be treated as stale.
+        self._seed(db_session, datetime.now(timezone.utc) - timedelta(days=2))
+        assert is_stale(db_session, "forecast_map:0:12", "snapshot") is True
+
+    def test_not_stale_when_computed_today(self, db_session):
+        # Same snapshot, built today → relative day still maps to today → fresh.
+        self._seed(db_session, datetime.now(timezone.utc))
+        assert is_stale(db_session, "forecast_map:0:12", "snapshot") is False
 
 
 class TestRebuildStatsCache:

--- a/tests/test_map_queries.py
+++ b/tests/test_map_queries.py
@@ -493,3 +493,29 @@ class TestAvailableHoursEndpoint:
         resp = client.get("/api/maps/forecast/hours?day=3")
         assert resp.status_code == 200
         assert resp.json()["hours"] == []
+
+
+class TestAvailableDaysEndpoint:
+    """Tests for GET /api/maps/forecast/days — drives the day-picker
+    disable/“not forecast yet” behaviour."""
+
+    def test_reports_per_day_availability(self, app_db, tmp_path, monkeypatch):
+        client = _make_client(app_db, tmp_path, monkeypatch)
+
+        # Seed D-0 (today) only; D-3 stays unforecast, as it would be before
+        # the next twice-daily model run extends the horizon.
+        today_12z = datetime.now(timezone.utc).replace(
+            hour=12, minute=0, second=0, microsecond=0)
+        session = app_db()
+        _insert_snapshot(session, icao="LFPG", model="gfs", forecast_hour=today_12z)
+        session.commit()
+        session.close()
+
+        resp = client.get("/api/maps/forecast/days")
+        assert resp.status_code == 200
+        days = {d["day"]: d for d in resp.json()["days"]}
+        assert set(days) == {0, 1, 2, 3}
+        assert days[0]["available"] is True
+        assert days[3]["available"] is False
+        # Date label tracks today + day so the UI label stays consistent.
+        assert days[0]["date"] == datetime.now(timezone.utc).date().isoformat()

--- a/web/maps.html
+++ b/web/maps.html
@@ -26,6 +26,10 @@
     .maps-controls .btn-group .btn-toggle.active { background: var(--primary); color: #fff; border-color: var(--primary); }
     .maps-controls .btn-group .btn-toggle:hover:not(.active) { background: var(--bg); }
     .maps-controls .btn-group .btn-toggle:disabled { opacity: 0.4; cursor: not-allowed; }
+    /* Day beyond model horizon: greyed but still clickable so a click can
+       explain why (see maps.dayNotForecastDetail). */
+    .maps-controls .btn-group .btn-toggle.day-unavailable { opacity: 0.4; cursor: not-allowed; }
+    .maps-controls .btn-group .btn-toggle.day-unavailable:hover:not(.active) { background: transparent; }
 
     .maps-controls select {
       padding: 0.3rem 0.5rem; border: 1px solid var(--border);

--- a/web/ts/adapters/maps-adapter.ts
+++ b/web/ts/adapters/maps-adapter.ts
@@ -65,3 +65,11 @@ export async function fetchAvailableHours(day: number): Promise<{ hours: number[
   if (!resp.ok) throw new Error(`Available hours: ${resp.status}`);
   return resp.json();
 }
+
+export interface DayAvailability { day: number; date: string; available: boolean; }
+
+export async function fetchAvailableDays(): Promise<{ days: DayAvailability[] }> {
+  const resp = await fetch(`${apiBase}/maps/forecast/days`, { credentials: 'include' });
+  if (!resp.ok) throw new Error(`Available days: ${resp.status}`);
+  return resp.json();
+}

--- a/web/ts/i18n/locales/de.json
+++ b/web/ts/i18n/locales/de.json
@@ -84,6 +84,8 @@
   "maps.shareLinkTitle": "Link zu dieser Ansicht kopieren",
   "maps.shareLinkCopied": "Link kopiert",
   "maps.shareLinkFallback": "Diesen Link zum Teilen kopieren:",
+  "maps.dayNotForecast": "Noch nicht vorhergesagt",
+  "maps.dayNotForecastDetail": "{date} ist noch nicht vorhergesagt — verfügbar nach dem nächsten Modelllauf (07Z/19Z).",
   "briefing.noFlightSpecified": "Kein Flug angegeben. Zurück zur Flugliste.",
   "briefing.noBriefings": "Noch keine Briefings vorhanden",
   "briefing.noAssessment": "Keine Bewertung verfügbar",

--- a/web/ts/i18n/locales/en.json
+++ b/web/ts/i18n/locales/en.json
@@ -89,6 +89,8 @@
   "maps.shareLinkTitle": "Copy a link to this view",
   "maps.shareLinkCopied": "Link copied",
   "maps.shareLinkFallback": "Copy this link to share:",
+  "maps.dayNotForecast": "Not forecast yet",
+  "maps.dayNotForecastDetail": "{date} isn't forecast yet — it becomes available after the next model run (07Z/19Z).",
   "briefing.noFlightSpecified": "No flight specified. Go back to flights list.",
   "briefing.noBriefings": "No briefings yet",
   "briefing.noAssessment": "No assessment available",

--- a/web/ts/i18n/locales/es.json
+++ b/web/ts/i18n/locales/es.json
@@ -84,6 +84,8 @@
   "maps.shareLinkTitle": "Copiar un enlace a esta vista",
   "maps.shareLinkCopied": "Enlace copiado",
   "maps.shareLinkFallback": "Copia este enlace para compartir:",
+  "maps.dayNotForecast": "Aún sin pronóstico",
+  "maps.dayNotForecastDetail": "{date} aún no tiene pronóstico — estará disponible tras la próxima pasada del modelo (07Z/19Z).",
   "briefing.noFlightSpecified": "No se ha especificado ningún vuelo. Vuelva a la lista de vuelos.",
   "briefing.noBriefings": "Aún no hay briefings",
   "briefing.noAssessment": "No hay evaluación disponible",

--- a/web/ts/i18n/locales/fr.json
+++ b/web/ts/i18n/locales/fr.json
@@ -84,6 +84,8 @@
   "maps.shareLinkTitle": "Copier un lien vers cette vue",
   "maps.shareLinkCopied": "Lien copié",
   "maps.shareLinkFallback": "Copiez ce lien pour partager :",
+  "maps.dayNotForecast": "Pas encore prévu",
+  "maps.dayNotForecastDetail": "{date} n'est pas encore prévu — disponible après la prochaine sortie du modèle (07Z/19Z).",
   "briefing.noFlightSpecified": "Aucun vol spécifié. Retournez à la liste des vols.",
   "briefing.noBriefings": "Aucun briefing pour le moment",
   "briefing.noAssessment": "Aucune évaluation disponible",

--- a/web/ts/maps-main.ts
+++ b/web/ts/maps-main.ts
@@ -2,7 +2,7 @@
 
 import { fetchCurrentUser } from './adapters/auth-adapter';
 import {
-  fetchForecastMap, fetchAvailableHours,
+  fetchForecastMap, fetchAvailableHours, fetchAvailableDays,
   type ForecastMapResponse,
 } from './adapters/maps-adapter';
 import {
@@ -147,19 +147,80 @@ function showInfo(text: string, targetId: string = 'map-info'): void {
 const _DAYS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
 const _MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
 
-function updateForecastDatetime(): void {
-  const el = $('forecast-datetime');
-  if (!el) return;
+/** "Sat 13-Jun-26" for the calendar date `day` offsets from today (UTC).
+ *  Mirrors the server's `now + day` mapping so the displayed date stays
+ *  consistent with the forecast data resolved for that (day, hour). */
+function dayDateLabel(day: number): string {
   const now = new Date();
   const target = new Date(Date.UTC(
-    now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() + fcDay,
-    fcHour, 0, 0,
+    now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() + day, 0, 0, 0,
   ));
-  const day = _DAYS[target.getUTCDay()];
+  const dow = _DAYS[target.getUTCDay()];
   const dd = String(target.getUTCDate()).padStart(2, '0');
   const mon = _MONTHS[target.getUTCMonth()];
   const yr = String(target.getUTCFullYear()).slice(2);
-  el.textContent = `${day} ${dd}-${mon}-${yr} ${String(fcHour).padStart(2, '0')}Z`;
+  return `${dow} ${dd}-${mon}-${yr}`;
+}
+
+function updateForecastDatetime(): void {
+  const el = $('forecast-datetime');
+  if (!el) return;
+  el.textContent = `${dayDateLabel(fcDay)} ${String(fcHour).padStart(2, '0')}Z`;
+}
+
+// Which relative days (0..3) currently have forecast data. The far day
+// (today+3) is empty until the next twice-daily model run extends the
+// horizon; such days are disabled in the picker with an explanation.
+let availableDays = new Set<number>([0, 1, 2, 3]);
+
+function applyDayAvailability(): void {
+  const group = $('day-picker');
+  if (!group) return;
+  for (const btn of group.querySelectorAll('button')) {
+    const d = parseInt((btn as HTMLElement).dataset.day || '0');
+    const avail = availableDays.has(d);
+    btn.classList.toggle('day-unavailable', !avail);
+    (btn as HTMLElement).title = avail ? '' : t('maps.dayNotForecast');
+  }
+}
+
+/** Sync the hour picker's enabled buttons to the selected day. */
+async function syncHoursForDay(): Promise<void> {
+  try {
+    const { hours } = await fetchAvailableHours(fcDay);
+    const hourBtns = $('hour-picker')?.querySelectorAll('button');
+    if (!hourBtns) return;
+    for (const btn of hourBtns) {
+      const h = parseInt((btn as HTMLElement).dataset.hour || '0');
+      btn.classList.toggle('disabled', !hours.includes(h));
+      (btn as HTMLButtonElement).disabled = !hours.includes(h);
+    }
+    if (!hours.includes(fcHour) && hours.length > 0) {
+      fcHour = hours[0];
+      setActive('hour-picker', String(fcHour), 'hour');
+    }
+  } catch { /* ignore */ }
+}
+
+/** Refresh day availability and snap the selection back into range if the
+ *  selected day fell outside the horizon (e.g. after a UTC-midnight rollover
+ *  before the next model run). */
+async function refreshDayAvailability(): Promise<void> {
+  try {
+    const { days } = await fetchAvailableDays();
+    availableDays = new Set(days.filter((d) => d.available).map((d) => d.day));
+  } catch {
+    availableDays = new Set([0, 1, 2, 3]);
+  }
+  applyDayAvailability();
+  if (!availableDays.has(fcDay)) {
+    const fallback = [...availableDays].sort((a, b) => b - a)[0] ?? 0;
+    fcDay = fallback;
+    setActive('day-picker', String(fcDay), 'day');
+    await syncHoursForDay();
+    updateForecastDatetime();
+    syncUrl();
+  }
 }
 
 // --- Data loading ---
@@ -263,25 +324,23 @@ function wireButtonGroup(groupId: string, attr: string, onChange: (value: string
 }
 
 function wireForecastControls(): void {
-  wireButtonGroup('day-picker', 'day', async (v) => {
-    fcDay = parseInt(v);
-    // Update available hours
-    try {
-      const { hours } = await fetchAvailableHours(fcDay);
-      const hourBtns = $('hour-picker')?.querySelectorAll('button');
-      if (hourBtns) {
-        for (const btn of hourBtns) {
-          const h = parseInt(btn.dataset.hour || '0');
-          btn.classList.toggle('disabled', !hours.includes(h));
-          (btn as HTMLButtonElement).disabled = !hours.includes(h);
-        }
-        // If current hour is unavailable, switch to first available
-        if (!hours.includes(fcHour) && hours.length > 0) {
-          fcHour = hours[0];
-          setActive('hour-picker', String(fcHour), 'hour');
-        }
-      }
-    } catch { /* ignore */ }
+  // Custom day-picker handler (not the generic wireButtonGroup) so a click on
+  // a day beyond the model horizon explains itself instead of selecting an
+  // empty/mislabelled map.
+  const dayGroup = $('day-picker');
+  dayGroup?.addEventListener('click', async (e) => {
+    const btn = (e.target as HTMLElement).closest('button');
+    if (!btn || btn.dataset.day == null) return;
+    const d = parseInt(btn.dataset.day);
+    if (!availableDays.has(d)) {
+      showInfo(t('maps.dayNotForecastDetail', { date: dayDateLabel(d) }));
+      return;
+    }
+    if (d === fcDay) return;
+    for (const b of dayGroup.querySelectorAll('button')) b.classList.remove('active');
+    btn.classList.add('active');
+    fcDay = d;
+    await syncHoursForDay();
     syncUrl();
     loadForecast();
     refreshAirportPanelOnHourChange();
@@ -996,6 +1055,9 @@ async function main(): Promise<void> {
   // tab from the URL, switchTab() handles its lazy init; the forecast tab
   // is already the default-visible panel so we just kick off the fetch.
   updateForecastDatetime();
+  // Resolve day availability first so a hydrated/default day that's beyond
+  // the current horizon snaps into range before the initial fetch.
+  await refreshDayAvailability();
   if (currentTab === 'forecast') {
     loadForecast();
   } else {


### PR DESCRIPTION
## Problem

The forecast overview map labels days as **D-0 = today, D-3 = today+3** purely from the client clock, but the data behind those labels could be a day stale.

Root cause: the map cache is keyed by **relative day index** (`forecast_map:{day}:{hour}`) yet stores **absolute-dated** payloads, and `is_stale` only checks whether a newer snapshot was fetched. Snapshots refresh just twice a day (`FORECAST_FETCH_HOURS_UTC = [7, 19]`), so in the **00Z–07Z window** — after the UTC day rolls over but before the next model run — `fetched_at` is unchanged, the stale entry is served, and the relative day now points at the wrong calendar date.

Concretely, viewing the map at 03Z on Sat 13-Jun:
- **D-0** showed Fri 12-Jun's data under a "13-Jun" label.
- **D-3** showed Mon 15-Jun's data under a "Tue 16-Jun" label (Tuesday wasn't forecast yet by the 12-Jun run), or an empty map on a cache miss.

## Fix

**Backend**
- `is_stale`: a `forecast_map:*` entry computed on an earlier UTC day is now stale, forcing the live path (which re-derives the correct absolute hour from `now + day`). D-0 then resolves to today, served from the latest run that covers it (e.g. "today as predicted by yesterday's run").
- `/maps/airport-weather`: no longer serves stale cache across the rollover — falls back to a live, correct-date query; returns 503 only when the day is genuinely beyond the model horizon.
- New `GET /maps/forecast/days` (+ pure, unit-tested `compute_day_availability`) reporting which of D-0..D-3 have any snapshots.

**Frontend (maps page)**
- The day picker disables days beyond the current horizon and explains *"{date} isn't forecast yet — available after the next model run (07Z/19Z)"* on click, instead of an empty/mislabelled map.
- After a rollover, a selected-but-now-unavailable day snaps back into range.
- The date label is refactored to a shared helper so the displayed date stays consistent with the data resolved for each `(day, hour)`.

## Tradeoff

During the ~7h post-midnight window the worst-consensus map now runs **live** (cache bypassed) rather than serving a wrong-date cache — a heavier query for that window only. Individual-model and majority modes already ran live. Alternative (rebuild the cache at midnight) was rejected as more moving parts for little gain.

## Tests
- `is_stale` date-rollover: stale when computed yesterday, fresh when computed today (`test_cache_builder.py`).
- `/maps/forecast/days` end-to-end: D-0 available, D-3 not, date label tracks today+day (`test_map_queries.py`).
- All affected suites pass (54), `tsc --noEmit` clean, maps bundle builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)