### PR TITLE
analytics: snapshot cross-section displayed config per view (#232)

### DIFF
--- a/alembic/versions/071_analytics_xsection_config.py
+++ b/alembic/versions/071_analytics_xsection_config.py
@@ -1,0 +1,49 @@
+"""Add cross-section config snapshot rollup table.
+
+``analytics_xsection_config_daily`` preserves the per-dimension breakdown of
+the cross-section display config (theme/preset/layout/cloud-style/display-mode/
+model + per-layer attachment) rolled up from ``xsection.viewed`` snapshot
+events. Like the other ``*_daily`` rollups it is kept forever, so the config
+history survives the 60-day raw-event retention purge.
+
+Composite natural PK ``(day, dimension, value)`` matches the existing
+``*_daily`` tables — no surrogate id needed. Pure ``op.create_table`` (works
+identically on SQLite + MySQL without batch mode).
+
+Revision ID: 071
+Revises: 070
+Create Date: 2026-06-19
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "071"
+down_revision: Union[str, None] = "070"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "analytics_xsection_config_daily",
+        sa.Column("day", sa.Date(), nullable=False),
+        # Scalar dim key ('theme', 'preset', 'layout', …) or 'layer'.
+        sa.Column("dimension", sa.String(32), nullable=False),
+        # The bucket value: enum/id/bool-as-string, or a layer id.
+        sa.Column("value", sa.String(64), nullable=False),
+        # Views with this (dimension, value); for 'layer', views with the
+        # layer enabled.
+        sa.Column("views", sa.Integer(), nullable=False, server_default="0"),
+        # Distinct anonymous viewers contributing to this bucket.
+        sa.Column("unique_anons", sa.Integer(), nullable=False, server_default="0"),
+        sa.PrimaryKeyConstraint("day", "dimension", "value", name="pk_axcd_day_dim_val"),
+        sa.Index("ix_axcd_day", "day"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("analytics_xsection_config_daily")

--- a/src/weatherbrief/analytics/admin_api.py
+++ b/src/weatherbrief/analytics/admin_api.py
@@ -23,6 +23,7 @@ from weatherbrief.analytics.models import (
     AnalyticsEventDailyRow,
     AnalyticsFlightDimRow,
     AnalyticsSessionRow,
+    AnalyticsXsectionConfigDailyRow,
 )
 from weatherbrief.api.admin import require_admin
 
@@ -293,6 +294,76 @@ def briefing_shape(
         "by_seq": _count_by(AnalyticsBriefingDimRow.briefing_seq),
     }
     return {dim: _sort_buckets(dim, buckets) for dim, buckets in raw.items()}
+
+
+@router.get("/xsection-config")
+def xsection_config(
+    _admin_id: Annotated[str, Depends(require_admin)],
+    db: Annotated[Session, Depends(get_db)],
+    days: int = Query(_DEFAULT_WINDOW_DAYS, ge=1, le=_MAX_WINDOW_DAYS),
+) -> dict:
+    """Per-dimension breakdown of the cross-section display config.
+
+    Sums ``analytics_xsection_config_daily`` over the window grouped by
+    ``dimension`` → sorted ``[{value, views, unique_anons}]``. ``total_views``
+    / ``unique_viewers`` (the denominator for shares and per-layer attachment)
+    come from ``analytics_event_daily`` for ``xsection.viewed``.
+    """
+    start_day, end_day, _start_dt, _end_dt = _window(days)
+
+    # Denominator: total xsection views + unique viewers in the window, from
+    # the per-event daily rollup (same source the events table uses, so the
+    # numbers reconcile). unique_viewers is summed across days → a user active
+    # on multiple days counts once per day (slight overcount — acceptable for
+    # a share denominator, matches the feature-table convention).
+    total_views = int(db.scalar(
+        select(func.coalesce(func.sum(AnalyticsEventDailyRow.total_count), 0))
+        .where(AnalyticsEventDailyRow.event == Event.XSECTION_VIEWED.value)
+        .where(AnalyticsEventDailyRow.day >= start_day)
+        .where(AnalyticsEventDailyRow.day <= end_day)
+    ) or 0)
+    unique_viewers = int(db.scalar(
+        select(func.coalesce(func.sum(AnalyticsEventDailyRow.unique_anons), 0))
+        .where(AnalyticsEventDailyRow.event == Event.XSECTION_VIEWED.value)
+        .where(AnalyticsEventDailyRow.day >= start_day)
+        .where(AnalyticsEventDailyRow.day <= end_day)
+    ) or 0)
+
+    rows = db.execute(
+        select(
+            AnalyticsXsectionConfigDailyRow.dimension,
+            AnalyticsXsectionConfigDailyRow.value,
+            func.coalesce(func.sum(AnalyticsXsectionConfigDailyRow.views), 0),
+            func.coalesce(func.sum(AnalyticsXsectionConfigDailyRow.unique_anons), 0),
+        )
+        .where(AnalyticsXsectionConfigDailyRow.day >= start_day)
+        .where(AnalyticsXsectionConfigDailyRow.day <= end_day)
+        .group_by(
+            AnalyticsXsectionConfigDailyRow.dimension,
+            AnalyticsXsectionConfigDailyRow.value,
+        )
+    ).all()
+
+    dimensions: dict[str, list[dict]] = {}
+    for dimension, value, views, uniq in rows:
+        dimensions.setdefault(dimension, []).append(
+            {"value": value, "views": int(views), "unique_anons": int(uniq)}
+        )
+    # Within each dimension, biggest bucket first (matches the "what's most
+    # used" reading); the layer dimension's attachment % then sorts desc too.
+    for buckets in dimensions.values():
+        buckets.sort(key=lambda b: b["views"], reverse=True)
+
+    return {
+        "window": {
+            "start": start_day.isoformat(),
+            "end": end_day.isoformat(),
+            "days": days,
+        },
+        "total_views": total_views,
+        "unique_viewers": unique_viewers,
+        "dimensions": dimensions,
+    }
 
 
 @router.get("/digest")

--- a/src/weatherbrief/analytics/events.py
+++ b/src/weatherbrief/analytics/events.py
@@ -36,6 +36,12 @@ class Event(StrEnum):
     BRIEFING_REFRESH_REQUESTED = "briefing.refresh_requested"
     BRIEFING_REFRESHED = "briefing.refreshed"
 
+    # Cross-section snapshot -------------------------------------------------
+    # One snapshot per cross-section view carrying the current display config
+    # (theme/preset/layout/layers/…). Rolled up into per-dimension
+    # distributions, not the briefing-feature attachment rollup.
+    XSECTION_VIEWED = "xsection.viewed"
+
     # Visualization features -------------------------------------------------
     FORECAST_MAP_OPENED = "forecast_map.opened"
     FORECAST_MAP_LAYER_CHANGED = "forecast_map.layer_changed"
@@ -90,3 +96,42 @@ KNOWN_FEATURES: tuple[str, ...] = (
     "manual_refresh",
     "detailed_mode",
 )
+
+
+# ---------------------------------------------------------------------------
+# Cross-section config snapshot (``xsection.viewed``)
+# ---------------------------------------------------------------------------
+#
+# The snapshot event's ``props`` are rolled up into a per-dimension breakdown
+# in ``analytics_xsection_config_daily``. Two kinds of dimension:
+#
+# * Scalar dimensions — each props key is a single low-cardinality value
+#   (enum/id/bool). One view contributes one ``(dimension, value)`` row.
+#   Booleans are normalised to ``"true"``/``"false"`` so they GROUP BY as
+#   strings.
+# * Set dimensions — the props key holds an array; each element becomes a
+#   value under a single output dimension. ``layers`` → dimension ``"layer"``,
+#   one row per *enabled layer* per view (the per-layer attachment signal).
+#
+# The rollup is generic over whatever keys are present, so adding/removing a
+# dimension here is the only change needed (plus the mirrored client props).
+XSECTION_SCALAR_DIMENSIONS: tuple[str, ...] = (
+    "theme",
+    "preset",
+    "layout",
+    "cloud_style",
+    "display_mode",
+    "model",
+    "route_graph_visible",
+    "map_fronts_visible",
+    # Optional medium-cardinality metrics (omitted by the client when N/A).
+    "route_graph_left_metric",
+    "route_graph_right_metric",
+    "map_color_metric",
+    "map_width_metric",
+)
+
+# Array-valued props key → output dimension name for each element.
+XSECTION_SET_DIMENSIONS: dict[str, str] = {
+    "layers": "layer",
+}

--- a/src/weatherbrief/analytics/models.py
+++ b/src/weatherbrief/analytics/models.py
@@ -128,3 +128,33 @@ class AnalyticsBriefingFeatureDailyRow(Base):
     briefings_total: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
     briefings_with_feature: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
     total_uses: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+
+
+class AnalyticsXsectionConfigDailyRow(Base):
+    """Daily per-dimension breakdown of cross-section display config.
+
+    Rolled up from ``xsection.viewed`` snapshot events. Each row is one
+    ``(day, dimension, value)`` bucket:
+
+    * scalar dimensions (``theme``, ``preset``, ``layout``, …) — ``views`` is
+      the count of cross-section views that had that value;
+    * the ``"layer"`` dimension — one row per enabled layer id, ``views`` is
+      the count of views with that layer enabled (per-layer attachment).
+
+    The denominator (total xsection views / unique viewers that day) comes
+    from ``analytics_event_daily`` for ``xsection.viewed``; the client divides
+    to get shares and attachment percentages. Kept forever, like the other
+    ``*_daily`` rollups.
+    """
+
+    __tablename__ = "analytics_xsection_config_daily"
+    __table_args__ = (
+        PrimaryKeyConstraint("day", "dimension", "value", name="pk_axcd_day_dim_val"),
+        Index("ix_axcd_day", "day"),
+    )
+
+    day: Mapped[date_t] = mapped_column(Date, nullable=False)
+    dimension: Mapped[str] = mapped_column(String(32), nullable=False)
+    value: Mapped[str] = mapped_column(String(64), nullable=False)
+    views: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    unique_anons: Mapped[int] = mapped_column(Integer, nullable=False, default=0)

--- a/src/weatherbrief/analytics/rollup.py
+++ b/src/weatherbrief/analytics/rollup.py
@@ -25,12 +25,18 @@ from datetime import date, datetime, timedelta, timezone
 from sqlalchemy import case, delete, distinct, func, select
 from sqlalchemy.orm import Session
 
-from weatherbrief.analytics.events import FEATURE_OF, Event
+from weatherbrief.analytics.events import (
+    FEATURE_OF,
+    XSECTION_SCALAR_DIMENSIONS,
+    XSECTION_SET_DIMENSIONS,
+    Event,
+)
 from weatherbrief.analytics.models import (
     AnalyticsBriefingFeatureDailyRow,
     AnalyticsEventDailyRow,
     AnalyticsEventRow,
     AnalyticsSessionRow,
+    AnalyticsXsectionConfigDailyRow,
 )
 
 logger = logging.getLogger(__name__)
@@ -210,7 +216,111 @@ def rollup_day(db: Session, day: date) -> dict[str, int]:
     )
     n_features += 1
 
-    return {"events": n_events, "features": n_features, "briefings": briefings_total}
+    # ---- xsection_config_daily -------------------------------------------
+    n_xsection = _rollup_xsection_config(db, day, day_start, day_end)
+
+    return {
+        "events": n_events,
+        "features": n_features,
+        "briefings": briefings_total,
+        "xsection_config": n_xsection,
+    }
+
+
+def _rollup_xsection_config(
+    db: Session,
+    day: date,
+    day_start: datetime,
+    day_end: datetime,
+) -> int:
+    """Roll up ``xsection.viewed`` snapshots into per-dimension breakdowns.
+
+    Idempotent (DELETE+INSERT on the day). Volume is one row per cross-section
+    view, so we pull ``(props, anon_id)`` and aggregate in Python — no
+    dialect-specific JSON functions, identical on SQLite/MySQL.
+
+    For each scalar dimension present in ``props`` we increment a
+    ``(dimension, value)`` bucket; for the ``layers`` array we increment a
+    ``("layer", layer_id)`` bucket per enabled layer. ``unique_anons`` per
+    bucket is the size of the distinct anon set. Malformed/empty ``props`` are
+    skipped without error.
+
+    Returns the number of breakdown rows written.
+    """
+    db.execute(
+        delete(AnalyticsXsectionConfigDailyRow).where(
+            AnalyticsXsectionConfigDailyRow.day == day,
+        )
+    )
+
+    rows = db.execute(
+        select(AnalyticsEventRow.props, AnalyticsEventRow.anon_id)
+        .where(AnalyticsEventRow.event == Event.XSECTION_VIEWED.value)
+        .where(AnalyticsEventRow.ts >= day_start)
+        .where(AnalyticsEventRow.ts < day_end)
+    ).all()
+
+    # (dimension, value) -> [views, set-of-anon-ids]
+    views: dict[tuple[str, str], int] = {}
+    anons: dict[tuple[str, str], set[str]] = {}
+
+    def _bump(dimension: str, value: str, anon_id: str | None) -> None:
+        key = (dimension, value)
+        views[key] = views.get(key, 0) + 1
+        if anon_id is not None:
+            anons.setdefault(key, set()).add(anon_id)
+
+    for props_json, anon_id in rows:
+        try:
+            props = json.loads(props_json or "{}")
+        except Exception:
+            continue
+        if not isinstance(props, dict):
+            continue
+
+        for dim in XSECTION_SCALAR_DIMENSIONS:
+            if dim not in props:
+                continue
+            raw = props[dim]
+            if raw is None:
+                continue
+            # Normalise booleans to "true"/"false" so they GROUP BY cleanly;
+            # everything else is a bounded enum/id stringified and truncated
+            # to the column width as a defensive cap.
+            if isinstance(raw, bool):
+                value = "true" if raw else "false"
+            else:
+                value = str(raw)[:64]
+            _bump(dim, value, anon_id)
+
+        for props_key, dimension in XSECTION_SET_DIMENSIONS.items():
+            arr = props.get(props_key)
+            if not isinstance(arr, list):
+                continue
+            # De-dupe within a single view so a malformed payload listing a
+            # layer twice can't double-count attachment for that view.
+            seen: set[str] = set()
+            for elem in arr:
+                if elem is None:
+                    continue
+                value = str(elem)[:64]
+                if value in seen:
+                    continue
+                seen.add(value)
+                _bump(dimension, value, anon_id)
+
+    for (dimension, value), n_views in views.items():
+        db.add(
+            AnalyticsXsectionConfigDailyRow(
+                day=day,
+                dimension=dimension,
+                value=value,
+                views=n_views,
+                unique_anons=len(anons.get((dimension, value), ())),
+            )
+        )
+
+    return len(views)
 
 
 def _extract_detailed_mode(
@@ -295,7 +405,9 @@ def run_rollup_and_retention(db: Session) -> dict:
     counts = rollup_day(db, yesterday)
     purged = purge_old_events(db)
     logger.info(
-        "analytics rollup: day=%s events=%d features=%d briefings=%d purged=%d",
-        yesterday, counts["events"], counts["features"], counts["briefings"], purged,
+        "analytics rollup: day=%s events=%d features=%d briefings=%d "
+        "xsection_config=%d purged=%d",
+        yesterday, counts["events"], counts["features"], counts["briefings"],
+        counts["xsection_config"], purged,
     )
     return {"day": yesterday.isoformat(), "purged": purged, **counts}

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -22,6 +22,7 @@ from weatherbrief.analytics.events import Event
 from weatherbrief.analytics.models import (
     AnalyticsBriefingFeatureDailyRow,
     AnalyticsEventRow,
+    AnalyticsXsectionConfigDailyRow,
 )
 from weatherbrief.analytics.rollup import rollup_day
 
@@ -37,17 +38,45 @@ def analytics_db(db_session):
 
 
 def _add_event(db, *, event: str, briefing_id: int | None, hour: int,
-               props: dict | None = None) -> None:
+               props: dict | None = None, anon_id: str = "anon-1") -> None:
     db.add(
         AnalyticsEventRow(
             ts=_DAY_START + timedelta(hours=hour),
-            anon_id="anon-1",
+            anon_id=anon_id,
             session_id="sess-1",
             briefing_id=briefing_id,
             event=event,
             props=json.dumps(props) if props is not None else None,
         )
     )
+
+
+def _add_xsection(db, *, hour: int, anon_id: str = "anon-1",
+                  props: dict | None = None, raw_props: str | None = None) -> None:
+    """Add an ``xsection.viewed`` event.
+
+    ``raw_props`` injects a literal props string (for malformed-JSON tests);
+    otherwise ``props`` is JSON-encoded as normal.
+    """
+    row = AnalyticsEventRow(
+        ts=_DAY_START + timedelta(hours=hour),
+        anon_id=anon_id,
+        session_id="sess-1",
+        briefing_id=None,
+        event=Event.XSECTION_VIEWED.value,
+        props=raw_props if raw_props is not None else (
+            json.dumps(props) if props is not None else None
+        ),
+    )
+    db.add(row)
+
+
+def _xsection_rows(db) -> dict[tuple[str, str], AnalyticsXsectionConfigDailyRow]:
+    db.flush()
+    return {
+        (r.dimension, r.value): r
+        for r in db.query(AnalyticsXsectionConfigDailyRow).filter_by(day=_DAY).all()
+    }
 
 
 def _detailed_row(db) -> AnalyticsBriefingFeatureDailyRow | None:
@@ -148,3 +177,124 @@ class TestSortBuckets:
     def test_unknown_dim_passthrough(self):
         buckets = [{"key": "z"}, {"key": "a"}]
         assert _sort_buckets("by_something_else", buckets) == buckets
+
+
+_FULL_PROPS = {
+    "theme": "gramet",
+    "preset": "windy",
+    "layout": "cross-section",
+    "cloud_style": "natural",
+    "display_mode": "full",
+    "model": "icon",
+    "route_graph_visible": True,
+    "map_fronts_visible": False,
+    "layers": ["freezing-level", "cloud-bands", "icing-bands"],
+}
+
+
+class TestXsectionConfigRollup:
+    def test_scalar_and_layer_rows(self, analytics_db):
+        db = analytics_db
+        _add_xsection(db, hour=1, anon_id="a", props=_FULL_PROPS)
+        _add_xsection(db, hour=2, anon_id="b", props={
+            **_FULL_PROPS,
+            "theme": "standard",
+            "preset": "custom",
+            "layers": ["freezing-level"],  # only one layer in common
+        })
+        db.flush()
+
+        rollup_day(db, _DAY)
+        rows = _xsection_rows(db)
+
+        # Scalar dimension with two distinct values, one view each.
+        assert rows[("theme", "gramet")].views == 1
+        assert rows[("theme", "standard")].views == 1
+        # Scalar dimension shared by both views.
+        assert rows[("layout", "cross-section")].views == 2
+        assert rows[("layout", "cross-section")].unique_anons == 2
+        # Booleans normalised to "true"/"false".
+        assert rows[("route_graph_visible", "true")].views == 2
+        assert rows[("map_fronts_visible", "false")].views == 2
+        # Layer attachment: freezing-level on both, cloud-bands on one.
+        assert rows[("layer", "freezing-level")].views == 2
+        assert rows[("layer", "freezing-level")].unique_anons == 2
+        assert rows[("layer", "cloud-bands")].views == 1
+        assert rows[("layer", "icing-bands")].views == 1
+        # ``preset`` carries the literal "custom" sentinel for the dirty state.
+        assert rows[("preset", "windy")].views == 1
+        assert rows[("preset", "custom")].views == 1
+
+    def test_unique_anons_dedupes_within_dimension(self, analytics_db):
+        db = analytics_db
+        # Same anon views twice → 2 views but 1 unique anon.
+        _add_xsection(db, hour=1, anon_id="a", props=_FULL_PROPS)
+        _add_xsection(db, hour=2, anon_id="a", props=_FULL_PROPS)
+        db.flush()
+
+        rollup_day(db, _DAY)
+        rows = _xsection_rows(db)
+
+        assert rows[("theme", "gramet")].views == 2
+        assert rows[("theme", "gramet")].unique_anons == 1
+        assert rows[("layer", "freezing-level")].views == 2
+        assert rows[("layer", "freezing-level")].unique_anons == 1
+
+    def test_duplicate_layer_in_one_view_counts_once(self, analytics_db):
+        db = analytics_db
+        _add_xsection(db, hour=1, anon_id="a", props={
+            **_FULL_PROPS,
+            "layers": ["freezing-level", "freezing-level", "cloud-bands"],
+        })
+        db.flush()
+
+        rollup_day(db, _DAY)
+        rows = _xsection_rows(db)
+
+        assert rows[("layer", "freezing-level")].views == 1
+
+    def test_idempotent_rerun(self, analytics_db):
+        db = analytics_db
+        _add_xsection(db, hour=1, anon_id="a", props=_FULL_PROPS)
+        db.flush()
+
+        rollup_day(db, _DAY)
+        rollup_day(db, _DAY)  # re-run same day
+        rows = _xsection_rows(db)
+
+        # DELETE+INSERT means counts don't double on re-run.
+        assert rows[("theme", "gramet")].views == 1
+        assert rows[("layer", "icing-bands")].views == 1
+
+    def test_malformed_and_empty_props_skipped(self, analytics_db):
+        db = analytics_db
+        # Valid event so the rollup has something to write.
+        _add_xsection(db, hour=1, anon_id="a", props=_FULL_PROPS)
+        # Malformed / non-dict / null props must be skipped without error.
+        _add_xsection(db, hour=2, anon_id="b", raw_props="{not json")
+        _add_xsection(db, hour=3, anon_id="c", raw_props="[1, 2, 3]")  # not a dict
+        _add_xsection(db, hour=4, anon_id="d", raw_props=None)  # null props
+        _add_xsection(db, hour=5, anon_id="e", props={})  # empty dict
+        db.flush()
+
+        rollup_day(db, _DAY)  # must not raise
+        rows = _xsection_rows(db)
+
+        # Only the one valid event contributed.
+        assert rows[("theme", "gramet")].views == 1
+        assert ("theme", "standard") not in rows
+
+    def test_non_list_layers_skipped(self, analytics_db):
+        db = analytics_db
+        _add_xsection(db, hour=1, anon_id="a", props={
+            **_FULL_PROPS,
+            "layers": "not-a-list",
+        })
+        db.flush()
+
+        rollup_day(db, _DAY)  # must not raise
+        rows = _xsection_rows(db)
+
+        # Scalars still rolled up; the bad layers value produced no layer rows.
+        assert rows[("theme", "gramet")].views == 1
+        assert not any(dim == "layer" for dim, _ in rows)

--- a/web/admin.html
+++ b/web/admin.html
@@ -561,6 +561,17 @@
         </div>
 
         <div class="section">
+          <h3>Cross-section config</h3>
+          <p class="muted" style="font-size:0.85rem;">
+            What config the cross-section is actually displayed with, snapshotted once
+            per view (including returning users who never change a setting). Shares are
+            % of <span id="xsection-total-views">0</span> views; layers show attachment
+            % (views with the layer enabled ÷ total views).
+          </p>
+          <div id="xsection-config-grid" class="shape-grid"></div>
+        </div>
+
+        <div class="section">
           <h3>Weekly digest</h3>
           <p class="muted" style="font-size:0.85rem;">
             Same text the Monday cron writes to the log.

--- a/web/ts/admin-usage-view.ts
+++ b/web/ts/admin-usage-view.ts
@@ -66,6 +66,19 @@ interface DigestResponse {
   text: string;
 }
 
+interface XsectionConfigBucket {
+  value: string;
+  views: number;
+  unique_anons: number;
+}
+
+interface XsectionConfigResponse {
+  window: { start: string; end: string; days: number };
+  total_views: number;
+  unique_viewers: number;
+  dimensions: Record<string, XsectionConfigBucket[]>;
+}
+
 async function loadAll(days: number): Promise<void> {
   const loading = document.getElementById('ua-loading')!;
   const page = document.getElementById('ua-content')!;
@@ -75,15 +88,17 @@ async function loadAll(days: number): Promise<void> {
   errBox.style.display = 'none';
 
   try {
-    const [summary, shape, timeseries, digest] = await Promise.all([
+    const [summary, shape, timeseries, xsection, digest] = await Promise.all([
       apiFetch<SummaryResponse>(`/admin/usage/summary?days=${days}`),
       apiFetch<ShapeResponse>(`/admin/usage/briefing-shape?days=${days}`),
       apiFetch<TimeseriesResponse>(`/admin/usage/timeseries?days=${days}`),
+      apiFetch<XsectionConfigResponse>(`/admin/usage/xsection-config?days=${days}`),
       apiFetch<DigestResponse>('/admin/usage/digest'),
     ]);
     renderSummary(summary);
     renderTimeseries(timeseries);
     renderShape(shape);
+    renderXsectionConfig(xsection);
     renderDigest(digest);
     loading.style.display = 'none';
     page.style.display = '';
@@ -284,6 +299,73 @@ function formatKey(dim: keyof ShapeResponse, key: string | null): string {
     return key === '1' || key === 'true' ? 'yes' : 'no';
   }
   return key;
+}
+
+// Display order + labels for the scalar config dimensions. The ``layer``
+// dimension is rendered separately (attachment %, not share-of-views).
+const _XSECTION_DIM_LABELS: Array<[string, string]> = [
+  ['theme', 'Theme'],
+  ['preset', 'Preset'],
+  ['layout', 'Layout'],
+  ['cloud_style', 'Cloud style'],
+  ['display_mode', 'Display mode'],
+  ['model', 'Model'],
+  ['route_graph_visible', 'Route graph shown'],
+  ['map_fronts_visible', 'Map fronts shown'],
+  ['route_graph_left_metric', 'Route graph (left)'],
+  ['route_graph_right_metric', 'Route graph (right)'],
+  ['map_color_metric', 'Map color metric'],
+  ['map_width_metric', 'Map width metric'],
+];
+
+function renderXsectionConfig(x: XsectionConfigResponse): void {
+  const totalEl = document.getElementById('xsection-total-views');
+  if (totalEl) totalEl.textContent = x.total_views.toLocaleString();
+
+  const grid = document.getElementById('xsection-config-grid');
+  if (!grid) return;
+
+  const total = x.total_views;
+  if (total === 0) {
+    grid.innerHTML =
+      '<div class="shape-card"><div class="muted" style="font-size:0.85rem;">No cross-section views in this window.</div></div>';
+    return;
+  }
+
+  // ``pct`` is share of all views — for scalar dims the buckets are mutually
+  // exclusive (one value per view); for layers it's attachment % (a view can
+  // contribute to several layers, so these don't sum to 100).
+  const card = (label: string, buckets: XsectionConfigBucket[], suffix: string): string => {
+    if (!buckets || buckets.length === 0) {
+      return `<div class="shape-card"><h4>${escapeHtml(label)}</h4><div class="muted" style="font-size:0.85rem;">no data</div></div>`;
+    }
+    const rows = buckets
+      .map((b) => {
+        const pct = (b.views * 100) / total;
+        const pctStr = Number.isInteger(pct) ? pct.toFixed(0) : pct.toFixed(1);
+        return `
+          <div class="shape-row">
+            <span class="key">${escapeHtml(b.value)}</span>
+            <span class="count">${b.views.toLocaleString()} · ${pctStr}%${suffix}</span>
+          </div>`;
+      })
+      .join('');
+    return `<div class="shape-card"><h4>${escapeHtml(label)}</h4>${rows}</div>`;
+  };
+
+  const cards: string[] = [];
+  for (const [key, label] of _XSECTION_DIM_LABELS) {
+    const buckets = x.dimensions[key];
+    if (!buckets || buckets.length === 0) continue;
+    cards.push(card(label, buckets, ''));
+  }
+  // Layers last — attachment %, already sorted desc by the server.
+  const layers = x.dimensions['layer'];
+  if (layers && layers.length > 0) {
+    cards.push(card('Layers (attachment %)', layers, ''));
+  }
+
+  grid.innerHTML = cards.join('') || '<div class="shape-card"><div class="muted" style="font-size:0.85rem;">no data</div></div>';
 }
 
 function renderDigest(d: DigestResponse): void {

--- a/web/ts/analytics/events.ts
+++ b/web/ts/analytics/events.ts
@@ -16,6 +16,9 @@ export const EVENTS = {
   BRIEFING_REFRESH_REQUESTED: 'briefing.refresh_requested',
   BRIEFING_REFRESHED: 'briefing.refreshed',
 
+  // Cross-section snapshot (one per view, carries current display config)
+  XSECTION_VIEWED: 'xsection.viewed',
+
   // Visualization features
   FORECAST_MAP_OPENED: 'forecast_map.opened',
   FORECAST_MAP_LAYER_CHANGED: 'forecast_map.layer_changed',

--- a/web/ts/analytics/track.ts
+++ b/web/ts/analytics/track.ts
@@ -29,7 +29,11 @@ const SESSION_IDLE_MS = 30 * 60 * 1000;
 const FLUSH_INTERVAL_MS = 10_000;
 const ENDPOINT = '/api/events';
 
-type Props = Record<string, string | number | boolean | null>;
+// Arrays of strings are allowed for bounded *set* dimensions (e.g. the
+// cross-section's enabled-layer ids). They serialise to a JSON array in the
+// stored props blob; the server rollup iterates them. Keep set values
+// low-cardinality bounded id lists — never free text or unbounded counts.
+type Props = Record<string, string | number | boolean | null | string[]>;
 
 interface QueuedEvent {
   event: EventName;

--- a/web/ts/briefing-main.ts
+++ b/web/ts/briefing-main.ts
@@ -52,6 +52,40 @@ import { maybeOfferTour } from './tour/tour-offer';
 import { initBriefingLayout } from './managers/sidebar-layout';
 
 
+// --- Cross-section config snapshot (analytics, #232) -----------------------
+// Build the ``xsection.viewed`` snapshot props from current store state. Read
+// at the briefing.opened lifecycle point (after vizSettings hydrated from
+// localStorage + preset resolved) so it reflects what's actually on screen,
+// not defaults. All values are low-cardinality enums/ids/bools; ``layers`` is
+// the bounded set of enabled layer ids. Keep keys in sync with
+// ``XSECTION_SCALAR_DIMENSIONS`` / ``XSECTION_SET_DIMENSIONS`` in events.py.
+function buildXsectionSnapshotProps(
+  s: BriefingState,
+): Record<string, string | number | boolean | string[]> {
+  const v = s.vizSettings;
+  // A layer is enabled unless explicitly set to ``false`` (mirrors the store's
+  // own toggle semantics in toggleLayer).
+  const layers = Object.keys(v.enabledLayers).filter(
+    (id) => v.enabledLayers[id] !== false,
+  );
+  return {
+    theme: v.vizTheme ?? 'standard',
+    preset: v.activePreset ?? 'custom',
+    layout: v.layout,
+    cloud_style: v.cloudStyle ?? 'square',
+    display_mode: s.displayMode,
+    model: s.selectedModel,
+    route_graph_visible: v.routeGraphVisible,
+    map_fronts_visible: v.mapFrontsVisible ?? false,
+    route_graph_left_metric: v.routeGraphLeftMetric,
+    route_graph_right_metric: v.routeGraphRightMetric,
+    map_color_metric: v.mapColorMetric,
+    map_width_metric: v.mapWidthMetric,
+    layers,
+  };
+}
+
+
 // --- Route-map gated front lines (experimental #196) -----------------------
 // The 2-D TFP=0 front axes for the *selected* model, drawn on the route map when
 // the fronts layer is on. Reuses the same precomputed Hewson snapshot + the same
@@ -1617,6 +1651,12 @@ async function init(): Promise<void> {
     if (s.flight && s.currentPack) {
       setBriefingContext(s.flight.id, s.currentPack.fetch_timestamp);
       track(EVENTS.BRIEFING_OPENED, { days_out: s.currentPack.days_out });
+      // Snapshot the cross-section display config as it is right now — the
+      // store is hydrated from localStorage and any preset already resolved,
+      // so this captures the persisted steady state even for users who never
+      // change a setting. One event per view; navigating to another briefing
+      // is a fresh page load and re-emits.
+      track(EVENTS.XSECTION_VIEWED, buildXsectionSnapshotProps(s));
     }
     ui.renderAssessment(s.currentPack, s.flight, s.routeAdvisories, s.altAdvisories, s.digestPending, () => store.getState().generateDigest());
     renderAdvisories(getEffectiveAdvisories(s), () => store.getState().recalculateAdvisories(), s.displayMode, getAltitudeOverrideConfig(s), handleAltitudeTable, getAltTimeToggleConfig(s), getProfileSelectorConfig(s), handleAdvisoryChip);


### PR DESCRIPTION
Instrument the cross-section visualization with a per-view config snapshot
so we can answer "what config is the cross-section actually displayed
with?" — theme, preset, layout, cloud style, display mode, model, and
enabled layers — for every view, including returning users who keep their
persisted settings and never change anything.

Design: snapshot-on-view, not change-events. One `xsection.viewed` event
per cross-section view carries the current config (read from the hydrated
viz store at the briefing.opened lifecycle point), rolled up into
per-dimension distributions and per-layer attachment rates, surfaced on
the admin usage page.

Server:
- events.py: add XSECTION_VIEWED + XSECTION_SCALAR_DIMENSIONS /
  XSECTION_SET_DIMENSIONS helpers driving a generic rollup.
- models.py + migration 071: analytics_xsection_config_daily
  (day, dimension, value) -> views, unique_anons. Kept forever so config
  history survives the 60-day raw-event purge.
- rollup.py: DELETE+INSERT day block, aggregated in Python (no
  dialect-specific JSON), idempotent, defensive props parsing.
- admin_api.py: GET /admin/usage/xsection-config?days= returns
  per-dimension breakdowns + total_views/unique_viewers denominator.

Client:
- events.ts: mirror XSECTION_VIEWED (enums stay in sync).
- track.ts: allow string[] props for bounded set dimensions (layers).
- briefing-main.ts: emit one snapshot at the briefing.opened point from
  hydrated store state.
- admin-usage-view.ts + admin.html: "Cross-section config" section with
  per-dimension shares and per-layer attachment %.

Tests: rollup scalar+layer rows, unique-anon dedupe, intra-view layer
dedupe, idempotent re-run, malformed/empty/non-dict props skipped,
non-list layers skipped.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EwjxL72ZYSsMTLVdxvpSAk