### PR TITLE
connectors: extract shared agent-facing shapers into connectors/views

### DIFF
--- a/designs/INDEX.md
+++ b/designs/INDEX.md
@@ -167,6 +167,13 @@ Pilot post-flight judgement (cancelled/flown) on past flights — Phase 1 of #92
 Key exports: `FlightDebrief`, `Decision`, `ConditionTag`, `OutcomeValue`, `compute_stats`, `upsert_debrief`, `list_debriefed_flight_ids`
 → Full doc: debrief.md
 
+## Connectors (agent integrations)
+
+### chatgpt-connector [project]
+Native ChatGPT support (Custom GPT + OpenAPI Action) as the sibling of the Claude MCP connector: two thin front-doors over one core. Shared response shaping + meteorological guardrails in `connectors/views.py`; the ChatGPT REST router (`api/agent.py`, mounted `/agent/v1`) reuses upstream logic in-process (read endpoints via the same helpers, write endpoints by calling the existing route handlers directly). Isolated OpenAPI at `/agent/v1/openapi.json`; OAuth reuses the `mcp` scope with a pre-provisioned (DCR-registered) confidential client. No CORS change (server-to-server).
+Key exports: `summarize_advisories`, `summarize_altitude_table`, `advisory_detail`, `convective_detail`, `briefing_freshness_status`, `agent.router`
+→ Full doc: chatgpt-connector.md
+
 ## Infrastructure & operations
 
 ### grib-decode-dispatcher [project]

