### PR TITLE
fronts: link air-mass boundaries across pressure levels into sloping chains

### DIFF
--- a/designs/future/hewson-fields-aviation-advisories.md
+++ b/designs/future/hewson-fields-aviation-advisories.md
@@ -362,10 +362,19 @@ Sibling to the map layer — overlays Hewson information on the existing route c
 
 **Phase D.1 (Open-Meteo era — now)**:
 - Reads the **precompute snapshot** at each waypoint × {925, 850, 700} via bilinear-sample
-- Renders 3 horizontal **bands** at 2,500 / 5,000 / 10,000 ft, coloured by the selected metric
-- Same colormap as the map (consistency)
-- Metric picker shared with the map — changing the map metric changes the cross-section bands
 - Cost: <1 ms per briefing (just three bilinear samples per waypoint)
+
+> **As-built note (drift correction, 2026-06-19):** the "3 horizontal θe bands
+> coloured by the selected metric" originally specified here were **not** built.
+> What shipped (#196) is a **front-marker** layer
+> (`web/ts/visualization/cross-section/layers/fronts-markers.ts`): it draws the
+> *detected front lines* on the cross-section, not a continuous metric field.
+> As of the vertical-linking work it draws each front as a **slanted line**
+> through its per-level crossing positions (see §7.9.1), falling back to a
+> vertical marker per crossing on pre-linking packs. The generic per-metric band
+> overlay (θe / |∇θe| / advection shaded across the column) remains unbuilt and is
+> still a reasonable future addition; it would sit alongside the front-line layer,
+> not replace it.
 
 **Phase D.2 (GRIB era — later, gated on native-GRIB ingestion)**:
 - Per-briefing **stencil** sampling: around each waypoint, extract a 3×3 (or 5×5 for cleaner 2nd derivatives) stencil from the briefing's already-loaded GRIB at each of the **25+ native pressure levels** the ingestion subsets
@@ -375,6 +384,63 @@ Sibling to the map layer — overlays Hewson information on the existing route c
 - Reuses the same `CrossSectionLayer` surfaces — UI doesn't change, data source upgrades silently
 
 The 3-level precompute is kept small on purpose: it exists to feed the map, and the map shows one level at a time anyway. Adding levels to the precompute just to support the cross-section would be wasteful when the cross-section can draw from richer per-briefing data.
+
+### 7.9.1 Vertical linking of front lines across levels (#196, added 2026-06-19)
+
+A front is a sloping 3-D surface, so the *same* air-mass boundary is detected at
+~the same along-route distance on 925, 850 and 700 — displaced toward the cold
+air with height. The pipeline links those per-level crossings into **front
+chains** so the cross-section can draw one **slanted line** per front (tilting
+back over the cold air) instead of three independent vertical markers, and so we
+know a front's **depth** (how many levels it spans = shallow vs. deep).
+
+**History.** The first cut of this was `_stamp_vertical_coherence` in
+`tasks/fronts.py`: it clustered crossings across levels purely by along-route
+distance (complete-linkage, reusing the 60 km `merge_km`) and stamped each with a
+`vertical_levels` count used to dim single-level (shallow/suspect) detections.
+That count was correct in spirit but had two weaknesses — it ignored *what kind*
+of boundary each crossing was, and 60 km is too tight for warm fronts (which
+slope shallowly and can sit 100–200 km apart between levels), so it under-linked
+them.
+
+**As-built (`_link_front_chains`).** It now grows chains bottom→top (925→850→700),
+attaching each level's crossing to the best open chain one level below, gated on:
+- **kind-compatible** — cold↔cold / warm↔warm; quasi-stationary (an advection-only
+  label) wildcards. A cold front never links to a nearby warm front.
+- **same Δθe sign** — the air-mass contrast must point the same way (both flying
+  into colder air, or both into warmer); otherwise it is a different boundary.
+- **slope budget** — max along-route displacement per level pair, derived from
+  textbook frontal slope (925→850 ≈ 100 km, 850→700 ≈ 170 km for cold; ×1.4 for
+  warm). Wider than `merge_km`, and the reason warm fronts now link.
+
+Among passing candidates a **soft coldward prior** (the physical norm — the front
+shifts toward the cold air with height) breaks ties; it is *not* a hard gate,
+because the 3-level data is coarse and occlusions genuinely tilt the other way.
+Unattached crossings become single-level chains (`n_levels == 1`, drawn faint).
+
+**Artifact.** `route_fronts.json` gains `front_chains: {model → [FrontChain]}`,
+each chain carrying its ordered per-level `nodes` (level, distance, kind,
+intensity, gradient, Δθe), a consensus `kind`, `n_levels` (depth), and a `tilt`
+diagnostic (`coldward` / `upright` / `warmward`). `vertical_levels` is still
+stamped on each crossing (now from chain membership) so the marker opacity and
+the `fronts` advisory keep working unchanged.
+
+**Rendering.** `fronts-markers.ts` draws each chain as a slanted polyline through
+its node positions (x = along-route distance at that level, y = the level's
+representative altitude 2,500/5,000/10,000 ft), colour = kind, weight =
+intensity, opacity = depth, with a node dot per level and a dashed extrapolation
+to the column edges. Single-level chains draw as a short faint tick; pre-linking
+packs (no `front_chains`) fall back to the original vertical markers.
+
+**Honesty.** With only 3 levels and the §8 ±50–100 km per-level positional
+uncertainty, the slope is a 2-segment sketch, not a surveyed surface — present it
+qualitatively. The clean version arrives with the Phase D.2 **GRIB stencil**: with
+25+ native levels the front falls out as the locus of max gradient / TFP=0 *in the
+(along-route × pressure) plane*, so vertical continuity is intrinsic and no
+cross-level association heuristic is needed. The linker is the deliberate
+3-level stopgap that proves the UX until then. **Calibration of the link gates
+against a known frontal case (Storm Ciarán, the May-4 fronts) is still pending**
+— the thresholds above are physically-motivated defaults, not validated numbers.
 
 ## 8. Accuracy expectations
 
@@ -628,7 +694,7 @@ Opens after Phase D so the map + cross-section surface has something to show moi
 | **Phase D.0** (precompute loop) | ✅ Done (2026-04-24) — `run_hewson_precompute_loop` + `weatherbrief.hewson.run_once()` + `python -m weatherbrief.hewson` CLI |
 | **Phase D.1** (backend endpoints) | ✅ Done (2026-04-25, PR #96) — `/api/hewson-map`, `/api/hewson-map/manifest`, `/api/hewson-map/all-metrics`; admin-gated via `_synoptic_auth = require_admin` while calibrating |
 | **Phase D.2** (map layer + tooltips + ERA5 cases) | ✅ Done (2026-04-25, PR #96) — Synoptic Forecast tab on `/maps.html`, canvas grid overlay, cursor-following tooltip with all 6 metrics, default/storm scale toggle, briefing-style (i) modal with Discuss-with-AI prompts, `era5-case` CLI for historical events (Storm Ciarán test case) |
-| Phase D.3 (cross-section θe bands) | Full 3-band θe visualization still pending; the **front-marker** cross-section layer shipped in #196 (`layers/fronts-markers.ts`) as the first Phase D.3 layer |
+| Phase D.3 (cross-section θe bands) | Generic per-metric θe band overlay still **unbuilt** (and optional — see §7.9 drift note). What shipped (#196, `layers/fronts-markers.ts`) is the **front-line** layer: vertical markers per crossing, now upgraded to **slanted vertically-linked front lines** (§7.9.1, `_link_front_chains` + `front_chains` artifact). Link-gate calibration still pending. |
 | Phase D.4 (stencil in GRIB era) | Gated on native-GRIB ingestion being live for the user's briefing model |
 | **Phase C data layer** (#195 Part 1) | ✅ Done — `FrontGateConfig` + `HewsonFieldSource` (snapshot/case), candidate/decision split, `run_fronts` stage + `route_fronts.json` + `auto_front_detection` pref + `GET .../route-fronts`, 2-D TFP=0 extractor + `GET /api/hewson-map/fronts` + synoptic-map overlay, `front-calibrate` sweep CLI + DWD chart overlay. Detection reads the precompute snapshot — milliseconds, zero fetch. |
 | **Phase C advisory evaluators** (#196 Part 2) | ✅ Done — `fronts` advisory evaluator (`analysis/advisories/fronts.py`, `default_enabled=False`, auto-enabled when `route_fronts.json` present, RED on sharp / AMBER on classical+closing); `route_fronts` on `RouteContext` populated in the 3 `tasks/advise.py` sites; pipeline runs fronts *before* advisories; recalc re-runs/clears the artifact per pref; AI digest picks it up via the generic advisory loop; route-map `frontsGroup` overlay + toggle; cross-section `fronts-markers` layer; `routeFronts` in the briefing store + `fetchRouteFronts` adapter (non-blocking); "Experimental Auto Front Detection" settings toggle (`auto_front_detection`). Synoptic maps-page overlay left gated by `_synoptic_auth` for now (testers) — pref is the long-term gate. |

--- a/designs/meteorology-decisions.md
+++ b/designs/meteorology-decisions.md
@@ -1169,3 +1169,48 @@ selection is **NCO.OP.143** (tiered DH+200/1500 m, DH+400/3000 m, or no-IAP
 2000 ft/5000 m); FAA is 14 CFR 91.169 (2000/3 trigger, 600-2 / 800-2 alternate).
 The conservatism above is only in the *conditional-group* handling and in
 bracketing the unknown plate DH with a high-side proxy range.
+
+---
+
+## 13. Vertical linking of Hewson front lines across pressure levels
+
+**Date:** 2026-06-19
+**Status:** Implemented (experimental, gated by `auto_front_detection`); link-gate
+calibration pending.
+**Context:** Fronts are detected independently at 925/850/700 hPa
+(`tasks/fronts.py`, see [hewson-fields-aviation-advisories.md](./future/hewson-fields-aviation-advisories.md)
+§7.9.1). A front is a sloping surface, so the same boundary appears at all three
+levels, displaced toward the cold air with height. We associate those per-level
+crossings into one **chain** to (a) draw a single slanted front line on the
+cross-section and (b) know the front's depth (shallow single-level vs. deep).
+
+### Decision
+
+`_link_front_chains` grows chains bottom→top, attaching a crossing to a chain one
+level below it only when **all** hold: kind-compatible (cold↔cold / warm↔warm,
+quasi wildcards), **same Δθe sign** (same air-mass-contrast direction), and within
+a **frontal-slope budget** (925→850 ≈ 100 km, 850→700 ≈ 170 km, ×1.4 for warm
+fronts). A **soft coldward prior** breaks ties (prefer the physically-normal slope
+back over the cold air) but does not reject anti-slope links.
+
+### Rejected alternatives
+
+- **Distance-only clustering at `merge_km` (the prior `_stamp_vertical_coherence`).**
+  Ignored front kind and Δθe sign (could link a cold front to a nearby warm one),
+  and 60 km is too tight for warm fronts (shallow slope → 100–200 km between
+  levels) so it under-linked them. Kept only its `vertical_levels` output, now
+  derived from chain depth.
+- **Hard directional (coldward) gate.** Rejected: with only 3 levels and ±50–100 km
+  per-level positional uncertainty (§8), plus genuine occlusions that tilt the
+  other way, a hard gate would drop real links. Used as a soft tie-break instead.
+- **Per-metric θe bands as the cross-section front visual.** The original §7.9 plan;
+  never built and not the right primitive for *front lines* (it shades a field, it
+  doesn't draw the boundary). The slanted-line layer is what shipped.
+
+### Honesty / open item
+
+The slope budgets and the upright threshold are **physically-motivated defaults,
+not validated numbers** — calibration against a known frontal case (Storm Ciarán,
+the May-4 fronts) is still pending. With 3 levels the slant is a 2-segment sketch;
+the clean version is the Phase D.2 GRIB stencil (detect in the along-route ×
+pressure plane, continuity intrinsic, no association heuristic).

--- a/src/weatherbrief/models/__init__.py
+++ b/src/weatherbrief/models/__init__.py
@@ -92,6 +92,8 @@ from weatherbrief.models.advisories import (  # noqa: F401
     RouteAdvisoryResult,
 )
 from weatherbrief.models.fronts import (  # noqa: F401
+    FrontChainModel,
+    FrontChainNodeModel,
     FrontCrossingModel,
     FrontDecisionModel,
     FrontProximityModel,

--- a/src/weatherbrief/models/fronts.py
+++ b/src/weatherbrief/models/fronts.py
@@ -45,6 +45,37 @@ class FrontCrossingModel(BaseModel):
     vertical_levels: int | None = None
 
 
+class FrontChainNodeModel(BaseModel):
+    """One pressure level's view of a vertically-linked front (a chain node)."""
+
+    level_hPa: int             # 925 / 850 / 700
+    distance_km: float         # along-route position of the crossing at this level
+    kind: str                  # "cold" | "warm" | "quasi-stationary"
+    intensity: str             # "significant" | "classical" | "sharp"
+    gradient: float            # |∇θe|  K/100km
+    delta_theta_e: float       # signed θe jump across the window, K
+
+
+class FrontChainModel(BaseModel):
+    """A single physical front linked across pressure levels (issue #196).
+
+    A front is a sloping 3-D surface: the same air-mass boundary shows up at
+    ~the same along-route distance on 925 / 850 / 700, displaced toward the cold
+    air with height. ``nodes`` are the per-level crossings the linker associated
+    into one feature, ordered bottom→top (925→850→700). ``n_levels`` is the depth
+    (1 = shallow / single-level / suspect; ≥2 = a front that slopes through the
+    GA flight band). ``tilt`` describes the geometry the cross-section draws:
+    ``coldward`` is the meteorological norm (sloping back over cold air),
+    ``upright`` is near-vertical, ``warmward`` is anomalous (occlusion or coarse-
+    data noise). The cross-section connects the nodes into one slanted line.
+    """
+
+    nodes: list[FrontChainNodeModel] = Field(default_factory=list)
+    kind: str                  # consensus kind across nodes
+    n_levels: int              # distinct levels in the chain (depth)
+    tilt: str = "upright"      # "coldward" | "upright" | "warmward"
+
+
 class FrontProximityModel(BaseModel):
     """Nearest gated front to the route (on- or off-track) + approach sense."""
 
@@ -121,6 +152,10 @@ class RouteFrontsManifest(BaseModel):
     models: list[str] = Field(default_factory=list)
     # model → analyses (one per level the model has; match by level_hPa).
     per_model: dict[str, list[RouteFrontAnalysisModel]] = Field(default_factory=dict)
+    # model → vertically-linked front chains (the same boundary associated across
+    # 925/850/700). Drives the cross-section's slanted front lines. Empty on
+    # pre-#196-linking packs; consumers fall back to the per-level crossings.
+    front_chains: dict[str, list[FrontChainModel]] = Field(default_factory=dict)
     # Models requested but with no precompute snapshot (degraded gracefully).
     models_without_snapshot: list[str] = Field(default_factory=list)
     # Snapshot init each model's detection read (model → ISO 8601 Z).

--- a/src/weatherbrief/tasks/fronts.py
+++ b/src/weatherbrief/tasks/fronts.py
@@ -57,6 +57,8 @@ from weatherbrief.hewson.precompute import (
     snapshot_for_window,
 )
 from weatherbrief.models import (
+    FrontChainModel,
+    FrontChainNodeModel,
     FrontCrossingModel,
     FrontDecisionModel,
     FrontProximityModel,
@@ -232,51 +234,185 @@ def _colocate(analyses, model: str, dist_km: float, level_hpa: int):
     return category, weather_top_ft
 
 
-def _stamp_vertical_coherence(
-    analyses: list[RouteFrontAnalysisModel], tolerance_km: float
-) -> None:
-    """Mutate ``analyses`` (one per level, same model) so each crossing carries
-    ``vertical_levels`` — the count of distinct levels detecting that feature.
+# Vertical-linking budget — how far apart (along-route km) two crossings on
+# adjacent levels may sit and still be the *same* sloping front. A front tilts
+# back over the cold air with height, so the upper-level crossing is displaced;
+# the budget bounds that displacement from textbook frontal slopes:
+#   925→850 (~760 m gap): cold ~1:50–1:100 → ~40–75 km; warm ~1:150 → ~110 km
+#   850→700 (~1500 m gap): cold ~75–150 km; warm ~225 km
+# These are wider than the 60 km ``merge_km`` (which collapses duplicates *at one
+# level*) — the old coherence cluster reused merge_km and so under-linked warm
+# fronts. Warm fronts get a slope multiplier (shallower slope, larger displacement).
+_LINK_BUDGET_KM: dict[tuple[int, int], float] = {
+    (925, 850): 100.0,
+    (850, 700): 170.0,
+}
+_WARM_LINK_FACTOR = 1.4   # warm fronts slope shallower → allow more displacement
+_UPRIGHT_KM = 30.0        # |head−base| below this reads as a near-vertical front
 
-    A genuine front slopes through several pressure levels, so the same crossing
-    appears at ~the same along-route distance on 850 *and* 925 (and maybe 700).
-    A shallow / artifactual boundary shows on one level only. We cluster all
-    crossings across levels by along-route distance and stamp every member with
-    how many distinct levels its cluster spans.
 
-    Clustering is **complete-linkage**: a crossing joins a cluster only if it is
-    within ``tolerance_km`` of the cluster's *first* (nearest) member, so the
-    whole cluster span stays ≤ ``tolerance_km``. Single-linkage (compare to the
-    last member) would let a shallow feature chain into a distant front through
-    intermediate crossings and inherit a multi-level count it doesn't deserve —
-    the false-positive this signal exists to suppress. ``tolerance_km`` is the
-    same "same physical front" distance as ``merge_km``.
+def _kinds_compatible(a: str, b: str) -> bool:
+    """True if two crossings could belong to one front by type.
 
-    ``vertical_levels`` counts only **successfully analyzed** levels: if a level
-    raised in ``compute_route_fronts`` (bad grid, NaN field) it isn't in
-    ``analyses``, so a genuinely multi-level front can read as single-level. The
-    effect is conservative (caps to AMBER, never inflates a RED) and the failure
-    is logged upstream.
+    cold↔cold and warm↔warm link; ``quasi-stationary`` is an advection-only label
+    (weak cross-front wind) and wildcards — it links to either. cold↔warm never
+    links: two genuinely different boundaries that happen to be vertically near.
     """
-    items: list[tuple[int, FrontCrossingModel]] = sorted(
-        ((a.level_hPa, c) for a in analyses for c in a.crossings),
-        key=lambda lc: lc[1].distance_km,
-    )
-    if not items:
-        return
-    cluster: list[tuple[int, FrontCrossingModel]] = [items[0]]
-    clusters: list[list[tuple[int, FrontCrossingModel]]] = [cluster]
-    for lvl_c in items[1:]:
-        # vs cluster[0] (the nearest member) → bounds total span ≤ tolerance_km.
-        if lvl_c[1].distance_km - cluster[0][1].distance_km <= tolerance_km:
-            cluster.append(lvl_c)
-        else:
-            cluster = [lvl_c]
-            clusters.append(cluster)
-    for cl in clusters:
-        n_levels = len({lvl for lvl, _ in cl})
-        for _, c in cl:
+    if a == b:
+        return True
+    return "quasi-stationary" in (a, b)
+
+
+def _link_budget_km(lower: int, upper: int, kind_a: str, kind_b: str) -> float:
+    """Max along-route displacement for a link between adjacent levels."""
+    base = _LINK_BUDGET_KM.get((lower, upper))
+    if base is None:
+        # Non-adjacent / unknown pair: scale the 925→850 budget by the level gap.
+        base = _LINK_BUDGET_KM[(925, 850)] * abs(lower - upper) / 75.0
+    if "warm" in (kind_a, kind_b):
+        base *= _WARM_LINK_FACTOR
+    return base
+
+
+def _consensus_kind(kinds: Sequence[str]) -> str:
+    """Front kind for a chain: majority of the decisive (non-quasi) labels, else
+    quasi-stationary. Ties fall to the first decisive label (bottom-most node)."""
+    decisive = [k for k in kinds if k != "quasi-stationary"]
+    if not decisive:
+        return "quasi-stationary"
+    return Counter(decisive).most_common(1)[0][0]
+
+
+def _chain_tilt(base_dist: float, head_dist: float, base_delta_theta_e: float) -> str:
+    """Geometry label for the rendered slant.
+
+    The cold side is where θe is lower. ``delta_theta_e`` is θe(downroute) −
+    θe(uproute), so cold air is downroute (larger distance) when it is negative.
+    A front sloping back over the cold air with height (the norm) therefore has
+    its upper/head node displaced toward the cold side. ``coldward`` = that norm,
+    ``warmward`` = the anomalous opposite, ``upright`` = near-vertical.
+    """
+    disp = head_dist - base_dist
+    if abs(disp) < _UPRIGHT_KM:
+        return "upright"
+    # Cold air is downroute (larger distance) when Δθe < 0, so the cold direction
+    # in distance is +1 then, −1 otherwise.
+    cold_dir = 1.0 if base_delta_theta_e < 0 else -1.0
+    return "coldward" if (disp * cold_dir) > 0 else "warmward"
+
+
+def _link_front_chains(
+    analyses: list[RouteFrontAnalysisModel],
+) -> list[FrontChainModel]:
+    """Link crossings across 925/850/700 into sloping front chains; also stamp
+    ``vertical_levels`` on every crossing (chain depth) for the marker/advisory.
+
+    A genuine front slopes through several pressure levels, so the same air-mass
+    boundary shows up at ~the same along-route distance on each level, displaced
+    toward the cold air with height. We grow chains bottom→top: starting from the
+    lowest level's crossings, each level up attaches to the best open chain whose
+    head is one level below it, subject to physical gates —
+
+      * **kind-compatible** (:func:`_kinds_compatible`) — cold↔cold / warm↔warm,
+        quasi wildcards; a cold front never links to a warm front nearby;
+      * **same Δθe sign** — both flying into colder air or both into warmer;
+        it is the same boundary only if the air-mass contrast points the same way;
+      * **within the slope budget** (:func:`_link_budget_km`) — bounded by
+        textbook frontal slope, wider than ``merge_km`` and wider for warm fronts.
+
+    Among candidates that pass, the one whose displacement is *coldward* (the
+    physical norm) and smallest wins — a soft directional prior, not a hard gate,
+    because the 3-level data is coarse and occlusions genuinely tilt the other way.
+
+    Crossings that attach to nothing become single-level chains (``n_levels == 1``)
+    — shallow / suspect, but kept so the count and the marker still reflect them.
+    Replaces the old distance-only coherence cluster, which ignored kind / Δθe sign
+    and reused the too-tight ``merge_km`` (under-linking warm fronts).
+    """
+    by_level: dict[int, list[FrontCrossingModel]] = {}
+    for a in analyses:
+        if a.crossings:
+            by_level[a.level_hPa] = sorted(a.crossings, key=lambda c: c.distance_km)
+    if not by_level:
+        return []
+
+    # Bottom→top: 925, 850, 700 (descending hPa = ascending altitude).
+    levels = sorted(by_level, reverse=True)
+
+    # A chain is the list of (level, crossing) nodes accumulated so far; its head
+    # is the last (highest) node. ``open_chains`` may still grow upward.
+    chains: list[list[tuple[int, FrontCrossingModel]]] = []
+    open_chains: list[list[tuple[int, FrontCrossingModel]]] = []
+
+    for li, level in enumerate(levels):
+        crossings = by_level[level]
+        if li == 0:
+            for c in crossings:
+                ch = [(level, c)]
+                chains.append(ch)
+                open_chains.append(ch)
+            continue
+
+        used_chains: set[int] = set()
+        still_open: list[list[tuple[int, FrontCrossingModel]]] = []
+        for c in crossings:
+            best_idx: int | None = None
+            best_score = float("inf")
+            for idx, ch in enumerate(open_chains):
+                if idx in used_chains:
+                    continue
+                h_level, head = ch[-1]
+                if not _kinds_compatible(head.kind, c.kind):
+                    continue
+                if np.sign(head.delta_theta_e) != np.sign(c.delta_theta_e):
+                    continue
+                disp = c.distance_km - head.distance_km
+                budget = _link_budget_km(h_level, level, head.kind, c.kind)
+                if abs(disp) > budget:
+                    continue
+                # Soft coldward prior: penalise anti-slope links, then prefer the
+                # nearest. Cold air is downroute (larger distance) when Δθe < 0, so
+                # the cold direction in distance is +1 then, −1 otherwise; a
+                # coldward link (the physical norm) has disp in that direction.
+                cold_dir = 1.0 if head.delta_theta_e < 0 else -1.0
+                anti = disp * cold_dir < 0
+                score = abs(disp) + (budget if anti else 0.0)
+                if score < best_score:
+                    best_score, best_idx = score, idx
+            if best_idx is not None:
+                open_chains[best_idx].append((level, c))
+                used_chains.add(best_idx)
+                still_open.append(open_chains[best_idx])
+            else:
+                ch = [(level, c)]
+                chains.append(ch)
+                still_open.append(ch)
+        open_chains = still_open
+
+    # Stamp vertical_levels (chain depth) back onto every crossing, then project.
+    out: list[FrontChainModel] = []
+    for ch in chains:
+        n_levels = len({lvl for lvl, _ in ch})
+        for _, c in ch:
             c.vertical_levels = n_levels
+        ordered = sorted(ch, key=lambda lc: -lc[0])  # 925→850→700 (bottom→top)
+        base_lvl, base_c = ordered[0]
+        head_lvl, head_c = ordered[-1]
+        out.append(FrontChainModel(
+            nodes=[
+                FrontChainNodeModel(
+                    level_hPa=lvl, distance_km=c.distance_km, kind=c.kind,
+                    intensity=c.intensity, gradient=c.gradient,
+                    delta_theta_e=c.delta_theta_e,
+                )
+                for lvl, c in ordered
+            ],
+            kind=_consensus_kind([c.kind for _, c in ordered]),
+            n_levels=n_levels,
+            tilt=_chain_tilt(base_c.distance_km, head_c.distance_km,
+                             base_c.delta_theta_e),
+        ))
+    return out
 
 
 def _persistence(source, model, lat, lon, level_hpa, eta_hour, gradient_min):
@@ -458,6 +594,7 @@ def compute_route_fronts(
     terrain_mask, terrain_elevation = _load_terrain_cache(output_dir)
 
     per_model: dict[str, list[RouteFrontAnalysisModel]] = {}
+    front_chains: dict[str, list[FrontChainModel]] = {}
     per_model_primary: dict[str, int] = {}
     snapshot_inits: dict[str, str] = {}
     missing: list[str] = []
@@ -550,13 +687,18 @@ def compute_route_fronts(
                 )
                 continue
             analyses.append(_to_analysis_model(result))
-        # Cross-level coherence: stamp each crossing with how many levels see it,
-        # so the advisory / cross-section can down-weight single-level (shallow)
-        # detections. Per-model — vertical slope is a within-model property.
-        _stamp_vertical_coherence(analyses, base_config.merge_km)
+        # Vertical linking: associate crossings across 925/850/700 into sloping
+        # front chains (kind / Δθe-sign / slope-budget gated) and stamp each
+        # crossing with its chain depth (vertical_levels) so the advisory /
+        # cross-section can down-weight single-level (shallow) detections. The
+        # chains drive the cross-section's slanted front lines. Per-model —
+        # vertical slope is a within-model property.
+        chains = _link_front_chains(analyses)
         if analyses:
             per_model[model] = analyses
             per_model_primary[model] = model_primary
+            if chains:
+                front_chains[model] = chains
 
     # Representative manifest-wide primary (display / back-compat): the modal
     # per-model value, falling back to the legacy default when nothing detected.
@@ -590,6 +732,7 @@ def compute_route_fronts(
         gate_config=base_config.with_overrides(level_hPa=primary_level).to_dict(),
         models=list(per_model.keys()),
         per_model=per_model,
+        front_chains=front_chains,
         models_without_snapshot=missing,
         snapshot_inits=snapshot_inits,
         notes=notes,

--- a/tests/test_tasks_fronts.py
+++ b/tests/test_tasks_fronts.py
@@ -13,8 +13,8 @@ from weatherbrief.tasks.artifacts import load_route_fronts
 from weatherbrief.models.fronts import FrontCrossingModel, RouteFrontAnalysisModel
 from weatherbrief.tasks.fronts import (
     _colocate,
+    _link_front_chains,
     _persistence,
-    _stamp_vertical_coherence,
     compute_route_fronts,
     nearest_cruise_level,
     run_fronts,
@@ -310,67 +310,85 @@ def _analysis(level: int, *crossings: FrontCrossingModel) -> RouteFrontAnalysisM
     )
 
 
-class TestVerticalCoherence:
-    """Cross-level stamping: a real front slopes through several levels; a
-    single-level detection is shallow/suspect (vertical_levels == 1)."""
+class TestVerticalLinking:
+    """Cross-level linking: a real front slopes through several levels into one
+    chain; the linker gates on kind, Δθe sign, and a slope budget, and stamps
+    each crossing with its chain depth (vertical_levels; 1 = shallow/suspect)."""
 
-    def test_same_feature_across_two_levels_is_coherent(self):
-        # Cold front seen at 850 (387 km) and 925 (355 km) — 32 km apart, within
-        # merge_km (60) → one feature spanning 2 levels.
+    def test_same_feature_across_two_levels_links(self):
+        # Cold front at 925 (355 km) and 850 (387 km) — 32 km apart, well inside
+        # the 925→850 budget → one chain spanning 2 levels.
         analyses = [_analysis(850, _xing(387.0)), _analysis(925, _xing(355.0))]
-        _stamp_vertical_coherence(analyses, tolerance_km=60.0)
+        chains = _link_front_chains(analyses)
+        assert len(chains) == 1
+        assert chains[0].n_levels == 2
+        assert [n.level_hPa for n in chains[0].nodes] == [925, 850]  # bottom→top
+        assert chains[0].kind == "cold"
         assert analyses[0].crossings[0].vertical_levels == 2
         assert analyses[1].crossings[0].vertical_levels == 2
 
     def test_single_level_feature_is_shallow(self):
-        # A 925-only boundary far from any other-level crossing → vertical_levels 1.
+        # A 925-only boundary far from any other-level crossing → 2 singleton chains.
         analyses = [_analysis(925, _xing(84.0)), _analysis(850, _xing(387.0))]
-        _stamp_vertical_coherence(analyses, tolerance_km=60.0)
-        shallow = analyses[0].crossings[0]
-        deep = analyses[1].crossings[0]
-        assert shallow.vertical_levels == 1
-        assert deep.vertical_levels == 1  # 850 one is also alone here
+        chains = _link_front_chains(analyses)
+        assert sorted(c.n_levels for c in chains) == [1, 1]
+        assert analyses[0].crossings[0].vertical_levels == 1
+        assert analyses[1].crossings[0].vertical_levels == 1
 
-    def test_three_levels_cluster_together(self):
+    def test_three_levels_link_into_one_sloping_chain(self):
+        # 925@350, 850@370, 700@390: gaps 20 + 20, each within budget → one
+        # 3-level chain. Δθe < 0 (cold downroute) and the front shifts to larger
+        # distance with height → the physical coldward slope.
         analyses = [
             _analysis(925, _xing(350.0)),
             _analysis(850, _xing(370.0)),
             _analysis(700, _xing(390.0)),
         ]
-        _stamp_vertical_coherence(analyses, tolerance_km=60.0)
+        chains = _link_front_chains(analyses)
+        assert len(chains) == 1 and chains[0].n_levels == 3
+        assert chains[0].tilt == "coldward"
         assert all(a.crossings[0].vertical_levels == 3 for a in analyses)
 
-    def test_two_distinct_features_not_merged(self):
-        # An early 925 feature (84 km) and a late front on 850+925 (~355-387):
-        # early stays single-level, late spans 2.
+    def test_warm_front_displaced_beyond_merge_km_still_links(self):
+        # The key improvement over the old merge_km (60 km) cluster: a warm front
+        # slopes shallowly, so 925→850 can be ~90 km apart and still be one front.
         analyses = [
-            _analysis(925, _xing(84.0), _xing(355.0)),
-            _analysis(850, _xing(387.0)),
+            _analysis(925, _xing(200.0, kind="warm", delta_theta_e=12.0, advection=2.0)),
+            _analysis(850, _xing(290.0, kind="warm", delta_theta_e=12.0, advection=2.0)),
         ]
-        _stamp_vertical_coherence(analyses, tolerance_km=60.0)
-        early = analyses[0].crossings[0]
-        late_925 = analyses[0].crossings[1]
-        late_850 = analyses[1].crossings[0]
-        assert early.vertical_levels == 1
-        assert late_925.vertical_levels == 2 and late_850.vertical_levels == 2
+        chains = _link_front_chains(analyses)
+        assert len(chains) == 1 and chains[0].n_levels == 2
+        assert chains[0].kind == "warm"
 
-    def test_complete_linkage_prevents_chaining(self):
-        # 925@250, 850@300, 700@360: single-linkage would chain all three
-        # (gaps 50, 60) into one 110 km cluster → every crossing vlev=3, inflating
-        # a shallow 250 km feature. Complete-linkage caps the span at tolerance:
-        # {250, 300} cluster (span 50), and 360 splits off alone.
+    def test_kind_mismatch_does_not_link(self):
+        # A cold front at 925 and a warm front at 850 sitting nearby are two
+        # different boundaries — never one chain.
         analyses = [
-            _analysis(925, _xing(250.0)),
-            _analysis(850, _xing(300.0)),
-            _analysis(700, _xing(360.0)),
+            _analysis(925, _xing(300.0, kind="cold", delta_theta_e=-12.0)),
+            _analysis(850, _xing(320.0, kind="warm", delta_theta_e=12.0, advection=2.0)),
         ]
-        _stamp_vertical_coherence(analyses, tolerance_km=60.0)
-        assert analyses[0].crossings[0].vertical_levels == 2  # 925@250 with 850@300
-        assert analyses[1].crossings[0].vertical_levels == 2  # 850@300
-        assert analyses[2].crossings[0].vertical_levels == 1  # 700@360 not chained
+        chains = _link_front_chains(analyses)
+        assert sorted(c.n_levels for c in chains) == [1, 1]
 
-    def test_empty_is_noop(self):
-        _stamp_vertical_coherence([], tolerance_km=60.0)  # no crash
+    def test_opposite_delta_theta_e_sign_does_not_link(self):
+        # Same kind label but the air-mass contrast points opposite ways → not the
+        # same boundary.
+        analyses = [
+            _analysis(925, _xing(300.0, kind="cold", delta_theta_e=-12.0)),
+            _analysis(850, _xing(315.0, kind="cold", delta_theta_e=12.0)),
+        ]
+        chains = _link_front_chains(analyses)
+        assert sorted(c.n_levels for c in chains) == [1, 1]
+
+    def test_beyond_slope_budget_does_not_link(self):
+        # 925@250 and 850@400 are 150 km apart — past the 100 km cold 925→850
+        # budget → two separate chains.
+        analyses = [_analysis(925, _xing(250.0)), _analysis(850, _xing(400.0))]
+        chains = _link_front_chains(analyses)
+        assert sorted(c.n_levels for c in chains) == [1, 1]
+
+    def test_empty_returns_no_chains(self):
+        assert _link_front_chains([]) == []
 
 
 class TestNearestCruiseLevel:
@@ -406,6 +424,17 @@ class TestComputeRouteFronts:
         assert len(a.crossings) >= 1
         assert a.crossings[0].kind == "cold"
         assert a.decisions  # candidate/decision trace stamped in
+
+        # The meridional cold front is the same boundary at all three levels, so
+        # the linker chains it vertically (depth ≥ 2) and exposes it in front_chains.
+        chains = manifest.front_chains["ecmwf"]
+        assert chains, "expected at least one linked front chain"
+        deepest = max(chains, key=lambda c: c.n_levels)
+        assert deepest.n_levels >= 2
+        assert deepest.kind == "cold"
+        assert [n.level_hPa for n in deepest.nodes] == sorted(
+            (n.level_hPa for n in deepest.nodes), reverse=True
+        )  # ordered bottom→top (925→850→700)
 
     def test_gate_config_stamped(self, tmp_path):
         out_dir = tmp_path / "hewson"

--- a/web/ts/types/fronts.ts
+++ b/web/ts/types/fronts.ts
@@ -30,6 +30,29 @@ export interface FrontCrossing {
 
 export type FrontCoLocation = 'dry' | 'partly' | 'wet' | 'convective';
 
+export type FrontTilt = 'coldward' | 'upright' | 'warmward';
+
+/** One pressure level's node in a vertically-linked front chain. */
+export interface FrontChainNode {
+  level_hPa: number;        // 925 / 850 / 700
+  distance_km: number;      // along-route position of the crossing at this level
+  kind: FrontKind;
+  intensity: FrontIntensity;
+  gradient: number;
+  delta_theta_e: number;
+}
+
+/** A single front linked across pressure levels — the same air-mass boundary
+ *  seen at 925/850/700, displaced toward the cold air with height. The cross-
+ *  section connects the nodes into one slanted line. `n_levels` is the depth
+ *  (1 = shallow/single-level). */
+export interface FrontChain {
+  nodes: FrontChainNode[];  // ordered bottom→top (925→850→700)
+  kind: FrontKind;          // consensus kind
+  n_levels: number;
+  tilt: FrontTilt;
+}
+
 export interface FrontProximity {
   distance_km: number;
   lat: number;
@@ -60,6 +83,7 @@ export interface RouteFrontsManifest {
   gate_config: Record<string, unknown>;
   models: string[];
   per_model: Record<string, RouteFrontAnalysis[]>;  // match by level_hPa
+  front_chains?: Record<string, FrontChain[]>;      // model → vertically-linked chains
   models_without_snapshot: string[];
   snapshot_inits: Record<string, string>;
   notes: string[];

--- a/web/ts/visualization/cross-section/layers/fronts-markers.ts
+++ b/web/ts/visualization/cross-section/layers/fronts-markers.ts
@@ -1,20 +1,171 @@
 /** Front markers (experimental, #196) — first Phase D.3 cross-section layer.
  *
- *  Draws a vertical marker at each on-track Hewson front crossing, positioned
- *  by along-route distance, colored by kind (cold=blue, warm=red,
- *  quasi=purple) and weighted by intensity. Advisory-only, free-atmosphere
- *  boundaries — not drawn SIGWX, and blind to low IMC / fog (§10a.2).
+ *  A front is a sloping 3-D surface, so when the linker associates a boundary
+ *  across 925/850/700 (`data.fronts.chains`) we draw it as ONE slanted line
+ *  through the per-level crossing positions — tilting back over the cold air
+ *  with height — rather than independent vertical markers. Color = kind
+ *  (cold=blue, warm=red, quasi=purple), weight = intensity, opacity = depth
+ *  (single-level chains draw faint — shallow/suspect). A node dot marks each
+ *  level the front was detected at; the segments are extrapolated (dashed) to
+ *  the column edges to suggest the surface spanning the flight band.
  *
- *  Phase D.4 (GRIB era) will replace these single markers with continuous-
- *  altitude θe bands; this layer is the discrete-marker precursor. */
+ *  Pre-linking packs carry no chains → we fall back to the original vertical
+ *  marker per crossing. Advisory-only, free-atmosphere boundaries — not drawn
+ *  SIGWX, and blind to low IMC / fog (§10a.2). Phase D.4 (GRIB era) will replace
+ *  these with continuous-altitude θe from a per-briefing stencil. */
 
 import type { CrossSectionLayer, CoordTransform, VizRouteData } from '../../types';
+import type { FrontChain } from '../../../types/fronts';
 import {
   frontColor, frontKindLabel, frontAlpha, frontDash, frontIsConvective,
   FRONT_INTENSITY_WEIGHT,
 } from '../../front-style';
 
 const KM_PER_NM = 1.852;
+
+/** Pressure level → representative MSL altitude (ft), matching the backend
+ *  `_LEVEL_FT` in tasks/fronts.py. Drives the vertical placement of each node. */
+const LEVEL_FT: Record<number, number> = { 925: 2_500, 850: 5_000, 700: 10_000 };
+
+interface Pt { x: number; y: number; }
+
+/** Extrapolate the line through (a, b) to the edge y-coordinate `yEdge`,
+ *  returning the x there. Falls back to b.x when the segment is horizontal. */
+function extendTo(a: Pt, b: Pt, yEdge: number): number {
+  const dy = b.y - a.y;
+  if (Math.abs(dy) < 1e-6) return b.x;
+  const t = (yEdge - a.y) / dy;
+  return a.x + t * (b.x - a.x);
+}
+
+function chainAlpha(chain: FrontChain): number {
+  return chain.n_levels >= 2 ? 0.95 : 0.5;  // single-level = shallow/suspect → faint
+}
+
+function chainWeight(chain: FrontChain): number {
+  return Math.max(...chain.nodes.map((n) => FRONT_INTENSITY_WEIGHT[n.intensity] ?? 2));
+}
+
+function renderChain(
+  ctx: CanvasRenderingContext2D, transform: CoordTransform, chain: FrontChain,
+  yTop: number, yBottom: number,
+): void {
+  const pts: Pt[] = chain.nodes.map((n) => ({
+    x: transform.distanceToX(n.distance_km / KM_PER_NM),
+    y: transform.altitudeToY(LEVEL_FT[n.level_hPa] ?? 5_000),
+  }));
+  if (pts.length === 0) return;
+
+  const color = frontColor(chain.kind);
+  ctx.strokeStyle = color;
+  ctx.fillStyle = color;
+  ctx.lineWidth = chainWeight(chain);
+  ctx.globalAlpha = chainAlpha(chain);
+
+  if (pts.length === 1) {
+    // Single-level (unlinked / shallow) front: a full-height vertical line like
+    // the original marker, but dashed + faint so it reads as "one level only,
+    // less certain" — only a vertically-linked front earns the solid slant.
+    const x = pts[0].x;
+    ctx.setLineDash([5, 5]);
+    ctx.beginPath();
+    ctx.moveTo(x, yTop);
+    ctx.lineTo(x, yBottom);
+    ctx.stroke();
+    ctx.setLineDash([]);
+  } else {
+    // Dashed extrapolation to the column edges (the surface continues beyond the
+    // outermost detected levels), then the solid slanted line through the nodes.
+    const topX = extendTo(pts[1], pts[0], yTop);          // above the top node
+    const botX = extendTo(pts[pts.length - 2], pts[pts.length - 1], yBottom);
+    ctx.setLineDash([5, 5]);
+    ctx.globalAlpha = chainAlpha(chain) * 0.5;
+    ctx.beginPath();
+    ctx.moveTo(topX, yTop);
+    ctx.lineTo(pts[0].x, pts[0].y);
+    ctx.moveTo(pts[pts.length - 1].x, pts[pts.length - 1].y);
+    ctx.lineTo(botX, yBottom);
+    ctx.stroke();
+    ctx.setLineDash([]);
+
+    ctx.globalAlpha = chainAlpha(chain);
+    ctx.beginPath();
+    ctx.moveTo(pts[0].x, pts[0].y);
+    for (let i = 1; i < pts.length; i++) ctx.lineTo(pts[i].x, pts[i].y);
+    ctx.stroke();
+  }
+
+  // Node dot at each detected level.
+  for (const p of pts) {
+    ctx.beginPath();
+    ctx.arc(p.x, p.y, 3, 0, Math.PI * 2);
+    ctx.fill();
+  }
+
+  // Kind-initial chip — at the column top for a single-level line, at the top
+  // node for a slanted chain.
+  const top = pts[0];
+  const label = frontKindLabel(chain.kind).charAt(0).toUpperCase();
+  ctx.font = 'bold 11px system-ui, sans-serif';
+  const tw = ctx.measureText(label).width;
+  const pad = 3;
+  const chipW = tw + pad * 2;
+  const chipH = 15;
+  const chipY = pts.length === 1 ? yTop : Math.max(yTop, top.y - chipH - 4);
+  ctx.fillStyle = color;
+  ctx.fillRect(top.x - chipW / 2, chipY, chipW, chipH);
+  ctx.fillStyle = '#ffffff';
+  ctx.textBaseline = 'middle';
+  ctx.textAlign = 'center';
+  ctx.fillText(label, top.x, chipY + chipH / 2);
+}
+
+/** Pre-linking fallback: one vertical marker per merged crossing (the original
+ *  rendering, kept for packs generated before vertical linking landed). */
+function renderVerticalMarkers(
+  ctx: CanvasRenderingContext2D, transform: CoordTransform, data: VizRouteData,
+  yTop: number, yBottom: number,
+): void {
+  const fronts = data.fronts;
+  if (!fronts) return;
+  for (const c of fronts.crossings) {
+    const x = transform.distanceToX(c.distance_km / KM_PER_NM);
+    const color = frontColor(c.kind);
+    ctx.globalAlpha = frontAlpha(c);
+    ctx.strokeStyle = color;
+    ctx.lineWidth = FRONT_INTENSITY_WEIGHT[c.intensity] ?? 2;
+    ctx.setLineDash(frontDash(c));
+    ctx.beginPath();
+    ctx.moveTo(x, yTop);
+    ctx.lineTo(x, yBottom);
+    ctx.stroke();
+    ctx.setLineDash([]);
+
+    const label = frontKindLabel(c.kind).charAt(0).toUpperCase();
+    ctx.font = 'bold 11px system-ui, sans-serif';
+    const tw = ctx.measureText(label).width;
+    const pad = 3;
+    const chipW = tw + pad * 2;
+    const chipH = 15;
+    ctx.fillStyle = color;
+    ctx.fillRect(x - chipW / 2, yTop, chipW, chipH);
+    ctx.fillStyle = '#ffffff';
+    ctx.textBaseline = 'middle';
+    ctx.textAlign = 'center';
+    ctx.fillText(label, x, yTop + chipH / 2);
+
+    if (frontIsConvective(c)) {
+      const ty = yTop + chipH + 2;
+      ctx.fillStyle = color;
+      ctx.beginPath();
+      ctx.moveTo(x, ty);
+      ctx.lineTo(x - 5, ty + 8);
+      ctx.lineTo(x + 5, ty + 8);
+      ctx.closePath();
+      ctx.fill();
+    }
+  }
+}
 
 export const frontsMarkersLayer: CrossSectionLayer = {
   id: 'fronts-markers',
@@ -24,61 +175,29 @@ export const frontsMarkersLayer: CrossSectionLayer = {
 
   render(ctx: CanvasRenderingContext2D, transform: CoordTransform, data: VizRouteData) {
     const fronts = data.fronts;
-    if (!fronts || fronts.crossings.length === 0) return;
+    if (!fronts) return;
     // Front distances are great-circle km; the X axis is in nautical miles.
     if (data.timeAxisMode) return;  // single-airport time view has no route distance
+
+    const chains = fronts.chains ?? [];
+    if (chains.length === 0 && fronts.crossings.length === 0) return;
 
     const { top, height } = transform.plotArea;
     const yTop = top;
     const yBottom = top + height;
 
     ctx.save();
-    // Visual encoding (matches the advisory gate so the picture reads like the
-    // grade): colour = kind, line weight = intensity, SOLID vs DASHED = wet/dry
-    // co-location, OPACITY = persistence (faint = flickering/uncertain), and a
-    // small triangle flags convective boundaries (towers above an overflown front).
-    for (const c of fronts.crossings) {
-      const x = transform.distanceToX(c.distance_km / KM_PER_NM);
-      const color = frontColor(c.kind);
-      const savedAlpha = ctx.globalAlpha;
-      ctx.globalAlpha = frontAlpha(c);
-
-      ctx.strokeStyle = color;
-      ctx.lineWidth = FRONT_INTENSITY_WEIGHT[c.intensity] ?? 2;
-      ctx.setLineDash(frontDash(c));
-      ctx.beginPath();
-      ctx.moveTo(x, yTop);
-      ctx.lineTo(x, yBottom);
-      ctx.stroke();
-      ctx.setLineDash([]);
-
-      // Label chip at the top of the marker (kind initial).
-      const label = frontKindLabel(c.kind).charAt(0).toUpperCase();
-      ctx.font = 'bold 11px system-ui, sans-serif';
-      const tw = ctx.measureText(label).width;
-      const pad = 3;
-      const chipW = tw + pad * 2;
-      const chipH = 15;
-      ctx.fillStyle = color;
-      ctx.fillRect(x - chipW / 2, yTop, chipW, chipH);
-      ctx.fillStyle = '#ffffff';
-      ctx.textBaseline = 'middle';
-      ctx.textAlign = 'center';
-      ctx.fillText(label, x, yTop + chipH / 2);
-
-      // Convective glyph: a small upward triangle below the chip = towers.
-      if (frontIsConvective(c)) {
-        const ty = yTop + chipH + 2;
-        ctx.fillStyle = color;
-        ctx.beginPath();
-        ctx.moveTo(x, ty);
-        ctx.lineTo(x - 5, ty + 8);
-        ctx.lineTo(x + 5, ty + 8);
-        ctx.closePath();
-        ctx.fill();
-      }
-      ctx.globalAlpha = savedAlpha;
+    const savedAlpha = ctx.globalAlpha;
+    if (chains.length > 0) {
+      // Draw the slanted, vertically-linked fronts. Visual encoding: colour =
+      // kind, weight = intensity, opacity = depth (single-level chains faint).
+      for (const chain of chains) renderChain(ctx, transform, chain, yTop, yBottom);
+    } else {
+      // Pre-linking pack — original vertical markers (colour=kind, weight=
+      // intensity, dash=wet/dry, opacity=persistence, triangle=convective).
+      renderVerticalMarkers(ctx, transform, data, yTop, yBottom);
     }
+    ctx.globalAlpha = savedAlpha;
     ctx.restore();
   },
 };

--- a/web/ts/visualization/data-extract.ts
+++ b/web/ts/visualization/data-extract.ts
@@ -175,8 +175,10 @@ function buildFronts(
     if (better) nearest = nf;
   }
 
-  if (crossings.length === 0 && !nearest) return null;
-  return { crossings, nearest, primaryLevelHpa: manifest.primary_level_hPa };
+  const chains = manifest.front_chains?.[model] ?? [];
+
+  if (crossings.length === 0 && !nearest && chains.length === 0) return null;
+  return { crossings, nearest, primaryLevelHpa: manifest.primary_level_hPa, chains };
 }
 
 /**

--- a/web/ts/visualization/types.ts
+++ b/web/ts/visualization/types.ts
@@ -1,6 +1,6 @@
 /** Shared types for the cross-section and map visualizations. */
 
-import type { FrontCrossing, FrontProximity } from '../types/fronts';
+import type { FrontCrossing, FrontProximity, FrontChain } from '../types/fronts';
 
 // --- Settings ---
 
@@ -168,6 +168,10 @@ export interface VizFronts {
   nearest: FrontProximity | null;
   /** Pressure level (hPa) the crossings were detected at — for tooltip provenance. */
   primaryLevelHpa: number;
+  /** Vertically-linked front chains (the same boundary across 925/850/700) for
+   *  the rendered model — drives the slanted front lines. Empty on pre-linking
+   *  packs (the renderer falls back to vertical markers from `crossings`). */
+  chains: FrontChain[];
 }
 
 /** METAR-reporting airport projected onto the cross-section X axis. */


### PR DESCRIPTION
## What
Vertical **linking** for the experimental Hewson front detection: associate the per-level front crossings (925 / 850 / 700 hPa) into sloping **chains**, and draw each linked front as one **slanted line** on the cross-section instead of independent vertical markers. Extends the #196 front surfaces.

## Why
A front is a sloping 3-D surface — the same air-mass boundary appears at all three levels, displaced toward the cold air with height. Linking them tells us a front's **depth** (shallow vs deep) and lets the cross-section show the slope. The previous primitive (`_stamp_vertical_coherence`) clustered by along-route distance only: it ignored front kind and Δθe sign (could link a cold front to a nearby warm one) and reused the 60 km merge distance — too tight for warm fronts, which slope shallowly and sit 100–200 km apart between levels.

## Changes
- **Backend** — `_link_front_chains` (kind / Δθe-sign / slope-budget gates + soft coldward tie-break) replaces `_stamp_vertical_coherence`; new `FrontChainModel` / `front_chains` in the manifest; `vertical_levels` now derived from chain depth.
- **Frontend** — `fronts-markers.ts` draws slanted node-to-node lines for linked fronts, a faint dashed vertical for single-level, and the vertical-marker fallback for pre-linking packs.
- **Docs** — fixes two drifts in the Hewson design doc (the "3 θe bands" were never built; the linking primitive was undocumented) + new §7.9.1; logs the decision in `meteorology-decisions.md` §13.
- **Tests** — rewritten linking tests (kind / Δθe / budget gates, warm-front displacement, depth) + an end-to-end chain assertion.

## Behavior / prod impact
Gated behind the experimental **`auto_front_detection`** preference (**default off**) — **no change for normal users**. For pref-on flights:
- `vertical_levels` is recomputed, and the `fronts` advisory gates **RED on `vertical_levels ≥ 2`**, so a front advisory can shift **RED↔AMBER** on a handful of flights (and move the badge if that advisory is enabled).
- `front_chains` is additive/optional (no `schema_version` bump); cross-section change is on an experimental layer (`defaultEnabled: false`).
- No migration, no new env var, precompute loop untouched; existing packs unaffected until regenerated.

## Caveat (not a basis to broaden the pref default)
The slope-budget thresholds are **physically-motivated defaults, not yet calibrated** against a real tilted-front case — the May 1/4 pair only has a low, near-vertical front. Validated on synthetic data + the regenerated May-4 snapshots: links 925↔850 where coherent, keeps single-model detections shallow, and produces no deep chains on the smooth control day.

## Verification
- `pytest tests/test_tasks_fronts.py tests/test_frontal_route_sampling.py` → green
- `tsc --noEmit` clean (pre-existing `eval/label-panel.ts` errors excluded); briefing bundle builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)