### PR TITLE
Return all alternate candidates; move major-airport + distance filtering to the UI

### DIFF
--- a/designs/alternates.md
+++ b/designs/alternates.md
@@ -113,10 +113,18 @@ run_alternates(
 `ALT_POSITION_MARGIN_NM = 10.0`.
 
 Candidate selection: (1) geometry union of near-route corridor ∪ dest-radius;
-(2) drop departure + destination; (3) GA-appropriateness (exclude
-`large_airport`, `scheduled_service == "yes"`) + runway suitability (hard runway,
-length ≥ min); (4) cap to nearest `max_candidates` by dest distance; (5) fresh
-fetch + shared assembly at ETA; (6) **per-candidate** approach gate (below).
+(2) drop departure + destination; (3) runway suitability (hard runway, length ≥
+min); (4) cap to nearest `max_candidates` by dest distance; (5) fresh fetch +
+shared assembly at ETA; (6) **per-candidate** approach gate (below).
+
+> **No backend preference filtering (changed).** `large_airport` and
+> `scheduled_service` are **no longer dropped** server-side — that silently
+> excluded good IFR diversions (e.g. EGTE/Exeter: airline service, but a 6811 ft
+> ILS runway 3 nm off the corridor). The backend now **returns every reachable
+> candidate** and only flags `is_major = (type == "large_airport")`. Hiding
+> majors and limiting distance are **view** choices, applied client-side (see
+> "List-view controls"). Only genuine reachability/safety gates stay
+> server-side: hard runway, `min_runway_ft`, and the sub-VFR-no-approach gate.
 
 ### The candidate funnel: "evaluated" vs "shown"
 The summary count and the table row count are **two different stages**, and the
@@ -127,25 +135,51 @@ gap between them surprised a reader (e.g. *"25 candidates within 50 nm" but only
 |-------|--------------|-------------|
 | 1. Geometry | corridor (≤`corridor_nm`) ∪ dest-radius (≤`radius_nm`) | — |
 | 2. Drop self | remove departure + destination | — |
-| 3. GA-suitability | drop `large_airport`, scheduled service, no hard runway, runway `< min_runway_ft`, missing coords | — |
+| 3. Runway suitability | drop no hard runway, runway `< min_runway_ft`, missing coords (`large_airport` / scheduled service are **kept**, just flagged `is_major`) | — |
 | 4. Cap | nearest `max_candidates` (30) by dest distance | **`candidates_evaluated`** (the "N candidates" headline) |
 | 5. Weather fetch | drop any candidate with **no model snapshot** at the ETA hour (`_assess` → None) | — |
 | 6. Approach gate | drop a field that is **itself** MVFR/IFR/LIFR *and* has **no published IAP** (unreachable in those conditions); VFR always kept, any field with an IAP always kept | — |
-| → | survivors, ranked closest-first | **`len(alternates)`** (the table rows) |
+| → | survivors, ranked closest-first | **`len(alternates)`** (returned to the client) |
+| 7. View filters (client) | hide `is_major` (default on) + max-distance-from-dest (default 100 nm) | the **rows the pilot sees** |
 
 So **`candidates_evaluated` is the post-cap count (stage 4)**, *not* the number
-shown. The shown list is what survives stages 5–6. For a typical IFR destination
-the gate (stage 6) is the dominant reducer — most nearby fields are sub-VFR with
-no published approach. Worked example (EGTE, IFR ceiling 1597 ft): 25 evaluated →
-7 shown = 3 MVFR-with-approach + 4 VFR; the ~18 dropped are sub-VFR fields with no
-published instrument approach.
+returned. The returned list is what survives stages 5–6; the **shown** list is
+that minus the client-side view filters (stage 7). For a typical IFR destination
+the gate (stage 6) is the dominant server-side reducer — most nearby fields are
+sub-VFR with no published approach.
 
-The shown list is **not** filtered to "beats the destination" — it shows every
+**Cap × majors interaction:** because majors now reach stage 4, they compete for
+the 30 nearest-to-dest slots. The effect is minor (large_airports are rare within
+the corridor/radius) and the default-visible set — non-major fields closest to the
+destination — is exactly what the nearest-to-dest cap favours, so it survives.
+The distance selector's **"All"** means *all returned* candidates, still bounded
+by the stage-4 cap (it does not re-query the backend for a wider net).
+
+The returned list is **not** filtered to "beats the destination" — it shows every
 survivor with a per-row `dominates_destination` flag and `vs dest` Δ tags; the
 "which is the nearest *improvement*" question is answered separately by
-`nearest_improving`. The UI surfaces the evaluated→shown gap with a caption
-(`renderRouteAlternates`); `approach_filter_relaxed` (stage 6 graceful
-degradation) suppresses the gate entirely.
+`nearest_improving` (computed over the full returned set, **not** re-filtered by
+the view controls). `approach_filter_relaxed` (stage 6 graceful degradation)
+suppresses the gate entirely.
+
+### List-view controls
+`renderRouteAlternates` (web) renders two controls above the table, defaulting to
+a concise near-destination view; both are **session state** (persist across store
+re-renders, reset on reload), not user prefs:
+
+- **Hide major airports** (default **on**) — hides `is_major` rows
+  (`large_airport`: Heathrow/Gatwick/Manchester). Regional fields with airline
+  service (Exeter, Newquay, Bournemouth) are *not* major and stay visible. When
+  off, major rows carry a `MAJOR` chip.
+- **Within 50 / 100 / All nm** (default **100 nm**) — filters by
+  `distance_from_dest_nm`. 100 nm shows near-destination diversions (incl. Exeter
+  ≈ 63 nm) while hiding the far en-route/early-divert corridor candidates; "All"
+  shows everything returned.
+
+The summary line reports the breakdown (`N evaluated · M shown within Dnm · K
+major hidden · …`). The **text digest mirrors this default view** (hide major,
+≤ 100 nm; `_format_route_alternates` in `digest/text.py`), appending a
+`(+N more … — see web)` line when items are hidden.
 
 ### Per-candidate instrument-approach gate
 Applied **after** each candidate's own weather is assessed (not at
@@ -194,7 +228,8 @@ regulatory minima there.
 assessment: `flight_category`, `wind_speed_kt`, `crosswind_kt`, `headwind_kt`,
 `best_runway_id`, `ceiling_ft`, `visibility_m`, `agreement`, `per_model`;
 suitability: `has_instrument_approach`, `best_approach_type`, `longest_runway_ft`,
-`has_hard_runway`, `point_of_entry`; vs-dest flags: `better_category`,
+`has_hard_runway`, `point_of_entry`, `is_major` (== `large_airport`; hidden by
+default in the UI list controls); vs-dest flags: `better_category`,
 `better_wind`, `better_crosswind`, `dominates_destination`; regulatory:
 `faa`, `easa` — per-candidate alternate-minima qualification, filled by the
 **alternate-requirement post-step**, NOT by `run_alternates` — see below).

--- a/src/weatherbrief/digest/text.py
+++ b/src/weatherbrief/digest/text.py
@@ -394,6 +394,10 @@ def _format_route_sigmets(sig: RouteSigmets) -> list[str]:
     return lines
 
 
+# Digest mirrors the web default view: near-destination candidates only.
+_ALT_DIGEST_MAX_DIST_NM = 100.0
+
+
 def _format_route_alternates(alt: RouteAlternates) -> list[str]:
     """Format weather alternates for plain-text digest."""
     lines: list[str] = ["--- Weather Alternates ---"]
@@ -437,7 +441,15 @@ def _format_route_alternates(alt: RouteAlternates) -> list[str]:
         lines.append(f"  Nearest weather alternate ({label}): {p.icao}{dist}{pos}")
 
     lines.append("")
-    for a in alt.alternates[:8]:
+    # Mirror the web default view: hide major (large) airports and limit to the
+    # near-destination candidates (≤100 nm). The full set incl. major airports
+    # and far en-route fields is available on the web via the list controls.
+    visible = [
+        a for a in alt.alternates
+        if not a.is_major and a.distance_from_dest_nm <= _ALT_DIGEST_MAX_DIST_NM
+    ]
+    hidden = len(alt.alternates) - len(visible)
+    for a in visible[:8]:
         bits = [f"{a.distance_from_dest_nm:.0f}nm", a.position, a.flight_category]
         if a.crosswind_kt is not None:
             bits.append(f"xwind {a.crosswind_kt:.0f}kt")
@@ -463,6 +475,9 @@ def _format_route_alternates(alt: RouteAlternates) -> list[str]:
         elif qual_src == "nwp":
             bits.append("via model")
         lines.append(f"  {a.icao}: " + ", ".join(str(b) for b in bits if b))
+
+    if hidden > 0:
+        lines.append(f"  (+{hidden} more incl. major airports / >{_ALT_DIGEST_MAX_DIST_NM:.0f}nm — see web)")
 
     lines.append("")
     return lines

--- a/src/weatherbrief/models/alternates.py
+++ b/src/weatherbrief/models/alternates.py
@@ -64,6 +64,7 @@ class AlternateAirport(BaseModel):
     longest_runway_ft: int | None = None
     has_hard_runway: bool = False
     point_of_entry: bool = False  # customs/border crossing
+    is_major: bool = False  # type == large_airport — hidden by default in the UI
 
     # --- vs-destination flags ---
     better_category: bool = False

--- a/src/weatherbrief/tasks/alternates.py
+++ b/src/weatherbrief/tasks/alternates.py
@@ -65,11 +65,6 @@ def _haversine_nm(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
     return dist_nm
 
 
-def _is_scheduled_service(value: object) -> bool:
-    """True when an airport advertises scheduled commercial service."""
-    return str(value).strip().lower() == "yes"
-
-
 def _eta_hour(target_time: datetime, duration_hours: float) -> datetime:
     """Destination ETA rounded to the nearest whole UTC hour (the fetch sample hour)."""
     eta = target_time
@@ -278,14 +273,15 @@ def run_alternates(
     candidates.pop(dest.icao, None)
     candidates.pop(origin.icao, None)
 
-    # --- 3. GA-appropriateness + runway suitability ---
+    # --- 3. Runway suitability ---
+    # NB: large_airport / scheduled_service are NOT dropped here — they are
+    # returned and flagged (is_major, below) so the UI can hide them by default
+    # while letting the pilot reveal them. Only genuine reachability/safety
+    # filters (hard runway, min length, the sub-VFR-no-approach gate) stay
+    # server-side.
     filtered: list[dict] = []
     for c in candidates.values():
         ap = c["airport"]
-        if ap.type == "large_airport":
-            continue
-        if _is_scheduled_service(ap.scheduled_service):
-            continue
         if require_hard_runway and not ap.has_hard_runway:
             continue
         if (
@@ -442,6 +438,7 @@ def run_alternates(
             longest_runway_ft=ap.longest_runway_length_ft,
             has_hard_runway=bool(ap.has_hard_runway),
             point_of_entry=bool(ap.point_of_entry),
+            is_major=ap.type == "large_airport",
             better_category=better_category,
             better_wind=better_wind,
             better_crosswind=better_crosswind,

--- a/tests/test_alternates.py
+++ b/tests/test_alternates.py
@@ -2,7 +2,8 @@
 
 Covers:
 - geometry: before/after classification + the detour pair
-- candidate filters: instrument-approach gate, large_airport / scheduled exclusion
+- candidate filters: instrument-approach gate, runway suitability; major/scheduled
+  fields are returned and flagged (is_major), not excluded
 - consistency: the shared assembly yields the same category/crosswind as the
   forecast map's ``map_queries`` wrappers for a fixed snapshot ("Seam 2").
 """
@@ -266,7 +267,11 @@ def test_approach_gate_relaxed_when_no_procedure_data():
 # ---------------------------------------------------------------------------
 
 
-def test_large_airport_and_scheduled_service_excluded():
+def test_major_and_scheduled_returned_and_flagged():
+    """large_airport / scheduled_service are no longer dropped — they are
+    returned and flagged so the UI can hide them by default. Only is_major
+    (== large_airport) marks a candidate; scheduled-service regional fields
+    (e.g. EGTE Exeter) stay non-major and visible (the #-regression)."""
     route = _route()
     ok = _FakeAirport("EGPN", 55.50, -3.40)
     large = _FakeAirport("EGPK", 55.51, -4.59, type="large_airport")
@@ -284,7 +289,14 @@ def test_large_airport_and_scheduled_service_excluded():
     }
     result = _run(route, near, snaps)
     assert result is not None
-    assert {a.icao for a in result.alternates} == {"EGPN"}
+    # All three now survive (each has a hard runway, length and an approach).
+    by_icao = {a.icao: a for a in result.alternates}
+    assert set(by_icao) == {"EGPN", "EGPK", "EGPH"}
+    # Only the large_airport is flagged major.
+    assert by_icao["EGPK"].is_major is True
+    # A scheduled-service regional field is NOT major and stays visible.
+    assert by_icao["EGPH"].is_major is False
+    assert by_icao["EGPN"].is_major is False
 
 
 def test_short_runway_excluded():

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -3970,6 +3970,36 @@ label {
   font-weight: 600;
 }
 
+/* Major (airline-hub) marker — neutral grey, distinct from the improvement
+   tints; only visible once the pilot unchecks "Hide major airports". */
+.alt-tag-major {
+  background: rgba(120, 120, 120, 0.22);
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+/* List-view controls: hide-major + max-distance, above the candidate table. */
+.alt-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem 1.25rem;
+  align-items: center;
+  margin: 0.5rem 0 0.6rem;
+  font-size: 0.8rem;
+}
+
+.alt-control {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  color: var(--text-secondary);
+}
+
+.alt-control select {
+  font-size: 0.8rem;
+  padding: 0.1rem 0.3rem;
+}
+
 .alt-agree {
   font-size: 0.7rem;
   color: var(--text-tertiary, #888);

--- a/web/ts/managers/briefing-ui.ts
+++ b/web/ts/managers/briefing-ui.ts
@@ -1164,6 +1164,12 @@ export function renderRouteObservations(
 
 // --- Weather-based alternates (D-2 inward) ---
 
+// List-view controls (session state — persists across store re-renders, resets
+// on reload). Default to a concise near-destination view: hide major (large)
+// airports, limit to within 100 nm of the destination. `null` distance = "All".
+let altHideMajor = true;
+let altMaxDistNm: number | null = 100;
+
 function detourLabel(apt: AlternateAirport): string {
   if (apt.detour_early_nm == null && apt.detour_late_nm == null) return '—';
   const early = apt.detour_early_nm != null ? `${apt.detour_early_nm >= 0 ? '+' : ''}${Math.round(apt.detour_early_nm)}` : '?';
@@ -1506,21 +1512,30 @@ export function renderRouteAlternates(snapshot: ForecastSnapshot | null): void {
     : `<p class="muted">No weather alternate improves on the destination across the evaluated candidates.</p>`;
 
   const approachNote = alt.approach_filter_relaxed ? ', approach data unavailable' : '';
-  const shownCount = alt.alternates.length;
-  const summaryHtml = `<p class="obs-summary">${header} <span class="obs-fetch-time">${alt.candidates_evaluated} evaluated → ${shownCount} shown within ${Math.round(alt.radius_nm)}nm${approachNote}</span></p>`;
-  // Explain the evaluated→shown gap. The drop is the per-candidate
-  // instrument-approach gate (a field that is itself sub-VFR with no published
-  // approach is unreachable in those conditions) plus any with no ETA forecast.
-  const droppedCount = Math.max(0, alt.candidates_evaluated - shownCount);
-  const funnelHtml = droppedCount > 0
-    ? `<p class="muted alt-funnel-note">From ${alt.candidates_evaluated} GA-suitable fields within ${Math.round(alt.radius_nm)}nm (hard runway, no scheduled service), ${droppedCount} were filtered out — sub-VFR fields with no published instrument approach (unreachable in those conditions), or no forecast at ETA.</p>`
-    : '';
   const reqBannerHtml = altRequirementBanner(alt.alternate_requirement);
   const relaxedHtml = alt.approach_filter_relaxed
     ? `<p class="muted alt-caption">⚠️ No published-approach data is available for the candidates, so non-VFR fields could not be filtered by approach — confirm an approach independently.</p>`
     : '';
 
-  const rows = alt.alternates.map((apt) => {
+  // The backend returns ALL reachable candidates (incl. major airports and far
+  // en-route fields). The hide-major + max-distance controls below filter the
+  // *view* only — defaults give a concise near-destination list, the pilot can
+  // relax them to review everything.
+  const distSel = (v: number | null): string =>
+    altMaxDistNm === v ? ' selected' : '';
+  const controlsHtml = `
+    <div class="alt-controls">
+      <label class="alt-control"><input type="checkbox" id="alt-hide-major"${altHideMajor ? ' checked' : ''}> Hide major airports</label>
+      <label class="alt-control">Within
+        <select id="alt-max-dist">
+          <option value="50"${distSel(50)}>50 nm</option>
+          <option value="100"${distSel(100)}>100 nm</option>
+          <option value="all"${distSel(null)}>All</option>
+        </select>
+      </label>
+    </div>`;
+
+  const buildRow = (apt: AlternateAirport): string => {
     const tip = windTooltip(apt.best_runway_id, apt.crosswind_kt);
     const windStr = apt.wind_speed_kt != null ? `${Math.round(apt.wind_speed_kt)}kt` : '—';
     const xwStr = apt.crosswind_kt != null
@@ -1529,9 +1544,11 @@ export function renderRouteAlternates(snapshot: ForecastSnapshot | null): void {
       ? (apt.best_approach_type ? escapeHtml(apt.best_approach_type) : '✓') : '—';
     const agreeCat = apt.agreement?.['flight_category'];
     const agreeBadge = agreeCat ? ` <span class="alt-agree alt-agree-${agreeCat}">${escapeHtml(agreeCat)}</span>` : '';
+    const majorChip = apt.is_major
+      ? ` <span class="alt-tag alt-tag-major" title="Major airport (airline hub) — hidden by default">MAJOR</span>` : '';
     return `
       <tr>
-        <td class="obs-icao">${escapeHtml(apt.icao)} <button class="alt-info-btn" data-icao="${escapeHtml(apt.icao)}" title="Details" aria-label="info">i</button></td>
+        <td class="obs-icao">${escapeHtml(apt.icao)}${majorChip} <button class="alt-info-btn" data-icao="${escapeHtml(apt.icao)}" title="Details" aria-label="info">i</button></td>
         <td>${Math.round(apt.distance_from_dest_nm)}nm</td>
         <td>${escapeHtml(apt.position)} <span class="muted">(${detourLabel(apt)})</span></td>
         <td>${flightCatBadge(apt.flight_category)}${agreeBadge}</td>
@@ -1543,13 +1560,14 @@ export function renderRouteAlternates(snapshot: ForecastSnapshot | null): void {
         <td>${deltaTags(apt)}</td>
       </tr>
     `;
-  }).join('');
+  };
 
   el.innerHTML = `
-    ${summaryHtml}
+    <p class="obs-summary">${header} <span class="obs-fetch-time" id="alt-summary-counts"></span></p>
     ${reqBannerHtml}
     <p class="muted alt-caption">Planning-grade divert candidates that improve on the destination weather — not an operational alternate (no fuel, minima, NOTAM, customs or PPR check). Non-VFR fields are shown only with a published instrument approach.</p>
     ${relaxedHtml}
+    ${controlsHtml}
     ${picksHtml}
     <div class="table-scroll">
       <table class="band-table obs-table">
@@ -1567,11 +1585,64 @@ export function renderRouteAlternates(snapshot: ForecastSnapshot | null): void {
             <th>vs dest</th>
           </tr>
         </thead>
-        <tbody>${rows}</tbody>
+        <tbody id="alt-tbody"></tbody>
       </table>
     </div>
-    ${funnelHtml}
+    <p class="muted alt-funnel-note" id="alt-funnel"></p>
   `;
+
+  // Filter the *view* from module state and (re)paint the rows + counts. Wired
+  // to the controls below; also called once now for the initial paint.
+  const applyAltFilter = (): void => {
+    const withinDist = (a: AlternateAirport): boolean =>
+      altMaxDistNm == null || a.distance_from_dest_nm <= altMaxDistNm;
+    const visible = alt.alternates.filter((a) => (!altHideMajor || !a.is_major) && withinDist(a));
+    const hiddenMajor = alt.alternates.filter((a) => altHideMajor && a.is_major).length;
+    const hiddenDist = alt.alternates.filter((a) => (!altHideMajor || !a.is_major) && !withinDist(a)).length;
+
+    const tbody = $('alt-tbody');
+    if (tbody) {
+      tbody.innerHTML = visible.length
+        ? visible.map(buildRow).join('')
+        : `<tr><td colspan="10" class="muted">No candidates match the current filters — try “Hide major airports” off or a larger distance.</td></tr>`;
+    }
+
+    const distLabel = altMaxDistNm == null ? '' : ` within ${altMaxDistNm}nm`;
+    const hiddenBits: string[] = [];
+    if (hiddenMajor > 0) hiddenBits.push(`${hiddenMajor} major hidden`);
+    if (hiddenDist > 0) hiddenBits.push(`${hiddenDist} beyond ${altMaxDistNm}nm`);
+    const hiddenStr = hiddenBits.length ? ` · ${hiddenBits.join(' · ')}` : '';
+    const counts = $('alt-summary-counts');
+    if (counts) {
+      counts.textContent = `${alt.candidates_evaluated} evaluated · ${visible.length} shown${distLabel}${hiddenStr}${approachNote}`;
+    }
+
+    // Backend evaluated→returned gap (the reachability gate + missing ETA
+    // forecast). Distinct from the view filters above, which hide nothing
+    // permanently.
+    const droppedByBackend = Math.max(0, alt.candidates_evaluated - alt.alternates.length);
+    const funnel = $('alt-funnel');
+    if (funnel) {
+      funnel.textContent = droppedByBackend > 0
+        ? `${droppedByBackend} of ${alt.candidates_evaluated} GA-suitable fields (hard runway, within range) were dropped server-side — sub-VFR fields with no published instrument approach (unreachable in those conditions), or no forecast at ETA.`
+        : '';
+    }
+  };
+  applyAltFilter();
+
+  // Re-filter on control change. Controls are recreated each render, so fresh
+  // listeners each time — no stacking.
+  const hideMajorEl = $('alt-hide-major') as HTMLInputElement | null;
+  if (hideMajorEl) {
+    hideMajorEl.onchange = () => { altHideMajor = hideMajorEl.checked; applyAltFilter(); };
+  }
+  const maxDistEl = $('alt-max-dist') as HTMLSelectElement | null;
+  if (maxDistEl) {
+    maxDistEl.onchange = () => {
+      altMaxDistNm = maxDistEl.value === 'all' ? null : Number(maxDistEl.value);
+      applyAltFilter();
+    };
+  }
 
   // Assign (not addEventListener) so repeated renders from the store
   // subscription replace the handler rather than stacking duplicates.

--- a/web/ts/store/types.ts
+++ b/web/ts/store/types.ts
@@ -675,6 +675,7 @@ export interface AlternateAirport {
   longest_runway_ft: number | null;
   has_hard_runway: boolean;
   point_of_entry: boolean;
+  is_major: boolean;
   better_category: boolean;
   better_wind: boolean;
   better_crosswind: boolean;


### PR DESCRIPTION
## Why

The backend hard-dropped `large_airport` **and** `scheduled_service` candidates at the GA-suitability stage, silently excluding perfectly good IFR diversions. The trigger case: on an **EGTF→EGHQ** flight, **EGTE (Exeter)** — 3 nm off the route corridor, 6811 ft hard runway, ILS — was dropped purely because it carries scheduled airline service. Separately, on long flights the corridor produced a noisily large list of far en-route candidates.

## What changed

**Backend** — `tasks/alternates.py`, `models/alternates.py`
- Stop dropping `large_airport` / `scheduled_service`. Return every reachable candidate and only flag `is_major = (type == "large_airport")`.
- Genuine safety/reachability gates stay server-side: hard runway, `min_runway_ft`, and the per-candidate sub-VFR-no-approach gate.

**Frontend** — `briefing-ui.ts`, `store/types.ts`, `style.css`
- Two **view controls** above the candidate table (session state; defaults give a concise near-destination list the pilot can relax):
  - **Hide major airports** (default **on**) — hides `is_major` rows; revealed rows carry a `MAJOR` chip. Regional airline fields (Exeter, Newquay, Bournemouth) are **not** major and stay visible.
  - **Within 50 / 100 / All nm** (default **100**) — filters by `distance_from_dest_nm`. "All" = all returned (still bounded by the backend nearest-30 cap).
- Summary line reports the breakdown (`N evaluated · M shown within Dnm · K major hidden · …`).

**Digest** — `digest/text.py`
- Text digest mirrors the default web view (hide major, ≤100 nm) with a `(+N more incl. major airports / >100nm — see web)` overflow line.

**Docs / tests**
- `designs/alternates.md`: updated funnel (stage 3 no longer drops major/scheduled; new client-side stage 7 view filters), worked example, cap×majors note, list-view controls section.
- `tests/test_alternates.py`: rewrote the exclusion test → `test_major_and_scheduled_returned_and_flagged` (majors/scheduled now returned and flagged). 8/8 pass.

## Verification

Live `run_alternates` on EGTF→EGHQ (regenerated `briefing.json`): returned set 4 → **9**, with **EGTE present (`is_major=false`)**, Cardiff/Bristol flagged `is_major=true`. Default view (hide major, ≤100 nm) shows **EGHC + EGTE**; digest matches. `npm` esbuild + `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)