### PR TITLE
Add drill-down tools for advisory explanation (issue #278)

### DIFF
--- a/src/weatherbrief/api/packs.py
+++ b/src/weatherbrief/api/packs.py
@@ -3158,6 +3158,27 @@ def get_digest_json(
     return FileResponse(json_path, media_type="application/json")
 
 
+@router.get("/{timestamp}/digest/context")
+def get_digest_context(
+    flight_id: str,
+    timestamp: str,
+    user_id: str = Depends(current_user_id),
+    db: Session = Depends(get_db),
+):
+    """Get the exact plain-text context that was fed to the LLM digest.
+
+    This is ``digest_context.txt`` — the byte-faithful input the digest LLM
+    saw (every advisory, route stats, raw DWD overview). Written per pack at
+    digest time (``tasks/outputs.py``); 404 for older packs that predate it
+    or when the digest was not generated.
+    """
+    pack_dir = _get_pack_dir(db, flight_id, timestamp, viewer_id=user_id)
+    ctx_path = pack_dir / "digest_context.txt"
+    if not ctx_path.exists():
+        raise HTTPException(status_code=404, detail="Digest context not available")
+    return FileResponse(ctx_path, media_type="text/plain")
+
+
 @router.get("/{timestamp}/dwd-chart/{chart_id}")
 def get_dwd_chart(
     flight_id: str,

--- a/src/weatherbrief/mcp/client.py
+++ b/src/weatherbrief/mcp/client.py
@@ -110,6 +110,15 @@ class WeatherbriefClient:
                 return None
             raise
 
+    def get_route_analyses(self, flight_id: str, timestamp: str) -> dict | None:
+        """Get the per-point route analyses (soundings per model) for a pack."""
+        try:
+            return self._get(f"/flights/{flight_id}/packs/{timestamp}/route-analyses")
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 404:
+                return None
+            raise
+
     def get_digest_json(self, flight_id: str, timestamp: str) -> dict | None:
         try:
             return self._get(f"/flights/{flight_id}/packs/{timestamp}/digest/json")
@@ -123,6 +132,19 @@ class WeatherbriefClient:
         try:
             r = self._client.get(
                 f"/api/flights/{flight_id}/packs/{timestamp}/digest",
+            )
+            r.raise_for_status()
+            return r.text
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 404:
+                return None
+            raise
+
+    def get_digest_context(self, flight_id: str, timestamp: str) -> str | None:
+        """Get the exact plain-text context the LLM digest saw, if persisted."""
+        try:
+            r = self._client.get(
+                f"/api/flights/{flight_id}/packs/{timestamp}/digest/context",
             )
             r.raise_for_status()
             return r.text

--- a/src/weatherbrief/mcp/server.py
+++ b/src/weatherbrief/mcp/server.py
@@ -129,8 +129,13 @@ mcp = FastMCP(
         "(e.g. 'why is convective red when it looks like blue sky?'), call "
         "get_advisory_detail (and get_digest_context for the deepest context) "
         "before answering — never explain a red/amber from the aggregate status "
-        "alone. Treat cross-check notes as context for the discussion, not a "
-        "reason to downgrade an advisory.\n\n"
+        "alone. Treat cross-check notes and per-model splits as context for the "
+        "discussion, not a reason to downgrade an advisory.\n\n"
+        "Provenance note: the AI digest narrates 'convective tops' that are "
+        "parcel-derived (the thermodynamic equilibrium level from CAPE), NOT the "
+        "model's own convective cloud field. A convective advisory driven RED by "
+        "high CAPE while the model's convective cover is ~0 ('blue sky') is "
+        "consistent, not contradictory — explain it, don't argue it down.\n\n"
         "All tools return a web_url for the full interactive briefing with "
         "cross-sections, Skew-T diagrams, and route maps — present this link "
         "to the pilot for visual details."
@@ -440,37 +445,33 @@ def get_briefing(
     return result
 
 
-_GRADED_STATUSES = ("green", "amber", "red")
-
-
 def _summarize_advisories(advisories: dict) -> list[dict]:
     """Extract advisory information for the agent, retaining per-model detail.
 
     Unlike a flat status list, this keeps each model's status/detail and the
     ``cross_check`` note plus the ``parameters_used`` thresholds, so the agent
-    can see model disagreement and the reasoning behind a grade directly in the
-    briefing output. That visible disagreement is the primary discoverability
+    can see the per-model split and the reasoning behind a grade directly in
+    the briefing output. That visible detail is the primary discoverability
     hook (Layer A): it provokes the follow-up question and a ``detail_tool``
     pointer names the drill-down tool.
 
-    The cross-check is display-only **context for discussion**, never a
-    downgrade signal (#178) — high CAPE matters even when the deterministic
-    model scheme is quiet.
+    The hint flags are deliberately **neutral** (``cross_check_present`` /
+    ``per_model_present``, never "model_disagreement"): a valenced flag would
+    prime the exact red→amber downgrade the guardrail forbids. The cross-check
+    is display-only **context for discussion**, never a downgrade signal
+    (#178) — high CAPE matters even when the deterministic model scheme is
+    quiet.
     """
     catalog = {c.get("id"): c for c in advisories.get("catalog", [])}
     results = []
     for adv in advisories.get("advisories", []):
         adv_id = adv.get("advisory_id")
         per_model: list[dict] = []
-        graded: set[str] = set()
         cross_check_present = False
         for m in adv.get("per_model", []):
-            status = m.get("status")
-            if status in _GRADED_STATUSES:
-                graded.add(status)
             entry_m: dict[str, Any] = {
                 "model": m.get("model"),
-                "status": status,
+                "status": m.get("status"),
                 "detail": m.get("detail"),
                 "affected_pct": m.get("affected_pct"),
             }
@@ -480,7 +481,6 @@ def _summarize_advisories(advisories: dict) -> list[dict]:
                 entry_m["cross_check"] = cc
             per_model.append(entry_m)
 
-        model_disagreement = len(graded) > 1
         entry: dict[str, Any] = {
             "id": adv_id,
             "status": adv.get("aggregate_status"),
@@ -488,7 +488,7 @@ def _summarize_advisories(advisories: dict) -> list[dict]:
             "per_model": per_model,
             "parameters_used": adv.get("parameters_used", {}),
             "cross_check_present": cross_check_present,
-            "model_disagreement": model_disagreement,
+            "per_model_present": bool(per_model),
         }
         cat = catalog.get(adv_id)
         if cat:
@@ -496,10 +496,9 @@ def _summarize_advisories(advisories: dict) -> list[dict]:
             entry["category"] = cat.get("category")
 
         # Layer A: point the agent at the drill-down tool whenever there is
-        # something worth explaining (a non-green grade, model disagreement, or
-        # a cross-check note). Green-and-quiet advisories omit it to avoid
-        # nudging wasteful drills.
-        if entry["status"] in ("amber", "red") or cross_check_present or model_disagreement:
+        # something worth explaining (a non-green grade or a cross-check note).
+        # Green-and-quiet advisories omit it to avoid nudging wasteful drills.
+        if entry["status"] in ("amber", "red") or cross_check_present:
             entry["detail_tool"] = "get_advisory_detail"
 
         results.append(entry)
@@ -695,6 +694,23 @@ def get_advisory_detail(
         catalog = {c.get("id"): c for c in advisories.get("catalog", [])}
         result = _advisory_detail(adv, catalog.get(advisory_id))
 
+        # Per-briefing staleness so a forensic per-model answer carries the
+        # caveat: reasoning on stale data is confidently-wrong territory.
+        try:
+            freshness = client.get_freshness(flight_id)
+            if not freshness.get("fresh", True):
+                result["stale"] = True
+                result["stale_models"] = freshness.get("stale_models", [])
+                result["model_init_times"] = freshness.get("model_init_times", {})
+                result["stale_note"] = (
+                    "Models have updated since this briefing was generated. This "
+                    "drill-down reflects the run used at briefing time, not the "
+                    "latest — caveat any forensic reasoning and suggest "
+                    "refresh_briefing for current data."
+                )
+        except httpx.HTTPStatusError:
+            pass
+
         if advisory_id == "convective":
             try:
                 route_analyses = client.get_route_analyses(flight_id, timestamp)
@@ -703,6 +719,15 @@ def get_advisory_detail(
             if route_analyses:
                 models = [m.get("model") for m in adv.get("per_model", [])]
                 result["convective"] = _convective_detail(route_analyses, models)
+                result["convective_note"] = (
+                    "thermo.peak.el_top_ft is parcel-derived (the equilibrium "
+                    "level the digest narrates as 'convective tops'), NOT the "
+                    "model's convective cloud field. nwp.max_cover_pct ~0 means "
+                    "the model's own convective scheme is quiet ('blue sky'); "
+                    "high CAPE with cover ~0 is the expected pattern, not a "
+                    "contradiction. assessment_method is which derivation graded "
+                    "the route."
+                )
 
         result["flight_id"] = flight_id
         result["web_url"] = _flight_web_url(flight_id)
@@ -748,54 +773,83 @@ def _advisory_detail(adv: dict, catalog_entry: dict | None) -> dict[str, Any]:
 def _convective_detail(route_analyses: dict, models: list[str]) -> dict[str, Any]:
     """Per-model convective drill-down from the route analyses soundings.
 
-    For each model: CAPE range across the route, the peak point (CAPE, cover %,
-    location), the max convective cover %, and which assessment method
-    (thermo vs NWP) each point used. ``cover_pct`` near 0 is the model scheme
-    saying "blue sky" even when CAPE (thermo) is high — the apparent
-    contradiction the cross-check explains.
+    Splits the two independent derivations so a digest that narrates "tops to
+    27,000 ft" reconciles with a quiet model scheme:
+
+    - ``thermo`` — the CAPE/parcel view: CAPE range across the route and the
+      peak point (CAPE, the equilibrium-level top the digest calls "convective
+      tops", location, and the forecast valid-time vs flight ETA so the diurnal
+      timing is explicit).
+    - ``nwp`` — the model's own convective scheme: max convective cover %
+      (``~0`` is the machine-readable "blue sky" signal) and its convective top.
+    - ``assessment_method`` — which derivation actually graded the route.
+
+    cover ~0 next to high CAPE is the expected pattern, not a contradiction —
+    this surfaces the data so it can be explained, never argued down.
     """
     points = route_analyses.get("analyses", [])
     out: dict[str, Any] = {}
     for model in models:
-        capes: list[float] = []
-        peak: dict | None = None
-        max_cover: float | None = None
+        thermo_capes: list[float] = []
+        thermo_peak: dict | None = None
+        nwp_max_cover: float | None = None
+        nwp_peak_top: float | None = None
         method_counts: dict[str, int] = {}
         for p in points:
             sounding = (p.get("sounding") or {}).get(model)
             if not sounding:
                 continue
-            conv = sounding.get("convective")
-            if not conv:
-                continue
-            method = conv.get("method")
+            resolved = sounding.get("convective")
+            method = resolved.get("method") if resolved else None
             if method:
                 method_counts[method] = method_counts.get(method, 0) + 1
-            cover = conv.get("cover_pct")
-            if cover is not None:
-                max_cover = cover if max_cover is None else max(max_cover, cover)
-            cape = conv.get("cape_jkg")
-            if cape is not None:
-                capes.append(cape)
-                if peak is None or cape > peak["cape_jkg"]:
-                    peak = {
-                        "cape_jkg": round(cape),
-                        "cover_pct": round(cover) if cover is not None else None,
-                        "risk_level": conv.get("risk_level"),
-                        "method": method,
-                        "distance_nm": p.get("distance_from_origin_nm"),
-                        "waypoint_icao": p.get("waypoint_icao"),
-                    }
-        if not capes and not method_counts:
+
+            # Parcel/CAPE view — explicit thermo, falling back to the resolved
+            # assessment for old packs that never split the two.
+            thermo = sounding.get("convective_thermo") or resolved
+            if thermo:
+                cape = thermo.get("cape_jkg")
+                if cape is not None:
+                    thermo_capes.append(cape)
+                    if thermo_peak is None or cape > thermo_peak["cape_jkg"]:
+                        top = thermo.get("top_ft")
+                        thermo_peak = {
+                            "cape_jkg": round(cape),
+                            "el_top_ft": round(top) if top is not None else None,
+                            "risk_level": thermo.get("risk_level"),
+                            "distance_nm": p.get("distance_from_origin_nm"),
+                            "waypoint_icao": p.get("waypoint_icao"),
+                            "valid_time": p.get("forecast_hour"),
+                            "eta": p.get("interpolated_time"),
+                        }
+
+            # Model's own convective scheme.
+            nwp = sounding.get("convective_nwp")
+            if nwp:
+                cover = nwp.get("cover_pct")
+                if cover is not None:
+                    nwp_max_cover = cover if nwp_max_cover is None else max(nwp_max_cover, cover)
+                top = nwp.get("top_ft")
+                if top is not None:
+                    nwp_peak_top = top if nwp_peak_top is None else max(nwp_peak_top, top)
+
+        if not thermo_capes and not method_counts and nwp_max_cover is None:
             continue
         out[model] = {
-            "cape_range_jkg": [round(min(capes)), round(max(capes))] if capes else None,
-            "peak": peak,
-            "max_cover_pct": round(max_cover) if max_cover is not None else None,
             "assessment_method": (
                 max(method_counts, key=lambda k: method_counts[k]) if method_counts else None
             ),
             "method_counts": method_counts,
+            "thermo": {
+                "cape_range_jkg": (
+                    [round(min(thermo_capes)), round(max(thermo_capes))] if thermo_capes else None
+                ),
+                "peak": thermo_peak,
+            },
+            "nwp": {
+                "max_cover_pct": round(nwp_max_cover) if nwp_max_cover is not None else None,
+                "peak_top_ft": round(nwp_peak_top) if nwp_peak_top is not None else None,
+            },
         }
     return out
 
@@ -816,8 +870,13 @@ def get_digest_context(
     Use when the user wants the deepest possible context behind the briefing —
     e.g. to reconcile a red/amber advisory with the digest narrative, or to see
     every advisory, route statistic, and the raw DWD synoptic overview exactly
-    as the digest LLM received them. This is the maximum detail exposed over MCP;
-    pair it with get_advisory_detail when diagnosing a specific advisory.
+    as the digest LLM received them.
+
+    This is the maximum detail exposed over MCP and a genuine last resort: the
+    text can be large (typically a few KB up to tens of KB) and will consume a
+    meaningful slice of the context window. Do NOT fetch it reflexively —
+    prefer get_advisory_detail for a targeted, structured drill-down, and reach
+    for this only when you specifically need the byte-faithful LLM input.
 
     Returns the plain-text digest context, or status 'none' for older briefings
     that predate this artifact / had no digest generated.

--- a/src/weatherbrief/mcp/server.py
+++ b/src/weatherbrief/mcp/server.py
@@ -125,6 +125,12 @@ mcp = FastMCP(
         "5. get_airport_weather — quick forecast + METAR for specific airports\n\n"
         "Briefing generation takes ~2 minutes. If get_briefing returns "
         "status='processing', tell the user and check again shortly.\n\n"
+        "When the user questions, doubts, or wants to understand an advisory "
+        "(e.g. 'why is convective red when it looks like blue sky?'), call "
+        "get_advisory_detail (and get_digest_context for the deepest context) "
+        "before answering — never explain a red/amber from the aggregate status "
+        "alone. Treat cross-check notes as context for the discussion, not a "
+        "reason to downgrade an advisory.\n\n"
         "All tools return a web_url for the full interactive briefing with "
         "cross-sections, Skew-T diagrams, and route maps — present this link "
         "to the pilot for visual details."
@@ -164,6 +170,36 @@ def _get_client() -> WeatherbriefClient:
 
 def _flight_web_url(flight_id: str) -> str:
     return f"{WEATHER_BASE_URL}/briefing.html?flight={flight_id}"
+
+
+def _resolve_pack(client: WeatherbriefClient, flight_id: str) -> tuple[str | None, dict | None]:
+    """Resolve the latest pack timestamp for a flight, or a status dict.
+
+    Returns ``(timestamp, None)`` when a pack exists, or ``(None, status)``
+    when there is none / one is still generating — the status dict is shaped
+    like the other tools' early returns so callers can return it directly.
+    """
+    try:
+        refresh_info = client.get_refresh_status(flight_id)
+        if refresh_info.get("active"):
+            return None, {
+                "status": "processing",
+                "flight_id": flight_id,
+                "message": "Briefing is being generated. Check again in ~1-2 minutes.",
+                "web_url": _flight_web_url(flight_id),
+            }
+    except httpx.HTTPStatusError:
+        pass
+
+    pack = client.get_latest_pack(flight_id)
+    if pack is None:
+        return None, {
+            "status": "none",
+            "flight_id": flight_id,
+            "message": "No briefing exists yet. Call refresh_briefing to generate one.",
+            "web_url": _flight_web_url(flight_id),
+        }
+    return pack["fetch_timestamp"], None
 
 
 def _error_result(message: str, code: int | None = None) -> dict:
@@ -404,20 +440,68 @@ def get_briefing(
     return result
 
 
+_GRADED_STATUSES = ("green", "amber", "red")
+
+
 def _summarize_advisories(advisories: dict) -> list[dict]:
-    """Extract the key advisory information for the agent."""
+    """Extract advisory information for the agent, retaining per-model detail.
+
+    Unlike a flat status list, this keeps each model's status/detail and the
+    ``cross_check`` note plus the ``parameters_used`` thresholds, so the agent
+    can see model disagreement and the reasoning behind a grade directly in the
+    briefing output. That visible disagreement is the primary discoverability
+    hook (Layer A): it provokes the follow-up question and a ``detail_tool``
+    pointer names the drill-down tool.
+
+    The cross-check is display-only **context for discussion**, never a
+    downgrade signal (#178) — high CAPE matters even when the deterministic
+    model scheme is quiet.
+    """
+    catalog = {c.get("id"): c for c in advisories.get("catalog", [])}
     results = []
     for adv in advisories.get("advisories", []):
-        entry = {
-            "id": adv.get("advisory_id"),
+        adv_id = adv.get("advisory_id")
+        per_model: list[dict] = []
+        graded: set[str] = set()
+        cross_check_present = False
+        for m in adv.get("per_model", []):
+            status = m.get("status")
+            if status in _GRADED_STATUSES:
+                graded.add(status)
+            entry_m: dict[str, Any] = {
+                "model": m.get("model"),
+                "status": status,
+                "detail": m.get("detail"),
+                "affected_pct": m.get("affected_pct"),
+            }
+            cc = m.get("cross_check")
+            if cc:
+                cross_check_present = True
+                entry_m["cross_check"] = cc
+            per_model.append(entry_m)
+
+        model_disagreement = len(graded) > 1
+        entry: dict[str, Any] = {
+            "id": adv_id,
             "status": adv.get("aggregate_status"),
             "detail": adv.get("aggregate_detail"),
+            "per_model": per_model,
+            "parameters_used": adv.get("parameters_used", {}),
+            "cross_check_present": cross_check_present,
+            "model_disagreement": model_disagreement,
         }
-        for cat in advisories.get("catalog", []):
-            if cat.get("id") == adv.get("advisory_id"):
-                entry["name"] = cat.get("name")
-                entry["category"] = cat.get("category")
-                break
+        cat = catalog.get(adv_id)
+        if cat:
+            entry["name"] = cat.get("name")
+            entry["category"] = cat.get("category")
+
+        # Layer A: point the agent at the drill-down tool whenever there is
+        # something worth explaining (a non-green grade, model disagreement, or
+        # a cross-check note). Green-and-quiet advisories omit it to avoid
+        # nudging wasteful drills.
+        if entry["status"] in ("amber", "red") or cross_check_present or model_disagreement:
+            entry["detail_tool"] = "get_advisory_detail"
+
         results.append(entry)
     return results
 
@@ -542,6 +626,265 @@ def get_airport_weather(
         return _error_result(f"API error: {e.response.text}", e.response.status_code)
     except ValueError as e:
         return _error_result(str(e))
+
+
+# ---------------------------------------------------------------------------
+# Tool: get_advisory_detail
+# ---------------------------------------------------------------------------
+
+@mcp.tool()
+def get_advisory_detail(
+    flight_id: Annotated[
+        str,
+        Field(description="Flight ID from list_flights or create_flight"),
+    ],
+    advisory_id: Annotated[
+        str,
+        Field(description="Advisory id to drill into, e.g. 'convective', 'fiki_icing', 'cloud_top' (the 'id' field from get_briefing's advisories)"),
+    ],
+) -> dict[str, Any]:
+    """Drill into ONE advisory to explain WHY it is red/amber (or any grade).
+
+    Use this when the user asks why an advisory is red/amber, questions a
+    result that looks inconsistent (e.g. "red convective but clear skies"),
+    doubts a grade, or wants the per-model breakdown and cross-check reasoning.
+    Never explain a red/amber from the aggregate status alone — call this first.
+
+    Returns a server-side summary (never the raw forecast grid):
+    - per-model status, detail, affected extent, and the cross-check note
+    - parameters_used: the thresholds that produced the grade
+    - for the convective advisory: per-model CAPE range + the location (nm /
+      waypoint) of the peak, the convective cover % (cover ≈ 0 is the
+      machine-readable "blue sky" signal), and whether the assessment used the
+      thermo (CAPE-derived) or NWP (model-scheme) method.
+
+    The cross-check is **context for discussion, not a downgrade signal** — high
+    CAPE matters even when the model's own convective scheme is quiet. Use it to
+    EXPLAIN the grade, not to argue it down.
+    """
+    try:
+        client = _get_client()
+    except ValueError as e:
+        return _error_result(str(e))
+
+    with client:
+        try:
+            timestamp, status = _resolve_pack(client, flight_id)
+        except httpx.HTTPStatusError as e:
+            return _error_result(f"API error: {e.response.text}", e.response.status_code)
+        if status is not None:
+            return status
+
+        try:
+            advisories = client.get_advisories(flight_id, timestamp)
+        except httpx.HTTPStatusError as e:
+            return _error_result(f"API error: {e.response.text}", e.response.status_code)
+        if not advisories:
+            return _error_result("No advisories available for this briefing.")
+
+        adv = next(
+            (a for a in advisories.get("advisories", []) if a.get("advisory_id") == advisory_id),
+            None,
+        )
+        if adv is None:
+            available = [a.get("advisory_id") for a in advisories.get("advisories", [])]
+            return _error_result(
+                f"Advisory '{advisory_id}' not found. Available: {', '.join(available)}"
+            )
+
+        catalog = {c.get("id"): c for c in advisories.get("catalog", [])}
+        result = _advisory_detail(adv, catalog.get(advisory_id))
+
+        if advisory_id == "convective":
+            try:
+                route_analyses = client.get_route_analyses(flight_id, timestamp)
+            except httpx.HTTPStatusError:
+                route_analyses = None
+            if route_analyses:
+                models = [m.get("model") for m in adv.get("per_model", [])]
+                result["convective"] = _convective_detail(route_analyses, models)
+
+        result["flight_id"] = flight_id
+        result["web_url"] = _flight_web_url(flight_id)
+
+    return result
+
+
+def _advisory_detail(adv: dict, catalog_entry: dict | None) -> dict[str, Any]:
+    """Build a generic per-model drill-down summary for one advisory."""
+    per_model: list[dict] = []
+    for m in adv.get("per_model", []):
+        entry_m: dict[str, Any] = {
+            "model": m.get("model"),
+            "status": m.get("status"),
+            "detail": m.get("detail"),
+            "affected_pct": m.get("affected_pct"),
+            "affected_nm": m.get("affected_nm"),
+            "total_nm": m.get("total_nm"),
+        }
+        cc = m.get("cross_check")
+        if cc:
+            entry_m["cross_check"] = cc
+        per_model.append(entry_m)
+
+    result: dict[str, Any] = {
+        "advisory_id": adv.get("advisory_id"),
+        "aggregate_status": adv.get("aggregate_status"),
+        "aggregate_detail": adv.get("aggregate_detail"),
+        "per_model": per_model,
+        "parameters_used": adv.get("parameters_used", {}),
+        "cross_check_note": (
+            "Cross-check notes are display-only context for discussion, not a "
+            "downgrade signal. Explain the grade with them; do not argue it down."
+        ),
+    }
+    if catalog_entry:
+        result["name"] = catalog_entry.get("name")
+        result["category"] = catalog_entry.get("category")
+        result["description"] = catalog_entry.get("description")
+    return result
+
+
+def _convective_detail(route_analyses: dict, models: list[str]) -> dict[str, Any]:
+    """Per-model convective drill-down from the route analyses soundings.
+
+    For each model: CAPE range across the route, the peak point (CAPE, cover %,
+    location), the max convective cover %, and which assessment method
+    (thermo vs NWP) each point used. ``cover_pct`` near 0 is the model scheme
+    saying "blue sky" even when CAPE (thermo) is high — the apparent
+    contradiction the cross-check explains.
+    """
+    points = route_analyses.get("analyses", [])
+    out: dict[str, Any] = {}
+    for model in models:
+        capes: list[float] = []
+        peak: dict | None = None
+        max_cover: float | None = None
+        method_counts: dict[str, int] = {}
+        for p in points:
+            sounding = (p.get("sounding") or {}).get(model)
+            if not sounding:
+                continue
+            conv = sounding.get("convective")
+            if not conv:
+                continue
+            method = conv.get("method")
+            if method:
+                method_counts[method] = method_counts.get(method, 0) + 1
+            cover = conv.get("cover_pct")
+            if cover is not None:
+                max_cover = cover if max_cover is None else max(max_cover, cover)
+            cape = conv.get("cape_jkg")
+            if cape is not None:
+                capes.append(cape)
+                if peak is None or cape > peak["cape_jkg"]:
+                    peak = {
+                        "cape_jkg": round(cape),
+                        "cover_pct": round(cover) if cover is not None else None,
+                        "risk_level": conv.get("risk_level"),
+                        "method": method,
+                        "distance_nm": p.get("distance_from_origin_nm"),
+                        "waypoint_icao": p.get("waypoint_icao"),
+                    }
+        if not capes and not method_counts:
+            continue
+        out[model] = {
+            "cape_range_jkg": [round(min(capes)), round(max(capes))] if capes else None,
+            "peak": peak,
+            "max_cover_pct": round(max_cover) if max_cover is not None else None,
+            "assessment_method": (
+                max(method_counts, key=lambda k: method_counts[k]) if method_counts else None
+            ),
+            "method_counts": method_counts,
+        }
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Tool: get_digest_context
+# ---------------------------------------------------------------------------
+
+@mcp.tool()
+def get_digest_context(
+    flight_id: Annotated[
+        str,
+        Field(description="Flight ID from list_flights or create_flight"),
+    ],
+) -> dict[str, Any]:
+    """Get the exact text input the AI weather digest saw for this flight.
+
+    Use when the user wants the deepest possible context behind the briefing —
+    e.g. to reconcile a red/amber advisory with the digest narrative, or to see
+    every advisory, route statistic, and the raw DWD synoptic overview exactly
+    as the digest LLM received them. This is the maximum detail exposed over MCP;
+    pair it with get_advisory_detail when diagnosing a specific advisory.
+
+    Returns the plain-text digest context, or status 'none' for older briefings
+    that predate this artifact / had no digest generated.
+    """
+    try:
+        client = _get_client()
+    except ValueError as e:
+        return _error_result(str(e))
+
+    with client:
+        try:
+            timestamp, status = _resolve_pack(client, flight_id)
+        except httpx.HTTPStatusError as e:
+            return _error_result(f"API error: {e.response.text}", e.response.status_code)
+        if status is not None:
+            return status
+
+        try:
+            context = client.get_digest_context(flight_id, timestamp)
+        except httpx.HTTPStatusError as e:
+            return _error_result(f"API error: {e.response.text}", e.response.status_code)
+
+    if not context:
+        return {
+            "status": "none",
+            "flight_id": flight_id,
+            "message": "No digest context available for this briefing.",
+            "web_url": _flight_web_url(flight_id),
+        }
+
+    return {
+        "status": "ready",
+        "flight_id": flight_id,
+        "briefing_timestamp": timestamp,
+        "digest_context": context,
+        "web_url": _flight_web_url(flight_id),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Prompt: explain_advisory
+# ---------------------------------------------------------------------------
+
+@mcp.prompt()
+def explain_advisory(
+    flight_id: Annotated[
+        str,
+        Field(description="Flight ID to investigate"),
+    ],
+    advisory_id: Annotated[
+        str,
+        Field(description="Advisory to explain, e.g. 'convective'"),
+    ] = "convective",
+) -> str:
+    """On-ramp for an in-depth, per-model discussion of one advisory's grade."""
+    return (
+        f"For flight {flight_id}, explain why the '{advisory_id}' advisory has its "
+        "current status. First call get_briefing to see the per-model split and any "
+        f"cross-check notes, then get_advisory_detail('{flight_id}', '{advisory_id}') "
+        "for the per-model breakdown — for convective that includes CAPE range, the "
+        "location of the peak, convective cover % (cover ~0 means the model scheme "
+        "sees blue sky), and whether the thermo or NWP method was used. Pull "
+        "get_digest_context if you need the exact LLM input. Explain the grade from "
+        "that evidence, including when high CAPE drives a red while the model's own "
+        "convective scheme is quiet. Treat the cross-check as context for the "
+        "discussion, not a reason to downgrade the advisory."
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_digest_context_api.py
+++ b/tests/test_digest_context_api.py
@@ -1,0 +1,106 @@
+"""API test for GET /api/flights/{id}/packs/{ts}/digest/context (#278)."""
+
+from __future__ import annotations
+
+import hashlib
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import sessionmaker
+
+from flyfun_common.db import current_user_id, get_db, DEV_USER_ID
+from flyfun_common.db.models import UserPreferencesRow, UserRow
+from weatherbrief.api.app import create_app
+from weatherbrief.models import BriefingPackMeta, Flight
+from weatherbrief.storage.flights import pack_dir_for, save_flight, save_pack_meta
+
+
+_NOW = datetime.now(timezone.utc)
+_DEP = (_NOW + timedelta(days=2)).replace(hour=9, minute=0, second=0, microsecond=0)
+
+
+@pytest.fixture
+def app_db():
+    from conftest import make_app_engine
+
+    engine = make_app_engine()
+    TestSession = sessionmaker(bind=engine)
+    session = TestSession()
+    session.add(UserRow(
+        id=DEV_USER_ID, provider="local", provider_sub="dev",
+        email="dev@localhost", display_name="Dev", approved=True,
+    ))
+    session.flush()
+    session.add(UserPreferencesRow(user_id=DEV_USER_ID))
+    session.commit()
+    session.close()
+    yield TestSession
+    engine.dispose()
+
+
+@pytest.fixture
+def client(app_db, tmp_path, monkeypatch):
+    monkeypatch.setenv("DATA_DIR", str(tmp_path / "data"))
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.setenv("JWT_SECRET", "test-secret")
+    app = create_app()
+
+    def _override_get_db():
+        session = app_db()
+        try:
+            yield session
+            session.commit()
+        finally:
+            session.close()
+
+    app.dependency_overrides[get_db] = _override_get_db
+    app.dependency_overrides[current_user_id] = lambda: DEV_USER_ID
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def _seed(app_db) -> tuple[Flight, BriefingPackMeta]:
+    fid = "egtk_lsgs-" + hashlib.sha256(b"ctx").hexdigest()[:4]
+    session = app_db()
+    flight = Flight(
+        id=fid, user_id=DEV_USER_ID, route_name="egtk_lsgs",
+        waypoints=["EGTK", "LSGS"], departure_time=_DEP,
+        cruise_altitude_ft=8000, flight_ceiling_ft=18000,
+        flight_duration_hours=4.5, created_at=_NOW - timedelta(days=1),
+    )
+    save_flight(session, flight, DEV_USER_ID)
+    meta = BriefingPackMeta(
+        flight_id=flight.id, fetch_timestamp=_NOW - timedelta(hours=1),
+        days_out=2, has_gramet=False, has_skewt=False, has_digest=True,
+        assessment="RED", assessment_reason="convective",
+    )
+    save_pack_meta(session, meta)
+    session.commit()
+    session.close()
+    return flight, meta
+
+
+def test_digest_context_returns_text(client, app_db):
+    flight, meta = _seed(app_db)
+    ts = meta.fetch_timestamp.isoformat()
+    pack_dir = Path(pack_dir_for(DEV_USER_ID, flight.id, ts))
+    pack_dir.mkdir(parents=True, exist_ok=True)
+    (pack_dir / "digest_context.txt").write_text(
+        "=== ADVISORIES ===\nconvective: RED (CAPE 2970)\n", encoding="utf-8"
+    )
+
+    resp = client.get(f"/api/flights/{flight.id}/packs/{ts}/digest/context")
+    assert resp.status_code == 200, resp.text
+    assert resp.headers["content-type"].startswith("text/plain")
+    assert "convective: RED" in resp.text
+
+
+def test_digest_context_404_when_absent(client, app_db):
+    flight, meta = _seed(app_db)
+    ts = meta.fetch_timestamp.isoformat()
+    pack_dir = Path(pack_dir_for(DEV_USER_ID, flight.id, ts))
+    pack_dir.mkdir(parents=True, exist_ok=True)  # pack exists, no digest_context.txt
+
+    resp = client.get(f"/api/flights/{flight.id}/packs/{ts}/digest/context")
+    assert resp.status_code == 404

--- a/tests/test_mcp_advisory_detail.py
+++ b/tests/test_mcp_advisory_detail.py
@@ -1,0 +1,249 @@
+"""Tests for the MCP advisory-detail / digest-context tools (issue #278).
+
+Covers the in-process logic of the MCP server's drill-down surface:
+- Tier 1: ``_summarize_advisories`` retains per_model / cross_check /
+  parameters_used and emits discoverability hints (Layer A).
+- Tier 2: ``get_advisory_detail`` + ``_convective_detail`` build a server-side
+  per-model summary (CAPE range, peak, cover %, thermo-vs-NWP method).
+- Tier 3: ``get_digest_context`` returns the persisted LLM context.
+
+The tools are thin proxies, so the WeatherbriefClient is faked rather than
+hitting the API.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from weatherbrief.mcp import server
+
+
+# --------------------------------------------------------------------------
+# Fixtures: a fake client + sample manifests
+# --------------------------------------------------------------------------
+
+ADVISORIES = {
+    "advisories": [
+        {
+            "advisory_id": "convective",
+            "aggregate_status": "red",
+            "aggregate_detail": "EXTREME over 57%",
+            "parameters_used": {"min_risk": 2, "affected_pct_red": 50},
+            "per_model": [
+                {"model": "gfs", "status": "amber", "detail": "MODERATE over 20%",
+                 "affected_pct": 20.0, "affected_nm": 30.0, "total_nm": 150.0,
+                 "cross_check": None},
+                {"model": "ecmwf", "status": "red", "detail": "EXTREME over 57%",
+                 "affected_pct": 57.0, "affected_nm": 85.0, "total_nm": 150.0,
+                 "cross_check": "DD MODERATE not corroborated — model scheme quiet over 40nm"},
+                {"model": "meteofrance", "status": "red", "detail": "EXTREME over 60%",
+                 "affected_pct": 60.0, "affected_nm": 90.0, "total_nm": 150.0,
+                 "cross_check": None},
+            ],
+        },
+        {
+            "advisory_id": "cloud_top",
+            "aggregate_status": "green",
+            "aggregate_detail": "Can climb above cloud",
+            "parameters_used": {"margin_ft": 1000},
+            "per_model": [
+                {"model": "gfs", "status": "green", "detail": "clear",
+                 "affected_pct": 0.0, "affected_nm": 0.0, "total_nm": 150.0},
+                {"model": "ecmwf", "status": "green", "detail": "clear",
+                 "affected_pct": 0.0, "affected_nm": 0.0, "total_nm": 150.0},
+            ],
+        },
+    ],
+    "catalog": [
+        {"id": "convective", "name": "Convective Activity", "category": "convective",
+         "description": "Convective risk per point."},
+        {"id": "cloud_top", "name": "Cloud Top", "category": "cloud",
+         "description": "Can we fly above the clouds?"},
+    ],
+}
+
+ROUTE_ANALYSES = {
+    "analyses": [
+        {
+            "point_index": 0,
+            "distance_from_origin_nm": 0.0,
+            "waypoint_icao": "LFMD",
+            "sounding": {
+                "gfs": {"convective": {"risk_level": "low", "cape_jkg": 800.0,
+                                       "cover_pct": 5.0, "method": "thermo"}},
+                "ecmwf": {"convective": {"risk_level": "moderate", "cape_jkg": 2600.0,
+                                         "cover_pct": 0.0, "method": "thermo"}},
+            },
+        },
+        {
+            "point_index": 1,
+            "distance_from_origin_nm": 40.0,
+            "waypoint_icao": "PERUS",
+            "sounding": {
+                "gfs": {"convective": {"risk_level": "low", "cape_jkg": 950.0,
+                                       "cover_pct": 10.0, "method": "thermo"}},
+                "ecmwf": {"convective": {"risk_level": "extreme", "cape_jkg": 2970.0,
+                                         "cover_pct": 0.0, "method": "thermo"}},
+            },
+        },
+    ],
+}
+
+
+class FakeClient:
+    """Stand-in for WeatherbriefClient that returns canned payloads."""
+
+    def __init__(self, **overrides):
+        self._refresh = overrides.get("refresh", {"active": False})
+        self._pack = overrides.get("pack", {"fetch_timestamp": "20260620T0600Z"})
+        self._advisories = overrides.get("advisories", ADVISORIES)
+        self._route_analyses = overrides.get("route_analyses", ROUTE_ANALYSES)
+        self._digest_context = overrides.get("digest_context", "ADVISORIES\nconvective: red\n")
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def get_refresh_status(self, flight_id):
+        return self._refresh
+
+    def get_latest_pack(self, flight_id):
+        return self._pack
+
+    def get_advisories(self, flight_id, timestamp):
+        return self._advisories
+
+    def get_route_analyses(self, flight_id, timestamp):
+        return self._route_analyses
+
+    def get_digest_context(self, flight_id, timestamp):
+        return self._digest_context
+
+
+@pytest.fixture
+def patch_client(monkeypatch):
+    def _install(**overrides):
+        client = FakeClient(**overrides)
+        monkeypatch.setattr(server, "_get_client", lambda: client)
+        return client
+    return _install
+
+
+# --------------------------------------------------------------------------
+# Tier 1: _summarize_advisories
+# --------------------------------------------------------------------------
+
+def test_summarize_retains_per_model_and_cross_check():
+    out = server._summarize_advisories(ADVISORIES)
+    conv = next(a for a in out if a["id"] == "convective")
+
+    # per_model retained with each model's status/detail
+    models = {m["model"]: m for m in conv["per_model"]}
+    assert models["gfs"]["status"] == "amber"
+    assert models["ecmwf"]["status"] == "red"
+    # cross_check carried through only where present
+    assert "cross_check" in models["ecmwf"]
+    assert "cross_check" not in models["gfs"]
+
+    # parameters_used retained
+    assert conv["parameters_used"]["affected_pct_red"] == 50
+
+
+def test_summarize_emits_discoverability_hints():
+    out = server._summarize_advisories(ADVISORIES)
+    conv = next(a for a in out if a["id"] == "convective")
+    green = next(a for a in out if a["id"] == "cloud_top")
+
+    # Layer A hints on the red advisory with disagreement + cross-check
+    assert conv["cross_check_present"] is True
+    assert conv["model_disagreement"] is True  # amber + red
+    assert conv["detail_tool"] == "get_advisory_detail"
+    assert conv["name"] == "Convective Activity"
+
+    # Quiet, all-green advisory: no drill pointer, no false signals
+    assert green["cross_check_present"] is False
+    assert green["model_disagreement"] is False
+    assert "detail_tool" not in green
+
+
+# --------------------------------------------------------------------------
+# Tier 2: _convective_detail + get_advisory_detail
+# --------------------------------------------------------------------------
+
+def test_convective_detail_cape_peak_cover_method():
+    detail = server._convective_detail(ROUTE_ANALYSES, ["gfs", "ecmwf"])
+
+    ec = detail["ecmwf"]
+    assert ec["cape_range_jkg"] == [2600, 2970]
+    assert ec["peak"]["cape_jkg"] == 2970
+    assert ec["peak"]["distance_nm"] == 40.0
+    assert ec["peak"]["waypoint_icao"] == "PERUS"
+    # cover ~0 = "blue sky" signal preserved
+    assert ec["max_cover_pct"] == 0
+    assert ec["peak"]["cover_pct"] == 0
+    assert ec["assessment_method"] == "thermo"
+
+    gfs = detail["gfs"]
+    assert gfs["cape_range_jkg"] == [800, 950]
+    assert gfs["max_cover_pct"] == 10
+
+
+def test_convective_detail_skips_absent_model():
+    detail = server._convective_detail(ROUTE_ANALYSES, ["meteofrance"])
+    assert detail == {}
+
+
+def test_get_advisory_detail_convective(patch_client):
+    patch_client()
+    res = server.get_advisory_detail("flight-1", "convective")
+
+    assert res["advisory_id"] == "convective"
+    assert res["aggregate_status"] == "red"
+    assert res["name"] == "Convective Activity"
+    # generic per-model carries extent + cross_check
+    ec = next(m for m in res["per_model"] if m["model"] == "ecmwf")
+    assert ec["affected_nm"] == 85.0
+    assert "cross_check" in ec
+    # guardrail framing present
+    assert "not a downgrade" in res["cross_check_note"]
+    # convective specialization attached
+    assert res["convective"]["ecmwf"]["peak"]["cape_jkg"] == 2970
+    assert res["flight_id"] == "flight-1"
+
+
+def test_get_advisory_detail_unknown_id_lists_available(patch_client):
+    patch_client()
+    res = server.get_advisory_detail("flight-1", "nonexistent")
+    assert "error" in res
+    assert "convective" in res["error"]
+
+
+def test_get_advisory_detail_no_pack(patch_client):
+    patch_client(pack=None)
+    res = server.get_advisory_detail("flight-1", "convective")
+    assert res["status"] == "none"
+
+
+def test_get_advisory_detail_processing(patch_client):
+    patch_client(refresh={"active": True})
+    res = server.get_advisory_detail("flight-1", "convective")
+    assert res["status"] == "processing"
+
+
+# --------------------------------------------------------------------------
+# Tier 3: get_digest_context
+# --------------------------------------------------------------------------
+
+def test_get_digest_context_ready(patch_client):
+    patch_client()
+    res = server.get_digest_context("flight-1")
+    assert res["status"] == "ready"
+    assert "convective: red" in res["digest_context"]
+
+
+def test_get_digest_context_missing(patch_client):
+    patch_client(digest_context=None)
+    res = server.get_digest_context("flight-1")
+    assert res["status"] == "none"

--- a/tests/test_mcp_advisory_detail.py
+++ b/tests/test_mcp_advisory_detail.py
@@ -62,30 +62,45 @@ ADVISORIES = {
     ],
 }
 
+def _point(idx, dist, icao, valid, eta, gfs, ecmwf):
+    return {
+        "point_index": idx,
+        "distance_from_origin_nm": dist,
+        "waypoint_icao": icao,
+        "forecast_hour": valid,
+        "interpolated_time": eta,
+        "sounding": {"gfs": gfs, "ecmwf": ecmwf},
+    }
+
+
 ROUTE_ANALYSES = {
     "analyses": [
-        {
-            "point_index": 0,
-            "distance_from_origin_nm": 0.0,
-            "waypoint_icao": "LFMD",
-            "sounding": {
-                "gfs": {"convective": {"risk_level": "low", "cape_jkg": 800.0,
-                                       "cover_pct": 5.0, "method": "thermo"}},
-                "ecmwf": {"convective": {"risk_level": "moderate", "cape_jkg": 2600.0,
-                                         "cover_pct": 0.0, "method": "thermo"}},
+        _point(
+            0, 0.0, "LFMD", "2026-06-21T13:00:00+00:00", "2026-06-21T13:05:00+00:00",
+            gfs={
+                "convective": {"risk_level": "low", "cape_jkg": 800.0, "method": "thermo", "top_ft": 18000.0},
+                "convective_thermo": {"risk_level": "low", "cape_jkg": 800.0, "top_ft": 18000.0},
+                "convective_nwp": {"risk_level": "none", "cape_jkg": None, "cover_pct": 5.0, "top_ft": None},
             },
-        },
-        {
-            "point_index": 1,
-            "distance_from_origin_nm": 40.0,
-            "waypoint_icao": "PERUS",
-            "sounding": {
-                "gfs": {"convective": {"risk_level": "low", "cape_jkg": 950.0,
-                                       "cover_pct": 10.0, "method": "thermo"}},
-                "ecmwf": {"convective": {"risk_level": "extreme", "cape_jkg": 2970.0,
-                                         "cover_pct": 0.0, "method": "thermo"}},
+            ecmwf={
+                "convective": {"risk_level": "moderate", "cape_jkg": 2600.0, "method": "thermo", "top_ft": 25000.0},
+                "convective_thermo": {"risk_level": "moderate", "cape_jkg": 2600.0, "top_ft": 25000.0},
+                "convective_nwp": {"risk_level": "none", "cape_jkg": None, "cover_pct": 0.0, "top_ft": None},
             },
-        },
+        ),
+        _point(
+            1, 40.0, "PERUS", "2026-06-21T14:00:00+00:00", "2026-06-21T15:20:00+00:00",
+            gfs={
+                "convective": {"risk_level": "low", "cape_jkg": 950.0, "method": "thermo", "top_ft": 19000.0},
+                "convective_thermo": {"risk_level": "low", "cape_jkg": 950.0, "top_ft": 19000.0},
+                "convective_nwp": {"risk_level": "none", "cape_jkg": None, "cover_pct": 10.0, "top_ft": None},
+            },
+            ecmwf={
+                "convective": {"risk_level": "extreme", "cape_jkg": 2970.0, "method": "thermo", "top_ft": 27000.0},
+                "convective_thermo": {"risk_level": "extreme", "cape_jkg": 2970.0, "top_ft": 27000.0},
+                "convective_nwp": {"risk_level": "none", "cape_jkg": None, "cover_pct": 0.0, "top_ft": None},
+            },
+        ),
     ],
 }
 
@@ -99,6 +114,7 @@ class FakeClient:
         self._advisories = overrides.get("advisories", ADVISORIES)
         self._route_analyses = overrides.get("route_analyses", ROUTE_ANALYSES)
         self._digest_context = overrides.get("digest_context", "ADVISORIES\nconvective: red\n")
+        self._freshness = overrides.get("freshness", {"fresh": True})
 
     def __enter__(self):
         return self
@@ -111,6 +127,9 @@ class FakeClient:
 
     def get_latest_pack(self, flight_id):
         return self._pack
+
+    def get_freshness(self, flight_id):
+        return self._freshness
 
     def get_advisories(self, flight_id, timestamp):
         return self._advisories
@@ -156,15 +175,17 @@ def test_summarize_emits_discoverability_hints():
     conv = next(a for a in out if a["id"] == "convective")
     green = next(a for a in out if a["id"] == "cloud_top")
 
-    # Layer A hints on the red advisory with disagreement + cross-check
+    # Layer A hints on the red advisory with a cross-check. Flags are neutral
+    # (no "model_disagreement" that would prime a red→amber downgrade).
     assert conv["cross_check_present"] is True
-    assert conv["model_disagreement"] is True  # amber + red
+    assert conv["per_model_present"] is True
+    assert "model_disagreement" not in conv
     assert conv["detail_tool"] == "get_advisory_detail"
     assert conv["name"] == "Convective Activity"
 
-    # Quiet, all-green advisory: no drill pointer, no false signals
+    # Quiet, all-green advisory: no drill pointer, no cross-check signal
     assert green["cross_check_present"] is False
-    assert green["model_disagreement"] is False
+    assert green["per_model_present"] is True
     assert "detail_tool" not in green
 
 
@@ -176,18 +197,23 @@ def test_convective_detail_cape_peak_cover_method():
     detail = server._convective_detail(ROUTE_ANALYSES, ["gfs", "ecmwf"])
 
     ec = detail["ecmwf"]
-    assert ec["cape_range_jkg"] == [2600, 2970]
-    assert ec["peak"]["cape_jkg"] == 2970
-    assert ec["peak"]["distance_nm"] == 40.0
-    assert ec["peak"]["waypoint_icao"] == "PERUS"
-    # cover ~0 = "blue sky" signal preserved
-    assert ec["max_cover_pct"] == 0
-    assert ec["peak"]["cover_pct"] == 0
+    # thermo (parcel/CAPE) view
+    assert ec["thermo"]["cape_range_jkg"] == [2600, 2970]
+    assert ec["thermo"]["peak"]["cape_jkg"] == 2970
+    # parcel-derived "tops" the digest narrates (EL), reconciles with cover ~0
+    assert ec["thermo"]["peak"]["el_top_ft"] == 27000
+    assert ec["thermo"]["peak"]["distance_nm"] == 40.0
+    assert ec["thermo"]["peak"]["waypoint_icao"] == "PERUS"
+    # diurnal/time axis: forecast valid-time vs flight ETA at the peak
+    assert ec["thermo"]["peak"]["valid_time"] == "2026-06-21T14:00:00+00:00"
+    assert ec["thermo"]["peak"]["eta"] == "2026-06-21T15:20:00+00:00"
+    # nwp scheme: cover ~0 = "blue sky" signal preserved
+    assert ec["nwp"]["max_cover_pct"] == 0
     assert ec["assessment_method"] == "thermo"
 
     gfs = detail["gfs"]
-    assert gfs["cape_range_jkg"] == [800, 950]
-    assert gfs["max_cover_pct"] == 10
+    assert gfs["thermo"]["cape_range_jkg"] == [800, 950]
+    assert gfs["nwp"]["max_cover_pct"] == 10
 
 
 def test_convective_detail_skips_absent_model():
@@ -208,8 +234,9 @@ def test_get_advisory_detail_convective(patch_client):
     assert "cross_check" in ec
     # guardrail framing present
     assert "not a downgrade" in res["cross_check_note"]
-    # convective specialization attached
-    assert res["convective"]["ecmwf"]["peak"]["cape_jkg"] == 2970
+    # convective specialization attached, with provenance note
+    assert res["convective"]["ecmwf"]["thermo"]["peak"]["cape_jkg"] == 2970
+    assert "blue sky" in res["convective_note"]
     assert res["flight_id"] == "flight-1"
 
 
@@ -230,6 +257,18 @@ def test_get_advisory_detail_processing(patch_client):
     patch_client(refresh={"active": True})
     res = server.get_advisory_detail("flight-1", "convective")
     assert res["status"] == "processing"
+
+
+def test_get_advisory_detail_surfaces_staleness(patch_client):
+    patch_client(freshness={
+        "fresh": False,
+        "stale_models": ["ecmwf", "gfs"],
+        "model_init_times": {"ecmwf": 0, "gfs": 6},
+    })
+    res = server.get_advisory_detail("flight-1", "convective")
+    assert res["stale"] is True
+    assert "ecmwf" in res["stale_models"]
+    assert "refresh_briefing" in res["stale_note"]
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds two new MCP tools and a prompt to enable in-depth, per-model explanation of weather advisories. When a user questions why an advisory is red/amber (especially when it appears inconsistent with visual conditions), the agent can now drill into the per-model breakdown, CAPE ranges, convective cover percentages, and the exact LLM context that produced the briefing.

## Key Changes

- **`get_advisory_detail(flight_id, advisory_id)`** — Tier 2 drill-down tool that returns:
  - Per-model status, detail, affected extent, and cross-check notes
  - Parameters used (thresholds that produced the grade)
  - For convective: CAPE range, peak location/time, convective cover % (cover ~0 = "blue sky"), and whether thermo (parcel-derived) or NWP (model scheme) method was used
  - Staleness metadata if models have updated since briefing generation

- **`get_digest_context(flight_id)`** — Tier 3 tool that returns the exact plain-text context fed to the LLM digest (every advisory, route statistic, raw DWD overview). Last resort for maximum context when targeted drill-down isn't enough.

- **`explain_advisory(flight_id, advisory_id)`** — New prompt that on-ramps the agent into a structured investigation: call `get_briefing` for the summary, then `get_advisory_detail` for per-model breakdown, then optionally `get_digest_context` for the full LLM input.

- **`_summarize_advisories` refactor** — Now retains per-model detail, cross-check notes, and parameters_used in the briefing output. Emits neutral discoverability hints (`cross_check_present`, `per_model_present`, `detail_tool`) to surface drill-down opportunities without priming a red→amber downgrade.

- **`_resolve_pack` helper** — Extracted common pack-resolution logic (check refresh status, get latest pack, return timestamp or status dict) used by both new tools.

- **`_convective_detail` function** — Splits thermo (CAPE/parcel) and NWP (model scheme) derivations so high CAPE with cover ~0 can be explained as consistent, not contradictory. Includes peak location, forecast valid-time vs flight ETA, and assessment method.

- **API endpoint** `GET /api/flights/{id}/packs/{ts}/digest/context` — Serves `digest_context.txt` (the byte-faithful LLM input) as plain text. Returns 404 for older packs that predate this artifact.

- **Client method** `get_route_analyses()` and `get_digest_context()` — New WeatherbriefClient methods to fetch route analyses (per-point soundings) and digest context from the API.

## Implementation Details

- **Guardrail framing**: The cross-check note is explicitly marked as "context for discussion, not a downgrade signal" in both the tool docstring and the returned data. The prompt and tool descriptions emphasize explaining the grade with the evidence, never arguing it down.

- **Provenance clarity**: The convective detail includes a note that "convective tops" in the digest are parcel-derived (equilibrium level from CAPE), not the model's convective cloud field. This reconciles high CAPE with low convective cover.

- **Staleness handling**: `get_advisory_detail` checks freshness and surfaces stale model init times with a caveat to call `refresh_briefing` for current data.

- **Discoverability (Layer A)**: The `detail_tool` hint in `_summarize_advisories` only appears on non-green advisories or those with cross-check notes, avoiding nudging wasteful drills on quiet advisories.

- **Tests**: Comprehensive test suite (`test_mcp_advisory_detail.py`) covers all three tiers with a fake client, plus API test (`test_digest_context_api.py`) for the new endpoint.

https://claude.ai/code/session_01GD1bDYmE7BWP9mx6QuNsYw