### PR TITLE
Add regulatory alternate-requirement assessment (FAA 91.169 + EASA Part-NCO)

### DIFF
--- a/designs/INDEX.md
+++ b/designs/INDEX.md
@@ -73,6 +73,11 @@ Weather-based alternate airports (D-2 inward, gated by `compute_alternates` pref
 Key exports: `run_alternates`, `RouteAlternates`, `AlternateAirport`, `AlternateAxisPick`, `best_ceiling`, `flight_category`, `enrich_wind`, `consensus`, `compute_route_distances`
 → Full doc: alternates.md
 
+### alternate-requirement
+Regulatory "is a filed alternate required?" for the destination, computed two ways — FAA (14 CFR 91.169, binary) and EASA Part-NCO (Likely/Marginal/Unlikely band) — plus per-candidate alternate-minima qualification for each #210 divert candidate. Forecast ceiling/visibility are real (TAF at D-0, NWP consensus otherwise); the unknown plate minima are estimated as a per-approach-class range that sets the Marginal band width. Pure logic in `analysis/alternate_requirement.py`, wired as a pipeline post-step.
+Key exports: `run_alternate_requirement`, `compute_faa_trigger`, `compute_easa_trigger`, `compute_faa_qual`, `compute_easa_qual`, `build_window`, `APPROACH_CLASS_PROXY`, `AlternateRequirement`, `AlternateQual`, `BandVerdict`, `TriggerVerdict`
+→ Full doc: alternate-requirement.md
+
 ### time-alignment
 Time and spatial alignment in the data pipeline: aware-UTC datetime convention, per-hour GRIB enrichment across flight windows, spatial index consistency, hour-matching merge logic, old pack backward compatibility.
 Key exports: `compute_flight_window_hours`, `compute_icon_eu_flight_window_hours`, `_forecast_hour_to_utc`, `_merge_cloud_water_into_sections`

--- a/designs/alternate-requirement.md
+++ b/designs/alternate-requirement.md
@@ -1,0 +1,161 @@
+# Regulatory Alternate Requirement (FAA 91.169 + EASA Part-NCO)
+
+> For a briefing's destination, answer **"is a filed alternate required?"** two
+> ways — **FAA (14 CFR 91.169)** and **EASA Part-NCO** — and, for each
+> weather-computed divert candidate (#210), **"does it meet alternate minima?"**.
+> Planning-grade and advisory, never a go/no-go verdict.
+
+**Status: Shipped (#249).** Computed as a pipeline post-step whenever the
+alternates stage ran (D-2 inward + `compute_alternates` opt-in).
+
+## The core idea: transparent requirement + confidence band
+
+Ceiling and visibility are two independent criteria, each evaluated from **real
+forecast data** (TAF or NWP). The forecast values are never proxied. What we
+lack is the **published plate minima** (DA/MDA and RVR/visibility) — we only know
+the approach *type*.
+
+Rather than hide the missing minima behind one conservative number, we **compute
+the actual requirement** (e.g. EASA needs `ceiling ≥ DH + 200`), express the
+unknown plate value as a **plausible range** per approach class, and report a
+**confidence band**:
+
+- **Likely** — the forecast clears even the worst-case plate minima.
+- **Unlikely** — it fails even the best-case.
+- **Marginal** — inside the band; genuinely undeterminable without the plate.
+
+**FAA** thresholds are fixed regulatory numbers (2000/3 trigger; 600-2 / 800-2
+alternate), so the band collapses (`req_lo == req_hi`) and FAA stays **binary**
+(Yes/No, never Marginal). **EASA** derives thresholds from the unknown plate
+minima + margins, so it uses the 3-state band. Where a hard yes/no is forced,
+**Marginal counts conservatively** (marginal alternate → not qualifying; marginal
+trigger → required).
+
+## Architecture
+
+```
+analysis/alternate_requirement.py   ← PURE (no I/O, no euro_aip) — all the logic
+  APPROACH_CLASS_PROXY              ← estimated plate-minima ranges (the only tuning surface)
+  proxy_for_approach()              ← approach_type string → ApproachProxy | None (VFR)
+  easa_ceiling_band/easa_vis_band   ← DH+200 / vis+1500(floor 1500)
+  band_qualification/band_trigger   ← verdict primitives (collapsed band ⇒ no Marginal)
+  combine_qual/combine_trigger      ← worst-of-criteria
+  TrendView / build_window          ← worst-case ceiling/vis over the ETA window
+  nwp_window / no_forecast_window   ← fallbacks
+  compute_faa_trigger / compute_easa_trigger
+  compute_faa_qual / compute_easa_qual
+
+tasks/alternate_requirement.py      ← WIRING (the only euro_aip / airports-DB touch)
+  run_alternate_requirement(snapshot, airports_db_path)
+    _build_destination_window()     ← destination TAF (WeatherReport.from_taf +
+                                       WeatherAnalyzer.applicable_trends) else NWP
+    _destination_approach_class()   ← airport.procedures_query.approaches().most_precise()
+    → writes snapshot.alternates.alternate_requirement + per-candidate .faa/.easa
+
+models/alternate_requirement.py     ← BandVerdict, TriggerVerdict, CriterionAssessment,
+                                       RegAlternateTrigger, AlternateQual, AlternateRequirement
+```
+
+The euro_aip TAF→`TrendView` extraction (`_taf_instant_trends`) takes an
+injectable `applicable_trends_fn`, so the whole windowing path is unit-testable
+without euro_aip installed.
+
+## Inputs (no new fetching)
+
+| Input | Source |
+|---|---|
+| Destination raw TAF (D-0 only) | `snapshot.route_observations.airports[*].taf_raw` (matched on `obs.icao == destination`) |
+| Destination NWP fallback (D-2/D-1) | `RouteAlternates.destination_ceiling_ft` / `destination_visibility_m` — the destination's NWP-consensus assessment at ETA, stored by `run_alternates` (worst across models) |
+| Destination ETA | `RouteAlternates.eta` (rounded ETA hour) |
+| Candidate ceiling/vis | `AlternateAirport.ceiling_ft` / `.visibility_m` (NWP-consensus, `mode="worst"`) |
+| Candidate / destination approach class | `best_approach_type` (candidates) / `procedures_query.approaches().most_precise()` (destination) |
+
+The NWP fallback deliberately reuses the alternates stage's own destination
+assessment rather than recomputing `AirportConditions.arrival`, so the trigger is
+NWP-consistent with the candidate qualifications (same shared code path, same ETA
+hour).
+
+## Proxy ranges (the only tuning surface)
+
+Keyed on the values that actually exist in `nav.db` (`procedures.approach_type`).
+There is **no LPV/LNAV granularity** in the data — `approach_type` is the ICAO
+chart family; minima lines live inside the chart. So the GNSS bucket spans
+LPV-best to LNAV-worst and the Marginal band absorbs the ambiguity.
+
+| Class | `approach_type` | DH range (ft) | Vis range (m) | FAA branch |
+|---|---|---|---|---|
+| Precision | `ILS` | 200–300 | 550–1500 | precision → 600-2 |
+| GNSS | `RNP`, `RNAV` | 250–600 | 1000–2000 | non-precision → 800-2 |
+| Non-precision | `VOR`, `NDB`, `LOC` | 400–900 | 1500–3000 | non-precision → 800-2 |
+| Unknown/other | empty/NULL/TACAN/unmapped | 400–900 | 1500–3000 | non-precision → 800-2 |
+| No IAP | `has_instrument_approach=False` | VFR proxy | VFR proxy | VFR proxy |
+
+EASA ceiling req = `[DH_lo+200, DH_hi+200]`; vis req = `[vis_lo+1500, vis_hi+1500]`
+with a 1500 m floor. **Only ILS** is the FAA precision branch (no confirmable LPV).
+
+## Verdict logic
+
+Per criterion, forecast `F` vs band `[lo, hi]`:
+- **Qualification** (higher better): `F ≥ hi` → Likely; `F < lo` → Unlikely; else Marginal.
+- **Trigger** (lower forces alternate): `F ≥ hi` → not-forced; `F < lo` → Required; else Marginal.
+- Combine: worst wins.
+- FAA: `lo == hi` ⇒ only the two extremes.
+
+## Conservative bias
+
+- Proxy ranges bracket reality; `hi` end at/above the class maximum.
+- Ambiguous/unmapped `approach_type` → most-demanding non-precision range.
+- No procedure data (`approach_filter_relaxed`) → VFR-only treatment + surfaced caveat.
+- Forecast side already worst-case (lowest ceiling/vis across models + window) — kept.
+- **Missing/unparseable forecast value → fail.** Exception: genuine clear sky
+  (CAVOK/NSC/SKC) → good. A ceiling of `None` from a *present* forecast means
+  "no BKN/OVC layer" (good); the only "no forecast" path is no TAF **and** no NWP
+  (`has_forecast=False` → both triggers Required, `source="none"`).
+- Hard gates count Marginal conservatively.
+
+## Window builder
+
+`build_window(instant_trends, source, include_prob30=False)` reduces the trends
+applicable at each sample time (ETA−60/−30/0/+30/+60) to the worst-case ceiling
+and visibility. At each instant the prevailing line is the base group plus the
+latest applicable FM/BECMG (supersession by `validity_start`); TEMPO/PROB groups
+can only make it *worse*. PROB policy: TEMPO + PROB40 honoured; **PROB30
+disregarded** by default. `triggered_by_tempo` records whether a binding worst
+value came from a temporary group.
+
+## Surfacing
+
+- **Alternates UI** (`briefing-ui.ts:renderRouteAlternates`): a destination
+  banner (`Alternate required? — FAA: … · EASA: …`, with reason, `(forecast)` vs
+  `(model estimate)`, a TEMPO tag, and an info button for the proxy caveat), plus
+  two table columns — **FAA alt** (Yes/No) and **EASA alt** (Likely/Marginal/
+  Unlikely, green/amber/grey). Tooltips + the candidate popup show the computed
+  requirement vs forecast.
+- **Plain-text digest** (`digest/text.py:_format_route_alternates`): a trigger
+  line + per-candidate `FAA alt yes/no` and `EASA <verdict>` on each row.
+- **LLM digest / PDF report:** out of scope (matches the alternates decision).
+
+## Mandatory caveats
+
+Surfaced via `AlternateRequirement.caveats`: EASA requirements are computed from
+estimated plate minima expressed as a range (band reflects that uncertainty;
+forecast inputs are real); per-candidate qualification uses NWP consensus not a
+TAF; `source="nwp"` triggers are model estimates; planning guidance only.
+
+## Out of scope / follow-ups
+
+- User-entered Field-16 alternate list.
+- Fetching TAFs for the divert candidates themselves.
+- Real plate minima from a procedures DB (would replace the proxy ranges and
+  shrink Marginal toward exact Yes/No).
+- Route advisory evaluator (GREEN/AMBER/RED), isolated-aerodrome fuel rules.
+
+## References
+
+- Pure logic + tests: `analysis/alternate_requirement.py`, `tests/test_alternate_requirement.py`
+- Wiring: `tasks/alternate_requirement.py`; pipeline step 4.1 in `pipeline.py`
+- Models: `models/alternate_requirement.py`; fields added to `models/alternates.py`
+- Upstream: [alternates.md](./alternates.md) (#210),
+  [metar-taf-route-weather.md](./metar-taf-route-weather.md)
+- euro_aip: `briefing/weather/models.py` (`WeatherReport.from_taf`),
+  `briefing/weather/analysis.py` (`WeatherAnalyzer.applicable_trends`)

--- a/src/weatherbrief/analysis/alternate_requirement.py
+++ b/src/weatherbrief/analysis/alternate_requirement.py
@@ -468,7 +468,10 @@ def _build_trigger(
         regime=regime,
         status=status,
         reason=reason,
-        source=window.source if window.source in ("taf", "nwp") else "nwp",
+        # Invariant: a forecast-present window's source is "taf" or "nwp" (the
+        # "none" source only reaches the no-forecast branch above). Pydantic's
+        # Literal validation makes a broken invariant loud rather than silent.
+        source=window.source,
         triggered_by_tempo=window.triggered_by_tempo,
         ceiling=ceiling_c,
         visibility=vis_c,

--- a/src/weatherbrief/analysis/alternate_requirement.py
+++ b/src/weatherbrief/analysis/alternate_requirement.py
@@ -1,0 +1,630 @@
+"""Pure functions for the regulatory alternate-requirement assessment (issue #249).
+
+No I/O — every function here is unit-testable in isolation. The euro_aip TAF
+parsing and the snapshot wiring live in ``tasks/alternate_requirement.py``; this
+module only reasons over already-extracted ceiling/visibility values and the
+approach-class proxy table.
+
+Two regimes:
+
+* **FAA (14 CFR 91.169)** — fixed regulatory thresholds, so every band
+  collapses (``req_lo == req_hi``) and verdicts are only ever the two extremes
+  (Yes/No, never Marginal). The only proxy is the precision-vs-non-precision
+  classification, kept conservative (ILS-only = precision).
+* **EASA Part-NCO** — derives thresholds from the (unknown) plate minima plus
+  margins, expressed as a range; the band yields Likely / Marginal / Unlikely.
+
+The forecast ceiling/visibility *inputs* are always real. Only the *plate-minima
+thresholds* (which drive the EASA band) are estimated.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime
+
+from weatherbrief.models.alternate_requirement import (
+    AlternateQual,
+    BandVerdict,
+    CriterionAssessment,
+    RegAlternateTrigger,
+    TriggerVerdict,
+)
+from weatherbrief.units import M_PER_SM
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Tuning surface: estimated plate minima per approach class (issue #249).
+#
+# We lack the published minima, so each approach class's DH/MDH and published
+# visibility are estimated as a RANGE [lo, hi]. The lo ends are the PANS-OPS /
+# regulatory best case; the hi ends are conservative category estimates. The
+# Marginal band's width is set entirely by these ranges — widen upward when
+# unsure, never narrow so a marginal case reads as Likely.
+#
+# Keyed on the values that actually exist in nav.db (procedures.approach_type).
+# There is NO LPV/LNAV granularity in the data (approach_type is the ICAO chart
+# family; minima lines live inside the chart), so the GNSS bucket deliberately
+# spans LPV-best to LNAV-only-worst and the Marginal band absorbs the ambiguity.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ApproachProxy:
+    """Estimated plate-minima range for one approach class."""
+
+    dh_lo: float  # decision/minimum height, best case (ft)
+    dh_hi: float  # decision/minimum height, worst case (ft)
+    vis_lo: float  # published visibility, best case (m)
+    vis_hi: float  # published visibility, worst case (m)
+    faa_precision: bool  # FAA 600-2 (precision) vs 800-2 (non-precision) branch
+
+
+# Precision (ILS only — the sole FAA precision branch).
+_PRECISION = ApproachProxy(dh_lo=200, dh_hi=300, vis_lo=550, vis_hi=1500, faa_precision=True)
+# RNP / RNAV (GNSS) — no confirmable LPV line in the data, so a wide bucket.
+_GNSS = ApproachProxy(dh_lo=250, dh_hi=600, vis_lo=1000, vis_hi=2000, faa_precision=False)
+# Non-precision (VOR / NDB / LOC) and the unknown/other fallback.
+_NONPRECISION = ApproachProxy(dh_lo=400, dh_hi=900, vis_lo=1500, vis_hi=3000, faa_precision=False)
+
+APPROACH_CLASS_PROXY: dict[str, ApproachProxy] = {
+    "ILS": _PRECISION,
+    "RNP": _GNSS,
+    "RNAV": _GNSS,
+    "VOR": _NONPRECISION,
+    "NDB": _NONPRECISION,
+    "LOC": _NONPRECISION,
+}
+# Empty / NULL / TACAN / any unmapped string → most-demanding (non-precision).
+_DEFAULT_PROXY = _NONPRECISION
+
+# EASA Part-NCO planning margins.
+EASA_CEILING_MARGIN_FT = 200.0  # ceiling requirement = DH + 200 ft
+EASA_VIS_MARGIN_M = 1500.0  # visibility requirement = published vis + 1500 m
+EASA_VIS_FLOOR_M = 1500.0  # ... with a 1500 m hard floor
+
+# FAA fixed thresholds (14 CFR 91.169). Statute miles for visibility.
+FAA_TRIGGER_CEILING_FT = 2000.0
+FAA_TRIGGER_VIS_SM = 3.0
+FAA_ALT_PRECISION_CEILING_FT = 600.0  # ILS only
+FAA_ALT_NONPRECISION_CEILING_FT = 800.0
+FAA_ALT_VIS_SM = 2.0
+FAA_ALT_VFR_CEILING_FT = 1000.0  # no-IAP VFR proxy
+FAA_ALT_VFR_VIS_SM = 3.0
+
+# EASA VFR proxy (no instrument approach), metric.
+VFR_PROXY_CEILING_FT = 1000.0
+VFR_PROXY_VIS_M = 5000.0
+
+# A ceiling forecast of ``None`` means "no ceiling layer" (clear / good); map it
+# to +inf for the band comparison so it clears every requirement.
+_NO_CEILING = float("inf")
+
+
+def proxy_for_approach(approach_type: str | None, has_iap: bool = True) -> ApproachProxy | None:
+    """Return the estimated plate-minima range for an approach class.
+
+    ``None`` means "no instrument approach" — the caller applies the VFR proxy.
+    An unknown/unmapped ``approach_type`` (with an IAP present) degrades to the
+    most-demanding non-precision range, never a more permissive one.
+    """
+    if not has_iap:
+        return None
+    if not approach_type:
+        return _DEFAULT_PROXY
+    return APPROACH_CLASS_PROXY.get(approach_type.strip().upper(), _DEFAULT_PROXY)
+
+
+def easa_ceiling_band(proxy: ApproachProxy) -> tuple[float, float]:
+    """EASA ceiling requirement band ``[DH_lo + 200, DH_hi + 200]`` (ft)."""
+    return (proxy.dh_lo + EASA_CEILING_MARGIN_FT, proxy.dh_hi + EASA_CEILING_MARGIN_FT)
+
+
+def easa_vis_band(proxy: ApproachProxy) -> tuple[float, float]:
+    """EASA visibility requirement band ``[vis_lo + 1500, vis_hi + 1500]`` (m, 1500 floor)."""
+    return (
+        max(proxy.vis_lo + EASA_VIS_MARGIN_M, EASA_VIS_FLOOR_M),
+        max(proxy.vis_hi + EASA_VIS_MARGIN_M, EASA_VIS_FLOOR_M),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Verdict primitives. ``req_lo == req_hi`` collapses the band (FAA), so only the
+# two extremes are reachable — never Marginal.
+# ---------------------------------------------------------------------------
+
+
+def band_qualification(forecast: float | None, req_lo: float, req_hi: float) -> BandVerdict:
+    """Qualification verdict (higher forecast is better — alternate eligible?).
+
+    ``forecast=None`` is a missing/unparseable value → conservative fail.
+    """
+    if forecast is None:
+        return BandVerdict.UNLIKELY
+    if forecast >= req_hi:
+        return BandVerdict.LIKELY
+    if forecast < req_lo:
+        return BandVerdict.UNLIKELY
+    return BandVerdict.MARGINAL
+
+
+def band_trigger(forecast: float | None, req_lo: float, req_hi: float) -> TriggerVerdict:
+    """Trigger verdict (lower forecast forces an alternate — alternate required?).
+
+    ``forecast=None`` is a missing/unparseable value → conservative require.
+    """
+    if forecast is None:
+        return TriggerVerdict.REQUIRED
+    if forecast >= req_hi:
+        return TriggerVerdict.NOT_REQUIRED
+    if forecast < req_lo:
+        return TriggerVerdict.REQUIRED
+    return TriggerVerdict.MARGINAL
+
+
+_QUAL_RANK = {BandVerdict.LIKELY: 0, BandVerdict.MARGINAL: 1, BandVerdict.UNLIKELY: 2}
+_TRIG_RANK = {
+    TriggerVerdict.NOT_REQUIRED: 0,
+    TriggerVerdict.MARGINAL: 1,
+    TriggerVerdict.REQUIRED: 2,
+}
+
+
+def combine_qual(verdicts: list[BandVerdict]) -> BandVerdict:
+    """Worst-of-criteria: any Unlikely → Unlikely; else any Marginal → Marginal."""
+    if not verdicts:
+        return BandVerdict.UNLIKELY
+    return max(verdicts, key=lambda v: _QUAL_RANK[v])
+
+
+def combine_trigger(verdicts: list[TriggerVerdict]) -> TriggerVerdict:
+    """Worst-of-criteria: any Required → Required; else any Marginal → Marginal."""
+    if not verdicts:
+        return TriggerVerdict.REQUIRED
+    return max(verdicts, key=lambda v: _TRIG_RANK[v])
+
+
+def _ceiling_for_band(ceiling_ft: float | None) -> float | None:
+    """Map a window ceiling to the value used for the band comparison.
+
+    ``None`` here means "no ceiling layer" (clear) and clears every requirement.
+    The genuine "no forecast at all" case is handled upstream (``has_forecast``),
+    so ``None`` is never the missing-data case once we reach a criterion.
+    """
+    return _NO_CEILING if ceiling_ft is None else ceiling_ft
+
+
+# ---------------------------------------------------------------------------
+# Forecast window (ceiling + visibility over the ETA window). Pure: the euro_aip
+# TAF → TrendView extraction is in tasks/, and feeds ``build_window`` here.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class TrendView:
+    """euro_aip-agnostic view of one TAF trend group needed for windowing."""
+
+    ceiling_ft: float | None = None  # None = no BKN/OVC layer (clear, good)
+    visibility_m: float | None = None
+    cavok: bool = False  # CAVOK / SKC / NSC → no ceiling constraint, vis good
+    trend_type: str | None = None  # None/"BASE"/"FM"/"BECMG" (prevailing) | "TEMPO"/"PROB"/"INTER"
+    probability: int | None = None  # PROB %
+    validity_start: datetime | None = None  # used to pick the latest prevailing group
+
+
+@dataclass
+class CeilingVisWindow:
+    """Worst-case ceiling/visibility over the ETA window.
+
+    ``ceiling_ft=None`` means no ceiling layer over the whole window (clear,
+    good); a finite value is the lowest ceiling. ``visibility_m=None`` means the
+    visibility could not be determined (conservative fail) — distinct from a
+    clear ceiling. ``has_forecast=False`` short-circuits to Required/Unlikely.
+    """
+
+    ceiling_ft: float | None
+    visibility_m: float | None
+    source: str  # "taf" | "nwp" | "none"
+    triggered_by_tempo: bool = False
+    has_forecast: bool = True
+
+    @property
+    def visibility_sm(self) -> float | None:
+        """Visibility in statute miles (for FAA), or ``None`` if undetermined."""
+        return None if self.visibility_m is None else self.visibility_m / M_PER_SM
+
+
+_TEMPORARY_TYPES = {"TEMPO", "PROB", "PROB30", "PROB40", "INTER", "PROB30 TEMPO", "PROB40 TEMPO"}
+
+
+def _is_temporary(trend: TrendView) -> bool:
+    """A TEMPO / PROB / INTER group (candidate-worse), not a prevailing line."""
+    tt = (trend.trend_type or "").strip().upper()
+    if tt in _TEMPORARY_TYPES:
+        return True
+    if "TEMPO" in tt or tt.startswith("PROB") or "INTER" in tt:
+        return True
+    # A bare PROB group with no trend_type but a probability set.
+    return trend.probability is not None and tt in ("", "BASE")
+
+
+def _prob_allowed(trend: TrendView, include_prob30: bool) -> bool:
+    """PROB policy: TEMPO and PROB40 honoured; PROB30 disregarded by default."""
+    if trend.probability is None:
+        return True
+    if trend.probability <= 30:
+        return include_prob30
+    return True
+
+
+def _eff_ceiling(trend: TrendView) -> float:
+    """Effective ceiling for the band comparison (clear / no layer → +inf)."""
+    if trend.cavok or trend.ceiling_ft is None:
+        return _NO_CEILING
+    return trend.ceiling_ft
+
+
+def _eff_visibility(trend: TrendView) -> float | None:
+    """Effective visibility (CAVOK → at-least-9999 m; else the reported value)."""
+    if trend.cavok:
+        return max(trend.visibility_m or 0.0, 9999.0)
+    return trend.visibility_m
+
+
+def _instant_worst(
+    trends: list[TrendView], include_prob30: bool
+) -> tuple[float, float | None, bool, bool]:
+    """Worst-case (ceiling, vis, ceiling_from_tempo, vis_from_tempo) at one instant.
+
+    The prevailing condition is the latest-by-validity FM/BECMG/base group;
+    TEMPO/PROB groups can only make it *worse* (never improve it).
+    """
+    prevailing = [t for t in trends if not _is_temporary(t)]
+    temporary = [
+        t for t in trends if _is_temporary(t) and _prob_allowed(t, include_prob30)
+    ]
+
+    gov = None
+    if prevailing:
+        gov = max(prevailing, key=lambda t: t.validity_start or datetime.min)
+
+    ceiling = _eff_ceiling(gov) if gov is not None else _NO_CEILING
+    vis = _eff_visibility(gov) if gov is not None else None
+    c_tempo = False
+    v_tempo = False
+
+    for t in temporary:
+        ct = _eff_ceiling(t)
+        if ct < ceiling:
+            ceiling = ct
+            c_tempo = True
+        vt = _eff_visibility(t)
+        if vt is not None and (vis is None or vt < vis):
+            vis = vt
+            v_tempo = True
+
+    return ceiling, vis, c_tempo, v_tempo
+
+
+def build_window(
+    instant_trends: list[list[TrendView]],
+    *,
+    source: str = "taf",
+    include_prob30: bool = False,
+) -> CeilingVisWindow:
+    """Reduce per-instant applicable trends to the worst-case window.
+
+    ``instant_trends`` is the list of applicable trends at each sample time
+    (ETA−60/−30/0/+30/+60 min, say). Tracks the lowest ceiling and lowest
+    visibility across the window and whether the binding value came from a
+    temporary (TEMPO/PROB) group.
+    """
+    has_forecast = any(instant_trends)
+    if not has_forecast:
+        return CeilingVisWindow(
+            ceiling_ft=None, visibility_m=None, source="none",
+            triggered_by_tempo=False, has_forecast=False,
+        )
+
+    best_c = _NO_CEILING
+    best_c_tempo = False
+    best_v: float | None = None
+    best_v_tempo = False
+
+    for trends in instant_trends:
+        if not trends:
+            continue
+        c, v, ct, vt = _instant_worst(trends, include_prob30)
+        if c < best_c:
+            best_c = c
+            best_c_tempo = ct
+        if v is not None and (best_v is None or v < best_v):
+            best_v = v
+            best_v_tempo = vt
+
+    ceiling_out = None if best_c == _NO_CEILING else best_c
+    triggered_by_tempo = (ceiling_out is not None and best_c_tempo) or (
+        best_v is not None and best_v_tempo
+    )
+    return CeilingVisWindow(
+        ceiling_ft=ceiling_out,
+        visibility_m=best_v,
+        source=source,
+        triggered_by_tempo=triggered_by_tempo,
+        has_forecast=True,
+    )
+
+
+def nwp_window(ceiling_ft: float | None, visibility_m: float | None) -> CeilingVisWindow:
+    """Single-point NWP-consensus fallback window (no TAF available).
+
+    A ``None`` ceiling here means "no ceiling layer" (clear). When both the
+    ceiling and visibility are missing we have no usable forecast at all.
+    """
+    has_forecast = ceiling_ft is not None or visibility_m is not None
+    return CeilingVisWindow(
+        ceiling_ft=ceiling_ft,
+        visibility_m=visibility_m,
+        source="nwp" if has_forecast else "none",
+        triggered_by_tempo=False,
+        has_forecast=has_forecast,
+    )
+
+
+def no_forecast_window() -> CeilingVisWindow:
+    """Window for "no TAF and no NWP fallback" → both triggers Required."""
+    return CeilingVisWindow(
+        ceiling_ft=None, visibility_m=None, source="none",
+        triggered_by_tempo=False, has_forecast=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Formatting helpers for reason strings.
+# ---------------------------------------------------------------------------
+
+
+def _fmt_req(lo: float, hi: float, unit: str) -> str:
+    """Format a requirement band: "600 ft" if collapsed, else "~600–1100 ft"."""
+    if lo == hi:
+        return f"{lo:.0f} {unit}"
+    return f"~{lo:.0f}–{hi:.0f} {unit}"
+
+
+def _fmt_forecast(value: float | None, unit: str, *, is_ceiling: bool) -> str:
+    """Format a forecast value, distinguishing "no ceiling" from "missing"."""
+    if value is None:
+        return "no ceiling" if is_ceiling else "missing"
+    return f"{value:.0f} {unit}"
+
+
+def _criterion(
+    label: str,
+    unit: str,
+    forecast: float | None,
+    req_lo: float,
+    req_hi: float,
+    verdict_value: str,
+) -> CriterionAssessment:
+    return CriterionAssessment(
+        label=label,
+        unit=unit,
+        forecast=forecast,
+        required_min=req_lo,
+        required_max=req_hi,
+        verdict=verdict_value,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Destination triggers (is an alternate required?).
+# ---------------------------------------------------------------------------
+
+
+def _build_trigger(
+    regime: str,
+    window: CeilingVisWindow,
+    *,
+    ceiling_lo: float,
+    ceiling_hi: float,
+    vis_lo: float,
+    vis_hi: float,
+    vis_unit: str,
+) -> RegAlternateTrigger:
+    """Assemble a destination trigger for one regime from its requirement bands."""
+    vis_forecast = window.visibility_sm if vis_unit == "SM" else window.visibility_m
+
+    if not window.has_forecast:
+        ceiling_c = _criterion(
+            "ceiling", "ft", None, ceiling_lo, ceiling_hi, TriggerVerdict.REQUIRED.value
+        )
+        vis_c = _criterion(
+            "visibility", vis_unit, None, vis_lo, vis_hi, TriggerVerdict.REQUIRED.value
+        )
+        return RegAlternateTrigger(
+            regime=regime,
+            status=TriggerVerdict.REQUIRED,
+            reason="no forecast available",
+            source="none",
+            triggered_by_tempo=False,
+            ceiling=ceiling_c,
+            visibility=vis_c,
+        )
+
+    cverd = band_trigger(_ceiling_for_band(window.ceiling_ft), ceiling_lo, ceiling_hi)
+    vverd = band_trigger(vis_forecast, vis_lo, vis_hi)
+    status = combine_trigger([cverd, vverd])
+
+    ceiling_c = _criterion(
+        "ceiling", "ft", window.ceiling_ft, ceiling_lo, ceiling_hi, cverd.value
+    )
+    vis_c = _criterion(
+        "visibility", vis_unit, vis_forecast, vis_lo, vis_hi, vverd.value
+    )
+    reason = _trigger_reason(status, window, ceiling_c, vis_c, vis_unit)
+    return RegAlternateTrigger(
+        regime=regime,
+        status=status,
+        reason=reason,
+        source=window.source if window.source in ("taf", "nwp") else "nwp",
+        triggered_by_tempo=window.triggered_by_tempo,
+        ceiling=ceiling_c,
+        visibility=vis_c,
+    )
+
+
+def _trigger_reason(
+    status: TriggerVerdict,
+    window: CeilingVisWindow,
+    ceiling_c: CriterionAssessment,
+    vis_c: CriterionAssessment,
+    vis_unit: str,
+) -> str:
+    src = "model estimate" if window.source == "nwp" else "forecast"
+    if status == TriggerVerdict.NOT_REQUIRED:
+        return f"ceiling/visibility comfortably above minima ({src})"
+    # Name the binding criterion(s).
+    bits: list[str] = []
+    if ceiling_c.verdict != TriggerVerdict.NOT_REQUIRED.value:
+        bits.append(
+            f"ceiling {_fmt_forecast(ceiling_c.forecast, 'ft', is_ceiling=True)} "
+            f"vs {_fmt_req(ceiling_c.required_min, ceiling_c.required_max, 'ft')}"
+        )
+    if vis_c.verdict != TriggerVerdict.NOT_REQUIRED.value:
+        bits.append(
+            f"vis {_fmt_forecast(vis_c.forecast, vis_unit, is_ceiling=False)} "
+            f"vs {_fmt_req(vis_c.required_min, vis_c.required_max, vis_unit)}"
+        )
+    tempo = " (temporary)" if window.triggered_by_tempo else ""
+    return f"{'; '.join(bits)}{tempo} ({src})"
+
+
+def compute_faa_trigger(window: CeilingVisWindow) -> RegAlternateTrigger:
+    """FAA 14 CFR 91.169 destination trigger (2000 ft / 3 SM, binary)."""
+    return _build_trigger(
+        "faa",
+        window,
+        ceiling_lo=FAA_TRIGGER_CEILING_FT,
+        ceiling_hi=FAA_TRIGGER_CEILING_FT,
+        vis_lo=FAA_TRIGGER_VIS_SM,
+        vis_hi=FAA_TRIGGER_VIS_SM,
+        vis_unit="SM",
+    )
+
+
+def compute_easa_trigger(
+    window: CeilingVisWindow, proxy: ApproachProxy | None
+) -> RegAlternateTrigger:
+    """EASA Part-NCO destination trigger (DH+200 / vis+1500 bands).
+
+    ``proxy=None`` (destination has no IAP) → VFR proxy collapsed band.
+    """
+    if proxy is None:
+        cl = ch = VFR_PROXY_CEILING_FT
+        vl = vh = VFR_PROXY_VIS_M
+    else:
+        cl, ch = easa_ceiling_band(proxy)
+        vl, vh = easa_vis_band(proxy)
+    return _build_trigger(
+        "easa",
+        window,
+        ceiling_lo=cl,
+        ceiling_hi=ch,
+        vis_lo=vl,
+        vis_hi=vh,
+        vis_unit="m",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Per-candidate qualification (does this alternate meet alternate minima?).
+# ---------------------------------------------------------------------------
+
+
+def _qual_reason(
+    verdict: BandVerdict,
+    ceiling_c: CriterionAssessment,
+    vis_c: CriterionAssessment,
+    vis_unit: str,
+    *,
+    vfr_only: bool,
+) -> str:
+    note = "VFR only (no instrument approach); " if vfr_only else ""
+    return (
+        f"{note}ceiling {_fmt_forecast(ceiling_c.forecast, 'ft', is_ceiling=True)} "
+        f"vs {_fmt_req(ceiling_c.required_min, ceiling_c.required_max, 'ft')}; "
+        f"vis {_fmt_forecast(vis_c.forecast, vis_unit, is_ceiling=False)} "
+        f"vs {_fmt_req(vis_c.required_min, vis_c.required_max, vis_unit)} "
+        f"→ {verdict.value}"
+    )
+
+
+def compute_faa_qual(
+    ceiling_ft: float | None,
+    visibility_m: float | None,
+    approach_type: str | None,
+    has_iap: bool,
+) -> AlternateQual:
+    """FAA per-candidate alternate minima (ILS→600-2, else→800-2, no-IAP→VFR)."""
+    proxy = proxy_for_approach(approach_type, has_iap)
+    if not has_iap or proxy is None:
+        cl = ch = FAA_ALT_VFR_CEILING_FT
+        vl = vh = FAA_ALT_VFR_VIS_SM
+        vfr_only = True
+    elif proxy.faa_precision:
+        cl = ch = FAA_ALT_PRECISION_CEILING_FT
+        vl = vh = FAA_ALT_VIS_SM
+        vfr_only = False
+    else:
+        cl = ch = FAA_ALT_NONPRECISION_CEILING_FT
+        vl = vh = FAA_ALT_VIS_SM
+        vfr_only = False
+
+    vis_sm = None if visibility_m is None else visibility_m / M_PER_SM
+    cverd = band_qualification(_ceiling_for_band(ceiling_ft), cl, ch)
+    vverd = band_qualification(vis_sm, vl, vh)
+    verdict = combine_qual([cverd, vverd])
+
+    ceiling_c = _criterion("ceiling", "ft", ceiling_ft, cl, ch, cverd.value)
+    vis_c = _criterion("visibility", "SM", vis_sm, vl, vh, vverd.value)
+    return AlternateQual(
+        regime="faa",
+        verdict=verdict,
+        reason=_qual_reason(verdict, ceiling_c, vis_c, "SM", vfr_only=vfr_only),
+        ceiling=ceiling_c,
+        visibility=vis_c,
+    )
+
+
+def compute_easa_qual(
+    ceiling_ft: float | None,
+    visibility_m: float | None,
+    approach_type: str | None,
+    has_iap: bool,
+) -> AlternateQual:
+    """EASA per-candidate alternate minima (DH+200 / vis+1500 bands; no-IAP→VFR)."""
+    proxy = proxy_for_approach(approach_type, has_iap)
+    if not has_iap or proxy is None:
+        cl = ch = VFR_PROXY_CEILING_FT
+        vl = vh = VFR_PROXY_VIS_M
+        vfr_only = True
+    else:
+        cl, ch = easa_ceiling_band(proxy)
+        vl, vh = easa_vis_band(proxy)
+        vfr_only = False
+
+    cverd = band_qualification(_ceiling_for_band(ceiling_ft), cl, ch)
+    vverd = band_qualification(visibility_m, vl, vh)
+    verdict = combine_qual([cverd, vverd])
+
+    ceiling_c = _criterion("ceiling", "ft", ceiling_ft, cl, ch, cverd.value)
+    vis_c = _criterion("visibility", "m", visibility_m, vl, vh, vverd.value)
+    return AlternateQual(
+        regime="easa",
+        verdict=verdict,
+        reason=_qual_reason(verdict, ceiling_c, vis_c, "m", vfr_only=vfr_only),
+        ceiling=ceiling_c,
+        visibility=vis_c,
+    )

--- a/src/weatherbrief/digest/text.py
+++ b/src/weatherbrief/digest/text.py
@@ -409,7 +409,9 @@ def _format_route_alternates(alt: RouteAlternates) -> list[str]:
 
     req = alt.alternate_requirement
     if req is not None:
-        faa = "Required" if req.faa.status.value == "required" else "Not required"
+        # FAA is binary, but guard the safe direction: anything but an explicit
+        # not_required reads as Required (a stray marginal must not under-report).
+        faa = "Not required" if req.faa.status.value == "not_required" else "Required"
         easa_map = {
             "required": "Required", "marginal": "Marginal", "not_required": "Not required",
         }

--- a/src/weatherbrief/digest/text.py
+++ b/src/weatherbrief/digest/text.py
@@ -407,6 +407,19 @@ def _format_route_alternates(alt: RouteAlternates) -> list[str]:
         f"({alt.candidates_evaluated} candidates{approach_note})"
     )
 
+    req = alt.alternate_requirement
+    if req is not None:
+        faa = "Required" if req.faa.status.value == "required" else "Not required"
+        easa_map = {
+            "required": "Required", "marginal": "Marginal", "not_required": "Not required",
+        }
+        easa = easa_map.get(req.easa.status.value, req.easa.status.value)
+        src = "model estimate" if req.faa.source == "nwp" else (
+            "forecast" if req.faa.source == "taf" else "no forecast")
+        lines.append(
+            f"  Alternate required? FAA: {faa} | EASA: {easa} ({src})"
+        )
+
     for p in alt.nearest_improving:
         if not p.icao:
             continue
@@ -424,6 +437,11 @@ def _format_route_alternates(alt: RouteAlternates) -> list[str]:
             bits.append(a.best_approach_type)
         if a.dominates_destination:
             bits.append("dominates")
+        if a.faa is not None:
+            faa_ok = "yes" if a.faa.verdict.value == "likely" else "no"
+            bits.append(f"FAA alt {faa_ok}")
+        if a.easa is not None:
+            bits.append(f"EASA {a.easa.verdict.value}")
         lines.append(f"  {a.icao}: " + ", ".join(str(b) for b in bits if b))
 
     lines.append("")

--- a/src/weatherbrief/models/__init__.py
+++ b/src/weatherbrief/models/__init__.py
@@ -105,6 +105,14 @@ from weatherbrief.models.airport_conditions import (  # noqa: F401
     RunwayEnd,
     RunwayWind,
 )
+from weatherbrief.models.alternate_requirement import (  # noqa: F401
+    AlternateQual,
+    AlternateRequirement,
+    BandVerdict,
+    CriterionAssessment,
+    RegAlternateTrigger,
+    TriggerVerdict,
+)
 from weatherbrief.models.alternates import (  # noqa: F401
     ALT_AXIS_LABELS,
     AlternateAirport,

--- a/src/weatherbrief/models/alternate_requirement.py
+++ b/src/weatherbrief/models/alternate_requirement.py
@@ -1,0 +1,106 @@
+"""Regulatory "alternate required?" assessment models (issue #249).
+
+A planning-grade, advisory layer that answers two questions for a briefing,
+computed two ways — **FAA (14 CFR 91.169)** and **EASA Part-NCO** —:
+
+1. **Destination trigger** — is a filed alternate required? (FAA: Yes/No;
+   EASA: No / Marginal / Required).
+2. **Per-candidate qualification** — does each weather-computed divert
+   candidate meet alternate minima at its ETA? (FAA: Yes/No;
+   EASA: Likely / Marginal / Unlikely).
+
+Ceiling and visibility are evaluated independently from **real forecast data**
+(TAF when available, NWP consensus otherwise). What we lack is the published
+plate minima (DA/MDA and RVR/visibility) — we only know the approach *type*. So
+the EASA requirement is computed transparently from an estimated plate-minima
+**range** per approach class, and the unknown is expressed as a confidence band:
+**Likely / Marginal / Unlikely**. FAA thresholds are fixed regulatory numbers,
+so FAA stays binary.
+
+See ``designs/alternate-requirement.md`` for the full design.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class BandVerdict(str, Enum):
+    """Per-candidate qualification confidence band.
+
+    ``LIKELY`` clears even the worst-case plate minima; ``UNLIKELY`` fails even
+    the best-case; ``MARGINAL`` falls inside the proxy band — genuinely
+    undeterminable without the published plate. FAA collapses the band (fixed
+    thresholds) so it only ever yields ``LIKELY`` / ``UNLIKELY``.
+    """
+
+    LIKELY = "likely"
+    MARGINAL = "marginal"
+    UNLIKELY = "unlikely"
+
+
+class TriggerVerdict(str, Enum):
+    """Destination "is an alternate required?" verdict.
+
+    FAA only ever yields ``NOT_REQUIRED`` / ``REQUIRED`` (fixed thresholds).
+    """
+
+    NOT_REQUIRED = "not_required"
+    MARGINAL = "marginal"
+    REQUIRED = "required"
+
+
+class CriterionAssessment(BaseModel):
+    """One criterion (ceiling or visibility) evaluated against a requirement band.
+
+    ``forecast`` is the worst-in-window real forecast value (``None`` means it
+    could not be determined, OR — for ceiling — that there is no ceiling layer;
+    the ``verdict`` disambiguates: a good verdict with ``forecast=None`` is
+    "no ceiling", a bad verdict with ``forecast=None`` is "missing"). The
+    requirement band ``[required_min, required_max]`` collapses to a single value
+    for FAA (``required_min == required_max``).
+    """
+
+    label: str  # "ceiling" | "visibility"
+    unit: str  # "ft" | "m" | "SM"
+    forecast: float | None
+    required_min: float  # best-case plate requirement (band low end)
+    required_max: float  # worst-case (conservative) requirement; == min for FAA
+    verdict: str  # BandVerdict or TriggerVerdict value
+
+
+class RegAlternateTrigger(BaseModel):
+    """Destination "alternate required?" assessment for one regulatory regime."""
+
+    regime: Literal["faa", "easa"]
+    status: TriggerVerdict  # FAA: only NOT_REQUIRED / REQUIRED
+    reason: str
+    source: Literal["taf", "nwp", "none"]
+    triggered_by_tempo: bool = False
+    ceiling: CriterionAssessment
+    visibility: CriterionAssessment
+
+
+class AlternateQual(BaseModel):
+    """Per-candidate alternate-minima qualification for one regime."""
+
+    regime: Literal["faa", "easa"]
+    verdict: BandVerdict  # combined (worst of the two criteria)
+    reason: str
+    ceiling: CriterionAssessment
+    visibility: CriterionAssessment
+
+
+class AlternateRequirement(BaseModel):
+    """Regulatory alternate-requirement assessment for a route's destination."""
+
+    destination_icao: str
+    eta: datetime | None = None
+    faa: RegAlternateTrigger
+    easa: RegAlternateTrigger
+    caveats: list[str] = Field(default_factory=list)
+    computed_at: datetime | None = None

--- a/src/weatherbrief/models/alternate_requirement.py
+++ b/src/weatherbrief/models/alternate_requirement.py
@@ -70,7 +70,8 @@ class CriterionAssessment(BaseModel):
     forecast: float | None
     required_min: float  # best-case plate requirement (band low end)
     required_max: float  # worst-case (conservative) requirement; == min for FAA
-    verdict: str  # BandVerdict or TriggerVerdict value
+    # A BandVerdict value (qualification) or a TriggerVerdict value (trigger).
+    verdict: Literal["likely", "marginal", "unlikely", "not_required", "required"]
 
 
 class RegAlternateTrigger(BaseModel):

--- a/src/weatherbrief/models/alternates.py
+++ b/src/weatherbrief/models/alternates.py
@@ -17,6 +17,11 @@ from datetime import datetime
 
 from pydantic import BaseModel, Field
 
+from weatherbrief.models.alternate_requirement import (
+    AlternateQual,
+    AlternateRequirement,
+)
+
 # Canonical per-axis labels for the nearest-improving picks, shared by the web
 # UI / text digest / LLM prompt so the wording can't drift between surfaces.
 ALT_AXIS_LABELS = {
@@ -66,6 +71,11 @@ class AlternateAirport(BaseModel):
     better_crosswind: bool = False
     dominates_destination: bool = False  # better-or-equal on all axes (Pareto)
 
+    # --- regulatory alternate-minima qualification (issue #249) ---
+    # Computed from the candidate's NWP-consensus ceiling/vis + best_approach_type.
+    faa: AlternateQual | None = None  # Yes/No (Likely/Unlikely)
+    easa: AlternateQual | None = None  # Likely/Marginal/Unlikely
+
 
 class AlternateAxisPick(BaseModel):
     """The nearest improving alternate for one deficient axis."""
@@ -82,6 +92,10 @@ class RouteAlternates(BaseModel):
     destination_icao: str
     destination_category: str
     destination_crosswind_kt: float | None = None
+    # Destination NWP-consensus ceiling/visibility at ETA (worst across models).
+    # The regulatory-trigger NWP fallback (#249) when no destination TAF exists.
+    destination_ceiling_ft: float | None = None
+    destination_visibility_m: float | None = None
     eta: datetime | None = None
     corridor_nm: float
     radius_nm: float
@@ -90,4 +104,7 @@ class RouteAlternates(BaseModel):
     candidates_evaluated: int = 0
     alternates: list[AlternateAirport] = Field(default_factory=list)  # ranked, closest-first
     nearest_improving: list[AlternateAxisPick] = Field(default_factory=list)
+    # Regulatory "is an alternate required?" for the destination (FAA + EASA),
+    # co-located with the candidates it qualifies (#249). None until wired.
+    alternate_requirement: AlternateRequirement | None = None
     computed_at: datetime | None = None

--- a/src/weatherbrief/pipeline.py
+++ b/src/weatherbrief/pipeline.py
@@ -574,6 +574,25 @@ def execute_briefing(
         alternates=alternates,
     )
 
+    # === 4.1 Regulatory alternate requirement (FAA 91.169 + EASA Part-NCO) ===
+    # Post-step (after alternates + route weather): does the destination need a
+    # filed alternate, and does each computed divert candidate meet alternate
+    # minima? Uses the destination TAF when available (D-0), else the NWP
+    # consensus fallback. Mutates snapshot.alternates in place (#249).
+    if (
+        snapshot.alternates is not None
+        and options.airports_db_path
+        and not options.historical_mode
+    ):
+        _t0 = perf_counter()
+        try:
+            from weatherbrief.tasks.alternate_requirement import run_alternate_requirement
+
+            run_alternate_requirement(snapshot, options.airports_db_path)
+        except Exception:
+            logger.warning("Alternate-requirement stage failed", exc_info=True)
+        stage_timings["alternate_requirement"] = perf_counter() - _t0
+
     if pack_dir:
         from weatherbrief.tasks.artifacts import save_analysis_artifacts
 

--- a/src/weatherbrief/tasks/alternate_requirement.py
+++ b/src/weatherbrief/tasks/alternate_requirement.py
@@ -89,7 +89,9 @@ def _trend_to_view(obj, *, is_base: bool) -> TrendView:
         cavok=bool(getattr(obj, "cavok", False)),
         # The base group is always the prevailing line (trend_type None).
         trend_type=None if is_base else getattr(obj, "trend_type", None),
-        probability=getattr(obj, "probability", None),
+        # The base group never has a PROB; don't let a stray attribute on the
+        # parent WeatherReport misclassify it as a temporary group (#250 review).
+        probability=None if is_base else getattr(obj, "probability", None),
         validity_start=_coerce_dt(getattr(obj, "validity_start", None)),
     )
 
@@ -120,7 +122,12 @@ def _taf_instant_trends(taf, sample_times, applicable_trends_fn=None) -> list[li
     return instants
 
 
-def _build_destination_window(taf_raw: str | None, eta: datetime, nwp_ceiling, nwp_vis):
+def _build_destination_window(
+    taf_raw: str | None,
+    eta: datetime,
+    nwp_ceiling: float | None,
+    nwp_vis: float | None,
+):
     """Build the destination window: prefer a TAF that covers the ETA, else NWP."""
     if taf_raw:
         try:

--- a/src/weatherbrief/tasks/alternate_requirement.py
+++ b/src/weatherbrief/tasks/alternate_requirement.py
@@ -1,0 +1,231 @@
+"""Wiring step: regulatory alternate-requirement assessment (issue #249).
+
+A pipeline post-step run **after both** ``run_alternates`` and
+``run_route_weather`` (so the destination TAF, if any, is available). It is the
+only place that touches euro_aip / the airports DB for this feature; all the
+verdict logic lives in the pure ``analysis.alternate_requirement`` module.
+
+Steps:
+1. Find the destination observation → ``taf_raw`` → ``WeatherReport.from_taf``.
+2. Build the destination ceiling/visibility window (TAF when it covers the ETA,
+   else the NWP-consensus fallback stored on ``RouteAlternates``).
+3. Look up the destination approach class.
+4. Compute the ``AlternateRequirement`` (FAA + EASA triggers).
+5. For each candidate, compute FAA / EASA ``AlternateQual`` from its consensus
+   ceiling/vis + ``best_approach_type``.
+6. Write results back onto ``snapshot.alternates``.
+
+Gated on ``snapshot.alternates is not None`` (the alternates stage gate already
+bounds this to D-2 inward + opt-in).
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta, timezone
+
+from weatherbrief.analysis.alternate_requirement import (
+    TrendView,
+    build_window,
+    compute_easa_qual,
+    compute_easa_trigger,
+    compute_faa_qual,
+    compute_faa_trigger,
+    no_forecast_window,
+    nwp_window,
+    proxy_for_approach,
+)
+from weatherbrief.models.alternate_requirement import AlternateRequirement
+
+logger = logging.getLogger(__name__)
+
+# Sample offsets within the ETA window (ETA−60 .. ETA+60 min) for the TAF path.
+_WINDOW_OFFSETS_MIN = (-60, -30, 0, 30, 60)
+
+# Mandatory display caveats (issue #249). The UI/digest surface these verbatim.
+_CAVEATS = [
+    "EASA requirements are computed from estimated plate minima expressed as a "
+    "range; the Likely/Marginal/Unlikely band reflects that uncertainty. "
+    "Forecast ceiling/visibility inputs are real.",
+    "Per-candidate qualification uses NWP consensus, not a TAF.",
+    "Planning guidance only — not an operational minima computation or a "
+    "go/no-go decision.",
+]
+_NWP_CAVEAT = (
+    "The destination trigger uses an NWP model estimate (no TAF covers the ETA "
+    "window yet), not an aviation forecast product."
+)
+_RELAXED_CAVEAT = (
+    "Published-approach data is missing for some candidates; approach-class "
+    "estimates are degraded and treated as VFR-only."
+)
+
+
+def _coerce_dt(value) -> datetime | None:
+    """Coerce a euro_aip validity marker (datetime or day/hour) to a datetime.
+
+    Only used to order prevailing groups within the small ETA window, so a
+    synthetic month/year is fine — we just need a consistent ordering key.
+    """
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value
+    day = getattr(value, "day", None)
+    hour = getattr(value, "hour", None)
+    if day is None or hour is None:
+        return None
+    try:
+        return datetime(2000, 1, int(day), int(hour))
+    except (ValueError, TypeError):
+        return None
+
+
+def _trend_to_view(obj, *, is_base: bool) -> TrendView:
+    """Map a euro_aip WeatherReport / trend to the pure ``TrendView``."""
+    return TrendView(
+        ceiling_ft=getattr(obj, "ceiling_ft", None),
+        visibility_m=getattr(obj, "visibility_meters", None),
+        cavok=bool(getattr(obj, "cavok", False)),
+        # The base group is always the prevailing line (trend_type None).
+        trend_type=None if is_base else getattr(obj, "trend_type", None),
+        probability=getattr(obj, "probability", None),
+        validity_start=_coerce_dt(getattr(obj, "validity_start", None)),
+    )
+
+
+def _taf_instant_trends(taf, sample_times, applicable_trends_fn=None) -> list[list[TrendView]]:
+    """Build the per-instant applicable-trend lists for the window builder.
+
+    At each sample time the prevailing line is the base TAF group plus any
+    applicable FM/BECMG groups; TEMPO/PROB groups come in as candidate-worse.
+    ``applicable_trends_fn`` is injectable so the windowing can be tested without
+    euro_aip installed.
+    """
+    if applicable_trends_fn is None:  # pragma: no cover - exercised in CI
+        from euro_aip.briefing.weather.analysis import WeatherAnalyzer
+
+        applicable_trends_fn = WeatherAnalyzer.applicable_trends
+
+    base_view = _trend_to_view(taf, is_base=True)
+    instants: list[list[TrendView]] = []
+    for t in sample_times:
+        views = [base_view]
+        try:
+            for change in applicable_trends_fn(taf, t) or []:
+                views.append(_trend_to_view(change, is_base=False))
+        except Exception:
+            logger.debug("alternate_requirement: applicable_trends failed", exc_info=True)
+        instants.append(views)
+    return instants
+
+
+def _build_destination_window(taf_raw: str | None, eta: datetime, nwp_ceiling, nwp_vis):
+    """Build the destination window: prefer a TAF that covers the ETA, else NWP."""
+    if taf_raw:
+        try:
+            from euro_aip.briefing.weather.models import WeatherReport
+
+            taf = WeatherReport.from_taf(taf_raw)
+            sample_times = [eta + timedelta(minutes=m) for m in _WINDOW_OFFSETS_MIN]
+            instants = _taf_instant_trends(taf, sample_times)
+            window = build_window(instants, source="taf")
+            if window.has_forecast:
+                return window
+        except Exception:
+            logger.warning(
+                "alternate_requirement: TAF parse/window failed; falling back to NWP",
+                exc_info=True,
+            )
+
+    if nwp_ceiling is not None or nwp_vis is not None:
+        return nwp_window(nwp_ceiling, nwp_vis)
+    return no_forecast_window()
+
+
+def _destination_approach_class(airports_db_path: str, dest_icao: str) -> tuple[str | None, bool]:
+    """Look up the destination's most-precise approach type + IAP presence.
+
+    Mirrors the per-candidate approach query in ``tasks/alternates.py``.
+    """
+    try:
+        from weatherbrief.airports import _load_airport_model
+
+        model = _load_airport_model(airports_db_path)
+        airport = model.airports.get(dest_icao)
+        if airport is None:
+            return None, False
+        approaches = airport.procedures_query.approaches()
+        if not approaches.exists():
+            return None, False
+        best = approaches.most_precise()
+        return (best.approach_type if best is not None else None), True
+    except Exception:
+        logger.debug(
+            "alternate_requirement: destination approach lookup failed for %s",
+            dest_icao, exc_info=True,
+        )
+        return None, False
+
+
+def run_alternate_requirement(snapshot, airports_db_path: str, *, now: datetime | None = None):
+    """Compute and attach the regulatory alternate-requirement assessment.
+
+    Mutates ``snapshot.alternates`` in place (destination trigger +
+    per-candidate qualification). No-op when the alternates stage didn't run.
+    """
+    alternates = getattr(snapshot, "alternates", None)
+    if alternates is None:
+        return
+
+    now = now or datetime.now(timezone.utc)
+    route = snapshot.route
+    dest_icao = route.destination.icao
+    eta = alternates.eta or now
+
+    # 1. Destination TAF (only present on D-0 via run_route_weather).
+    taf_raw = None
+    obs = getattr(snapshot, "route_observations", None)
+    if obs is not None:
+        for a in obs.airports:
+            if a.icao == dest_icao and a.taf_raw:
+                taf_raw = a.taf_raw
+                break
+
+    # 2. Destination window (TAF preferred, else NWP-consensus fallback).
+    window = _build_destination_window(
+        taf_raw, eta,
+        alternates.destination_ceiling_ft,
+        alternates.destination_visibility_m,
+    )
+
+    # 3. Destination approach class.
+    dest_approach_type, dest_has_iap = _destination_approach_class(airports_db_path, dest_icao)
+    dest_proxy = proxy_for_approach(dest_approach_type, dest_has_iap)
+
+    # 4. Destination trigger (FAA + EASA).
+    caveats = list(_CAVEATS)
+    if window.source == "nwp":
+        caveats.append(_NWP_CAVEAT)
+    if alternates.approach_filter_relaxed:
+        caveats.append(_RELAXED_CAVEAT)
+
+    alternates.alternate_requirement = AlternateRequirement(
+        destination_icao=dest_icao,
+        eta=eta,
+        faa=compute_faa_trigger(window),
+        easa=compute_easa_trigger(window, dest_proxy),
+        caveats=caveats,
+        computed_at=now,
+    )
+
+    # 5. Per-candidate qualification from each candidate's consensus ceiling/vis.
+    for cand in alternates.alternates:
+        cand.faa = compute_faa_qual(
+            cand.ceiling_ft, cand.visibility_m, cand.best_approach_type,
+            cand.has_instrument_approach,
+        )
+        cand.easa = compute_easa_qual(
+            cand.ceiling_ft, cand.visibility_m, cand.best_approach_type,
+            cand.has_instrument_approach,
+        )

--- a/src/weatherbrief/tasks/alternate_requirement.py
+++ b/src/weatherbrief/tasks/alternate_requirement.py
@@ -61,27 +61,56 @@ _RELAXED_CAVEAT = (
 )
 
 
-def _coerce_dt(value) -> datetime | None:
+def _add_months(year: int, month: int, n: int) -> tuple[int, int]:
+    """Shift a (year, month) by ``n`` months."""
+    idx = (year * 12 + (month - 1)) + n
+    return idx // 12, idx % 12 + 1
+
+
+def _coerce_dt(value, ref: datetime | None):
     """Coerce a euro_aip validity marker (datetime or day/hour) to a datetime.
 
-    Only used to order prevailing groups within the small ETA window, so a
-    synthetic month/year is fine — we just need a consistent ordering key.
+    Only used to order prevailing groups within the ETA window (FM supersession),
+    so we need a consistent ordering key — but a TAF can straddle a month
+    boundary (a 29th-of-month TAF valid to 01/06Z), so a fixed Jan anchor would
+    sort an early-of-next-month FM *before* the late-of-this-month base and drop
+    the FM's (possibly worse) conditions. Resolve the day/hour to the calendar
+    month nearest ``ref`` (the ETA) so the ordering is rollover-safe. Returns a
+    naive datetime so the ordering key never mixes aware/naive with the
+    ``datetime.min`` sentinel used for groups without a validity_start.
     """
     if value is None:
         return None
     if isinstance(value, datetime):
-        return value
+        return value.replace(tzinfo=None)
     day = getattr(value, "day", None)
     hour = getattr(value, "hour", None)
     if day is None or hour is None:
         return None
     try:
-        return datetime(2000, 1, int(day), int(hour))
+        day = int(day)
+        hour = int(hour)
     except (ValueError, TypeError):
         return None
+    if ref is None:
+        try:
+            return datetime(2000, 1, day, hour)
+        except ValueError:
+            return None
+    ref_naive = ref.replace(tzinfo=None)
+    candidates: list[datetime] = []
+    for delta in (-1, 0, 1):
+        y, m = _add_months(ref_naive.year, ref_naive.month, delta)
+        try:
+            candidates.append(datetime(y, m, day, hour))
+        except ValueError:
+            continue  # day out of range for that month (e.g. 31 in a 30-day month)
+    if not candidates:
+        return None
+    return min(candidates, key=lambda d: abs((d - ref_naive).total_seconds()))
 
 
-def _trend_to_view(obj, *, is_base: bool) -> TrendView:
+def _trend_to_view(obj, *, is_base: bool, ref: datetime | None = None) -> TrendView:
     """Map a euro_aip WeatherReport / trend to the pure ``TrendView``."""
     return TrendView(
         ceiling_ft=getattr(obj, "ceiling_ft", None),
@@ -92,30 +121,37 @@ def _trend_to_view(obj, *, is_base: bool) -> TrendView:
         # The base group never has a PROB; don't let a stray attribute on the
         # parent WeatherReport misclassify it as a temporary group (#250 review).
         probability=None if is_base else getattr(obj, "probability", None),
-        validity_start=_coerce_dt(getattr(obj, "validity_start", None)),
+        validity_start=_coerce_dt(getattr(obj, "validity_start", None), ref),
     )
 
 
-def _taf_instant_trends(taf, sample_times, applicable_trends_fn=None) -> list[list[TrendView]]:
+def _taf_instant_trends(
+    taf, sample_times, applicable_trends_fn=None, ref: datetime | None = None
+) -> list[list[TrendView]]:
     """Build the per-instant applicable-trend lists for the window builder.
 
     At each sample time the prevailing line is the base TAF group plus any
     applicable FM/BECMG groups; TEMPO/PROB groups come in as candidate-worse.
     ``applicable_trends_fn`` is injectable so the windowing can be tested without
-    euro_aip installed.
+    euro_aip installed. ``ref`` (the ETA) anchors validity-marker rollover so a
+    month-straddling TAF orders its FM groups correctly; it defaults to the first
+    sample time when not given.
     """
     if applicable_trends_fn is None:  # pragma: no cover - exercised in CI
         from euro_aip.briefing.weather.analysis import WeatherAnalyzer
 
         applicable_trends_fn = WeatherAnalyzer.applicable_trends
 
-    base_view = _trend_to_view(taf, is_base=True)
+    if ref is None and sample_times:
+        ref = sample_times[0]
+
+    base_view = _trend_to_view(taf, is_base=True, ref=ref)
     instants: list[list[TrendView]] = []
     for t in sample_times:
         views = [base_view]
         try:
             for change in applicable_trends_fn(taf, t) or []:
-                views.append(_trend_to_view(change, is_base=False))
+                views.append(_trend_to_view(change, is_base=False, ref=ref))
         except Exception:
             logger.debug("alternate_requirement: applicable_trends failed", exc_info=True)
         instants.append(views)
@@ -135,7 +171,7 @@ def _build_destination_window(
 
             taf = WeatherReport.from_taf(taf_raw)
             sample_times = [eta + timedelta(minutes=m) for m in _WINDOW_OFFSETS_MIN]
-            instants = _taf_instant_trends(taf, sample_times)
+            instants = _taf_instant_trends(taf, sample_times, ref=eta)
             window = build_window(instants, source="taf")
             if window.has_forecast:
                 return window

--- a/src/weatherbrief/tasks/alternates.py
+++ b/src/weatherbrief/tasks/alternates.py
@@ -338,6 +338,10 @@ def run_alternates(
     dest_category = dest_cons["flight_category"]
     dest_wind = dest_cons.get("wind_speed_kt")
     dest_crosswind = dest_cons.get("crosswind_kt")
+    # Destination NWP-consensus ceiling/vis at ETA (worst across models) — the
+    # regulatory-trigger NWP fallback (#249) when no destination TAF is fetched.
+    dest_ceiling_ft = dest_cons.get("ceiling_ft")
+    dest_visibility_m = dest_cons.get("visibility_m")
     dest_idx = _cat_idx(dest_category)
     # Informational only: is the destination itself MVFR/IFR/LIFR (i.e. you'd
     # need an instrument approach to get into the *destination*). The candidate
@@ -499,6 +503,8 @@ def run_alternates(
         destination_icao=dest.icao,
         destination_category=dest_category,
         destination_crosswind_kt=dest_crosswind,
+        destination_ceiling_ft=dest_ceiling_ft,
+        destination_visibility_m=dest_visibility_m,
         eta=eta_dt,
         corridor_nm=corridor_nm,
         radius_nm=radius_nm,

--- a/tests/test_alternate_requirement.py
+++ b/tests/test_alternate_requirement.py
@@ -20,6 +20,7 @@ from weatherbrief.analysis.alternate_requirement import (
     combine_qual,
     combine_trigger,
     compute_easa_qual,
+    compute_easa_trigger,
     compute_faa_qual,
     compute_faa_trigger,
     easa_ceiling_band,
@@ -149,6 +150,43 @@ class TestFaaTrigger:
         assert trig.status == TriggerVerdict.REQUIRED
         assert trig.source == "none"
         assert trig.reason == "no forecast available"
+
+
+# --- EASA trigger (destination, three-state) ---------------------------------
+
+class TestEasaTrigger:
+    # _NONPRECISION → ceiling band 600–1100 ft, vis band 3000–4500 m.
+    def test_above_band_not_required(self):
+        trig = compute_easa_trigger(nwp_window(1500, 5000), _NONPRECISION)
+        assert trig.status == TriggerVerdict.NOT_REQUIRED
+
+    def test_inside_band_marginal(self):
+        # ceiling 800 in 600–1100 → marginal; vis 5000 ≥ 4500 → not-required
+        trig = compute_easa_trigger(nwp_window(800, 5000), _NONPRECISION)
+        assert trig.ceiling.verdict == TriggerVerdict.MARGINAL.value
+        assert trig.status == TriggerVerdict.MARGINAL
+
+    def test_below_band_required(self):
+        trig = compute_easa_trigger(nwp_window(500, 5000), _NONPRECISION)
+        assert trig.status == TriggerVerdict.REQUIRED
+
+    def test_visibility_can_force_marginal(self):
+        # ceiling clears (1500 ≥ 1100); vis 3500 in 3000–4500 → marginal
+        trig = compute_easa_trigger(nwp_window(1500, 3500), _NONPRECISION)
+        assert trig.visibility.verdict == TriggerVerdict.MARGINAL.value
+        assert trig.status == TriggerVerdict.MARGINAL
+
+    def test_no_iap_uses_vfr_proxy(self):
+        # proxy None (destination has no IAP) → VFR proxy 1000 ft / 5000 m
+        trig = compute_easa_trigger(nwp_window(1200, 6000), None)
+        assert trig.status == TriggerVerdict.NOT_REQUIRED
+        trig = compute_easa_trigger(nwp_window(800, 6000), None)
+        assert trig.status == TriggerVerdict.REQUIRED  # collapsed band, never marginal
+
+    def test_no_forecast_required(self):
+        trig = compute_easa_trigger(no_forecast_window(), _NONPRECISION)
+        assert trig.status == TriggerVerdict.REQUIRED
+        assert trig.source == "none"
 
 
 # --- FAA alternate minima (per candidate) ------------------------------------
@@ -367,6 +405,9 @@ class TestWiringSmoke:
         assert req.faa.source == "nwp"
         # 1500 ft / ~3.7 SM → FAA ceiling < 2000 → required
         assert req.faa.status == TriggerVerdict.REQUIRED
+        # EASA: no destination IAP (bogus DB) → VFR proxy 1000 ft / 5000 m;
+        # 1500 ft / 6000 m clears both → not required.
+        assert req.easa.status == TriggerVerdict.NOT_REQUIRED
         # caveats present
         assert any("planning guidance" in c.lower() for c in req.caveats)
 

--- a/tests/test_alternate_requirement.py
+++ b/tests/test_alternate_requirement.py
@@ -368,6 +368,42 @@ class TestTafExtraction:
         assert w.ceiling_ft == 600  # tempo worsens
         assert w.triggered_by_tempo
 
+    def test_base_group_with_stray_probability_not_temporary(self):
+        # #250 review: a parent WeatherReport with a stray `probability` must NOT
+        # cause the base view to be classed temporary (which would drop its
+        # ceiling to clear / its vis to fail and set a false TEMPO tag).
+        taf = SimpleNamespace(
+            ceiling_ft=500, visibility_meters=8000, cavok=False,
+            trend_type=None, probability=30, validity_start=None,
+        )
+        eta = datetime(2026, 6, 13, 12, tzinfo=timezone.utc)
+        instants = _taf_instant_trends(taf, [eta], applicable_trends_fn=lambda _t, _s: [])
+        w = build_window(instants, source="taf")
+        assert w.ceiling_ft == 500  # real ceiling kept (not optimistically clear)
+        assert w.visibility_m == 8000  # real vis kept (not pessimistically None)
+        assert not w.triggered_by_tempo
+
+    def test_month_straddling_taf_orders_fm_after_base(self):
+        # #250 review: base valid from day 29, FM from day 01 (next month). At an
+        # ETA on day 01, the FM must supersede the base (rollover-safe ordering),
+        # so its worse ceiling wins — not silently dropped by a fixed-Jan anchor.
+        base = SimpleNamespace(
+            ceiling_ft=3000, visibility_meters=9999, cavok=False,
+            trend_type=None, probability=None,
+            validity_start=SimpleNamespace(day=29, hour=6),
+        )
+        fm = SimpleNamespace(
+            ceiling_ft=800, visibility_meters=9999, cavok=False,
+            trend_type="FM", probability=None,
+            validity_start=SimpleNamespace(day=1, hour=0),
+        )
+        eta = datetime(2026, 7, 1, 6, tzinfo=timezone.utc)
+        instants = _taf_instant_trends(taf=base, sample_times=[eta], ref=eta,
+                                       applicable_trends_fn=lambda _t, _s: [fm])
+        w = build_window(instants, source="taf")
+        assert w.ceiling_ft == 800  # FM superseded the base, not the reverse
+        assert not w.triggered_by_tempo  # FM is prevailing, not a temporary group
+
 
 # --- Wiring smoke test (NWP path, no euro_aip) -------------------------------
 

--- a/tests/test_alternate_requirement.py
+++ b/tests/test_alternate_requirement.py
@@ -1,0 +1,380 @@
+"""Tests for the regulatory alternate-requirement assessment (issue #249).
+
+Pure-function tests first (no euro_aip / no I/O), then a wiring smoke test that
+exercises the NWP fallback path end-to-end without euro_aip installed.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+from weatherbrief.analysis.alternate_requirement import (
+    _GNSS,
+    _NONPRECISION,
+    _PRECISION,
+    TrendView,
+    band_qualification,
+    band_trigger,
+    build_window,
+    combine_qual,
+    combine_trigger,
+    compute_easa_qual,
+    compute_faa_qual,
+    compute_faa_trigger,
+    easa_ceiling_band,
+    easa_vis_band,
+    no_forecast_window,
+    nwp_window,
+    proxy_for_approach,
+)
+from weatherbrief.models.alternate_requirement import BandVerdict, TriggerVerdict
+from weatherbrief.models.alternates import AlternateAirport, RouteAlternates
+from weatherbrief.tasks.alternate_requirement import (
+    _taf_instant_trends,
+    run_alternate_requirement,
+)
+from weatherbrief.units import M_PER_SM
+
+
+# --- Verdict logic -----------------------------------------------------------
+
+class TestVerdictLogic:
+    def test_qualification_likely_marginal_unlikely(self):
+        # higher forecast is better; band [600, 1100]
+        assert band_qualification(1200, 600, 1100) == BandVerdict.LIKELY
+        assert band_qualification(1100, 600, 1100) == BandVerdict.LIKELY  # >= hi
+        assert band_qualification(700, 600, 1100) == BandVerdict.MARGINAL
+        assert band_qualification(599, 600, 1100) == BandVerdict.UNLIKELY
+        assert band_qualification(600, 600, 1100) == BandVerdict.MARGINAL  # == lo
+
+    def test_qualification_missing_fails(self):
+        assert band_qualification(None, 600, 1100) == BandVerdict.UNLIKELY
+
+    def test_trigger_mirrors_qualification(self):
+        # lower forecast forces an alternate; band [600, 1100]
+        assert band_trigger(1200, 600, 1100) == TriggerVerdict.NOT_REQUIRED
+        assert band_trigger(700, 600, 1100) == TriggerVerdict.MARGINAL
+        assert band_trigger(599, 600, 1100) == TriggerVerdict.REQUIRED
+
+    def test_trigger_missing_requires(self):
+        assert band_trigger(None, 600, 1100) == TriggerVerdict.REQUIRED
+
+    def test_faa_collapsed_band_never_marginal(self):
+        # req_lo == req_hi → only the two extremes
+        assert band_qualification(800, 600, 600) == BandVerdict.LIKELY
+        assert band_qualification(599, 600, 600) == BandVerdict.UNLIKELY
+        for f in (601, 600.0, 599.9, 700, 599):
+            assert band_qualification(f, 600, 600) != BandVerdict.MARGINAL
+            assert band_trigger(f, 2000, 2000) != TriggerVerdict.MARGINAL
+
+    def test_combine_worst_of_criteria(self):
+        assert combine_qual([BandVerdict.LIKELY, BandVerdict.MARGINAL]) == BandVerdict.MARGINAL
+        assert combine_qual([BandVerdict.MARGINAL, BandVerdict.UNLIKELY]) == BandVerdict.UNLIKELY
+        assert combine_qual([BandVerdict.LIKELY, BandVerdict.LIKELY]) == BandVerdict.LIKELY
+        assert combine_trigger(
+            [TriggerVerdict.NOT_REQUIRED, TriggerVerdict.MARGINAL]
+        ) == TriggerVerdict.MARGINAL
+        assert combine_trigger(
+            [TriggerVerdict.MARGINAL, TriggerVerdict.REQUIRED]
+        ) == TriggerVerdict.REQUIRED
+
+
+# --- EASA bands per approach class -------------------------------------------
+
+class TestEasaBands:
+    def test_precision_ceiling_band(self):
+        # ILS DH 200–300 → ceiling 400–500
+        assert easa_ceiling_band(_PRECISION) == (400.0, 500.0)
+
+    def test_gnss_ceiling_band(self):
+        # RNP/RNAV DH 250–600 → ceiling 450–800
+        assert easa_ceiling_band(_GNSS) == (450.0, 800.0)
+
+    def test_nonprecision_ceiling_band(self):
+        # VOR/NDB DH 400–900 → ceiling 600–1100
+        assert easa_ceiling_band(_NONPRECISION) == (600.0, 1100.0)
+
+    def test_vis_band_with_floor(self):
+        # precision vis 550–1500 → +1500 = 2050–3000 (floor not binding here)
+        assert easa_vis_band(_PRECISION) == (2050.0, 3000.0)
+        # non-precision 1500–3000 → 3000–4500
+        assert easa_vis_band(_NONPRECISION) == (3000.0, 4500.0)
+
+
+# --- Approach proxy selection / conservative rules ---------------------------
+
+class TestProxySelection:
+    def test_known_classes(self):
+        assert proxy_for_approach("ILS") is _PRECISION
+        assert proxy_for_approach("RNP") is _GNSS
+        assert proxy_for_approach("RNAV") is _GNSS
+        assert proxy_for_approach("VOR") is _NONPRECISION
+        assert proxy_for_approach("ndb") is _NONPRECISION  # case-insensitive
+
+    def test_unknown_class_is_nonprecision(self):
+        assert proxy_for_approach("TACAN") is _NONPRECISION
+        assert proxy_for_approach("") is _NONPRECISION
+        assert proxy_for_approach(None, has_iap=True) is _NONPRECISION
+
+    def test_no_iap_is_none(self):
+        assert proxy_for_approach("ILS", has_iap=False) is None
+        assert proxy_for_approach(None, has_iap=False) is None
+
+
+# --- FAA trigger -------------------------------------------------------------
+
+class TestFaaTrigger:
+    def test_below_ceiling_threshold_required(self):
+        # 1900 ft / 5 SM → ceiling forces it
+        trig = compute_faa_trigger(nwp_window(1900, 5 * M_PER_SM))
+        assert trig.status == TriggerVerdict.REQUIRED
+
+    def test_above_thresholds_not_required(self):
+        trig = compute_faa_trigger(nwp_window(2100, 4 * M_PER_SM))
+        assert trig.status == TriggerVerdict.NOT_REQUIRED
+
+    def test_low_visibility_required(self):
+        # 3000 ft but vis 2 SM → required
+        trig = compute_faa_trigger(nwp_window(3000, 2 * M_PER_SM))
+        assert trig.status == TriggerVerdict.REQUIRED
+
+    def test_never_marginal(self):
+        for ceil, vis_sm in [(2000, 3), (1999, 2.9), (5000, 10)]:
+            trig = compute_faa_trigger(nwp_window(ceil, vis_sm * M_PER_SM))
+            assert trig.status in (TriggerVerdict.REQUIRED, TriggerVerdict.NOT_REQUIRED)
+
+    def test_no_forecast_required(self):
+        trig = compute_faa_trigger(no_forecast_window())
+        assert trig.status == TriggerVerdict.REQUIRED
+        assert trig.source == "none"
+        assert trig.reason == "no forecast available"
+
+
+# --- FAA alternate minima (per candidate) ------------------------------------
+
+class TestFaaAlternateMinima:
+    def test_ils_precision_600_2(self):
+        # ILS: ceiling >= 600 AND vis >= 2 SM
+        q = compute_faa_qual(650, 2.5 * M_PER_SM, "ILS", has_iap=True)
+        assert q.verdict == BandVerdict.LIKELY
+        q = compute_faa_qual(550, 2.5 * M_PER_SM, "ILS", has_iap=True)
+        assert q.verdict == BandVerdict.UNLIKELY  # 550 < 600
+
+    def test_nonprecision_800_2(self):
+        # anything-but-ILS uses 800-2
+        q = compute_faa_qual(750, 2.5 * M_PER_SM, "RNAV", has_iap=True)
+        assert q.verdict == BandVerdict.UNLIKELY  # 750 < 800
+        q = compute_faa_qual(850, 2.5 * M_PER_SM, "RNAV", has_iap=True)
+        assert q.verdict == BandVerdict.LIKELY
+
+    def test_lpv_lands_in_nonprecision(self):
+        # No confirmable LPV in FAA precision branch → 800-2
+        q = compute_faa_qual(750, 2.5 * M_PER_SM, "RNP", has_iap=True)
+        assert q.verdict == BandVerdict.UNLIKELY
+
+    def test_no_iap_vfr_proxy(self):
+        # no IAP: ceiling >= 1000 AND vis >= 3 SM
+        q = compute_faa_qual(1200, 3.5 * M_PER_SM, None, has_iap=False)
+        assert q.verdict == BandVerdict.LIKELY
+        q = compute_faa_qual(900, 3.5 * M_PER_SM, None, has_iap=False)
+        assert q.verdict == BandVerdict.UNLIKELY
+        assert "VFR only" in q.reason
+
+    def test_faa_qual_never_marginal(self):
+        q = compute_faa_qual(801, 2.01 * M_PER_SM, "VOR", has_iap=True)
+        assert q.verdict != BandVerdict.MARGINAL
+
+
+# --- EASA alternate minima (per candidate) -----------------------------------
+
+class TestEasaAlternateMinima:
+    def test_marginal_in_band(self):
+        # non-precision ceiling band 600–1100; 700 ft is in-band → marginal
+        q = compute_easa_qual(700, 5000, "VOR", has_iap=True)
+        assert q.ceiling.verdict == BandVerdict.MARGINAL.value
+
+    def test_likely_clears_worst_case(self):
+        q = compute_easa_qual(1200, 5000, "VOR", has_iap=True)
+        assert q.verdict == BandVerdict.LIKELY
+
+    def test_unlikely_fails_best_case(self):
+        q = compute_easa_qual(500, 5000, "VOR", has_iap=True)
+        assert q.verdict == BandVerdict.UNLIKELY  # 500 < 600
+
+    def test_combine_worst_axis(self):
+        # ceiling likely, vis unlikely → unlikely overall
+        q = compute_easa_qual(1200, 1000, "VOR", has_iap=True)  # vis 1000 < 3000
+        assert q.visibility.verdict == BandVerdict.UNLIKELY.value
+        assert q.verdict == BandVerdict.UNLIKELY
+
+    def test_no_iap_vfr_only(self):
+        q = compute_easa_qual(1200, 6000, None, has_iap=False)
+        assert "VFR only" in q.reason
+        assert q.verdict == BandVerdict.LIKELY
+
+
+# --- Conservative rules ------------------------------------------------------
+
+class TestConservativeRules:
+    def test_missing_ceiling_in_nwp_is_clear_not_fail(self):
+        # NWP None ceiling = no layer = clear (good), vis high
+        q = compute_easa_qual(None, 6000, "ILS", has_iap=True)
+        assert q.ceiling.verdict == BandVerdict.LIKELY.value
+
+    def test_missing_visibility_fails(self):
+        q = compute_easa_qual(1200, None, "ILS", has_iap=True)
+        assert q.visibility.verdict == BandVerdict.UNLIKELY.value
+        assert q.verdict == BandVerdict.UNLIKELY
+
+    def test_unknown_approach_uses_nonprecision_band(self):
+        # ILS band would clear 700 ft (band 400–500) Likely; non-precision (600–1100)
+        # makes it Marginal — confirm the unknown class is the demanding one.
+        q = compute_easa_qual(700, 5000, "WEIRD", has_iap=True)
+        assert q.ceiling.verdict == BandVerdict.MARGINAL.value
+
+
+# --- Window builder ----------------------------------------------------------
+
+class TestWindowBuilder:
+    def test_cavok_is_clear(self):
+        w = build_window([[TrendView(cavok=True)]])
+        assert w.ceiling_ft is None  # no ceiling constraint
+        assert w.visibility_m >= 9999
+        assert w.has_forecast
+
+    def test_no_ceiling_layer_is_good(self):
+        # no BKN/OVC but vis reported — ceiling None (good), vis kept
+        w = build_window([[TrendView(ceiling_ft=None, visibility_m=8000)]])
+        assert w.ceiling_ft is None
+        assert w.visibility_m == 8000
+
+    def test_multi_group_worst_case(self):
+        base = TrendView(ceiling_ft=3000, visibility_m=9999)
+        tempo = TrendView(ceiling_ft=800, visibility_m=3000, trend_type="TEMPO")
+        w = build_window([[base, tempo]])
+        assert w.ceiling_ft == 800
+        assert w.visibility_m == 3000
+        assert w.triggered_by_tempo
+
+    def test_fm_supersedes_base(self):
+        # base is worse but an applicable FM improves it → prevailing = FM
+        base = TrendView(ceiling_ft=500, visibility_m=9999)
+        fm = TrendView(
+            ceiling_ft=3000, visibility_m=9999, trend_type="FM",
+            validity_start=datetime(2000, 1, 1, 12),
+        )
+        w = build_window([[base, fm]])
+        assert w.ceiling_ft == 3000  # base 500 superseded
+        assert not w.triggered_by_tempo
+
+    def test_prob30_disregarded_by_default(self):
+        base = TrendView(ceiling_ft=3000, visibility_m=9999)
+        prob30 = TrendView(ceiling_ft=400, visibility_m=2000, trend_type="TEMPO", probability=30)
+        w = build_window([[base, prob30]])
+        assert w.ceiling_ft == 3000  # PROB30 ignored
+        w2 = build_window([[base, prob30]], include_prob30=True)
+        assert w2.ceiling_ft == 400  # honoured when opted-in
+
+    def test_prob40_honoured(self):
+        base = TrendView(ceiling_ft=3000, visibility_m=9999)
+        prob40 = TrendView(ceiling_ft=400, visibility_m=2000, trend_type="TEMPO", probability=40)
+        w = build_window([[base, prob40]])
+        assert w.ceiling_ft == 400
+        assert w.triggered_by_tempo
+
+    def test_worst_across_instants(self):
+        i1 = [TrendView(ceiling_ft=2000, visibility_m=8000)]
+        i2 = [TrendView(ceiling_ft=900, visibility_m=5000)]
+        w = build_window([i1, i2])
+        assert w.ceiling_ft == 900
+        assert w.visibility_m == 5000
+
+    def test_empty_window_no_forecast(self):
+        w = build_window([])
+        assert not w.has_forecast
+        assert w.source == "none"
+
+    def test_nwp_fallback_path(self):
+        w = nwp_window(1500, 6000)
+        assert w.source == "nwp"
+        assert w.has_forecast
+        assert not w.triggered_by_tempo
+        assert w.ceiling_ft == 1500
+
+
+# --- TAF → instant trends extraction (injected applicable_trends) ------------
+
+class TestTafExtraction:
+    def test_base_plus_applicable_trends(self):
+        taf = SimpleNamespace(
+            ceiling_ft=3000, visibility_meters=9999, cavok=False,
+            trend_type=None, probability=None, validity_start=None,
+        )
+        tempo = SimpleNamespace(
+            ceiling_ft=600, visibility_meters=3000, cavok=False,
+            trend_type="TEMPO", probability=40,
+            validity_start=SimpleNamespace(day=1, hour=12),
+        )
+
+        def fake_applicable(_taf, _t):
+            return [tempo]
+
+        eta = datetime(2026, 6, 13, 12, tzinfo=timezone.utc)
+        sample_times = [eta + timedelta(minutes=m) for m in (-60, 0, 60)]
+        instants = _taf_instant_trends(taf, sample_times, applicable_trends_fn=fake_applicable)
+        assert len(instants) == 3
+        # each instant: base + tempo
+        assert all(len(group) == 2 for group in instants)
+        w = build_window(instants, source="taf")
+        assert w.ceiling_ft == 600  # tempo worsens
+        assert w.triggered_by_tempo
+
+
+# --- Wiring smoke test (NWP path, no euro_aip) -------------------------------
+
+def _make_snapshot(dest_icao: str, alternates: RouteAlternates):
+    route = SimpleNamespace(destination=SimpleNamespace(icao=dest_icao))
+    return SimpleNamespace(route=route, alternates=alternates, route_observations=None)
+
+
+class TestWiringSmoke:
+    def test_nwp_path_populates_triggers_and_quals(self):
+        cand_good = AlternateAirport(
+            icao="EGAA", lat=54.0, lon=-6.0, distance_from_dest_nm=30, position="after",
+            flight_category="VFR", ceiling_ft=4000, visibility_m=9999,
+            has_instrument_approach=True, best_approach_type="ILS",
+        )
+        cand_marginal = AlternateAirport(
+            icao="EGAC", lat=54.6, lon=-5.9, distance_from_dest_nm=10, position="after",
+            flight_category="MVFR", ceiling_ft=700, visibility_m=5000,
+            has_instrument_approach=True, best_approach_type="VOR",
+        )
+        alt = RouteAlternates(
+            destination_icao="EIDW", destination_category="MVFR",
+            destination_ceiling_ft=1500, destination_visibility_m=6000,
+            corridor_nm=40, radius_nm=50,
+            eta=datetime(2026, 6, 13, 12, tzinfo=timezone.utc),
+            alternates=[cand_good, cand_marginal],
+        )
+        snap = _make_snapshot("EIDW", alt)
+
+        # bogus db path → approach lookup degrades to (None, False) gracefully
+        run_alternate_requirement(snap, "/nonexistent/nav.db")
+
+        req = alt.alternate_requirement
+        assert req is not None
+        assert req.faa.source == "nwp"
+        # 1500 ft / ~3.7 SM → FAA ceiling < 2000 → required
+        assert req.faa.status == TriggerVerdict.REQUIRED
+        # caveats present
+        assert any("planning guidance" in c.lower() for c in req.caveats)
+
+        # per-candidate quals populated
+        assert cand_good.faa.verdict == BandVerdict.LIKELY  # ILS, 4000/9999
+        assert cand_good.easa.verdict == BandVerdict.LIKELY
+        assert cand_marginal.easa.verdict == BandVerdict.MARGINAL  # 700 in 600–1100
+
+    def test_no_alternates_is_noop(self):
+        snap = SimpleNamespace(alternates=None)
+        run_alternate_requirement(snap, "/nonexistent/nav.db")  # must not raise

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -3910,6 +3910,62 @@ label {
   color: var(--danger, #b8860b);
 }
 
+/* Regulatory alternate-requirement badges (#249): green=ok, amber=marginal,
+   grey=fails / not-met. Reused by the destination banner + per-candidate cells. */
+.alt-reg {
+  display: inline-block;
+  padding: 0.05rem 0.4rem;
+  font-size: 0.72rem;
+  font-weight: 600;
+  border-radius: var(--radius, 4px);
+  cursor: help;
+}
+
+.alt-reg-yes {
+  background: rgba(46, 125, 50, 0.18);
+  color: var(--success, #2e7d32);
+}
+
+.alt-reg-marginal {
+  background: rgba(180, 134, 11, 0.2);
+  color: var(--danger, #b8860b);
+}
+
+.alt-reg-no {
+  background: rgba(120, 120, 120, 0.2);
+  color: var(--text-secondary);
+}
+
+.alt-reg-banner {
+  margin-top: 0.25rem;
+}
+
+.alt-reg-reason {
+  font-size: 0.78rem;
+}
+
+.alt-reg-tempo {
+  display: inline-block;
+  padding: 0 0.3rem;
+  font-size: 0.65rem;
+  font-weight: 600;
+  border-radius: var(--radius, 4px);
+  background: rgba(180, 134, 11, 0.2);
+  color: var(--danger, #b8860b);
+}
+
+.alt-reg-info {
+  margin-left: 0.3rem;
+  padding: 0 0.35rem;
+  font-size: 0.7rem;
+  line-height: 1.3;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--surface);
+  color: var(--text-secondary);
+  cursor: help;
+}
+
 .obs-refresh-btn:hover {
   background: var(--surface-hover, #f0f0f0);
 }

--- a/web/ts/managers/briefing-ui.ts
+++ b/web/ts/managers/briefing-ui.ts
@@ -7,6 +7,8 @@
 import type {
   AirportObservation,
   AlternateAirport,
+  AlternateQual,
+  AlternateRequirement,
   AltitudeAdvisories,
   ConvectiveAssessment,
   DataStatus,
@@ -1141,6 +1143,58 @@ function deltaTags(apt: AlternateAirport): string {
   return tags.join(' ') || '—';
 }
 
+// --- Regulatory alternate-requirement badges (#249) ---
+
+/** FAA badge for a per-candidate qualification (binary: Yes/No). */
+function faaQualBadge(q: AlternateQual | null): string {
+  if (!q) return '—';
+  const ok = q.verdict === 'likely';
+  const cls = ok ? 'alt-reg-yes' : 'alt-reg-no';
+  const label = ok ? 'Yes' : 'No';
+  return `<span class="alt-reg ${cls}" title="${escapeHtml(q.reason)}">${label}</span>`;
+}
+
+/** EASA badge for a per-candidate qualification (Likely/Marginal/Unlikely). */
+function easaQualBadge(q: AlternateQual | null): string {
+  if (!q) return '—';
+  const cls = q.verdict === 'likely'
+    ? 'alt-reg-yes' : q.verdict === 'marginal' ? 'alt-reg-marginal' : 'alt-reg-no';
+  const label = q.verdict.charAt(0).toUpperCase() + q.verdict.slice(1);
+  return `<span class="alt-reg ${cls}" title="${escapeHtml(q.reason)}">${label}</span>`;
+}
+
+/** Destination "alternate required?" banner (FAA + EASA). */
+function altRequirementBanner(req: AlternateRequirement | null | undefined): string {
+  if (!req) return '';
+  const faaTxt = req.faa.status === 'required' ? 'Required' : 'Not required';
+  const easaMap: Record<string, string> = {
+    required: 'Required', marginal: 'Marginal', not_required: 'Not required',
+  };
+  const easaTxt = easaMap[req.easa.status] ?? req.easa.status;
+  const faaCls = req.faa.status === 'required' ? 'alt-reg-no' : 'alt-reg-yes';
+  const easaCls = req.easa.status === 'required'
+    ? 'alt-reg-no' : req.easa.status === 'marginal' ? 'alt-reg-marginal' : 'alt-reg-yes';
+  const srcLabel = req.faa.source === 'nwp'
+    ? 'model estimate' : req.faa.source === 'taf' ? 'forecast' : 'no forecast';
+  const tempo = (req.faa.triggered_by_tempo || req.easa.triggered_by_tempo)
+    ? ' <span class="alt-reg-tempo" title="The governing dip is from a TEMPO/PROB group">TEMPO</span>' : '';
+  const reason = escapeHtml(req.easa.reason || req.faa.reason || '');
+  return `
+    <p class="obs-summary alt-reg-banner">
+      Alternate required? —
+      FAA: <span class="alt-reg ${faaCls}">${faaTxt}</span> ·
+      EASA: <span class="alt-reg ${easaCls}">${easaTxt}</span>
+      <span class="muted">(${srcLabel})</span>${tempo}
+      <button class="alt-reg-info" title="${escapeHtml(ALT_REG_CAVEAT)}" aria-label="about alternate minima">i</button>
+      <br><span class="muted alt-reg-reason">${reason}</span>
+    </p>`;
+}
+
+const ALT_REG_CAVEAT =
+  "We don't have published approach minima; the EASA requirement is estimated "
+  + "from approach type as a range. 'Likely/Marginal/Unlikely' reflects that "
+  + 'uncertainty. Forecast ceiling/visibility inputs are real. Planning guidance only.';
+
 function renderAltPopup(apt: AlternateAirport): string {
   const rows = Object.entries(apt.per_model).map(([model, d]) => {
     const cat = (d['flight_category'] as string) ?? '—';
@@ -1152,12 +1206,15 @@ function renderAltPopup(apt: AlternateAirport): string {
     ? (apt.best_approach_type ? escapeHtml(apt.best_approach_type) : 'yes')
     : 'none';
   const rwy = apt.longest_runway_ft != null ? `${apt.longest_runway_ft}ft${apt.has_hard_runway ? ' hard' : ''}` : '—';
-  const meta = [
+  const metaRows = [
     `Distance from dest: ${Math.round(apt.distance_from_dest_nm)}nm (${escapeHtml(apt.position)})`,
     `Detour early/late: ${detourLabel(apt)}`,
     `Approach: ${approach}`,
     `Longest runway: ${rwy}`,
-  ].join('\n');
+  ];
+  if (apt.faa) metaRows.push(`FAA alternate: ${escapeHtml(apt.faa.reason)}`);
+  if (apt.easa) metaRows.push(`EASA alternate: ${escapeHtml(apt.easa.reason)}`);
+  const meta = metaRows.join('\n');
   return `
     <div class="popup-header"><h3>${escapeHtml(apt.icao)}${apt.name ? ' — ' + escapeHtml(apt.name) : ''}</h3></div>
     <pre class="obs-wind-summary">${meta}</pre>
@@ -1200,6 +1257,7 @@ export function renderRouteAlternates(snapshot: ForecastSnapshot | null): void {
 
   const approachNote = alt.approach_filter_relaxed ? ', approach data unavailable' : '';
   const summaryHtml = `<p class="obs-summary">${header} <span class="obs-fetch-time">${alt.candidates_evaluated} candidates within ${Math.round(alt.radius_nm)}nm${approachNote}</span></p>`;
+  const reqBannerHtml = altRequirementBanner(alt.alternate_requirement);
   const relaxedHtml = alt.approach_filter_relaxed
     ? `<p class="muted alt-caption">⚠️ No published-approach data is available for the candidates, so non-VFR fields could not be filtered by approach — confirm an approach independently.</p>`
     : '';
@@ -1222,6 +1280,8 @@ export function renderRouteAlternates(snapshot: ForecastSnapshot | null): void {
         <td>${windStr}</td>
         <td>${xwStr}</td>
         <td>${approach}</td>
+        <td>${faaQualBadge(apt.faa)}</td>
+        <td>${easaQualBadge(apt.easa)}</td>
         <td>${deltaTags(apt)}</td>
       </tr>
     `;
@@ -1229,6 +1289,7 @@ export function renderRouteAlternates(snapshot: ForecastSnapshot | null): void {
 
   el.innerHTML = `
     ${summaryHtml}
+    ${reqBannerHtml}
     <p class="muted alt-caption">Planning-grade divert candidates that improve on the destination weather — not an operational alternate (no fuel, minima, NOTAM, customs or PPR check). Non-VFR fields are shown only with a published instrument approach.</p>
     ${relaxedHtml}
     ${picksHtml}
@@ -1243,6 +1304,8 @@ export function renderRouteAlternates(snapshot: ForecastSnapshot | null): void {
             <th>Wind</th>
             <th>Xwind</th>
             <th>Approach</th>
+            <th title="FAA 14 CFR 91.169 alternate minima (binary)">FAA alt</th>
+            <th title="EASA Part-NCO alternate minima (Likely/Marginal/Unlikely)">EASA alt</th>
             <th>vs dest</th>
           </tr>
         </thead>

--- a/web/ts/managers/briefing-ui.ts
+++ b/web/ts/managers/briefing-ui.ts
@@ -1166,12 +1166,14 @@ function easaQualBadge(q: AlternateQual | null): string {
 /** Destination "alternate required?" banner (FAA + EASA). */
 function altRequirementBanner(req: AlternateRequirement | null | undefined): string {
   if (!req) return '';
-  const faaTxt = req.faa.status === 'required' ? 'Required' : 'Not required';
+  // FAA is binary, but keep the safe direction: only an explicit not_required
+  // reads as "Not required"; anything else (incl. a stray marginal) → Required.
+  const faaTxt = req.faa.status === 'not_required' ? 'Not required' : 'Required';
   const easaMap: Record<string, string> = {
     required: 'Required', marginal: 'Marginal', not_required: 'Not required',
   };
   const easaTxt = easaMap[req.easa.status] ?? req.easa.status;
-  const faaCls = req.faa.status === 'required' ? 'alt-reg-no' : 'alt-reg-yes';
+  const faaCls = req.faa.status === 'not_required' ? 'alt-reg-yes' : 'alt-reg-no';
   const easaCls = req.easa.status === 'required'
     ? 'alt-reg-no' : req.easa.status === 'marginal' ? 'alt-reg-marginal' : 'alt-reg-yes';
   const srcLabel = req.faa.source === 'nwp'

--- a/web/ts/store/types.ts
+++ b/web/ts/store/types.ts
@@ -580,7 +580,7 @@ export interface CriterionAssessment {
   forecast: number | null;
   required_min: number;
   required_max: number;
-  verdict: string;
+  verdict: 'likely' | 'marginal' | 'unlikely' | 'not_required' | 'required';
 }
 
 /** Destination "alternate required?" for one regulatory regime (#249). */

--- a/web/ts/store/types.ts
+++ b/web/ts/store/types.ts
@@ -573,6 +573,46 @@ export interface RealtimeRefreshResult {
 }
 
 /** One weather-based divert candidate (issue #210). */
+/** One criterion (ceiling or visibility) vs its requirement band (#249). */
+export interface CriterionAssessment {
+  label: string;
+  unit: string;
+  forecast: number | null;
+  required_min: number;
+  required_max: number;
+  verdict: string;
+}
+
+/** Destination "alternate required?" for one regulatory regime (#249). */
+export interface RegAlternateTrigger {
+  regime: 'faa' | 'easa';
+  status: 'not_required' | 'marginal' | 'required';
+  reason: string;
+  source: 'taf' | 'nwp' | 'none';
+  triggered_by_tempo: boolean;
+  ceiling: CriterionAssessment;
+  visibility: CriterionAssessment;
+}
+
+/** Per-candidate alternate-minima qualification for one regime (#249). */
+export interface AlternateQual {
+  regime: 'faa' | 'easa';
+  verdict: 'likely' | 'marginal' | 'unlikely';
+  reason: string;
+  ceiling: CriterionAssessment;
+  visibility: CriterionAssessment;
+}
+
+/** Regulatory alternate-requirement assessment for the destination (#249). */
+export interface AlternateRequirement {
+  destination_icao: string;
+  eta: string | null;
+  faa: RegAlternateTrigger;
+  easa: RegAlternateTrigger;
+  caveats: string[];
+  computed_at: string | null;
+}
+
 export interface AlternateAirport {
   icao: string;
   name: string | null;
@@ -602,6 +642,8 @@ export interface AlternateAirport {
   better_wind: boolean;
   better_crosswind: boolean;
   dominates_destination: boolean;
+  faa: AlternateQual | null;
+  easa: AlternateQual | null;
 }
 
 /** The nearest improving alternate for one deficient axis. */
@@ -617,6 +659,8 @@ export interface RouteAlternates {
   destination_icao: string;
   destination_category: string;
   destination_crosswind_kt: number | null;
+  destination_ceiling_ft: number | null;
+  destination_visibility_m: number | null;
   eta: string | null;
   corridor_nm: number;
   radius_nm: number;
@@ -625,6 +669,7 @@ export interface RouteAlternates {
   candidates_evaluated: number;
   alternates: AlternateAirport[];
   nearest_improving: AlternateAxisPick[];
+  alternate_requirement: AlternateRequirement | null;
   computed_at: string | null;
 }
 


### PR DESCRIPTION
Implements issue #249: a planning-grade advisory layer that answers "is a filed alternate required?" and "does each divert candidate meet alternate minima?" for both FAA (14 CFR 91.169) and EASA Part-NCO regimes.

## Summary

The feature computes regulatory alternate requirements transparently from real forecast data (TAF when available, NWP consensus fallback) and estimated plate-minima ranges per approach class. Rather than hide the missing published minima behind a single conservative number, it expresses the unknown as a confidence band:

- **FAA**: Binary verdicts (Yes/No) based on fixed regulatory thresholds (2000 ft / 3 SM trigger; 600-2 / 800-2 alternate minima)
- **EASA**: Three-state verdicts (Likely / Marginal / Unlikely) derived from estimated plate minima ± margins

## Key Changes

**Core logic** (`analysis/alternate_requirement.py`):
- Pure functions for verdict computation (no I/O, fully unit-testable)
- `ApproachProxy` dataclass with estimated plate-minima ranges per approach class (ILS, RNP/RNAV, VOR/NDB/LOC)
- `TrendView` / `CeilingVisWindow` for TAF trend aggregation and worst-case windowing over the ETA window
- `band_qualification()` / `band_trigger()` verdict primitives; `combine_qual()` / `combine_trigger()` for worst-of-criteria
- `compute_faa_trigger()` / `compute_easa_trigger()` for destination alternate requirement
- `compute_faa_qual()` / `compute_easa_qual()` for per-candidate qualification

**Wiring** (`tasks/alternate_requirement.py`):
- Post-pipeline step (after `run_alternates` + `run_route_weather`) that builds the destination ceiling/visibility window from TAF (via `euro_aip.briefing.weather`) or NWP fallback
- Looks up destination approach class from `nav.db`
- Computes `AlternateRequirement` (FAA + EASA triggers) and per-candidate `AlternateQual` verdicts
- Writes results to `snapshot.alternates.alternate_requirement`

**Models** (`models/alternate_requirement.py`):
- `BandVerdict` enum (LIKELY / MARGINAL / UNLIKELY)
- `TriggerVerdict` enum (NOT_REQUIRED / MARGINAL / REQUIRED)
- `CriterionAssessment` (one criterion vs its requirement band)
- `RegAlternateTrigger` (destination trigger for one regime)
- `AlternateQual` (per-candidate qualification for one regime)
- `AlternateRequirement` (full assessment: destination + per-candidate)

**UI** (`web/ts/managers/briefing-ui.ts`, `web/css/style.css`):
- `faaQualBadge()` / `easaQualBadge()` for per-candidate qualification display
- `altRequirementBanner()` for destination trigger display
- CSS classes for verdict styling (green=ok, amber=marginal, grey=fails)

**Integration**:
- Pipeline wiring in `pipeline.py` (post-step after alternates)
- Text digest output in `digest/text.py`
- Model exports in `models/__init__.py` and `models/alternates.py`
- TypeScript types in `web/ts/store/types.ts`

## Notable Implementation Details

- **Conservative rules**: Missing ceiling in NWP = clear (good); missing visibility = fail. Unknown approach class degrades to non-precision (most demanding).
- **TAF windowing**: Samples at ETA±60/±30/0/+30/+60 min; TEMPO/PROB groups can only worsen the prevailing condition; tracks whether the binding value came from a temporary group.
- **Approach proxy tuning surface**: `APPROACH_CLASS_PROXY` dict maps `procedures.approach_type` strings to estimated DH/MDH and visibility ranges.

https://claude.ai/code/session_01Dwj1Ek17b5h7zdN2pjF7Fe