### PR TITLE
fetch: classify route region from origin/destination only

### DIFF
--- a/designs/fetch.md
+++ b/designs/fetch.md
@@ -23,7 +23,7 @@ Each model has a `ModelEndpoint` dataclass (`name`, `base_url`, `max_days`, `mod
 | `meteofrance` | `/v1/meteofrance` | 6 | europe, needs `LF…` | No precip_probability, freezing_level, visibility, convective_inhibition, lifted_index, vertical_velocity |
 | `gem` | `/v1/gem` | 10 | north_america | No freezing_level, visibility, convective_inhibition, lifted_index, vertical_velocity |
 
-`region` (`ModelRegion.GLOBAL/EUROPE/NORTH_AMERICA`) and `required_icao_prefixes` let the pipeline skip models irrelevant to a route (`detect_model_region(route)`, `route_covers_prefixes(route, prefixes)`).
+`region` (`ModelRegion.GLOBAL/EUROPE/NORTH_AMERICA`) and `required_country` let the pipeline skip models irrelevant to a route (`_should_skip_for_region` in `tasks/fetch.py`). The broad region comes from `detect_model_region(route)`, which classifies on the **origin/destination** ICAO prefixes only (`K`/`C`/`P` → North America) — intermediate nav fixes like `KONAN`/`CINDY` are ignored so they can't misclassify a route. Country-specific models (Météo-France→`FR`, UKMO→`GB`) are gated on `airports.route_countries(route)`, which samples the great-circle route into timezone polygons and so detects genuine **overflight**, not just landings. If that geometry can't be resolved it falls back to `route_covers_prefixes(route, prefixes)` (4-letter ICAO airports only).
 
 `build_hourly_params()` constructs the API parameter string, excluding each model's unavailable variables. Pressure levels are **per-model** via `ModelEndpoint.pressure_levels` (named constants in `variables.py`):
 

--- a/src/weatherbrief/airports.py
+++ b/src/weatherbrief/airports.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Literal
 from euro_aip.storage.database_storage import DatabaseStorage
 from timezonefinder import TimezoneFinder
 
+from weatherbrief.fetch.route_walk import walk_route
 from weatherbrief.models import RunwayEnd, Waypoint
 
 if TYPE_CHECKING:
@@ -53,6 +54,40 @@ def _load_airport_model(db_path: str):
 def get_timezone(lat: float, lon: float) -> str | None:
     """Return the IANA timezone name for a lat/lon, or None if unknown."""
     return _timezone_finder().timezone_at(lat=lat, lng=lon)
+
+
+# IANA timezones identifying the countries we gate country-specific weather
+# models on. Mainland coverage is sufficient — a route over French or UK soil
+# returns these from the timezone polygons. Extend as country-specific models
+# are added.
+_COUNTRY_TIMEZONES: dict[str, frozenset[str]] = {
+    "FR": frozenset({"Europe/Paris"}),
+    "GB": frozenset({"Europe/London"}),
+}
+_TZ_TO_COUNTRY: dict[str, str] = {
+    tz: iso for iso, tzs in _COUNTRY_TIMEZONES.items() for tz in tzs
+}
+
+
+def route_countries(route, spacing_nm: float = 25.0) -> set[str]:
+    """ISO-3166 alpha-2 countries (from the gated set) the route passes over.
+
+    Samples the great-circle route every ``spacing_nm`` (named waypoints are
+    always included) and maps each point to a country via timezone polygons.
+    Detects genuine overflight — a route crossing France without landing there
+    still reports ``"FR"`` — which ICAO-prefix matching cannot.
+
+    Only countries in ``_COUNTRY_TIMEZONES`` are reported; that is all the
+    model gate needs, so no full boundary dataset is required. ``spacing_nm``
+    of 25 keeps even a thin corner-clip from slipping between samples while
+    staying a handful of sub-millisecond lookups per route.
+    """
+    found: set[str] = set()
+    for lat, lon, *_ in walk_route(route, spacing_nm):
+        iso = _TZ_TO_COUNTRY.get(get_timezone(lat, lon) or "")
+        if iso:
+            found.add(iso)
+    return found
 
 
 def is_known_waypoint(code: str, db_path: str) -> bool:

--- a/src/weatherbrief/fetch/variables.py
+++ b/src/weatherbrief/fetch/variables.py
@@ -123,7 +123,14 @@ class ModelEndpoint:
     region: ModelRegion = ModelRegion.GLOBAL
     # If set, route must contain at least one airport whose ICAO starts with
     # one of these prefixes (e.g. ["LF"] for France, ["EG"] for UK).
+    # Used as a fallback when route geometry can't be resolved.
     required_icao_prefixes: list[str] | None = None
+    # If set, the route must pass through this ISO-3166 alpha-2 country,
+    # detected from the route geometry (great-circle samples → timezone
+    # polygons). Primary country gate; catches overflight that prefix
+    # matching misses. Falls back to required_icao_prefixes if geometry
+    # detection is unavailable.
+    required_country: str | None = None
 
 
 MODEL_ENDPOINTS: dict[str, ModelEndpoint] = {
@@ -163,6 +170,7 @@ MODEL_ENDPOINTS: dict[str, ModelEndpoint] = {
         pressure_levels=list(UKMO_PRESSURE_LEVELS),
         region=ModelRegion.EUROPE,
         required_icao_prefixes=["EG"],
+        required_country="GB",
     ),
     "meteofrance": ModelEndpoint(
         name="Météo-France",
@@ -175,6 +183,7 @@ MODEL_ENDPOINTS: dict[str, ModelEndpoint] = {
         pressure_levels=list(METEOFRANCE_PRESSURE_LEVELS),
         region=ModelRegion.EUROPE,
         required_icao_prefixes=["LF"],
+        required_country="FR",
     ),
     "gem": ModelEndpoint(
         name="GEM",

--- a/src/weatherbrief/fetch/variables.py
+++ b/src/weatherbrief/fetch/variables.py
@@ -227,12 +227,31 @@ def build_hourly_params(endpoint: ModelEndpoint) -> str:
 _NORTH_AMERICA_PREFIXES = ("K", "C", "P")
 
 
+def _is_icao_airport(code: str) -> bool:
+    """True if ``code`` looks like a 4-letter ICAO *airport* identifier.
+
+    Country-prefix matching must only count real airports. Named navigation
+    fixes (5 letters, e.g. KONAN, CINDY) and navaids (2-3 letters) can begin
+    with a country prefix purely by coincidence and would otherwise produce
+    false positives.
+    """
+    return len(code) == 4 and code.isalpha()
+
+
 def route_covers_prefixes(route, prefixes: list[str]) -> bool:
-    """Return True if at least one waypoint ICAO starts with any of the given prefixes."""
+    """Return True if at least one *airport* on the route has an ICAO code
+    starting with any of the given prefixes.
+
+    Only 4-letter ICAO airport codes are considered (see ``_is_icao_airport``);
+    intermediate navigation fixes are ignored. Airports are matched anywhere on
+    the route (not just origin/destination) so an intermediate fuel stop in,
+    e.g., France still pulls in Météo-France.
+    """
     if not route or not route.waypoints:
         return False
+    pfx = tuple(prefixes)
     return any(
-        wp.icao.upper().startswith(tuple(prefixes))
+        _is_icao_airport(icao := wp.icao.upper()) and icao.startswith(pfx)
         for wp in route.waypoints
     )
 

--- a/src/weatherbrief/fetch/variables.py
+++ b/src/weatherbrief/fetch/variables.py
@@ -240,11 +240,18 @@ def route_covers_prefixes(route, prefixes: list[str]) -> bool:
 def detect_model_region(route) -> ModelRegion:
     """Classify a route's region for model coverage filtering.
 
-    Checks ALL waypoint ICAO prefixes:
+    Only the origin and destination airports are considered — checking the
+    first letter of their ICAO codes:
     - K, C, P prefixes → NORTH_AMERICA
     - Everything else → EUROPE
 
-    If mixed, defaults to GLOBAL (no filtering — safe fallback).
+    Intermediate waypoints are deliberately ignored: they are often named
+    navigation fixes (e.g. KONAN, CINDY) whose names start with a
+    North-American ICAO prefix and would otherwise misclassify a European
+    route as NORTH_AMERICA.
+
+    If origin and destination disagree, defaults to GLOBAL (no filtering —
+    safe fallback).
 
     Takes a RouteConfig but declared untyped to avoid circular imports.
     """
@@ -252,7 +259,7 @@ def detect_model_region(route) -> ModelRegion:
         return ModelRegion.GLOBAL
 
     regions: set[ModelRegion] = set()
-    for wp in route.waypoints:
+    for wp in (route.waypoints[0], route.waypoints[-1]):
         icao = wp.icao.upper()
         if any(icao.startswith(p) for p in _NORTH_AMERICA_PREFIXES):
             regions.add(ModelRegion.NORTH_AMERICA)

--- a/src/weatherbrief/tasks/fetch.py
+++ b/src/weatherbrief/tasks/fetch.py
@@ -79,19 +79,43 @@ def _open_meteo_live_horizons() -> dict[str, datetime]:
 
 
 def _should_skip_for_region(endpoint, route_region: ModelRegion, route=None) -> bool:
-    """Return True if a model's coverage region doesn't match the route.
+    """Return True if a model's coverage doesn't match the route.
 
     Two-level check:
-    1. Broad region (EUROPE / NORTH_AMERICA / GLOBAL)
-    2. Country-level ICAO prefix (e.g. MeteoFrance requires an LF airport)
+    1. Broad region (EUROPE / NORTH_AMERICA / GLOBAL), from origin/destination.
+    2. Country presence (e.g. Météo-France requires the route to touch France),
+       detected from route geometry — catches overflight, not just landings.
     """
     if endpoint.region != ModelRegion.GLOBAL and route_region != ModelRegion.GLOBAL:
         if endpoint.region != route_region:
             return True
-    if endpoint.required_icao_prefixes and route is not None:
-        if not route_covers_prefixes(route, endpoint.required_icao_prefixes):
+    if endpoint.required_country and route is not None:
+        if not _route_in_required_country(endpoint, route):
             return True
     return False
+
+
+def _route_in_required_country(endpoint, route) -> bool:
+    """Whether ``route`` passes through ``endpoint.required_country``.
+
+    Uses coordinate-based detection (timezone polygons over the route's
+    great-circle samples). If that can't run (e.g. timezone data unavailable),
+    falls back to the airport ICAO-prefix heuristic; if even that is absent we
+    keep the model rather than wrongly dropping it.
+    """
+    try:
+        from weatherbrief.airports import route_countries
+
+        return endpoint.required_country in route_countries(route)
+    except Exception:
+        logger.warning(
+            "Country detection failed for %s; falling back to ICAO prefixes",
+            endpoint.name,
+            exc_info=True,
+        )
+        if endpoint.required_icao_prefixes:
+            return route_covers_prefixes(route, endpoint.required_icao_prefixes)
+        return True
 
 
 @dataclass

--- a/tests/test_model_region.py
+++ b/tests/test_model_region.py
@@ -140,6 +140,21 @@ class TestRequiredIcaoPrefixes:
         route = _route("lfpb", "eddk")
         assert route_covers_prefixes(route, ["LF"])
 
+    def test_five_letter_fix_does_not_cover_prefix(self):
+        """A nav fix like LFXYZ must not count as a French airport."""
+        route = _route("EGLL", "LFXYZ", "EDDK")
+        assert not route_covers_prefixes(route, ["LF"])
+
+    def test_intermediate_french_airport_covers_prefix(self):
+        """A real 4-letter French airport en route still counts."""
+        route = _route("EGLL", "LFPB", "EDDK")
+        assert route_covers_prefixes(route, ["LF"])
+
+    def test_navaid_does_not_cover_prefix(self):
+        """A 2-3 letter navaid starting with the prefix must not count."""
+        route = _route("EGLL", "LFA", "EDDK")
+        assert not route_covers_prefixes(route, ["LF"])
+
     def test_skip_meteofrance_on_non_french_route(self):
         """MeteoFrance skipped for Germany-only route."""
         ep = MODEL_ENDPOINTS["meteofrance"]

--- a/tests/test_model_region.py
+++ b/tests/test_model_region.py
@@ -17,11 +17,33 @@ from weatherbrief.tasks.fetch import _should_skip_for_region
 
 # --- Fixtures ---
 
+# Real coordinates for the airports used in country-gating tests, so the
+# geometry-based detector resolves the right country. Unknown codes (nav-fix
+# names, navaids in prefix tests) fall back to (0, 0) — fine for the
+# ICAO-string-only checks that use them.
+_COORDS: dict[str, tuple[float, float]] = {
+    "EGTK": (51.8369, -1.3200),   # Oxford, UK
+    "EGLL": (51.4700, -0.4543),   # London Heathrow, UK
+    "LFPB": (48.9694, 2.4414),    # Paris Le Bourget, FR
+    "EDDK": (50.8659, 7.1427),    # Cologne, DE
+    "EDDM": (48.3538, 11.7861),   # Munich, DE
+    "LSGS": (46.2196, 7.3268),    # Sion, CH
+}
+
+
 def _route(*icaos: str) -> RouteConfig:
-    """Build a minimal RouteConfig from ICAO codes."""
+    """Build a minimal RouteConfig from ICAO codes (real coords when known)."""
     return RouteConfig(
         name="Test",
-        waypoints=[Waypoint(icao=icao, name=icao, lat=0, lon=0) for icao in icaos],
+        waypoints=[
+            Waypoint(
+                icao=icao,
+                name=icao,
+                lat=_COORDS.get(icao.upper(), (0.0, 0.0))[0],
+                lon=_COORDS.get(icao.upper(), (0.0, 0.0))[1],
+            )
+            for icao in icaos
+        ],
     )
 
 
@@ -112,10 +134,13 @@ class TestShouldSkipForRegion:
         assert not _should_skip_for_region(ep, ModelRegion.GLOBAL)
 
 
-# --- required_icao_prefixes ---
+# --- route_covers_prefixes (airport ICAO-prefix fallback) ---
 
-class TestRequiredIcaoPrefixes:
-    """Country-level ICAO prefix filtering (e.g. MeteoFrance → LF)."""
+class TestAirportPrefixFallback:
+    """ICAO-prefix matching, used as the fallback when geometry is unavailable.
+
+    Only real 4-letter ICAO airports count — nav fixes and navaids don't.
+    """
 
     def test_route_covers_french_prefix(self):
         route = _route("EGTK", "LFPB", "LSGS")
@@ -155,6 +180,12 @@ class TestRequiredIcaoPrefixes:
         route = _route("EGLL", "LFA", "EDDK")
         assert not route_covers_prefixes(route, ["LF"])
 
+
+# --- Country gating (geometry-based) ---
+
+class TestCountryGating:
+    """Country-specific models gated on the route's geometry (overflight)."""
+
     def test_skip_meteofrance_on_non_french_route(self):
         """MeteoFrance skipped for Germany-only route."""
         ep = MODEL_ENDPOINTS["meteofrance"]
@@ -162,9 +193,17 @@ class TestRequiredIcaoPrefixes:
         assert _should_skip_for_region(ep, ModelRegion.EUROPE, route)
 
     def test_keep_meteofrance_on_french_route(self):
-        """MeteoFrance kept when route touches France."""
+        """MeteoFrance kept when route lands in France."""
         ep = MODEL_ENDPOINTS["meteofrance"]
         route = _route("EGTK", "LFPB")
+        assert not _should_skip_for_region(ep, ModelRegion.EUROPE, route)
+
+    def test_keep_meteofrance_on_french_overflight(self):
+        """The headline gain: a route that overflies France without landing
+        there (London → Sion crosses French airspace) keeps MeteoFrance —
+        ICAO-prefix matching would have wrongly skipped it."""
+        ep = MODEL_ENDPOINTS["meteofrance"]
+        route = _route("EGLL", "LSGS")
         assert not _should_skip_for_region(ep, ModelRegion.EUROPE, route)
 
     def test_skip_ukmo_on_non_uk_route(self):
@@ -179,16 +218,69 @@ class TestRequiredIcaoPrefixes:
         route = _route("EGLL", "LFPB")
         assert not _should_skip_for_region(ep, ModelRegion.EUROPE, route)
 
-    def test_no_prefix_requirement_never_skips(self):
-        """Models without required_icao_prefixes are unaffected."""
+    def test_no_country_requirement_never_skips(self):
+        """Models without required_country are unaffected by the country gate."""
         ep = MODEL_ENDPOINTS["icon"]
         route = _route("EDDK", "EDDM")
         assert not _should_skip_for_region(ep, ModelRegion.EUROPE, route)
 
-    def test_prefix_check_skipped_when_no_route(self):
-        """Backward compat: no route passed → prefix check not applied."""
+    def test_country_check_skipped_when_no_route(self):
+        """Backward compat: no route passed → country check not applied."""
         ep = MODEL_ENDPOINTS["meteofrance"]
         assert not _should_skip_for_region(ep, ModelRegion.EUROPE, None)
+
+    def test_falls_back_to_prefixes_when_detection_fails(self, monkeypatch):
+        """If geometry detection raises, fall back to the ICAO-prefix heuristic."""
+        import weatherbrief.airports as airports
+
+        def _boom(route, spacing_nm=25.0):
+            raise RuntimeError("timezone data unavailable")
+
+        monkeypatch.setattr(airports, "route_countries", _boom)
+        ep = MODEL_ENDPOINTS["meteofrance"]  # required_icao_prefixes=["LF"]
+        # French airport present → fallback keeps the model.
+        assert not _should_skip_for_region(
+            ep, ModelRegion.EUROPE, _route("EGTK", "LFPB")
+        )
+        # No French airport → fallback skips it.
+        assert _should_skip_for_region(
+            ep, ModelRegion.EUROPE, _route("EDDK", "EDDM")
+        )
+
+
+# --- route_countries (geometry → country) ---
+
+class TestRouteCountries:
+    def test_maps_timezones_to_countries(self, monkeypatch):
+        """Hermetic: stub the walk + timezone lookup, check the FR/GB mapping."""
+        import weatherbrief.airports as airports
+
+        monkeypatch.setattr(
+            airports,
+            "walk_route",
+            lambda route, spacing_nm: [
+                (51.47, -0.45, 0.0, None, None),   # London → Europe/London
+                (48.97, 2.44, 0.0, None, None),    # Paris → Europe/Paris
+            ],
+        )
+        monkeypatch.setattr(
+            airports,
+            "get_timezone",
+            lambda lat, lon: "Europe/London" if lon < 1 else "Europe/Paris",
+        )
+        assert airports.route_countries(object()) == {"GB", "FR"}
+
+    def test_ignores_ungated_countries(self, monkeypatch):
+        """Timezones outside the gated set (e.g. Germany) are not reported."""
+        import weatherbrief.airports as airports
+
+        monkeypatch.setattr(
+            airports,
+            "walk_route",
+            lambda route, spacing_nm: [(50.87, 7.14, 0.0, None, None)],
+        )
+        monkeypatch.setattr(airports, "get_timezone", lambda lat, lon: "Europe/Berlin")
+        assert airports.route_countries(object()) == set()
 
 
 # --- MODEL_ENDPOINTS region assignments ---
@@ -204,3 +296,10 @@ class TestModelEndpointRegions:
 
     def test_north_america_models(self):
         assert MODEL_ENDPOINTS["gem"].region == ModelRegion.NORTH_AMERICA
+
+    def test_country_gated_models(self):
+        assert MODEL_ENDPOINTS["meteofrance"].required_country == "FR"
+        assert MODEL_ENDPOINTS["ukmo"].required_country == "GB"
+        # Prefix fallback still declared alongside the country gate.
+        assert MODEL_ENDPOINTS["meteofrance"].required_icao_prefixes == ["LF"]
+        assert MODEL_ENDPOINTS["ukmo"].required_icao_prefixes == ["EG"]

--- a/tests/test_model_region.py
+++ b/tests/test_model_region.py
@@ -63,6 +63,20 @@ class TestDetectModelRegion:
         route = _route("kjfk", "kord")
         assert detect_model_region(route) == ModelRegion.NORTH_AMERICA
 
+    def test_intermediate_nav_fix_ignored(self):
+        """Only origin/destination count; nav fixes like KONAN/CINDY don't.
+
+        A purely European route (LF→LS) routed via fixes whose names start
+        with North-American ICAO prefixes must stay EUROPE.
+        """
+        route = _route("LFPB", "KONAN", "CINDY", "LSGS")
+        assert detect_model_region(route) == ModelRegion.EUROPE
+
+    def test_intermediate_european_fix_on_us_route_ignored(self):
+        """Symmetric: a US route via an oddly-named fix stays NORTH_AMERICA."""
+        route = _route("KJFK", "EAGLE", "KORD")
+        assert detect_model_region(route) == ModelRegion.NORTH_AMERICA
+
 
 # --- _should_skip_for_region ---
 


### PR DESCRIPTION
detect_model_region previously scanned every waypoint's ICAO prefix.
Intermediate navigation fixes (e.g. KONAN, CINDY) start with K/C, the
North-American prefixes, so a purely European route routed via such fixes
was misclassified as NORTH_AMERICA — causing GEM (a North-America-only
model) to be fetched for European routes.

Only the origin and destination airports are now considered. Added
regression tests for European/US routes routed via misleadingly-named
intermediate fixes.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01SHAvjnApGdfdjsGUdLBJMk