### PR TITLE
Digest eval Phase 2 foundation — faithful fixtures + situation tagging

### DIFF
--- a/scripts/extract_digest_eval.py
+++ b/scripts/extract_digest_eval.py
@@ -6,7 +6,17 @@ reconstruct the LLM context string, this script saves a compact fixture
 containing:
   - context.txt  — the exact string sent to the LLM as the user message
   - digest.json  — the LLM's structured output (for comparison)
-  - meta.json    — route, date, days_out, advisory summary, model counts
+  - meta.json    — route, date, days_out, advisory summary, situations,
+                   and fidelity (faithful vs reconstructed)
+
+Context fidelity (#254): the LLM is sent more than the snapshot can rebuild —
+text forecasts (NWS AFD / DWD), DWD translations, and the previous digest. So
+we prefer the *persisted* ``digest_context.txt`` written into the pack at digest
+generation time (byte-faithful). When that's absent (older back-catalog packs),
+we reconstruct best-effort: rebuild the context from the snapshot and splice in
+the DWD overview if the pack saved one. Reconstructed fixtures are tagged
+``faithful=False`` because the text-forecast/previous-digest sections the LLM
+actually saw cannot be fully recovered — the eval treats them more leniently.
 
 Usage:
     python scripts/extract_digest_eval.py [--output-dir tests/eval_data/digests]
@@ -19,8 +29,8 @@ from __future__ import annotations
 import argparse
 import json
 import shutil
-from collections import defaultdict
-from datetime import datetime
+from collections import Counter, defaultdict
+from datetime import date, datetime
 from pathlib import Path
 
 from weatherbrief.digest.prompt_builder import build_digest_context
@@ -82,6 +92,113 @@ def find_packs() -> list[Path]:
     )
 
 
+# Map an advisory_id to the situation tag it contributes when its aggregate is
+# not green. Several ids fold into one tag (icing_escape + fiki_icing + freezing
+# _level → "icing"). Unmapped ids are ignored for tagging.
+_ADVISORY_SITUATION: dict[str, str] = {
+    "icing_escape": "icing",
+    "fiki_icing": "icing",
+    "freezing_level": "icing",
+    "convective": "convective",
+    "turbulence": "turbulence",
+    "mountain_wind": "turbulence",
+    "cloud_top": "cloud",
+    "vmc_cruise": "cloud",
+    "airport_wind": "wind",
+    "flight_category": "low_category",
+    "vfr_feasibility": "vfr_marginal",
+    "ifr_feasibility": "ifr_marginal",
+}
+
+# The coverage matrix we want the curated set to fill (parent #252 / #254).
+# A fixture may carry several tags; these are the cells we report on.
+SITUATION_VOCAB: tuple[str, ...] = (
+    "all_green", "single_red", "multi_red",
+    "icing", "convective", "icing_plus_convective", "cloud", "turbulence",
+    "wind", "low_category", "vfr_marginal", "ifr_marginal",
+    "d0", "metar", "sigmet", "previous_digest",
+    "us_route", "alpine", "channel_crossing",
+)
+
+
+def _load_dwd_translated(pack_dir: Path) -> list | None:
+    """Reconstruct the ``dwd_translated`` list from a saved ``dwd_overview.json``.
+
+    Returns ``[(DWDDayBlock, english), ...]`` so a reconstructed context can
+    splice the DWD section back in, or ``None`` if the pack has no overview.
+    """
+    overview_path = pack_dir / "dwd_overview.json"
+    if not overview_path.exists():
+        return None
+    try:
+        from weatherbrief.fetch.dwd_text import DWDDayBlock
+
+        overview = json.loads(overview_path.read_text())
+        out = []
+        for entry in overview.get("entries", []):
+            iso = entry.get("date_iso")
+            block = DWDDayBlock(
+                day_name_de=entry.get("day_name_de", ""),
+                date_iso=date.fromisoformat(iso) if iso else None,
+                text=entry.get("text_de", "") or "",
+                source=entry.get("source", "") or "",
+            )
+            out.append((block, entry.get("text_en", "") or ""))
+        return out or None
+    except Exception:
+        return None
+
+
+def _classify_situations(
+    snapshot: ForecastSnapshot, adv_summary: dict, context: str, days_out: int
+) -> list[str]:
+    """Tag a fixture with the meteorological/structural situations it covers."""
+    tags: set[str] = set()
+
+    counts = adv_summary.get("counts", {})
+    reds = counts.get("red", 0)
+    non_green = [
+        a for a in adv_summary.get("advisories", []) if a["aggregate"] != "green"
+    ]
+    if adv_summary.get("has_advisories") and not non_green:
+        tags.add("all_green")
+    if reds == 1:
+        tags.add("single_red")
+    elif reds >= 2:
+        tags.add("multi_red")
+
+    for adv in non_green:
+        tag = _ADVISORY_SITUATION.get(adv["id"])
+        if tag:
+            tags.add(tag)
+    if "icing" in tags and "convective" in tags:
+        tags.add("icing_plus_convective")
+
+    # Structural / context-derived tags.
+    if days_out == 0:
+        tags.add("d0")
+    if "=== METAR/TAF OBSERVATIONS" in context:
+        tags.add("metar")
+    if "=== SIGMETs ALONG ROUTE" in context or "=== SIGMET" in context:
+        tags.add("sigmet")
+    if "=== PREVIOUS DIGEST" in context:
+        tags.add("previous_digest")
+
+    # Route/region tags from waypoint ICAOs.
+    icaos = [wp.icao.upper() for wp in snapshot.route.waypoints]
+    if any(c.startswith(("K", "PA", "PH")) for c in icaos):
+        tags.add("us_route")
+    # Switzerland (LS) / Austria (LO) prefixes are a coarse Alpine proxy.
+    if any(c.startswith(("LS", "LO")) for c in icaos):
+        tags.add("alpine")
+    if any(c.startswith("EG") for c in icaos) and any(
+        c.startswith("LF") for c in icaos
+    ):
+        tags.add("channel_crossing")
+
+    return sorted(tags)
+
+
 def extract_one(pack_dir: Path) -> dict | None:
     """Extract eval data from a single pack. Returns meta dict or None."""
     snapshot = load_snapshot_from_pack(pack_dir)
