### PR TITLE
Attach digest thumb ratings to LangSmith runs (#244)

### DIFF
--- a/alembic/versions/066_pack_digest_trace_id.py
+++ b/alembic/versions/066_pack_digest_trace_id.py
@@ -1,0 +1,34 @@
+"""Add digest_trace_id to briefing_packs.
+
+Stores the LangSmith root run id of the digest LLM call (issue #244) so a
+later 👍/👎 thumb rating can attach feedback to the run that produced the
+digest. Nullable: NULL for legacy packs created before #244 and for packs
+whose digest hasn't run / didn't succeed.
+
+Revision ID: 066
+Revises: 065
+Create Date: 2026-06-13
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "066"
+down_revision: Union[str, None] = "065"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("briefing_packs") as batch_op:
+        batch_op.add_column(
+            sa.Column("digest_trace_id", sa.String(length=36), nullable=True),
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("briefing_packs") as batch_op:
+        batch_op.drop_column("digest_trace_id")

--- a/designs/digest.md
+++ b/designs/digest.md
@@ -101,7 +101,7 @@ START → briefer → END
 
 `run_digest()` orchestrates three stages:
 - **pre-graph (not traced)**: `_fetch_and_translate_text()` calls `fetch_text_forecasts(route)` (dispatches NWS vs DWD by route, None on failure) and, for European routes, translates DWD day-blocks via `translate_dwd_blocks()` (synoptic-extract mode when the route doesn't cross Germany). Then `build_digest_context()` assembles the context string.
-- **graph (traced — lightweight state)**: `briefer_node` calls the LLM with `with_structured_output(WeatherDigest, include_raw=True)`, loading the system prompt via `config.load_prompt("briefer", locale=, guidance_key=)`, and captures token usage from the raw `AIMessage`.
+- **graph (traced — lightweight state)**: `briefer_node` calls the LLM with `with_structured_output(WeatherDigest, include_raw=True)`, loading the system prompt via `config.load_prompt("briefer", locale=, guidance_key=)`, and captures token usage from the raw `AIMessage`. The invocation runs with a **pre-generated `run_id`** (`config={"run_id": uuid4()}`) so we own the LangSmith trace id rather than letting LangChain auto-generate-and-discard it. The id is returned as `result["digest_trace_id"]` and persisted on the pack (see below).
 - **post-graph (not traced)**: formats markdown; re-attaches `dwd_translated` to the result.
 
 ```python
@@ -113,10 +113,31 @@ result["digest_text"]       # → formatted markdown string
 result["llm_input_tokens"]  # → token usage (or None)
 result["llm_output_tokens"]
 result["dwd_translated"]    # → translated DWD blocks (attached post-graph)
+result["digest_trace_id"]   # → controlled LangSmith root run id (str UUID)
 result["diagnostic"]        # → typed Diagnostic if the LLM call failed, else None
                             #   (see weatherbrief.models.Diagnostic +
                             #    weatherbrief.digest.exceptions.classify_llm_exception)
 ```
+
+### Digest run id → thumb feedback (LangSmith, issue #244)
+
+The digest's LangSmith run id is threaded out and persisted so a later pilot
+rating can be attached to the run that produced the digest:
+
+`run_digest` (generates `run_id`) → `run_llm_digest` (`DigestResult.digest_trace_id`)
+→ `pipeline.BriefingResult.digest_trace_id` → `_build_pack_meta`
+(`BriefingPackMeta.digest_trace_id`) → `BriefingPackRow.digest_trace_id`
+(migration `066`, nullable `String(36)`). NULL on the provisional pack row
+(digest hasn't run yet) and for legacy packs created before #244.
+
+When a 👍/👎 lands at `POST /api/feedback` with `category="digest_rating"`,
+`submit_feedback` looks up the pack by `(flight_id, pack_timestamp)`, reads its
+`digest_trace_id`, and calls `digest/langsmith_feedback.py:push_digest_thumb_feedback`
+→ `langsmith.Client().create_feedback(run_id, key="user_thumb", score=1.0/0.0,
+comment=…)`. **Fire-and-forget**: a no-op when LangSmith isn't configured
+(`LANGCHAIN_API_KEY`/`LANGSMITH_API_KEY` unset — local/dev) or the pack has no
+trace id, and it never raises into the user's POST (the DB `feedback` row is
+written regardless).
 
 `briefer_node` gates its failure log level by `diagnostic.level` so retryable
 transients (rate-limited / overloaded) log at warning, not error.

--- a/src/weatherbrief/api/feedback.py
+++ b/src/weatherbrief/api/feedback.py
@@ -146,10 +146,12 @@ def submit_feedback(
             from weatherbrief.storage.flights import load_pack_meta
 
             meta = load_pack_meta(db, body.flight_id, pack_ts)
+            # push_digest_thumb_feedback normalizes "" → None at the LangSmith
+            # boundary, so pass the raw comment rather than duplicating it here.
             push_digest_thumb_feedback(
                 run_id=meta.digest_trace_id,
                 sentiment=body.sentiment,
-                comment=body.comment or None,
+                comment=body.comment,
             )
         except KeyError:
             # Pack not found (old/legacy pack, or mismatched ids) — nothing to

--- a/src/weatherbrief/api/feedback.py
+++ b/src/weatherbrief/api/feedback.py
@@ -136,6 +136,28 @@ def submit_feedback(
     db.flush()
     logger.info("Feedback #%d from user %s on flight %s", row.id, user_id, body.flight_id)
 
+    # Mirror digest thumb ratings to LangSmith as run feedback (issue #244).
+    # Fire-and-forget: look up the pack's digest_trace_id and attach the rating
+    # to that run so digest quality is reviewable in LangSmith. Never fails the
+    # POST — pack missing (legacy), no trace id, or a LangSmith hiccup all no-op.
+    if body.category == "digest_rating" and body.sentiment and body.flight_id and pack_ts:
+        try:
+            from weatherbrief.digest.langsmith_feedback import push_digest_thumb_feedback
+            from weatherbrief.storage.flights import load_pack_meta
+
+            meta = load_pack_meta(db, body.flight_id, pack_ts)
+            push_digest_thumb_feedback(
+                run_id=meta.digest_trace_id,
+                sentiment=body.sentiment,
+                comment=body.comment or None,
+            )
+        except KeyError:
+            # Pack not found (old/legacy pack, or mismatched ids) — nothing to
+            # attach feedback to in LangSmith. The DB row above still records it.
+            pass
+        except Exception:
+            logger.warning("Failed to mirror digest rating to LangSmith", exc_info=True)
+
     # Email admin (fire-and-forget)
     try:
         from weatherbrief.notify.admin_email import send_feedback_notification

--- a/src/weatherbrief/api/packs.py
+++ b/src/weatherbrief/api/packs.py
@@ -1174,6 +1174,9 @@ def _build_pack_meta(
         llm_digest_requested=result.llm_digest_requested,
         assessment=assessment,
         assessment_reason=assessment_reason,
+        # NULL on the provisional pass (digest hasn't run); set on finalize from
+        # the run_digest-controlled run_id so thumb feedback can reach LangSmith.
+        digest_trace_id=result.digest_trace_id,
         artifact_path=str(pack_path),
         model_init_times=init_times,
         grib_init_times=result.grib_init_times,

--- a/src/weatherbrief/db/models.py
+++ b/src/weatherbrief/db/models.py
@@ -224,6 +224,10 @@ class BriefingPackRow(Base):
     )
     assessment: Mapped[str | None] = mapped_column(String(16), nullable=True)
     assessment_reason: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # LangSmith root run id of the digest LLM call (issue #244). NULL for
+    # provisional rows (digest not yet run) and packs created before #244.
+    # The feedback endpoint reads this to attach thumb ratings to the run.
+    digest_trace_id: Mapped[str | None] = mapped_column(String(36), nullable=True)
     artifact_path: Mapped[str] = mapped_column(Text, default="")
     model_init_times_json: Mapped[str] = mapped_column(Text, default="{}")
     grib_init_times_json: Mapped[str] = mapped_column(Text, default="{}")

--- a/src/weatherbrief/digest/langsmith_feedback.py
+++ b/src/weatherbrief/digest/langsmith_feedback.py
@@ -1,0 +1,69 @@
+"""Push pilot digest thumb ratings to LangSmith as run feedback (issue #244).
+
+The digest LLM call is traced in LangSmith (enabled in prod, off locally) under
+a controlled ``run_id`` that ``run_digest`` generates and the pipeline persists
+on the pack (``BriefingPackRow.digest_trace_id``). When a pilot rates the digest
+👍/👎, we attach that as feedback on the run so digest quality can be reviewed
+and evaluated in LangSmith alongside the actual model run that produced it.
+
+Best-effort by design: a no-op when LangSmith isn't configured (so local/dev
+POSTs aren't blocked by a ``Client()`` that would error), and never raises into
+the caller's request path — a LangSmith hiccup must not fail the user's POST.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+
+def _tracing_configured() -> bool:
+    """True when LangSmith is set up to receive feedback.
+
+    Mirrors the env vars LangChain itself reads for the API key. Locally these
+    are unset (``.env.sample`` ships ``LANGCHAIN_TRACING_V2=false`` next to a
+    blank key), so we skip constructing a ``Client()`` that would otherwise
+    raise for a missing key.
+    """
+    return bool(os.getenv("LANGCHAIN_API_KEY") or os.getenv("LANGSMITH_API_KEY"))
+
+
+def push_digest_thumb_feedback(
+    *,
+    run_id: str | None,
+    sentiment: str,
+    comment: str | None = None,
+) -> None:
+    """Attach a 👍/👎 digest rating to its LangSmith run (fire-and-forget).
+
+    Maps ``sentiment`` → score (``up`` = 1.0, ``down`` = 0.0). No-op when the
+    pack has no ``run_id`` (legacy/old pack, or digest never ran) or when
+    LangSmith isn't configured. Swallows every error so feedback submission
+    stays unaffected when the call fails.
+    """
+    if not run_id:
+        return
+    if not _tracing_configured():
+        logger.debug("LangSmith not configured — skipping digest feedback push")
+        return
+    try:
+        from langsmith import Client
+
+        score = 1.0 if sentiment == "up" else 0.0
+        Client().create_feedback(
+            run_id,
+            key="user_thumb",
+            score=score,
+            comment=comment or None,
+        )
+        logger.info(
+            "Pushed digest thumb feedback to LangSmith run %s (score=%.1f)",
+            run_id, score,
+        )
+    except Exception:
+        logger.warning(
+            "Failed to push digest feedback to LangSmith (run_id=%s)",
+            run_id, exc_info=True,
+        )

--- a/src/weatherbrief/digest/llm_digest.py
+++ b/src/weatherbrief/digest/llm_digest.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import logging
 from datetime import date, datetime
 from typing import Literal
+from uuid import uuid4
 
 from langgraph.graph import END, START, StateGraph
 from langgraph.graph.state import CompiledStateGraph
@@ -214,13 +215,23 @@ def run_digest(
     )
 
     # --- LLM call via graph (traced — lightweight state) ---
+    # Pre-generate the root run id so we own it and can persist it with the
+    # pack. ``run_id`` in the RunnableConfig sets the id of the trace this
+    # invocation produces in LangSmith, which is what digest thumb feedback
+    # later attaches to (issue #244). Generated unconditionally — harmless
+    # when tracing is off locally (no trace is created), persisted regardless.
+    trace_id = str(uuid4())
     graph = build_digest_graph(config)
-    result = graph.invoke({
-        "context": context,
-        "config": config,
-        "locale": locale,
-        "guidance_key": guidance_key,
-    })
+    result = graph.invoke(
+        {
+            "context": context,
+            "config": config,
+            "locale": locale,
+            "guidance_key": guidance_key,
+        },
+        config={"run_id": trace_id},
+    )
+    result["digest_trace_id"] = trace_id
 
     # --- Post-graph formatting (not traced) ---
     if result.get("digest") is not None:

--- a/src/weatherbrief/digest/llm_digest.py
+++ b/src/weatherbrief/digest/llm_digest.py
@@ -218,9 +218,12 @@ def run_digest(
     # Pre-generate the root run id so we own it and can persist it with the
     # pack. ``run_id`` in the RunnableConfig sets the id of the trace this
     # invocation produces in LangSmith, which is what digest thumb feedback
-    # later attaches to (issue #244). Generated unconditionally — harmless
-    # when tracing is off locally (no trace is created), persisted regardless.
-    trace_id = str(uuid4())
+    # later attaches to (issue #244). Pass a UUID object (not a str) to match
+    # RunnableConfig.run_id's declared Optional[UUID] type — relying on string
+    # coercion would silently break the trace<->feedback link if a pinned
+    # LangChain stopped coercing. Generated unconditionally — harmless when
+    # tracing is off locally (no trace is created), persisted regardless.
+    trace_id = uuid4()
     graph = build_digest_graph(config)
     result = graph.invoke(
         {
@@ -231,7 +234,7 @@ def run_digest(
         },
         config={"run_id": trace_id},
     )
-    result["digest_trace_id"] = trace_id
+    result["digest_trace_id"] = str(trace_id)
 
     # --- Post-graph formatting (not traced) ---
     if result.get("digest") is not None:

--- a/src/weatherbrief/models/storage.py
+++ b/src/weatherbrief/models/storage.py
@@ -96,6 +96,11 @@ class BriefingPackMeta(BaseModel):
     llm_digest_requested: bool = True
     assessment: Optional[str] = None  # GREEN/AMBER/RED from digest
     assessment_reason: Optional[str] = None
+    # LangSmith root run id of the digest LLM call (issue #244). Set when the
+    # digest is generated with tracing-controlled run_id; NULL for provisional
+    # rows (digest not yet run) and legacy packs created before #244. Used by
+    # the feedback endpoint to attach thumb ratings to the LangSmith run.
+    digest_trace_id: Optional[str] = None
     artifact_path: str = ""  # path to pack directory
     model_init_times: dict[str, int] = Field(default_factory=dict)
     grib_init_times: dict[str, int] = Field(default_factory=dict)

--- a/src/weatherbrief/pipeline.py
+++ b/src/weatherbrief/pipeline.py
@@ -150,6 +150,9 @@ class BriefingResult:
     # AI off), so the UI shows "AI summary off" rather than a "generating"
     # spinner. Set from ``options.generate_llm_digest`` at run start.
     llm_digest_requested: bool = False
+    # LangSmith root run id for the digest LLM call (issue #244). Persisted with
+    # the pack so a later 👍/👎 can attach feedback to the run that produced it.
+    digest_trace_id: str | None = None
     text_digest: str | None = None
     grib_init_times: dict[str, int] = field(default_factory=dict)
     models_fetched: list[str] = field(default_factory=list)
@@ -723,6 +726,8 @@ def execute_briefing(
         )
         if digest_result.digest is not None:
             result.digest = digest_result.digest
+        if digest_result.digest_trace_id:
+            result.digest_trace_id = digest_result.digest_trace_id
         if digest_result.path:
             result.digest_path = digest_result.path
         if digest_result.text:

--- a/src/weatherbrief/storage/flights.py
+++ b/src/weatherbrief/storage/flights.py
@@ -213,6 +213,7 @@ def _apply_meta_to_row(row: BriefingPackRow, meta: BriefingPackMeta) -> None:
     row.llm_digest_requested = meta.llm_digest_requested
     row.assessment = meta.assessment
     row.assessment_reason = meta.assessment_reason
+    row.digest_trace_id = meta.digest_trace_id
     row.artifact_path = meta.artifact_path
     row.model_init_times_json = json.dumps(meta.model_init_times)
     row.grib_init_times_json = json.dumps(meta.grib_init_times)
@@ -332,6 +333,7 @@ def _row_to_meta(row: BriefingPackRow) -> BriefingPackMeta:
         llm_digest_requested=row.llm_digest_requested,
         assessment=row.assessment,
         assessment_reason=row.assessment_reason,
+        digest_trace_id=row.digest_trace_id,
         artifact_path=_resolve_artifact_path(row.artifact_path),
         model_init_times=json.loads(row.model_init_times_json) if row.model_init_times_json else {},
         grib_init_times=json.loads(row.grib_init_times_json) if row.grib_init_times_json else {},

--- a/src/weatherbrief/tasks/outputs.py
+++ b/src/weatherbrief/tasks/outputs.py
@@ -51,6 +51,9 @@ class DigestResult:
     llm_model: str | None = None
     llm_input_tokens: int | None = None
     llm_output_tokens: int | None = None
+    # LangSmith root run id for the digest LLM call, persisted with the pack so
+    # later thumb ratings can attach feedback to the run (issue #244).
+    digest_trace_id: str | None = None
     diagnostic: Diagnostic | None = None
 
 
@@ -247,6 +250,7 @@ def run_llm_digest(
         llm_model = f"{config.llm.provider}:{config.llm.model}"
         llm_input_tokens = digest_result.get("llm_input_tokens")
         llm_output_tokens = digest_result.get("llm_output_tokens")
+        digest_trace_id = digest_result.get("digest_trace_id")
 
         # Save markdown + structured JSON digest
         digest_path: Path | None = None
@@ -269,6 +273,7 @@ def run_llm_digest(
                 llm_model=llm_model,
                 llm_input_tokens=llm_input_tokens,
                 llm_output_tokens=llm_output_tokens,
+                digest_trace_id=digest_trace_id,
             )
 
         md_path.write_text(digest_result["digest_text"])
@@ -297,6 +302,7 @@ def run_llm_digest(
             llm_model=llm_model,
             llm_input_tokens=llm_input_tokens,
             llm_output_tokens=llm_output_tokens,
+            digest_trace_id=digest_trace_id,
         )
 
     except Exception as exc:

--- a/tests/test_feedback_api.py
+++ b/tests/test_feedback_api.py
@@ -169,13 +169,13 @@ def test_digest_rating_pushes_langsmith_feedback(client, app_db, monkeypatch):
     assert pushed[0]["comment"] == "Spot on."
 
 
-def test_digest_rating_unknown_pack_does_not_fail(client, monkeypatch):
-    """Rating a pack with no stored trace id (legacy) still returns 200 (#244)."""
-    pushed = []
-    import weatherbrief.digest.langsmith_feedback as ls
-    monkeypatch.setattr(ls, "push_digest_thumb_feedback",
-                        lambda **kw: pushed.append(kw))
+def test_digest_rating_unknown_pack_does_not_fail(client):
+    """Rating with no matching pack (legacy/missing) still returns 200 (#244).
 
+    ``load_pack_meta`` raises ``KeyError``, which submit_feedback swallows —
+    the feedback row is recorded regardless. No push helper is patched: the
+    point is that the swallowed lookup doesn't surface to the user.
+    """
     resp = client.post("/api/feedback", json={
         "flight_id": "does-not-exist",
         "pack_timestamp": "2026-06-12T06:00:00+00:00",
@@ -185,8 +185,55 @@ def test_digest_rating_unknown_pack_does_not_fail(client, monkeypatch):
         "target": "digest",
     })
     assert resp.status_code == 200, resp.text
-    # No pack → no LangSmith push, but the feedback row is still recorded.
-    assert pushed == []
+
+
+def test_digest_rating_pack_without_trace_id_noops(client, app_db, monkeypatch):
+    """A pack with no digest_trace_id (digest never ran) passes run_id=None (#244).
+
+    The pack lookup succeeds, so the push helper IS invoked — but with
+    ``run_id=None``, which it treats as a no-op (no LangSmith call). Submission
+    still succeeds.
+    """
+    from datetime import datetime, timezone
+
+    from weatherbrief.models.storage import BriefingPackMeta
+    from weatherbrief.storage.flights import save_pack_meta
+    from weatherbrief.db.models import FlightRow
+
+    flight_id = "egtk_lfat-2026-06-12-notrace"
+    pack_ts = datetime(2026, 6, 12, 6, 0, 0, tzinfo=timezone.utc)
+
+    s = app_db()
+    try:
+        s.add(FlightRow(
+            id=flight_id, user_id=DEV_USER_ID, route_name="EGTK-LFAT",
+            waypoints_json="[]", departure_time=pack_ts, cruise_altitude_ft=8000,
+        ))
+        s.flush()
+        save_pack_meta(s, BriefingPackMeta(
+            flight_id=flight_id, fetch_timestamp=pack_ts, days_out=0,
+            digest_trace_id=None,
+        ))
+        s.commit()
+    finally:
+        s.close()
+
+    pushed = []
+    import weatherbrief.digest.langsmith_feedback as ls
+    monkeypatch.setattr(ls, "push_digest_thumb_feedback",
+                        lambda **kw: pushed.append(kw))
+
+    resp = client.post("/api/feedback", json={
+        "flight_id": flight_id,
+        "pack_timestamp": pack_ts.isoformat(),
+        "category": "digest_rating",
+        "comment": "",
+        "sentiment": "up",
+        "target": "digest",
+    })
+    assert resp.status_code == 200, resp.text
+    assert len(pushed) == 1
+    assert pushed[0]["run_id"] is None
 
 
 def test_thumb_down_bare_is_recorded(client, app_db):

--- a/tests/test_feedback_api.py
+++ b/tests/test_feedback_api.py
@@ -120,6 +120,75 @@ def test_thumb_down_with_comment_and_consent(client, app_db):
     assert row.contact_ok is True
 
 
+def test_digest_rating_pushes_langsmith_feedback(client, app_db, monkeypatch):
+    """A 👍 on a digest attaches feedback to the pack's LangSmith run (#244)."""
+    from datetime import datetime, timezone
+
+    from weatherbrief.models.storage import BriefingPackMeta
+    from weatherbrief.storage.flights import save_pack_meta
+    from weatherbrief.db.models import FlightRow
+
+    flight_id = "egtk_lfat-2026-06-12-trace"
+    pack_ts = datetime(2026, 6, 12, 6, 0, 0, tzinfo=timezone.utc)
+
+    # Seed a flight + pack carrying a digest_trace_id.
+    s = app_db()
+    try:
+        s.add(FlightRow(
+            id=flight_id, user_id=DEV_USER_ID, route_name="EGTK-LFAT",
+            waypoints_json="[]", departure_time=pack_ts,
+            cruise_altitude_ft=8000,
+        ))
+        s.flush()
+        save_pack_meta(s, BriefingPackMeta(
+            flight_id=flight_id, fetch_timestamp=pack_ts, days_out=0,
+            digest_trace_id="11111111-2222-3333-4444-555555555555",
+        ))
+        s.commit()
+    finally:
+        s.close()
+
+    # Capture the LangSmith push instead of hitting the network.
+    pushed = []
+    import weatherbrief.digest.langsmith_feedback as ls
+    monkeypatch.setattr(ls, "push_digest_thumb_feedback",
+                        lambda **kw: pushed.append(kw))
+
+    resp = client.post("/api/feedback", json={
+        "flight_id": flight_id,
+        "pack_timestamp": pack_ts.isoformat(),
+        "category": "digest_rating",
+        "comment": "Spot on.",
+        "sentiment": "up",
+        "target": "digest",
+    })
+    assert resp.status_code == 200, resp.text
+    assert len(pushed) == 1
+    assert pushed[0]["run_id"] == "11111111-2222-3333-4444-555555555555"
+    assert pushed[0]["sentiment"] == "up"
+    assert pushed[0]["comment"] == "Spot on."
+
+
+def test_digest_rating_unknown_pack_does_not_fail(client, monkeypatch):
+    """Rating a pack with no stored trace id (legacy) still returns 200 (#244)."""
+    pushed = []
+    import weatherbrief.digest.langsmith_feedback as ls
+    monkeypatch.setattr(ls, "push_digest_thumb_feedback",
+                        lambda **kw: pushed.append(kw))
+
+    resp = client.post("/api/feedback", json={
+        "flight_id": "does-not-exist",
+        "pack_timestamp": "2026-06-12T06:00:00+00:00",
+        "category": "digest_rating",
+        "comment": "",
+        "sentiment": "down",
+        "target": "digest",
+    })
+    assert resp.status_code == 200, resp.text
+    # No pack → no LangSmith push, but the feedback row is still recorded.
+    assert pushed == []
+
+
 def test_thumb_down_bare_is_recorded(client, app_db):
     resp = client.post("/api/feedback", json={
         "category": "digest_rating",

--- a/tests/test_llm_digest.py
+++ b/tests/test_llm_digest.py
@@ -144,6 +144,14 @@ def test_run_digest_full_graph(mock_fetch_text, mock_create_llm, minimal_snapsho
     assert result.get("llm_input_tokens") == 1000
     assert result.get("llm_output_tokens") == 200
 
+    # A controlled root run_id is generated and returned for LangSmith feedback
+    # (issue #244). It must be a parseable UUID and be passed as the graph's
+    # root run_id so the trace can be located later.
+    from uuid import UUID
+    trace_id = result.get("digest_trace_id")
+    assert trace_id is not None
+    UUID(trace_id)  # raises if not a valid UUID
+
 
 @patch("weatherbrief.digest.llm_digest.create_llm")
 @patch("weatherbrief.digest.llm_digest.fetch_text_forecasts")


### PR DESCRIPTION
## Summary

Enables pilots' 👍/👎 ratings on weather digests to be attached as feedback to the LangSmith runs that produced them, allowing digest quality to be reviewed and evaluated in LangSmith alongside the model outputs.

## Key Changes

- **New module `digest/langsmith_feedback.py`**: Fire-and-forget feedback submission that:
  - Maps sentiment (`up`/`down`) to LangSmith scores (1.0/0.0)
  - No-ops gracefully when LangSmith isn't configured (local/dev) or pack has no trace id
  - Never raises into the caller's request path — LangSmith hiccups don't fail user POSTs

- **Controlled LangSmith run id generation**: `run_digest()` now pre-generates a UUID and passes it as the graph's `run_id` config, ensuring we own the trace id rather than letting LangChain auto-generate it. The id is returned as `result["digest_trace_id"]` and threaded through the pipeline.

- **Database schema (migration 066)**: Adds nullable `digest_trace_id` column to `briefing_packs` table to persist the LangSmith run id with each pack.

- **Feedback endpoint integration**: `POST /api/feedback` with `category="digest_rating"` now:
  - Looks up the pack's `digest_trace_id` from storage
  - Calls `push_digest_thumb_feedback()` to attach the rating to the run
  - Gracefully handles missing packs (legacy/old) and LangSmith errors

- **Data model updates**: Added `digest_trace_id` field to `DigestResult`, `BriefingResult`, `BriefingPackMeta`, and `BriefingPackRow` to carry the trace id through the pipeline.

## Implementation Details

- The trace id is generated unconditionally (harmless when tracing is off locally, persisted regardless)
- LangSmith feedback submission is best-effort: checks for `LANGCHAIN_API_KEY` or `LANGSMITH_API_KEY` env vars before attempting to construct a client
- All errors during feedback submission are logged but swallowed — the user's feedback POST always succeeds and the DB row is always recorded
- Backward compatible: NULL trace ids on legacy packs and provisional rows (digest not yet run) result in no-op feedback pushes

https://claude.ai/code/session_01Lzih882FA4KyGJ6gZ6yJqX