### PR TITLE
docs(help,readme): document recent features; soften disclaimer; gate support section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,27 @@
-# WeatherBrief
+# Flyfun Weather
 
 **Medium-range aviation weather assessment for cross-country GA flights in Europe**
 
-WeatherBrief fetches forecast data from multiple numerical weather prediction (NWP) models, performs aviation-specific analysis (icing, turbulence, convection, clouds), and presents everything side-by-side so pilots can compare models and start forming an early view of what conditions will look like from D-7 through D-0.
+> The Python package and module are named `weatherbrief`; the product is **Flyfun Weather**.
 
-> **Disclaimer** — This is an early-stage exploratory tool, not built by a meteorologist. It is meant to help pilots explore the wealth of NWP data available and see how models converge (or diverge) on metrics that matter for flying. It is **not** a substitute for official weather briefings, MET reports, or professional meteorological advice. Always consult official sources before flying.
+Flyfun Weather fetches forecast data from multiple numerical weather prediction (NWP) models, performs aviation-specific analysis (icing, turbulence, convection, clouds), and presents everything side-by-side so pilots can compare models and start forming an early view of what conditions will look like from D-7 through D-0.
+
+> **Disclaimer** — Flyfun Weather is built to help and support flight planning and decision-making, giving pilots an early, multi-model picture of the weather and surfacing the factors that matter for a route. It relies on automated analysis and AI, which can make mistakes or miss things, and it has not been reviewed by a professional meteorologist. It is **not** a substitute for official weather briefings, MET reports, or professional meteorological advice. Always consult official sources before flying — the pilot in command remains the sole decision-maker.
 
 ## What it does
 
-- **Multi-model forecasting** — Fetches from 6 NWP models via Open-Meteo (GFS, ECMWF IFS, DWD ICON, UKMO, Meteo-France, Best Match) at 8 pressure levels along your route
-- **~40 derived metrics** — From raw NWP data, derives thermodynamic indices (CAPE, CIN, Lifted Index, K-Index, etc.), cloud layers, icing zones, CAT turbulence risk, convective potential, wind shear, and more using MetPy
-- **13 route advisories** — Deterministic hazard evaluators (icing escape, FIKI icing, freezing level, cloud top, VMC cruise, VFR/IFR feasibility, flight category, turbulence, mountain wind, airport wind, convective, model agreement) with per-model GREEN/AMBER/RED severity grading
-- **Model comparison** — Side-by-side divergence scoring across 15 metrics so you can see where models agree and where they don't
-- **Interactive cross-section** — Canvas-rendered visualization with 17 toggleable layers (terrain, clouds, icing, SFIP, CAT, inversions, convective, temperature lines, stability levels, NWP cloud bands) and hover/click interaction
-- **Skew-T soundings** — Per-waypoint, per-model diagrams with CAPE/CIN shading, hodograph, and indices panel
+- **Multi-model forecasting** — Fetches 6 NWP models via Open-Meteo (GFS, ECMWF IFS, DWD ICON, UKMO, Meteo-France, Best Match) at 8 pressure levels along your route, with high-resolution **GRIB2 enrichment** (upper-air soundings, cloud microphysics) direct from ECMWF IFS, DWD ICON-EU, and NOAA GFS where coverage allows
+- **~85 derived metrics** — From raw NWP data, derives thermodynamic indices (CAPE, CIN, Lifted Index, K-Index, etc.), cloud layers, icing zones (multiple methods), CAT turbulence risk, convective potential, wind shear, and more using MetPy
+- **20+ route advisories across 11 categories** — Deterministic hazard evaluators (icing incl. freezing precipitation, cloud, en-route visibility/precipitation, turbulence incl. wave-corroborated mountain wind, convective incl. terminal convective & LLWS, winds-aloft trip impact, airport conditions incl. density altitude, feasibility, model quality, fronts, sun/daylight) with per-model GREEN/AMBER/RED severity grading and worst/majority aggregation
+- **D-0 observations** — METAR/TAF for departure/arrival airports plus route **SIGMETs** (area hazards), with a deterministic banner flagging conditions that have worsened since the last refresh
+- **Weather-based alternates** — When a destination is marginal (D-2 inward), surfaces nearby divert candidates that fix the deficient axis (category/wind/crosswind), classified before/after along the route, plus a regulatory **"is an alternate required?"** estimate (FAA 14 CFR 91.169 + EASA Part-NCO)
+- **Model comparison** — Side-by-side divergence scoring so you can see where models agree and where they don't
+- **Interactive cross-section** — Canvas-rendered visualization with ~25 toggleable layers (terrain, clouds, icing, SFIP, CAT, inversions, convective, temperature lines, stability levels, NWP cloud bands), switchable themes, a compare-across-models mode, and hover/click interaction
+- **Route map & route graph** — Leaflet route map with an altitude slider and metric-colored segments (incl. an "alternate required?" mode), plus a scalar route graph sharing the cross-section's x-axis
+- **Skew-T soundings** — Per-waypoint, per-model diagrams: a dynamic canvas Skew-T with a multi-variable side panel and overlay bands, a multi-model compare mode, and the classic MetPy PNG (CAPE/CIN shading, hodograph, indices panel)
 - **GRAMET cross-section** — From the Autorouter API (requires credentials)