@@ -101,19 +218,42 @@ def extract_one(pack_dir: Path) -> dict | None:
     else:
         target_time = datetime.fromisoformat(f"{snapshot.target_date}T09:00:00")
 
-    # Build context string (the exact LLM input)
-    context = build_digest_context(
-        snapshot, target_time,
-        route_advisories=advisories,
-        flight_rules="vfr_ifr",
-    )
+    # Prefer the persisted context (byte-faithful to what the LLM saw). Fall
+    # back to best-effort reconstruction for older packs that predate
+    # digest_context.txt — splicing the DWD overview back in when available.
+    persisted = pack_dir / "digest_context.txt"
+    if persisted.exists():
+        context = persisted.read_text()
+        faithful = True
+        context_source = "persisted"
+    else:
+        context = build_digest_context(
+            snapshot, target_time,
+            route_advisories=advisories,
+            dwd_translated=_load_dwd_translated(pack_dir),
+            flight_rules="vfr_ifr",
+        )
+        faithful = False
+        context_source = "reconstructed"
 
     # Load existing digest output
     digest = json.loads((pack_dir / "digest.json").read_text())
 
+    # Skip long-range outlooks — they are a different output type
+    # (LongRangeDigest: outlook/outlook_reason, no GREEN/AMBER/RED assessment)
+    # with its own contract, so the WeatherDigest eval/guardrails don't apply.
+    # Long-range gets its own eval track later (see project_longrange_outlook).
+    if "outlook" in digest or digest.get("assessment") not in (
+        "GREEN", "AMBER", "RED"
+    ):
+        return None
+
     # Build metadata
     route = " -> ".join(wp.icao for wp in snapshot.route.waypoints)
     adv_summary = extract_advisory_summary(adv_path)
+    situations = _classify_situations(
+        snapshot, adv_summary, context, snapshot.days_out
+    )
 
     meta = {
         "pack_path": str(pack_dir),
@@ -124,6 +264,9 @@ def extract_one(pack_dir: Path) -> dict | None:
         "assessment": digest.get("assessment"),
         "assessment_reason": digest.get("assessment_reason"),
         "advisory_summary": adv_summary,
+        "situations": situations,
+        "faithful": faithful,
+        "context_source": context_source,
         "context_chars": len(context),
     }
 
