### PR TITLE
Add "use my account email" opt-out on the donation page

### DIFF
--- a/src/weatherbrief/api/donations.py
+++ b/src/weatherbrief/api/donations.py
@@ -145,6 +145,11 @@ class CheckoutRequest(BaseModel):
     amount: float = Field(..., gt=0)
     currency: str = "USD"
     recurring: bool = False
+    # When true (default) a logged-in donor's account email pre-fills the
+    # (locked) Stripe Checkout email field. Unchecking it omits customer_email so
+    # Stripe shows a blank, editable field — letting the donor use a different
+    # address. No effect for anonymous donors (they always type their email).
+    use_account_email: bool = True
 
 
 class CheckoutResponse(BaseModel):
@@ -181,9 +186,11 @@ def create_checkout(
 
     # Pre-fill the (mandatory, non-removable) Stripe Checkout email field for
     # logged-in donors so they don't retype it — and so the Checkout contact
-    # matches their account email.
+    # matches their account email. Stripe locks a pre-filled email; a donor who
+    # wants a different address opts out (use_account_email=False), leaving the
+    # field blank and editable at Checkout.
     customer_email: str | None = None
-    if viewer_id:
+    if viewer_id and body.use_account_email:
         user = db.get(UserRow, viewer_id)
         if user and user.email:
             customer_email = user.email

--- a/tests/test_donations_api.py
+++ b/tests/test_donations_api.py
@@ -160,6 +160,23 @@ class TestCheckout:
         assert "/donate-thanks.html?session_id={CHECKOUT_SESSION_ID}" in captured["success_url"]
         assert captured["cancel_url"].endswith("/donate-cancel.html")
 
+    def test_opt_out_of_account_email(self, make_client, monkeypatch):
+        # Donor unchecks "use my account email" → don't pre-fill, so Stripe shows
+        # a blank, editable email field for a different address.
+        captured = {}
+
+        class _Sess:
+            url = "https://x/y"
+
+        monkeypatch.setattr(donations, "create_checkout_session",
+                            lambda **kw: captured.update(kw) or _Sess())
+        client = make_client()
+        r = client.post("/api/donations/checkout",
+                        json={"amount": 25, "use_account_email": False})
+        assert r.status_code == 200, r.text
+        assert captured["user_id"] == DEV_USER_ID  # still attributed to the account
+        assert captured["customer_email"] is None  # but email left for the donor to enter
+
     def test_anonymous_allowed(self, make_client, monkeypatch):
         captured = {}
 

--- a/web/donate.html
+++ b/web/donate.html
@@ -33,6 +33,26 @@
 
     .recurring-row { display: flex; align-items: center; gap: 0.5rem; margin-bottom: 1rem; font-size: 0.9rem; }
 
+    /* "Use my account email" opt-out with an on-hover explanation. */
+    .email-opt-row { display: flex; align-items: center; gap: 0.4rem; margin-bottom: 0.9rem; font-size: 0.9rem; }
+    .email-opt-label { display: inline-flex; align-items: center; gap: 0.5rem; margin: 0; }
+    .hint { position: relative; display: inline-flex; }
+    .hint .hint-mark {
+      display: inline-flex; align-items: center; justify-content: center;
+      width: 1.05rem; height: 1.05rem; border-radius: 50%;
+      border: 1px solid var(--border); color: var(--text-muted);
+      font-size: 0.72rem; font-weight: 700; cursor: help; user-select: none;
+    }
+    .hint .hint-pop {
+      position: absolute; left: 50%; bottom: calc(100% + 0.5rem); transform: translateX(-50%);
+      width: 17rem; max-width: 70vw; padding: 0.6rem 0.7rem; z-index: 5;
+      background: var(--surface); color: var(--text); border: 1px solid var(--border);
+      border-radius: var(--radius); box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18);
+      font-size: 0.8rem; font-weight: 400; line-height: 1.35;
+      opacity: 0; visibility: hidden; transition: opacity 0.12s ease;
+    }
+    .hint:hover .hint-pop, .hint:focus-within .hint-pop { opacity: 1; visibility: visible; }
+
     #loading { text-align: center; padding: 3rem; color: var(--text-muted); }
     #error-message { color: var(--danger); text-align: center; padding: 1rem; display: none; }
 
