### PR TITLE
Add personal lifetime impact & adaptive donation translation ladder

### DIFF
--- a/designs/cost-attribution-design.md
+++ b/designs/cost-attribution-design.md
@@ -274,35 +274,94 @@ registered webhook endpoint) is a manual prerequisite for the weatherbrief side.
 
 ### Impact framing (pure, testable — like `costs.py`)
 
-Donors see coverage, never "you gave $X". Inputs come from the program cost report:
+Donors see coverage, never "you gave $X". The framing is **retrospective**: a
+donation *offsets cost already incurred*, it is not a forward prepayment (the
+droplet/ECMWF/model bills are largely sunk + fixed, so a gift doesn't draw down
+anyone's marginal bill). Verb policy, enforced in the phrasing layer:
+**offset / contribute / cover / help cover** — never "pay for" or "fund your next
+N months". Inputs come from the program cost report (`impact.py`,
+`economics_from_report`):
 
 ```python
 # Operator's real monthly run cost — margin EXCLUDED (donations cover real cost, not the buffer)
-monthly_run_cost_usd = fixed_monthly_usd + variable_usd * (30 / window_days)
+scale                = 30 / window_days
+monthly_run_cost_usd = fixed_monthly_usd + variable_usd * scale
 active_users         = num_users                         # distinct briefing users, 30d window
-cost_per_user_month  = monthly_run_cost_usd / active_users   # guard active_users == 0
-
-# Per-donation (amount already in USD)
-user_months     = amount_usd / cost_per_user_month
-users_until_eoy = amount_usd / (cost_per_user_month * months_until_dec31)
-
-# Yearly aggregate (sum of donation_ledger.amount_usd, this calendar year, status="succeeded")
-months_covered  = total_year_usd / monthly_run_cost_usd
-users_full_year = total_year_usd / (cost_per_user_month * 12)
-coverage_ratio  = total_year_usd / (monthly_run_cost_usd * months_elapsed_this_year)
+cost_per_user_month  = monthly_run_cost_usd / active_users           # guard active_users == 0
+cost_per_briefing    = monthly_run_cost_usd / (num_briefings * scale) # margin-excluded, for "X briefings funded"
 ```
 
-Phrasing rules (pick the most natural unit, never show "0"):
+**Denominators (decided):**
 
-- `user_months ≥ 18` → "covers one user for ~{user_months/12:.1f} years"; else
-  "covers one user for ~{user_months:.0f} months" (or, when the amount covers ≥~2 users,
-  "covers ~{N} users for a month").
-- `months_covered ≥ 12` → "this year's donations cover ~{months_covered/12:.1f} years of
-  running costs"; else "~{months_covered:.1f} months".
+- **Community = this calendar year.** `coverage_ratio = total_year_usd /
+  (monthly_run_cost_usd * months_elapsed_this_year)` — donations-this-year ÷
+  cost-incurred-this-year-so-far. Resets annually.
+- **Personal = lifetime.** The user's whole relationship with the app: lifetime
+  cost from `cost_ledger` (`credits.user_cost_stats`, which also yields the
+  realized **monthly burn rate** = lifetime cost ÷ months active) vs lifetime
+  donations (`get_user_total_usd`).
 
-A frozen `DonationImpact` dataclass holds the raw numbers; phrasing lives in a thin
-formatter (i18n-friendly). Returns a neutral empty state when there are no donations or
-`active_users == 0`.
+#### Personal panel — retrospective with forward overflow
+
+`impact.personal_impact()` returns a `PersonalImpact` with a `band`:
+
+1. **`retrospective`** (`coverage_ratio < 1.0`, the normal case): "covers ~N
+   months of your own usage so far" (donation ÷ burn rate) or, when the burn
+   rate is too thin to round to a whole month, "covers ~Y% of what your usage
+   has cost."
+2. **`covers_others`** (own usage covered, but the whole site is *not*):
+   "fully covers your own usage — plus ~N other pilots", where N = surplus ÷
+   `cost_per_user_month`, **rounded to a whole number, minimum 1** (0.x rounds up
+   to "another pilot"; never a fraction). This intermediate band stops us
+   jumping to a future promise the moment a small footprint over-covers.
+3. **`future`** (only once community `coverage_ratio ≥ 1.0` — `site_covered`):
+   forward framing unlocks — "fully covers your own usage and helped others —
+   and contributes ~N months toward the service ahead" (N = surplus ÷ monthly
+   run cost).
+
+#### Community panel
+
+`impact.yearly_impact()` → `YearlyImpact`; phrasing flips at full coverage:
+
+- below 1.0 → "this year's donations have offset ~{coverage_ratio*100:.0f}% of
+  the running costs so far."
+- `coverage_ratio ≥ 1.0` → "this year's costs are fully covered" (+ "plus ~N
+  months ahead" when `surplus_months = months_covered − months_elapsed ≥ 1`).
+
+#### Adaptive translation ladder (prospective "donate €X" preview)
+
+`impact.choose_translation()` adapts the *translation type* (not just the unit)
+so the chosen number lands ~2–24 and never reads "0"/"0.3". `GET
+/api/donations/preview?amount=&currency=` serializes it; logged-in pilots with
+history get the personal path (small amounts vs their own burn rate), everyone
+else the program average.
+
+| Amount (USD, rough) | Preferred translation (`kind`) | Source |
+|---|---|---|
+| small (≤25) | "covers ~N months of **your own** usage" (`personal_months`, logged-in w/ history); else "covers one pilot for ~N months" (`user_months`); else "funds ~N briefings" (`briefings`) | burn rate / `cost_per_user_month` / `cost_per_briefing` |
+| medium (≤150) | "covers ~N pilots for a month" (`users_for_month`) or "funds ~N briefings" (`briefings`) | `cost_per_user_month` / `cost_per_briefing` |
+| large (>150) | "covers ~N months of running the whole service" (`service_months`) | `monthly_run_cost_usd` |
+
+#### Stats trio (transparency header on the donate page)
+
+`GET /api/donations/summary` carries a `stats` block + a `run_cost` block:
+
+- **active_pilots_30d** — `num_users` from the 30d cost report.
+- **briefings_all_time** — `COUNT(*)` over `briefing_packs`.
+- **analysis_words_all_time** — `SUM(briefing_usage.llm_output_tokens) × 0.75`.
+  **Output tokens only** (what the AI *wrote*, not input/total). `words_to_books`
+  (~90,000 words/novel) is an optional, clearly-approximate flourish; words is
+  the headline.
+- **run_cost** — `monthly_run_cost_usd` + `cost_per_user_month_usd`, rendered in
+  the viewer's currency. Publishing active pilots + run cost lets a reader back
+  out per-pilot cost — **intended** (transparency), not a leak. (A standalone
+  public cost-breakdown page/link is deferred; the donate page itself is the
+  public transparency surface for now.)
+
+Frozen dataclasses (`ProgramEconomics`, `DonationImpact`, `YearlyImpact`,
+`PersonalImpact`, `TranslationChoice`) hold the raw numbers; phrasing lives in a
+thin formatter (i18n-friendly). Every path returns a neutral empty state when
+there are no donations or `active_users == 0`.
 
 ### API endpoints (proposed)
 
@@ -310,8 +369,9 @@ formatter (i18n-friendly). Returns a neutral empty state when there are no donat
 |----------|--------|------|---------|
 | `/api/donations/checkout` | POST | User or anon | Create a Stripe Checkout Session (`{amount, currency, recurring}`) → returns redirect URL |
 | `/api/donations/webhook` | POST | Stripe sig | **Source of truth**: record/refund on `checkout.session.completed`, `charge.refunded`; verifies `STRIPE_WEBHOOK_SECRET`; idempotent on `provider_ref` |
-| `/api/donations/me` | GET | User | The viewer's own donation total + impact (USD + `fx` block) |
-| `/api/donations/summary` | GET | None | Public: this-year community total + coverage framing (no per-user data) |
+| `/api/donations/me` | GET | User | Viewer's donation total + program-average `impact` + retrospective `personal` panel (lifetime cost, "+N pilots"/forward overflow) (USD + `fx`) |
+| `/api/donations/summary` | GET | None | Public: this-year community coverage + `stats` trio (active pilots 30d, briefings all-time, AI words) + `run_cost` block |
+| `/api/donations/preview` | GET | User or anon | Adaptive-ladder translation of a prospective `?amount=&currency=` (personal path when logged-in w/ history, else program average) |
 
 ### Stripe flow
 

--- a/src/weatherbrief/api/credits.py
+++ b/src/weatherbrief/api/credits.py
@@ -165,19 +165,48 @@ def _transaction_to_response(row: CostLedgerRow) -> TransactionResponse:
     )
 
 
