### PR TITLE
Use candidate TAF (when available) for alternate-minima qualification

### DIFF
--- a/designs/alternate-requirement.md
+++ b/designs/alternate-requirement.md
@@ -50,8 +50,12 @@ tasks/alternate_requirement.py      ← WIRING (the only euro_aip / airports-DB 
   run_alternate_requirement(snapshot, airports_db_path)
     _build_destination_window()     ← destination TAF (WeatherReport.from_taf +
                                        WeatherAnalyzer.applicable_trends) else NWP
+    _collect_candidate_tafs()       ← reuse route_observations TAFs + fetch the gaps
+    _fetch_candidate_tafs()         ← RouteWeatherService (corridor=1) for gap ICAOs
+    _candidate_taf_window()         ← per-candidate TAF window (reuses _build_destination_window)
     _destination_approach_class()   ← airport.procedures_query.approaches().most_precise()
     → writes snapshot.alternates.alternate_requirement + per-candidate .faa/.easa
+      (per-candidate qual from a TAF covering the ETA when available, else NWP)
 
 models/alternate_requirement.py     ← BandVerdict, TriggerVerdict, CriterionAssessment,
                                        RegAlternateTrigger, AlternateQual, AlternateRequirement
@@ -68,7 +72,7 @@ without euro_aip installed.
 | Destination raw TAF (D-0 only) | `snapshot.route_observations.airports[*].taf_raw` (matched on `obs.icao == destination`) |
 | Destination NWP fallback (D-2/D-1) | `RouteAlternates.destination_ceiling_ft` / `destination_visibility_m` — the destination's NWP-consensus assessment at ETA, stored by `run_alternates` (worst across models) |
 | Destination ETA | `RouteAlternates.eta` (rounded ETA hour) |
-| Candidate ceiling/vis | `AlternateAirport.ceiling_ft` / `.visibility_m` (NWP-consensus, `mode="worst"`) |
+| Candidate ceiling/vis | A candidate TAF covering its ETA when available (D-0; reused from `route_observations` or gap-fetched), else `AlternateAirport.ceiling_ft` / `.visibility_m` (NWP-consensus, `mode="worst"`). `AlternateQual.source` records which. |
 | Candidate / destination approach class | `best_approach_type` (candidates) / `procedures_query.approaches().most_precise()` (destination) |
 
 The NWP fallback deliberately reuses the alternates stage's own destination
@@ -109,6 +113,21 @@ An IFR flight needs a destination alternate **unless**, for ETA−1h..ETA+1h:
 No IAP at destination → must be VMC (proxy ceiling **1500 ft** / 5000 m). This is a
 far higher bar than selection minima, so an IFR destination requires an alternate.
 `EASA_DEST_CEILING_MARGIN_FT=1000`, `EASA_DEST_VIS_M=5000`.
+
+**Candidate forecast source (D-0 TAF, mirroring the destination trigger).** The
+per-candidate qualification prefers a **TAF covering the candidate's ETA** over the
+NWP consensus — the same TAF-else-NWP precedence the destination trigger uses, via
+the same `_build_destination_window` / `build_window` machinery (TEMPO/PROB
+worst-case policy, CAVOK handling, all identical). Candidate TAFs are sourced
+**reuse-first, fetch-the-gaps**: `_collect_candidate_tafs` reuses any TAF already in
+`snapshot.route_observations` (the 30 nm METAR/TAF corridor) and explicitly fetches
+the rest via `RouteWeatherService` with a minimal corridor (`tasks/verification.py`'s
+arbitrary-ICAO pattern). The whole TAF path is gated on `route_observations` being
+present (D-0 only) — at D-1/D-2 a current TAF would not cover the ETA, so candidates
+stay on NWP. `AlternateQual.source` (`"taf"` | `"nwp"`) records which fed each
+verdict; the network fetch is wrapped so a failure degrades silently to NWP. A TAF
+that parses but yields neither ceiling nor visibility does **not** override a valid
+NWP consensus (guards against a degenerate parse flipping a candidate to a fail).
 
 ### Alternate selection — NCO.OP.143 (does candidate X qualify?)
 Tiered on the approach DH; **visibility is a fixed value per tier**:
@@ -184,6 +203,11 @@ window with how it was treated (`AlternateRequirement.main_body_ceiling_ft` /
     mirrors the per-candidate `ceiling_basis` but with the *trigger* margin —
     EASA `"{class}: est DH {lo}–{hi} ft + 1000 ft margin (NCO.OP.140)"`, FAA
     `"fixed 2000 ft / 3 SM trigger (14 CFR 91.169)"`.
+  - **Per-candidate forecast source.** Each `AlternateQual` carries `source`
+    (`"taf"` | `"nwp"`); the qual popup shows a "Based on: TAF (forecast)" /
+    "NWP consensus (model estimate)" line, and the text-digest candidate row gets a
+    `via TAF` / `via model` tag — mirroring the destination banner's
+    `(forecast)`/`(model estimate)` badge.
   - **Per-candidate requirement provenance.** Each `AlternateQual` carries a
     display-only `ceiling_basis` string explaining *why* the required ceiling band
     is what it is, rendered as a muted second line under the required value in the
@@ -222,13 +246,14 @@ window with how it was treated (`AlternateRequirement.main_body_ceiling_ft` /
 
 Surfaced via `AlternateRequirement.caveats`: EASA requirements are computed from
 estimated plate minima expressed as a range (band reflects that uncertainty;
-forecast inputs are real); per-candidate qualification uses NWP consensus not a
-TAF; `source="nwp"` triggers are model estimates; planning guidance only.
+forecast inputs are real); per-candidate qualification uses a TAF when one covers
+the candidate's ETA window (D-0) and NWP consensus otherwise (per-candidate
+`AlternateQual.source` records which); `source="nwp"` triggers are model
+estimates; planning guidance only.
 
 ## Out of scope / follow-ups
 
 - User-entered Field-16 alternate list.
-- Fetching TAFs for the divert candidates themselves.
 - Real plate minima from a procedures DB (would replace the proxy ranges and
   shrink Marginal toward exact Yes/No).
 - Route advisory evaluator (GREEN/AMBER/RED), isolated-aerodrome fuel rules.

--- a/src/weatherbrief/analysis/alternate_requirement.py
+++ b/src/weatherbrief/analysis/alternate_requirement.py
@@ -716,8 +716,15 @@ def compute_faa_qual(
     visibility_m: float | None,
     approach_type: str | None,
     has_iap: bool,
+    *,
+    source: str = "nwp",
 ) -> AlternateQual:
-    """FAA per-candidate alternate minima (ILS→600-2, else→800-2, no-IAP→VFR)."""
+    """FAA per-candidate alternate minima (ILS→600-2, else→800-2, no-IAP→VFR).
+
+    ``source`` records where the forecast ceiling/visibility came from ("taf"
+    when a TAF covered the ETA window, else "nwp"); it is provenance only and
+    never changes the verdict.
+    """
     proxy = proxy_for_approach(approach_type, has_iap)
     if not has_iap or proxy is None:
         cl = ch = FAA_ALT_VFR_CEILING_FT
@@ -749,6 +756,7 @@ def compute_faa_qual(
         reason=_qual_reason(verdict, ceiling_c, vis_c, "SM", vfr_only=vfr_only),
         ceiling=ceiling_c,
         visibility=vis_c,
+        source=source,
         ceiling_basis=basis,
     )
 
@@ -758,12 +766,18 @@ def compute_easa_qual(
     visibility_m: float | None,
     approach_type: str | None,
     has_iap: bool,
+    *,
+    source: str = "nwp",
 ) -> AlternateQual:
     """EASA NCO.OP.143 alternate planning minima.
 
     DH<250 ft (ILS) → ceiling DH+200 / vis 1500 m; DH>=250 ft (RNP / non-
     precision) → ceiling DH+400 / vis 3000 m; no IAP → ceiling 2000 ft / vis
     5000 m. The DH proxy range yields a ceiling band; visibility is a fixed bar.
+
+    ``source`` records where the forecast ceiling/visibility came from ("taf"
+    when a TAF covered the ETA window, else "nwp"); provenance only, never
+    affects the verdict.
     """
     proxy = proxy_for_approach(approach_type, has_iap)
     if not has_iap or proxy is None:
@@ -798,5 +812,6 @@ def compute_easa_qual(
         reason=_qual_reason(verdict, ceiling_c, vis_c, "m", vfr_only=vfr_only),
         ceiling=ceiling_c,
         visibility=vis_c,
+        source=source,
         ceiling_basis=basis,
     )

--- a/src/weatherbrief/digest/text.py
+++ b/src/weatherbrief/digest/text.py
@@ -456,6 +456,12 @@ def _format_route_alternates(alt: RouteAlternates) -> list[str]:
             if v == "likely" and (a.flight_category or "").upper() in ("VFR", "MVFR"):
                 v = "yes"
             bits.append(f"EASA {v}")
+        # Provenance of the qualifying forecast (FAA/EASA share the same source).
+        qual_src = (a.faa or a.easa).source if (a.faa or a.easa) is not None else None
+        if qual_src == "taf":
+            bits.append("via TAF")
+        elif qual_src == "nwp":
+            bits.append("via model")
         lines.append(f"  {a.icao}: " + ", ".join(str(b) for b in bits if b))
 
     lines.append("")

--- a/src/weatherbrief/models/alternate_requirement.py
+++ b/src/weatherbrief/models/alternate_requirement.py
@@ -97,6 +97,12 @@ class AlternateQual(BaseModel):
     reason: str
     ceiling: CriterionAssessment
     visibility: CriterionAssessment
+    # Provenance of the forecast ceiling/visibility the verdict was computed
+    # from: ``"taf"`` when an aviation TAF covered the candidate's ETA window
+    # (D-0), else ``"nwp"`` for the NWP-consensus model estimate. Mirrors the
+    # destination trigger's ``source`` so the UI/digest can badge "(forecast)"
+    # vs "(model estimate)" per candidate.
+    source: Literal["taf", "nwp"] = "nwp"
     # Human-readable provenance of the ceiling requirement — explains *why* the
     # required band is what it is (approach class · estimated DH + alternate
     # margin for EASA; fixed regulatory value for FAA). Display-only.

--- a/src/weatherbrief/tasks/alternate_requirement.py
+++ b/src/weatherbrief/tasks/alternate_requirement.py
@@ -51,7 +51,8 @@ _CAVEATS = [
     "EASA requirements are computed from estimated plate minima expressed as a "
     "range; the Likely/Marginal/Unlikely band reflects that uncertainty. "
     "Forecast ceiling/visibility inputs are real.",
-    "Per-candidate qualification uses NWP consensus, not a TAF.",
+    "Per-candidate qualification uses a TAF when one covers the candidate's ETA "
+    "window (D-0), and NWP consensus otherwise.",
     "Planning guidance only — not an operational minima computation or a "
     "go/no-go decision.",
 ]
@@ -258,6 +259,90 @@ def _build_destination_window(
     return no_forecast_window(), []
 
 
+def _candidate_taf_window(taf_raw: str | None, eta: datetime) -> CeilingVisWindow | None:
+    """Build a TAF-only window for a divert candidate at the divert ETA.
+
+    Reuses the destination window builder (same TEMPO/PROB worst-case policy) but
+    ignores the NWP fallback: returns the window only when a TAF actually covered
+    the ETA (``source == "taf"``), else ``None`` so the caller keeps the
+    NWP-consensus ceiling/vis. A parse failure or an empty TAF also yields
+    ``None``.
+    """
+    if not taf_raw:
+        return None
+    window, _ = _build_destination_window(taf_raw, eta, None, None)
+    # Require the TAF window to carry at least one usable value. A string that
+    # parses but yields neither ceiling nor visibility (e.g. an unparseable TAF
+    # body) must not flip a candidate to a failing verdict — keep the valid NWP
+    # consensus in that case. Real TAFs covering the ETA always carry a base
+    # visibility (or CAVOK, which sets a high visibility).
+    if (
+        window.source == "taf"
+        and window.has_forecast
+        and (window.ceiling_ft is not None or window.visibility_m is not None)
+    ):
+        return window
+    return None
+
+
+def _fetch_candidate_tafs(icaos: list[str], airports_db_path: str) -> dict[str, str]:
+    """Fetch raw TAFs for candidate ICAOs not already covered by the route corridor.
+
+    Uses the same euro_aip ``RouteWeatherService`` path as ``run_route_weather``
+    with a minimal corridor (just enough to resolve the named airports — the
+    pattern ``tasks/verification.py`` uses for arbitrary ICAO lists). Returns an
+    ``icao -> taf_raw`` map. Never raises: a network/source failure degrades the
+    affected candidates to the NWP-consensus path.
+    """
+    if not icaos:
+        return {}
+    try:
+        from euro_aip.briefing.weather.route_weather import RouteWeatherService
+
+        from weatherbrief.airports import _load_airport_model
+
+        model = _load_airport_model(airports_db_path)
+        service = RouteWeatherService()
+        result = service.fetch_route_weather(
+            route_icaos=list(icaos),
+            corridor_nm=1,  # minimal — just resolve the named airports themselves
+            model=model,
+        )
+        out: dict[str, str] = {}
+        for raw in result.airports:
+            taf = raw.latest_taf
+            if taf is not None and taf.raw_text:
+                out[raw.icao] = taf.raw_text
+        return out
+    except Exception:
+        logger.warning(
+            "alternate_requirement: candidate TAF fetch failed; candidates fall "
+            "back to NWP consensus", exc_info=True,
+        )
+        return {}
+
+
+def _collect_candidate_tafs(obs, candidate_icaos: set[str], airports_db_path: str) -> dict[str, str]:
+    """Assemble ``icao -> taf_raw`` for the candidates: reuse first, fetch the gaps.
+
+    TAFs are only meaningful at D-0; ``obs`` (``route_observations``) is present
+    only then, so its absence gates the whole TAF path off for D-1/D-2 (where a
+    current TAF would not cover the ETA window anyway).
+    """
+    if obs is None or not candidate_icaos:
+        return {}
+    taf_by_icao: dict[str, str] = {}
+    # Reuse TAFs already fetched along the route corridor (zero extra network).
+    for a in obs.airports:
+        if a.icao in candidate_icaos and a.taf_raw:
+            taf_by_icao[a.icao] = a.taf_raw
+    # Explicitly fetch the candidates the corridor didn't cover.
+    gap = [icao for icao in candidate_icaos if icao not in taf_by_icao]
+    if gap:
+        taf_by_icao.update(_fetch_candidate_tafs(gap, airports_db_path))
+    return taf_by_icao
+
+
 def _destination_approach_class(airports_db_path: str, dest_icao: str) -> tuple[str | None, bool]:
     """Look up the destination's most-precise approach type + IAP presence.
 
@@ -337,13 +422,25 @@ def run_alternate_requirement(snapshot, airports_db_path: str, *, now: datetime 
         computed_at=now,
     )
 
-    # 5. Per-candidate qualification from each candidate's consensus ceiling/vis.
+    # 5. Per-candidate qualification. Prefer a TAF covering the candidate's ETA
+    #    (D-0 only; reuse the route-corridor TAFs, fetch the gaps), exactly as the
+    #    destination trigger above does — falling back to the NWP-consensus
+    #    ceiling/vis that run_alternates assembled. `source` records which path
+    #    fed the verdict so the UI/digest can badge "(forecast)" vs "(model)".
+    taf_by_icao = _collect_candidate_tafs(
+        obs, {c.icao for c in alternates.alternates}, airports_db_path,
+    )
     for cand in alternates.alternates:
+        taf_window = _candidate_taf_window(taf_by_icao.get(cand.icao), eta)
+        if taf_window is not None:
+            ceiling_ft, vis_m, source = taf_window.ceiling_ft, taf_window.visibility_m, "taf"
+        else:
+            ceiling_ft, vis_m, source = cand.ceiling_ft, cand.visibility_m, "nwp"
         cand.faa = compute_faa_qual(
-            cand.ceiling_ft, cand.visibility_m, cand.best_approach_type,
-            cand.has_instrument_approach,
+            ceiling_ft, vis_m, cand.best_approach_type,
+            cand.has_instrument_approach, source=source,
         )
         cand.easa = compute_easa_qual(
-            cand.ceiling_ft, cand.visibility_m, cand.best_approach_type,
-            cand.has_instrument_approach,
+            ceiling_ft, vis_m, cand.best_approach_type,
+            cand.has_instrument_approach, source=source,
         )

--- a/tests/test_alternate_requirement.py
+++ b/tests/test_alternate_requirement.py
@@ -562,10 +562,120 @@ class TestWiringSmoke:
         assert cand_good.faa.verdict == BandVerdict.LIKELY  # ILS, 4000/9999
         assert cand_good.easa.verdict == BandVerdict.LIKELY
         assert cand_marginal.easa.verdict == BandVerdict.MARGINAL  # 1000 in 800–1300
+        # No route_observations (D-2/D-1) → candidates qualify on NWP consensus.
+        assert cand_good.faa.source == "nwp"
+        assert cand_good.easa.source == "nwp"
 
     def test_no_alternates_is_noop(self):
         snap = SimpleNamespace(alternates=None)
         run_alternate_requirement(snap, "/nonexistent/nav.db")  # must not raise
+
+
+# --- Candidate TAF path (D-0): reuse route-corridor TAFs, fetch the gaps ------
+
+def _obs(airports):
+    """Minimal route_observations stand-in: only .airports is read."""
+    return SimpleNamespace(airports=airports)
+
+
+class TestCandidateTafQualification:
+    """A TAF covering a candidate's ETA overrides its NWP-consensus qualification."""
+
+    def _alt_with_candidate(self, cand):
+        return RouteAlternates(
+            destination_icao="EIDW", destination_category="VFR",
+            destination_ceiling_ft=4000, destination_visibility_m=9999,
+            corridor_nm=40, radius_nm=50,
+            eta=datetime(2026, 6, 13, 12, tzinfo=timezone.utc),
+            alternates=[cand],
+        )
+
+    def test_reused_taf_overrides_nwp_consensus(self):
+        # NWP consensus says LIFR (would be UNLIKELY even for ILS minima), but a
+        # TAF covering the ETA reports CAVOK → the candidate qualifies on the TAF.
+        cand = AlternateAirport(
+            icao="EGAC", lat=54.6, lon=-5.9, distance_from_dest_nm=10, position="after",
+            flight_category="LIFR", ceiling_ft=100, visibility_m=400,
+            has_instrument_approach=True, best_approach_type="ILS",
+        )
+        alt = self._alt_with_candidate(cand)
+        obs = _obs([SimpleNamespace(
+            icao="EGAC", taf_raw="TAF EGAC 130600Z 1306/1406 28010KT CAVOK",
+        )])
+        snap = SimpleNamespace(
+            route=SimpleNamespace(destination=SimpleNamespace(icao="EIDW")),
+            alternates=alt, route_observations=obs,
+        )
+
+        run_alternate_requirement(snap, "/nonexistent/nav.db")
+
+        assert cand.faa.source == "taf"
+        assert cand.easa.source == "taf"
+        # CAVOK clears the fixed/estimated minima → LIKELY, not the NWP UNLIKELY.
+        assert cand.faa.verdict == BandVerdict.LIKELY
+        assert cand.easa.verdict == BandVerdict.LIKELY
+
+    def test_gap_candidate_taf_is_fetched(self, monkeypatch):
+        # Candidate is NOT in route_observations → the gap-fetch path supplies
+        # its TAF. We stub the network fetch to keep the test offline.
+        cand = AlternateAirport(
+            icao="EGAA", lat=54.0, lon=-6.0, distance_from_dest_nm=30, position="after",
+            flight_category="LIFR", ceiling_ft=100, visibility_m=400,
+            has_instrument_approach=True, best_approach_type="ILS",
+        )
+        alt = self._alt_with_candidate(cand)
+        # route_observations present (D-0) but without this candidate.
+        obs = _obs([SimpleNamespace(icao="EISOMEWHERE", taf_raw="TAF ...")])
+        snap = SimpleNamespace(
+            route=SimpleNamespace(destination=SimpleNamespace(icao="EIDW")),
+            alternates=alt, route_observations=obs,
+        )
+
+        import weatherbrief.tasks.alternate_requirement as mod
+        called = {}
+
+        def fake_fetch(icaos, db_path):
+            called["icaos"] = list(icaos)
+            return {"EGAA": "TAF EGAA 130600Z 1306/1406 28010KT CAVOK"}
+
+        monkeypatch.setattr(mod, "_fetch_candidate_tafs", fake_fetch)
+
+        run_alternate_requirement(snap, "/nonexistent/nav.db")
+
+        assert called["icaos"] == ["EGAA"]  # only the uncovered candidate
+        assert cand.faa.source == "taf"
+        assert cand.faa.verdict == BandVerdict.LIKELY
+
+    def test_no_taf_for_candidate_keeps_nwp(self, monkeypatch):
+        # route_observations present but no TAF for the candidate and gap-fetch
+        # finds none → NWP consensus is kept (source stays "nwp").
+        cand = AlternateAirport(
+            icao="EGAC", lat=54.6, lon=-5.9, distance_from_dest_nm=10, position="after",
+            flight_category="VFR", ceiling_ft=4000, visibility_m=9999,
+            has_instrument_approach=True, best_approach_type="ILS",
+        )
+        alt = self._alt_with_candidate(cand)
+        obs = _obs([SimpleNamespace(icao="EGAC", taf_raw=None)])
+        snap = SimpleNamespace(
+            route=SimpleNamespace(destination=SimpleNamespace(icao="EIDW")),
+            alternates=alt, route_observations=obs,
+        )
+
+        import weatherbrief.tasks.alternate_requirement as mod
+        monkeypatch.setattr(mod, "_fetch_candidate_tafs", lambda icaos, db: {})
+
+        run_alternate_requirement(snap, "/nonexistent/nav.db")
+
+        assert cand.faa.source == "nwp"
+        assert cand.faa.verdict == BandVerdict.LIKELY  # VFR clears on NWP too
+
+    def test_candidate_taf_window_rejects_empty_parse(self):
+        from weatherbrief.tasks.alternate_requirement import _candidate_taf_window
+        eta = datetime(2026, 6, 13, 12, tzinfo=timezone.utc)
+        # An unparseable body yields neither ceiling nor visibility → no override.
+        assert _candidate_taf_window("not a taf", eta) is None
+        assert _candidate_taf_window("", eta) is None
+        assert _candidate_taf_window(None, eta) is None
 
 
 class TestConditionalExtraction:

--- a/web/ts/managers/briefing-ui.ts
+++ b/web/ts/managers/briefing-ui.ts
@@ -1254,9 +1254,14 @@ function renderQualPopup(apt: AlternateAirport, regime: 'faa' | 'easa'): string 
       + 'below even the least demanding estimate.'
     : 'FAA alternate minima are fixed regulatory values (ILS → 600 ft &amp; 2 SM, otherwise '
       + '800 ft &amp; 2 SM; a VFR proxy applies with no instrument approach).';
+  const srcLabel = q.source === 'taf'
+    ? 'TAF (forecast)' : q.source === 'nwp' ? 'NWP consensus (model estimate)' : '';
+  const srcHtml = srcLabel
+    ? `<p class="muted">Based on: <strong>${escapeHtml(srcLabel)}</strong></p>` : '';
   return `
     <div class="popup-header"><h3>${escapeHtml(apt.icao)} — ${escapeHtml(title)}</h3></div>
     <p class="muted">Overall: <strong>${escapeHtml(qualLabelFor(q, regime, apt.flight_category))}</strong></p>
+    ${srcHtml}
     <table class="band-table">
       <thead><tr><th>Criterion</th><th>Forecast</th><th>Required (estimated)</th></tr></thead>
       <tbody>${renderCriterionRow(q.ceiling, q.ceiling_basis)}${renderCriterionRow(q.visibility)}</tbody>

--- a/web/ts/store/types.ts
+++ b/web/ts/store/types.ts
@@ -620,6 +620,9 @@ export interface AlternateQual {
   reason: string;
   ceiling: CriterionAssessment;
   visibility: CriterionAssessment;
+  /** Forecast provenance: 'taf' when a TAF covered the candidate's ETA window
+   * (D-0), else 'nwp' for the NWP-consensus model estimate. */
+  source: 'taf' | 'nwp';
   /** Provenance of the ceiling requirement (approach class · est DH + margin). */
   ceiling_basis?: string | null;
 }


### PR DESCRIPTION
Per-candidate alternate qualification previously used only the NWP-consensus
ceiling/visibility, even at D-0 when TAFs exist — asymmetric with the
destination trigger, which already prefers a TAF covering the ETA.

Mirror that precedence for candidates: prefer a TAF covering the candidate's
ETA, falling back to NWP consensus. TAFs are sourced reuse-first / fetch-the-gaps
(_collect_candidate_tafs): reuse any TAF already in route_observations, then
gap-fetch the rest via RouteWeatherService (minimal corridor, the verification.py
arbitrary-ICAO pattern). The whole TAF path is gated on route_observations being
present (D-0 only); the network fetch degrades silently to NWP on failure.

Reuses _build_destination_window/build_window so TEMPO/PROB, CAVOK and None
semantics are identical to the destination path. A degenerate parse (neither
ceiling nor visibility) does not override a valid NWP consensus.

AlternateQual gains a source ("taf" | "nwp") field; surfaced in the qual popup
("Based on: TAF (forecast)" / "NWP consensus (model estimate)") and the text
digest candidate row (via TAF / via model).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GCYi8HAkmxUqLP15iTq9La