-- **LLM-powered synopsis** — Optional AI-generated weather narrative via Claude or ChatGPT, combining DWD synoptic text with quantitative analysis
+- **LLM-powered synopsis** — Optional AI-generated weather narrative via Claude or ChatGPT, combining DWD synoptic text with quantitative analysis; beyond the high-resolution horizon it switches to a cheaper, confidence-led **long-range early outlook**
+- **Navigation database** — Resolves non-airport waypoints (5-letter fixes, navaids, free-route points) from ~95,900 deduplicated points built from four free public sources, refreshed on the 28-day AIRAC/NASR cycle
 - **PDF/HTML reports & email** — Self-contained briefing reports you can download or email to yourself
 - **Terrain-aware** — SRTM 90m elevation profiles for mountain crossing risk assessment
 
@@ -34,22 +40,27 @@ Not all variables are available from all models (e.g., omega/vertical velocity i
 
 ## Route Advisories
 
-Each advisory evaluates a specific weather hazard along your route, per model:
+Each advisory evaluates a specific weather hazard along your route, per model. The set has grown to 20+ evaluators across 11 categories; a representative selection:
 
 | Advisory | What it checks |
 |----------|---------------|
 | Icing Escape | Can you descend below freezing to escape icing? (terrain clearance) |
 | FIKI Icing | Icing layer thickness and severity for FIKI-equipped aircraft |
 | Freezing Level | Freezing level vs terrain (mountain icing risk) |
+| Freezing Precipitation | Freezing rain / ice pellets in the column |
 | Cloud Top | Can you fly above the clouds? (cloud top vs flight ceiling) |
 | VMC Cruise | Cloud coverage at cruise altitude (VFR viability) |
-| VFR Feasibility | Overall VFR viability considering ceiling, visibility, and cloud layers |
-| IFR Feasibility | IFR flight viability considering ceiling and visibility minimums |
+| En-route Visibility | Visibility and precipitation along the route |
+| VFR / IFR Feasibility | Overall VFR/IFR viability vs ceiling, visibility, and cloud layers |
 | Flight Category | VFR/MVFR/IFR/LIFR classification at departure, en-route, and arrival |
 | Turbulence | Clear Air Turbulence + strong vertical motion at cruise |
-| Mountain Wind | Orographic/rotor wind risk near significant terrain |
-| Airport Wind | Surface wind and crosswind at departure and arrival airports |
+| Mountain Wind | Orographic/rotor wind risk near significant terrain (wave-corroborated) |
+| Winds Aloft | Headwind/tailwind trip impact along the route |
+| Airport Conditions | Surface wind, gusts, crosswind, and density altitude at departure/arrival |
+| Terminal Convective / LLWS | Low-level wind shear and convective risk near the airports |
 | Convective | Thunderstorm development risk from CAPE and instability indices |
+| Fronts | Frontal passages crossing the route |
+| Sun | Daylight / sun position relative to the flight window |
 | Model Agreement | How much do the models agree with each other? |
 
 Advisory parameters are user-tunable (terrain margins, percentage thresholds, etc.) and can be recalculated without re-fetching weather data.
@@ -72,7 +83,7 @@ src/weatherbrief/
 ├── analysis/
 │   ├── wind.py       # Headwind/crosswind decomposition
 │   ├── comparison.py # Multi-model divergence scoring
-│   ├── advisories/   # 13 route hazard evaluators (registry pattern)
+│   ├── advisories/   # 20+ route hazard evaluators (registry pattern)
 │   └── sounding/     # MetPy thermodynamic analysis (clouds, icing, CAT, convective)
 ├── digest/           # Text digest, Skew-T plots, LLM briefing (LangGraph)
 ├── api/              # FastAPI app (auth, flights, packs, preferences, admin)
@@ -83,23 +94,26 @@ src/weatherbrief/
 
 web/
 ├── ts/
-│   ├── visualization/  # Canvas cross-section renderer (17 layers)
+│   ├── visualization/  # Canvas cross-section renderer (~25 layers)
 │   ├── store/          # Zustand state management
 │   ├── managers/       # DOM rendering (briefing, advisories, flights)
 │   ├── adapters/       # API communication
 │   └── data/           # Metrics catalog, display config
 ├── css/style.css
 ├── index.html          # Flights list
-├── briefing.html       # Briefing report (10 collapsible sections)
+├── briefing.html       # Briefing report (collapsible sections)
 ├── flight.html         # Single flight detail / edit
+├── maps.html           # Pan-European forecast map
 ├── settings.html       # User preferences + advisory tuning
 ├── admin.html          # User approval + usage tracking
 ├── login.html          # Authentication page
-├── help.html           # User help / FAQ
+├── help.html           # User help / FAQ + What's New
+├── donate.html         # Optional support / donations (Stripe)
+├── cost-summary.html   # Service cost transparency (admin)
 └── user-costs.html     # Personal usage & cost tracking
 
 configs/              # LLM digest configuration and prompts
-designs/              # Design documentation (21 docs)
+designs/              # Design documentation (40+ docs)
 tests/                # pytest test suite
 ```
 
@@ -188,11 +202,13 @@ The Docker image runs as a non-root user (UID 2000). Data is persisted via volum
 
 ## Data Sources
 
-- **NWP forecasts** — [Open-Meteo](https://open-meteo.com/) (free, open-source weather API)
+- **NWP forecasts** — [Open-Meteo](https://open-meteo.com/) (free, open-source weather API), plus high-resolution GRIB2 enrichment direct from ECMWF IFS, DWD ICON-EU, and NOAA GFS where available
+- **METAR / TAF & SIGMETs** — [NOAA Aviation Weather Center](https://aviationweather.gov/data/api/) for day-of observations, terminal forecasts, and route SIGMETs
 - **Terrain elevation** — [SRTM](https://www.usgs.gov/centers/eros/science/usgs-eros-archive-digital-elevation-shuttle-radar-topography-mission-srtm-1) 90m resolution via srtm.py
 - **Airport database** — [euro-aip](https://github.com/roznet/rzflight) (European AIP data)
+- **Navigation waypoints** — Eurocontrol FRA, OpenNav, OurAirports NAVAIDs, and FAA NASR (free public sources; ~95,900 deduplicated points on the 28-day AIRAC/NASR cycle)
 - **GRAMET cross-sections** — [Autorouter](https://www.autorouter.aero/) (requires free account)
-- **Synoptic text forecasts** — DWD (German Weather Service) open data
+- **Synoptic text forecasts** — DWD (German Weather Service) open data; NWS Area Forecast Discussions for US routes
 
 ## How the Analysis Works
 
@@ -205,7 +221,7 @@ The pipeline fetches NWP data for ~20 interpolated points along your route (ever
 - **Convective risk** — from CAPE thresholds with CIN modulation and severe weather modifiers (shear, hail indicators)
 - **Vertical motion** — omega profiles classified as quiescent, synoptic ascent/subsidence, oscillating, or convective
 
-These per-point results feed into the 13 route-level advisory evaluators that produce the GREEN/AMBER/RED hazard assessment.
+These per-point results feed into the 20+ route-level advisory evaluators that produce the GREEN/AMBER/RED hazard assessment.
 
 ## Known Limitations
 
@@ -217,7 +233,7 @@ These per-point results feed into the 13 route-level advisory evaluators that pr
 
 ## Design Documentation
 
-The `designs/` directory contains 21 detailed design documents covering architecture, data models, analysis methods, metrics catalog, and implementation plans. Start with `designs/architecture.md` for the system overview.
+The `designs/` directory contains 40+ detailed design documents covering architecture, data models, analysis methods, metrics catalog, and implementation plans. Start with `designs/architecture.md` for the system overview, or `designs/INDEX.md` for the module map.
 
 ## AI Acknowledgment
 

--- a/web/help.html
+++ b/web/help.html
@@ -62,8 +62,13 @@
     <div class="help-section">
       <h3>Getting Started</h3>
       <div id="help-tour-cta-host"></div>
+      <p>
+        Flyfun Weather is updated frequently with new features and refinements. Check the
+        <a href="?tab=whats-new" data-tab-link="whats-new"><strong>What's New</strong></a>
+        tab to see the latest changes.
+      </p>
       <ol>
-        <li><strong>Create a flight</strong> on the Flights page by entering your waypoints (airports, navaids, or fixes), date, time, altitude, and ceiling.</li>
+        <li><strong>Create a flight</strong> on the Flights page by entering your waypoints (airports, navaids, or fixes), date, time, altitude, and ceiling. Flights can be planned up to about <strong>9 days ahead</strong> &mdash; the limit of the global model horizon.</li>
         <li><strong>Open the briefing</strong> by clicking the flight card. Flyfun Weather will fetch forecast data from each enabled model, run thermodynamic analysis, compute advisories, and generate a synopsis.</li>
         <li><strong>Refresh</strong> the briefing at any time to pull the latest available forecasts. Each refresh creates a new snapshot you can compare via the history dropdown.</li>
       </ol>
@@ -101,6 +106,14 @@
         derived from the worst-rated advisories. It's the headline read on your flight
         before you dig into the detail below.
       </p>
+      <p>
+        For flights more than about a week out &mdash; beyond the high-resolution model
+        horizon &mdash; the banner instead shows a dashed <strong>Early outlook</strong>
+        badge (<em>Trending Settled</em>, <em>Mixed Signals</em>, or
+        <em>Trending Unsettled</em>) rather than a green/amber/red verdict. This far ahead
+        the models only agree on the broad pattern, so the briefing gives a confidence-led
+        trend and tells you when more detailed analysis will become available.
+      </p>
 
       <h4>Route Advisories</h4>
       <p>
@@ -124,7 +137,7 @@
         <li><strong>Cloud &amp; Visibility</strong> &mdash; cloud base height relative to your ceiling, coverage, and visibility conditions at departure and arrival.</li>
         <li><strong>Turbulence &amp; Wind</strong> &mdash; vertical wind shear, crosswind components at departure and arrival airports, headwind/tailwind along the route.</li>
         <li><strong>Airport Conditions</strong> &mdash; surface wind, gusts, and crosswind at departure and arrival relative to available runways.</li>
-        <li><strong>Altitude Advisory</strong> &mdash; analyses conditions at multiple flight levels and suggests the best altitude considering winds, icing, turbulence, and cloud avoidance.</li>
+        <li><strong>Altitude Advisory</strong> &mdash; analyses conditions at multiple flight levels and suggests the best altitude considering winds, icing, turbulence, and cloud avoidance. An interactive <strong>altitude lever</strong> lets you probe other flight levels and instantly see how each advisory shifts versus your planned altitude.</li>
       </ul>
       <p>
         You can enable, disable, and tune the thresholds of each advisory in
@@ -132,12 +145,43 @@
         are used for icing and cloud detection.
       </p>
 
-      <h4>METAR/TAF Observations</h4>
+      <h4>METAR/TAF Observations &amp; SIGMETs</h4>
       <p>
         On the day of the flight, a METAR/TAF section is shown with current observations and
         TAF forecasts for your departure and arrival airports, fetched from official aviation
         weather sources. Useful for cross-referencing the NWP model output with real-time
         and near-term observations.
+      </p>
+      <p>
+        Alongside the airport observations, any <strong>SIGMETs</strong> that intersect your
+        route corridor (turbulence, icing, thunderstorms, mountain wave, etc.) are listed
+        with their hazard type, altitude band, and validity. When you refresh on the day of
+        the flight, a banner highlights any conditions that have <strong>worsened</strong>
+        since your last check &mdash; a degraded flight category, or a new or escalated
+        SIGMET &mdash; so changes don't slip by while the rest of the briefing stays put.
+      </p>
+
+      <h4>Weather-Based Alternates</h4>
+      <p>
+        As the flight gets close (about two days out), if your destination's forecast looks
+        marginal, Flyfun Weather suggests nearby <strong>alternate airports</strong> that
+        would fix the specific problem &mdash; a better flight category, lighter wind, or a
+        kinder crosswind. Each candidate is shown as reachable <strong>before</strong> the
+        destination (an early-decision diversion that avoids backtracking) or
+        <strong>after</strong> it, with the extra distance each option costs. These are
+        planning-grade divert ideas, not an operational alternate-minima calculation. Turn
+        them on with the <em>Alternates</em> preference in <a href="/settings.html">Settings</a>.
+      </p>
+
+      <h4>Is an Alternate Required?</h4>
+      <p>
+        For the destination, the briefing also estimates whether the regulations would
+        require you to <strong>file an alternate</strong>, computed two ways:
+        <strong>FAA</strong> (14 CFR 91.169 &mdash; a binary Yes/No) and <strong>EASA</strong>
+        Part-NCO (a <em>Likely / Marginal / Unlikely</em> confidence band). Because the
+        published plate minima aren't known, the unknown value is expressed as a plausible
+        range per approach type, which sets the width of the EASA band. Like the alternates
+        above, this is advisory planning guidance, never a go/no-go verdict.
       </p>
 
       <h4>Synopsis</h4>
@@ -263,7 +307,7 @@
       <ul>
         <li><strong>Language</strong> &mdash; choose the display language (English, French, German, Spanish).</li>
         <li><strong>Autorouter Credentials</strong> &mdash; enter your autorouter.aero username and password for GRAMET charts. Credentials are encrypted at rest.</li>
-        <li><strong>Usage &amp; Costs</strong> &mdash; view your briefing usage (this week, this month, and total) and per-briefing cost breakdown.</li>
+        <li><strong>Usage</strong> &mdash; view your briefing usage (this week, this month, and total).</li>
       </ul>
     </div>
 
@@ -425,6 +469,18 @@
       </p>
     </div>
 
+    <!-- Supporting the service (revealed by help-main.ts only when donations are enabled) -->
+    <div class="help-section" id="help-support-section" style="display:none;">
+      <h3>Supporting the Service</h3>
+      <p>
+        Flyfun Weather is free to use. Running the models, the analysis, and the AI briefings
+        does cost money, so if you find it useful you can optionally chip in from the
+        <a href="/donate.html">Support</a> page &mdash; every contribution helps keep the
+        service running for the whole pilot community. There is no paywall, and contributing
+        is entirely voluntary.
+      </p>
+    </div>
+
     <!-- Feedback -->
     <div class="help-section">
       <h3>Feedback</h3>
@@ -442,10 +498,17 @@
     <div class="help-section">
       <h3>Disclaimer</h3>
       <p>
-        Flyfun Weather is an <strong>experimental, non-certified</strong> tool for educational
-        and planning purposes. It is not a substitute for official weather briefings from
-        your national aviation authority. Always cross-check with official sources (METARs,
-        TAFs, SIGMETs, AIRMETs) before flying.
+        Flyfun Weather is designed to <strong>help and support your flight planning and
+        decision-making</strong> &mdash; giving you an early, multi-model picture of the
+        weather and surfacing the factors that matter for your route. It relies on automated
+        analysis and AI, which can make mistakes or miss things, so treat its output as one
+        input among many rather than the final word.
+      </p>
+      <p>
+        It is not a substitute for official weather briefings from your national aviation
+        authority. Always cross-check with official sources (METARs, TAFs, SIGMETs, AIRMETs)
+        before flying. The <strong>pilot in command remains the sole decision-maker</strong>
+        and is responsible for the safe conduct of the flight.
       </p>
       <p class="muted" style="margin-top: 0.5rem;">
         This application was built with AI assistance (Claude, Anthropic).

--- a/web/ts/help-main.ts
+++ b/web/ts/help-main.ts
@@ -48,6 +48,10 @@ async function init(): Promise<void> {
     }
   }
 
+  // Reveal the "Supporting the service" section only when donations are
+  // enabled (Stripe configured). Mirrors the gating on the Settings page.
+  maybeShowSupportSection();
+
   // Render the data-driven Data Sources & Models table in summary mode for
   // the guide tab. The full-detail table mounts lazily on tab switch.
   const dataSourcesHost = document.getElementById('data-sources-table-host');
@@ -70,6 +74,22 @@ async function init(): Promise<void> {
   const initialTab = params.get('tab');
   if (initialTab === 'whats-new' || initialTab === 'data-sources') {
     switchTab(initialTab, 'deeplink');
+  }
+}
+
+/** Show the "Supporting the service" help section only when the global
+ *  donations flag is set (Stripe configured). Non-critical: any failure
+ *  (e.g. signed-out 401) leaves the section hidden. */
+async function maybeShowSupportSection(): Promise<void> {
+  try {
+    const { fetchPreferences } = await import('./adapters/preferences-adapter');
+    const prefs = await fetchPreferences();
+    if (prefs.donations_enabled) {
+      const el = document.getElementById('help-support-section');
+      if (el) el.style.display = '';
+    }
+  } catch {
+    // non-critical — leave the section hidden
   }
 }
 

--- a/web/ts/help-main.ts
+++ b/web/ts/help-main.ts
@@ -36,6 +36,11 @@ async function init(): Promise<void> {
 
     // Load unseen count for the tab badge
     loadTabBadge();
+
+    // Reveal the "Supporting the service" section only when donations are
+    // enabled (Stripe configured). Gated to signed-in users since the flag
+    // requires auth to read. Mirrors the gating on the Settings page.
+    maybeShowSupportSection();
   } else {
     const info = document.getElementById('user-info');
     if (info) {
@@ -47,10 +52,6 @@ async function init(): Promise<void> {
       `;
     }
   }