@@ -137,6 +280,51 @@ def make_fixture_id(meta: dict) -> str:
     days = f"d{meta['days_out']}"
     fetch = meta["fetch_date"]
     return f"{route}_{date}_{days}_{fetch}"
+
+
+def _read_synthetic_fixtures(output_dir: Path) -> list[dict]:
+    """Read hand-authored fixtures (``meta.json`` with ``synthetic: true``).
+
+    Returns ``[{"id": dir_name, "files": {filename: text}}, ...]`` so they can
+    be re-written verbatim after the pack-derived set is regenerated. These are
+    not in ``data/packs`` and would otherwise be lost on rmtree.
+    """
+    preserved: list[dict] = []
+    if not output_dir.exists():
+        return preserved
+    for child in sorted(output_dir.iterdir()):
+        meta_path = child / "meta.json"
+        if not child.is_dir() or not meta_path.exists():
+            continue
+        try:
+            meta = json.loads(meta_path.read_text())
+        except Exception:
+            continue
+        if not meta.get("synthetic"):
+            continue
+        files = {f.name: f.read_text() for f in child.iterdir() if f.is_file()}
+        preserved.append({"id": child.name, "files": files})
+    return preserved
+
+
+def preserved_index(preserved: list[dict]):
+    """Yield index entries for preserved synthetic fixtures."""
+    for p in preserved:
+        meta = json.loads(p["files"]["meta.json"])
+        yield {
+            "id": p["id"],
+            "assessment": meta.get("assessment"),
+            "route": meta.get("route"),
+            "days_out": meta.get("days_out"),
+            "has_advisories": meta.get("advisory_summary", {}).get(
+                "has_advisories", False
+            ),
+            "advisory_counts": meta.get("advisory_summary", {}).get("counts", {}),
+            "situations": meta.get("situations", []),
+            "faithful": meta.get("faithful", True),
+            "synthetic": True,
+            "context_chars": meta.get("context_chars", len(p["files"].get("context.txt", ""))),
+        }
 
 
 def main():
@@ -251,13 +439,24 @@ def main():
         results = pruned
         print(f"After prune: {len(results)} fixtures (from {before})")
 
-    # Write output
+    # Write output. Preserve hand-authored synthetic fixtures (meta.json with
+    # "synthetic": true) across a regenerate — they are not derived from packs,
+    # so rmtree would silently destroy them (e.g. the injection fixture).
+    preserved = _read_synthetic_fixtures(args.output_dir)
+    if preserved:
+        print(f"Preserving {len(preserved)} synthetic fixture(s): "
+              f"{', '.join(p['id'] for p in preserved)}")
     if args.output_dir.exists():
         shutil.rmtree(args.output_dir)
     args.output_dir.mkdir(parents=True, exist_ok=True)
+    for p in preserved:
+        dst = args.output_dir / p["id"]
+        dst.mkdir(parents=True, exist_ok=True)
+        for name, content in p["files"].items():
+            (dst / name).write_text(content)
 
     # Write index
-    index = []
+    index = list(preserved_index(preserved))
     for r in sorted(results, key=lambda x: (x["meta"]["route"], x["meta"]["target_date"])):
         fid = make_fixture_id(r["meta"])
         fixture_dir = args.output_dir / fid
@@ -278,21 +477,36 @@ def main():
             "days_out": r["meta"]["days_out"],
             "has_advisories": r["meta"]["advisory_summary"].get("has_advisories", False),
             "advisory_counts": r["meta"]["advisory_summary"].get("counts", {}),
+            "situations": r["meta"].get("situations", []),
+            "faithful": r["meta"].get("faithful", False),
             "context_chars": r["meta"]["context_chars"],
         }
         index.append(idx_entry)
 
     (args.output_dir / "index.json").write_text(
-        json.dumps(index, indent=2, ensure_ascii=False)
+        json.dumps(index, indent=2, ensure_ascii=False) + "\n"
     )
 
     # Print summary
-    from collections import Counter
     assess_counts = Counter(r["meta"]["assessment"] for r in results)
     total_kb = sum(r["meta"]["context_chars"] for r in results) / 1024