-def _cost_since(db: Session, user_id: str, since: datetime) -> float:
-    """Sum of USD costs since a given time."""
-    result = (
-        db.query(func.coalesce(func.sum(CostLedgerRow.cost), 0.0))
+def _cost_since(db: Session, user_id: str, since: datetime | None = None) -> float:
+    """Sum of a user's briefing USD costs.
+
+    With ``since`` it is windowed (this-week/this-month); with ``since=None`` it
+    is the user's **lifetime** briefing cost — the denominator the donation
+    personal panel needs.
+    """
+    q = db.query(func.coalesce(func.sum(CostLedgerRow.cost), 0.0)).filter(
+        CostLedgerRow.user_id == user_id,
+        CostLedgerRow.service == SERVICE,
+        CostLedgerRow.category == "briefing",
+    )
+    if since is not None:
+        q = q.filter(CostLedgerRow.created_at >= since)
+    return float(q.scalar())
+
+
+def user_cost_stats(db: Session, user_id: str) -> tuple[float, float, float]:
+    """Return ``(lifetime_cost_usd, months_active, burn_rate_monthly_usd)``.
+
+    ``burn_rate`` is the user's realized lifetime cost ÷ months active (months
+    since their first briefing, floored at half a month so a brand-new user's
+    rate isn't divide-by-tiny). All zero when the user has no briefing history —
+    the donation layer then falls back to the program average.
+    """
+    lifetime = _cost_since(db, user_id)
+    first = (
+        db.query(func.min(CostLedgerRow.created_at))
         .filter(
             CostLedgerRow.user_id == user_id,
             CostLedgerRow.service == SERVICE,
             CostLedgerRow.category == "briefing",
-            CostLedgerRow.created_at >= since,
         )
         .scalar()
     )
-    return float(result)
+    if first is None or lifetime <= 0:
+        return 0.0, 0.0, 0.0
+    if first.tzinfo is None:
+        first = first.replace(tzinfo=timezone.utc)
+    days = (datetime.now(timezone.utc) - first).total_seconds() / 86400.0
+    months_active = max(days / 30.0, 0.5)
+    return lifetime, months_active, lifetime / months_active
 
 
 # ---------------------------------------------------------------------------

--- a/src/weatherbrief/api/donations.py
+++ b/src/weatherbrief/api/donations.py
@@ -22,6 +22,7 @@ from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel, Field
+from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from flyfun_common import fx
@@ -41,7 +42,7 @@ from flyfun_common.payments import (
 )
 from flyfun_common.payments.stripe_client import SignatureVerificationError
 
-from weatherbrief.api.credits import build_program_report
+from weatherbrief.api.credits import build_program_report, user_cost_stats
 from weatherbrief.api.preferences import (
     FxBlock,
     fx_block_for_currency,
@@ -49,11 +50,19 @@ from weatherbrief.api.preferences import (
     stripe_configured,
     usd_fx_block,
 )
+from weatherbrief.db.models import BriefingPackRow, BriefingUsageRow
 from weatherbrief.impact import (
     ProgramEconomics,
+    choose_translation,
     donation_impact,
     economics_from_report,
+    format_words_written,
     impact_to_dict,
+    personal_impact,
+    personal_to_dict,
+    tokens_to_words,
+    translation_to_dict,
+    words_to_books,
     yearly_impact,
     yearly_to_dict,
 )
@@ -84,6 +93,24 @@ def _economics(db: Session) -> ProgramEconomics | None:
 def _empty_economics() -> ProgramEconomics:
     """Neutral economics → impact layer renders a neutral empty state."""
     return ProgramEconomics(monthly_run_cost_usd=0.0, active_users=0, cost_per_user_month_usd=0.0)
+
+
+def _program_stats(db: Session) -> tuple[int, int]:
+    """All-time ``(briefings_generated, ai_output_tokens)`` for the stats header.
+
+    Briefings = every ``briefing_packs`` row; AI words derive from the sum of
+    ``briefing_usage.llm_output_tokens`` (output only — what the AI *wrote*).
+    """
+    briefings = db.query(func.count()).select_from(BriefingPackRow).scalar() or 0
+    out_tokens = (
+        db.query(func.coalesce(func.sum(BriefingUsageRow.llm_output_tokens), 0)).scalar() or 0
+    )
+    return int(briefings), int(out_tokens)
+
+
+def _site_covered(total_year_usd: float, econ: ProgramEconomics, *, now: datetime) -> bool:
+    """Whether the whole site's cost is covered this year (forward-framing gate)."""
+    return yearly_impact(total_year_usd, econ, now=now).coverage_ratio >= 1.0
 
 
 def _redirect_urls(request: Request) -> tuple[str, str]:
@@ -319,9 +346,24 @@ class YearlyImpactResponse(BaseModel):
     summary: str
 
 
+class PersonalImpactResponse(BaseModel):
+    """Per-viewer lifetime coverage (mirror of personal_to_dict)."""
+
+    donation_total_usd: float
+    lifetime_cost_usd: float
+    own_months_covered: float
+    coverage_ratio: float
+    extra_pilots: int
+    future_months: float
+    band: str
+    empty: bool
+    summary: str
+
+
 class DonationMeResponse(BaseModel):
     total_usd: float
     impact: DonationImpactResponse
+    personal: PersonalImpactResponse
     fx: FxBlock
 
 
@@ -333,25 +375,53 @@ def get_my_donations(
 ) -> DonationMeResponse:
     """The viewer's own donation total + impact framing (USD + ``fx`` block).
 
-    ``?currency=`` overrides the viewer's saved display currency for this
-    response (used for instant reformatting when the picker changes).
+    Carries both the program-average ``impact`` (legacy) and the retrospective
+    ``personal`` panel (donation total vs the viewer's *lifetime* cost, with the
+    "+N other pilots" / forward overflow). ``?currency=`` overrides the viewer's
+    saved display currency for this response.
     """
     total = get_user_total_usd(db, viewer_id, service=SERVICE)
     econ = _economics(db) or _empty_economics()
     now = datetime.now(timezone.utc)
     impact = donation_impact(total, econ, now=now)
+
+    _lifetime, _months, burn_rate = user_cost_stats(db, viewer_id)
+    year_total = get_year_total_usd(db, now.year, service=SERVICE)
+    site_covered = _site_covered(year_total, econ, now=now)
+    personal = personal_impact(total, _lifetime, burn_rate, econ, site_covered=site_covered)
+
     fx_block = fx_block_for_currency(currency) if currency else fx_block_for_user(db, viewer_id)
     return DonationMeResponse(
         total_usd=round(total, 2),
         impact=impact_to_dict(impact),
+        personal=personal_to_dict(personal),
         fx=fx_block,
     )
+
+
+class StatsResponse(BaseModel):
+    """Transparency stats trio for the donate-page header (all human-facing)."""
+
+    active_pilots_30d: int
+    briefings_all_time: int
+    analysis_words_all_time: int
+    analysis_books_equiv: float
+    words_summary: str
+
+
+class RunCostResponse(BaseModel):
+    """Margin-excluded run cost, in USD (frontend renders via the ``fx`` block)."""
+
+    monthly_run_cost_usd: float
+    cost_per_user_month_usd: float
 
 
 class DonationSummaryResponse(BaseModel):
     year: int
     total_year_usd: float
     impact: YearlyImpactResponse
+    stats: StatsResponse
+    run_cost: RunCostResponse
     fx: FxBlock
     enabled: bool
 
@@ -362,15 +432,28 @@ def get_summary(
     db: Session = Depends(get_db),
     currency: str | None = None,
 ) -> DonationSummaryResponse:
-    """Public this-year community total + coverage framing (no per-user data).
+    """Public this-year community total + coverage framing + stats header.
 
-    ``?currency=`` overrides the display currency for this response — needed for
-    anonymous viewers (who have no saved pref) and for instant reformatting.
+    Adds the transparency stats trio (active pilots 30d, all-time briefings,
+    all-time AI words) and the margin-excluded run cost — publishing these lets a
+    reader back out per-pilot cost, which is intended. ``?currency=`` overrides
+    the display currency (needed for anonymous viewers and instant reformatting).
     """
     now = datetime.now(timezone.utc)
     total = get_year_total_usd(db, now.year, service=SERVICE)
     econ = _economics(db) or _empty_economics()
     yi = yearly_impact(total, econ, now=now)
+
+    briefings, out_tokens = _program_stats(db)
+    words = tokens_to_words(out_tokens)
+    stats = StatsResponse(
+        active_pilots_30d=econ.active_users,
+        briefings_all_time=briefings,
+        analysis_words_all_time=words,
+        analysis_books_equiv=words_to_books(words),
+        words_summary=format_words_written(out_tokens),
+    )
+
     if currency:
         fx_block = fx_block_for_currency(currency)
     elif viewer_id:
@@ -381,6 +464,63 @@ def get_summary(
         year=now.year,
         total_year_usd=round(total, 2),
         impact=yearly_to_dict(yi),
+        stats=stats,
+        run_cost=RunCostResponse(
+            monthly_run_cost_usd=econ.monthly_run_cost_usd,
+            cost_per_user_month_usd=econ.cost_per_user_month_usd,
+        ),
         fx=fx_block,
         enabled=stripe_configured(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Prospective donation preview (the "donate €X" button → translation)
+# ---------------------------------------------------------------------------
+
+
+class TranslationChoiceResponse(BaseModel):
+    """One chosen prospective-donation translation (mirror of translation_to_dict)."""
+
+    amount_usd: float
+    kind: str
+    value: float
+    summary: str
+    empty: bool
+
+
+class DonationPreviewResponse(BaseModel):
+    amount_usd: float
+    translation: TranslationChoiceResponse
+    fx: FxBlock
+
+
+@router.get("/preview", response_model=DonationPreviewResponse)
+def preview_donation(
+    amount: float,
+    currency: str | None = None,
+    viewer_id: str | None = Depends(optional_user_id),
+    db: Session = Depends(get_db),
+) -> DonationPreviewResponse:
+    """Translate a prospective amount via the adaptive ladder.
+
+    For a logged-in pilot with usage history, small amounts translate against
+    *their own* burn rate; otherwise the program average. ``amount`` is in the
+    display currency — convert to USD-canonical before running the math.
+    """
+    fx_block = fx_block_for_currency(currency) if currency else (
+        fx_block_for_user(db, viewer_id) if viewer_id else usd_fx_block()
+    )
+    rate = fx_block.rate or 1.0
+    amount_usd = amount / rate if rate else amount
+
+    econ = _economics(db) or _empty_economics()
+    burn_rate = 0.0
+    if viewer_id:
+        _lifetime, _months, burn_rate = user_cost_stats(db, viewer_id)
+    tc = choose_translation(amount_usd, econ, burn_rate_monthly_usd=burn_rate)
+    return DonationPreviewResponse(
+        amount_usd=round(amount_usd, 2),
+        translation=translation_to_dict(tc),
+        fx=fx_block,
     )

--- a/src/weatherbrief/api/donations.py
+++ b/src/weatherbrief/api/donations.py
@@ -352,7 +352,8 @@ class PersonalImpactResponse(BaseModel):
     donation_total_usd: float
     lifetime_cost_usd: float
     own_months_covered: float
-    coverage_ratio: float
+    # null when the pilot has no realized cost yet (ratio is donation ÷ 0).
+    coverage_ratio: float | None = None
     extra_pilots: int
     future_months: float
     band: str
@@ -512,7 +513,7 @@ def preview_donation(
         fx_block_for_user(db, viewer_id) if viewer_id else usd_fx_block()
     )
     rate = fx_block.rate or 1.0
-    amount_usd = amount / rate if rate else amount
+    amount_usd = amount / rate
 
     econ = _economics(db) or _empty_economics()
     burn_rate = 0.0

--- a/src/weatherbrief/impact.py
+++ b/src/weatherbrief/impact.py
@@ -303,7 +303,10 @@ class PersonalImpact:
     donation_total_usd: float
     lifetime_cost_usd: float
     own_months_covered: float
-    coverage_ratio: float
+    # None when the pilot has no realized cost yet (brand-new donor): the ratio
+    # is undefined (donation ÷ 0), so we expose null rather than a sentinel that
+    # a consumer would render as a nonsensical percentage.
+    coverage_ratio: float | None
     extra_pilots: int
     future_months: float
     band: str
@@ -361,7 +364,7 @@ def personal_impact(
         donation_total_usd=round(donation_total_usd, 2),
         lifetime_cost_usd=round(lifetime_cost_usd, 4),
         own_months_covered=round(own_months, 4),
-        coverage_ratio=round(coverage_ratio, 4) if coverage_ratio != float("inf") else -1.0,
+        coverage_ratio=round(coverage_ratio, 4) if coverage_ratio != float("inf") else None,
         extra_pilots=int(extra_pilots),
         future_months=round(future_months, 4),
         band=band,
@@ -385,7 +388,7 @@ def format_personal_coverage(pi: PersonalImpact) -> str:
         # Coverage ratio is the honest fallback when burn rate is too thin to
         # round to a whole month.
         ratio = pi.coverage_ratio
-        if ratio < 0:  # sentinel for "no realized cost" — shouldn't reach here
+        if ratio is None:  # no realized cost — never reaches the retrospective band
             return "covers your usage so far"
         pct = max(1, round(ratio * 100))
         return f"covers ~{pct}% of what your usage has cost"
@@ -536,9 +539,11 @@ def choose_translation(
         )
     # Very large per-pilot economics make even a big amount sub-month — fall back
     # to pilots-for-a-month so the number stays meaningful.
+    n = max(1, round(user_months))
+    pilot_word = "pilot" if n == 1 else "pilots"
     return _choice(
         amount_usd, TRANSLATION_USERS_FOR_MONTH, max(user_months, 0.0),
-        f"covers ~{max(1, round(user_months))} pilots for a month",
+        f"covers ~{n} {pilot_word} for a month",
     )
 
 

--- a/src/weatherbrief/impact.py
+++ b/src/weatherbrief/impact.py
@@ -21,6 +21,12 @@ _DAYS_PER_MONTH = 30.0
 # Below this, "covers one user for ~N years" reads more naturally than months.
 _YEARS_THRESHOLD_MONTHS = 18.0
 
+# Tokens → words: an output token is ~0.75 English words. Output tokens only —
+# that is what the AI *wrote* (input/total tokens are data fed in, not prose).
+_WORDS_PER_TOKEN = 0.75
+# Rough novel length, for the optional "~N books" flourish (clearly approximate).
+_WORDS_PER_NOVEL = 90_000.0
+
 
 @dataclass(frozen=True)
 class ProgramEconomics:
@@ -29,11 +35,14 @@ class ProgramEconomics:
     ``monthly_run_cost_usd`` is the operator's real monthly cost with **margin
     excluded**. ``cost_per_user_month_usd`` is ``0.0`` when there are no active
     users (the impact layer treats that as a neutral empty state).
+    ``cost_per_briefing_usd`` is the margin-excluded per-briefing run cost, used
+    for the relatable "X briefings funded" translation.
     """
 
     monthly_run_cost_usd: float
     active_users: int
     cost_per_user_month_usd: float
+    cost_per_briefing_usd: float = 0.0
 
     @property
     def available(self) -> bool:
@@ -45,21 +54,48 @@ def economics_from_report(report: ProgramCostReport) -> ProgramEconomics:
     """Derive margin-excluded run-cost economics from a program cost report.
 
     Fixed cost is already monthly; variable cost is over the report window, so it
-    is scaled to a 30-day month. Margin is intentionally dropped.
+    is scaled to a 30-day month. Margin is intentionally dropped. The
+    per-briefing cost is the monthly run cost divided by the window's briefing
+    count scaled to a month — so it, too, excludes margin (unlike
+    ``report.cost_per_briefing_usd``, which includes it).
     """
-    variable_monthly = (
-        report.variable_usd * (_DAYS_PER_MONTH / report.window_days)
-        if report.window_days
-        else 0.0
-    )
+    scale = _DAYS_PER_MONTH / report.window_days if report.window_days else 0.0
+    variable_monthly = report.variable_usd * scale
     monthly = report.fixed_monthly_usd + variable_monthly
     users = report.num_users
     cpum = monthly / users if users > 0 else 0.0
+    briefings_per_month = report.num_briefings * scale
+    cpb = monthly / briefings_per_month if briefings_per_month > 0 else 0.0
     return ProgramEconomics(
         monthly_run_cost_usd=round(monthly, 4),
         active_users=users,
         cost_per_user_month_usd=round(cpum, 6),
+        cost_per_briefing_usd=round(cpb, 6),
     )
+
+
+def tokens_to_words(output_tokens: int) -> int:
+    """AI words written from output token count (~0.75 words/token)."""
+    return int(max(output_tokens, 0) * _WORDS_PER_TOKEN)
+
+
+def words_to_books(words: int) -> float:
+    """Approximate novel-equivalents for a word count (~90k words/novel)."""
+    return round(max(words, 0) / _WORDS_PER_NOVEL, 1)
+
+
+def format_words_written(output_tokens: int) -> str:
+    """Headline phrasing for the AI-analysis stat. Words is the headline; the
+    book equivalence is an optional, clearly-approximate flourish appended by the
+    frontend from ``words_to_books`` if it wants it."""
+    words = tokens_to_words(output_tokens)
+    if words <= 0:
+        return ""
+    if words >= 1_000_000:
+        return f"{words / 1_000_000:.1f} million words of AI weather analysis"
+    if words >= 10_000:
+        return f"{round(words / 1_000) * 1000:,} words of AI weather analysis"
+    return f"{words:,} words of AI weather analysis"
 
 
 def _months_until_year_end(now: datetime) -> float:
@@ -116,13 +152,20 @@ def donation_impact(
 
 @dataclass(frozen=True)
 class YearlyImpact:
-    """Coverage this calendar year's community total buys. ``empty`` ⇒ neutral."""
+    """Coverage this calendar year's community total buys. ``empty`` ⇒ neutral.
+
+    ``coverage_ratio`` ≥ 1.0 means this year's donations have offset everything
+    spent so far; ``surplus_months`` is then how far *ahead* the surplus reaches
+    (donations beyond cost-incurred-so-far, in months of run cost). Below 1.0 it
+    is the expected retrospective case and ``surplus_months`` is 0.
+    """
 
     total_year_usd: float
     months_covered: float
     users_full_year: float
     coverage_ratio: float
     months_elapsed: float
+    surplus_months: float
     empty: bool
 
 
@@ -138,16 +181,21 @@ def yearly_impact(
             users_full_year=0.0,
             coverage_ratio=0.0,
             months_elapsed=round(months_elapsed, 4),
+            surplus_months=0.0,
             empty=True,
         )
     monthly = economics.monthly_run_cost_usd
     cpum = economics.cost_per_user_month_usd
+    months_covered = total_year_usd / monthly
+    # "Ahead" only counts donations beyond what's been spent so far this year.
+    surplus_months = max(months_covered - months_elapsed, 0.0)
     return YearlyImpact(
         total_year_usd=round(total_year_usd, 2),
-        months_covered=round(total_year_usd / monthly, 4),
+        months_covered=round(months_covered, 4),
         users_full_year=round(total_year_usd / (cpum * 12), 4),
         coverage_ratio=round(total_year_usd / (monthly * months_elapsed), 4),
         months_elapsed=round(months_elapsed, 4),
+        surplus_months=round(surplus_months, 4),
         empty=False,
     )
 
@@ -177,17 +225,21 @@ def format_user_coverage(impact: DonationImpact) -> str:
 
 
 def format_yearly_coverage(yi: YearlyImpact) -> str:
-    """Natural-language community coverage. ``""`` for the empty state."""
+    """Natural-language community coverage. ``""`` for the empty state.
+
+    Below full coverage this is retrospective ("offset ~62% of the running costs
+    so far"). Once ``coverage_ratio`` ≥ 1.0 the year is fully covered and forward
+    framing unlocks: "fully covered, plus ~N months ahead."
+    """
     if yi.empty:
         return ""
-    mc = yi.months_covered
-    if mc >= 12:
-        return f"this year's donations cover ~{mc / 12:.1f} years of running costs"
-    if mc >= 1.5:
-        return f"this year's donations cover ~{mc:.1f} months of running costs"
-    if mc >= 0.95:  # avoids the grammatically odd "~1.0 months"
-        return "this year's donations cover ~1 month of running costs"
-    return "this year's donations help cover the running costs"
+    if yi.coverage_ratio >= 1.0:
+        ahead = round(yi.surplus_months)
+        if ahead >= 1:
+            return f"this year's costs are fully covered, plus ~{ahead} months ahead"
+        return "this year's costs are fully covered"
+    pct = round(yi.coverage_ratio * 100)
+    return f"this year's donations have offset ~{pct}% of the running costs so far"
 
 
 def impact_to_dict(impact: DonationImpact) -> dict:
@@ -210,6 +262,292 @@ def yearly_to_dict(yi: YearlyImpact) -> dict:
         "users_full_year": yi.users_full_year,
         "coverage_ratio": yi.coverage_ratio,
         "months_elapsed": yi.months_elapsed,
+        "surplus_months": yi.surplus_months,
         "empty": yi.empty,
         "summary": format_yearly_coverage(yi),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Personal lifetime coverage — retrospective, with forward overflow
+# ---------------------------------------------------------------------------
+#
+# A donation is *retrospective*: it offsets cost a pilot has already incurred,
+# not a prepayment. So the personal panel is donation-total ÷ the pilot's own
+# lifetime cost. The escalation ladder:
+#
+#   1. below 100% of own usage  → retrospective ("covers ~N months of your own
+#      usage so far" / "~Y% of what your usage has cost").
+#   2. at/above own usage       → surplus goes to *other pilots* first
+#      ("…plus ~N other pilots", whole number, min 1) — NOT the future.
+#   3. only once the whole site is covered (community coverage ≥ 1.0) does
+#      forward framing unlock ("…and contributed ~N months toward the service
+#      ahead").
+
+_BAND_RETROSPECTIVE = "retrospective"
+_BAND_COVERS_OTHERS = "covers_others"
+_BAND_FUTURE = "future"
+
+
+@dataclass(frozen=True)
+class PersonalImpact:
+    """A pilot's lifetime coverage. ``empty`` ⇒ neutral (no economics/donations).
+
+    ``band`` is one of ``retrospective`` / ``covers_others`` / ``future``.
+    ``own_months_covered`` is the donation total against the pilot's realized
+    monthly burn rate; ``coverage_ratio`` is against their lifetime cost.
+    ``extra_pilots`` (whole, ≥1 in the overflow bands) and ``future_months``
+    quantify the surplus once own usage is covered.
+    """
+
+    donation_total_usd: float
+    lifetime_cost_usd: float
+    own_months_covered: float
+    coverage_ratio: float
+    extra_pilots: int
+    future_months: float
+    band: str
+    empty: bool
+
+
+def personal_impact(
+    donation_total_usd: float,
+    lifetime_cost_usd: float,
+    burn_rate_monthly_usd: float,
+    economics: ProgramEconomics,
+    *,
+    site_covered: bool,
+) -> PersonalImpact:
+    """Lifetime coverage for one pilot.
+
+    ``site_covered`` is the community coverage gate (yearly ``coverage_ratio`` ≥
+    1.0): forward framing only unlocks when the whole site is paid for. Returns a
+    neutral empty impact when economics are unavailable or nothing was donated.
+    """
+    if not economics.available or donation_total_usd <= 0:
+        return PersonalImpact(
+            donation_total_usd=round(max(donation_total_usd, 0.0), 2),
+            lifetime_cost_usd=round(max(lifetime_cost_usd, 0.0), 4),
+            own_months_covered=0.0,
+            coverage_ratio=0.0,
+            extra_pilots=0,
+            future_months=0.0,
+            band=_BAND_RETROSPECTIVE,
+            empty=True,
+        )
+
+    own_months = donation_total_usd / burn_rate_monthly_usd if burn_rate_monthly_usd > 0 else 0.0
+    # No realized cost yet (brand-new donor) ⇒ treat as fully covered so the
+    # surplus framing kicks in rather than a divide-by-zero.
+    coverage_ratio = (
+        donation_total_usd / lifetime_cost_usd if lifetime_cost_usd > 0 else float("inf")
+    )
+    surplus = max(donation_total_usd - max(lifetime_cost_usd, 0.0), 0.0)
+    avg_user_cost = economics.cost_per_user_month_usd  # representative per-pilot unit
+
+    if coverage_ratio < 1.0:
+        band, extra_pilots, future_months = _BAND_RETROSPECTIVE, 0, 0.0
+    elif not site_covered:
+        # Round 0.x up to "plus another pilot" — never a fraction, never zero.
+        extra_pilots = max(1, round(surplus / avg_user_cost)) if avg_user_cost > 0 else 1
+        band, future_months = _BAND_COVERS_OTHERS, 0.0
+    else:
+        extra_pilots = max(1, round(surplus / avg_user_cost)) if avg_user_cost > 0 else 1
+        monthly = economics.monthly_run_cost_usd
+        future_months = surplus / monthly if monthly > 0 else 0.0
+        band = _BAND_FUTURE
+
+    return PersonalImpact(
+        donation_total_usd=round(donation_total_usd, 2),
+        lifetime_cost_usd=round(lifetime_cost_usd, 4),
+        own_months_covered=round(own_months, 4),
+        coverage_ratio=round(coverage_ratio, 4) if coverage_ratio != float("inf") else -1.0,
+        extra_pilots=int(extra_pilots),
+        future_months=round(future_months, 4),
+        band=band,
+        empty=False,
+    )
+
+
+def format_personal_coverage(pi: PersonalImpact) -> str:
+    """Natural-language personal coverage. ``""`` for the empty state.
+
+    Verbs stay in the offset/contribute/cover family — never "pay for" or "fund
+    your next N months". All counts are whole numbers so the phrasing never shows
+    a fraction.
+    """
+    if pi.empty:
+        return ""
+    if pi.band == _BAND_RETROSPECTIVE:
+        months = round(pi.own_months_covered)
+        if months >= 1:
+            return f"covers ~{months} months of your own usage so far"
+        # Coverage ratio is the honest fallback when burn rate is too thin to
+        # round to a whole month.
+        ratio = pi.coverage_ratio
+        if ratio < 0:  # sentinel for "no realized cost" — shouldn't reach here
+            return "covers your usage so far"
+        pct = max(1, round(ratio * 100))
+        return f"covers ~{pct}% of what your usage has cost"
+    pilots = pi.extra_pilots
+    pilot_word = "pilot" if pilots == 1 else "pilots"
+    if pi.band == _BAND_COVERS_OTHERS:
+        return f"fully covers your own usage — plus ~{pilots} other {pilot_word}"
+    months_ahead = round(pi.future_months)
+    if months_ahead >= 1:
+        return (
+            "fully covers your own usage and helped others — and contributes "
+            f"~{months_ahead} months toward the service ahead"
+        )
+    return f"fully covers your own usage — plus ~{pilots} other {pilot_word}"
+
+
+def personal_to_dict(pi: PersonalImpact) -> dict:
+    """Serialize a PersonalImpact (+ phrasing) for the API."""
+    return {
+        "donation_total_usd": pi.donation_total_usd,
+        "lifetime_cost_usd": pi.lifetime_cost_usd,
+        "own_months_covered": pi.own_months_covered,
+        "coverage_ratio": pi.coverage_ratio,
+        "extra_pilots": pi.extra_pilots,
+        "future_months": pi.future_months,
+        "band": pi.band,
+        "empty": pi.empty,
+        "summary": format_personal_coverage(pi),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Adaptive translation ladder (prospective "donate €X" preview)
+# ---------------------------------------------------------------------------
+#
+# Picks the *type* of translation so the chosen number lands in a satisfying
+# range (~2–24) rather than "0" or "0.3". Bands by amount, with graceful
+# fallthrough when a band's number would read poorly. Pure + testable.
+
+# Translation kinds (stable identifiers the frontend can branch on).
+TRANSLATION_PERSONAL_MONTHS = "personal_months"
+TRANSLATION_USER_MONTHS = "user_months"
+TRANSLATION_USERS_FOR_MONTH = "users_for_month"
+TRANSLATION_BRIEFINGS = "briefings"
+TRANSLATION_SERVICE_MONTHS = "service_months"
+
+_SMALL_MAX = 25.0
+_MEDIUM_MAX = 150.0
+
+
+@dataclass(frozen=True)
+class TranslationChoice:
+    """One chosen prospective-donation translation. ``empty`` ⇒ neutral."""
+
+    amount_usd: float
+    kind: str
+    value: float
+    summary: str
+    empty: bool
+
+
+def _choice(amount_usd: float, kind: str, value: float, summary: str) -> TranslationChoice:
+    return TranslationChoice(
+        amount_usd=round(amount_usd, 2), kind=kind, value=round(value, 4),
+        summary=summary, empty=False,
+    )
+
+
+def choose_translation(
+    amount_usd: float,
+    economics: ProgramEconomics,
+    *,
+    burn_rate_monthly_usd: float = 0.0,
+) -> TranslationChoice:
+    """Pick the most relatable translation for a prospective donation.
+
+    For a logged-in pilot with usage history (``burn_rate_monthly_usd`` > 0) a
+    small amount is translated against *their own* usage; otherwise the program
+    average is used. Larger amounts climb to per-pilot, briefings-funded, and
+    whole-service framings. Degrades to a neutral empty state when economics are
+    unavailable.
+    """
+    if not economics.available or amount_usd <= 0:
+        return TranslationChoice(
+            amount_usd=round(max(amount_usd, 0.0), 2), kind="", value=0.0,
+            summary="", empty=True,
+        )
+
+    cpum = economics.cost_per_user_month_usd
+    cpb = economics.cost_per_briefing_usd
+    monthly = economics.monthly_run_cost_usd
+    user_months = amount_usd / cpum if cpum > 0 else 0.0
+    personal_months = amount_usd / burn_rate_monthly_usd if burn_rate_monthly_usd > 0 else 0.0
+    briefings = amount_usd / cpb if cpb > 0 else 0.0
+    service_months = amount_usd / monthly if monthly > 0 else 0.0
+
+    # Small: relate to the donor's own usage when we can, else one pilot's.
+    if amount_usd <= _SMALL_MAX:
+        if personal_months >= 1.5:
+            return _choice(
+                amount_usd, TRANSLATION_PERSONAL_MONTHS, personal_months,
+                f"covers ~{round(personal_months)} months of your own usage",
+            )
+        if user_months >= 1.5:
+            return _choice(
+                amount_usd, TRANSLATION_USER_MONTHS, user_months,
+                f"covers one pilot for ~{round(user_months)} months",
+            )
+        # Tiny relative to cost — briefings keep the number off "0".
+        if briefings >= 2:
+            return _choice(
+                amount_usd, TRANSLATION_BRIEFINGS, briefings,
+                f"funds ~{round(briefings)} briefings",
+            )
+        return _choice(
+            amount_usd, TRANSLATION_USER_MONTHS, max(user_months, 0.0),
+            "helps cover one pilot's usage",
+        )
+
+    # Medium: "N pilots for a month" reads better than "one pilot for N months"
+    # once N ≥ 2; otherwise the concrete "briefings funded".
+    if amount_usd <= _MEDIUM_MAX:
+        if user_months >= 2:
+            return _choice(
+                amount_usd, TRANSLATION_USERS_FOR_MONTH, user_months,
+                f"covers ~{round(user_months)} pilots for a month",
+            )
+        if briefings >= 2:
+            return _choice(
+                amount_usd, TRANSLATION_BRIEFINGS, briefings,
+                f"funds ~{round(briefings)} briefings",
+            )
+        return _choice(
+            amount_usd, TRANSLATION_SERVICE_MONTHS, max(service_months, 0.0),
+            "helps cover the running costs",
+        )
+
+    # Large (and site totals): whole-service months.
+    if service_months >= 1.5:
+        return _choice(
+            amount_usd, TRANSLATION_SERVICE_MONTHS, service_months,
+            f"covers ~{round(service_months)} months of running the whole service",
+        )
+    if service_months >= 0.95:
+        return _choice(
+            amount_usd, TRANSLATION_SERVICE_MONTHS, service_months,
+            "covers ~1 month of running the whole service",
+        )
+    # Very large per-pilot economics make even a big amount sub-month — fall back
+    # to pilots-for-a-month so the number stays meaningful.
+    return _choice(
+        amount_usd, TRANSLATION_USERS_FOR_MONTH, max(user_months, 0.0),
+        f"covers ~{max(1, round(user_months))} pilots for a month",
+    )
+
+
+def translation_to_dict(tc: TranslationChoice) -> dict:
+    """Serialize a TranslationChoice for the API."""
+    return {
+        "amount_usd": tc.amount_usd,
+        "kind": tc.kind,
+        "value": tc.value,
+        "summary": tc.summary,
+        "empty": tc.empty,
     }

--- a/tests/test_donations_api.py
+++ b/tests/test_donations_api.py
@@ -420,3 +420,101 @@ class TestSummary:
         _record_donation(session_factory, 500.0, provider_ref="pi_old", year=2023)
         body = make_client(viewer=None, optional=None).get("/api/donations/summary").json()
         assert body["total_year_usd"] == pytest.approx(50.0)
+
+
+def _seed_stats(session_factory, *, packs=3, output_tokens=10_000):
+    """A flight + briefing packs + a usage row carrying output tokens."""
+    from weatherbrief.db.models import BriefingPackRow, BriefingUsageRow, FlightRow
+
+    s = session_factory()
+    s.add(FlightRow(id="flt-1", user_id=DEV_USER_ID,
+                    departure_time=datetime(2026, 6, 1, tzinfo=timezone.utc)))
+    s.flush()
+    for i in range(packs):
+        s.add(BriefingPackRow(
+            flight_id="flt-1",
+            fetch_timestamp=datetime(2026, 6, 1, tzinfo=timezone.utc),
+            days_out=i,
+        ))
+    s.add(BriefingUsageRow(user_id=DEV_USER_ID, flight_id="flt-1",
+                           llm_output_tokens=output_tokens, llm_input_tokens=999_999))
+    s.commit()
+    s.close()
+
+
+class TestSummaryStats:
+    def test_stats_trio(self, make_client, session_factory):
+        _seed_economics(session_factory)  # 2 distinct briefing users (30d)
+        _seed_stats(session_factory, packs=4, output_tokens=10_000)
+        body = make_client(viewer=None, optional=None).get("/api/donations/summary").json()
+        stats = body["stats"]
+        assert stats["active_pilots_30d"] == 2
+        assert stats["briefings_all_time"] == 4
+        # Output tokens only, ~0.75 words/token: 10_000 → 7_500 words.
+        assert stats["analysis_words_all_time"] == 7_500
+        assert stats["words_summary"]  # non-empty phrasing
+        # run-cost block exposed for transparency.
+        assert body["run_cost"]["monthly_run_cost_usd"] > 0
+        assert body["run_cost"]["cost_per_user_month_usd"] > 0
+
+    def test_stats_zero_when_empty(self, make_client, session_factory):
+        # No economics, no packs/usage → neutral zeros, no crash.
+        body = make_client(viewer=None, optional=None).get("/api/donations/summary").json()
+        assert body["stats"]["briefings_all_time"] == 0
+        assert body["stats"]["analysis_words_all_time"] == 0
+        assert body["stats"]["words_summary"] == ""
+
+
+class TestMePersonal:
+    def test_personal_retrospective(self, make_client, session_factory):
+        # DEV has one $0.1 briefing row (from _seed_economics) → lifetime $0.1; a
+        # donation below that covers only a fraction → retrospective band.
+        _seed_economics(session_factory)
+        _record_donation(session_factory, 0.05)
+        body = make_client().get("/api/donations/me").json()
+        p = body["personal"]
+        assert p["empty"] is False
+        assert p["band"] == "retrospective"
+        assert p["summary"]
+
+    def test_personal_covers_others(self, make_client, session_factory):
+        # Donation far exceeds DEV's tiny lifetime cost → surplus to other pilots.
+        _seed_economics(session_factory)
+        _record_donation(session_factory, 56.0)
+        body = make_client().get("/api/donations/me").json()
+        p = body["personal"]
+        assert p["band"] == "covers_others"
+        assert p["extra_pilots"] >= 1
+        assert "other pilot" in p["summary"]
+
+    def test_personal_empty_without_economics(self, make_client, session_factory):
+        _record_donation(session_factory, 56.0)
+        body = make_client().get("/api/donations/me").json()
+        assert body["personal"]["empty"] is True
+        assert body["personal"]["summary"] == ""
+
+
+class TestPreview:
+    def test_program_average_for_anon(self, make_client, session_factory):
+        _seed_economics(session_factory)  # cpum from default config / 2 users
+        body = make_client(viewer=None, optional=None).get(
+            "/api/donations/preview?amount=20&currency=USD"
+        ).json()
+        assert body["amount_usd"] == pytest.approx(20.0)
+        assert body["translation"]["empty"] is False
+        assert body["translation"]["summary"]
+
+    def test_currency_converted_to_usd(self, make_client, session_factory):
+        _seed_economics(session_factory)
+        # EUR 18 at rate 0.9 → $20 USD-canonical.
+        body = make_client(viewer=None, optional=None).get(
+            "/api/donations/preview?amount=18&currency=EUR"
+        ).json()
+        assert body["amount_usd"] == pytest.approx(20.0)
+        assert body["fx"]["currency"] == "EUR"
+
+    def test_empty_when_no_economics(self, make_client, session_factory):
+        body = make_client(viewer=None, optional=None).get(
+            "/api/donations/preview?amount=20&currency=USD"
+        ).json()
+        assert body["translation"]["empty"] is True

--- a/tests/test_impact.py
+++ b/tests/test_impact.py
@@ -257,6 +257,12 @@ class TestPersonalImpact:
         assert pi.band == "covers_others"
         assert pi.extra_pilots >= 1
 
+    def test_no_history_coverage_ratio_is_none(self):
+        # Ratio is donation ÷ 0 → exposed as None, not a sentinel/percentage.
+        pi = personal_impact(20.0, 0.0, 0.0, self._econ(), site_covered=False)
+        assert pi.coverage_ratio is None
+        assert personal_to_dict(pi)["coverage_ratio"] is None
+
     def test_empty_when_no_economics(self):
         econ = ProgramEconomics(monthly_run_cost_usd=0.0, active_users=0,
                                 cost_per_user_month_usd=0.0)
@@ -317,6 +323,15 @@ class TestAdaptiveLadder:
                                 cost_per_user_month_usd=0.0)
         tc = choose_translation(20.0, econ)
         assert tc.empty and tc.summary == ""
+
+    def test_large_band_fallback_singular_pilot(self):
+        # Very high per-pilot economics: a big amount is sub-month for the whole
+        # service AND ~1 pilot-month → must read "1 pilot", never "1 pilots".
+        econ = ProgramEconomics(monthly_run_cost_usd=100_000.0, active_users=1,
+                                cost_per_user_month_usd=200.0, cost_per_briefing_usd=50.0)
+        tc = choose_translation(200.0, econ)  # service_months tiny; user_months = 1
+        assert tc.kind == TRANSLATION_USERS_FOR_MONTH
+        assert "~1 pilot for a month" in tc.summary
 
     def test_briefings_kind_for_tiny_amount(self):
         # Below a user-month but ≥2 briefings → "funds ~N briefings".

--- a/tests/test_impact.py
+++ b/tests/test_impact.py
@@ -11,11 +11,23 @@ from weatherbrief.impact import (
     DonationImpact,
     ProgramEconomics,
     YearlyImpact,
+    TRANSLATION_BRIEFINGS,
+    TRANSLATION_PERSONAL_MONTHS,
+    TRANSLATION_SERVICE_MONTHS,
+    TRANSLATION_USER_MONTHS,
+    TRANSLATION_USERS_FOR_MONTH,
+    choose_translation,
     donation_impact,
     economics_from_report,
+    format_personal_coverage,
     format_user_coverage,
+    format_words_written,
     format_yearly_coverage,
     impact_to_dict,
+    personal_impact,
+    personal_to_dict,
+    tokens_to_words,
+    words_to_books,
     yearly_impact,
     yearly_to_dict,
 )
@@ -128,15 +140,26 @@ class TestPhrasing:
                                 months_until_eoy=6, empty=False)
         assert format_user_coverage(impact) == "covers part of a user's monthly cost"
 
-    def test_yearly_years(self):
-        yi = YearlyImpact(total_year_usd=900, months_covered=18, users_full_year=3,
-                          coverage_ratio=3, months_elapsed=6, empty=False)
-        assert format_yearly_coverage(yi) == "this year's donations cover ~1.5 years of running costs"
-
-    def test_yearly_months(self):
+    def test_yearly_retrospective_percent(self):
+        # Below full coverage → retrospective "offset ~N%".
         yi = YearlyImpact(total_year_usd=112, months_covered=2.0, users_full_year=1,
-                          coverage_ratio=0.3, months_elapsed=6, empty=False)
-        assert format_yearly_coverage(yi) == "this year's donations cover ~2.0 months of running costs"
+                          coverage_ratio=0.62, months_elapsed=6, surplus_months=0.0, empty=False)
+        assert format_yearly_coverage(yi) == (
+            "this year's donations have offset ~62% of the running costs so far"
+        )
+
+    def test_yearly_fully_covered_with_overflow(self):
+        # coverage_ratio >= 1.0 unlocks forward framing.
+        yi = YearlyImpact(total_year_usd=900, months_covered=9, users_full_year=3,
+                          coverage_ratio=1.5, months_elapsed=6, surplus_months=3.0, empty=False)
+        assert format_yearly_coverage(yi) == (
+            "this year's costs are fully covered, plus ~3 months ahead"
+        )
+
+    def test_yearly_fully_covered_no_overflow(self):
+        yi = YearlyImpact(total_year_usd=340, months_covered=6.2, users_full_year=1,
+                          coverage_ratio=1.03, months_elapsed=6, surplus_months=0.2, empty=False)
+        assert format_yearly_coverage(yi) == "this year's costs are fully covered"
 
 
 class TestSerialization:
@@ -150,4 +173,168 @@ class TestSerialization:
         econ = economics_from_report(_report(num_users=10))
         d = yearly_to_dict(yearly_impact(112.0, econ, now=NOW))
         assert d["months_covered"] == pytest.approx(2.0)
+        assert "summary" in d and "surplus_months" in d
+
+
+# Default config: droplet 24 + misc 2 + subscriptions 30 = $56/month fixed.
+# With num_users=10 → cpum = $5.60; num_briefings = 30 → cost/briefing ≈ $1.867.
+
+
+class TestTokensToWords:
+    def test_output_tokens_only_075_per_token(self):
+        assert tokens_to_words(1000) == 750
+        assert tokens_to_words(0) == 0
+        assert tokens_to_words(-5) == 0  # never negative
+
+    def test_books_equivalence(self):
+        # 1.8M words ≈ 20 novels at ~90k words each.
+        assert words_to_books(1_800_000) == pytest.approx(20.0)
+        assert words_to_books(0) == 0.0
+
+    def test_words_summary_phrasing(self):
+        assert "million words" in format_words_written(3_000_000)  # 2.25M words
+        assert format_words_written(0) == ""
+        # Mid-range rounds to thousands.
+        s = format_words_written(20_000)  # 15,000 words
+        assert "words of AI weather analysis" in s
+
+
+class TestEconomicsCostPerBriefing:
+    def test_margin_excluded_per_briefing(self):
+        # $56/month over 30 briefings/30d window → ~$1.867 per briefing.
+        econ = economics_from_report(_report(num_users=10))  # num_briefings = 30
+        assert econ.cost_per_briefing_usd == pytest.approx(56.0 / 30.0, abs=1e-3)
+
+    def test_zero_when_no_briefings(self):
+        econ = economics_from_report(_report(num_users=0))
+        assert econ.cost_per_briefing_usd == 0.0
+
+
+class TestPersonalImpact:
+    def _econ(self):
+        return economics_from_report(_report(num_users=10))  # cpum 5.6, monthly 56
+
+    def test_retrospective_below_full_coverage(self):
+        # Lifetime cost $10, donated $5 → 50% covered, retrospective band.
+        pi = personal_impact(5.0, 10.0, 2.0, self._econ(), site_covered=False)
+        assert pi.band == "retrospective"
+        assert pi.extra_pilots == 0
+        assert pi.coverage_ratio == pytest.approx(0.5)
+        # $5 / $2/mo burn = 2.5 months → "~2 months of your own usage so far"
+        assert "your own usage so far" in format_personal_coverage(pi)
+
+    def test_retrospective_percent_fallback_when_burn_thin(self):
+        # Burn rate too small to round to a whole month → percent phrasing.
+        pi = personal_impact(3.0, 10.0, 0.0, self._econ(), site_covered=False)
+        assert pi.band == "retrospective"
+        assert "% of what your usage has cost" in format_personal_coverage(pi)
+
+    def test_covers_others_band_rounds_min_one(self):
+        # Donated $20, lifetime cost $2 → surplus $18; cpum 5.6 → ~3 pilots.
+        pi = personal_impact(20.0, 2.0, 1.0, self._econ(), site_covered=False)
+        assert pi.band == "covers_others"
+        assert pi.extra_pilots == round(18.0 / 5.6)
+        assert pi.future_months == 0.0
+        assert "other pilots" in format_personal_coverage(pi)
+
+    def test_covers_others_min_one_when_surplus_tiny(self):
+        # Surplus rounds to 0 → bumped to "another pilot" (min 1, never a fraction).
+        pi = personal_impact(2.5, 2.0, 1.0, self._econ(), site_covered=False)
+        assert pi.band == "covers_others"
+        assert pi.extra_pilots == 1
+        assert "1 other pilot" in format_personal_coverage(pi)
+
+    def test_future_band_only_when_site_covered(self):
+        # Same over-coverage, but the whole site is covered → forward framing.
+        pi = personal_impact(120.0, 2.0, 1.0, self._econ(), site_covered=True)
+        assert pi.band == "future"
+        assert pi.future_months > 0
+        assert "toward the service ahead" in format_personal_coverage(pi)
+
+    def test_no_history_treated_as_fully_covered(self):
+        # Brand-new donor: lifetime cost 0 → surplus = full donation, covers_others.
+        pi = personal_impact(20.0, 0.0, 0.0, self._econ(), site_covered=False)
+        assert pi.band == "covers_others"
+        assert pi.extra_pilots >= 1
+
+    def test_empty_when_no_economics(self):
+        econ = ProgramEconomics(monthly_run_cost_usd=0.0, active_users=0,
+                                cost_per_user_month_usd=0.0)
+        pi = personal_impact(20.0, 5.0, 2.0, econ, site_covered=False)
+        assert pi.empty
+        assert format_personal_coverage(pi) == ""
+
+    def test_empty_when_zero_donation(self):
+        pi = personal_impact(0.0, 5.0, 2.0, self._econ(), site_covered=False)
+        assert pi.empty
+
+    def test_serialization_has_summary(self):
+        d = personal_to_dict(personal_impact(5.0, 10.0, 2.0, self._econ(), site_covered=False))
+        assert d["band"] == "retrospective"
         assert "summary" in d
+
+
+class TestAdaptiveLadder:
+    def _econ(self):
+        return economics_from_report(_report(num_users=10))  # cpum 5.6, cpb ~1.867
+
+    def test_small_uses_personal_when_history(self):
+        # $20 at $5/mo personal burn → 4 months of your own usage.
+        tc = choose_translation(20.0, self._econ(), burn_rate_monthly_usd=5.0)
+        assert tc.kind == TRANSLATION_PERSONAL_MONTHS
+        assert "your own usage" in tc.summary
+        assert round(tc.value) == 4
+
+    def test_small_falls_back_to_program_average(self):
+        # No burn rate → one-pilot-for-N-months. $20 / 5.6 ≈ 3.6 months.
+        tc = choose_translation(20.0, self._econ())
+        assert tc.kind == TRANSLATION_USER_MONTHS
+        assert "one pilot for" in tc.summary
+
+    def test_medium_uses_pilots_for_a_month(self):
+        # $100 / 5.6 ≈ 18 pilots for a month.
+        tc = choose_translation(100.0, self._econ())
+        assert tc.kind == TRANSLATION_USERS_FOR_MONTH
+        assert "pilots for a month" in tc.summary
+        assert round(tc.value) == round(100.0 / 5.6)
+
+    def test_large_uses_service_months(self):
+        # $200 / $56/mo ≈ 3.6 months of the whole service.
+        tc = choose_translation(200.0, self._econ())
+        assert tc.kind == TRANSLATION_SERVICE_MONTHS
+        assert "running the whole service" in tc.summary
+
+    def test_never_shows_zero(self):
+        # Every band's chosen value rounds to a non-zero, readable number.
+        econ = self._econ()
+        for amount in (5, 10, 25, 50, 100, 150, 250, 1000):
+            tc = choose_translation(float(amount), econ)
+            assert not tc.empty
+            assert tc.summary and "~0 " not in tc.summary
+
+    def test_empty_when_no_economics(self):
+        econ = ProgramEconomics(monthly_run_cost_usd=0.0, active_users=0,
+                                cost_per_user_month_usd=0.0)
+        tc = choose_translation(20.0, econ)
+        assert tc.empty and tc.summary == ""
+
+    def test_briefings_kind_for_tiny_amount(self):
+        # Below a user-month but ≥2 briefings → "funds ~N briefings".
+        tc = choose_translation(5.0, self._econ())  # 5/5.6 < 1.5 months; 5/1.867 ≈ 2.7 briefings
+        assert tc.kind == TRANSLATION_BRIEFINGS
+        assert "briefings" in tc.summary
+
+
+class TestYearlyOverflow:
+    def test_surplus_months_zero_below_coverage(self):
+        econ = economics_from_report(_report(num_users=10))  # monthly 56
+        yi = yearly_impact(112.0, econ, now=NOW)  # 2 months covered, ~6 elapsed
+        assert yi.coverage_ratio < 1.0
+        assert yi.surplus_months == 0.0
+
+    def test_surplus_months_positive_when_over_covered(self):
+        econ = economics_from_report(_report(num_users=10))  # monthly 56
+        # 12 months covered vs ~6 elapsed → ~6 months ahead.
+        yi = yearly_impact(56.0 * 12, econ, now=NOW)
+        assert yi.coverage_ratio >= 1.0
+        assert yi.surplus_months == pytest.approx(12 - yi.months_elapsed, abs=1e-3)

--- a/web/donate.html
+++ b/web/donate.html
@@ -35,6 +35,22 @@
 
     #loading { text-align: center; padding: 3rem; color: var(--text-muted); }
     #error-message { color: var(--danger); text-align: center; padding: 1rem; display: none; }
+
+    .stats-grid {
+      display: flex; flex-wrap: wrap; gap: 0.75rem; margin-bottom: 1.5rem;
+    }
+    .stat-card {
+      flex: 1 1 8rem; background: var(--surface); border: 1px solid var(--border);
+      border-radius: var(--radius); padding: 0.85rem 1rem; text-align: center;
+    }
+    .stat-card .value { font-size: 1.3rem; font-weight: 700; font-variant-numeric: tabular-nums; }
+    .stat-card .label { font-size: 0.72rem; color: var(--text-muted); margin-top: 0.2rem; }
+    .run-cost-note { color: var(--text-muted); font-size: 0.8rem; margin: -0.5rem 0 1.25rem; }
+
+    .preview-note {
+      min-height: 1.2rem; color: var(--accent, #2563eb); font-size: 0.85rem;
+      font-weight: 600; margin-bottom: 0.75rem;
+    }
   </style>
 </head>
 <body>
@@ -60,6 +76,25 @@
         no perks, no premium tier — they simply offset the real cost of running the
         service. You're not buying anything; you're keeping it free for everyone.
       </p>
+
+      <!-- Transparency stats header -->
+      <div class="section" id="stats-section" style="display:none;">
+        <div class="stats-grid">
+          <div class="stat-card">
+            <div class="value" id="stat-pilots">—</div>
+            <div class="label">active pilots (30 days)</div>
+          </div>
+          <div class="stat-card">
+            <div class="value" id="stat-briefings">—</div>
+            <div class="label">briefings generated</div>
+          </div>
+          <div class="stat-card">
+            <div class="value" id="stat-words">—</div>
+            <div class="label" id="stat-words-label">of AI weather analysis</div>
+          </div>
+        </div>
+        <p class="run-cost-note" id="run-cost-note"></p>
+      </div>
 
       <!-- Community impact -->
       <div class="section">
@@ -97,6 +132,9 @@
             <select id="input-currency" class="input-select input-narrow"></select>
           </div>
         </div>
+
+        <!-- Live translation of the entered amount (adaptive ladder). -->
+        <p class="preview-note" id="amount-preview"></p>
 
         <!-- Recurring is backend-capable but the subscription lifecycle webhooks
              (renewal rows, cancel UI) aren't handled yet, so the toggle stays

--- a/web/ts/adapters/donations-adapter.ts
+++ b/web/ts/adapters/donations-adapter.ts
@@ -38,7 +38,7 @@ export interface PersonalImpact {
   donation_total_usd: number;
   lifetime_cost_usd: number;
   own_months_covered: number;
-  coverage_ratio: number;
+  coverage_ratio: number | null; // null when no realized cost yet (donation ÷ 0)
   extra_pilots: number;
   future_months: number;
   band: 'retrospective' | 'covers_others' | 'future';
@@ -78,7 +78,13 @@ export interface DonationSummary {
   enabled: boolean; // false when Stripe isn't configured → hide the donate UI
 }
 
-/** One chosen prospective-donation translation (the adaptive ladder result). */
+/** One chosen prospective-donation translation (the adaptive ladder result).
+ *
+ * `value` is the raw dimensionless quantity, whose meaning depends on `kind`
+ * (pilot-months for `user_months`/`personal_months`, a pilot count for
+ * `users_for_month`, a briefing count for `briefings`, months of service for
+ * `service_months`). Prefer `summary` — it is the canonical human-readable form;
+ * only read `value` if you intend to re-render it yourself per `kind`. */
 export interface TranslationChoice {
   amount_usd: number;
   kind: string;

--- a/web/ts/adapters/donations-adapter.ts
+++ b/web/ts/adapters/donations-adapter.ts
@@ -28,6 +28,20 @@ export interface YearlyImpact {
   users_full_year: number;
   coverage_ratio: number;
   months_elapsed: number;
+  surplus_months: number;
+  empty: boolean;
+  summary: string;
+}
+
+/** A pilot's lifetime coverage (retrospective, with "+N pilots" / forward overflow). */
+export interface PersonalImpact {
+  donation_total_usd: number;
+  lifetime_cost_usd: number;
+  own_months_covered: number;
+  coverage_ratio: number;
+  extra_pilots: number;
+  future_months: number;
+  band: 'retrospective' | 'covers_others' | 'future';
   empty: boolean;
   summary: string;
 }
@@ -35,15 +49,48 @@ export interface YearlyImpact {
 export interface DonationMe {
   total_usd: number;
   impact: DonationImpact;
+  personal: PersonalImpact;
   fx: FxBlock;
+}
+
+/** Transparency stats trio for the donate-page header. */
+export interface DonationStats {
+  active_pilots_30d: number;
+  briefings_all_time: number;
+  analysis_words_all_time: number;
+  analysis_books_equiv: number;
+  words_summary: string;
+}
+
+/** Margin-excluded run cost (USD; render via the fx block). */
+export interface RunCost {
+  monthly_run_cost_usd: number;
+  cost_per_user_month_usd: number;
 }
 
 export interface DonationSummary {
   year: number;
   total_year_usd: number;
   impact: YearlyImpact;
+  stats: DonationStats;
+  run_cost: RunCost;
   fx: FxBlock;
   enabled: boolean; // false when Stripe isn't configured → hide the donate UI
+}
+
+/** One chosen prospective-donation translation (the adaptive ladder result). */
+export interface TranslationChoice {
+  amount_usd: number;
+  kind: string;
+  value: number;
+  summary: string;
+  empty: boolean;
+}
+
+export interface DonationPreview {
+  amount_usd: number;
+  translation: TranslationChoice;
+  fx: FxBlock;
 }
 
 export interface CheckoutRequest {
@@ -72,6 +119,18 @@ export async function fetchMyDonations(currency?: string): Promise<DonationMe> {
 export async function fetchDonationSummary(currency?: string): Promise<DonationSummary> {
   const q = currency ? `?currency=${encodeURIComponent(currency)}` : '';
   return apiFetch<DonationSummary>(`/donations/summary${q}`);
+}
+
+/** Translate a prospective amount via the adaptive ladder.
+ * `amount` is in the display `currency`; personal framing applies when the
+ * viewer is logged in with usage history (resolved server-side). */
+export async function fetchDonationPreview(
+  amount: number,
+  currency?: string,
+): Promise<DonationPreview> {
+  const params = new URLSearchParams({ amount: String(amount) });
+  if (currency) params.set('currency', currency);
+  return apiFetch<DonationPreview>(`/donations/preview?${params.toString()}`);
 }
 
 /** Render a USD amount in the viewer's currency using an fx block. */

--- a/web/ts/donate-main.ts
+++ b/web/ts/donate-main.ts
@@ -10,6 +10,7 @@
 import { fetchCurrentUser } from './adapters/auth-adapter';
 import {
   createCheckout,
+  fetchDonationPreview,
   fetchDonationSummary,
   fetchMyDonations,
   formatMoney,
@@ -73,6 +74,7 @@ async function init(): Promise<void> {
     return;
   }
 
+  renderStats(summary);
   renderCommunity(summary);
   initCurrency();
 
@@ -128,15 +130,60 @@ function renderCommunity(s: DonationSummary): void {
   sub.textContent = `${total} donated in ${s.year}.`;
 }
 
+/** Transparency stats trio + the run-cost note. Hidden until data is present. */
+function renderStats(s: DonationSummary): void {
+  const stats = s.stats;
+  const section = document.getElementById('stats-section')!;
+  // Nothing meaningful yet → leave the header hidden.
+  if (!stats || (stats.briefings_all_time <= 0 && stats.active_pilots_30d <= 0)) {
+    section.style.display = 'none';
+    return;
+  }
+  section.style.display = '';
+  document.getElementById('stat-pilots')!.textContent = stats.active_pilots_30d.toLocaleString();
+  document.getElementById('stat-briefings')!.textContent =
+    stats.briefings_all_time.toLocaleString();
+
+  // Words is the headline; the ~N books equivalence is an optional flourish.
+  const words = stats.analysis_words_all_time;
+  document.getElementById('stat-words')!.textContent = formatWords(words);
+  const booksNote =
+    stats.analysis_books_equiv >= 1
+      ? ` (~${Math.round(stats.analysis_books_equiv)} novels)`
+      : '';
+  document.getElementById('stat-words-label')!.textContent =
+    `words of AI weather analysis${booksNote}`;
+
+  // Run cost: transparent, in the viewer's currency. Lets a reader back out the
+  // per-pilot cost — that's intended.
+  const note = document.getElementById('run-cost-note')!;
+  if (s.run_cost && s.run_cost.monthly_run_cost_usd > 0) {
+    const monthly = formatMoney(s.run_cost.monthly_run_cost_usd, s.fx);
+    const perPilot = formatMoney(s.run_cost.cost_per_user_month_usd, s.fx);
+    note.textContent =
+      `Running the service costs about ${monthly}/month — roughly ${perPilot} per active pilot. ` +
+      `Donations offset that real cost; the operator keeps no margin on them.`;
+  } else {
+    note.textContent = '';
+  }
+}
+
+/** Compact word count: 2.3M / 45k / 900. */
+function formatWords(words: number): string {
+  if (words >= 1_000_000) return `${(words / 1_000_000).toFixed(1)}M`;
+  if (words >= 1_000) return `${Math.round(words / 1_000)}k`;
+  return words.toLocaleString();
+}
+
 function renderPersonal(me: DonationMe): void {
   if (me.total_usd <= 0) return; // nothing donated yet — keep the panel hidden
   document.getElementById('personal-section')!.style.display = '';
   const headline = document.getElementById('personal-headline')!;
   const sub = document.getElementById('personal-sub')!;
   headline.textContent = formatMoney(me.total_usd, me.fx);
-  sub.textContent = me.impact.summary
-    ? `Your support ${me.impact.summary}.`
-    : 'Thank you for your support.';
+  // Prefer the retrospective personal panel; fall back to program-average impact.
+  const phrase = me.personal && !me.personal.empty ? me.personal.summary : me.impact.summary;
+  sub.textContent = phrase ? `Your support ${phrase}.` : 'Thank you for your support.';
 }
 
 function initCurrency(): void {
@@ -154,11 +201,14 @@ function initCurrency(): void {
     persistCurrency(selectedCurrency, null); // explicit change → always persist
     renderPresets();
     try {
-      renderCommunity(await fetchDonationSummary(selectedCurrency));
+      const s = await fetchDonationSummary(selectedCurrency);
+      renderStats(s);
+      renderCommunity(s);
       if (isLoggedIn) renderPersonal(await fetchMyDonations(selectedCurrency));
     } catch {
       /* keep the previously rendered totals on a refetch hiccup */
     }
+    previewAmount(); // re-translate the entered amount in the new currency
   });
   renderPresets();
 }
@@ -175,14 +225,51 @@ function renderPresets(): void {
       amountInput.value = btn.dataset.amount || '';
       grid.querySelectorAll('.amount-btn').forEach((b) => b.classList.remove('active'));
       btn.classList.add('active');
+      previewAmount();
     });
   });
+}
+
+let previewTimer: ReturnType<typeof setTimeout> | undefined;
+let previewSeq = 0; // guards against out-of-order responses
+
+/** Translate the entered amount via the backend ladder and show the phrasing.
+ * Debounced so typing doesn't spam the endpoint. */
+function previewAmount(): void {
+  const note = document.getElementById('amount-preview');
+  const amountInput = document.getElementById('input-amount') as HTMLInputElement | null;
+  if (!note || !amountInput) return;
+  const amount = parseFloat(amountInput.value);
+  if (!Number.isFinite(amount) || amount < 1) {
+    note.textContent = '';
+    return;
+  }
+  clearTimeout(previewTimer);
+  const seq = ++previewSeq;
+  previewTimer = setTimeout(async () => {
+    try {
+      const { translation } = await fetchDonationPreview(amount, selectedCurrency);
+      if (seq !== previewSeq) return; // a newer request superseded this one
+      note.textContent = translation.empty ? '' : translation.summary;
+    } catch {
+      if (seq === previewSeq) note.textContent = '';
+    }
+  }, 250);
 }
 
 function initForm(): void {
   const btn = document.getElementById('btn-donate') as HTMLButtonElement;
   const amountInput = document.getElementById('input-amount') as HTMLInputElement;
   const recurring = document.getElementById('input-recurring') as HTMLInputElement;
+
+  // Typing a custom amount clears any active preset highlight + re-translates.
+  amountInput.addEventListener('input', () => {
+    document
+      .getElementById('amount-grid')
+      ?.querySelectorAll('.amount-btn')
+      .forEach((b) => b.classList.remove('active'));
+    previewAmount();
+  });
 
   btn.addEventListener('click', async () => {
     const amount = parseFloat(amountInput.value);


### PR DESCRIPTION
## Summary

Extends the donation impact system with two major features:

1. **Personal lifetime coverage panel** — shows each donor how their gifts offset *their own* realized usage (retrospective), with overflow bands for covering other pilots and (once the whole site is covered) contributing to future service costs.

2. **Adaptive translation ladder** — intelligently picks the most relatable unit for prospective donations ("your next N months" → "N pilots for a month" → "N briefings funded" → "N months of service"), ensuring the displayed number lands in a satisfying ~2–24 range rather than "0" or "0.3".

Also adds transparency stats (all-time briefings, AI words written, active pilots) and exposes margin-excluded run costs so readers can back out per-pilot economics.

## Key Changes

**Impact layer (`src/weatherbrief/impact.py`)**
- Added `cost_per_briefing_usd` to `ProgramEconomics` (margin-excluded per-briefing cost for "X briefings funded" translations)
- New `PersonalImpact` dataclass with three bands:
  - `retrospective`: donation covers <100% of own usage ("~N months of your own usage so far" or "~Y%")
  - `covers_others`: own usage covered, site not yet ("fully covers your own usage — plus ~N other pilots")
  - `future`: whole site covered, forward framing unlocks ("…and contributes ~N months toward the service ahead")
- `personal_impact()` function computes lifetime coverage with band selection logic
- `format_personal_coverage()` generates natural-language phrasing per band
- New `TranslationChoice` dataclass and `choose_translation()` function implementing the adaptive ladder (5 translation kinds: personal months, user months, users-for-month, briefings, service months)
- Token/word conversion helpers: `tokens_to_words()`, `words_to_books()`, `format_words_written()`
- Updated `YearlyImpact` with `surplus_months` field and flipped phrasing to retrospective ("offset ~N%") below full coverage, forward ("fully covered, plus ~N months ahead") at/above

**API layer (`src/weatherbrief/api/donations.py`)**
- New `StatsResponse` (active pilots 30d, all-time briefings, AI words, book equivalence)
- New `RunCostResponse` (margin-excluded monthly + per-pilot costs for transparency)
- New `PersonalImpactResponse` mirroring the impact layer
- Updated `DonationSummaryResponse` to include `stats` and `run_cost`
- Updated `DonationMeResponse` to include `personal` panel
- New `/api/donations/preview` endpoint for prospective-donation translation
- Helper functions: `_program_stats()` (briefing count + output token sum), `_site_covered()` (community coverage gate)

**Credits layer (`src/weatherbrief/api/credits.py`)**
- New `user_cost_stats()` function returning `(lifetime_cost_usd, months_active, burn_rate_monthly_usd)` — the denominator for personal impact calculations

**Frontend (`web/ts/donate-main.ts`, `web/ts/adapters/donations-adapter.ts`, `web/donate.html`)**
- New `renderStats()` function displaying the transparency trio (pilots, briefings, words + book equivalence)
- Updated `renderPersonal()` to prefer the retrospective personal panel over program-average impact
- New `previewAmount()` and `renderPreview()` for the adaptive translation ladder
- Currency picker now re-translates the preview amount on change
- New TypeScript interfaces: `PersonalImpact`, `DonationStats`, `RunCost`, `TranslationChoice`, `DonationPreview`
- HTML: stats grid, run-cost note, preview section with adaptive phrasing

**Tests**
- New test classes: `TestTokensToWords`, `TestEconomicsCostPerBriefing`, `TestPersonalImpact`, `TestAdaptiveLadder`
- Updated yearly impact tests to reflect new retrospective/forward framing logic
- API

https://claude.ai/code/session_01YBudrqg2z1efUTUAiwsLNj