--- a/designs/chatgpt-connector.md
+++ b/designs/chatgpt-connector.md
@@ -1,0 +1,124 @@
+# ChatGPT connector (Custom GPT + OpenAPI Action)
+
+> Native ChatGPT support as the sibling of the Claude MCP connector — same seven
+> capabilities, one shared core, two front-doors.
+
+## Why two front-doors
+
+The Claude integration is an **MCP server** (`weatherbrief.mcp.server`, deployed at
+`mcp.flyfun.aero/weather`, OAuth 2.1 + DCR). ChatGPT's cleanest path for a
+shareable, end-user-facing integration is a **Custom GPT** with an **OpenAPI
+Action**: ChatGPT calls a small REST surface directly (server-to-server) and the
+builder is configured with a pre-registered OAuth client.
+
+Rather than re-implement the meteorology (all of which is upstream in the
+analysis pipeline and served as raw JSON by the REST API), both front-doors are
+thin and **share their response shaping + meteorological guardrails**, so Claude
+and ChatGPT cannot drift.
+
+```
+              ┌──────────────────────────┐
+  Claude  ──▶ │ weatherbrief.mcp.server  │ ─┐
+   (MCP)      └──────────────────────────┘  │   shared shaping + guardrails
+                                            ├─▶ weatherbrief.connectors.views
+  ChatGPT ──▶ │ weatherbrief.api.agent    │ ─┘   (summarize_advisories,
+ (OpenAPI)    └──────────────────────────┘        convective_detail, advisory_detail,
+                                                   summarize_altitude_table,
+              both reuse upstream logic            briefing_freshness_status, …)
+              (analysis pipeline, REST handlers)
+```
+
+## Modules
+
+- **`weatherbrief/connectors/views.py`** `[project]` — pure `dict → dict` shapers,
+  the only logic shared between the two connectors. Carries the guardrails:
+  cross-check is *context, not a downgrade signal* (#178); the convective
+  provenance note (parcel-derived "tops" vs the model's own convective cover).
+  Key exports: `summarize_advisories`, `summarize_altitude_table`,
+  `advisory_detail`, `convective_detail`, `briefing_freshness_status`,
+  `CROSS_CHECK_NOTE`, `CONVECTIVE_NOTE`.
+
+- **`weatherbrief/api/agent.py`** `[project]` — the ChatGPT front-door router,
+  mounted at `/agent/v1`. **In-process reuse, no localhost loopback:**
+  - *Read* endpoints reuse the same helpers the main REST handlers use
+    (`_get_pack_dir`, `list_packs`, `_build_data_status`, `decide_refresh`) and
+    read the pack JSON artifacts directly, then apply the shared shapers.
+  - *Write* endpoints (`createFlight`, `refreshBriefing`) call the existing
+    route handlers directly with **every dependency passed explicitly** — reusing
+    all the throttling / gating / background-task machinery with zero
+    duplication. (Passing every `Depends`/`Query` param avoids the sentinel
+    footgun called out in CLAUDE.md.)
+
+- **`weatherbrief/api/app.py`** — registers `agent_router` (own `/agent/v1`
+  prefix, not `/api`) and serves an **isolated OpenAPI** at
+  `/agent/v1/openapi.json`: only the seven operations + the OAuth2
+  authorization-code security scheme. That tiny document is the artifact pasted
+  into the Custom GPT builder, decoupled from the app's large internal API.
+
+## Endpoint ↔ MCP tool parity
+
+| OpenAPI operation (`operation_id`) | Method + path | MCP tool |
+|---|---|---|
+| `listFlights` | `GET /agent/v1/flights` | `list_flights` |
+| `createFlight` | `POST /agent/v1/flights` | `create_flight` |
+| `getBriefing` | `GET /agent/v1/flights/{id}/briefing` | `get_briefing` |
+| `refreshBriefing` | `POST /agent/v1/flights/{id}/briefing/refresh` | `refresh_briefing` |
+| `getAdvisoryDetail` | `GET /agent/v1/flights/{id}/advisories/{advisory_id}` | `get_advisory_detail` |
+| `getDigestContext` | `GET /agent/v1/flights/{id}/digest-context` | `get_digest_context` |
+| `getAirportWeather` | `GET /agent/v1/airport-weather` | `get_airport_weather` |
+
+The operation **descriptions** (docstrings) mirror the MCP tool docstrings,
+including the "drill in before answering / cross-check is not a downgrade signal"
+guidance, so the GPT behaves like the Claude connector.
+
+> Note: `getBriefing` reads the **cached** `altitude_table.json` (the cheap GET
+> path persisted at refresh, #259) rather than recomputing the sweep; it is
+> omitted for packs that predate that artifact.
+
+## Authentication
+
+Reuses the existing OAuth stack (`flyfun_common.oauth`) and the broad **`mcp`
+scope** — no new scope, same consent screen as the Claude connector. Endpoints
+under `/agent/v1` are not in any `register_scope_paths` allowlist, so `mcp`-scoped
+(and unscoped) tokens reach them; a `flights:read`-only token does not.
+
+Unlike the MCP connector (which uses Dynamic Client Registration), **Custom GPT
+Actions require a pre-registered confidential client** (you type `client_id` +
+`client_secret` into the builder). The AS already supports this — provision the
+client through the existing **DCR endpoint** so the secret is hashed the way the
+token endpoint verifies it:
+
+OAuth endpoints (from `deploy/weather.flyfun.aero.caddy`):
+- authorize: `https://weather.flyfun.aero/oauth/authorize`
+- token: `https://weather.flyfun.aero/oauth/token` (`client_secret_post`)
+- register (DCR): `https://weather.flyfun.aero/oauth/register`
+
+### Setup steps
+
+1. In ChatGPT (Pro/Team/Enterprise/Edu) **create the Custom GPT**, add an
+   **Action**, and import the schema from `https://weather.flyfun.aero/agent/v1/openapi.json`.
+2. Set Authentication = **OAuth**, scope `mcp`, token exchange = **POST**.
+   Authorization URL / Token URL as above. Save the GPT — ChatGPT now shows its
+   **callback URL**: `https://chatgpt.com/aip/g-<gpt-id>/oauth/callback`.
+3. **Provision the client** with that callback as the redirect URI, e.g.:
+   ```bash
+   curl -sX POST https://weather.flyfun.aero/oauth/register \
+     -H 'Content-Type: application/json' \
+     -d '{"client_name":"FlyFun Weather GPT",
+          "redirect_uris":["https://chatgpt.com/aip/g-<gpt-id>/oauth/callback"]}'
+   ```
+   The response returns `client_id` + `client_secret` (shown once).
+4. Paste `client_id` + `client_secret` into the GPT builder's OAuth panel.
+5. Open the GPT, run a tool → complete the FlyFun login + `mcp` consent → tools work.
+
+**No CORS change is required**: Actions are called server-to-server by OpenAI, not
+from a browser (unlike the Claude MCP connector, whose browser handshake needs the
+scoped `claude.ai`/`claude.com` CORS allowlist).
+
+## Testing
+
+- `tests/test_connectors_views.py` — the shared shapers (pure; runnable without
+  the heavy deps).
+- The MCP suite (`tests/test_mcp_advisory_detail.py`) still exercises the same
+  shapers via `weatherbrief.mcp.server` aliases — proof the two front-doors share
+  one implementation.

--- a/src/weatherbrief/api/agent.py
+++ b/src/weatherbrief/api/agent.py
@@ -1,0 +1,501 @@
+"""ChatGPT Custom GPT / OpenAPI front-door for the weather briefing tools.
+
+This is the ChatGPT-native sibling of the Claude MCP server
+(``weatherbrief.mcp.server``): the same seven capabilities, exposed as a small,
+self-contained REST surface that a ChatGPT Custom GPT calls via an OpenAPI
+*Action*. The two front-doors share their response *shaping* and meteorological
+guardrails through ``weatherbrief.connectors.views`` so the Claude and ChatGPT
+integrations cannot drift.
+
+Reuse strategy (in-process, no localhost loopback):
+
+* **Read** endpoints call the same helpers the main REST handlers use
+  (``_get_pack_dir``, ``list_packs``, ``_build_data_status``, ``decide_refresh``)
+  and read the pack JSON artifacts directly, then apply the shared shapers.
+* **Write** endpoints (create / refresh) call the existing route handlers
+  directly with every dependency passed explicitly — reusing all the
+  throttling, gating and background-task machinery with zero duplication.
+
+Mounted at ``/agent/v1``. Its OpenAPI schema (served at ``/agent/v1/openapi.json``
+by ``app.py``) is the artifact pasted into the Custom GPT builder. Auth is the
+same OAuth-bearer / api-token stack as the rest of the app, using the existing
+``mcp`` scope.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Annotated, Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
+from pydantic import BaseModel, Field
+from sqlalchemy.orm import Session
+
+from flyfun_common.db import current_user_id, get_db
+from weatherbrief.api import flights as flights_api
+from weatherbrief.api import maps as maps_api
+from weatherbrief.api import packs as packs_api
+from weatherbrief.connectors import views
+
+WEATHER_BASE_URL = os.getenv("WEATHER_BASE_URL", "https://weather.flyfun.aero")
+
+router = APIRouter(prefix="/agent/v1", tags=["agent"])
+
+
+# ---------------------------------------------------------------------------
+# Small in-process helpers (shared shaping lives in connectors.views)
+# ---------------------------------------------------------------------------
+
+def _flight_web_url(flight_id: str) -> str:
+    return f"{WEATHER_BASE_URL}/briefing.html?flight={flight_id}"
+
+
+def _read_json(pack_dir: Path, name: str) -> Any | None:
+    """Read and parse a pack JSON artifact, or None if absent."""
+    path = pack_dir / name
+    if not path.exists():
+        return None
+    return json.loads(path.read_text())
+
+
+def _read_text(pack_dir: Path, name: str) -> str | None:
+    path = pack_dir / name
+    if not path.exists():
+        return None
+    return path.read_text()
+
+
+def _processing(flight_id: str) -> dict[str, Any]:
+    return {
+        "status": "processing",
+        "flight_id": flight_id,
+        "message": "Briefing is being generated. Check again in ~1-2 minutes.",
+        "web_url": _flight_web_url(flight_id),
+    }
+
+
+def _none_status(flight_id: str) -> dict[str, Any]:
+    return {
+        "status": "none",
+        "flight_id": flight_id,
+        "message": "No briefing exists yet. Call refresh_briefing to generate one.",
+        "web_url": _flight_web_url(flight_id),
+    }
+
+
+def _resolve_latest_pack(db: Session, user_id: str, flight_id: str):
+    """Resolve the latest pack for a flight, or a status dict.
+
+    Returns ``(pack_meta, timestamp, None)`` when a pack exists, or
+    ``(None, None, status)`` when a refresh is running / no pack exists — the
+    status dict mirrors the MCP early-return shapes so callers return it
+    directly. Mirrors ``mcp.server._resolve_pack`` but in-process.
+    """
+    refresh = packs_api.get_refresh_status(flight_id=flight_id, user_id=user_id)
+    if refresh.get("active"):
+        return None, None, _processing(flight_id)
+
+    packs = packs_api.list_packs(db, flight_id)
+    if not packs:
+        return None, None, _none_status(flight_id)
+    pack = packs[0]
+    return pack, pack.fetch_timestamp.isoformat(), None
+
+
+def _freshness_dict(db: Session, user_id: str, flight_id: str) -> dict[str, Any]:
+    """Build the ``/packs/freshness`` payload in-process (DataStatus + gate)."""
+    flight = flights_api._load_flight_or_404(db, flight_id, viewer_id=user_id)
+    packs = packs_api.list_packs(db, flight_id)
+    if not packs:
+        return {"fresh": False}
+    status = packs_api._build_data_status(packs[0], flight)
+    status.refresh_decision = packs_api.decide_refresh(status, packs_api._days_out_now(flight))
+    return status.model_dump()
+
+
+# ---------------------------------------------------------------------------
+# Request / lightweight response models (for a clean OpenAPI)
+# ---------------------------------------------------------------------------
+
+class CreateFlightInput(BaseModel):
+    """A new flight to plan a briefing for."""
+
+    waypoints: list[str] = Field(
+        ...,
+        min_length=2,
+        description="Route waypoints as ICAO codes or navaid names, e.g. ['LFBO', 'LFML']. Minimum 2.",
+    )
+    departure_time: str = Field(
+        ...,
+        description="Departure time as ISO 8601 with timezone, e.g. '2026-04-10T14:00:00+02:00'.",
+    )
+    flight_duration_hours: float = Field(
+        ..., description="Expected flight duration in hours, e.g. 1.5.",
+    )
+    cruise_altitude_ft: int | None = Field(
+        None,
+        description="Cruise altitude in feet (default: from user profile, typically 8000).",
+    )
+
+
+# ---------------------------------------------------------------------------
+# GET /agent/v1/flights  — list_flights
+# ---------------------------------------------------------------------------
+
+@router.get("/flights", operation_id="listFlights")
+def list_flights(
+    user_id: str = Depends(current_user_id),
+    db: Session = Depends(get_db),
+) -> dict[str, Any]:
+    """List the user's upcoming flights with briefing status.
+
+    Returns each flight's route, departure time, and weather assessment
+    (GREEN/AMBER/RED) from the latest briefing. Use this to see which flights
+    need attention or have stale briefings.
+    """
+    flights = flights_api.list_all_flights(
+        response=Response(), past_limit=None, past_offset=0, user_id=user_id, db=db,
+    )
+    result = []
+    for f in flights:
+        entry: dict[str, Any] = {
+            "id": f.id,
+            "route_name": f.route_name,
+            "waypoints": f.waypoints,
+            "departure_time": f.departure_time,
+            "cruise_altitude_ft": f.cruise_altitude_ft,
+            "web_url": _flight_web_url(f.id),
+        }
+        lb = f.latest_briefing
+        if lb is not None:
+            entry["assessment"] = lb.assessment
+            entry["assessment_reason"] = lb.assessment_reason
+            entry["has_digest"] = lb.has_digest
+            entry["briefing_timestamp"] = lb.fetch_timestamp
+            entry["days_out"] = lb.days_out
+        else:
+            entry["assessment"] = None
+            entry["briefing_timestamp"] = None
+        result.append(entry)
+    return {"flights": result}
+
+
+# ---------------------------------------------------------------------------
+# POST /agent/v1/flights  — create_flight (+ auto-refresh)
+# ---------------------------------------------------------------------------
+
+@router.post("/flights", operation_id="createFlight")
+async def create_flight(
+    body: CreateFlightInput,
+    request: Request,
+    user_id: str = Depends(current_user_id),
+    db: Session = Depends(get_db),
+) -> dict[str, Any]:
+    """Create a new flight and automatically trigger a weather briefing.
+
+    The briefing generation takes ~2 minutes. The response includes the flight
+    details and a processing status. Call get_briefing after a couple of minutes
+    to retrieve the results.
+    """
+    req = flights_api.CreateFlightRequest(
+        waypoints=body.waypoints,
+        departure_time=body.departure_time,
+        flight_duration_hours=body.flight_duration_hours,
+        cruise_altitude_ft=body.cruise_altitude_ft,
+    )
+    flight = flights_api.create_flight(req=req, request=request, user_id=user_id, db=db)
+    flight_id = flight.id
+
+    # Auto-trigger the briefing refresh, mirroring the MCP tool's status mapping.
+    refresh_status: dict[str, Any]
+    try:
+        await packs_api.refresh_briefing(
+            flight_id=flight_id, request=request, force=False, as_of_date=None,
+            user_id=user_id, db=db,
+        )
+        refresh_status = {
+            "status": "processing",
+            "estimated_seconds": 120,
+            "message": "Briefing is being generated. Call get_briefing in ~2 minutes.",
+        }
+    except HTTPException as e:
+        if e.status_code == 409:
+            refresh_status = {"status": "already_in_progress"}
+        elif e.status_code == 429:
+            refresh_status = {"status": "rate_limited", "message": str(e.detail)}
+        else:
+            refresh_status = {"status": "failed", "message": str(e.detail)}
+
+    return {
+        "flight": {
+            "id": flight_id,
+            "route_name": flight.route_name,
+            "waypoints": flight.waypoints,
+            "departure_time": flight.departure_time,
+            "cruise_altitude_ft": flight.cruise_altitude_ft,
+            "flight_duration_hours": flight.flight_duration_hours,
+            "web_url": _flight_web_url(flight_id),
+        },
+        "briefing": refresh_status,
+    }
+
+
+# ---------------------------------------------------------------------------
+# GET /agent/v1/flights/{flight_id}/briefing  — get_briefing
+# ---------------------------------------------------------------------------
+
+@router.get("/flights/{flight_id}/briefing", operation_id="getBriefing")
+def get_briefing(
+    flight_id: str,
+    user_id: str = Depends(current_user_id),
+    db: Session = Depends(get_db),
+) -> dict[str, Any]:
+    """Get the latest weather briefing for a flight.
+
+    Returns the overall assessment (GREEN/AMBER/RED), route advisories, AI
+    weather digest, and a link to the full interactive briefing.
+
+    Status values: ready (fresh), stale (models updated since), processing
+    (generating now), none (call refresh_briefing first).
+    """
+    pack, timestamp, status = _resolve_latest_pack(db, user_id, flight_id)
+    if status is not None:
+        return status
+
+    fresh = views.briefing_freshness_status(_freshness_dict(db, user_id, flight_id))
+
+    result: dict[str, Any] = {
+        "status": fresh["status"],
+        "flight_id": flight_id,
+        "assessment": pack.assessment,
+        "assessment_reason": pack.assessment_reason,
+        "days_out": pack.days_out,
+        "briefing_timestamp": timestamp,
+        "web_url": _flight_web_url(flight_id),
+    }
+    if not fresh["is_fresh"]:
+        result["stale_models"] = fresh.get("stale_models", [])
+        result["stale_note"] = fresh["stale_note"]
+
+    pack_dir = packs_api._get_pack_dir(db, flight_id, timestamp, viewer_id=user_id)
+
+    advisories = _read_json(pack_dir, "route_advisories.json")
+    if advisories:
+        result["advisories"] = views.summarize_advisories(advisories)
+
+    digest_json = _read_json(pack_dir, "digest.json")
+    if digest_json:
+        result["digest"] = digest_json
+
+    digest_text = _read_text(pack_dir, "digest.md")
+    if digest_text:
+        result["digest_text"] = digest_text
+
+    # Cheap cached altitude table (the GET path); omitted for packs predating it.
+    alt_table = _read_json(pack_dir, "altitude_table.json")
+    if alt_table:
+        result["altitude_table"] = views.summarize_altitude_table(alt_table)
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# POST /agent/v1/flights/{flight_id}/briefing/refresh  — refresh_briefing
+# ---------------------------------------------------------------------------
+
+@router.post("/flights/{flight_id}/briefing/refresh", operation_id="refreshBriefing")
+async def refresh_briefing(
+    flight_id: str,
+    request: Request,
+    user_id: str = Depends(current_user_id),
+    db: Session = Depends(get_db),
+) -> dict[str, Any]:
+    """Trigger a weather briefing refresh for a flight.
+
+    Checks model freshness first — if all data is current, returns without
+    re-running the pipeline. Safe to call repeatedly. The refresh takes ~2
+    minutes; call get_briefing to check results.
+    """
+    try:
+        accepted = await packs_api.refresh_briefing(
+            flight_id=flight_id, request=request, force=False, as_of_date=None,
+            user_id=user_id, db=db,
+        )
+    except HTTPException as e:
+        code = e.status_code
+        if code == 409:
+            return {
+                "status": "already_in_progress", "flight_id": flight_id,
+                "message": "A refresh is already running for this flight.",
+            }
+        if code == 429:
+            return {"status": "rate_limited", "flight_id": flight_id, "message": str(e.detail)}
+        if code == 503:
+            return {
+                "status": "server_busy", "flight_id": flight_id,
+                "message": "Server is busy with other refreshes. Try again shortly.",
+            }
+        raise
+
+    # RefreshAccepted: status is "queued" | "already_fresh" | "realtime".
+    data = accepted.model_dump() if hasattr(accepted, "model_dump") else dict(accepted)
+    resp: dict[str, Any] = {
+        "status": data.get("status", "queued"),
+        "flight_id": flight_id,
+        "message": data.get("message", ""),
+        "web_url": _flight_web_url(flight_id),
+    }
+    if resp["status"] == "queued":
+        resp["estimated_seconds"] = 120
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# GET /agent/v1/flights/{flight_id}/advisories/{advisory_id}  — get_advisory_detail
+# ---------------------------------------------------------------------------
+
+@router.get("/flights/{flight_id}/advisories/{advisory_id}", operation_id="getAdvisoryDetail")
+def get_advisory_detail(
+    flight_id: str,
+    advisory_id: Annotated[
+        str,
+        Field(description="Advisory id to drill into, e.g. 'convective', 'fiki_icing', 'cloud_top'."),
+    ],
+    user_id: str = Depends(current_user_id),
+    db: Session = Depends(get_db),
+) -> dict[str, Any]:
+    """Drill into ONE advisory to explain WHY it is red/amber (or any grade).
+
+    Use this when the user asks why an advisory is red/amber, questions a result
+    that looks inconsistent (e.g. "red convective but clear skies"), or wants the
+    per-model breakdown and cross-check reasoning. Never explain a red/amber from
+    the aggregate status alone — call this first.
+
+    The cross-check is context for discussion, not a downgrade signal — high CAPE
+    matters even when the model's own convective scheme is quiet. Use it to
+    EXPLAIN the grade, not to argue it down.
+    """
+    pack, timestamp, status = _resolve_latest_pack(db, user_id, flight_id)
+    if status is not None:
+        return status
+
+    pack_dir = packs_api._get_pack_dir(db, flight_id, timestamp, viewer_id=user_id)
+    advisories = _read_json(pack_dir, "route_advisories.json")
+    if not advisories:
+        raise HTTPException(status_code=404, detail="No advisories available for this briefing.")
+
+    adv = next(
+        (a for a in advisories.get("advisories", []) if a.get("advisory_id") == advisory_id),
+        None,
+    )
+    if adv is None:
+        available = [a.get("advisory_id") for a in advisories.get("advisories", [])]
+        raise HTTPException(
+            status_code=404,
+            detail=f"Advisory '{advisory_id}' not found. Available: {', '.join(available)}",
+        )
+
+    catalog = {c.get("id"): c for c in advisories.get("catalog", [])}
+    result = views.advisory_detail(adv, catalog.get(advisory_id))
+
+    # Per-briefing staleness caveat — a forensic per-model answer on stale data
+    # is confidently-wrong territory. Uses the raw min-rule (matches MCP).
+    freshness = _freshness_dict(db, user_id, flight_id)
+    if not freshness.get("fresh", True):
+        result["stale"] = True
+        result["stale_models"] = freshness.get("stale_models", [])
+        result["model_init_times"] = freshness.get("model_init_times", {})
+        result["stale_note"] = (
+            "Models have updated since this briefing was generated. This "
+            "drill-down reflects the run used at briefing time, not the latest — "
+            "caveat any forensic reasoning and suggest refresh_briefing for "
+            "current data."
+        )
+
+    if advisory_id == "convective":
+        route_analyses = _read_json(pack_dir, "route_analyses.json")
+        if route_analyses:
+            models = [m.get("model") for m in adv.get("per_model", [])]
+            result["convective"] = views.convective_detail(route_analyses, models)
+            result["convective_note"] = views.CONVECTIVE_NOTE
+
+    result["flight_id"] = flight_id
+    result["web_url"] = _flight_web_url(flight_id)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# GET /agent/v1/flights/{flight_id}/digest-context  — get_digest_context
+# ---------------------------------------------------------------------------
+
+@router.get("/flights/{flight_id}/digest-context", operation_id="getDigestContext")
+def get_digest_context(
+    flight_id: str,
+    user_id: str = Depends(current_user_id),
+    db: Session = Depends(get_db),
+) -> dict[str, Any]:
+    """Get the exact text input the AI weather digest saw for this flight.
+
+    Use when the user wants the deepest possible context behind the briefing —
+    e.g. to reconcile a red/amber advisory with the digest narrative. The text
+    can be large (a few KB up to tens of KB); prefer get_advisory_detail for a
+    targeted drill-down and reach for this only when you need the byte-faithful
+    LLM input.
+    """
+    pack, timestamp, status = _resolve_latest_pack(db, user_id, flight_id)
+    if status is not None:
+        return status
+
+    pack_dir = packs_api._get_pack_dir(db, flight_id, timestamp, viewer_id=user_id)
+    context = _read_text(pack_dir, "digest_context.txt")
+    if not context:
+        return {
+            "status": "none",
+            "flight_id": flight_id,
+            "message": "No digest context available for this briefing.",
+            "web_url": _flight_web_url(flight_id),
+        }
+
+    return {
+        "status": "ready",
+        "flight_id": flight_id,
+        "briefing_timestamp": timestamp,
+        "digest_context": context,
+        "web_url": _flight_web_url(flight_id),
+    }
+
+
+# ---------------------------------------------------------------------------
+# GET /agent/v1/airport-weather  — get_airport_weather
+# ---------------------------------------------------------------------------
+
+@router.get("/airport-weather", operation_id="getAirportWeather")
+def get_airport_weather(
+    icao: Annotated[
+        list[str],
+        Query(description="Airport ICAO codes, e.g. ['LFBO', 'LFML']. Max 20. European airports only."),
+    ],
+    day: Annotated[
+        int, Query(description="Days from today: 0=today, 1=tomorrow, 2=D+2, 3=D+3", ge=0, le=3),
+    ] = 0,
+    hour: Annotated[
+        int, Query(description="Forecast hour in UTC: 6, 9, 12, 15, or 18", ge=0, le=23),
+    ] = 12,
+    user_id: str = Depends(current_user_id),
+    db: Session = Depends(get_db),
+    airports_db: str = Depends(maps_api._airports_db),
+) -> dict[str, Any]:
+    """Get weather forecasts and observations for specific airports.
+
+    Returns multi-model predictions (GFS, ICON, ECMWF) with consensus flight
+    category and agreement scoring. For today (day=0), also includes the latest
+    METAR and TAF from the verification cache (may be up to ~3 hours old).
+
+    Airports not in the monitoring network resolve to the nearest monitored
+    airport (with distance noted). Non-European airports return as 'unsupported'.
+    """
+    return maps_api.get_airport_weather(
+        icao=icao, day=day, hour=hour, _user_id=user_id, db=db, airports_db=airports_db,
+    )

--- a/src/weatherbrief/api/agent.py
+++ b/src/weatherbrief/api/agent.py
@@ -29,7 +29,9 @@ import os
 from pathlib import Path
 from typing import Annotated, Any
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
+from fastapi import APIRouter, Depends, HTTPException
+from fastapi import Path as PathParam
+from fastapi import Query, Request, Response
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
@@ -361,7 +363,7 @@ def get_advisory_detail(
     flight_id: str,
     advisory_id: Annotated[
         str,
-        Field(description="Advisory id to drill into, e.g. 'convective', 'fiki_icing', 'cloud_top'."),
+        PathParam(description="Advisory id to drill into, e.g. 'convective', 'fiki_icing', 'cloud_top'."),
     ],
     user_id: str = Depends(current_user_id),
     db: Session = Depends(get_db),

--- a/src/weatherbrief/api/agent.py
+++ b/src/weatherbrief/api/agent.py
@@ -95,6 +95,10 @@ def _resolve_latest_pack(db: Session, user_id: str, flight_id: str):
     status dict mirrors the MCP early-return shapes so callers return it
     directly. Mirrors ``mcp.server._resolve_pack`` but in-process.
     """
+    # Ownership gate first — match every packs.py read endpoint and avoid
+    # leaking pack existence / refresh state for a flight the user can't see.
+    flights_api._load_flight_or_404(db, flight_id, viewer_id=user_id)
+
     refresh = packs_api.get_refresh_status(flight_id=flight_id, user_id=user_id)
     if refresh.get("active"):
         return None, None, _processing(flight_id)
@@ -394,9 +398,10 @@ def get_advisory_detail(
     )
     if adv is None:
         available = [a.get("advisory_id") for a in advisories.get("advisories", [])]
+        listed = ", ".join(x for x in available if x)
         raise HTTPException(
             status_code=404,
-            detail=f"Advisory '{advisory_id}' not found. Available: {', '.join(available)}",
+            detail=f"Advisory '{advisory_id}' not found. Available: {listed}",
         )
 
     catalog = {c.get("id"): c for c in advisories.get("catalog", [])}

--- a/src/weatherbrief/api/app.py
+++ b/src/weatherbrief/api/app.py
@@ -33,6 +33,7 @@ from flyfun_common.db import (
 )
 from flyfun_common.db.models import UserPreferencesRow
 
+from weatherbrief.api.agent import router as agent_router
 from weatherbrief.api.aircraft import router as aircraft_router
 from weatherbrief.api.debriefs import router as debriefs_router
 from weatherbrief.api.pireps import router as pireps_router
@@ -546,6 +547,59 @@ def create_app() -> FastAPI:
     app.include_router(refresh_router, prefix="/api")
     app.include_router(transparency_router, prefix="/api")
     app.include_router(donations_router, prefix="/api")
+
+    # ChatGPT Custom GPT / OpenAPI front-door. Mounted at its OWN /agent/v1
+    # prefix (not /api) and served with an isolated OpenAPI schema below, so the
+    # tiny 7-operation contract pasted into the Custom GPT builder is decoupled
+    # from the app's large internal API surface. Auth reuses the existing OAuth
+    # "mcp" scope (broad-scope/unscoped tokens are unaffected by scope gating).
+    app.include_router(agent_router)
+
+    @app.get("/agent/v1/openapi.json", include_in_schema=False)
+    def agent_openapi():
+        """Isolated OpenAPI schema for the Custom GPT Action.
+
+        Only the ``/agent/v1`` operations, plus the OAuth2 authorization-code
+        security scheme pointing at weather.flyfun.aero. This is the document a
+        Custom GPT imports; the GPT then needs a pre-provisioned OAuth client
+        (client_id + secret) whose redirect_uri allowlists the GPT's
+        ``/aip/g-<id>/oauth/callback``.
+        """
+        from fastapi.openapi.utils import get_openapi
+
+        schema = get_openapi(
+            title="FlyFun Weather — Pilot Briefing Tools",
+            version="1.0.0",
+            description=(
+                "Aviation weather briefing tools for GA flight planning in Europe: "
+                "multi-model forecasts, route advisories, AI weather digests, and "
+                "METAR/TAF observations for ~620 European airports. Briefing "
+                "generation takes ~2 minutes; if a briefing is 'processing', tell "
+                "the user and check again shortly. When the user questions or "
+                "doubts an advisory, call getAdvisoryDetail (and getDigestContext "
+                "for the deepest context) before answering — the cross-check is "
+                "context for discussion, never a downgrade signal."
+            ),
+            routes=agent_router.routes,
+        )
+        weather_base = os.getenv("WEATHER_BASE_URL", "https://weather.flyfun.aero")
+        schema["servers"] = [{"url": weather_base}]
+        schema.setdefault("components", {})["securitySchemes"] = {
+            "oauth2": {
+                "type": "oauth2",
+                "flows": {
+                    "authorizationCode": {
+                        "authorizationUrl": f"{weather_base}/oauth/authorize",
+                        "tokenUrl": f"{weather_base}/oauth/token",
+                        "scopes": {
+                            "mcp": "Full access to your flights, briefings, and account settings",
+                        },
+                    },
+                },
+            },
+        }
+        schema["security"] = [{"oauth2": ["mcp"]}]
+        return schema
 
     # OAuth least-privilege: a token granted only the "flights:read" scope may
     # reach ONLY these two read endpoints; anything else is 403 insufficient_scope.

--- a/src/weatherbrief/connectors/__init__.py
+++ b/src/weatherbrief/connectors/__init__.py
@@ -1,0 +1,9 @@
+"""Agent-facing connector layer shared by the MCP server and the GPT/OpenAPI router.
+
+The heavy meteorological logic lives upstream (analysis pipeline, served as raw
+JSON by the REST API). This package holds only the thin agent-facade layer:
+the response *shaping* that compresses raw payloads into LLM-sized structures
+and carries the meteorological guardrails. Both connector front-doors —
+``weatherbrief.mcp.server`` (Claude) and ``weatherbrief.api.agent`` (ChatGPT
+Custom GPT) — share these views so the two integrations cannot drift.
+"""

--- a/src/weatherbrief/connectors/views.py
+++ b/src/weatherbrief/connectors/views.py
@@ -1,0 +1,288 @@
+"""Pure response shapers shared by every agent-facing connector.
+
+These functions take the raw JSON the weatherbrief REST API returns and compress
+it into the compact, LLM-sized structures the connectors expose to Claude (MCP)
+and ChatGPT (Custom GPT / OpenAPI). They are pure ``dict -> dict`` transforms
+with no I/O, so the same shaping — and the same meteorological guardrails baked
+into it — is reused by both front-doors.
+
+Guardrail note (do not "optimise" away): the cross-check / per-model detail is
+display-only **context for discussion, never a downgrade signal** (#178). The
+hint flags are deliberately neutral (``cross_check_present`` / ``per_model_present``)
+so a connector LLM is not primed to argue a red down to amber.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+CROSS_CHECK_NOTE = (
+    "Cross-check notes are display-only context for discussion, not a "
+    "downgrade signal. Explain the grade with them; do not argue it down."
+)
+
+CONVECTIVE_NOTE = (
+    "thermo.peak.el_top_ft is parcel-derived (the equilibrium level the digest "
+    "narrates as 'convective tops'), NOT the model's convective cloud field. "
+    "nwp.max_cover_pct ~0 means the model's own convective scheme is quiet "
+    "('blue sky'); high CAPE with cover ~0 is the expected pattern, not a "
+    "contradiction. assessment_method is which derivation graded the route."
+)
+
+
+def briefing_freshness_status(freshness: dict) -> dict[str, Any]:
+    """Map a ``/packs/freshness`` payload to the connector's status + stale note.
+
+    Prefers the tiered refresh-gate decision (what the web refresh button
+    actually does at this lead time) over the raw ``fresh`` min-rule: the
+    min-rule flips to stale whenever *any* model has a newer run, even when the
+    gate has decided a refresh isn't worthwhile yet — which surfaced as a false
+    "needs refresh" right after a manual refresh.
+
+    Returns ``{"status": "ready"|"stale", "is_fresh": bool}`` and, when stale,
+    ``stale_models`` + a human ``stale_note`` whose wording matches the web
+    button (it reuses the gate's own ``reason``). The caller merges these keys
+    into its result envelope.
+    """
+    decision = freshness.get("refresh_decision") or {}
+    mode = decision.get("mode")
+    if mode is not None:
+        # "none" -> nothing worthwhile to refresh; "full"/"realtime" -> an
+        # update the button would actually fetch.
+        is_fresh = mode == "none"
+    else:
+        # Gate didn't run (no flight ctx) — fall back to the min-rule.
+        is_fresh = freshness.get("fresh", True)
+
+    out: dict[str, Any] = {
+        "status": "ready" if is_fresh else "stale",
+        "is_fresh": is_fresh,
+    }
+    if not is_fresh:
+        out["stale_models"] = freshness.get("stale_models", [])
+        # Use the gate's own reason so the note matches the web button — and
+        # only when a refresh is genuinely worthwhile (mode != "none").
+        note = decision.get("reason") or "Newer model data is available for this briefing."
+        note += " Call refresh_briefing for the latest data."
+        pending_models = decision.get("pending_models", [])
+        if pending_models:
+            note += f" Awaiting updated runs: {', '.join(pending_models)}."
+        eta_useful = decision.get("eta_useful")
+        if eta_useful:
+            note += f" Useful refresh ETA: {eta_useful}."
+        out["stale_note"] = note
+    return out
+
+
+def summarize_advisories(advisories: dict) -> list[dict]:
+    """Extract advisory information for the agent, retaining per-model detail.
+
+    Unlike a flat status list, this keeps each model's status/detail and the
+    ``cross_check`` note plus the ``parameters_used`` thresholds, so the agent
+    can see the per-model split and the reasoning behind a grade directly in
+    the briefing output. That visible detail is the primary discoverability
+    hook (Layer A): it provokes the follow-up question and a ``detail_tool``
+    pointer names the drill-down tool.
+
+    The hint flags are deliberately **neutral** (``cross_check_present`` /
+    ``per_model_present``, never "model_disagreement"): a valenced flag would
+    prime the exact red->amber downgrade the guardrail forbids. The cross-check
+    is display-only **context for discussion**, never a downgrade signal
+    (#178) — high CAPE matters even when the deterministic model scheme is
+    quiet.
+    """
+    catalog = {c.get("id"): c for c in advisories.get("catalog", [])}
+    results = []
+    for adv in advisories.get("advisories", []):
+        adv_id = adv.get("advisory_id")
+        per_model: list[dict] = []
+        cross_check_present = False
+        for m in adv.get("per_model", []):
+            entry_m: dict[str, Any] = {
+                "model": m.get("model"),
+                "status": m.get("status"),
+                "detail": m.get("detail"),
+                "affected_pct": m.get("affected_pct"),
+            }
+            cc = m.get("cross_check")
+            if cc:
+                cross_check_present = True
+                entry_m["cross_check"] = cc
+            per_model.append(entry_m)
+
+        entry: dict[str, Any] = {
+            "id": adv_id,
+            "status": adv.get("aggregate_status"),
+            "detail": adv.get("aggregate_detail"),
+            "cross_check_present": cross_check_present,
+            "per_model_present": bool(per_model),
+        }
+        cat = catalog.get(adv_id)
+        if cat:
+            entry["name"] = cat.get("name")
+            entry["category"] = cat.get("category")
+
+        # Layer A: expand the full per-model detail + thresholds, and point the
+        # agent at the drill-down tool, only when there is something worth
+        # explaining (a non-green grade or a cross-check note). Green-and-quiet
+        # advisories keep just the ``*_present`` flags so every get_briefing
+        # call stays compact — their per-model data is almost always noise, and
+        # the agent can still call get_advisory_detail explicitly if asked.
+        if entry["status"] in ("amber", "red") or cross_check_present:
+            entry["per_model"] = per_model
+            entry["parameters_used"] = adv.get("parameters_used", {})
+            entry["detail_tool"] = "get_advisory_detail"
+
+        results.append(entry)
+    return results
+
+
+def summarize_altitude_table(table: dict) -> dict:
+    """Summarize the altitude advisory table for the agent."""
+    return {
+        "cruise_altitude_ft": table.get("cruise_altitude_ft"),
+        "best_below_cruise": table.get("best_below_cruise"),
+        "best_above_cruise": table.get("best_above_cruise"),
+        "advisory_names": table.get("advisory_names", {}),
+        "rows": [
+            {
+                "altitude_ft": row.get("altitude_ft"),
+                "red_count": row.get("red_count"),
+                "amber_count": row.get("amber_count"),
+                "green_count": row.get("green_count"),
+                "statuses": row.get("statuses"),
+            }
+            for row in table.get("rows", [])
+        ],
+    }
+
+
+def advisory_detail(adv: dict, catalog_entry: dict | None) -> dict[str, Any]:
+    """Build a generic per-model drill-down summary for one advisory."""
+    per_model: list[dict] = []
+    for m in adv.get("per_model", []):
+        entry_m: dict[str, Any] = {
+            "model": m.get("model"),
+            "status": m.get("status"),
+            "detail": m.get("detail"),
+            "affected_pct": m.get("affected_pct"),
+            "affected_nm": m.get("affected_nm"),
+            "total_nm": m.get("total_nm"),
+        }
+        cc = m.get("cross_check")
+        if cc:
+            entry_m["cross_check"] = cc
+        per_model.append(entry_m)
+
+    result: dict[str, Any] = {
+        "advisory_id": adv.get("advisory_id"),
+        "aggregate_status": adv.get("aggregate_status"),
+        "aggregate_detail": adv.get("aggregate_detail"),
+        "per_model": per_model,
+        "parameters_used": adv.get("parameters_used", {}),
+        "cross_check_note": CROSS_CHECK_NOTE,
+    }
+    if catalog_entry:
+        result["name"] = catalog_entry.get("name")
+        result["category"] = catalog_entry.get("category")
+        result["description"] = catalog_entry.get("description")
+    return result
+
+
+def convective_detail(route_analyses: dict, models: list[str]) -> dict[str, Any]:
+    """Per-model convective drill-down from the route analyses soundings.
+
+    Splits the two independent derivations so a digest that narrates "tops to
+    27,000 ft" reconciles with a quiet model scheme:
+
+    - ``thermo`` — the CAPE/parcel view: CAPE range across the route and the
+      peak point (CAPE, the equilibrium-level top the digest calls "convective
+      tops", location, and the forecast valid-time vs flight ETA so the diurnal
+      timing is explicit).
+    - ``nwp`` — the model's own convective scheme: max convective cover %
+      (``~0`` is the machine-readable "blue sky" signal) and its convective top.
+    - ``assessment_method`` — which derivation actually graded the route.
+
+    cover ~0 next to high CAPE is the expected pattern, not a contradiction —
+    this surfaces the data so it can be explained, never argued down.
+    """
+    points = route_analyses.get("analyses", [])
+    out: dict[str, Any] = {}
+    for model in models:
+        thermo_capes: list[float] = []
+        thermo_peak: dict | None = None
+        thermo_peak_cape: float | None = None  # raw CAPE for comparison (output rounds)
+        nwp_max_cover: float | None = None
+        nwp_peak_top: float | None = None
+        method_counts: dict[str, int] = {}
+        for p in points:
+            sounding = (p.get("sounding") or {}).get(model)
+            if not sounding:
+                continue
+            resolved = sounding.get("convective")
+            method = resolved.get("method") if resolved else None
+            if method:
+                method_counts[method] = method_counts.get(method, 0) + 1
+
+            # Parcel/CAPE view — explicit thermo, falling back to the resolved
+            # assessment for old packs that never split the two.
+            thermo = sounding.get("convective_thermo") or resolved
+            if thermo:
+                cape = thermo.get("cape_jkg")
+                if cape is not None:
+                    thermo_capes.append(cape)
+                    if thermo_peak is None or cape > thermo_peak_cape:
+                        thermo_peak_cape = cape
+                        top = thermo.get("top_ft")
+                        thermo_peak = {
+                            "cape_jkg": round(cape),
+                            "el_top_ft": round(top) if top is not None else None,
+                            "risk_level": thermo.get("risk_level"),
+                            "distance_nm": p.get("distance_from_origin_nm"),
+                            "waypoint_icao": p.get("waypoint_icao"),
+                            "valid_time": p.get("forecast_hour"),
+                            "eta": p.get("interpolated_time"),
+                        }
+
+            # Model's own convective scheme.
+            nwp = sounding.get("convective_nwp")
+            if nwp:
+                cover = nwp.get("cover_pct")
+                if cover is not None:
+                    nwp_max_cover = cover if nwp_max_cover is None else max(nwp_max_cover, cover)
+                top = nwp.get("top_ft")
+                if top is not None:
+                    nwp_peak_top = top if nwp_peak_top is None else max(nwp_peak_top, top)
+
+        if not thermo_capes and not method_counts and nwp_max_cover is None:
+            continue
+        out[model] = {
+            "assessment_method": (
+                max(method_counts, key=lambda k: method_counts[k]) if method_counts else None
+            ),
+            "method_counts": method_counts,
+            "thermo": {
+                "cape_range_jkg": (
+                    [round(min(thermo_capes)), round(max(thermo_capes))] if thermo_capes else None
+                ),
+                "peak": thermo_peak,
+            },
+            "nwp": nwp_block(nwp_max_cover, nwp_peak_top),
+        }
+    return out
+
+
+def nwp_block(max_cover: float | None, peak_top: float | None) -> dict[str, Any]:
+    """Model convective-scheme summary. ``max_cover_pct`` and ``peak_top_ft``
+    are maximized independently across the route, so they may come from
+    different points — the note guards against reading them as one peak."""
+    block: dict[str, Any] = {
+        "max_cover_pct": round(max_cover) if max_cover is not None else None,
+        "peak_top_ft": round(peak_top) if peak_top is not None else None,
+    }
+    if max_cover is not None or peak_top is not None:
+        block["note"] = (
+            "max_cover_pct and peak_top_ft are independent route-wide maxima "
+            "and may come from different points"
+        )
+    return block

--- a/src/weatherbrief/mcp/server.py
+++ b/src/weatherbrief/mcp/server.py
@@ -654,8 +654,9 @@ def get_advisory_detail(
         )
         if adv is None:
             available = [a.get("advisory_id") for a in advisories.get("advisories", [])]
+            listed = ", ".join(x for x in available if x)
             return _error_result(
-                f"Advisory '{advisory_id}' not found. Available: {', '.join(available)}"
+                f"Advisory '{advisory_id}' not found. Available: {listed}"
             )
 
         catalog = {c.get("id"): c for c in advisories.get("catalog", [])}

--- a/src/weatherbrief/mcp/server.py
+++ b/src/weatherbrief/mcp/server.py
@@ -29,6 +29,24 @@ from fastmcp.server.dependencies import get_http_request
 from mcp.types import ToolAnnotations
 from pydantic import AnyHttpUrl, Field
 
+from weatherbrief.connectors.views import (
+    CONVECTIVE_NOTE as _CONVECTIVE_NOTE,
+)
+from weatherbrief.connectors.views import (
+    advisory_detail as _advisory_detail,
+)
+from weatherbrief.connectors.views import (
+    briefing_freshness_status as _briefing_freshness_status,
+)
+from weatherbrief.connectors.views import (
+    convective_detail as _convective_detail,
+)
+from weatherbrief.connectors.views import (
+    summarize_advisories as _summarize_advisories,
+)
+from weatherbrief.connectors.views import (
+    summarize_altitude_table as _summarize_altitude_table,
+)
 from weatherbrief.mcp.client import API_BASE, WeatherbriefClient
 
 # Configure logging
@@ -416,37 +434,16 @@ def get_briefing(
 
         timestamp = pack["fetch_timestamp"]
 
-        # Check freshness. Prefer the tiered refresh-gate decision (what the web
-        # refresh button actually does at this lead time) over the raw ``fresh``
-        # min-rule: the min-rule flips to stale whenever *any* model has a newer
-        # run, even when the gate has decided a refresh isn't worthwhile yet —
-        # which surfaced as a false "needs refresh" right after a manual refresh.
+        # Map freshness → status + stale note via the shared shaper (identical
+        # tiered-gate logic across the MCP and GPT/OpenAPI connectors).
         try:
             freshness = client.get_freshness(flight_id)
-            decision = freshness.get("refresh_decision") or {}
-            mode = decision.get("mode")
-            if mode is not None:
-                # "none" → nothing worthwhile to refresh; "full"/"realtime" → an
-                # update the button would actually fetch.
-                is_fresh = mode == "none"
-            else:
-                # Gate didn't run (no flight ctx) — fall back to the min-rule.
-                is_fresh = freshness.get("fresh", True)
-            stale_models = freshness.get("stale_models", [])
-            stale_reason = decision.get("reason")
-            pending_models = decision.get("pending_models", [])
-            eta_useful = decision.get("eta_useful")
+            fresh_status = _briefing_freshness_status(freshness)
         except httpx.HTTPStatusError:
-            is_fresh = True
-            stale_models = []
-            stale_reason = None
-            pending_models = []
-            eta_useful = None
-
-        status = "ready" if is_fresh else "stale"
+            fresh_status = {"status": "ready", "is_fresh": True}
 
         result: dict[str, Any] = {
-            "status": status,
+            "status": fresh_status["status"],
             "flight_id": flight_id,
             "assessment": pack.get("assessment"),
             "assessment_reason": pack.get("assessment_reason"),
@@ -455,17 +452,9 @@ def get_briefing(
             "web_url": _flight_web_url(flight_id),
         }
 
-        if not is_fresh:
-            result["stale_models"] = stale_models
-            # Use the gate's own reason so the note matches the web button — and
-            # only when a refresh is genuinely worthwhile (mode != "none").
-            note = stale_reason or "Newer model data is available for this briefing."
-            note += " Call refresh_briefing for the latest data."
-            if pending_models:
-                note += f" Awaiting updated runs: {', '.join(pending_models)}."
-            if eta_useful:
-                note += f" Useful refresh ETA: {eta_useful}."
-            result["stale_note"] = note
+        if not fresh_status["is_fresh"]:
+            result["stale_models"] = fresh_status.get("stale_models", [])
+            result["stale_note"] = fresh_status["stale_note"]
 
         # Fetch advisories
         advisories = client.get_advisories(flight_id, timestamp)
@@ -487,89 +476,6 @@ def get_briefing(
             result["altitude_table"] = _summarize_altitude_table(alt_table)
 
     return result
-
-
-def _summarize_advisories(advisories: dict) -> list[dict]:
-    """Extract advisory information for the agent, retaining per-model detail.
-
-    Unlike a flat status list, this keeps each model's status/detail and the
-    ``cross_check`` note plus the ``parameters_used`` thresholds, so the agent
-    can see the per-model split and the reasoning behind a grade directly in
-    the briefing output. That visible detail is the primary discoverability
-    hook (Layer A): it provokes the follow-up question and a ``detail_tool``
-    pointer names the drill-down tool.
-
-    The hint flags are deliberately **neutral** (``cross_check_present`` /
-    ``per_model_present``, never "model_disagreement"): a valenced flag would
-    prime the exact red→amber downgrade the guardrail forbids. The cross-check
-    is display-only **context for discussion**, never a downgrade signal
-    (#178) — high CAPE matters even when the deterministic model scheme is
-    quiet.
-    """
-    catalog = {c.get("id"): c for c in advisories.get("catalog", [])}
-    results = []
-    for adv in advisories.get("advisories", []):
-        adv_id = adv.get("advisory_id")
-        per_model: list[dict] = []
-        cross_check_present = False
-        for m in adv.get("per_model", []):
-            entry_m: dict[str, Any] = {
-                "model": m.get("model"),
-                "status": m.get("status"),
-                "detail": m.get("detail"),
-                "affected_pct": m.get("affected_pct"),
-            }
-            cc = m.get("cross_check")
-            if cc:
-                cross_check_present = True
-                entry_m["cross_check"] = cc
-            per_model.append(entry_m)
-
-        entry: dict[str, Any] = {
-            "id": adv_id,
-            "status": adv.get("aggregate_status"),
-            "detail": adv.get("aggregate_detail"),
-            "cross_check_present": cross_check_present,
-            "per_model_present": bool(per_model),
-        }
-        cat = catalog.get(adv_id)
-        if cat:
-            entry["name"] = cat.get("name")
-            entry["category"] = cat.get("category")
-
-        # Layer A: expand the full per-model detail + thresholds, and point the
-        # agent at the drill-down tool, only when there is something worth
-        # explaining (a non-green grade or a cross-check note). Green-and-quiet
-        # advisories keep just the ``*_present`` flags so every get_briefing
-        # call stays compact — their per-model data is almost always noise, and
-        # the agent can still call get_advisory_detail explicitly if asked.
-        if entry["status"] in ("amber", "red") or cross_check_present:
-            entry["per_model"] = per_model
-            entry["parameters_used"] = adv.get("parameters_used", {})
-            entry["detail_tool"] = "get_advisory_detail"
-
-        results.append(entry)
-    return results
-
-
-def _summarize_altitude_table(table: dict) -> dict:
-    """Summarize the altitude advisory table for the agent."""
-    return {
-        "cruise_altitude_ft": table.get("cruise_altitude_ft"),
-        "best_below_cruise": table.get("best_below_cruise"),
-        "best_above_cruise": table.get("best_above_cruise"),
-        "advisory_names": table.get("advisory_names", {}),
-        "rows": [
-            {
-                "altitude_ft": row.get("altitude_ft"),
-                "red_count": row.get("red_count"),
-                "amber_count": row.get("amber_count"),
-                "green_count": row.get("green_count"),
-                "statuses": row.get("statuses"),
-            }
-            for row in table.get("rows", [])
-        ],
-    }
 
 
 # ---------------------------------------------------------------------------
@@ -780,154 +686,12 @@ def get_advisory_detail(
             if route_analyses:
                 models = [m.get("model") for m in adv.get("per_model", [])]
                 result["convective"] = _convective_detail(route_analyses, models)
-                result["convective_note"] = (
-                    "thermo.peak.el_top_ft is parcel-derived (the equilibrium "
-                    "level the digest narrates as 'convective tops'), NOT the "
-                    "model's convective cloud field. nwp.max_cover_pct ~0 means "
-                    "the model's own convective scheme is quiet ('blue sky'); "
-                    "high CAPE with cover ~0 is the expected pattern, not a "
-                    "contradiction. assessment_method is which derivation graded "
-                    "the route."
-                )
+                result["convective_note"] = _CONVECTIVE_NOTE
 
         result["flight_id"] = flight_id
         result["web_url"] = _flight_web_url(flight_id)
 
     return result
-
-
-def _advisory_detail(adv: dict, catalog_entry: dict | None) -> dict[str, Any]:
-    """Build a generic per-model drill-down summary for one advisory."""
-    per_model: list[dict] = []
-    for m in adv.get("per_model", []):
-        entry_m: dict[str, Any] = {
-            "model": m.get("model"),
-            "status": m.get("status"),
-            "detail": m.get("detail"),
-            "affected_pct": m.get("affected_pct"),
-            "affected_nm": m.get("affected_nm"),
-            "total_nm": m.get("total_nm"),
-        }
-        cc = m.get("cross_check")
-        if cc:
-            entry_m["cross_check"] = cc
-        per_model.append(entry_m)
-
-    result: dict[str, Any] = {
-        "advisory_id": adv.get("advisory_id"),
-        "aggregate_status": adv.get("aggregate_status"),
-        "aggregate_detail": adv.get("aggregate_detail"),
-        "per_model": per_model,
-        "parameters_used": adv.get("parameters_used", {}),
-        "cross_check_note": (
-            "Cross-check notes are display-only context for discussion, not a "
-            "downgrade signal. Explain the grade with them; do not argue it down."
-        ),
-    }
-    if catalog_entry:
-        result["name"] = catalog_entry.get("name")
-        result["category"] = catalog_entry.get("category")
-        result["description"] = catalog_entry.get("description")
-    return result
-
-
-def _convective_detail(route_analyses: dict, models: list[str]) -> dict[str, Any]:
-    """Per-model convective drill-down from the route analyses soundings.
-
-    Splits the two independent derivations so a digest that narrates "tops to
-    27,000 ft" reconciles with a quiet model scheme:
-
-    - ``thermo`` — the CAPE/parcel view: CAPE range across the route and the
-      peak point (CAPE, the equilibrium-level top the digest calls "convective
-      tops", location, and the forecast valid-time vs flight ETA so the diurnal
-      timing is explicit).
-    - ``nwp`` — the model's own convective scheme: max convective cover %
-      (``~0`` is the machine-readable "blue sky" signal) and its convective top.
-    - ``assessment_method`` — which derivation actually graded the route.
-
-    cover ~0 next to high CAPE is the expected pattern, not a contradiction —
-    this surfaces the data so it can be explained, never argued down.
-    """
-    points = route_analyses.get("analyses", [])
-    out: dict[str, Any] = {}
-    for model in models:
-        thermo_capes: list[float] = []
-        thermo_peak: dict | None = None
-        thermo_peak_cape: float | None = None  # raw CAPE for comparison (output rounds)
-        nwp_max_cover: float | None = None
-        nwp_peak_top: float | None = None
-        method_counts: dict[str, int] = {}
-        for p in points:
-            sounding = (p.get("sounding") or {}).get(model)
-            if not sounding:
-                continue
-            resolved = sounding.get("convective")
-            method = resolved.get("method") if resolved else None
-            if method:
-                method_counts[method] = method_counts.get(method, 0) + 1
-
-            # Parcel/CAPE view — explicit thermo, falling back to the resolved
-            # assessment for old packs that never split the two.
-            thermo = sounding.get("convective_thermo") or resolved
-            if thermo:
-                cape = thermo.get("cape_jkg")
-                if cape is not None:
-                    thermo_capes.append(cape)
-                    if thermo_peak is None or cape > thermo_peak_cape:
-                        thermo_peak_cape = cape
-                        top = thermo.get("top_ft")
-                        thermo_peak = {
-                            "cape_jkg": round(cape),
-                            "el_top_ft": round(top) if top is not None else None,
-                            "risk_level": thermo.get("risk_level"),
-                            "distance_nm": p.get("distance_from_origin_nm"),
-                            "waypoint_icao": p.get("waypoint_icao"),
-                            "valid_time": p.get("forecast_hour"),
-                            "eta": p.get("interpolated_time"),
-                        }
-
-            # Model's own convective scheme.
-            nwp = sounding.get("convective_nwp")
-            if nwp:
-                cover = nwp.get("cover_pct")
-                if cover is not None:
-                    nwp_max_cover = cover if nwp_max_cover is None else max(nwp_max_cover, cover)
-                top = nwp.get("top_ft")
-                if top is not None:
-                    nwp_peak_top = top if nwp_peak_top is None else max(nwp_peak_top, top)
-
-        if not thermo_capes and not method_counts and nwp_max_cover is None:
-            continue
-        out[model] = {
-            "assessment_method": (
-                max(method_counts, key=lambda k: method_counts[k]) if method_counts else None
-            ),
-            "method_counts": method_counts,
-            "thermo": {
-                "cape_range_jkg": (
-                    [round(min(thermo_capes)), round(max(thermo_capes))] if thermo_capes else None
-                ),
-                "peak": thermo_peak,
-            },
-            "nwp": _nwp_block(nwp_max_cover, nwp_peak_top),
-        }
-    return out
-
-
-def _nwp_block(max_cover: float | None, peak_top: float | None) -> dict[str, Any]:
-    """Model convective-scheme summary. ``max_cover_pct`` and ``peak_top_ft``
-    are maximized independently across the route, so they may come from
-    different points — the note guards against reading them as one peak."""
-    block: dict[str, Any] = {
-        "max_cover_pct": round(max_cover) if max_cover is not None else None,
-        "peak_top_ft": round(peak_top) if peak_top is not None else None,
-    }
-    if max_cover is not None or peak_top is not None:
-        block["note"] = (
-            "max_cover_pct and peak_top_ft are independent route-wide maxima "
-            "and may come from different points"
-        )
-    return block
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_connectors_views.py
+++ b/tests/test_connectors_views.py
@@ -103,6 +103,37 @@ def test_summarize_advisories_green_with_cross_check_expands():
 
 
 # --------------------------------------------------------------------------
+# advisory_detail — per-model drill-down + load-bearing guardrail note
+# --------------------------------------------------------------------------
+
+def test_advisory_detail_injects_cross_check_note_and_per_model():
+    adv = {
+        "advisory_id": "convective",
+        "aggregate_status": "red",
+        "aggregate_detail": "EXTREME over 57%",
+        "per_model": [
+            {"model": "gfs", "status": "red", "detail": "d", "affected_pct": 57,
+             "affected_nm": 80, "total_nm": 140, "cross_check": "CAPE 2200 J/kg"},
+        ],
+        "parameters_used": {"cape_red": 1500},
+    }
+    catalog = {"name": "Convective", "category": "convective", "description": "desc"}
+    out = views.advisory_detail(adv, catalog)
+    # The cross-check guardrail note is deliberately load-bearing — always present.
+    assert out["cross_check_note"] == views.CROSS_CHECK_NOTE
+    assert out["aggregate_status"] == "red"
+    assert out["per_model"][0]["cross_check"] == "CAPE 2200 J/kg"
+    assert out["per_model"][0]["affected_nm"] == 80
+    assert out["name"] == "Convective"
+
+
+def test_advisory_detail_without_catalog_entry_omits_name():
+    out = views.advisory_detail({"advisory_id": "cloud_top", "per_model": []}, None)
+    assert out["cross_check_note"] == views.CROSS_CHECK_NOTE
+    assert "name" not in out
+
+
+# --------------------------------------------------------------------------
 # convective_detail — thermo vs nwp split + blue-sky signal
 # --------------------------------------------------------------------------
 

--- a/tests/test_connectors_views.py
+++ b/tests/test_connectors_views.py
@@ -1,0 +1,135 @@
+"""Tests for the shared connector shapers (weatherbrief.connectors.views).
+
+These pure dict->dict transforms are shared by both agent front-doors — the
+Claude MCP server and the ChatGPT OpenAPI router — so the guardrails verified
+here (cross-check stays context-not-downgrade; convective provenance split)
+apply identically to both.
+"""
+
+from __future__ import annotations
+
+from weatherbrief.connectors import views
+
+
+# --------------------------------------------------------------------------
+# briefing_freshness_status — tiered refresh-gate -> status + stale note
+# --------------------------------------------------------------------------
+
+def test_freshness_stale_uses_gate_reason_and_note():
+    out = views.briefing_freshness_status(
+        {
+            "refresh_decision": {
+                "mode": "full",
+                "reason": "ECMWF run updated.",
+                "pending_models": ["icon"],
+                "eta_useful": "14:00Z",
+            },
+            "stale_models": ["ecmwf"],
+        }
+    )
+    assert out["status"] == "stale"
+    assert out["is_fresh"] is False
+    assert out["stale_models"] == ["ecmwf"]
+    assert out["stale_note"].startswith("ECMWF run updated.")
+    assert "Call refresh_briefing" in out["stale_note"]
+    assert "Awaiting updated runs: icon" in out["stale_note"]
+    assert "Useful refresh ETA: 14:00Z" in out["stale_note"]
+
+
+def test_freshness_gate_none_is_fresh_even_if_min_rule_stale():
+    # The tiered gate ("none" = nothing worthwhile to refresh) wins over the raw
+    # min-rule ``fresh=False`` — the false "needs refresh" right after a manual
+    # refresh must not resurface.
+    out = views.briefing_freshness_status({"refresh_decision": {"mode": "none"}, "fresh": False})
+    assert out["status"] == "ready"
+    assert out["is_fresh"] is True
+    assert "stale_note" not in out
+
+
+def test_freshness_falls_back_to_min_rule_when_gate_absent():
+    assert views.briefing_freshness_status({"fresh": True})["is_fresh"] is True
+    assert views.briefing_freshness_status({"fresh": False})["is_fresh"] is False
+
+
+# --------------------------------------------------------------------------
+# summarize_advisories — discoverability hints + neutral guardrail flags
+# --------------------------------------------------------------------------
+
+def _adv_manifest(status: str, cross_check: str | None = None):
+    per_model = [{"model": "gfs", "status": status, "detail": "d", "affected_pct": 40}]
+    if cross_check:
+        per_model[0]["cross_check"] = cross_check
+    return {
+        "advisories": [
+            {
+                "advisory_id": "convective",
+                "aggregate_status": status,
+                "aggregate_detail": "agg",
+                "per_model": per_model,
+                "parameters_used": {"cape_red": 1500},
+            }
+        ],
+        "catalog": [{"id": "convective", "name": "Convective", "category": "convective"}],
+    }
+
+
+def test_summarize_advisories_expands_red_with_detail_tool():
+    out = views.summarize_advisories(_adv_manifest("red"))
+    entry = out[0]
+    assert entry["id"] == "convective"
+    assert entry["status"] == "red"
+    assert entry["per_model_present"] is True
+    assert entry["detail_tool"] == "get_advisory_detail"
+    assert entry["parameters_used"] == {"cape_red": 1500}
+
+
+def test_summarize_advisories_green_stays_compact():
+    out = views.summarize_advisories(_adv_manifest("green"))
+    entry = out[0]
+    # Green-and-quiet: no per_model expansion, no drill-down pointer.
+    assert "per_model" not in entry
+    assert "detail_tool" not in entry
+    assert entry["cross_check_present"] is False
+
+
+def test_summarize_advisories_green_with_cross_check_expands():
+    # A cross-check on an otherwise-green advisory is still surfaced (the hook
+    # that provokes the follow-up question) without priming a downgrade.
+    out = views.summarize_advisories(_adv_manifest("green", cross_check="CAPE 1800 J/kg"))
+    entry = out[0]
+    assert entry["cross_check_present"] is True
+    assert entry["detail_tool"] == "get_advisory_detail"
+    assert entry["per_model"][0]["cross_check"] == "CAPE 1800 J/kg"
+
+
+# --------------------------------------------------------------------------
+# convective_detail — thermo vs nwp split + blue-sky signal
+# --------------------------------------------------------------------------
+
+def test_convective_detail_splits_thermo_and_nwp():
+    route_analyses = {
+        "analyses": [
+            {
+                "distance_from_origin_nm": 12,
+                "waypoint_icao": "LFBO",
+                "forecast_hour": 15,
+                "interpolated_time": "2026-06-21T15:00:00Z",
+                "sounding": {
+                    "gfs": {
+                        "convective": {"method": "thermo"},
+                        "convective_thermo": {
+                            "cape_jkg": 1800, "top_ft": 27000, "risk_level": "high",
+                        },
+                        "convective_nwp": {"cover_pct": 0, "top_ft": None},
+                    }
+                },
+            }
+        ]
+    }
+    out = views.convective_detail(route_analyses, ["gfs"])
+    gfs = out["gfs"]
+    assert gfs["assessment_method"] == "thermo"
+    assert gfs["thermo"]["peak"]["el_top_ft"] == 27000
+    assert gfs["thermo"]["peak"]["cape_jkg"] == 1800
+    # cover ~0 = the machine-readable "blue sky" signal next to high CAPE.
+    assert gfs["nwp"]["max_cover_pct"] == 0


### PR DESCRIPTION
Pull the pure response-shaping out of the MCP server into a neutral
connectors.views module so the upcoming GPT/OpenAPI front-door shares the
exact same shaping — and the same meteorological guardrails (cross-check is
context-not-downgrade; convective provenance note) — as the Claude MCP
connector, with no risk of the two drifting.

Moved verbatim (behaviour-preserving): summarize_advisories,
summarize_altitude_table, advisory_detail, convective_detail, nwp_block, plus
the CROSS_CHECK / CONVECTIVE note constants. New shared briefing_freshness_status
captures the tiered refresh-gate -> status/stale-note logic. mcp/server.py now
imports these (private aliases preserved so existing call sites and tests are
untouched).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011B1i4zRH3NPEg8Y199bYF5