### PR TITLE
Add ratings tab to admin panel with digest feedback filtering

### DIFF
--- a/src/weatherbrief/api/feedback.py
+++ b/src/weatherbrief/api/feedback.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 from datetime import datetime, timezone
 from typing import Optional
@@ -15,7 +16,7 @@ from weatherbrief.api.throttle import feedback_burst_limiter, feedback_daily_lim
 from flyfun_common.auth import is_dev_mode
 from flyfun_common.db import current_user_id, get_db
 from flyfun_common.db.models import UserRow
-from weatherbrief.db.models import FeedbackRow
+from weatherbrief.db.models import FeedbackRow, FlightRow
 from weatherbrief.triage.security import scan_for_exfil
 
 logger = logging.getLogger(__name__)
@@ -171,13 +172,32 @@ def _get_feedback_or_404(db: Session, feedback_id: int) -> FeedbackRow:
     return row
 
 
-def _serialize_feedback(fb: FeedbackRow, email: str, name: str) -> dict:
+def _parse_waypoints(waypoints_json: Optional[str]) -> list[str]:
+    """Parse a flight's waypoints_json column into a list of ICAO codes."""
+    if not waypoints_json:
+        return []
+    try:
+        value = json.loads(waypoints_json)
+    except (ValueError, TypeError):
+        return []
+    return [str(w) for w in value] if isinstance(value, list) else []
+
+
+def _serialize_feedback(
+    fb: FeedbackRow,
+    email: str,
+    name: str,
+    route_name: Optional[str] = None,
+    waypoints_json: Optional[str] = None,
+) -> dict:
     """Serialize a FeedbackRow + user info to a response dict."""
     return {
         "id": fb.id,
         "user_email": email,
         "user_name": name,
         "flight_id": fb.flight_id,
+        "route_name": route_name or "",
+        "waypoints": _parse_waypoints(waypoints_json),
         "pack_timestamp": fb.pack_timestamp.isoformat() if fb.pack_timestamp else "",
         "category": fb.category,
         "comment": fb.comment,
@@ -199,13 +219,24 @@ def _serialize_feedback(fb: FeedbackRow, email: str, name: str) -> dict:
 @router.get("/admin")
 def list_feedback(
     status: Optional[str] = Query(None, description="Comma-separated status filter"),
+    kind: Optional[str] = Query(
+        None,
+        description="'feedback' excludes digest_rating; 'ratings' returns only digest_rating",
+    ),
     _admin_id: str = Depends(require_admin),
     db: Session = Depends(get_db),
 ):
-    """List all feedback entries (admin only), optionally filtered by status."""
+    """List all feedback entries (admin only), optionally filtered by status/kind."""
     query = (
-        db.query(FeedbackRow, UserRow.email, UserRow.display_name)
+        db.query(
+            FeedbackRow,
+            UserRow.email,
+            UserRow.display_name,
+            FlightRow.route_name,
+            FlightRow.waypoints_json,
+        )
         .join(UserRow, FeedbackRow.user_id == UserRow.id)
+        .outerjoin(FlightRow, FeedbackRow.flight_id == FlightRow.id)
     )
 
     if status:
@@ -215,8 +246,18 @@ def list_feedback(
             raise HTTPException(400, f"Invalid status values: {', '.join(sorted(invalid))}")
         query = query.filter(FeedbackRow.status.in_(statuses))
 
+    if kind == "ratings":
+        query = query.filter(FeedbackRow.category == "digest_rating")
+    elif kind == "feedback":
+        query = query.filter(FeedbackRow.category != "digest_rating")
+    elif kind is not None:
+        raise HTTPException(400, "kind must be 'feedback' or 'ratings'")
+
     rows = query.order_by(FeedbackRow.created_at.desc()).all()
-    return [_serialize_feedback(fb, email, name) for fb, email, name in rows]
+    return [
+        _serialize_feedback(fb, email, name, route_name, waypoints_json)
+        for fb, email, name, route_name, waypoints_json in rows
+    ]
 
 
 @router.put("/admin/{feedback_id}/status")

--- a/tests/test_feedback_api.py
+++ b/tests/test_feedback_api.py
@@ -195,6 +195,48 @@ def test_admin_list_includes_new_fields(client):
     assert entry["contact_ok"] is True
 
 
+def test_admin_list_route_defaults_when_no_flight(client):
+    """route_name/waypoints default to empty when the flight_id has no match."""
+    resp = client.post("/api/feedback", json={
+        "category": "digest_rating",
+        "comment": "",
+        "sentiment": "up",
+        "target": "digest",
+    })
+    fb_id = resp.json()["id"]
+    entries = client.get("/api/feedback/admin").json()
+    entry = next(e for e in entries if e["id"] == fb_id)
+    assert entry["route_name"] == ""
+    assert entry["waypoints"] == []
+
+
+def test_admin_list_kind_filter_splits_streams(client):
+    """kind=ratings returns only digest_rating; kind=feedback excludes it."""
+    rating = client.post("/api/feedback", json={
+        "category": "digest_rating", "comment": "", "sentiment": "up", "target": "digest",
+    }).json()["id"]
+    form = client.post("/api/feedback", json={
+        "category": "data_issue", "comment": "Wind looked wrong.",
+    }).json()["id"]
+
+    ratings = client.get("/api/feedback/admin?kind=ratings").json()
+    rating_ids = {e["id"] for e in ratings}
+    assert rating in rating_ids
+    assert form not in rating_ids
+    assert all(e["category"] == "digest_rating" for e in ratings)
+
+    feedback = client.get("/api/feedback/admin?kind=feedback").json()
+    feedback_ids = {e["id"] for e in feedback}
+    assert form in feedback_ids
+    assert rating not in feedback_ids
+    assert all(e["category"] != "digest_rating" for e in feedback)
+
+
+def test_admin_list_invalid_kind_rejected(client):
+    resp = client.get("/api/feedback/admin?kind=bogus")
+    assert resp.status_code == 400
+
+
 def test_send_reply_blocked_without_consent(client, monkeypatch):
     from weatherbrief.notify import admin_email
     sent = []

--- a/web/admin.html
+++ b/web/admin.html
@@ -313,6 +313,7 @@
     <!-- Tabs -->
     <div class="settings-tabs">
       <button class="tab-btn active" data-tab="tab-feedback">Feedback</button>
+      <button class="tab-btn" data-tab="tab-ratings">Ratings</button>
       <button class="tab-btn" data-tab="tab-messages">Messages</button>
       <button class="tab-btn" data-tab="tab-usage">Usage</button>
       <button class="tab-btn" data-tab="tab-usage-analytics">Usage Analytics</button>
@@ -325,6 +326,22 @@
     <div id="tab-feedback" class="tab-panel active">
       <div id="feedback-list">
         <p class="muted" style="text-align:center;padding:2rem;">Loading feedback...</p>
+      </div>
+    </div>
+
+    <!-- Ratings tab (digest thumb feedback) -->
+    <div id="tab-ratings" class="tab-panel">
+      <div id="ratings-period-toggle" class="period-toggle">
+        <button class="toggle-btn active" data-period="30d">Last 30 days</button>
+        <button class="toggle-btn" data-period="all">All Time</button>
+      </div>
+      <div id="ratings-summary" style="margin:0 0 12px;font-size:15px;font-weight:600;"></div>
+      <div id="ratings-filter" class="period-toggle" style="margin-bottom:12px;">
+        <button class="toggle-btn active" data-filter="all">All</button>
+        <button class="toggle-btn" data-filter="attention">Needs attention</button>
+      </div>
+      <div id="ratings-list">
+        <p class="muted" style="text-align:center;padding:2rem;">Click the Ratings tab to load...</p>
       </div>
     </div>
 

--- a/web/ts/adapters/admin-adapter.ts
+++ b/web/ts/adapters/admin-adapter.ts
@@ -248,6 +248,8 @@ export interface FeedbackEntry {
   user_email: string;
   user_name: string;
   flight_id: string;
+  route_name: string;
+  waypoints: string[];
   pack_timestamp: string;
   category: string;
   comment: string;
@@ -265,9 +267,14 @@ export interface FeedbackEntry {
   processed_at: string | null;
 }
 
-export async function fetchAdminFeedback(status?: string): Promise<FeedbackEntry[]> {
-  const qs = status ? `?status=${encodeURIComponent(status)}` : '';
-  return apiFetch<FeedbackEntry[]>(`/feedback/admin${qs}`);
+export type FeedbackKind = 'feedback' | 'ratings';
+
+export async function fetchAdminFeedback(status?: string, kind?: FeedbackKind): Promise<FeedbackEntry[]> {
+  const params = new URLSearchParams();
+  if (status) params.set('status', status);
+  if (kind) params.set('kind', kind);
+  const qs = params.toString();
+  return apiFetch<FeedbackEntry[]>(`/feedback/admin${qs ? `?${qs}` : ''}`);
 }
 
 export async function updateFeedbackStatus(id: number, status: FeedbackStatus): Promise<void> {

--- a/web/ts/admin-main.ts
+++ b/web/ts/admin-main.ts
@@ -423,6 +423,7 @@ function renderRatings(): void {
   const inPeriod = ratingsData.filter((r) => {
     if (cutoff == null || !r.created_at) return true;
     const t = new Date(r.created_at).getTime();
+    // Include on parse failure so the admin can still see and action the entry.
     return Number.isNaN(t) || t >= cutoff;
   });
 
@@ -475,7 +476,7 @@ function renderRatingRow(fb: FeedbackEntry): string {
     detail += `<div style="background:var(--surface);border-radius:6px;padding:10px;white-space:pre-wrap;margin-bottom:8px;">${escapeHtml(fb.comment)}</div>`;
   }
   const consentNote = fb.contact_ok ? '' : ' · 🔕 opted out of replies';
-  detail += `<div style="color:var(--text-muted);font-size:12px;">${escapeHtml(fb.user_email)}${fb.flight_id ? ' · ' + escapeHtml(fb.flight_id) : ''}${fb.created_at ? ' · ' + formatDate(fb.created_at) : ''}${consentNote}</div>`;
+  detail += `<div style="color:var(--text-muted);font-size:12px;">${escapeHtml(fb.user_email)}${fb.flight_id ? ' · ' + escapeHtml(fb.flight_id) : ''}${fb.created_at ? ' · ' + escapeHtml(formatDate(fb.created_at)) : ''}${consentNote}</div>`;
 
   if (canReply) {
     detail += `

--- a/web/ts/admin-main.ts
+++ b/web/ts/admin-main.ts
@@ -9,7 +9,7 @@ import {
   type AdminUser, type AdminSummary, type AdminPeriod, type FeedbackEntry,
   type FeedbackStatus, type AdminMetrics, type AdminMetricsWindow, type HubResponse, type ApiUsageResponse,
 } from './adapters/admin-adapter';
-import { redirectToLogin, renderUserInfo, escapeHtml, formatDate } from './utils';
+import { redirectToLogin, renderUserInfo, escapeHtml, formatDate, flightTitle } from './utils';
 import { initTheme } from './theme';
 import { initI18n } from './i18n/i18n';
 import { initUsageAnalyticsTab } from './admin-usage-view';
@@ -52,6 +52,7 @@ function setupPeriodToggle(): void {
 
 let perfLoaded = false;
 let systemsLoaded = false;
+let ratingsLoaded = false;
 let messagesLoaded = false;
 let usageAnalyticsLoaded = false;
 let costLoaded = false;
@@ -80,6 +81,11 @@ function setupTabs(): void {
         systemsLoaded = true;
         setupSystemsPeriodToggle();
         loadSystems();
+      }
+      if (tabId === 'tab-ratings' && !ratingsLoaded) {
+        ratingsLoaded = true;
+        setupRatingsControls();
+        loadRatings();
       }
       if (tabId === 'tab-messages' && !messagesLoaded) {
         messagesLoaded = true;
@@ -123,7 +129,7 @@ const CLASSIFICATION_LABELS: Record<string, string> = {
 async function loadFeedback(): Promise<void> {
   const container = document.getElementById('feedback-list')!;
   try {
-    const entries = await fetchAdminFeedback();
+    const entries = await fetchAdminFeedback(undefined, 'feedback');
     if (entries.length === 0) {
       container.innerHTML = '<p class="muted" style="text-align:center;padding:2rem;">No feedback yet.</p>';
       return;
@@ -337,6 +343,186 @@ function attachFeedbackHandlers(container: HTMLElement): void {
       try {
         await reopenFeedback(id);
         loadFeedback();
+      } catch (err) {
+        if (statusEl) { statusEl.textContent = `Error: ${err}`; statusEl.style.color = '#dc3545'; }
+      }
+    });
+  });
+}
+
+// --- Ratings tab (digest thumb feedback) ---
+
+let ratingsPeriod: AdminPeriod = '30d';
+let ratingsFilter: 'all' | 'attention' = 'all';
+let ratingsData: FeedbackEntry[] = [];
+
+/** Relative time like "2h ago" / "3d ago" (admin is English-only). */
+function relativeTime(iso: string): string {
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return '';
+  const mins = Math.round((Date.now() - then) / 60000);
+  if (mins < 1) return 'just now';
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.round(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  const days = Math.round(hrs / 24);
+  if (days < 30) return `${days}d ago`;
+  return `${Math.round(days / 30)}mo ago`;
+}
+
+/** Briefing pack timestamp as "12 Jun 06:00Z" (UTC). */
+function formatBriefingDate(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  const month = d.toLocaleDateString('en-GB', { month: 'short', timeZone: 'UTC' });
+  const hh = String(d.getUTCHours()).padStart(2, '0');
+  const mm = String(d.getUTCMinutes()).padStart(2, '0');
+  return `${d.getUTCDate()} ${month} ${hh}:${mm}Z`;
+}
+
+function setupRatingsControls(): void {
+  document.querySelectorAll('#ratings-period-toggle .toggle-btn').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      const period = (btn as HTMLElement).dataset.period as AdminPeriod;
+      if (period === ratingsPeriod) return;
+      ratingsPeriod = period;
+      document.querySelectorAll('#ratings-period-toggle .toggle-btn').forEach((b) => b.classList.remove('active'));
+      btn.classList.add('active');
+      renderRatings();
+    });
+  });
+  document.querySelectorAll('#ratings-filter .toggle-btn').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      const filter = (btn as HTMLElement).dataset.filter as 'all' | 'attention';
+      if (filter === ratingsFilter) return;
+      ratingsFilter = filter;
+      document.querySelectorAll('#ratings-filter .toggle-btn').forEach((b) => b.classList.remove('active'));
+      btn.classList.add('active');
+      renderRatings();
+    });
+  });
+}
+
+async function loadRatings(): Promise<void> {
+  const container = document.getElementById('ratings-list')!;
+  container.innerHTML = '<p class="muted" style="text-align:center;padding:2rem;">Loading ratings...</p>';
+  try {
+    ratingsData = await fetchAdminFeedback(undefined, 'ratings');
+    renderRatings();
+  } catch (err) {
+    container.innerHTML = `<p style="color:#dc3545;text-align:center;padding:1rem;">Failed to load ratings: ${err}</p>`;
+  }
+}
+
+function renderRatings(): void {
+  const container = document.getElementById('ratings-list')!;
+  const summaryEl = document.getElementById('ratings-summary')!;
+  const pl = ratingsPeriod === '30d' ? '30d' : 'All';
+  const cutoff = ratingsPeriod === '30d' ? Date.now() - 30 * 86400000 : null;
+
+  const inPeriod = ratingsData.filter((r) => {
+    if (cutoff == null || !r.created_at) return true;
+    const t = new Date(r.created_at).getTime();
+    return Number.isNaN(t) || t >= cutoff;
+  });
+
+  // Summary bar
+  const up = inPeriod.filter((r) => r.sentiment === 'up').length;
+  const down = inPeriod.filter((r) => r.sentiment === 'down').length;
+  const total = up + down;
+  const pct = total > 0 ? Math.round((up / total) * 100) : 0;
+  summaryEl.textContent = total > 0
+    ? `👍 ${up} · 👎 ${down} · ${pct}% positive   (${pl})`
+    : `No ratings yet (${pl})`;
+
+  // Needs-attention filter: 👎 and/or has a comment worth a reply
+  let rows = inPeriod;
+  if (ratingsFilter === 'attention') {
+    rows = rows.filter((r) => r.sentiment === 'down' || !!r.comment);
+  }
+
+  if (rows.length === 0) {
+    container.innerHTML = '<p class="muted" style="text-align:center;padding:2rem;">No ratings match this filter.</p>';
+    return;
+  }
+  // Backend already returns newest-first.
+  container.innerHTML = rows.map(renderRatingRow).join('');
+  attachRatingsHandlers(container);
+}
+
+function renderRatingRow(fb: FeedbackEntry): string {
+  const thumb = fb.sentiment === 'up' ? '👍' : fb.sentiment === 'down' ? '👎' : '–';
+  const briefingDate = fb.pack_timestamp ? formatBriefingDate(fb.pack_timestamp) : '–';
+  const briefingHref = fb.flight_id
+    ? `/briefing.html?flight=${encodeURIComponent(fb.flight_id)}${fb.pack_timestamp ? `&t=${encodeURIComponent(fb.pack_timestamp)}` : ''}`
+    : '';
+  const briefingCell = briefingHref
+    ? `<a href="${briefingHref}" target="_blank" onclick="event.stopPropagation()" style="color:#2563eb;">${escapeHtml(briefingDate)}</a>`
+    : escapeHtml(briefingDate);
+  const route = fb.waypoints.length ? flightTitle(fb.waypoints) : (fb.route_name || '–');
+  const user = fb.user_name || fb.user_email || '–';
+  const snippet = fb.comment
+    ? `&ldquo;${escapeHtml(fb.comment.length > 60 ? fb.comment.slice(0, 60) + '…' : fb.comment)}&rdquo;`
+    : '—';
+  const when = fb.created_at ? relativeTime(fb.created_at) : '';
+
+  const isArchived = fb.status === 'replied' || fb.status === 'ignored';
+  const canReply = fb.sentiment === 'down' && !!fb.comment && fb.contact_ok && !isArchived;
+
+  // Expanded detail
+  let detail = '';
+  if (fb.comment) {
+    detail += `<div style="background:var(--surface);border-radius:6px;padding:10px;white-space:pre-wrap;margin-bottom:8px;">${escapeHtml(fb.comment)}</div>`;
+  }
+  const consentNote = fb.contact_ok ? '' : ' · 🔕 opted out of replies';
+  detail += `<div style="color:var(--text-muted);font-size:12px;">${escapeHtml(fb.user_email)}${fb.flight_id ? ' · ' + escapeHtml(fb.flight_id) : ''}${fb.created_at ? ' · ' + formatDate(fb.created_at) : ''}${consentNote}</div>`;
+
+  if (canReply) {
+    detail += `
+      <div style="margin-top:10px;">
+        <textarea class="rating-reply" data-id="${fb.id}" rows="4" placeholder="Reply to this rating…" style="width:100%;box-sizing:border-box;border:1px solid var(--border);border-radius:6px;padding:8px;font-size:13px;resize:vertical;background:var(--surface);color:var(--text);"></textarea>
+        <div style="margin-top:8px;display:flex;gap:8px;align-items:center;">
+          <button class="rating-send btn-sm" data-id="${fb.id}" style="background:#2563eb;color:#fff;border:none;border-radius:6px;padding:6px 16px;cursor:pointer;font-size:13px;font-weight:500;">Send Reply</button>
+          <span class="rating-status" data-id="${fb.id}" style="font-size:12px;"></span>
+        </div>
+      </div>`;
+  } else if (isArchived && fb.admin_reply) {
+    detail += `
+      <div style="margin-top:10px;">
+        <label style="font-size:12px;font-weight:600;color:var(--text-muted);display:block;margin-bottom:4px;">Reply${fb.replied_at ? ` (sent ${formatDate(fb.replied_at)})` : ''}</label>
+        <div style="background:var(--surface);border-radius:6px;padding:10px;font-size:13px;white-space:pre-wrap;">${escapeHtml(fb.admin_reply)}</div>
+      </div>`;
+  }
+
+  return `
+    <details class="rating-row" style="border:1px solid var(--border);border-radius:6px;margin-bottom:6px;overflow:hidden;">
+      <summary style="display:flex;align-items:center;gap:12px;padding:8px 12px;cursor:pointer;font-size:13px;list-style:none;">
+        <span style="font-size:15px;width:20px;text-align:center;flex-shrink:0;">${thumb}</span>
+        <span style="width:120px;flex-shrink:0;">${briefingCell}</span>
+        <span style="width:120px;flex-shrink:0;color:var(--text-muted);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">${escapeHtml(route)}</span>
+        <span style="width:140px;flex-shrink:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">${escapeHtml(user)}</span>
+        <span style="flex:1;min-width:0;color:var(--text-muted);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">${snippet}</span>
+        <span style="width:64px;flex-shrink:0;text-align:right;color:var(--text-muted);font-size:12px;">${when}</span>
+      </summary>
+      <div style="padding:0 12px 12px 44px;">${detail}</div>
+    </details>`;
+}
+
+function attachRatingsHandlers(container: HTMLElement): void {
+  container.querySelectorAll('.rating-send').forEach((btn) => {
+    btn.addEventListener('click', async (e) => {
+      const id = Number((e.currentTarget as HTMLElement).dataset.id);
+      const replyEl = container.querySelector(`.rating-reply[data-id="${id}"]`) as HTMLTextAreaElement | null;
+      const statusEl = container.querySelector(`.rating-status[data-id="${id}"]`) as HTMLElement | null;
+      const reply = replyEl?.value?.trim();
+      if (!reply) {
+        if (statusEl) { statusEl.textContent = 'Please enter a reply first.'; statusEl.style.color = '#dc3545'; }
+        return;
+      }
+      try {
+        const result = await sendFeedbackReply(id, reply);
+        if (statusEl) { statusEl.textContent = `Sent to ${result.sent_to}`; statusEl.style.color = '#16a34a'; }
+        setTimeout(() => loadRatings(), 1500);
       } catch (err) {
         if (statusEl) { statusEl.textContent = `Error: ${err}`; statusEl.style.color = '#dc3545'; }
       }


### PR DESCRIPTION
## Summary
Adds a new "Ratings" tab to the admin panel for viewing and managing digest thumb feedback (👍/👎) separately from general feedback. Includes filtering by time period and attention level, with the ability to reply to negative ratings.

## Changes

### Frontend (TypeScript/HTML)
- **New ratings tab UI** (`web/admin.html`): Added "Ratings" tab with period toggle (30d/All Time), filter toggle (All/Needs attention), and summary statistics
- **Ratings management logic** (`web/ts/admin-main.ts`):
  - Added `flightTitle` import from utils for route display
  - New state variables: `ratingsLoaded`, `ratingsPeriod`, `ratingsFilter`, `ratingsData`
  - `setupRatingsControls()`: Handles period and filter toggle interactions
  - `loadRatings()`: Fetches digest_rating feedback via new `kind='ratings'` parameter
  - `renderRatings()`: Displays filtered ratings with summary bar (👍/👎 counts and positive percentage)
  - `renderRatingRow()`: Formats individual rating rows with briefing link, route, user, comment snippet, and timestamp
  - `relativeTime()`: Converts ISO timestamps to relative format (e.g., "2h ago")
  - `formatBriefingDate()`: Formats briefing pack timestamps as "12 Jun 06:00Z"
  - `attachRatingsHandlers()`: Wires up reply send buttons with email notification
- Updated `loadFeedback()` to pass `kind='feedback'` to exclude digest ratings

### Backend (Python)
- **Feedback API enhancements** (`src/weatherbrief/api/feedback.py`):
  - Added `kind` query parameter to `/admin` endpoint: `'ratings'` returns only `digest_rating` entries, `'feedback'` excludes them
  - Extended `_serialize_feedback()` to include `route_name` and `waypoints` (parsed from flight's `waypoints_json`)
  - Added `_parse_waypoints()` helper to safely parse JSON waypoint arrays
  - Updated query to outer-join `FlightRow` for route and waypoint data
  - Validates `kind` parameter (must be 'feedback', 'ratings', or None)

### Tests
- **New test cases** (`tests/test_feedback_api.py`):
  - `test_admin_list_route_defaults_when_no_flight`: Verifies `route_name` and `waypoints` default to empty when flight_id has no match
  - `test_admin_list_kind_filter_splits_streams`: Confirms `kind=ratings` and `kind=feedback` correctly partition feedback by category
  - `test_admin_list_invalid_kind_rejected`: Validates rejection of invalid `kind` values

### Type Updates
- Extended `FeedbackEntry` interface in `web/ts/adapters/admin-adapter.ts` with `route_name` and `waypoints` fields
- Added `FeedbackKind` type for the new parameter
- Updated `fetchAdminFeedback()` to accept optional `kind` parameter with proper URL encoding

## Implementation Details
- Ratings are filtered by `created_at` timestamp when period is "30d"; "All Time" shows all entries
- "Needs attention" filter shows entries with negative sentiment or a comment (potential issues requiring admin response)
- Reply functionality only appears for negative ratings with comments and user consent (`contact_ok`)
- Briefing links include both flight ID and pack timestamp for precise navigation
- Route display falls back to `route_name` if waypoints are unavailable
- All timestamps use UTC formatting for consistency

https://claude.ai/code/session_01FAo2yQu4VicWfWAXuj3Mce