+    faithful_n = sum(1 for r in results if r["meta"].get("faithful"))
     print(f"\nDataset written to {args.output_dir}/")
     print(f"  {len(results)} fixtures, {total_kb:.0f}KB total context")
     print(f"  Assessment distribution: {dict(assess_counts)}")
+    print(f"  Fidelity: {faithful_n} faithful (persisted) / "
+          f"{len(results) - faithful_n} reconstructed")
+
+    # Coverage matrix — how many fixtures cover each situation cell, so we can
+    # see which cells are thin and need targeted sourcing (parent #252 / #254).
+    sit_counts: Counter[str] = Counter()
+    for r in results:
+        sit_counts.update(r["meta"].get("situations", []))
+    print("  Situation coverage:")
+    for cell in SITUATION_VOCAB:
+        n = sit_counts.get(cell, 0)
+        flag = "  <-- empty" if n == 0 else ("  <-- thin" if n < 2 else "")
+        print(f"    {cell:24} {n:>3}{flag}")
 
 
 if __name__ == "__main__":

--- a/scripts/extract_digest_eval.py
+++ b/scripts/extract_digest_eval.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import logging
 import shutil
 from collections import Counter, defaultdict
 from datetime import date, datetime
@@ -36,6 +37,8 @@ from pathlib import Path
 from weatherbrief.digest.prompt_builder import build_digest_context
 from weatherbrief.models import ForecastSnapshot, RouteAdvisoriesManifest
 
+
+logger = logging.getLogger(__name__)
 
 PACKS_DIR = Path("data/packs")
 DEFAULT_OUTPUT = Path("tests/eval_data/digests")
@@ -146,6 +149,9 @@ def _load_dwd_translated(pack_dir: Path) -> list | None:
             out.append((block, entry.get("text_en", "") or ""))
         return out or None
     except Exception:
+        # e.g. a DWDDayBlock schema change — fall back to a context without the
+        # DWD section, but leave a breadcrumb so it's diagnosable.
+        logger.debug("_load_dwd_translated failed for %s", pack_dir, exc_info=True)
         return None
 
 
@@ -218,12 +224,25 @@ def extract_one(pack_dir: Path) -> dict | None:
     else:
         target_time = datetime.fromisoformat(f"{snapshot.target_date}T09:00:00")
 
+    # Load the digest and skip long-range outlooks *before* touching the
+    # context — they are a different output type (LongRangeDigest:
+    # outlook/outlook_reason, no GREEN/AMBER/RED assessment) with its own
+    # contract, so the WeatherDigest eval/guardrails don't apply. Doing the
+    # skip first avoids reading/rebuilding a context we're about to discard
+    # (outputs.py persists digest_context.txt for longrange packs too).
+    # Long-range gets its own eval track later (see project_longrange_outlook).
+    digest = json.loads((pack_dir / "digest.json").read_text())
+    if "outlook" in digest or digest.get("assessment") not in (
+        "GREEN", "AMBER", "RED"
+    ):
+        return None
+
     # Prefer the persisted context (byte-faithful to what the LLM saw). Fall
     # back to best-effort reconstruction for older packs that predate
     # digest_context.txt — splicing the DWD overview back in when available.
     persisted = pack_dir / "digest_context.txt"
     if persisted.exists():
-        context = persisted.read_text()
+        context = persisted.read_text(encoding="utf-8")
         faithful = True
         context_source = "persisted"
     else:
@@ -235,18 +254,6 @@ def extract_one(pack_dir: Path) -> dict | None:
         )
         faithful = False
         context_source = "reconstructed"
-
-    # Load existing digest output
-    digest = json.loads((pack_dir / "digest.json").read_text())
-
-    # Skip long-range outlooks — they are a different output type
-    # (LongRangeDigest: outlook/outlook_reason, no GREEN/AMBER/RED assessment)
-    # with its own contract, so the WeatherDigest eval/guardrails don't apply.
-    # Long-range gets its own eval track later (see project_longrange_outlook).
-    if "outlook" in digest or digest.get("assessment") not in (
-        "GREEN", "AMBER", "RED"
-    ):
-        return None
 
     # Build metadata
     route = " -> ".join(wp.icao for wp in snapshot.route.waypoints)