@@ -171,6 +191,24 @@
         <label class="recurring-row" id="recurring-row" style="display:none;">
           <input type="checkbox" id="input-recurring"> Make this a monthly donation
         </label>
+
+        <!-- Logged-in donors only (revealed by donate-main.ts): pre-fill the
+             account email into Stripe's locked email field, or opt out to enter
+             a different one. -->
+        <div class="email-opt-row" id="email-opt-row" style="display:none;">
+          <label class="email-opt-label">
+            <input type="checkbox" id="input-use-account-email" checked>
+            Use my account email
+          </label>
+          <span class="hint" tabindex="0" aria-label="Why we ask for an email">
+            <span class="hint-mark" aria-hidden="true">i</span>
+            <span class="hint-pop" role="tooltip">
+              Stripe, our payment provider, requires an email for your receipt.
+              Leave this checked to use your account email, or uncheck it to
+              enter a different email at checkout.
+            </span>
+          </span>
+        </div>
 
         <button type="button" id="btn-donate" class="btn btn-primary">Donate</button>
         <p class="sub" style="margin-top:0.75rem;">

--- a/web/ts/adapters/donations-adapter.ts
+++ b/web/ts/adapters/donations-adapter.ts
@@ -116,6 +116,10 @@ export interface CheckoutRequest {
   amount: number;
   currency: string;
   recurring?: boolean;
+  // When false, a logged-in donor's account email is NOT pre-filled into Stripe
+  // Checkout, leaving the email field blank and editable. Defaults to true
+  // server-side; only send false to opt out. No effect for anonymous donors.
+  use_account_email?: boolean;
 }
 
 /** Create a Stripe Checkout Session and return its hosted redirect URL. */

--- a/web/ts/donate-main.ts
+++ b/web/ts/donate-main.ts
@@ -309,6 +309,13 @@ function initForm(): void {
   const btn = document.getElementById('btn-donate') as HTMLButtonElement;
   const amountInput = document.getElementById('input-amount') as HTMLInputElement;
   const recurring = document.getElementById('input-recurring') as HTMLInputElement;
+  const useAccountEmail = document.getElementById('input-use-account-email') as HTMLInputElement;
+
+  // The "use my account email" opt-out only makes sense when there's an account
+  // email to pre-fill — anonymous donors always type their email at Checkout.
+  if (isLoggedIn) {
+    document.getElementById('email-opt-row')!.style.display = '';
+  }
 
   // Typing a custom amount clears any active preset highlight + re-translates.
   amountInput.addEventListener('input', () => {
@@ -332,6 +339,8 @@ function initForm(): void {
         amount,
         currency: selectedCurrency,
         recurring: recurring.checked,
+        // Only meaningful for logged-in donors; harmless (and ignored) otherwise.
+        use_account_email: useAccountEmail.checked,
       });
       // Defense-in-depth: only ever navigate to a Stripe Checkout URL, never an
       // arbitrary (e.g. javascript:) scheme if the response were ever tampered with.


### PR DESCRIPTION
Stripe Checkout locks a pre-filled email field, so logged-in donors who
want their receipt to go to a different address than their account email
had no way to change it. Add a checked-by-default "Use my account email"
checkbox next to the Donate button (logged-in donors only) with a hover
tooltip explaining that Stripe requires an email. Unchecking it omits
customer_email so Stripe shows a blank, editable field.

- donations.py: CheckoutRequest.use_account_email (default true); only
  pre-fill customer_email when it's true.
- donations-adapter.ts: optional use_account_email on CheckoutRequest.
- donate.html / donate-main.ts: checkbox + hover hint, revealed for
  logged-in donors, wired into the checkout call.
- test_donations_api.py: cover the opt-out path.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011x7yGL6jtdq8Lwu4P8JT6C