-
-  // Reveal the "Supporting the service" section only when donations are
-  // enabled (Stripe configured). Mirrors the gating on the Settings page.
-  maybeShowSupportSection();
 
   // Render the data-driven Data Sources & Models table in summary mode for
   // the guide tab. The full-detail table mounts lazily on tab switch.


### PR DESCRIPTION
Help page (web/help.html):
- Getting Started: link to the What's New tab ("updated frequently") and note
  the ~9-day booking horizon
- Overall Assessment: explain the long-range "Early outlook" badge (Trending
  Settled / Mixed Signals / Trending Unsettled) shown beyond the high-res horizon
- METAR/TAF: add route SIGMETs and the deterministic worsened-conditions banner
- New sections: Weather-Based Alternates and "Is an Alternate Required?"
  (FAA 91.169 + EASA Part-NCO)
- Altitude Advisory: mention the interactive altitude lever
- Settings: reword the usage bullet (drop stale per-briefing cost-breakdown wording)
- Add a "Supporting the Service" section, hidden by default and revealed by
  help-main.ts only when donations are enabled (Stripe configured)
- Soften the disclaimer: drop "experimental / non-certified"; frame as
  decision-support that uses AI (which can err), with the PIC as sole decision-maker

README:
- Rebrand to "Flyfun Weather" (note the weatherbrief package name)
- Refresh counts/features: ~85 metrics, 20+ advisories across 11 categories,
  GRIB2 enrichment, ~25 cross-section layers
- Add D-0 obs + SIGMETs, weather-based alternates + regulatory alternate
  requirement, route map/graph, dynamic Skew-T, long-range early outlook,
  navigation waypoint database
- Update advisory table, data sources, project structure, and design-doc count
- Align the top disclaimer with the softened PIC-centric framing

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017oTfdxCXtHjEc7oGQCwfpe