@@ -302,7 +309,10 @@ def _read_synthetic_fixtures(output_dir: Path) -> list[dict]:
             continue
         if not meta.get("synthetic"):
             continue
-        files = {f.name: f.read_text() for f in child.iterdir() if f.is_file()}
+        files = {
+            f.name: f.read_text(encoding="utf-8")
+            for f in child.iterdir() if f.is_file()
+        }
         preserved.append({"id": child.name, "files": files})
     return preserved
 
@@ -310,7 +320,9 @@ def _read_synthetic_fixtures(output_dir: Path) -> list[dict]:
 def preserved_index(preserved: list[dict]):
     """Yield index entries for preserved synthetic fixtures."""
     for p in preserved:
-        meta = json.loads(p["files"]["meta.json"])
+        # meta.json is guaranteed present by _read_synthetic_fixtures (it only
+        # includes dirs where meta_path.exists()); the default is just defensive.
+        meta = json.loads(p["files"].get("meta.json", "{}"))
         yield {
             "id": p["id"],
             "assessment": meta.get("assessment"),
@@ -453,7 +465,7 @@ def main():
         dst = args.output_dir / p["id"]
         dst.mkdir(parents=True, exist_ok=True)
         for name, content in p["files"].items():
-            (dst / name).write_text(content)
+            (dst / name).write_text(content, encoding="utf-8")
 
     # Write index
     index = list(preserved_index(preserved))
@@ -462,12 +474,12 @@ def main():
         fixture_dir = args.output_dir / fid
         fixture_dir.mkdir(parents=True, exist_ok=True)
 
-        (fixture_dir / "context.txt").write_text(r["context"])
+        (fixture_dir / "context.txt").write_text(r["context"], encoding="utf-8")
         (fixture_dir / "digest.json").write_text(
-            json.dumps(r["digest"], indent=2, ensure_ascii=False)
+            json.dumps(r["digest"], indent=2, ensure_ascii=False), encoding="utf-8"
         )
         (fixture_dir / "meta.json").write_text(
-            json.dumps(r["meta"], indent=2, ensure_ascii=False)
+            json.dumps(r["meta"], indent=2, ensure_ascii=False), encoding="utf-8"
         )
 
         idx_entry = {
@@ -484,24 +496,28 @@ def main():
         index.append(idx_entry)
 
     (args.output_dir / "index.json").write_text(
-        json.dumps(index, indent=2, ensure_ascii=False) + "\n"
+        json.dumps(index, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
     )
 
-    # Print summary
-    assess_counts = Counter(r["meta"]["assessment"] for r in results)
-    total_kb = sum(r["meta"]["context_chars"] for r in results) / 1024
-    faithful_n = sum(1 for r in results if r["meta"].get("faithful"))
+    # Print summary over the combined index (pack-derived + preserved synthetic)
+    # so counts match what was actually written.
+    assess_counts = Counter(e.get("assessment") for e in index)
+    total_kb = sum(e.get("context_chars", 0) for e in index) / 1024
+    faithful_n = sum(1 for e in index if e.get("faithful"))
     print(f"\nDataset written to {args.output_dir}/")
-    print(f"  {len(results)} fixtures, {total_kb:.0f}KB total context")
+    print(f"  {len(index)} fixtures ({len(preserved)} synthetic), "
+          f"{total_kb:.0f}KB total context")
     print(f"  Assessment distribution: {dict(assess_counts)}")
-    print(f"  Fidelity: {faithful_n} faithful (persisted) / "
-          f"{len(results) - faithful_n} reconstructed")
+    print(f"  Fidelity: {faithful_n} faithful / "
+          f"{len(index) - faithful_n} reconstructed")
 
     # Coverage matrix — how many fixtures cover each situation cell, so we can
     # see which cells are thin and need targeted sourcing (parent #252 / #254).
+    # Accumulate from the combined index so preserved synthetic fixtures count
+    # too — otherwise a cell only covered by a synthetic fixture reads "empty".
     sit_counts: Counter[str] = Counter()
-    for r in results:
-        sit_counts.update(r["meta"].get("situations", []))
+    for entry in index:
+        sit_counts.update(entry.get("situations", []))
     print("  Situation coverage:")
     for cell in SITUATION_VOCAB:
         n = sit_counts.get(cell, 0)

--- a/src/weatherbrief/digest/guardrails.py
+++ b/src/weatherbrief/digest/guardrails.py
@@ -89,7 +89,9 @@ _NUMBER_RE = re.compile(r"\d[\d,]*")
 # model dumping 2x the longest real output). Conciseness/style is the LLM
 # judge's job (#255), not this deterministic layer. Observed maxima (non-
 # longrange): assessment_reason 525ch/2s, synoptic 1485ch/7s, specific_concerns
-# 2563ch/24s, trend 1368ch/10s, watch_items 1496ch/19s.
+# 2563ch/24s, trend 1368ch/10s, watch_items 1496ch/19s. Caps sit ~1.5x above
+# those, except assessment_reason (700/525 ≈ 1.33x) where the round number is a
+# touch tighter but still a generous backstop for a one-sentence field.
 @dataclass(frozen=True)
 class _FieldBound:
     min_chars: int

--- a/src/weatherbrief/digest/guardrails.py
+++ b/src/weatherbrief/digest/guardrails.py
@@ -80,15 +80,16 @@ _NUMBER_RE = re.compile(r"\d[\d,]*")
 # different model or prompt variant that still respects the contract passes —
 # they exist to catch egregious violations, not to police style.
 #
-# Calibrated against the real distribution of shipped prod digests (~35 packs):
-# observed maxima were assessment_reason 484ch/1s, synoptic 883ch/4s,
-# specific_concerns 1529ch/21s, trend 1022ch/8s, watch_items 1177ch/16s. The
-# only fields the prompt explicitly limits are assessment_reason ("one
-# sentence") and synoptic ("2-3 sentences") — those keep tight, contract-backed
-# bounds. The free-form fields (specific_concerns/trend/watch_items) carry no
-# prompt length contract, so their caps sit ~1.4x above observed max purely as a
-# runaway backstop, not a style cop. (See #253: earlier bounds were tuned to the
-# 3 committed fixtures and false-positived on the broader real distribution.)
+# These are RUNAWAY BACKSTOPS, not style policing. Length/sentence bounds are
+# inherently fragile — every prompt or model change shifts the output length
+# distribution, and a too-tight cap then false-positives on legitimate output
+# (we hit this twice: first tuned to 3 fixtures, then to a Feb/Mar sample that
+# the more verbose June packs exceeded). So caps sit ~1.5x above the observed
+# max across the real prod distribution and only catch egregious blow-ups (a
+# model dumping 2x the longest real output). Conciseness/style is the LLM
+# judge's job (#255), not this deterministic layer. Observed maxima (non-
+# longrange): assessment_reason 525ch/2s, synoptic 1485ch/7s, specific_concerns
+# 2563ch/24s, trend 1368ch/10s, watch_items 1496ch/19s.
 @dataclass(frozen=True)
 class _FieldBound:
     min_chars: int
@@ -97,14 +98,11 @@ class _FieldBound:
 
 
 _FIELD_BOUNDS: dict[str, _FieldBound] = {
-    # Prompt: "One sentence." Allow 2 to tolerate model phrasing.
-    "assessment_reason": _FieldBound(min_chars=10, max_chars=600, max_sentences=2),
-    # Prompt: "2-3 sentences." Allow generous headroom over observed 883ch/4s.
-    "synoptic": _FieldBound(min_chars=10, max_chars=1300, max_sentences=7),
-    # Free-form, no prompt length contract — runaway backstop only.
-    "specific_concerns": _FieldBound(min_chars=1, max_chars=2200, max_sentences=30),
-    "trend": _FieldBound(min_chars=1, max_chars=1600, max_sentences=14),
-    "watch_items": _FieldBound(min_chars=1, max_chars=1800, max_sentences=24),
+    "assessment_reason": _FieldBound(min_chars=10, max_chars=700, max_sentences=3),
+    "synoptic": _FieldBound(min_chars=10, max_chars=2200, max_sentences=11),
+    "specific_concerns": _FieldBound(min_chars=1, max_chars=3800, max_sentences=38),
+    "trend": _FieldBound(min_chars=1, max_chars=2000, max_sentences=16),
+    "watch_items": _FieldBound(min_chars=1, max_chars=2200, max_sentences=30),
 }
 
 # Fuzzy traceability tolerance: an output figure is "traceable" if some context

--- a/src/weatherbrief/digest/llm_digest.py
+++ b/src/weatherbrief/digest/llm_digest.py
@@ -343,6 +343,12 @@ def run_digest(
     # LangSmith trace payloads small), so we attach it post-graph instead.
     result["dwd_translated"] = dwd_translated
 
+    # Carry the exact context string (the user message sent to the LLM) out for
+    # persistence. Saving it in the pack lets the digest eval (#254) build
+    # byte-faithful fixtures — the reconstructed-from-snapshot context omits the
+    # text-forecast / previous-digest sections the LLM actually saw.
+    result["digest_context"] = context
+
     return result
 
 

--- a/src/weatherbrief/tasks/outputs.py
+++ b/src/weatherbrief/tasks/outputs.py
@@ -311,6 +311,16 @@ def run_llm_digest(
         if dwd_translated and pack_dir:
             _save_dwd_overview(pack_dir, dwd_translated)
 
+        # Persist the exact context string sent to the LLM so the digest eval
+        # (#254) can build byte-faithful fixtures. Cheap (~2-6 KB text) and
+        # best-effort: a failure here must never break digest generation.
+        digest_context = digest_result.get("digest_context")
+        if digest_context and pack_dir:
+            try:
+                (pack_dir / "digest_context.txt").write_text(digest_context)
+            except Exception:
+                logger.warning("Failed to save digest context", exc_info=True)
+
         return DigestResult(
             path=digest_path,
             text=digest_result["digest_text"],

--- a/src/weatherbrief/tasks/outputs.py
+++ b/src/weatherbrief/tasks/outputs.py
@@ -317,7 +317,9 @@ def run_llm_digest(
         digest_context = digest_result.get("digest_context")
         if digest_context and pack_dir:
             try:
-                (pack_dir / "digest_context.txt").write_text(digest_context)
+                (pack_dir / "digest_context.txt").write_text(
+                    digest_context, encoding="utf-8"
+                )
             except Exception:
                 logger.warning("Failed to save digest context", exc_info=True)
 

--- a/tests/test_digest_assertions.py
+++ b/tests/test_digest_assertions.py
@@ -87,15 +87,31 @@ def test_fixtures_present():
     assert FIXTURE_IDS, f"no committed digest fixtures found under {EVAL_DIR}"
 
 
+# Two guardrails compare the output against the context: fabricated-source and
+# number-traceability. They are only meaningful when the fixture's context is
+# byte-faithful to what the LLM actually saw. Reconstructed back-catalog
+# fixtures (meta ``faithful: false``) omit the text-forecast / previous-digest
+# sections, so a legitimate DWD citation or a figure drawn from a text forecast
+# would false-positive. We skip those two checks for non-faithful fixtures; the
+# fidelity-independent checks (structure, coordinate leak) always run. See #254.
+def _is_faithful(meta: dict) -> bool:
+    # Default True so legacy fixtures without the flag are still fully checked.
+    return meta.get("faithful", True)
+
+
 @pytest.mark.parametrize("fixture_id", FIXTURE_IDS)
 def test_baseline_passes_all_guardrails(fixture_id):
     """Every recorded baseline output must satisfy all guardrails.
 
     This is the acceptance gate: it must pass on the current briefer_v1.md
-    baseline outputs.
+    baseline outputs. Context-dependent checks are skipped for reconstructed
+    (non-faithful) fixtures — see the module note above.
     """
-    digest, context, _ = _load(fixture_id)
-    violations = run_guardrails(digest, context)
+    digest, context, meta = _load(fixture_id)
+    if _is_faithful(meta):
+        violations = run_guardrails(digest, context)
+    else:
+        violations = check_structure(digest) + check_coordinate_leak(digest)
     assert not violations, f"{fixture_id} violated guardrails:\n{_fmt(violations)}"
 
 
@@ -108,14 +124,18 @@ def test_no_coordinate_leak(fixture_id):
 
 @pytest.mark.parametrize("fixture_id", FIXTURE_IDS)
 def test_no_fabricated_sources(fixture_id):
-    digest, context, _ = _load(fixture_id)
+    digest, context, meta = _load(fixture_id)
+    if not _is_faithful(meta):
+        pytest.skip(f"{fixture_id} context is reconstructed (not byte-faithful)")
     violations = check_fabricated_sources(digest, context)
     assert not violations, f"{fixture_id} cited an absent source:\n{_fmt(violations)}"
 
 
 @pytest.mark.parametrize("fixture_id", FIXTURE_IDS)
 def test_number_traceability(fixture_id):
-    digest, context, _ = _load(fixture_id)
+    digest, context, meta = _load(fixture_id)
+    if not _is_faithful(meta):
+        pytest.skip(f"{fixture_id} context is reconstructed (not byte-faithful)")
     violations = check_number_traceability(digest, context)
     assert not violations, f"{fixture_id} has untraceable numbers:\n{_fmt(violations)}"
 

--- a/tests/test_digest_assertions.py
+++ b/tests/test_digest_assertions.py
@@ -71,10 +71,13 @@ FIXTURE_IDS = _committed_fixture_ids()
 
 def _load(fixture_id: str) -> tuple[dict, str, dict]:
     d = EVAL_DIR / fixture_id
-    digest = json.loads((d / "digest.json").read_text())
-    context = (d / "context.txt").read_text()
+    digest = json.loads((d / "digest.json").read_text(encoding="utf-8"))
+    context = (d / "context.txt").read_text(encoding="utf-8")
     meta_path = d / "meta.json"
-    meta = json.loads(meta_path.read_text()) if meta_path.exists() else {}
+    meta = (
+        json.loads(meta_path.read_text(encoding="utf-8"))
+        if meta_path.exists() else {}
+    )
     return digest, context, meta
 
 


### PR DESCRIPTION
## Phase 2 foundation for the digest eval set (#254, parent #252)

This is the **engineering foundation** for Phase 2 — fixture fidelity, situation coverage, and the tooling around them. **Golden-labeling stays with you (SME)** and comes after, once we have faithful fixtures to label.

### The root fix: byte-faithful context capture
The digest eval's fixtures were rebuilt from the snapshot only, omitting the text-forecast / DWD-translation / previous-digest sections the LLM actually saw (the cause of the guardrail false-positives in #253). Now:
- `run_digest` carries the exact context string out; `outputs.py` persists it as `digest_context.txt` in each pack (best-effort, ~2–6 KB on a 72 MB pack — negligible, and it's in `DATA_DIR`, not git).
- All **future** packs yield byte-faithful fixtures by construction. (Existing packs have none yet, so today's reconstructed set is still lossy — tagged as such.)

### `extract_digest_eval.py`
- Prefer persisted context; reconstruct best-effort for the back-catalog (splice the DWD overview back in) and **tag each fixture `faithful` vs `reconstructed`**.
- **Situation tagging + coverage-matrix report** so we can see which cells are thin and source against them.
- **Preserve hand-authored synthetic fixtures** across a regenerate (rmtree would otherwise delete the injection fixture etc.).
- **Skip long-range outlooks** (`LongRangeDigest` — different schema/contract; its own eval track later).

### Guardrails + tests
- Length/sentence bounds reset to generous **runaway backstops** (~1.5× the real prod max). Tight caps kept false-positiving as the output-length distribution shifted (we recalibrated twice) — style/conciseness belongs to the LLM judge (#255), not this deterministic layer.
- Context-dependent checks (fabricated-source, number-traceability) **skip reconstructed fixtures**; structure + coordinate-leak always run.

### 🔎 Findings surfaced by running guardrails against real packs
- **~12% of real digests (13/110) leak raw lat/lon** (`4°E`, `51°N`, `55°N`, …) into output, violating the prompt's "convert coordinates to plain references" promise. The coordinate-leak guardrail passes on the 3 hand-authored fixtures but catches this immediately on real data. **Worth its own prompt-fix issue** — not addressed here.
- Long-range digests need their own eval track (skipped for now).
- 11 old packs fail to load (pre-existing lowercase `mvfr` enum) — reduces back-catalog yield.

### Scope / what's committed
5 files (tooling + guardrails + tests). The bulk reconstructed fixtures are **gitignored** (transitional, ~1 MB) and intentionally **not** committed — the curated, golden-labeled set grows from faithful packs post-deploy. Committed guardrail gate is green (27 passed); related digest tests green (18 passed).

Part of #254 · parent #252
