### PR TITLE
Implement iOS modernisation epic (#285)

### DIFF
--- a/app/flyfun-weather/flyfun-weather.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/app/flyfun-weather/flyfun-weather.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -52,7 +52,7 @@
       "location" : "https://github.com/roznet/rzskewt.git",
       "state" : {
         "branch" : "main",
-        "revision" : "c7e7764e0a19f5967df58231c62ebb49f5a1f80d"
+        "revision" : "e3ab8d916902a949f4d18d5018b1d10fbf34cce4"
       }
     },
     {

--- a/app/flyfun-weather/flyfun-weather/Models/API/AdvisoriesResponse.swift
+++ b/app/flyfun-weather/flyfun-weather/Models/API/AdvisoriesResponse.swift
@@ -31,6 +31,7 @@ struct ModelAdvisoryResult: Codable, Identifiable, Sendable {
     let affectedPct: Double
     let affectedNm: Double
     let totalNm: Double
+    let crossCheck: String?
 
     var id: String { model }
 }

--- a/app/flyfun-weather/flyfun-weather/Models/API/AdvisoriesResponse.swift
+++ b/app/flyfun-weather/flyfun-weather/Models/API/AdvisoriesResponse.swift
@@ -22,6 +22,124 @@ struct RouteAdvisoryResult: Codable, Identifiable, Sendable {
     var id: String { advisoryId }
 }
 
+struct AdvisoryDetailResponse: Codable, Sendable {
+    let advisoryId: String?
+    let aggregateStatus: String?
+    let aggregateDetail: String?
+    let perModel: [AdvisoryDetailModelResult]
+    let parametersUsed: [String: Double]
+    let crossCheckNote: String?
+    let name: String?
+    let category: String?
+    let description: String?
+    let flightId: String?
+    let briefingTimestamp: String?
+    let routeName: String?
+    let cruiseAltitudeFt: Int?
+    let flightCeilingFt: Int?
+    let totalDistanceNm: Double?
+    let models: [String]?
+    let aggregation: String?
+    let convective: [String: AdvisoryConvectiveDetail]?
+    let convectiveNote: String?
+
+    var isEmpty: Bool {
+        perModel.isEmpty
+            && (aggregateDetail?.isEmpty ?? true)
+            && (description?.isEmpty ?? true)
+    }
+}
+
+struct AdvisoryDetailModelResult: Codable, Identifiable, Sendable {
+    let model: String?
+    let status: String?
+    let detail: String?
+    let affectedPct: Double?
+    let affectedNm: Double?
+    let totalNm: Double?
+    let crossCheck: String?
+
+    var id: String { model ?? UUID().uuidString }
+
+    enum CodingKeys: String, CodingKey {
+        case model
+        case status
+        case detail
+        case affectedPct
+        case affectedNm
+        case totalNm
+        case crossCheck
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        model = try container.decodeIfPresent(String.self, forKey: .model)
+        status = try container.decodeIfPresent(String.self, forKey: .status)
+        detail = try container.decodeIfPresent(String.self, forKey: .detail)
+        affectedPct = try container.decodeIfPresent(Double.self, forKey: .affectedPct)
+        affectedNm = try container.decodeIfPresent(Double.self, forKey: .affectedNm)
+        totalNm = try container.decodeIfPresent(Double.self, forKey: .totalNm)
+        crossCheck = Self.decodeFlexibleText(from: container, forKey: .crossCheck)
+    }
+
+    private static func decodeFlexibleText(
+        from container: KeyedDecodingContainer<CodingKeys>,
+        forKey key: CodingKeys
+    ) -> String? {
+        if let value = try? container.decodeIfPresent(String.self, forKey: key) {
+            return value
+        }
+        if let value = try? container.decodeIfPresent(Double.self, forKey: key) {
+            return String(format: "%.1f", value)
+        }
+        if let value = try? container.decodeIfPresent(Int.self, forKey: key) {
+            return String(value)
+        }
+        if let value = try? container.decodeIfPresent(Bool.self, forKey: key) {
+            return value ? "true" : "false"
+        }
+        if let dict = try? container.decodeIfPresent([String: String].self, forKey: key) {
+            return dict.sorted { $0.key < $1.key }
+                .map { "\($0.key): \($0.value)" }
+                .joined(separator: " · ")
+        }
+        if let dict = try? container.decodeIfPresent([String: Double].self, forKey: key) {
+            return dict.sorted { $0.key < $1.key }
+                .map { "\($0.key): \(String(format: "%.1f", $0.value))" }
+                .joined(separator: " · ")
+        }
+        return nil
+    }
+}
+
+struct AdvisoryConvectiveDetail: Codable, Sendable {
+    let assessmentMethod: String?
+    let methodCounts: [String: Int]
+    let thermo: AdvisoryThermoDetail?
+    let nwp: AdvisoryNwpDetail?
+}
+
+struct AdvisoryThermoDetail: Codable, Sendable {
+    let capeRangeJkg: [Double]?
+    let peak: AdvisoryThermoPeak?
+}
+
+struct AdvisoryThermoPeak: Codable, Sendable {
+    let capeJkg: Double?
+    let elTopFt: Double?
+    let riskLevel: String?
+    let distanceNm: Double?
+    let waypointIcao: String?
+    let validTime: Int?
+    let eta: String?
+}
+
+struct AdvisoryNwpDetail: Codable, Sendable {
+    let maxCoverPct: Double?
+    let peakTopFt: Double?
+    let note: String?
+}
+
 struct ModelAdvisoryResult: Codable, Identifiable, Sendable {
     let model: String
     let status: String

--- a/app/flyfun-weather/flyfun-weather/Models/API/CreateFlightRequest.swift
+++ b/app/flyfun-weather/flyfun-weather/Models/API/CreateFlightRequest.swift
@@ -50,6 +50,24 @@ struct UpdateFlightResponse: Decodable, Sendable {
     }
 }
 
+/// Aircraft type suggestion from GET /api/aircraft/types.
+struct AircraftTypeResponse: Codable, Identifiable, Hashable, Sendable {
+    var id: String { icao }
+
+    let icao: String
+    let manufacturer: String
+    let model: String
+    let category: String?
+
+    var displayName: String {
+        let title = [manufacturer, model]
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+        return title.isEmpty ? icao : "\(icao) - \(title)"
+    }
+}
+
 /// Aircraft entry from GET /api/aircraft for create/edit pickers.
 struct AircraftResponse: Codable, Identifiable, Hashable, Sendable {
     let id: Int
@@ -76,6 +94,22 @@ struct AircraftResponse: Codable, Identifiable, Hashable, Sendable {
         if let ceilingFt { parts.append("FL\(ceilingFt / 100)") }
         return parts.joined(separator: " · ")
     }
+
+    var pickerTitle: String {
+        displayName == typeName ? displayName : "\(displayName) - \(typeName)"
+    }
+}
+
+/// Request body for POST /api/aircraft.
+struct CreateAircraftRequest: Encodable {
+    let icaoType: String
+    var tailNumber: String? = nil
+    var nickname: String? = nil
+    var isIfr: Bool = false
+    var isFiki: Bool = false
+    var cruiseSpeedKt: Int? = nil
+    var ceilingFt: Int? = nil
+    var isDefault: Bool = false
 }
 
 /// Request body for parsing an ICAO flight plan string.

--- a/app/flyfun-weather/flyfun-weather/Models/API/CreateFlightRequest.swift
+++ b/app/flyfun-weather/flyfun-weather/Models/API/CreateFlightRequest.swift
@@ -5,9 +5,77 @@ struct CreateFlightRequest: Encodable {
     let waypoints: [String]
     let departureTime: String
     var routeName: String = ""
-    var cruiseAltitudeFt: Int?
-    var flightCeilingFt: Int?
-    var flightDurationHours: Double?
+    var rawRoute: String? = nil
+    var cruiseAltitudeFt: Int? = nil
+    var flightCeilingFt: Int? = nil
+    var flightDurationHours: Double? = nil
+    var profileId: Int? = nil
+    var aircraftId: Int? = nil
+}
+
+/// Request body for PATCH /api/flights/{id}.
+struct UpdateFlightRequest: Encodable {
+    var profileId: Int? = nil
+    var aircraftId: Int? = nil
+    var departureTime: String? = nil
+    var cruiseAltitudeFt: Int? = nil
+    var flightCeilingFt: Int? = nil
+    var flightDurationHours: Double? = nil
+    var waypoints: [String]? = nil
+    var rawRoute: String? = nil
+}
+
+enum FlightInvalidation: String, Codable, Sendable {
+    case none
+    case advisoriesOnly = "advisories_only"
+    case refetchNeeded = "refetch_needed"
+
+    var needsRegeneration: Bool {
+        self != .none
+    }
+}
+
+struct UpdateFlightResponse: Decodable, Sendable {
+    let flight: FlightResponse
+    let invalidation: FlightInvalidation
+
+    private enum CodingKeys: String, CodingKey {
+        case invalidation
+    }
+
+    init(from decoder: Decoder) throws {
+        flight = try FlightResponse(from: decoder)
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        invalidation = try container.decode(FlightInvalidation.self, forKey: .invalidation)
+    }
+}
+
+/// Aircraft entry from GET /api/aircraft for create/edit pickers.
+struct AircraftResponse: Codable, Identifiable, Hashable, Sendable {
+    let id: Int
+    let icaoType: String
+    let typeName: String
+    let tailNumber: String?
+    let nickname: String?
+    let isIfr: Bool
+    let isFiki: Bool
+    let cruiseSpeedKt: Int?
+    let ceilingFt: Int?
+    let isDefault: Bool
+    let createdAt: String
+
+    var displayName: String {
+        if let nickname, !nickname.isEmpty { return nickname }
+        if let tailNumber, !tailNumber.isEmpty { return tailNumber }
+        return typeName
+    }
+
+    var detailText: String {
+        var parts = [icaoType]
+        if let cruiseSpeedKt { parts.append("\(cruiseSpeedKt) kt") }
+        if let ceilingFt { parts.append("FL\(ceilingFt / 100)") }
+        return parts.joined(separator: " · ")
+    }
 }
 
 /// Request body for parsing an ICAO flight plan string.

--- a/app/flyfun-weather/flyfun-weather/Models/API/FlightResponse.swift
+++ b/app/flyfun-weather/flyfun-weather/Models/API/FlightResponse.swift
@@ -4,9 +4,12 @@ struct FlightResponse: Codable, Identifiable, Sendable {
     let id: String
     let userId: String
     let profileId: Int?
+    let aircraftId: Int?
+    let aircraft: AircraftInfo?
     let routeName: String
     let waypoints: [String]
     let departureTime: String
+    let altDepartureTime: String?
     let targetDate: String
     let targetTimeUtc: Int
     let cruiseAltitudeFt: Int
@@ -16,6 +19,15 @@ struct FlightResponse: Codable, Identifiable, Sendable {
     let autoRefresh: Bool
     let autoRefreshHour: Int?
     let createdAt: String
+    let latestBriefing: BriefingStatusInfo?
+    let role: FlightRole?
+    let ownerDisplayName: String?
+    let isSubscribed: Bool?
+    let debrief: DebriefResponse?
+    let section: FlightListSection?
+    let rawRoute: String?
+    let parserVersion: String?
+    let shareCode: String?
 
     /// Parsed departure date for display.
     var departureDate: Date? {
@@ -29,4 +41,103 @@ struct FlightResponse: Codable, Identifiable, Sendable {
         }
         return "\(origin.uppercased()) → \(dest.uppercased())"
     }
+
+    /// Backend section with a local fallback for older cached flight lists.
+    var displaySection: FlightListSection {
+        if let section { return section }
+        if let departureDate, departureDate >= Date() {
+            return .future
+        }
+        return .past
+    }
+
+    /// Changes when the same flight row was edited or rebriefed, forcing detail reloads.
+    var briefingIdentity: String {
+        [
+            id,
+            departureTime,
+            waypoints.joined(separator: "-"),
+            String(cruiseAltitudeFt),
+            String(flightDurationHours),
+            latestBriefing?.fetchTimestamp ?? "",
+        ].joined(separator: "|")
+    }
+}
+
+enum FlightListSection: String, Codable, CaseIterable, Sendable {
+    case future
+    case recent
+    case past
+
+    var title: String {
+        switch self {
+        case .future: "Future"
+        case .recent: "Recent"
+        case .past: "Past"
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .future: "calendar.badge.clock"
+        case .recent: "clock.badge.exclamationmark"
+        case .past: "archivebox"
+        }
+    }
+}
+
+enum FlightRole: String, Codable, Sendable {
+    case owner
+    case subscriber
+}
+
+struct AircraftInfo: Codable, Hashable, Sendable {
+    let id: Int
+    let icaoType: String
+    let typeName: String
+    let tailNumber: String?
+    let nickname: String?
+
+    var displayName: String {
+        if let nickname, !nickname.isEmpty { return nickname }
+        if let tailNumber, !tailNumber.isEmpty { return tailNumber }
+        return typeName
+    }
+}
+
+struct BriefingStatusInfo: Codable, Sendable {
+    let assessment: String?
+    let assessmentReason: String?
+    let outlook: String?
+    let outlookReason: String?
+    let hasDigest: Bool?
+    let daysOut: Int?
+    let fetchTimestamp: String?
+    let hasAdvisories: Bool?
+    let advisorySummary: AdvisorySummaryInfo?
+
+    var displayAssessment: String? {
+        assessment ?? outlook
+    }
+}
+
+struct AdvisorySummaryInfo: Codable, Sendable {
+    let red: Int?
+    let amber: Int?
+    let top: [AdvisoryChipInfo]?
+}
+
+struct AdvisoryChipInfo: Codable, Sendable {
+    let status: String
+    let name: String
+}
+
+struct DebriefResponse: Codable, Sendable {
+    let flightId: String
+    let decision: String
+    let reasons: [String]
+    let outcomes: [String: String]
+    let note: String?
+    let createdAt: String
+    let updatedAt: String
 }

--- a/app/flyfun-weather/flyfun-weather/Models/API/RouteAnalysesResponse.swift
+++ b/app/flyfun-weather/flyfun-weather/Models/API/RouteAnalysesResponse.swift
@@ -80,6 +80,7 @@ struct EnhancedCloudLayer: Codable, Sendable {
     let topFt: Double
     let coverage: String
     let meanDewpointDepressionC: Double?
+    let meanCloudCoverPct: Double?
 }
 
 struct IcingZone: Codable, Sendable {

--- a/app/flyfun-weather/flyfun-weather/Models/API/RouteAnalysesResponse.swift
+++ b/app/flyfun-weather/flyfun-weather/Models/API/RouteAnalysesResponse.swift
@@ -47,15 +47,32 @@ struct SoundingAnalysis: Codable, Sendable {
 }
 
 struct ThermodynamicIndices: Codable, Sendable {
+    let lclPressureHpa: Double?
     let freezingLevelFt: Double?
     let minus10cLevelFt: Double?
     let minus20cLevelFt: Double?
     let lclAltitudeFt: Double?
+    let lfcPressureHpa: Double?
     let lfcAltitudeFt: Double?
+    let elPressureHpa: Double?
     let elAltitudeFt: Double?
     let capeSurfaceJkg: Double?
+    let capeMostUnstableJkg: Double?
+    let capeMixedLayerJkg: Double?
+    let cinSurfaceJkg: Double?
+    let liftedIndex: Double?
+    let showalterIndex: Double?
+    let kIndex: Double?
+    let totalTotals: Double?
+    let precipitableWaterMm: Double?
     let soundingCeilingFt: Double?
     let nwpCeilingFt: Double?
+    let nwpCapeJkg: Double?
+    let nwpCapeType: String?
+    let nwpCinJkg: Double?
+    let nwpLiftedIndex: Double?
+    let nwpFreezingLevelFt: Double?
+    let capeRawVsCalcDivergent: Bool?
 }
 
 struct EnhancedCloudLayer: Codable, Sendable {

--- a/app/flyfun-weather/flyfun-weather/Models/API/SoundingProfileResponse.swift
+++ b/app/flyfun-weather/flyfun-weather/Models/API/SoundingProfileResponse.swift
@@ -11,10 +11,17 @@ struct SoundingProfileResponse: Codable, Sendable {
     let time: String
     let levels: [SoundingProfileLevel]
     let cruiseAltitudeFt: Int?
+    let trackDeg: Double?
+    let label: String?
     let indices: ThermodynamicIndices?
+    let parcelPath: [ParcelPathPoint]?
     let cloudLayers: [EnhancedCloudLayer]?
+    let nwpCloudLayers: [EnhancedCloudLayer]?
     let icingZones: [IcingZone]?
+    let icingOgimetNwpZones: [IcingZone]?
+    let sfipZones: [SfipZone]?
     let inversionLayers: [InversionLayer]?
+    let convective: ConvectiveAssessment?
 }
 
 struct SoundingProfileLevel: Codable, Sendable {
@@ -24,4 +31,23 @@ struct SoundingProfileLevel: Codable, Sendable {
     let dewpointC: Double?
     let windSpeedKt: Double?
     let windDirectionDeg: Double?
+    let relativeHumidityPct: Double?
+    let dewpointDepressionC: Double?
+    let wetBulbC: Double?
+    let thetaEK: Double?
+    let lapseRateCPerKm: Double?
+    let icingIndex: Double?
+    let icingIndexNwp: Double?
+    let sfip100: Double?
+    let cloudLiquidWaterGM3: Double?
+    let iceMixingRatioGKg: Double?
+    let cloudAreaFractionPct: Double?
+    let richardsonNumber: Double?
+    let omegaPaS: Double?
+    let wFpm: Double?
+}
+
+struct ParcelPathPoint: Codable, Sendable {
+    let pressureHpa: Double
+    let temperatureC: Double
 }

--- a/app/flyfun-weather/flyfun-weather/Models/Domain/VizData.swift
+++ b/app/flyfun-weather/flyfun-weather/Models/Domain/VizData.swift
@@ -80,6 +80,7 @@ struct VizCloudLayer {
     let topFt: Double
     let coverage: String
     let meanDewpointDepressionC: Double?
+    let meanCloudCoverPct: Double?
 }
 
 struct VizIcingZone {

--- a/app/flyfun-weather/flyfun-weather/Services/APIClient.swift
+++ b/app/flyfun-weather/flyfun-weather/Services/APIClient.swift
@@ -22,7 +22,12 @@ enum APIError: LocalizedError {
     var errorDescription: String? {
         switch self {
         case .unauthorized: "Session expired. Please sign in again."
-        case .forbidden(let msg): "Access denied: \(msg)"
+        case .forbidden(let msg):
+            if msg == "insufficient_scope" {
+                "This login is read-only. Sign out and use Dev Login or a full-access account."
+            } else {
+                "Access denied: \(msg)"
+            }
         case .notFound: "Resource not found."
         case .serverError(let code, let msg): "Server error \(code): \(msg ?? "Unknown")"
         case .networkError(let err): "Network error: \(err.localizedDescription)"
@@ -215,14 +220,52 @@ actor APIClient {
         case 200...299:
             return data
         case 403:
-            let msg = (try? JSONDecoder().decode([String: String].self, from: data))?["detail"]
+            let msg = Self.errorMessage(from: data)
             throw APIError.forbidden(msg ?? "Forbidden")
         case 404:
             throw APIError.notFound
         default:
-            let msg = String(data: data, encoding: .utf8)
+            let msg = Self.errorMessage(from: data)
             throw APIError.serverError(http.statusCode, msg)
         }
+    }
+
+    fileprivate nonisolated static func errorMessage(from data: Data) -> String? {
+        guard !data.isEmpty else { return nil }
+        if let object = try? JSONSerialization.jsonObject(with: data),
+           let dict = object as? [String: Any],
+           let detail = dict["detail"] {
+            return describeErrorDetail(detail)
+        }
+        return String(data: data, encoding: .utf8)
+    }
+
+    private nonisolated static func describeErrorDetail(_ detail: Any) -> String? {
+        if let message = detail as? String {
+            return message
+        }
+        if let issues = detail as? [[String: Any]] {
+            let messages = issues.compactMap { issue -> String? in
+                guard let message = issue["msg"] as? String else { return nil }
+                let location = (issue["loc"] as? [Any])?
+                    .map { String(describing: $0) }
+                    .dropFirst()
+                    .joined(separator: ".")
+                if let location, !location.isEmpty {
+                    return "\(location): \(message)"
+                }
+                return message
+            }
+            if !messages.isEmpty {
+                return messages.joined(separator: "\n")
+            }
+        }
+        if JSONSerialization.isValidJSONObject(detail),
+           let data = try? JSONSerialization.data(withJSONObject: detail),
+           let message = String(data: data, encoding: .utf8) {
+            return message
+        }
+        return nil
     }
 }
 
@@ -315,6 +358,8 @@ private final class SSEStreamDelegate: NSObject, URLSessionDataDelegate, @unchec
     private var buffer = Data()
     private var eventCount = 0
     private var finished = false
+    private var responseStatusCode: Int?
+    private var responseIsSuccessful = false
 
     /// SSE frames are separated by a blank line, i.e. a double newline.
     private static let frameSeparator = Data([0x0a, 0x0a]) // "\n\n"
@@ -340,18 +385,20 @@ private final class SSEStreamDelegate: NSObject, URLSessionDataDelegate, @unchec
         completionHandler: @escaping (URLSession.ResponseDisposition) -> Void
     ) {
         let code = (response as? HTTPURLResponse)?.statusCode ?? 0
+        responseStatusCode = code
         guard (200...299).contains(code) else {
             logger.error("SSE stream failed: HTTP \(code) for \(self.path, privacy: .public)")
-            finish(throwing: APIError.serverError(code, "SSE stream failed"))
-            completionHandler(.cancel)
+            completionHandler(.allow)
             return
         }
+        responseIsSuccessful = true
         logger.info("SSE connected (HTTP \(code)) for \(self.path, privacy: .public)")
         completionHandler(.allow)
     }
 
     func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
         buffer.append(data)
+        guard responseIsSuccessful else { return }
         while let range = buffer.range(of: Self.frameSeparator) {
             let frame = buffer.subdata(in: buffer.startIndex..<range.lowerBound)
             buffer.removeSubrange(buffer.startIndex..<range.upperBound)
@@ -369,6 +416,9 @@ private final class SSEStreamDelegate: NSObject, URLSessionDataDelegate, @unchec
         if let error {
             logger.error("SSE network error for \(self.path, privacy: .public): \(error.localizedDescription, privacy: .public)")
             finish(throwing: APIError.networkError(error))
+        } else if !responseIsSuccessful, let code = responseStatusCode {
+            logger.error("SSE stream failed: HTTP \(code) for \(self.path, privacy: .public)")
+            finish(throwing: httpError(statusCode: code, data: buffer))
         } else {
             logger.info("SSE stream ended after \(self.eventCount) event(s) for \(self.path, privacy: .public)")
             finish(throwing: nil)
@@ -408,6 +458,19 @@ private final class SSEStreamDelegate: NSObject, URLSessionDataDelegate, @unchec
                     message: obj["message"] as? String))
                 finish(throwing: nil)
             }
+        }
+    }
+
+    private func httpError(statusCode: Int, data: Data) -> APIError {
+        switch statusCode {
+        case 401:
+            return .unauthorized
+        case 403:
+            return .forbidden(APIClient.errorMessage(from: data) ?? "Forbidden")
+        case 404:
+            return .notFound
+        default:
+            return .serverError(statusCode, APIClient.errorMessage(from: data))
         }
     }
 

--- a/app/flyfun-weather/flyfun-weather/Services/BriefingRepository.swift
+++ b/app/flyfun-weather/flyfun-weather/Services/BriefingRepository.swift
@@ -8,6 +8,7 @@ protocol BriefingRepository: Sendable {
     func packs(flightId: String) async throws -> [PackMetaResponse]
     func latestPack(flightId: String) async throws -> PackMetaResponse
     func advisories(flightId: String, timestamp: String) async throws -> AdvisoriesResponse
+    func advisoryDetail(flightId: String, timestamp: String, advisoryId: String) async throws -> AdvisoryDetailResponse
     func digest(flightId: String, timestamp: String) async throws -> DigestResponse
     func snapshot(flightId: String, timestamp: String) async throws -> SnapshotResponse
     func routeAnalyses(flightId: String, timestamp: String) async throws -> RouteAnalysesResponse
@@ -56,6 +57,10 @@ final class OnlineBriefingRepository: BriefingRepository {
 
     func advisories(flightId: String, timestamp: String) async throws -> AdvisoriesResponse {
         try await client.request("/api/flights/\(flightId)/packs/\(timestamp)/advisories")
+    }
+
+    func advisoryDetail(flightId: String, timestamp: String, advisoryId: String) async throws -> AdvisoryDetailResponse {
+        try await client.request("/api/flights/\(flightId)/packs/\(timestamp)/advisories/\(advisoryId)/detail")
     }
 
     func digest(flightId: String, timestamp: String) async throws -> DigestResponse {

--- a/app/flyfun-weather/flyfun-weather/Services/BriefingRepository.swift
+++ b/app/flyfun-weather/flyfun-weather/Services/BriefingRepository.swift
@@ -6,6 +6,8 @@ protocol BriefingRepository: Sendable {
     func createFlight(_ request: CreateFlightRequest) async throws -> FlightResponse
     func updateFlight(flightId: String, _ request: UpdateFlightRequest) async throws -> UpdateFlightResponse
     func aircraft() async throws -> [AircraftResponse]
+    func searchAircraftTypes(_ query: String) async throws -> [AircraftTypeResponse]
+    func createAircraft(_ request: CreateAircraftRequest) async throws -> AircraftResponse
     func parseFpl(_ text: String) async throws -> ParseFplResponse
     func packs(flightId: String) async throws -> [PackMetaResponse]
     func latestPack(flightId: String) async throws -> PackMetaResponse
@@ -52,6 +54,16 @@ final class OnlineBriefingRepository: BriefingRepository {
 
     func aircraft() async throws -> [AircraftResponse] {
         try await client.request("/api/aircraft")
+    }
+
+    func searchAircraftTypes(_ query: String) async throws -> [AircraftTypeResponse] {
+        let encoded = query.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? query
+        return try await client.requestURL("/api/aircraft/types?q=\(encoded)")
+    }
+
+    func createAircraft(_ request: CreateAircraftRequest) async throws -> AircraftResponse {
+        let body = try JSONEncoder.weatherBrief.encode(request)
+        return try await client.request("/api/aircraft", method: "POST", body: body)
     }
 
     func parseFpl(_ text: String) async throws -> ParseFplResponse {

--- a/app/flyfun-weather/flyfun-weather/Services/BriefingRepository.swift
+++ b/app/flyfun-weather/flyfun-weather/Services/BriefingRepository.swift
@@ -4,11 +4,14 @@ import Foundation
 protocol BriefingRepository: Sendable {
     func flights() async throws -> [FlightResponse]
     func createFlight(_ request: CreateFlightRequest) async throws -> FlightResponse
+    func updateFlight(flightId: String, _ request: UpdateFlightRequest) async throws -> UpdateFlightResponse
+    func aircraft() async throws -> [AircraftResponse]
     func parseFpl(_ text: String) async throws -> ParseFplResponse
     func packs(flightId: String) async throws -> [PackMetaResponse]
     func latestPack(flightId: String) async throws -> PackMetaResponse
     func advisories(flightId: String, timestamp: String) async throws -> AdvisoriesResponse
     func advisoryDetail(flightId: String, timestamp: String, advisoryId: String) async throws -> AdvisoryDetailResponse
+    func recalculateAdvisories(flightId: String, timestamp: String, cruiseAltitudeFt: Int?) async throws
     func digest(flightId: String, timestamp: String) async throws -> DigestResponse
     func snapshot(flightId: String, timestamp: String) async throws -> SnapshotResponse
     func routeAnalyses(flightId: String, timestamp: String) async throws -> RouteAnalysesResponse
@@ -42,6 +45,15 @@ final class OnlineBriefingRepository: BriefingRepository {
         return try await client.request("/api/flights", method: "POST", body: body)
     }
 
+    func updateFlight(flightId: String, _ request: UpdateFlightRequest) async throws -> UpdateFlightResponse {
+        let body = try JSONEncoder.weatherBrief.encode(request)
+        return try await client.request("/api/flights/\(flightId)", method: "PATCH", body: body)
+    }
+
+    func aircraft() async throws -> [AircraftResponse] {
+        try await client.request("/api/aircraft")
+    }
+
     func parseFpl(_ text: String) async throws -> ParseFplResponse {
         let body = try JSONEncoder.weatherBrief.encode(ParseFplRequest(fplText: text))
         return try await client.request("/api/flights/parse-fpl", method: "POST", body: body)
@@ -61,6 +73,15 @@ final class OnlineBriefingRepository: BriefingRepository {
 
     func advisoryDetail(flightId: String, timestamp: String, advisoryId: String) async throws -> AdvisoryDetailResponse {
         try await client.request("/api/flights/\(flightId)/packs/\(timestamp)/advisories/\(advisoryId)/detail")
+    }
+
+    func recalculateAdvisories(flightId: String, timestamp: String, cruiseAltitudeFt: Int?) async throws {
+        let encodedTimestamp = timestamp.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? timestamp
+        var path = "/api/flights/\(flightId)/packs/\(encodedTimestamp)/advisories/recalculate"
+        if let cruiseAltitudeFt {
+            path += "?cruise_altitude_ft=\(cruiseAltitudeFt)"
+        }
+        _ = try await client.requestDataURL(path, method: "POST")
     }
 
     func digest(flightId: String, timestamp: String) async throws -> DigestResponse {

--- a/app/flyfun-weather/flyfun-weather/Services/CachingBriefingRepository.swift
+++ b/app/flyfun-weather/flyfun-weather/Services/CachingBriefingRepository.swift
@@ -37,10 +37,18 @@ final class CachingBriefingRepository: BriefingRepository {
         self.cache = cache
     }
 
-    // MARK: - Flight creation (pass-through, no caching)
+    // MARK: - Flight mutations (pass-through, no caching)
 
     func createFlight(_ request: CreateFlightRequest) async throws -> FlightResponse {
         try await online.createFlight(request)
+    }
+
+    func updateFlight(flightId: String, _ request: UpdateFlightRequest) async throws -> UpdateFlightResponse {
+        try await online.updateFlight(flightId: flightId, request)
+    }
+
+    func aircraft() async throws -> [AircraftResponse] {
+        try await online.aircraft()
     }
 
     func parseFpl(_ text: String) async throws -> ParseFplResponse {
@@ -152,6 +160,14 @@ final class CachingBriefingRepository: BriefingRepository {
             endpoint: "advisory-detail-\(advisoryId)",
             pathSuffix: "advisories/\(advisoryId)/detail",
             writeThrough: true
+        )
+    }
+
+    func recalculateAdvisories(flightId: String, timestamp: String, cruiseAltitudeFt: Int?) async throws {
+        try await online.recalculateAdvisories(
+            flightId: flightId,
+            timestamp: timestamp,
+            cruiseAltitudeFt: cruiseAltitudeFt
         )
     }
 

--- a/app/flyfun-weather/flyfun-weather/Services/CachingBriefingRepository.swift
+++ b/app/flyfun-weather/flyfun-weather/Services/CachingBriefingRepository.swift
@@ -145,6 +145,16 @@ final class CachingBriefingRepository: BriefingRepository {
         try await cachedOrFetch(flightId: flightId, timestamp: timestamp, endpoint: "advisories")
     }
 
+    func advisoryDetail(flightId: String, timestamp: String, advisoryId: String) async throws -> AdvisoryDetailResponse {
+        try await cachedOrFetch(
+            flightId: flightId,
+            timestamp: timestamp,
+            endpoint: "advisory-detail-\(advisoryId)",
+            pathSuffix: "advisories/\(advisoryId)/detail",
+            writeThrough: true
+        )
+    }
+
     func digest(flightId: String, timestamp: String) async throws -> DigestResponse {
         try await cachedOrFetch(flightId: flightId, timestamp: timestamp, endpoint: "digest")
     }

--- a/app/flyfun-weather/flyfun-weather/Services/CachingBriefingRepository.swift
+++ b/app/flyfun-weather/flyfun-weather/Services/CachingBriefingRepository.swift
@@ -51,6 +51,14 @@ final class CachingBriefingRepository: BriefingRepository {
         try await online.aircraft()
     }
 
+    func searchAircraftTypes(_ query: String) async throws -> [AircraftTypeResponse] {
+        try await online.searchAircraftTypes(query)
+    }
+
+    func createAircraft(_ request: CreateAircraftRequest) async throws -> AircraftResponse {
+        try await online.createAircraft(request)
+    }
+
     func parseFpl(_ text: String) async throws -> ParseFplResponse {
         try await online.parseFpl(text)
     }

--- a/app/flyfun-weather/flyfun-weather/ViewModels/AddFlightViewModel.swift
+++ b/app/flyfun-weather/flyfun-weather/ViewModels/AddFlightViewModel.swift
@@ -20,6 +20,19 @@ final class AddFlightViewModel {
     // Aircraft
     private(set) var aircraftOptions: [AircraftResponse] = []
     private(set) var isLoadingAircraft: Bool = false
+    var newAircraftIcaoType: String = ""
+    var newAircraftTailNumber: String = ""
+    var newAircraftNickname: String = ""
+    var newAircraftCruiseSpeedKt: String = ""
+    var newAircraftCeilingFt: String = ""
+    var newAircraftIsIfr: Bool = false
+    var newAircraftIsFiki: Bool = false
+    var newAircraftIsDefault: Bool = false
+    private(set) var selectedAircraftType: AircraftTypeResponse?
+    private(set) var aircraftTypeSuggestions: [AircraftTypeResponse] = []
+    private(set) var isSearchingAircraftTypes: Bool = false
+    private(set) var isSavingAircraft: Bool = false
+    var aircraftFormError: String?
 
     // Submission
     var isSubmitting: Bool = false
@@ -68,6 +81,15 @@ final class AddFlightViewModel {
         waypoints.count >= 2 && !isSubmitting && (!isEditing || hasChanges)
     }
 
+    var selectedAircraft: AircraftResponse? {
+        guard let selectedAircraftId else { return nil }
+        return aircraftOptions.first { $0.id == selectedAircraftId }
+    }
+
+    var canSaveAircraft: Bool {
+        resolvedNewAircraftIcaoType != nil && !isSavingAircraft
+    }
+
     var requiresRebriefConfirmation: Bool {
         isEditing && hasChanges
     }
@@ -100,12 +122,107 @@ final class AddFlightViewModel {
 
         do {
             let aircraft = try await repository.aircraft()
-            aircraftOptions = aircraft
+            aircraftOptions = aircraft.sortedForPicker()
             if !isEditing, selectedAircraftId == nil {
                 selectedAircraftId = aircraft.first(where: \.isDefault)?.id
             }
         } catch {
+            if let apiError = error as? APIError {
+                errorMessage = apiError.localizedDescription
+            }
             Self.logger.debug("Aircraft list unavailable: \(error)")
+        }
+    }
+
+    func prepareNewAircraftForm() {
+        newAircraftIcaoType = ""
+        newAircraftTailNumber = ""
+        newAircraftNickname = ""
+        newAircraftCruiseSpeedKt = ""
+        newAircraftCeilingFt = ""
+        newAircraftIsIfr = false
+        newAircraftIsFiki = false
+        newAircraftIsDefault = aircraftOptions.isEmpty
+        selectedAircraftType = nil
+        aircraftTypeSuggestions = []
+        aircraftFormError = nil
+    }
+
+    func searchAircraftTypes() async {
+        let query = newAircraftIcaoType.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let selectedAircraftType, query.uppercased() != selectedAircraftType.icao {
+            self.selectedAircraftType = nil
+        }
+        if let selectedAircraftType, query.uppercased() == selectedAircraftType.icao {
+            aircraftTypeSuggestions = []
+            isSearchingAircraftTypes = false
+            return
+        }
+        guard !query.isEmpty else {
+            aircraftTypeSuggestions = []
+            isSearchingAircraftTypes = false
+            return
+        }
+        guard query.count <= 20 else { return }
+
+        isSearchingAircraftTypes = true
+        defer { isSearchingAircraftTypes = false }
+        do {
+            aircraftTypeSuggestions = try await repository.searchAircraftTypes(query)
+        } catch {
+            aircraftTypeSuggestions = []
+            Self.logger.debug("Aircraft type search unavailable: \(error)")
+        }
+    }
+
+    func selectAircraftType(_ type: AircraftTypeResponse) {
+        selectedAircraftType = type
+        newAircraftIcaoType = type.icao
+        aircraftTypeSuggestions = []
+        aircraftFormError = nil
+    }
+
+    func createAircraft() async -> Bool {
+        guard let icaoType = resolvedNewAircraftIcaoType else {
+            aircraftFormError = "Enter a valid ICAO aircraft type, for example C172."
+            return false
+        }
+        aircraftFormError = nil
+        let cruiseSpeed = optionalPositiveInt(newAircraftCruiseSpeedKt, fieldName: "Cruise speed")
+        guard aircraftFormError == nil else {
+            return false
+        }
+        let ceiling = optionalPositiveInt(newAircraftCeilingFt, fieldName: "Ceiling")
+        guard aircraftFormError == nil else {
+            return false
+        }
+
+        isSavingAircraft = true
+        defer { isSavingAircraft = false }
+
+        let request = CreateAircraftRequest(
+            icaoType: icaoType,
+            tailNumber: optionalText(newAircraftTailNumber)?.uppercased(),
+            nickname: optionalText(newAircraftNickname),
+            isIfr: newAircraftIsIfr,
+            isFiki: newAircraftIsFiki,
+            cruiseSpeedKt: cruiseSpeed,
+            ceilingFt: ceiling,
+            isDefault: newAircraftIsDefault
+        )
+
+        do {
+            let aircraft = try await repository.createAircraft(request)
+            aircraftOptions.removeAll { $0.id == aircraft.id }
+            aircraftOptions.append(aircraft)
+            aircraftOptions = aircraftOptions.sortedForPicker()
+            selectedAircraftId = aircraft.id
+            prepareNewAircraftForm()
+            return true
+        } catch {
+            aircraftFormError = error.localizedDescription
+            Self.logger.error("Create aircraft failed: \(error)")
+            return false
         }
     }
 
@@ -271,6 +388,45 @@ final class AddFlightViewModel {
         }
         if !completed {
             Self.logger.warning("Refresh stream ended before a complete event while editing \(flightId)")
+        }
+    }
+
+    private var resolvedNewAircraftIcaoType: String? {
+        let value = newAircraftIcaoType
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .uppercased()
+        if let selectedAircraftType, value == selectedAircraftType.icao {
+            return selectedAircraftType.icao
+        }
+        guard value.range(of: #"^[A-Z0-9]{1,4}$"#, options: .regularExpression) != nil else {
+            return nil
+        }
+        return value
+    }
+
+    private func optionalText(_ value: String) -> String? {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private func optionalPositiveInt(_ value: String, fieldName: String) -> Int? {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        guard let intValue = Int(trimmed), intValue > 0 else {
+            aircraftFormError = "\(fieldName) must be a positive number."
+            return nil
+        }
+        return intValue
+    }
+}
+
+private extension [AircraftResponse] {
+    func sortedForPicker() -> [AircraftResponse] {
+        sorted { lhs, rhs in
+            if lhs.isDefault != rhs.isDefault {
+                return lhs.isDefault && !rhs.isDefault
+            }
+            return lhs.pickerTitle.localizedCaseInsensitiveCompare(rhs.pickerTitle) == .orderedAscending
         }
     }
 }

--- a/app/flyfun-weather/flyfun-weather/ViewModels/AddFlightViewModel.swift
+++ b/app/flyfun-weather/flyfun-weather/ViewModels/AddFlightViewModel.swift
@@ -1,7 +1,7 @@
 import Foundation
 import OSLog
 
-/// View model for creating a new flight.
+/// View model for creating or editing a flight.
 @Observable
 @MainActor
 final class AddFlightViewModel {
@@ -10,21 +10,37 @@ final class AddFlightViewModel {
     var departureDate: Date = Calendar.current.date(byAdding: .hour, value: 1, to: Date()) ?? Date()
     var cruiseAltitudeFt: Int = 5500
     var flightDurationHours: Double = 2.0
+    var selectedAircraftId: Int?
 
     // FPL paste
     var fplText: String = ""
     var isParsing: Bool = false
     var parseError: String?
 
+    // Aircraft
+    private(set) var aircraftOptions: [AircraftResponse] = []
+    private(set) var isLoadingAircraft: Bool = false
+
     // Submission
     var isSubmitting: Bool = false
     var errorMessage: String?
+    var statusMessage: String?
 
     private let repository: any BriefingRepository
+    private let editingFlight: FlightResponse?
     private static let logger = Logger(subsystem: "aero.flyfun.weather", category: "AddFlight")
 
-    init(repository: any BriefingRepository) {
+    init(repository: any BriefingRepository, editing flight: FlightResponse? = nil) {
         self.repository = repository
+        self.editingFlight = flight
+
+        if let flight {
+            waypointsText = flight.waypoints.joined(separator: " ")
+            departureDate = flight.departureDate ?? departureDate
+            cruiseAltitudeFt = flight.cruiseAltitudeFt
+            flightDurationHours = flight.flightDurationHours
+            selectedAircraftId = flight.aircraftId
+        }
     }
 
     /// Parsed waypoints from the text field.
@@ -36,8 +52,61 @@ final class AddFlightViewModel {
             .filter { !$0.isEmpty }
     }
 
+    var isEditing: Bool {
+        editingFlight != nil
+    }
+
+    var navigationTitle: String {
+        isEditing ? "Edit Flight" : "New Flight"
+    }
+
+    var submitTitle: String {
+        isEditing ? "Save" : "Create"
+    }
+
     var canSubmit: Bool {
-        waypoints.count >= 2 && !isSubmitting
+        waypoints.count >= 2 && !isSubmitting && (!isEditing || hasChanges)
+    }
+
+    var requiresRebriefConfirmation: Bool {
+        isEditing && hasChanges
+    }
+
+    var departureRange: ClosedRange<Date>? {
+        guard let original = editingFlight?.departureDate else { return nil }
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0) ?? TimeZone.current
+        let start = calendar.startOfDay(for: original)
+        guard let end = calendar.date(byAdding: DateComponents(day: 1, second: -1), to: start) else {
+            return nil
+        }
+        return start...end
+    }
+
+    var hasChanges: Bool {
+        guard let editingFlight else { return true }
+        if waypoints != editingFlight.waypoints.map({ $0.uppercased() }) { return true }
+        if cruiseAltitudeFt != editingFlight.cruiseAltitudeFt { return true }
+        if abs(flightDurationHours - editingFlight.flightDurationHours) > 0.01 { return true }
+        if selectedAircraftId != editingFlight.aircraftId { return true }
+        guard let originalDate = editingFlight.departureDate else { return true }
+        return abs(departureDate.timeIntervalSince(originalDate)) > 1
+    }
+
+    func loadAircraft() async {
+        guard !isLoadingAircraft else { return }
+        isLoadingAircraft = true
+        defer { isLoadingAircraft = false }
+
+        do {
+            let aircraft = try await repository.aircraft()
+            aircraftOptions = aircraft
+            if !isEditing, selectedAircraftId == nil {
+                selectedAircraftId = aircraft.first(where: \.isDefault)?.id
+            }
+        } catch {
+            Self.logger.debug("Aircraft list unavailable: \(error)")
+        }
     }
 
     /// Parse an ICAO FPL string and populate form fields.
@@ -95,7 +164,11 @@ final class AddFlightViewModel {
 
         isSubmitting = true
         errorMessage = nil
-        defer { isSubmitting = false }
+        statusMessage = "Creating flight…"
+        defer {
+            isSubmitting = false
+            statusMessage = nil
+        }
 
         let formatter = ISO8601DateFormatter()
         formatter.formatOptions = [.withInternetDateTime]
@@ -104,7 +177,8 @@ final class AddFlightViewModel {
             waypoints: waypoints,
             departureTime: formatter.string(from: departureDate),
             cruiseAltitudeFt: cruiseAltitudeFt,
-            flightDurationHours: flightDurationHours
+            flightDurationHours: flightDurationHours,
+            aircraftId: selectedAircraftId
         )
 
         do {
@@ -115,6 +189,88 @@ final class AddFlightViewModel {
             errorMessage = error.localizedDescription
             Self.logger.error("Create flight failed: \(error)")
             return nil
+        }
+    }
+
+    /// Save edits and run the follow-up regeneration path when requested.
+    func saveEditedFlight(regenerate: Bool) async -> FlightResponse? {
+        guard canSubmit, let editingFlight else { return nil }
+
+        isSubmitting = true
+        errorMessage = nil
+        statusMessage = "Saving flight…"
+        defer {
+            isSubmitting = false
+            statusMessage = nil
+        }
+
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        let aircraftId = selectedAircraftId ?? (editingFlight.aircraftId == nil ? nil : 0)
+        let request = UpdateFlightRequest(
+            aircraftId: aircraftId,
+            departureTime: formatter.string(from: departureDate),
+            cruiseAltitudeFt: cruiseAltitudeFt,
+            flightDurationHours: flightDurationHours,
+            waypoints: waypoints
+        )
+
+        do {
+            let response = try await repository.updateFlight(flightId: editingFlight.id, request)
+            if regenerate && response.invalidation.needsRegeneration {
+                try await regenerateBriefing(for: response.flight, invalidation: response.invalidation)
+            }
+            Self.logger.info("Updated flight \(response.flight.id): invalidation=\(response.invalidation.rawValue)")
+            return response.flight
+        } catch {
+            errorMessage = error.localizedDescription
+            Self.logger.error("Edit flight failed: \(error)")
+            return nil
+        }
+    }
+
+    private func regenerateBriefing(for flight: FlightResponse, invalidation: FlightInvalidation) async throws {
+        switch invalidation {
+        case .none:
+            return
+        case .advisoriesOnly:
+            statusMessage = "Updating advisories…"
+            do {
+                let pack = try await repository.latestPack(flightId: flight.id)
+                try await repository.recalculateAdvisories(
+                    flightId: flight.id,
+                    timestamp: pack.fetchTimestamp,
+                    cruiseAltitudeFt: flight.cruiseAltitudeFt
+                )
+            } catch APIError.notFound {
+                try await refreshBriefing(flightId: flight.id)
+            }
+        case .refetchNeeded:
+            try await refreshBriefing(flightId: flight.id)
+        }
+    }
+
+    private func refreshBriefing(flightId: String) async throws {
+        statusMessage = "Regenerating briefing…"
+        let stream = await repository.refreshStream(flightId: flightId)
+        var completed = false
+        for try await event in stream {
+            switch event.type {
+            case "progress":
+                statusMessage = event.label ?? event.stage ?? "Regenerating briefing…"
+            case "briefing_ready":
+                statusMessage = "Briefing ready…"
+            case "complete":
+                completed = true
+                statusMessage = "Briefing regenerated"
+            case "error":
+                throw APIError.serverError(500, event.message ?? "Briefing regeneration failed")
+            default:
+                break
+            }
+        }
+        if !completed {
+            Self.logger.warning("Refresh stream ended before a complete event while editing \(flightId)")
         }
     }
 }

--- a/app/flyfun-weather/flyfun-weather/ViewModels/BriefingViewModel.swift
+++ b/app/flyfun-weather/flyfun-weather/ViewModels/BriefingViewModel.swift
@@ -2,11 +2,50 @@ import Foundation
 import OSLog
 
 enum BriefingTab: String, Hashable {
-    case advisories
+    case brief
     case crossSection
+    case skewT
     case map
-    case digest
-    case pireps
+}
+
+struct BriefingActivePoint: Hashable, Sendable {
+    let pointIndex: Int
+    let distanceNm: Double
+    let waypointIcao: String?
+}
+
+struct BriefingFocusIntent: Hashable, Sendable {
+    enum Target: String, Hashable, Sendable {
+        case crossSection
+        case skewT
+        case map
+    }
+
+    let target: Target
+    let model: String?
+    let pointIndex: Int?
+    let distanceNm: Double?
+    let altitudeFt: Double?
+    let layerId: String?
+    let metricId: String?
+
+    init(
+        target: Target,
+        model: String? = nil,
+        pointIndex: Int? = nil,
+        distanceNm: Double? = nil,
+        altitudeFt: Double? = nil,
+        layerId: String? = nil,
+        metricId: String? = nil
+    ) {
+        self.target = target
+        self.model = model
+        self.pointIndex = pointIndex
+        self.distanceNm = distanceNm
+        self.altitudeFt = altitudeFt
+        self.layerId = layerId
+        self.metricId = metricId
+    }
 }
 
 /// Refresh pipeline state.
@@ -54,9 +93,12 @@ final class BriefingViewModel {
     private(set) var packCacheStatus: [String: Bool] = [:] // timestamp -> isCached
 
     // UI state
-    var selectedTab: BriefingTab = .advisories
+    var selectedTab: BriefingTab = .brief
     var selectedModel: String = "gfs"
+    var activePoint: BriefingActivePoint?
+    var focusIntent: BriefingFocusIntent?
     var availableModels: [String] = []
+    var selectedPack: PackMetaResponse? { pack }
     var selectedPackTimestamp: String = "" {
         didSet {
             guard oldValue != selectedPackTimestamp, !selectedPackTimestamp.isEmpty else { return }
@@ -361,6 +403,7 @@ final class BriefingViewModel {
         do {
             let response = try await repository.routeAnalyses(flightId: flight.id, timestamp: timestamp)
             routeAnalysesState = .loaded(response)
+            ensureActivePoint(in: response)
             if !response.models.isEmpty {
                 let raModels = response.models.sorted()
                 availableModels = raModels
@@ -373,6 +416,68 @@ final class BriefingViewModel {
             routeAnalysesState = .error(error)
             Self.logger.error("Failed to load route analyses: \(error)")
         }
+    }
+
+    func setActivePoint(_ point: RoutePointAnalysis?) {
+        guard let point else {
+            activePoint = nil
+            return
+        }
+        activePoint = BriefingActivePoint(
+            pointIndex: point.pointIndex,
+            distanceNm: point.distanceFromOriginNm,
+            waypointIcao: point.waypointIcao
+        )
+    }
+
+    func routePoint(for activePoint: BriefingActivePoint?) -> RoutePointAnalysis? {
+        guard let activePoint,
+              case .loaded(let analyses) = routeAnalysesState
+        else { return nil }
+        return analyses.analyses.first { $0.pointIndex == activePoint.pointIndex }
+    }
+
+    func setFocusIntent(_ intent: BriefingFocusIntent?) {
+        focusIntent = intent
+        guard let intent else { return }
+
+        if let model = intent.model,
+           availableModels.contains(model) {
+            selectedModel = model
+        }
+
+        if case .loaded(let analyses) = routeAnalysesState {
+            let targetPoint: RoutePointAnalysis?
+            if let pointIndex = intent.pointIndex {
+                targetPoint = analyses.analyses.first { $0.pointIndex == pointIndex }
+            } else if let distanceNm = intent.distanceNm {
+                targetPoint = analyses.analyses.min {
+                    abs($0.distanceFromOriginNm - distanceNm) < abs($1.distanceFromOriginNm - distanceNm)
+                }
+            } else {
+                targetPoint = nil
+            }
+            if let targetPoint {
+                setActivePoint(targetPoint)
+            }
+        }
+
+        switch intent.target {
+        case .crossSection:
+            selectedTab = .crossSection
+        case .skewT:
+            selectedTab = .skewT
+        case .map:
+            selectedTab = .map
+        }
+    }
+
+    private func ensureActivePoint(in analyses: RouteAnalysesResponse) {
+        if let activePoint,
+           analyses.analyses.contains(where: { $0.pointIndex == activePoint.pointIndex }) {
+            return
+        }
+        setActivePoint(analyses.analyses.first)
     }
 
     private func loadElevation(timestamp: String) async {

--- a/app/flyfun-weather/flyfun-weather/ViewModels/BriefingViewModel.swift
+++ b/app/flyfun-weather/flyfun-weather/ViewModels/BriefingViewModel.swift
@@ -131,6 +131,15 @@ final class BriefingViewModel {
             async let dataTask: () = loadPackData(timestamp: pack.fetchTimestamp)
             _ = await (historyTask, dataTask)
             await checkCacheStatus()
+        } catch APIError.notFound {
+            Self.logger.info("No briefing pack yet for \(self.flight.id); starting initial refresh")
+            await refresh()
+            if pack == nil {
+                let error = APIError.notFound
+                advisoriesState = .error(error)
+                digestState = .error(error)
+                snapshotState = .error(error)
+            }
         } catch {
             Self.logger.error("Failed to load pack meta: \(error)")
             advisoriesState = .error(error)

--- a/app/flyfun-weather/flyfun-weather/ViewModels/BriefingViewModel.swift
+++ b/app/flyfun-weather/flyfun-weather/ViewModels/BriefingViewModel.swift
@@ -378,6 +378,15 @@ final class BriefingViewModel {
         }
     }
 
+    func advisoryDetail(advisoryId: String) async throws -> AdvisoryDetailResponse {
+        guard let pack else { throw APIError.notFound }
+        return try await repository.advisoryDetail(
+            flightId: flight.id,
+            timestamp: pack.fetchTimestamp,
+            advisoryId: advisoryId
+        )
+    }
+
     private func loadDigest(timestamp: String) async {
         digestState = .loading
         do {

--- a/app/flyfun-weather/flyfun-weather/ViewModels/CrossSectionViewModel.swift
+++ b/app/flyfun-weather/flyfun-weather/ViewModels/CrossSectionViewModel.swift
@@ -16,6 +16,16 @@ final class CrossSectionViewModel {
         enabledLayers[id] = !(enabledLayers[id] ?? false)
     }
 
+    func setLayer(_ id: String, enabled: Bool) {
+        enabledLayers[id] = enabled
+    }
+
+    func applyLayerPreset(_ preset: [String: Bool]) {
+        for layer in CrossSectionLayer.allLayers {
+            enabledLayers[layer.id] = preset[layer.id] ?? false
+        }
+    }
+
     /// Currently-active method layer ID for a method group (clouds/icing/etc),
     /// or nil if all methods in the group are off.
     func activeMethod(for group: LayerGroup) -> String? {

--- a/app/flyfun-weather/flyfun-weather/ViewModels/CrossSectionViewModel.swift
+++ b/app/flyfun-weather/flyfun-weather/ViewModels/CrossSectionViewModel.swift
@@ -93,7 +93,13 @@ final class CrossSectionViewModel {
         )
 
         let cloudLayers = (sounding?.cloudLayers ?? []).map {
-            VizCloudLayer(baseFt: $0.baseFt, topFt: $0.topFt, coverage: $0.coverage, meanDewpointDepressionC: $0.meanDewpointDepressionC)
+            VizCloudLayer(
+                baseFt: $0.baseFt,
+                topFt: $0.topFt,
+                coverage: $0.coverage,
+                meanDewpointDepressionC: $0.meanDewpointDepressionC,
+                meanCloudCoverPct: $0.meanCloudCoverPct
+            )
         }
 
         // nwp_cloud_layers: nil = no NWP source for this model; [] = clear sky.
@@ -101,7 +107,13 @@ final class CrossSectionViewModel {
         // "no data" (disable) from "clear sky" (render nothing).
         let nwpCloudLayers: [VizCloudLayer]? = sounding?.nwpCloudLayers.map { layers in
             layers.map {
-                VizCloudLayer(baseFt: $0.baseFt, topFt: $0.topFt, coverage: $0.coverage, meanDewpointDepressionC: $0.meanDewpointDepressionC)
+                VizCloudLayer(
+                    baseFt: $0.baseFt,
+                    topFt: $0.topFt,
+                    coverage: $0.coverage,
+                    meanDewpointDepressionC: $0.meanDewpointDepressionC,
+                    meanCloudCoverPct: $0.meanCloudCoverPct
+                )
             }
         }
 

--- a/app/flyfun-weather/flyfun-weather/ViewModels/FlightListViewModel.swift
+++ b/app/flyfun-weather/flyfun-weather/ViewModels/FlightListViewModel.swift
@@ -9,6 +9,13 @@ enum LoadingState<T> {
     case error(Error)
 }
 
+struct FlightSectionGroup: Identifiable {
+    let section: FlightListSection
+    let flights: [FlightResponse]
+
+    var id: FlightListSection { section }
+}
+
 /// View model for the flight list screen.
 @Observable
 @MainActor
@@ -25,6 +32,11 @@ final class FlightListViewModel {
 
     init(repository: any BriefingRepository) {
         self.repository = repository
+    }
+
+    var sectionedFlights: [FlightSectionGroup] {
+        guard case .loaded(let flights) = state else { return [] }
+        return Self.groupFlights(flights)
     }
 
     func loadFlights() async {
@@ -45,6 +57,23 @@ final class FlightListViewModel {
         } catch {
             state = .error(error)
             Self.logger.error("Failed to load flights: \(error)")
+        }
+    }
+
+    static func groupFlights(_ flights: [FlightResponse]) -> [FlightSectionGroup] {
+        FlightListSection.allCases.compactMap { section in
+            let sectionFlights = flights
+                .filter { $0.displaySection == section }
+                .sorted { lhs, rhs in
+                    switch section {
+                    case .future:
+                        return (lhs.departureDate ?? .distantFuture) < (rhs.departureDate ?? .distantFuture)
+                    case .recent, .past:
+                        return (lhs.departureDate ?? .distantPast) > (rhs.departureDate ?? .distantPast)
+                    }
+                }
+            guard !sectionFlights.isEmpty else { return nil }
+            return FlightSectionGroup(section: section, flights: sectionFlights)
         }
     }
 }

--- a/app/flyfun-weather/flyfun-weather/ViewModels/RouteMapViewModel.swift
+++ b/app/flyfun-weather/flyfun-weather/ViewModels/RouteMapViewModel.swift
@@ -1,5 +1,458 @@
 import Foundation
 import MapKit
+import SwiftUI
+
+struct RouteMapLegendStop: Identifiable {
+    let value: Double
+    let label: String
+    let color: Color
+
+    var id: String { "\(label)-\(value)" }
+}
+
+/// Native sibling of the web MAP_METRICS registry.
+enum RouteMapMetric: String, CaseIterable, Identifiable {
+    case cloudCoverTotal = "cloud-cover-total"
+    case cloudCoverLow = "cloud-cover-low"
+    case convectiveRisk = "convective-risk"
+    case headwind = "headwind"
+    case tailwind = "tailwind"
+    case cape = "cape"
+    case nwpCeiling = "nwp-ceiling"
+    case tempAtLevel = "temp-at-level"
+    case modelAgreement = "model-agreement"
+    case icingRiskAtLevel = "icing-risk-at-level"
+    case sfipAtLevel = "sfip-at-level"
+    case catRiskAtLevel = "cat-risk-at-level"
+    case cloudAtLevel = "cloud-at-level"
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .cloudCoverTotal: "Cloud Cover (Total)"
+        case .cloudCoverLow: "Cloud Cover (Low)"
+        case .convectiveRisk: "Convective Risk"
+        case .headwind: "Headwind"
+        case .tailwind: "Tailwind"
+        case .cape: "CAPE"
+        case .nwpCeiling: "NWP Ceiling"
+        case .tempAtLevel: "Temperature at FL"
+        case .modelAgreement: "Model Agreement"
+        case .icingRiskAtLevel: "Icing Risk at FL"
+        case .sfipAtLevel: "SFIP at FL"
+        case .catRiskAtLevel: "CAT Risk at FL"
+        case .cloudAtLevel: "Cloud at FL"
+        }
+    }
+
+    var unit: String {
+        switch self {
+        case .cloudCoverTotal, .cloudCoverLow, .cloudAtLevel: "%"
+        case .headwind, .tailwind: "kt"
+        case .cape: "J/kg"
+        case .nwpCeiling: "ft"
+        case .tempAtLevel: "C"
+        default: ""
+        }
+    }
+
+    var altitudeDependent: Bool {
+        switch self {
+        case .tempAtLevel, .icingRiskAtLevel, .sfipAtLevel, .catRiskAtLevel, .cloudAtLevel:
+            true
+        default:
+            false
+        }
+    }
+
+    var legendStops: [RouteMapLegendStop] {
+        switch self {
+        case .cloudCoverTotal, .cloudCoverLow, .cloudAtLevel:
+            [
+                .init(value: 0, label: "Clear", color: Self.cloudCoverColor(0)),
+                .init(value: 25, label: "25%", color: Self.cloudCoverColor(25)),
+                .init(value: 50, label: "50%", color: Self.cloudCoverColor(50)),
+                .init(value: 75, label: "75%", color: Self.cloudCoverColor(75)),
+                .init(value: 100, label: "Overcast", color: Self.cloudCoverColor(100)),
+            ]
+        case .convectiveRisk:
+            [
+                .init(value: 0, label: "None", color: Self.riskColor("none")),
+                .init(value: 1, label: "Low", color: Self.riskColor("low")),
+                .init(value: 2, label: "Moderate", color: Self.riskColor("moderate")),
+                .init(value: 3, label: "High", color: Self.riskColor("high")),
+                .init(value: 4, label: "Extreme", color: Self.riskColor("extreme")),
+            ]
+        case .headwind:
+            [
+                .init(value: 0, label: "Calm", color: Self.headwindColor(0)),
+                .init(value: 10, label: "10 kt", color: Self.headwindColor(10)),
+                .init(value: 20, label: "20 kt", color: Self.headwindColor(20)),
+                .init(value: 30, label: "30 kt", color: Self.headwindColor(30)),
+            ]
+        case .tailwind:
+            [
+                .init(value: 0, label: "Calm", color: Self.headwindColor(0)),
+                .init(value: 10, label: "10 kt", color: Self.headwindColor(-10)),
+                .init(value: 20, label: "20 kt", color: Self.headwindColor(-20)),
+                .init(value: 30, label: "30 kt", color: Self.headwindColor(-30)),
+            ]
+        case .cape:
+            [
+                .init(value: 0, label: "0", color: Self.capeColor(0)),
+                .init(value: 500, label: "500", color: Self.capeColor(500)),
+                .init(value: 1000, label: "1000", color: Self.capeColor(1000)),
+                .init(value: 2000, label: "2000+", color: Self.capeColor(2000)),
+            ]
+        case .nwpCeiling:
+            [
+                .init(value: 200, label: "LIFR", color: Self.ceilingColor(200)),
+                .init(value: 800, label: "IFR", color: Self.ceilingColor(800)),
+                .init(value: 2000, label: "MVFR", color: Self.ceilingColor(2000)),
+                .init(value: 5000, label: "VFR", color: Self.ceilingColor(5000)),
+            ]
+        case .tempAtLevel:
+            [
+                .init(value: -20, label: "-20C", color: Self.temperatureColor(-20)),
+                .init(value: -10, label: "-10C", color: Self.temperatureColor(-10)),
+                .init(value: 0, label: "0C", color: Self.temperatureColor(0)),
+                .init(value: 10, label: "10C", color: Self.temperatureColor(10)),
+            ]
+        case .modelAgreement:
+            [
+                .init(value: 0, label: "Good", color: Self.agreementColor("good")),
+                .init(value: 1, label: "Moderate", color: Self.agreementColor("moderate")),
+                .init(value: 2, label: "Poor", color: Self.agreementColor("poor")),
+            ]
+        case .icingRiskAtLevel, .catRiskAtLevel:
+            [
+                .init(value: 0, label: "None", color: Self.riskColor("none")),
+                .init(value: 1, label: "Light", color: Self.riskColor("light")),
+                .init(value: 2, label: "Moderate", color: Self.riskColor("moderate")),
+                .init(value: 3, label: "Severe", color: Self.riskColor("severe")),
+            ]
+        case .sfipAtLevel:
+            [
+                .init(value: 0, label: "Low", color: .rgb(34, 197, 94)),
+                .init(value: 35, label: "Med", color: .rgb(250, 204, 21)),
+                .init(value: 65, label: "High", color: .rgb(249, 115, 22)),
+                .init(value: 90, label: "Very High", color: .rgb(239, 68, 68)),
+            ]
+        }
+    }
+
+    func value(for point: RoutePointAnalysis, model: String, altitudeFt: Double) -> Double? {
+        let sounding = point.sounding[model] ?? point.sounding.values.first
+        switch self {
+        case .cloudCoverTotal:
+            guard let sounding else { return nil }
+            return Self.randomOverlap(
+                low: sounding.cloudCoverLowPct ?? 0,
+                mid: sounding.cloudCoverMidPct ?? 0,
+                high: sounding.cloudCoverHighPct ?? 0
+            )
+        case .cloudCoverLow:
+            return sounding?.cloudCoverLowPct
+        case .convectiveRisk:
+            return Self.riskOrder(sounding?.convective?.riskLevel)
+        case .headwind:
+            guard let headwind = point.windComponents[model]?.headwindKt else { return nil }
+            return max(0, headwind)
+        case .tailwind:
+            guard let headwind = point.windComponents[model]?.headwindKt else { return nil }
+            return max(0, -headwind)
+        case .cape:
+            return sounding?.indices?.capeSurfaceJkg ?? sounding?.convective?.capeJkg
+        case .nwpCeiling:
+            return sounding?.nwpCloudDiagnostics?.ceilingFt
+        case .tempAtLevel:
+            guard let sounding else { return nil }
+            return Self.temperatureAtAltitude(sounding: sounding, altitudeFt: altitudeFt)
+        case .modelAgreement:
+            let worst = point.modelDivergence
+                .map { Self.agreementScore($0.agreement) }
+                .max()
+            return worst
+        case .icingRiskAtLevel:
+            return Self.worstRiskAtAlt(
+                sounding?.icingZones ?? [],
+                altitudeFt: altitudeFt,
+                base: { $0.baseFt },
+                top: { $0.topFt },
+                risk: { $0.risk }
+            )
+        case .sfipAtLevel:
+            return Self.sfipAtAlt(sounding?.sfipZones ?? [], altitudeFt: altitudeFt)
+        case .catRiskAtLevel:
+            return Self.worstRiskAtAlt(
+                sounding?.verticalMotion?.catRiskLayers ?? [],
+                altitudeFt: altitudeFt,
+                base: { $0.baseFt },
+                top: { $0.topFt },
+                risk: { $0.risk }
+            )
+        case .cloudAtLevel:
+            return Self.cloudAtAlt(sounding?.cloudLayers ?? [], altitudeFt: altitudeFt)
+        }
+    }
+
+    func color(for value: Double) -> Color {
+        switch self {
+        case .cloudCoverTotal, .cloudCoverLow, .cloudAtLevel:
+            return Self.cloudCoverColor(value)
+        case .convectiveRisk:
+            return Self.riskColor(Self.riskLabel(value, convective: true))
+        case .headwind:
+            return Self.headwindColor(value)
+        case .tailwind:
+            return Self.headwindColor(-value)
+        case .cape:
+            return Self.capeColor(value)
+        case .nwpCeiling:
+            return Self.ceilingColor(value)
+        case .tempAtLevel:
+            return Self.temperatureColor(value)
+        case .modelAgreement:
+            return value >= 2 ? Self.agreementColor("poor") : (value >= 1 ? Self.agreementColor("moderate") : Self.agreementColor("good"))
+        case .icingRiskAtLevel, .catRiskAtLevel:
+            return Self.riskColor(Self.riskLabel(value, convective: false))
+        case .sfipAtLevel:
+            if value <= 20 { return .rgb(34, 197, 94) }
+            if value <= 50 { return .rgb(250, 204, 21) }
+            if value <= 80 { return .rgb(249, 115, 22) }
+            return .rgb(239, 68, 68)
+        }
+    }
+
+    func width(for value: Double) -> CGFloat {
+        switch self {
+        case .cloudCoverTotal, .cloudCoverLow, .cloudAtLevel:
+            return Self.linearWidth(value, maxValue: 100, min: 3, max: 25)
+        case .convectiveRisk:
+            return Self.linearWidth(value, maxValue: 4, min: 3, max: 25)
+        case .headwind, .tailwind:
+            return Self.linearWidth(value, maxValue: 30, min: 3, max: 25)
+        case .cape:
+            return Self.linearWidth(value, maxValue: 2000, min: 3, max: 25)
+        case .nwpCeiling:
+            let clamped = Swift.max(0, Swift.min(5000, value))
+            return CGFloat(25 - (clamped / 5000) * 22)
+        case .tempAtLevel:
+            let clamped = Swift.max(-20, Swift.min(5, value))
+            return CGFloat(3 + (5 - clamped) / 25 * 22)
+        case .modelAgreement:
+            return Self.linearWidth(value, maxValue: 2, min: 3, max: 25)
+        case .icingRiskAtLevel, .catRiskAtLevel:
+            return Self.linearWidth(value, maxValue: 3, min: 3, max: 25)
+        case .sfipAtLevel:
+            return Self.linearWidth(value, maxValue: 100, min: 3, max: 25)
+        }
+    }
+
+    func format(_ value: Double) -> String {
+        switch self {
+        case .cloudCoverTotal, .cloudCoverLow, .cloudAtLevel:
+            return "\(Int(value.rounded()))%"
+        case .headwind:
+            return "\(Int(value.rounded())) kt HW"
+        case .tailwind:
+            return "\(Int(value.rounded())) kt TW"
+        case .cape:
+            return "\(Int(value.rounded())) J/kg"
+        case .nwpCeiling:
+            return "\(Int(value.rounded())) ft"
+        case .tempAtLevel:
+            return String(format: "%.1f C", value)
+        case .convectiveRisk:
+            return Self.riskLabel(value, convective: true)
+        case .modelAgreement:
+            return value >= 2 ? "poor" : (value >= 1 ? "moderate" : "good")
+        case .icingRiskAtLevel, .catRiskAtLevel:
+            return Self.riskLabel(value, convective: false)
+        case .sfipAtLevel:
+            return "SFIP \(Int(value.rounded()))"
+        }
+    }
+
+    private static func riskOrder(_ risk: String?) -> Double {
+        switch risk?.lowercased() {
+        case "marginal", "light", "low": 1
+        case "moderate": 2
+        case "high", "severe": 3
+        case "extreme": 4
+        default: 0
+        }
+    }
+
+    private static func riskLabel(_ value: Double, convective: Bool) -> String {
+        let rounded = Int(value.rounded())
+        if convective {
+            return ["none", "low", "moderate", "high", "extreme"][safe: min(rounded, 4)] ?? "none"
+        }
+        return ["none", "light", "moderate", "severe"][safe: min(rounded, 3)] ?? "none"
+    }
+
+    private static func agreementScore(_ agreement: String) -> Double {
+        switch agreement.lowercased() {
+        case "poor": 2
+        case "moderate": 1
+        default: 0
+        }
+    }
+
+    private static func randomOverlap(low: Double, mid: Double, high: Double) -> Double {
+        func clamp(_ value: Double) -> Double { Swift.min(100, Swift.max(0, value)) / 100 }
+        let l = clamp(low)
+        let m = clamp(mid)
+        let h = clamp(high)
+        return (1 - (1 - l) * (1 - m) * (1 - h)) * 100
+    }
+
+    private static func worstRiskAtAlt<Zone>(
+        _ zones: [Zone],
+        altitudeFt: Double,
+        base: (Zone) -> Double,
+        top: (Zone) -> Double,
+        risk: (Zone) -> String
+    ) -> Double {
+        var worst = 0.0
+        for zone in zones where altitudeFt >= base(zone) && altitudeFt <= top(zone) {
+            worst = Swift.max(worst, riskOrder(risk(zone)))
+        }
+        return worst
+    }
+
+    private static func sfipAtAlt(_ zones: [SfipZone], altitudeFt: Double) -> Double? {
+        var best: Double?
+        for zone in zones where altitudeFt >= zone.baseFt && altitudeFt <= zone.topFt {
+            guard let value = zone.meanSfip100 else { continue }
+            best = best.map { Swift.max($0, value) } ?? value
+        }
+        return best
+    }
+
+    private static func cloudAtAlt(_ layers: [EnhancedCloudLayer], altitudeFt: Double) -> Double {
+        var maxCoverage = 0.0
+        for layer in layers where altitudeFt >= layer.baseFt && altitudeFt <= layer.topFt {
+            let weight: Double
+            switch layer.coverage.lowercased() {
+            case "sct": weight = 0.3
+            case "bkn": weight = 0.7
+            case "ovc": weight = 1.0
+            default: weight = 0.5
+            }
+            maxCoverage = Swift.max(maxCoverage, weight)
+        }
+        return maxCoverage * 100
+    }
+
+    private static func temperatureAtAltitude(sounding: SoundingAnalysis, altitudeFt: Double) -> Double? {
+        guard let freezingLevel = sounding.indices?.freezingLevelFt else { return nil }
+        var refs: [(altitude: Double, temperature: Double)] = [(freezingLevel, 0)]
+        if let minus10 = sounding.indices?.minus10cLevelFt {
+            refs.append((minus10, -10))
+        }
+        if let minus20 = sounding.indices?.minus20cLevelFt {
+            refs.append((minus20, -20))
+        }
+        refs.sort { $0.altitude < $1.altitude }
+
+        if altitudeFt <= refs[0].altitude {
+            return refs[0].temperature + (refs[0].altitude - altitudeFt) * 2 / 1000
+        }
+        if altitudeFt >= refs[refs.count - 1].altitude {
+            return refs[refs.count - 1].temperature - (altitudeFt - refs[refs.count - 1].altitude) * 2 / 1000
+        }
+
+        for index in 0..<(refs.count - 1) where altitudeFt >= refs[index].altitude && altitudeFt <= refs[index + 1].altitude {
+            let lower = refs[index]
+            let upper = refs[index + 1]
+            let fraction = (altitudeFt - lower.altitude) / (upper.altitude - lower.altitude)
+            return lower.temperature + fraction * (upper.temperature - lower.temperature)
+        }
+        return nil
+    }
+
+    private static func riskColor(_ risk: String) -> Color {
+        switch risk.lowercased() {
+        case "light", "low": .rgb(250, 204, 21)
+        case "moderate": .rgb(249, 115, 22)
+        case "high", "severe": .rgb(239, 68, 68)
+        case "extreme": .rgb(153, 27, 27)
+        case "marginal": .rgb(163, 163, 163)
+        default: .rgb(34, 197, 94)
+        }
+    }
+
+    private static func cloudCoverColor(_ percent: Double) -> Color {
+        let t = Swift.min(1, Swift.max(0, percent / 100))
+        let v = Int((220 - 160 * t).rounded())
+        return .rgb(v, v, Swift.min(255, v + 10))
+    }
+
+    private static func headwindColor(_ kt: Double) -> Color {
+        let t = Swift.min(1, Swift.max(0, abs(kt) / 30))
+        if kt >= 0 {
+            return .rgb(255, Int((255 - 200 * t).rounded()), Int((255 - 200 * t).rounded()))
+        }
+        return .rgb(Int((255 - 200 * t).rounded()), Int((255 - 60 * t).rounded()), Int((255 - 200 * t).rounded()))
+    }
+
+    private static func capeColor(_ jkg: Double) -> Color {
+        if jkg <= 0 { return .rgb(34, 197, 94) }
+        if jkg >= 2000 { return .rgb(220, 38, 38) }
+        let t = Swift.min(1, jkg / 2000)
+        if t < 0.5 {
+            let s = t * 2
+            return .rgb(
+                Int((34 + 221 * s).rounded()),
+                Int((197 - 10 * s).rounded()),
+                Int((94 - 73 * s).rounded())
+            )
+        }
+        let s = (t - 0.5) * 2
+        return .rgb(
+            Int((255 - 35 * s).rounded()),
+            Int((187 - 149 * s).rounded()),
+            Int((21 + 17 * s).rounded())
+        )
+    }
+
+    private static func ceilingColor(_ feet: Double) -> Color {
+        if feet < 200 { return .rgb(142, 36, 170) }
+        if feet < 1000 { return .rgb(220, 53, 69) }
+        if feet < 3000 { return .rgb(245, 158, 11) }
+        return .rgb(34, 197, 94)
+    }
+
+    private static func temperatureColor(_ celsius: Double) -> Color {
+        let t = Swift.min(1, Swift.max(0, (celsius + 20) / 60))
+        if t < 0.33 {
+            let s = t / 0.33
+            return .rgb(Int((30 + 125 * s).rounded()), Int((80 + 125 * s).rounded()), Int((220 + 35 * s).rounded()))
+        }
+        if t < 0.67 {
+            let s = (t - 0.33) / 0.34
+            return .rgb(Int((155 + 100 * s).rounded()), Int((205 + 50 * s).rounded()), Int((255 - 40 * s).rounded()))
+        }
+        let s = (t - 0.67) / 0.33
+        return .rgb(255, Int((255 - 185 * s).rounded()), Int((215 - 175 * s).rounded()))
+    }
+
+    private static func agreementColor(_ agreement: String) -> Color {
+        switch agreement.lowercased() {
+        case "poor": .rgb(239, 68, 68)
+        case "moderate": .rgb(249, 115, 22)
+        default: .rgb(34, 197, 94)
+        }
+    }
+
+    private static func linearWidth(_ value: Double, maxValue: Double, min minWidth: CGFloat, max maxWidth: CGFloat) -> CGFloat {
+        let t = Swift.min(1, Swift.max(0, abs(value) / maxValue))
+        return minWidth + (maxWidth - minWidth) * CGFloat(t)
+    }
+}
 
 /// View model for the route map — extracts waypoint coordinates and computes map region.
 @Observable
@@ -11,8 +464,19 @@ final class RouteMapViewModel {
         let coordinate: CLLocationCoordinate2D
     }
 
+    struct RouteSegment: Identifiable {
+        let id: Int
+        let coordinates: [CLLocationCoordinate2D]
+        let color: Color
+        let width: CGFloat
+        let midpoint: CLLocationCoordinate2D
+        let targetPoint: RoutePointAnalysis
+        let valueDescription: String?
+    }
+
     var waypoints: [WaypointAnnotation] = []
     var routeCoordinates: [CLLocationCoordinate2D] = []
+    var routePoints: [RoutePointAnalysis] = []
     var mapRegion: MKCoordinateRegion = .init()
 
     func update(from snapshot: SnapshotResponse) {
@@ -21,6 +485,7 @@ final class RouteMapViewModel {
             WaypointAnnotation(id: $0.icao, name: $0.name, coordinate: CLLocationCoordinate2D(latitude: $0.lat, longitude: $0.lon))
         }
         routeCoordinates = wps.map { CLLocationCoordinate2D(latitude: $0.lat, longitude: $0.lon) }
+        routePoints = []
 
         // Compute region to fit all waypoints with padding
         guard !routeCoordinates.isEmpty else { return }
@@ -38,6 +503,7 @@ final class RouteMapViewModel {
     }
 
     func update(from analyses: RouteAnalysesResponse) {
+        routePoints = analyses.analyses
         // Use route analysis points for finer route line
         routeCoordinates = analyses.analyses.map {
             CLLocationCoordinate2D(latitude: $0.lat, longitude: $0.lon)
@@ -65,5 +531,78 @@ final class RouteMapViewModel {
             longitudeDelta: (lons.max()! - lons.min()!) * 1.4 + 0.5
         )
         mapRegion = MKCoordinateRegion(center: center, span: span)
+    }
+
+    func segments(
+        colorMetric: RouteMapMetric,
+        widthMetric: RouteMapMetric,
+        model: String,
+        altitudeFt: Double
+    ) -> [RouteSegment] {
+        guard routePoints.count > 1 else { return [] }
+
+        return (0..<(routePoints.count - 1)).map { index in
+            let start = routePoints[index]
+            let end = routePoints[index + 1]
+            let colorValue = averagedValue(
+                metric: colorMetric,
+                start: start,
+                end: end,
+                model: model,
+                altitudeFt: altitudeFt
+            )
+            let widthValue = averagedValue(
+                metric: widthMetric,
+                start: start,
+                end: end,
+                model: model,
+                altitudeFt: altitudeFt
+            )
+            let startCoord = CLLocationCoordinate2D(latitude: start.lat, longitude: start.lon)
+            let endCoord = CLLocationCoordinate2D(latitude: end.lat, longitude: end.lon)
+            return RouteSegment(
+                id: index,
+                coordinates: [startCoord, endCoord],
+                color: colorValue.map { colorMetric.color(for: $0) } ?? .blue,
+                width: widthValue.map { widthMetric.width(for: $0) } ?? 8,
+                midpoint: CLLocationCoordinate2D(
+                    latitude: (start.lat + end.lat) / 2,
+                    longitude: (start.lon + end.lon) / 2
+                ),
+                targetPoint: end,
+                valueDescription: colorValue.map { colorMetric.format($0) }
+            )
+        }
+    }
+
+    private func averagedValue(
+        metric: RouteMapMetric,
+        start: RoutePointAnalysis,
+        end: RoutePointAnalysis,
+        model: String,
+        altitudeFt: Double
+    ) -> Double? {
+        let startValue = metric.value(for: start, model: model, altitudeFt: altitudeFt)
+        let endValue = metric.value(for: end, model: model, altitudeFt: altitudeFt)
+        if let startValue, let endValue {
+            return (startValue + endValue) / 2
+        }
+        return startValue ?? endValue
+    }
+}
+
+private extension Array {
+    subscript(safe index: Index) -> Element? {
+        indices.contains(index) ? self[index] : nil
+    }
+}
+
+private extension Color {
+    static func rgb(_ red: Int, _ green: Int, _ blue: Int) -> Color {
+        Color(
+            red: Double(red) / 255,
+            green: Double(green) / 255,
+            blue: Double(blue) / 255
+        )
     }
 }

--- a/app/flyfun-weather/flyfun-weather/Views/Briefing/BriefTabView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Briefing/BriefTabView.swift
@@ -1,0 +1,349 @@
+import SwiftUI
+
+/// First-read briefing surface: hero, digest, watch items, airports, and advisory cards.
+struct BriefTabView: View {
+    @Bindable var viewModel: BriefingViewModel
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: WeatherTheme.Spacing.lg) {
+                BriefHeroSection(viewModel: viewModel)
+                BriefDigestSection(viewModel: viewModel)
+                AirportConditionsView(viewModel: viewModel)
+                BriefAdvisorySection(viewModel: viewModel)
+            }
+            .padding(.vertical, WeatherTheme.Spacing.lg)
+        }
+        .background(WeatherTheme.background(colorScheme))
+    }
+}
+
+private struct BriefHeroSection: View {
+    let viewModel: BriefingViewModel
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: WeatherTheme.Spacing.md) {
+            HStack(alignment: .firstTextBaseline) {
+                Text(assessmentText)
+                    .font(.system(.largeTitle, design: .rounded, weight: .bold))
+                    .foregroundStyle(assessmentColor)
+                    .lineLimit(1)
+                Spacer()
+                if let pack = viewModel.pack {
+                    Text(viewModel.packLabel(for: pack))
+                        .font(.caption.monospacedDigit())
+                        .foregroundStyle(WeatherTheme.mutedText(colorScheme))
+                }
+            }
+
+            if let reason = viewModel.pack?.assessmentReason, !reason.isEmpty {
+                Text(reason)
+                    .font(.subheadline)
+                    .foregroundStyle(WeatherTheme.text(colorScheme))
+                    .fixedSize(horizontal: false, vertical: true)
+            } else {
+                Text("Briefing assessment is loading.")
+                    .font(.subheadline)
+                    .foregroundStyle(WeatherTheme.mutedText(colorScheme))
+            }
+
+            HStack(spacing: WeatherTheme.Spacing.sm) {
+                Label("FL\(viewModel.flight.cruiseAltitudeFt / 100)", systemImage: "arrow.up.right")
+                Label("\(Int(viewModel.flight.flightDurationHours * 60)) min", systemImage: "timer")
+                if let point = viewModel.activePoint {
+                    Label("\(Int(point.distanceNm)) nm selected", systemImage: "scope")
+                }
+            }
+            .font(.caption.monospacedDigit())
+            .foregroundStyle(WeatherTheme.mutedText(colorScheme))
+        }
+        .padding(WeatherTheme.Spacing.lg)
+        .weatherCard(colorScheme)
+        .padding(.horizontal, WeatherTheme.Spacing.lg)
+    }
+
+    private var assessmentText: String {
+        viewModel.pack?.assessment?.uppercased() ?? "BRIEF"
+    }
+
+    private var assessmentColor: Color {
+        let status = viewModel.pack?.assessment?.lowercased() ?? "unavailable"
+        return (Assessment(rawValue: status) ?? .unavailable).color
+    }
+}
+
+private struct BriefDigestSection: View {
+    @Bindable var viewModel: BriefingViewModel
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        switch viewModel.digestState {
+        case .idle, .loading:
+            HStack {
+                ProgressView()
+                Text("Generating summary...")
+                    .font(.subheadline)
+                    .foregroundStyle(WeatherTheme.mutedText(colorScheme))
+                Spacer()
+            }
+            .padding(WeatherTheme.Spacing.lg)
+            .weatherCard(colorScheme)
+            .padding(.horizontal, WeatherTheme.Spacing.lg)
+        case .error(let error):
+            ContentUnavailableView("Digest Unavailable", systemImage: "doc.text", description: Text(error.localizedDescription))
+                .padding(.horizontal, WeatherTheme.Spacing.lg)
+        case .loaded(let digest):
+            VStack(alignment: .leading, spacing: WeatherTheme.Spacing.lg) {
+                if !digest.watchItemsList.isEmpty {
+                    BriefWatchSection(viewModel: viewModel, watchItems: digest.watchItemsList)
+                }
+
+                if !hazardSections(from: digest).isEmpty {
+                    VStack(alignment: .leading, spacing: WeatherTheme.Spacing.md) {
+                        Text("Digest")
+                            .font(.headline)
+                        ForEach(Array(hazardSections(from: digest).enumerated()), id: \.offset) { _, section in
+                            BriefTextSection(title: section.title, text: section.text)
+                        }
+                    }
+                    .padding(WeatherTheme.Spacing.lg)
+                    .weatherCard(colorScheme)
+                }
+
+                if let synoptic = digest.synoptic, !synoptic.isEmpty {
+                    VStack(alignment: .leading, spacing: WeatherTheme.Spacing.sm) {
+                        Text("Synopsis")
+                            .font(.headline)
+                        Text(synoptic)
+                            .font(.subheadline)
+                            .foregroundStyle(WeatherTheme.mutedText(colorScheme))
+                    }
+                    .padding(WeatherTheme.Spacing.lg)
+                    .weatherCard(colorScheme)
+                }
+            }
+            .padding(.horizontal, WeatherTheme.Spacing.lg)
+        }
+    }
+
+    private func hazardSections(from digest: DigestResponse) -> [(title: String, text: String)] {
+        digest.sections.filter { $0.title != "Synoptic Overview" }
+    }
+}
+
+private struct BriefWatchSection: View {
+    @Bindable var viewModel: BriefingViewModel
+    let watchItems: [String]
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: WeatherTheme.Spacing.md) {
+            Text("Watch")
+                .font(.headline)
+
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: WeatherTheme.Spacing.sm) {
+                    ForEach(watchItems, id: \.self) { item in
+                        Button {
+                            viewModel.setFocusIntent(.init(
+                                target: .crossSection,
+                                model: viewModel.selectedModel,
+                                pointIndex: viewModel.activePoint?.pointIndex
+                            ))
+                        } label: {
+                            Label(item, systemImage: "exclamationmark.circle")
+                                .font(.caption)
+                                .lineLimit(2)
+                                .frame(maxWidth: 260, alignment: .leading)
+                                .foregroundStyle(WeatherTheme.primary(colorScheme))
+                                .padding(.horizontal, WeatherTheme.Spacing.sm)
+                                .padding(.vertical, WeatherTheme.Spacing.xs)
+                                .background(
+                                    WeatherTheme.primary(colorScheme).opacity(0.10),
+                                    in: RoundedRectangle(cornerRadius: WeatherTheme.Radius.control)
+                                )
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+            }
+        }
+        .padding(WeatherTheme.Spacing.lg)
+        .weatherCard(colorScheme)
+    }
+}
+
+private struct BriefTextSection: View {
+    let title: String
+    let text: String
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: WeatherTheme.Spacing.xs) {
+            Text(title)
+                .font(.subheadline.bold())
+                .foregroundStyle(WeatherTheme.text(colorScheme))
+            Text(text)
+                .font(.subheadline)
+                .foregroundStyle(WeatherTheme.mutedText(colorScheme))
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+}
+
+private struct BriefAdvisorySection: View {
+    let viewModel: BriefingViewModel
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: WeatherTheme.Spacing.md) {
+            Text("Advisories")
+                .font(.headline)
+                .padding(.horizontal, WeatherTheme.Spacing.lg)
+
+            switch viewModel.advisoriesState {
+            case .idle, .loading:
+                ProgressView("Loading advisories...")
+                    .frame(maxWidth: .infinity)
+                    .padding(WeatherTheme.Spacing.lg)
+            case .error(let error):
+                ContentUnavailableView("Advisories Unavailable", systemImage: "exclamationmark.triangle", description: Text(error.localizedDescription))
+            case .loaded(let response):
+                let sorted = response.advisories.sorted { severityOrder($0.aggregateStatus) > severityOrder($1.aggregateStatus) }
+                LazyVStack(spacing: WeatherTheme.Spacing.md) {
+                    ForEach(sorted) { advisory in
+                        BriefAdvisoryCard(advisory: advisory, catalog: response.catalog)
+                    }
+                }
+                .padding(.horizontal, WeatherTheme.Spacing.lg)
+            }
+        }
+    }
+
+    private func severityOrder(_ status: String) -> Int {
+        switch status.lowercased() {
+        case "red": 3
+        case "amber": 2
+        case "green": 1
+        default: 0
+        }
+    }
+}
+
+private struct BriefAdvisoryCard: View {
+    let advisory: RouteAdvisoryResult
+    let catalog: [AdvisoryCatalogEntry]
+    @State private var isExpanded = false
+    @Environment(\.colorScheme) private var colorScheme
+
+    private var catalogEntry: AdvisoryCatalogEntry? {
+        catalog.first { $0.id == advisory.advisoryId }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: WeatherTheme.Spacing.sm) {
+            Button {
+                withAnimation(.snappy) { isExpanded.toggle() }
+            } label: {
+                HStack(alignment: .firstTextBaseline, spacing: WeatherTheme.Spacing.sm) {
+                    AssessmentStringBadge(status: advisory.aggregateStatus)
+                    Text(catalogEntry?.name ?? advisory.advisoryId)
+                        .font(.headline)
+                        .foregroundStyle(WeatherTheme.text(colorScheme))
+                    Spacer()
+                    Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
+                        .foregroundStyle(WeatherTheme.mutedText(colorScheme))
+                }
+            }
+            .buttonStyle(.plain)
+
+            Text(advisory.aggregateDetail)
+                .font(.subheadline)
+                .foregroundStyle(WeatherTheme.mutedText(colorScheme))
+                .fixedSize(horizontal: false, vertical: true)
+
+            HStack(spacing: WeatherTheme.Spacing.xs) {
+                ForEach(advisory.perModel) { modelResult in
+                    BriefModelStatusBadge(model: modelResult.model, status: modelResult.status)
+                }
+            }
+
+            if isExpanded {
+                Divider()
+                ForEach(advisory.perModel) { modelResult in
+                    VStack(alignment: .leading, spacing: WeatherTheme.Spacing.xs) {
+                        HStack {
+                            Text(modelResult.model.uppercased())
+                                .font(.caption.bold())
+                            Spacer()
+                            Text("\(Int(modelResult.affectedPct))% · \(Int(modelResult.affectedNm)) nm")
+                                .font(.caption.monospacedDigit())
+                                .foregroundStyle(WeatherTheme.mutedText(colorScheme))
+                        }
+                        Text(modelResult.detail)
+                            .font(.caption)
+                            .foregroundStyle(WeatherTheme.mutedText(colorScheme))
+                        if let crossCheck = modelResult.crossCheck, !crossCheck.isEmpty {
+                            Label(crossCheck, systemImage: "info.circle")
+                                .font(.caption)
+                                .foregroundStyle(WeatherTheme.primary(colorScheme))
+                        }
+                    }
+                }
+
+                if !advisory.parametersUsed.isEmpty {
+                    Text(parameterSummary)
+                        .font(.caption.monospacedDigit())
+                        .foregroundStyle(WeatherTheme.mutedText(colorScheme))
+                }
+            }
+        }
+        .padding(WeatherTheme.Spacing.lg)
+        .weatherCard(colorScheme)
+    }
+
+    private var parameterSummary: String {
+        advisory.parametersUsed
+            .sorted { $0.key < $1.key }
+            .map { "\($0.key): \(formatNumber($0.value))" }
+            .joined(separator: " · ")
+    }
+
+    private func formatNumber(_ value: Double) -> String {
+        if value.rounded() == value {
+            return String(Int(value))
+        }
+        return String(format: "%.1f", value)
+    }
+}
+
+private struct BriefModelStatusBadge: View {
+    let model: String
+    let status: String
+
+    private var color: Color {
+        (Assessment(rawValue: status.lowercased()) ?? .unavailable).color
+    }
+
+    var body: some View {
+        Text(model.shortModelName)
+            .font(.caption2.bold())
+            .foregroundStyle(.white)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(color, in: Capsule())
+    }
+}
+
+private extension View {
+    func weatherCard(_ scheme: ColorScheme) -> some View {
+        background(WeatherTheme.surface(scheme), in: RoundedRectangle(cornerRadius: WeatherTheme.Radius.card))
+            .overlay {
+                RoundedRectangle(cornerRadius: WeatherTheme.Radius.card)
+                    .stroke(WeatherTheme.border(scheme), lineWidth: 0.5)
+            }
+            .shadow(color: WeatherTheme.shadow(scheme), radius: 8, y: 3)
+    }
+}

--- a/app/flyfun-weather/flyfun-weather/Views/Briefing/BriefTabView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Briefing/BriefTabView.swift
@@ -214,7 +214,7 @@ private struct BriefAdvisorySection: View {
                 let sorted = response.advisories.sorted { severityOrder($0.aggregateStatus) > severityOrder($1.aggregateStatus) }
                 LazyVStack(spacing: WeatherTheme.Spacing.md) {
                     ForEach(sorted) { advisory in
-                        BriefAdvisoryCard(advisory: advisory, catalog: response.catalog)
+                        BriefAdvisoryCard(viewModel: viewModel, advisory: advisory, catalog: response.catalog)
                     }
                 }
                 .padding(.horizontal, WeatherTheme.Spacing.lg)
@@ -233,9 +233,11 @@ private struct BriefAdvisorySection: View {
 }
 
 private struct BriefAdvisoryCard: View {
+    let viewModel: BriefingViewModel
     let advisory: RouteAdvisoryResult
     let catalog: [AdvisoryCatalogEntry]
     @State private var isExpanded = false
+    @State private var showingDetail = false
     @Environment(\.colorScheme) private var colorScheme
 
     private var catalogEntry: AdvisoryCatalogEntry? {
@@ -244,18 +246,28 @@ private struct BriefAdvisoryCard: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: WeatherTheme.Spacing.sm) {
-            Button {
-                withAnimation(.snappy) { isExpanded.toggle() }
-            } label: {
-                HStack(alignment: .firstTextBaseline, spacing: WeatherTheme.Spacing.sm) {
-                    AssessmentStringBadge(status: advisory.aggregateStatus)
-                    Text(catalogEntry?.name ?? advisory.advisoryId)
-                        .font(.headline)
-                        .foregroundStyle(WeatherTheme.text(colorScheme))
-                    Spacer()
+            HStack(alignment: .firstTextBaseline, spacing: WeatherTheme.Spacing.sm) {
+                AssessmentStringBadge(status: advisory.aggregateStatus)
+                Text(catalogEntry?.name ?? advisory.advisoryId)
+                    .font(.headline)
+                    .foregroundStyle(WeatherTheme.text(colorScheme))
+                    .lineLimit(2)
+                Spacer(minLength: WeatherTheme.Spacing.sm)
+                Button {
+                    showingDetail = true
+                } label: {
+                    Image(systemName: "doc.text.magnifyingglass")
+                        .foregroundStyle(WeatherTheme.primary(colorScheme))
+                }
+                .accessibilityLabel("Advisory detail")
+
+                Button {
+                    withAnimation(.snappy) { isExpanded.toggle() }
+                } label: {
                     Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
                         .foregroundStyle(WeatherTheme.mutedText(colorScheme))
                 }
+                .accessibilityLabel(isExpanded ? "Collapse advisory" : "Expand advisory")
             }
             .buttonStyle(.plain)
 
@@ -302,6 +314,13 @@ private struct BriefAdvisoryCard: View {
         }
         .padding(WeatherTheme.Spacing.lg)
         .weatherCard(colorScheme)
+        .sheet(isPresented: $showingDetail) {
+            AdvisoryDetailSheet(
+                viewModel: viewModel,
+                advisory: advisory,
+                catalogEntry: catalogEntry
+            )
+        }
     }
 
     private var parameterSummary: String {
@@ -317,6 +336,321 @@ private struct BriefAdvisoryCard: View {
         }
         return String(format: "%.1f", value)
     }
+}
+
+private struct AdvisoryDetailSheet: View {
+    let viewModel: BriefingViewModel
+    let advisory: RouteAdvisoryResult
+    let catalogEntry: AdvisoryCatalogEntry?
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var state: LoadingState<AdvisoryDetailResponse> = .loading
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                switch state {
+                case .idle, .loading:
+                    ProgressView("Loading detail...")
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                case .error(let error):
+                    ContentUnavailableView {
+                        Label("Detail Unavailable", systemImage: "exclamationmark.triangle")
+                    } description: {
+                        Text(error.localizedDescription)
+                    } actions: {
+                        Button("Retry") {
+                            Task { await load() }
+                        }
+                    }
+                case .loaded(let detail):
+                    if detail.isEmpty {
+                        ContentUnavailableView(
+                            "No Detail Available",
+                            systemImage: "doc.text.magnifyingglass",
+                            description: Text("This advisory has no route-specific drilldown in the selected pack.")
+                        )
+                    } else {
+                        AdvisoryDetailContent(detail: detail, fallbackAdvisory: advisory, catalogEntry: catalogEntry)
+                    }
+                }
+            }
+            .navigationTitle(catalogEntry?.name ?? advisory.advisoryId)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Done") { dismiss() }
+                }
+            }
+        }
+        .task(id: advisory.advisoryId) {
+            await load()
+        }
+    }
+
+    private func load() async {
+        state = .loading
+        do {
+            state = .loaded(try await viewModel.advisoryDetail(advisoryId: advisory.advisoryId))
+        } catch {
+            state = .error(error)
+        }
+    }
+}
+
+private struct AdvisoryDetailContent: View {
+    let detail: AdvisoryDetailResponse
+    let fallbackAdvisory: RouteAdvisoryResult
+    let catalogEntry: AdvisoryCatalogEntry?
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: WeatherTheme.Spacing.lg) {
+                VStack(alignment: .leading, spacing: WeatherTheme.Spacing.sm) {
+                    HStack(spacing: WeatherTheme.Spacing.sm) {
+                        AssessmentStringBadge(status: detail.aggregateStatus ?? fallbackAdvisory.aggregateStatus)
+                        Text(detail.name ?? catalogEntry?.name ?? fallbackAdvisory.advisoryId)
+                            .font(.title3.bold())
+                            .foregroundStyle(WeatherTheme.text(colorScheme))
+                        Spacer()
+                    }
+
+                    Text(detail.aggregateDetail ?? fallbackAdvisory.aggregateDetail)
+                        .font(.subheadline)
+                        .foregroundStyle(WeatherTheme.text(colorScheme))
+                        .fixedSize(horizontal: false, vertical: true)
+
+                    VStack(alignment: .leading, spacing: WeatherTheme.Spacing.xs) {
+                        if let routeName = detail.routeName {
+                            Label(routeName.uppercased(), systemImage: "point.topleft.down.curvedto.point.bottomright.up")
+                        }
+                        if let timestamp = detail.briefingTimestamp {
+                            Label(timestamp, systemImage: "calendar.badge.clock")
+                        }
+                        if let totalDistance = detail.totalDistanceNm {
+                            Label("\(formatNumber(totalDistance)) nm analysed", systemImage: "ruler")
+                        }
+                    }
+                    .font(.caption.monospacedDigit())
+                    .foregroundStyle(WeatherTheme.mutedText(colorScheme))
+                }
+                .padding(WeatherTheme.Spacing.lg)
+                .weatherCard(colorScheme)
+
+                if !detail.perModel.isEmpty {
+                    AdvisoryDetailSection(title: "Route Notes") {
+                        ForEach(detail.perModel) { model in
+                            AdvisoryDetailModelRow(model: model)
+                            if model.id != detail.perModel.last?.id {
+                                Divider()
+                            }
+                        }
+                    }
+                }
+
+                if let convective = detail.convective, !convective.isEmpty {
+                    AdvisoryDetailSection(title: "Convective Split") {
+                        ForEach(convective.keys.sorted(), id: \.self) { model in
+                            if let convectiveDetail = convective[model] {
+                                AdvisoryConvectiveDetailRow(model: model, detail: convectiveDetail)
+                                if model != convective.keys.sorted().last {
+                                    Divider()
+                                }
+                            }
+                        }
+                        if let note = detail.convectiveNote {
+                            Text(note)
+                                .font(.caption)
+                                .foregroundStyle(WeatherTheme.mutedText(colorScheme))
+                                .fixedSize(horizontal: false, vertical: true)
+                        }
+                    }
+                }
+
+                if !detail.parametersUsed.isEmpty {
+                    AdvisoryDetailSection(title: "Thresholds") {
+                        Text(parameterSummary(detail.parametersUsed))
+                            .font(.caption.monospacedDigit())
+                            .foregroundStyle(WeatherTheme.mutedText(colorScheme))
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+
+                if let description = detail.description ?? catalogEntry?.description {
+                    AdvisoryDetailSection(title: "Implication") {
+                        Text(description)
+                            .font(.subheadline)
+                            .foregroundStyle(WeatherTheme.text(colorScheme))
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+
+                if let note = detail.crossCheckNote {
+                    AdvisoryDetailSection(title: "Cross-Check") {
+                        Text(note)
+                            .font(.caption)
+                            .foregroundStyle(WeatherTheme.mutedText(colorScheme))
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+            }
+            .padding(WeatherTheme.Spacing.lg)
+        }
+        .background(WeatherTheme.background(colorScheme))
+    }
+
+    private func parameterSummary(_ parameters: [String: Double]) -> String {
+        parameters
+            .sorted { $0.key < $1.key }
+            .map { "\($0.key): \(formatNumber($0.value))" }
+            .joined(separator: " · ")
+    }
+}
+
+private struct AdvisoryDetailSection<Content: View>: View {
+    let title: String
+    let content: Content
+    @Environment(\.colorScheme) private var colorScheme
+
+    init(title: String, @ViewBuilder content: () -> Content) {
+        self.title = title
+        self.content = content()
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: WeatherTheme.Spacing.md) {
+            Text(title)
+                .font(.headline)
+                .foregroundStyle(WeatherTheme.text(colorScheme))
+            content
+        }
+        .padding(WeatherTheme.Spacing.lg)
+        .weatherCard(colorScheme)
+    }
+}
+
+private struct AdvisoryDetailModelRow: View {
+    let model: AdvisoryDetailModelResult
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: WeatherTheme.Spacing.xs) {
+            HStack {
+                BriefModelStatusBadge(model: model.model ?? "model", status: model.status ?? "unavailable")
+                Spacer()
+                if let affected = affectedText {
+                    Text(affected)
+                        .font(.caption.monospacedDigit())
+                        .foregroundStyle(WeatherTheme.mutedText(colorScheme))
+                }
+            }
+            if let detail = model.detail {
+                Text(detail)
+                    .font(.subheadline)
+                    .foregroundStyle(WeatherTheme.text(colorScheme))
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            if let crossCheck = model.crossCheck, !crossCheck.isEmpty {
+                Label(crossCheck, systemImage: "info.circle")
+                    .font(.caption)
+                    .foregroundStyle(WeatherTheme.primary(colorScheme))
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+
+    private var affectedText: String? {
+        var parts: [String] = []
+        if let pct = model.affectedPct {
+            parts.append("\(formatNumber(pct))%")
+        }
+        if let nm = model.affectedNm {
+            if let total = model.totalNm {
+                parts.append("\(formatNumber(nm))/\(formatNumber(total)) nm")
+            } else {
+                parts.append("\(formatNumber(nm)) nm")
+            }
+        }
+        return parts.isEmpty ? nil : parts.joined(separator: " · ")
+    }
+}
+
+private struct AdvisoryConvectiveDetailRow: View {
+    let model: String
+    let detail: AdvisoryConvectiveDetail
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: WeatherTheme.Spacing.xs) {
+            Text(model.shortModelName.uppercased())
+                .font(.caption.bold())
+                .foregroundStyle(WeatherTheme.text(colorScheme))
+
+            if let method = detail.assessmentMethod {
+                Label(method, systemImage: "switch.2")
+                    .font(.caption)
+                    .foregroundStyle(WeatherTheme.mutedText(colorScheme))
+            }
+
+            if let range = detail.thermo?.capeRangeJkg, range.count == 2 {
+                Label("\(formatNumber(range[0]))-\(formatNumber(range[1])) J/kg CAPE", systemImage: "chart.line.uptrend.xyaxis")
+                    .font(.caption)
+                    .foregroundStyle(WeatherTheme.mutedText(colorScheme))
+            }
+
+            if let peak = detail.thermo?.peak {
+                Text(peakSummary(peak))
+                    .font(.caption)
+                    .foregroundStyle(WeatherTheme.text(colorScheme))
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            if let nwp = detail.nwp {
+                Text(nwpSummary(nwp))
+                    .font(.caption)
+                    .foregroundStyle(WeatherTheme.mutedText(colorScheme))
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+
+    private func peakSummary(_ peak: AdvisoryThermoPeak) -> String {
+        var parts: [String] = []
+        if let cape = peak.capeJkg {
+            parts.append("peak \(formatNumber(cape)) J/kg")
+        }
+        if let top = peak.elTopFt {
+            parts.append("tops \(formatNumber(top)) ft")
+        }
+        if let waypoint = peak.waypointIcao {
+            parts.append(waypoint)
+        } else if let distance = peak.distanceNm {
+            parts.append("\(formatNumber(distance)) nm")
+        }
+        return parts.joined(separator: " · ")
+    }
+
+    private func nwpSummary(_ nwp: AdvisoryNwpDetail) -> String {
+        var parts: [String] = []
+        if let cover = nwp.maxCoverPct {
+            parts.append("NWP cover \(formatNumber(cover))%")
+        }
+        if let top = nwp.peakTopFt {
+            parts.append("NWP tops \(formatNumber(top)) ft")
+        }
+        if let note = nwp.note {
+            parts.append(note)
+        }
+        return parts.joined(separator: " · ")
+    }
+}
+
+private func formatNumber(_ value: Double) -> String {
+    if value.rounded() == value {
+        return String(Int(value))
+    }
+    return String(format: "%.1f", value)
 }
 
 private struct BriefModelStatusBadge: View {

--- a/app/flyfun-weather/flyfun-weather/Views/Briefing/BriefingContainerView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Briefing/BriefingContainerView.swift
@@ -5,6 +5,7 @@ import SwiftUI
 struct BriefingContainerView: View {
     let flight: FlightResponse
     @Environment(AppState.self) private var appState
+    @Environment(\.colorScheme) private var colorScheme
     @State private var viewModel: BriefingViewModel?
     @State private var trackingService = FlightTrackingService()
     @State private var showingPirepSheet = false
@@ -22,36 +23,27 @@ struct BriefingContainerView: View {
         Group {
             if let viewModel {
                 VStack(spacing: 0) {
+                    BriefingHeaderView(
+                        viewModel: viewModel,
+                        trackingService: trackingService,
+                        isInFlightWindow: isInFlightWindow,
+                        canPublishPirep: appState.userPreferences.preferences.pirepCanPublish,
+                        reportPirep: { showingPirepSheet = true },
+                        startTracking: startTracking
+                    )
                     RefreshBannerView(state: viewModel.refreshState)
                     DownloadBannerView(state: viewModel.downloadState)
                     BriefingContentView(viewModel: viewModel, trackingService: trackingService)
                 }
+                .background(WeatherTheme.background(colorScheme))
             } else {
                 ProgressView("Loading briefing...")
             }
         }
         .navigationTitle(flight.shortTitle)
         .navigationBarTitleDisplayMode(.inline)
-        .toolbar {
-            if let viewModel {
-                ToolbarItem(placement: .topBarTrailing) {
-                    HStack(spacing: 12) {
-                        if isInFlightWindow && appState.userPreferences.preferences.pirepCanPublish {
-                            Button {
-                                showingPirepSheet = true
-                            } label: {
-                                Label("Report PIREP", systemImage: "square.and.pencil")
-                                    .font(.caption)
-                            }
-                        }
-                        BriefingToolbarView(viewModel: viewModel, trackingService: trackingService,
-                                            isInFlightWindow: isInFlightWindow, startTracking: startTracking)
-                    }
-                }
-            }
-        }
         .sheet(isPresented: $showingPirepSheet) {
-            if let viewModel, let repo = appState.repository {
+            if let repo = appState.repository {
                 PirepReportingView(viewModel: PirepViewModel(flight: flight, repository: repo,
                                                                       offlineStore: appState.pirepOfflineStore),
                                    trackingService: trackingService)
@@ -87,6 +79,167 @@ struct BriefingContainerView: View {
         }
         let flightEndTime = departure.addingTimeInterval((flight.flightDurationHours + 2) * 3600)
         trackingService.start(routePoints: routePoints, flightEndTime: flightEndTime)
+    }
+}
+
+/// Persistent briefing chrome shared by all briefing tabs.
+private struct BriefingHeaderView: View {
+    @Bindable var viewModel: BriefingViewModel
+    var trackingService: FlightTrackingService
+    var isInFlightWindow: Bool
+    var canPublishPirep: Bool
+    var reportPirep: () -> Void
+    var startTracking: () -> Void
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: WeatherTheme.Spacing.sm) {
+            HStack(alignment: .firstTextBaseline, spacing: WeatherTheme.Spacing.md) {
+                VStack(alignment: .leading, spacing: WeatherTheme.Spacing.xs) {
+                    Text(viewModel.flight.shortTitle)
+                        .font(.headline)
+                        .foregroundStyle(WeatherTheme.text(colorScheme))
+                        .lineLimit(1)
+                    Text(flightDetails)
+                        .font(.caption)
+                        .foregroundStyle(WeatherTheme.mutedText(colorScheme))
+                        .lineLimit(1)
+                }
+
+                Spacer(minLength: WeatherTheme.Spacing.sm)
+
+                if let assessment = viewModel.pack?.assessment {
+                    AssessmentStringBadge(status: assessment)
+                }
+            }
+
+            HStack(spacing: WeatherTheme.Spacing.sm) {
+                BriefingToolbarView(
+                    viewModel: viewModel,
+                    trackingService: trackingService,
+                    isInFlightWindow: isInFlightWindow,
+                    startTracking: startTracking
+                )
+
+                if isInFlightWindow && canPublishPirep {
+                    Button(action: reportPirep) {
+                        Image(systemName: "square.and.pencil")
+                    }
+                    .accessibilityLabel("Report PIREP")
+                }
+            }
+
+            HStack(spacing: WeatherTheme.Spacing.sm) {
+                statusPill(freshnessText, systemImage: freshnessIcon)
+                statusPill(cacheText, systemImage: cacheIcon)
+                if let activePointText {
+                    statusPill(activePointText, systemImage: "scope")
+                }
+            }
+
+            if let modelSummary {
+                Text(modelSummary)
+                    .font(.caption2.monospacedDigit())
+                    .foregroundStyle(WeatherTheme.mutedText(colorScheme))
+                    .lineLimit(1)
+            }
+        }
+        .padding(.horizontal, WeatherTheme.Spacing.lg)
+        .padding(.vertical, WeatherTheme.Spacing.md)
+        .background(WeatherTheme.surface(colorScheme))
+        .overlay(alignment: .bottom) {
+            Rectangle()
+                .fill(WeatherTheme.border(colorScheme))
+                .frame(height: 0.5)
+        }
+    }
+
+    private func statusPill(_ text: String, systemImage: String) -> some View {
+        Label(text, systemImage: systemImage)
+            .font(.caption2)
+            .lineLimit(1)
+            .foregroundStyle(WeatherTheme.mutedText(colorScheme))
+            .padding(.horizontal, WeatherTheme.Spacing.sm)
+            .padding(.vertical, WeatherTheme.Spacing.xs)
+            .background(WeatherTheme.background(colorScheme), in: RoundedRectangle(cornerRadius: WeatherTheme.Radius.control))
+            .overlay {
+                RoundedRectangle(cornerRadius: WeatherTheme.Radius.control)
+                    .stroke(WeatherTheme.border(colorScheme), lineWidth: 0.5)
+            }
+    }
+
+    private var flightDetails: String {
+        var parts: [String] = []
+        if let date = viewModel.flight.departureDate {
+            parts.append("\(DateFormatter.shortDate.string(from: date)) \(DateFormatter.utcTime.string(from: date))")
+        }
+        parts.append("FL\(viewModel.flight.cruiseAltitudeFt / 100)")
+        parts.append(String(format: "%.1fh", viewModel.flight.flightDurationHours))
+        return parts.joined(separator: " · ")
+    }
+
+    private var freshnessText: String {
+        guard let status = viewModel.pack?.dataStatus else { return "Freshness pending" }
+        if status.fresh { return "Fresh" }
+        if status.staleModels.isEmpty { return "Stale data" }
+        let models = status.staleModels.map(\.shortModelName).joined(separator: "/")
+        return "Stale \(models)"
+    }
+
+    private var freshnessIcon: String {
+        if viewModel.pack?.dataStatus?.fresh == true { return "checkmark.seal" }
+        return "clock.badge.exclamationmark"
+    }
+
+    private var cacheText: String {
+        switch viewModel.downloadState {
+        case .downloaded:
+            return "Downloaded"
+        case .downloading:
+            return "Downloading"
+        case .error:
+            return "Download issue"
+        case .notDownloaded:
+            return "Online pack"
+        }
+    }
+
+    private var cacheIcon: String {
+        switch viewModel.downloadState {
+        case .downloaded:
+            return "arrow.down.circle.fill"
+        case .downloading:
+            return "arrow.down.circle"
+        case .error:
+            return "exclamationmark.arrow.circlepath"
+        case .notDownloaded:
+            return "wifi"
+        }
+    }
+
+    private var activePointText: String? {
+        guard let activePoint = viewModel.activePoint else { return nil }
+        let point = activePoint.waypointIcao ?? "Pt \(activePoint.pointIndex)"
+        return "\(point) · \(Int(activePoint.distanceNm)) nm"
+    }
+
+    private var modelSummary: String? {
+        guard let pack = viewModel.pack else { return nil }
+        if pack.modelInitTimes.isEmpty {
+            return viewModel.availableModels.isEmpty ? nil : "\(viewModel.availableModels.count) models available"
+        }
+        let summary = pack.modelInitTimes
+            .sorted { $0.key < $1.key }
+            .prefix(3)
+            .map { "\($0.key.shortModelName) \(formatModelInit($0.value))" }
+            .joined(separator: " · ")
+        let overflow = pack.modelInitTimes.count > 3 ? " · +\(pack.modelInitTimes.count - 3)" : ""
+        return summary + overflow
+    }
+
+    private func formatModelInit(_ value: Int) -> String {
+        let date = Date(timeIntervalSince1970: TimeInterval(value))
+        return DateFormatter.utcTime.string(from: date)
     }
 }
 
@@ -336,32 +489,23 @@ private struct DownloadBannerView: View {
 private struct BriefingContentView: View {
     @Bindable var viewModel: BriefingViewModel
     var trackingService: FlightTrackingService
-    @Environment(AppState.self) private var appState
 
     var body: some View {
         TabView(selection: $viewModel.selectedTab) {
-            Tab("Advisories", systemImage: "exclamationmark.shield", value: BriefingTab.advisories) {
-                AdvisoryDashboardView(viewModel: viewModel)
+            Tab("Brief", systemImage: "doc.text.magnifyingglass", value: BriefingTab.brief) {
+                BriefTabView(viewModel: viewModel)
             }
 
             Tab("Cross-Section", systemImage: "chart.xyaxis.line", value: BriefingTab.crossSection) {
                 CrossSectionView(viewModel: viewModel, trackingService: trackingService)
             }
 
+            Tab("Skew-T", systemImage: "chart.line.uptrend.xyaxis", value: BriefingTab.skewT) {
+                SkewTTabView(viewModel: viewModel)
+            }
+
             Tab("Map", systemImage: "map", value: BriefingTab.map) {
                 RouteMapView(viewModel: viewModel, trackingService: trackingService)
-            }
-
-            Tab("Digest", systemImage: "doc.text", value: BriefingTab.digest) {
-                DigestView(viewModel: viewModel)
-            }
-
-            if appState.userPreferences.preferences.pirepCanView {
-                Tab("PIREPs", systemImage: "cloud.sun", value: BriefingTab.pireps) {
-                    PirepListView(pirepsState: viewModel.pirepsState) {
-                        await viewModel.loadPireps()
-                    }
-                }
             }
         }
     }

--- a/app/flyfun-weather/flyfun-weather/Views/CrossSection/ColorScales.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/CrossSection/ColorScales.swift
@@ -64,6 +64,9 @@ nonisolated enum ColorScales {
     static let freezingLevelColor = Color(.sRGB, red: 0, green: 188 / 255.0, blue: 212 / 255.0)
     static let minus10cColor = Color(.sRGB, red: 33 / 255.0, green: 150 / 255.0, blue: 243 / 255.0)
     static let minus20cColor = Color(.sRGB, red: 26 / 255.0, green: 35 / 255.0, blue: 126 / 255.0)
+    static let lclColor = Color(.sRGB, red: 76 / 255.0, green: 175 / 255.0, blue: 80 / 255.0)
+    static let lfcColor = Color(.sRGB, red: 1.0, green: 152 / 255.0, blue: 0)
+    static let elColor = Color(.sRGB, red: 244 / 255.0, green: 67 / 255.0, blue: 54 / 255.0)
 
     // MARK: - Reference
 

--- a/app/flyfun-weather/flyfun-weather/Views/CrossSection/CrossSectionView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/CrossSection/CrossSectionView.swift
@@ -9,12 +9,32 @@ struct CrossSectionView: View {
     var trackingService: FlightTrackingService
     @State private var csVM = CrossSectionViewModel()
     @State private var canvasSize: CGSize = .zero
+    @State private var scrubDistanceNm: Double?
+    @State private var scrubAltitudeFt: Double?
+    @State private var routeGraphLeftMetricId = "headwind"
+    @State private var routeGraphRightMetricId = "cloud-cover"
+    @State private var isRouteGraphVisible = true
+    @State private var isConfigPresented = false
+    @State private var isFocusMode = false
 
     var body: some View {
         ScrollView {
             VStack(spacing: 0) {
-                // Layer toggle chips
-                layerChips
+                if !isFocusMode {
+                    crossSectionChrome
+                }
+
+                if let vizData = csVM.vizData {
+                    CrossSectionReadoutStrip(
+                        viewModel: viewModel,
+                        vizData: vizData,
+                        enabledLayers: csVM.enabledLayers,
+                        distanceNm: selectedDistanceNm,
+                        altitudeFt: scrubAltitudeFt,
+                        leftMetricId: routeGraphLeftMetricId,
+                        rightMetricId: routeGraphRightMetricId
+                    )
+                }
 
                 // Cross-section canvas
                 crossSectionCanvas
@@ -24,8 +44,22 @@ struct CrossSectionView: View {
                 }
 
                 // Route graph below
-                RouteGraphView(viewModel: viewModel, vizData: csVM.vizData)
+                if isRouteGraphVisible && !isFocusMode {
+                    RouteGraphView(
+                        viewModel: viewModel,
+                        vizData: csVM.vizData,
+                        selectedDistanceNm: selectedDistanceNm,
+                        leftMetricId: $routeGraphLeftMetricId,
+                        rightMetricId: $routeGraphRightMetricId,
+                        onScrubDistance: scrubToDistance
+                    )
+                }
             }
+        }
+        .sheet(isPresented: $isConfigPresented) {
+            CrossSectionConfigSheet(csVM: csVM)
+                .presentationDetents([.medium, .large])
+                .presentationDragIndicator(.visible)
         }
         .onChange(of: viewModel.selectedModel) {
             updateVizData()
@@ -39,6 +73,46 @@ struct CrossSectionView: View {
         .task {
             updateVizData()
         }
+    }
+
+    private var crossSectionChrome: some View {
+        HStack(spacing: WeatherTheme.Spacing.sm) {
+            ModelSelectorView(selectedModel: Binding(
+                get: { viewModel.selectedModel },
+                set: { viewModel.selectedModel = $0 }
+            ), models: viewModel.availableModels)
+
+            Spacer()
+
+            Button {
+                isConfigPresented = true
+            } label: {
+                Label("Layers", systemImage: "slider.horizontal.3")
+                    .font(.caption.bold())
+            }
+            .buttonStyle(.bordered)
+
+            Button {
+                withAnimation(.snappy) {
+                    isRouteGraphVisible.toggle()
+                }
+            } label: {
+                Image(systemName: isRouteGraphVisible ? "chart.bar.xaxis" : "chart.bar.xaxis.ascending")
+            }
+            .accessibilityLabel(isRouteGraphVisible ? "Hide route graph" : "Show route graph")
+
+            Button {
+                withAnimation(.snappy) {
+                    isFocusMode.toggle()
+                }
+            } label: {
+                Image(systemName: "arrow.down.right.and.arrow.up.left")
+            }
+            .accessibilityLabel("Focus cross-section")
+        }
+        .padding(.horizontal, WeatherTheme.Spacing.lg)
+        .padding(.vertical, WeatherTheme.Spacing.sm)
+        .background(.regularMaterial)
     }
 
     @ViewBuilder
@@ -64,8 +138,38 @@ struct CrossSectionView: View {
                 Color.clear.onAppear { canvasSize = geo.size }
                     .onChange(of: geo.size) { _, newSize in canvasSize = newSize }
             })
-            .onTapGesture { location in
-                handleTap(at: location)
+            .gesture(
+                DragGesture(minimumDistance: 0)
+                    .onChanged { value in
+                        handleScrub(at: value.location)
+                    }
+                    .onEnded { value in
+                        handleScrub(at: value.location)
+                    }
+            )
+            .overlay(alignment: .topTrailing) {
+                if isFocusMode {
+                    HStack(spacing: WeatherTheme.Spacing.sm) {
+                        Button {
+                            isConfigPresented = true
+                        } label: {
+                            Image(systemName: "slider.horizontal.3")
+                        }
+                        .accessibilityLabel("Layers")
+
+                        Button {
+                            withAnimation(.snappy) {
+                                isFocusMode = false
+                            }
+                        } label: {
+                            Image(systemName: "arrow.up.left.and.arrow.down.right")
+                        }
+                        .accessibilityLabel("Exit focus")
+                    }
+                    .padding(WeatherTheme.Spacing.sm)
+                    .background(.regularMaterial, in: Capsule())
+                    .padding(WeatherTheme.Spacing.sm)
+                }
             }
         } else {
             switch viewModel.routeAnalysesState {
@@ -82,98 +186,6 @@ struct CrossSectionView: View {
         }
     }
 
-    private var layerChips: some View {
-        ScrollView(.horizontal, showsIndicators: false) {
-            HStack(spacing: 6) {
-                // Model selector
-                ModelSelectorView(selectedModel: Binding(
-                    get: { viewModel.selectedModel },
-                    set: { viewModel.selectedModel = $0 }
-                ), models: viewModel.availableModels)
-
-                Divider().frame(height: 20)
-
-                // Method-picker dropdowns: clouds / icing / turbulence / convection.
-                // Each is a single mutually-exclusive choice with a "None" option.
-                ForEach(LayerGroup.allCases.filter(\.isMethodGroup), id: \.self) { group in
-                    methodMenu(for: group)
-                }
-
-                Divider().frame(height: 20)
-
-                // Toggle chips: terrain / reference / temperature / stability layers
-                // remain independently toggleable.
-                ForEach(CrossSectionLayer.allLayers.filter { !$0.group.isMethodGroup }, id: \.id) { layer in
-                    toggleChip(for: layer)
-                }
-            }
-            .padding(.horizontal, 12)
-            .padding(.vertical, 6)
-        }
-    }
-
-    /// Dropdown menu for a method group (clouds / icing / turbulence / convection).
-    /// Items: "None" + each method in the group, with a checkmark on the active one.
-    @ViewBuilder
-    private func methodMenu(for group: LayerGroup) -> some View {
-        let active = csVM.activeMethod(for: group)
-        let activeLabel = active.flatMap { CrossSectionLayer.methodLabels[$0] } ?? "None"
-
-        Menu {
-            Button {
-                csVM.setMethod(nil, for: group)
-            } label: {
-                if active == nil {
-                    Label("None", systemImage: "checkmark")
-                } else {
-                    Text("None")
-                }
-            }
-            ForEach(CrossSectionLayer.methodGroupOrder[group] ?? [], id: \.self) { layerId in
-                Button {
-                    csVM.setMethod(layerId, for: group)
-                } label: {
-                    if active == layerId {
-                        Label(CrossSectionLayer.methodLabels[layerId] ?? layerId, systemImage: "checkmark")
-                    } else {
-                        Text(CrossSectionLayer.methodLabels[layerId] ?? layerId)
-                    }
-                }
-            }
-        } label: {
-            HStack(spacing: 4) {
-                Text("\(group.label): \(activeLabel)")
-                    .font(.caption2)
-                Image(systemName: "chevron.down")
-                    .font(.system(size: 8, weight: .semibold))
-            }
-            .padding(.horizontal, 8)
-            .padding(.vertical, 4)
-            .background(active != nil ? Color.accentColor.opacity(0.15) : Color.clear)
-            .foregroundStyle(active != nil ? .primary : .secondary)
-            .clipShape(Capsule())
-            .overlay(Capsule().stroke(active != nil ? Color.accentColor : Color.gray.opacity(0.3), lineWidth: 0.5))
-        }
-    }
-
-    @ViewBuilder
-    private func toggleChip(for layer: any CrossSectionLayerProtocol) -> some View {
-        let enabled = csVM.enabledLayers[layer.id] ?? false
-        Button {
-            csVM.toggleLayer(layer.id)
-        } label: {
-            Text(layer.name)
-                .font(.caption2)
-                .padding(.horizontal, 8)
-                .padding(.vertical, 4)
-                .background(enabled ? Color.accentColor.opacity(0.15) : Color.clear)
-                .foregroundStyle(enabled ? .primary : .secondary)
-                .clipShape(Capsule())
-                .overlay(Capsule().stroke(enabled ? Color.accentColor : Color.gray.opacity(0.3), lineWidth: 0.5))
-        }
-        .buttonStyle(.plain)
-    }
-
     /// Aircraft position for cross-section overlay, from flight tracking service.
     private var aircraftPosition: CrossSectionRenderer.AircraftPosition? {
         guard trackingService.isTracking, let pos = trackingService.projectedPosition,
@@ -183,39 +195,47 @@ struct CrossSectionView: View {
 
     /// Distance along route for the selected point, used to draw the vertical indicator.
     private var selectedDistanceNm: Double? {
-        viewModel.activePoint?.distanceNm
+        scrubDistanceNm ?? viewModel.activePoint?.distanceNm
     }
 
-    // MARK: - Tap handling
+    // MARK: - Scrub handling
 
-    private func handleTap(at location: CGPoint) {
+    private func handleScrub(at location: CGPoint) {
         guard let vizData = csVM.vizData else { return }
-        let points = vizData.points
-        guard !points.isEmpty, canvasSize.width > 0 else { return }
+        guard !vizData.points.isEmpty, canvasSize.width > 0 else { return }
 
         let transform = CoordTransform(
             size: canvasSize,
             maxDistanceNm: vizData.totalDistanceNm,
             maxAltitudeFt: vizData.flightCeilingFt
         )
-        let tapDistanceNm = transform.xToDistance(location.x)
-        let nearest = points.enumerated().min(by: {
-            abs($0.element.distanceNm - tapDistanceNm) < abs($1.element.distanceNm - tapDistanceNm)
-        })
+        let clampedX = min(max(location.x, transform.plotArea.left), transform.plotArea.right)
+        let clampedY = min(max(location.y, transform.plotArea.top), transform.plotArea.bottom)
+        let distanceNm = min(max(transform.xToDistance(clampedX), 0), vizData.totalDistanceNm)
+        let altitudeFt = min(max(transform.yToAltitude(clampedY), 0), vizData.flightCeilingFt)
 
-        guard let nearest else { return }
+        scrubDistanceNm = distanceNm
+        scrubAltitudeFt = altitudeFt
+        setActivePoint(nearestTo: distanceNm)
+    }
 
-        // Find the point_index from route analyses
+    private func scrubToDistance(_ distanceNm: Double) {
+        guard let vizData = csVM.vizData else { return }
+        let clamped = min(max(distanceNm, 0), vizData.totalDistanceNm)
+        scrubDistanceNm = clamped
+        setActivePoint(nearestTo: clamped)
+    }
+
+    private func setActivePoint(nearestTo distanceNm: Double) {
         if case .loaded(let analyses) = viewModel.routeAnalysesState {
             let routePoint = analyses.analyses.min(by: {
-                abs($0.distanceFromOriginNm - vizData.points[nearest.offset].distanceNm) <
-                abs($1.distanceFromOriginNm - vizData.points[nearest.offset].distanceNm)
+                abs($0.distanceFromOriginNm - distanceNm) < abs($1.distanceFromOriginNm - distanceNm)
             })
             if let routePoint {
                 withAnimation(.snappy) {
                     viewModel.setActivePoint(routePoint)
                 }
-                logger.info("Tapped point \(routePoint.pointIndex) at \(routePoint.distanceFromOriginNm)nm")
+                logger.debug("Scrubbed point \(routePoint.pointIndex) at \(routePoint.distanceFromOriginNm)nm")
             }
         }
     }
@@ -284,5 +304,387 @@ private struct CrossSectionActivePointBar: View {
     private var pointLabel: String {
         let name = activePoint.waypointIcao ?? "Point \(activePoint.pointIndex)"
         return "\(name) · \(Int(activePoint.distanceNm)) nm · \(viewModel.selectedModel.uppercased())"
+    }
+}
+
+private struct CrossSectionReadoutStrip: View {
+    let viewModel: BriefingViewModel
+    let vizData: VizRouteData
+    let enabledLayers: [String: Bool]
+    let distanceNm: Double?
+    let altitudeFt: Double?
+    let leftMetricId: String
+    let rightMetricId: String
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: WeatherTheme.Spacing.sm) {
+                ForEach(readoutItems) { item in
+                    VStack(alignment: .leading, spacing: 2) {
+                        HStack(spacing: 4) {
+                            Circle()
+                                .fill(item.color)
+                                .frame(width: 6, height: 6)
+                            Text(item.title)
+                                .font(.caption2)
+                                .foregroundStyle(WeatherTheme.mutedText(colorScheme))
+                        }
+                        Text(item.value)
+                            .font(.caption.monospacedDigit())
+                            .foregroundStyle(WeatherTheme.text(colorScheme))
+                    }
+                    .padding(.horizontal, WeatherTheme.Spacing.sm)
+                    .padding(.vertical, WeatherTheme.Spacing.xs)
+                    .background(WeatherTheme.surface(colorScheme), in: RoundedRectangle(cornerRadius: WeatherTheme.Radius.control))
+                    .overlay {
+                        RoundedRectangle(cornerRadius: WeatherTheme.Radius.control)
+                            .stroke(WeatherTheme.border(colorScheme), lineWidth: 0.5)
+                    }
+                }
+
+                Button {
+                    viewModel.setFocusIntent(.init(
+                        target: .skewT,
+                        model: viewModel.selectedModel,
+                        pointIndex: viewModel.activePoint?.pointIndex,
+                        distanceNm: distanceNm
+                    ))
+                } label: {
+                    Label("Sounding", systemImage: "chart.line.uptrend.xyaxis")
+                        .font(.caption.bold())
+                }
+                .buttonStyle(.borderedProminent)
+            }
+            .padding(.horizontal, WeatherTheme.Spacing.lg)
+            .padding(.vertical, WeatherTheme.Spacing.sm)
+        }
+        .background(.regularMaterial)
+    }
+
+    private var nearestPoint: VizPoint? {
+        guard let distanceNm else { return vizData.points.first }
+        return vizData.points.min {
+            abs($0.distanceNm - distanceNm) < abs($1.distanceNm - distanceNm)
+        }
+    }
+
+    private var readoutItems: [CrossSectionReadoutItem] {
+        guard let point = nearestPoint else { return [] }
+
+        var items: [CrossSectionReadoutItem] = [
+            .init(id: "distance", title: "Distance", value: "\(Int(point.distanceNm)) nm", color: WeatherTheme.primary(colorScheme)),
+            .init(id: "time", title: "ETA", value: timeLabel(point.time), color: .secondary),
+        ]
+
+        if let altitudeFt {
+            items.append(.init(id: "altitude", title: "Cursor", value: altitudeLabel(altitudeFt), color: .orange))
+        }
+
+        if let cloud = cloudReadout(point: point) {
+            items.append(cloud)
+        }
+        if let icing = icingReadout(point: point) {
+            items.append(icing)
+        }
+        if let turbulence = turbulenceReadout(point: point) {
+            items.append(turbulence)
+        }
+        if let convection = convectionReadout(point: point) {
+            items.append(convection)
+        }
+        if let metric = metricReadout(id: leftMetricId, point: point) {
+            items.append(metric)
+        }
+        if rightMetricId != "none", let metric = metricReadout(id: rightMetricId, point: point) {
+            items.append(metric)
+        }
+        return items
+    }
+
+    private func cloudReadout(point: VizPoint) -> CrossSectionReadoutItem? {
+        guard let active = activeMethod(for: .clouds) else { return nil }
+        let layers = active.contains("nwp") ? (point.nwpCloudLayers ?? []) : point.cloudLayers
+        if let altitudeFt,
+           let layer = layers.first(where: { altitudeFt >= $0.baseFt && altitudeFt <= $0.topFt }) {
+            return .init(id: "clouds", title: "Cloud", value: "\(layer.coverage.uppercased()) \(altitudeLabel(layer.baseFt))-\(altitudeLabel(layer.topFt))", color: .gray)
+        }
+        return .init(id: "clouds", title: "Cloud", value: "\(Int(point.cloudCoverTotalPct))%", color: .gray)
+    }
+
+    private func icingReadout(point: VizPoint) -> CrossSectionReadoutItem? {
+        guard let active = activeMethod(for: .icing) else { return nil }
+        let zones: [VizIcingZone]
+        switch active {
+        case "icing-ogimet-nwp-bands":
+            zones = point.icingOgimetNwpZones
+        case "sfip-bands":
+            zones = point.sfipZones.map { VizIcingZone(baseFt: $0.baseFt, topFt: $0.topFt, risk: $0.risk, type: $0.type) }
+        default:
+            zones = point.icingZones
+        }
+        guard !zones.isEmpty else { return nil }
+        if let altitudeFt,
+           let zone = zones.first(where: { altitudeFt >= $0.baseFt && altitudeFt <= $0.topFt }) {
+            return .init(id: "icing", title: "Icing", value: "\(zone.risk.capitalized) \(altitudeLabel(zone.baseFt))-\(altitudeLabel(zone.topFt))", color: .cyan)
+        }
+        let worst = zones.max { icingRank($0.risk) < icingRank($1.risk) }
+        return worst.map { .init(id: "icing", title: "Icing", value: $0.risk.capitalized, color: .cyan) }
+    }
+
+    private func turbulenceReadout(point: VizPoint) -> CrossSectionReadoutItem? {
+        guard activeMethod(for: .turbulence) != nil, !point.catLayers.isEmpty else { return nil }
+        if let altitudeFt,
+           let layer = point.catLayers.first(where: { altitudeFt >= $0.baseFt && altitudeFt <= $0.topFt }) {
+            return .init(id: "turbulence", title: "Turb", value: "\(layer.risk.capitalized) \(altitudeLabel(layer.baseFt))-\(altitudeLabel(layer.topFt))", color: .orange)
+        }
+        let worst = point.catLayers.max { icingRank($0.risk) < icingRank($1.risk) }
+        return worst.map { .init(id: "turbulence", title: "Turb", value: $0.risk.capitalized, color: .orange) }
+    }
+
+    private func convectionReadout(point: VizPoint) -> CrossSectionReadoutItem? {
+        guard let active = activeMethod(for: .convection) else { return nil }
+        let risk = active == "nwp-convective-bg" ? point.nwpConvectiveRisk : point.convectiveRisk
+        guard risk != "none" else { return nil }
+        return .init(id: "convection", title: "Convection", value: risk.capitalized, color: .red)
+    }
+
+    private func metricReadout(id: String, point: VizPoint) -> CrossSectionReadoutItem? {
+        guard let metric = RouteGraphMetrics.metric(byId: id),
+              let value = metric.getValue(point) else { return nil }
+        return .init(id: "metric-\(id)", title: metric.label, value: metric.formatValue(value), color: metric.color)
+    }
+
+    private func activeMethod(for group: LayerGroup) -> String? {
+        CrossSectionLayer.methodGroupOrder[group]?.first { enabledLayers[$0] == true }
+    }
+
+    private func altitudeLabel(_ feet: Double) -> String {
+        if feet >= 10_000 {
+            return "FL\(Int(feet / 100))"
+        }
+        return "\(Int(feet)) ft"
+    }
+
+    private func timeLabel(_ raw: String) -> String {
+        if let date = ISO8601DateFormatter().date(from: raw) {
+            return DateFormatter.utcTime.string(from: date)
+        }
+        return raw
+    }
+
+    private func icingRank(_ risk: String) -> Int {
+        switch risk.lowercased() {
+        case "severe", "extreme": 3
+        case "moderate", "high": 2
+        case "light", "low": 1
+        default: 0
+        }
+    }
+}
+
+private struct CrossSectionReadoutItem: Identifiable {
+    let id: String
+    let title: String
+    let value: String
+    let color: Color
+}
+
+private struct CrossSectionConfigSheet: View {
+    @Bindable var csVM: CrossSectionViewModel
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: WeatherTheme.Spacing.lg) {
+                    presetSection
+                    methodSection
+                    referenceSection
+                }
+                .padding(WeatherTheme.Spacing.lg)
+            }
+            .background(WeatherTheme.background(colorScheme))
+            .navigationTitle("Cross-Section")
+            .navigationBarTitleDisplayMode(.inline)
+        }
+    }
+
+    private var presetSection: some View {
+        VStack(alignment: .leading, spacing: WeatherTheme.Spacing.md) {
+            Text("Preset")
+                .font(.headline)
+
+            HStack(spacing: WeatherTheme.Spacing.sm) {
+                ForEach(CrossSectionLayerPreset.allCases, id: \.self) { preset in
+                    Button {
+                        csVM.applyLayerPreset(preset.enabledLayers)
+                    } label: {
+                        Label(preset.label, systemImage: preset.systemImage)
+                            .font(.caption.bold())
+                    }
+                    .buttonStyle(.bordered)
+                }
+            }
+        }
+        .padding(WeatherTheme.Spacing.lg)
+        .background(WeatherTheme.surface(colorScheme), in: RoundedRectangle(cornerRadius: WeatherTheme.Radius.card))
+    }
+
+    private var methodSection: some View {
+        VStack(alignment: .leading, spacing: WeatherTheme.Spacing.md) {
+            Text("Methods")
+                .font(.headline)
+
+            ForEach(LayerGroup.allCases.filter(\.isMethodGroup), id: \.self) { group in
+                methodRow(for: group)
+            }
+        }
+        .padding(WeatherTheme.Spacing.lg)
+        .background(WeatherTheme.surface(colorScheme), in: RoundedRectangle(cornerRadius: WeatherTheme.Radius.card))
+    }
+
+    private var referenceSection: some View {
+        VStack(alignment: .leading, spacing: WeatherTheme.Spacing.md) {
+            Text("Reference")
+                .font(.headline)
+
+            ForEach(CrossSectionLayer.allLayers.filter { !$0.group.isMethodGroup }, id: \.id) { layer in
+                Toggle(isOn: layerBinding(layer.id)) {
+                    HStack(spacing: WeatherTheme.Spacing.sm) {
+                        swatch(for: layer.id)
+                        Text(layer.name)
+                    }
+                }
+            }
+        }
+        .padding(WeatherTheme.Spacing.lg)
+        .background(WeatherTheme.surface(colorScheme), in: RoundedRectangle(cornerRadius: WeatherTheme.Radius.card))
+    }
+
+    private func methodRow(for group: LayerGroup) -> some View {
+        let active = csVM.activeMethod(for: group)
+        let activeLabel = active.flatMap { CrossSectionLayer.methodLabels[$0] } ?? "None"
+
+        return HStack(spacing: WeatherTheme.Spacing.md) {
+            swatch(for: active)
+            Text(group.label)
+                .font(.subheadline.bold())
+            Spacer()
+            Menu {
+                Button {
+                    csVM.setMethod(nil, for: group)
+                } label: {
+                    menuLabel("None", selected: active == nil)
+                }
+                ForEach(CrossSectionLayer.methodGroupOrder[group] ?? [], id: \.self) { layerId in
+                    Button {
+                        csVM.setMethod(layerId, for: group)
+                    } label: {
+                        menuLabel(CrossSectionLayer.methodLabels[layerId] ?? layerId, selected: active == layerId)
+                    }
+                }
+            } label: {
+                HStack(spacing: 4) {
+                    Text(activeLabel)
+                        .font(.caption.bold())
+                    Image(systemName: "chevron.down")
+                        .font(.caption2)
+                }
+                .padding(.horizontal, WeatherTheme.Spacing.sm)
+                .padding(.vertical, WeatherTheme.Spacing.xs)
+                .background(WeatherTheme.primary(colorScheme).opacity(active == nil ? 0 : 0.10), in: Capsule())
+            }
+            .buttonStyle(.plain)
+        }
+    }
+
+    private func menuLabel(_ title: String, selected: Bool) -> some View {
+        HStack {
+            Text(title)
+            if selected {
+                Image(systemName: "checkmark")
+            }
+        }
+    }
+
+    private func layerBinding(_ id: String) -> Binding<Bool> {
+        Binding(
+            get: { csVM.enabledLayers[id] ?? false },
+            set: { csVM.setLayer(id, enabled: $0) }
+        )
+    }
+
+    private func swatch(for layerId: String?) -> some View {
+        RoundedRectangle(cornerRadius: 3)
+            .fill(swatchColor(for: layerId))
+            .frame(width: 18, height: 12)
+            .overlay {
+                RoundedRectangle(cornerRadius: 3)
+                    .stroke(WeatherTheme.border(colorScheme), lineWidth: 0.5)
+            }
+    }
+
+    private func swatchColor(for layerId: String?) -> Color {
+        guard let layerId else { return .clear }
+        if layerId.contains("cloud") { return .gray.opacity(0.65) }
+        if layerId.contains("icing") || layerId.contains("sfip") { return .cyan.opacity(0.75) }
+        if layerId.contains("cat") { return .orange.opacity(0.75) }
+        if layerId.contains("convective") { return .red.opacity(0.65) }
+        if layerId.contains("terrain") { return ColorScales.terrainFill }
+        if layerId.contains("freezing") { return ColorScales.freezingLevelColor }
+        if layerId.contains("minus-10") { return ColorScales.minus10cColor }
+        if layerId.contains("minus-20") { return ColorScales.minus20cColor }
+        if layerId == "lcl" { return ColorScales.lclColor }
+        if layerId == "lfc" { return ColorScales.lfcColor }
+        if layerId == "el" { return ColorScales.elColor }
+        return WeatherTheme.primary(colorScheme)
+    }
+}
+
+private enum CrossSectionLayerPreset: CaseIterable {
+    case gramet
+    case windy
+    case foreFlight
+
+    var label: String {
+        switch self {
+        case .gramet: "GRAMET"
+        case .windy: "Windy"
+        case .foreFlight: "ForeFlight"
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .gramet: "cloud"
+        case .windy: "wind"
+        case .foreFlight: "square.grid.3x3"
+        }
+    }
+
+    var enabledLayers: [String: Bool] {
+        var layers = CrossSectionLayer.defaultEnabled
+        switch self {
+        case .gramet:
+            return layers
+        case .windy:
+            layers["soft-nwp-cloud-bands"] = false
+            layers["nwp-cloud-bands"] = true
+            layers["square-nwp-cloud-bands"] = false
+            layers["icing-ogimet-nwp-bands"] = true
+            layers["nwp-convective-bg"] = true
+            layers["minus-10c"] = true
+            layers["minus-20c"] = true
+            return layers
+        case .foreFlight:
+            layers["soft-nwp-cloud-bands"] = false
+            layers["square-nwp-cloud-bands"] = true
+            layers["nwp-cloud-bands"] = false
+            layers["icing-ogimet-nwp-bands"] = true
+            layers["cat-bands"] = true
+            layers["nwp-convective-bg"] = true
+            return layers
+        }
     }
 }

--- a/app/flyfun-weather/flyfun-weather/Views/CrossSection/CrossSectionView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/CrossSection/CrossSectionView.swift
@@ -8,7 +8,6 @@ struct CrossSectionView: View {
     let viewModel: BriefingViewModel
     var trackingService: FlightTrackingService
     @State private var csVM = CrossSectionViewModel()
-    @State private var selectedPointIndex: Int?
     @State private var canvasSize: CGSize = .zero
 
     var body: some View {
@@ -20,16 +19,12 @@ struct CrossSectionView: View {
                 // Cross-section canvas
                 crossSectionCanvas
 
+                if let activePoint = viewModel.activePoint {
+                    CrossSectionActivePointBar(viewModel: viewModel, activePoint: activePoint)
+                }
+
                 // Route graph below
                 RouteGraphView(viewModel: viewModel, vizData: csVM.vizData)
-
-                // Skew-T detail for selected point
-                if let pointIndex = selectedPointIndex {
-                    Divider()
-                    SkewTDetailView(viewModel: viewModel, pointIndex: pointIndex)
-                        .frame(minHeight: 300)
-                        .transition(.move(edge: .bottom))
-                }
             }
         }
         .onChange(of: viewModel.selectedModel) {
@@ -188,11 +183,7 @@ struct CrossSectionView: View {
 
     /// Distance along route for the selected point, used to draw the vertical indicator.
     private var selectedDistanceNm: Double? {
-        guard let idx = selectedPointIndex,
-              case .loaded(let analyses) = viewModel.routeAnalysesState,
-              let rpa = analyses.analyses.first(where: { $0.pointIndex == idx })
-        else { return nil }
-        return rpa.distanceFromOriginNm
+        viewModel.activePoint?.distanceNm
     }
 
     // MARK: - Tap handling
@@ -221,12 +212,8 @@ struct CrossSectionView: View {
                 abs($1.distanceFromOriginNm - vizData.points[nearest.offset].distanceNm)
             })
             if let routePoint {
-                withAnimation {
-                    if selectedPointIndex == routePoint.pointIndex {
-                        selectedPointIndex = nil // toggle off
-                    } else {
-                        selectedPointIndex = routePoint.pointIndex
-                    }
+                withAnimation(.snappy) {
+                    viewModel.setActivePoint(routePoint)
                 }
                 logger.info("Tapped point \(routePoint.pointIndex) at \(routePoint.distanceFromOriginNm)nm")
             }
@@ -254,5 +241,48 @@ struct CrossSectionView: View {
                 logger.warning("vizData is nil after update")
             }
         }
+    }
+}
+
+private struct CrossSectionActivePointBar: View {
+    let viewModel: BriefingViewModel
+    let activePoint: BriefingActivePoint
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        HStack(spacing: WeatherTheme.Spacing.sm) {
+            Label(pointLabel, systemImage: "scope")
+                .font(.caption.monospacedDigit())
+                .foregroundStyle(WeatherTheme.mutedText(colorScheme))
+                .lineLimit(1)
+
+            Spacer()
+
+            Button {
+                viewModel.setFocusIntent(.init(
+                    target: .skewT,
+                    model: viewModel.selectedModel,
+                    pointIndex: activePoint.pointIndex,
+                    distanceNm: activePoint.distanceNm
+                ))
+            } label: {
+                Label("Sounding", systemImage: "chart.line.uptrend.xyaxis")
+                    .font(.caption.bold())
+            }
+            .buttonStyle(.bordered)
+        }
+        .padding(.horizontal, WeatherTheme.Spacing.lg)
+        .padding(.vertical, WeatherTheme.Spacing.sm)
+        .background(WeatherTheme.surface(colorScheme))
+        .overlay(alignment: .bottom) {
+            Rectangle()
+                .fill(WeatherTheme.border(colorScheme))
+                .frame(height: 0.5)
+        }
+    }
+
+    private var pointLabel: String {
+        let name = activePoint.waypointIcao ?? "Point \(activePoint.pointIndex)"
+        return "\(name) · \(Int(activePoint.distanceNm)) nm · \(viewModel.selectedModel.uppercased())"
     }
 }

--- a/app/flyfun-weather/flyfun-weather/Views/CrossSection/Layers/CloudStyleBandsLayer.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/CrossSection/Layers/CloudStyleBandsLayer.swift
@@ -1,0 +1,381 @@
+import SwiftUI
+
+/// Natural and square cloud styles for the same DD/NWP source axis the web uses.
+/// Soft cloud bands stay in SoftCloudBandsLayer; these styles fill the parity gap
+/// for web's cloud-bands-factory source x style matrix.
+struct CloudStyleBandsLayer: CrossSectionLayerProtocol {
+    enum Source {
+        case dd
+        case nwp
+    }
+
+    enum Style {
+        case natural
+        case square
+    }
+
+    let source: Source
+    let style: Style
+
+    var id: String {
+        switch (source, style) {
+        case (.dd, .natural): "cloud-bands"
+        case (.nwp, .natural): "nwp-cloud-bands"
+        case (.dd, .square): "square-cloud-bands"
+        case (.nwp, .square): "square-nwp-cloud-bands"
+        }
+    }
+
+    var name: String {
+        switch (source, style) {
+        case (.dd, .natural): "DD Natural"
+        case (.nwp, .natural): "NWP Natural"
+        case (.dd, .square): "Square DD"
+        case (.nwp, .square): "Square NWP"
+        }
+    }
+
+    let group: LayerGroup = .clouds
+
+    func render(context: inout GraphicsContext, transform: CoordTransform, data: VizRouteData) {
+        let getZones: (VizPoint) -> [VizCloudLayer] = { pt in
+            source == .dd ? pt.cloudLayers : (pt.nwpCloudLayers ?? [])
+        }
+
+        guard data.points.contains(where: { getZones($0).isEmpty == false }) else { return }
+
+        renderMatchedCloudZones(
+            &context,
+            transform: transform,
+            data: data,
+            getZones: getZones,
+            draw: { ctx, points, cloud, matched in
+                switch style {
+                case .natural:
+                    drawNaturalCloudBand(&ctx, points: points, transform: transform, cloud: cloud, matched: matched, source: source)
+                case .square:
+                    drawSquareCloudBand(&ctx, points: points, transform: transform, cloud: cloud, matched: matched, source: source)
+                }
+            }
+        )
+    }
+}
+
+private struct NaturalCloudConfig {
+    let fillFraction: [String: Double]
+    let minFillFraction: Double
+    let blobSpacingPx: CGFloat
+    let blobRadiusXPx: CGFloat
+    let blobHeightFraction: CGFloat
+    let blobJitterX: CGFloat
+    let blobJitterY: CGFloat
+    let blobSizeVariation: CGFloat
+    let subBlobsPerSlot: Int
+    let subBlobOffsetFraction: CGFloat
+    let subBlobSizeFraction: CGFloat
+    let subBlobSizeJitter: CGFloat
+    let radiusCoverageScaleFloor: Double
+}
+
+private let defaultNaturalCloudConfig = NaturalCloudConfig(
+    fillFraction: ["FEW": 1.0, "SCT": 1.0, "BKN": 1.0, "OVC": 1.0],
+    minFillFraction: 1.0,
+    blobSpacingPx: 28,
+    blobRadiusXPx: 36,
+    blobHeightFraction: 0.6,
+    blobJitterX: 0.4,
+    blobJitterY: 0.15,
+    blobSizeVariation: 0.5,
+    subBlobsPerSlot: 3,
+    subBlobOffsetFraction: 0.35,
+    subBlobSizeFraction: 0.65,
+    subBlobSizeJitter: 0.25,
+    radiusCoverageScaleFloor: 1.0
+)
+
+private func renderMatchedCloudZones(
+    _ context: inout GraphicsContext,
+    transform: CoordTransform,
+    data: VizRouteData,
+    getZones: (VizPoint) -> [VizCloudLayer],
+    draw: (inout GraphicsContext, [BandPoint], VizCloudLayer, VizCloudLayer?) -> Void
+) {
+    let pts = data.points
+
+    if pts.count == 1 {
+        let p = pts[0]
+        for cloud in getZones(p) {
+            draw(
+                &context,
+                [BandPoint(distanceNm: p.distanceNm, baseFt: cloud.baseFt, topFt: cloud.topFt)],
+                cloud,
+                nil
+            )
+        }
+        return
+    }
+
+    guard pts.count >= 2 else { return }
+
+    for i in 0..<(pts.count - 1) {
+        let curr = pts[i]
+        let next = pts[i + 1]
+        let currZones = getZones(curr)
+        let nextZones = getZones(next)
+        var usedNext = Set<Int>()
+
+        for cloud in currZones {
+            var bestIdx = -1
+            var bestOverlap: Double = 0
+            for (j, nextCloud) in nextZones.enumerated() {
+                if usedNext.contains(j) { continue }
+                let overlap = min(cloud.topFt, nextCloud.topFt) - max(cloud.baseFt, nextCloud.baseFt)
+                if overlap > bestOverlap {
+                    bestOverlap = overlap
+                    bestIdx = j
+                }
+            }
+
+            if bestIdx >= 0 {
+                let matched = nextZones[bestIdx]
+                usedNext.insert(bestIdx)
+                draw(
+                    &context,
+                    [
+                        BandPoint(distanceNm: curr.distanceNm, baseFt: cloud.baseFt, topFt: cloud.topFt),
+                        BandPoint(distanceNm: next.distanceNm, baseFt: matched.baseFt, topFt: matched.topFt),
+                    ],
+                    cloud,
+                    matched
+                )
+            } else {
+                let midDist = (curr.distanceNm + next.distanceNm) / 2
+                let midAlt = (cloud.baseFt + cloud.topFt) / 2
+                draw(
+                    &context,
+                    [
+                        BandPoint(distanceNm: curr.distanceNm, baseFt: cloud.baseFt, topFt: cloud.topFt),
+                        BandPoint(distanceNm: midDist, baseFt: midAlt, topFt: midAlt),
+                    ],
+                    cloud,
+                    nil
+                )
+            }
+        }
+
+        for (j, nextCloud) in nextZones.enumerated() {
+            if usedNext.contains(j) { continue }
+            let midDist = (curr.distanceNm + next.distanceNm) / 2
+            let midAlt = (nextCloud.baseFt + nextCloud.topFt) / 2
+            draw(
+                &context,
+                [
+                    BandPoint(distanceNm: midDist, baseFt: midAlt, topFt: midAlt),
+                    BandPoint(distanceNm: next.distanceNm, baseFt: nextCloud.baseFt, topFt: nextCloud.topFt),
+                ],
+                nextCloud,
+                nil
+            )
+        }
+    }
+}
+
+private func drawNaturalCloudBand(
+    _ context: inout GraphicsContext,
+    points: [BandPoint],
+    transform: CoordTransform,
+    cloud: VizCloudLayer,
+    matched: VizCloudLayer?,
+    source: CloudStyleBandsLayer.Source
+) {
+    let config = defaultNaturalCloudConfig
+    let fill = matchedCloudColor(cloud, matched: matched, source: source)
+
+    if points.count == 1 {
+        guard let p = points.first else { return }
+        let x = transform.distanceToX(p.distanceNm)
+        let yTop = transform.altitudeToY(p.topFt)
+        let yBase = transform.altitudeToY(p.baseFt)
+        drawNaturalCloudBlobs(
+            &context,
+            xLeft: x - 10,
+            xRight: x + 10,
+            baseAt: { _ in yBase },
+            topAt: { _ in yTop },
+            fill: fill,
+            fillFraction: naturalFillFraction(cloud, matched: matched, config: config),
+            seed: bandSeed(cloud, source: source),
+            config: config
+        )
+        return
+    }
+
+    guard points.count >= 2 else { return }
+    let left = points[0]
+    let right = points[1]
+    let xLeft = transform.distanceToX(left.distanceNm)
+    let xRight = transform.distanceToX(right.distanceNm)
+    guard xRight > xLeft else { return }
+
+    let yBaseLeft = transform.altitudeToY(left.baseFt)
+    let yBaseRight = transform.altitudeToY(right.baseFt)
+    let yTopLeft = transform.altitudeToY(left.topFt)
+    let yTopRight = transform.altitudeToY(right.topFt)
+    let width = xRight - xLeft
+
+    drawNaturalCloudBlobs(
+        &context,
+        xLeft: xLeft,
+        xRight: xRight,
+        baseAt: { x in yBaseLeft + (yBaseRight - yBaseLeft) * (x - xLeft) / width },
+        topAt: { x in yTopLeft + (yTopRight - yTopLeft) * (x - xLeft) / width },
+        fill: fill,
+        fillFraction: naturalFillFraction(cloud, matched: matched, config: config),
+        seed: bandSeed(cloud, source: source),
+        config: config
+    )
+}
+
+private func drawNaturalCloudBlobs(
+    _ context: inout GraphicsContext,
+    xLeft: CGFloat,
+    xRight: CGFloat,
+    baseAt: (CGFloat) -> CGFloat,
+    topAt: (CGFloat) -> CGFloat,
+    fill: Color,
+    fillFraction: Double,
+    seed: Int,
+    config: NaturalCloudConfig
+) {
+    guard xRight > xLeft else { return }
+    let slotWidth = config.blobSpacingPx
+    let slotStart = Int(floor(xLeft / slotWidth)) - 1
+    let slotEnd = Int(ceil(xRight / slotWidth)) + 1
+    let radiusScale = CGFloat(config.radiusCoverageScaleFloor
+        + (1 - config.radiusCoverageScaleFloor) * min(1, max(0, fillFraction))
+    )
+
+    for slot in slotStart..<slotEnd {
+        if hash01(slot &* 0x1f1f1f &+ seed) > fillFraction { continue }
+
+        let xJitter = CGFloat(hash01(slot &* 0x2f3f4f &+ seed) - 0.5) * slotWidth * config.blobJitterX
+        let centerX = (CGFloat(slot) + 0.5) * slotWidth + xJitter
+        if centerX < xLeft || centerX >= xRight { continue }
+
+        let yTop = topAt(centerX)
+        let yBase = baseAt(centerX)
+        let bandHeight = yBase - yTop
+        if bandHeight <= 0 { continue }
+
+        let yJitter = CGFloat(hash01(slot &* 0x5b6c79 &+ seed) - 0.5) * bandHeight * config.blobJitterY
+        let centerY = (yTop + yBase) / 2 + yJitter
+        let sizeJitter = 1 + CGFloat(hash01(slot &* 0x7e8f91 &+ seed) - 0.5) * config.blobSizeVariation
+        let radiusX = config.blobRadiusXPx * sizeJitter * radiusScale
+        let radiusY = bandHeight * config.blobHeightFraction * sizeJitter * radiusScale
+        let aspect = radiusX > 0 ? radiusY / radiusX : 1
+
+        for i in 0..<max(1, config.subBlobsPerSlot) {
+            let subSeed = (slot &* 0x9e3779b1) ^ (i &* 0x85ebca6b) ^ seed
+            let angle = hash01(subSeed) * Double.pi * 2
+            let offsetMag = CGFloat(hash01(subSeed ^ 0x12345)) * config.subBlobOffsetFraction * radiusX
+            let offsetX = CGFloat(cos(angle)) * offsetMag
+            let offsetY = CGFloat(sin(angle)) * offsetMag * aspect
+            let subSize = config.subBlobSizeFraction
+                + CGFloat(hash01(subSeed ^ 0x67890) - 0.5) * config.subBlobSizeJitter
+            let rect = CGRect(
+                x: centerX + offsetX - radiusX * subSize,
+                y: centerY + offsetY - radiusY * subSize,
+                width: radiusX * subSize * 2,
+                height: radiusY * subSize * 2
+            )
+            context.fill(Path(ellipseIn: rect), with: .color(fill))
+        }
+    }
+}
+
+private func drawSquareCloudBand(
+    _ context: inout GraphicsContext,
+    points: [BandPoint],
+    transform: CoordTransform,
+    cloud: VizCloudLayer,
+    matched: VizCloudLayer?,
+    source: CloudStyleBandsLayer.Source
+) {
+    let fill = matchedCloudColor(cloud, matched: matched, source: source)
+
+    if points.count == 1, let point = points.first {
+        let x = transform.distanceToX(point.distanceNm)
+        let yTop = transform.altitudeToY(point.topFt)
+        let yBase = transform.altitudeToY(point.baseFt)
+        context.fill(Path(CGRect(x: x - 10, y: yTop, width: 20, height: yBase - yTop)), with: .color(fill))
+        return
+    }
+
+    guard points.count >= 2 else { return }
+    let left = points[0]
+    let right = points[1]
+    var path = Path()
+    path.move(to: CGPoint(x: transform.distanceToX(left.distanceNm), y: transform.altitudeToY(left.topFt)))
+    path.addLine(to: CGPoint(x: transform.distanceToX(right.distanceNm), y: transform.altitudeToY(right.topFt)))
+    path.addLine(to: CGPoint(x: transform.distanceToX(right.distanceNm), y: transform.altitudeToY(right.baseFt)))
+    path.addLine(to: CGPoint(x: transform.distanceToX(left.distanceNm), y: transform.altitudeToY(left.baseFt)))
+    path.closeSubpath()
+    context.fill(path, with: .color(fill))
+}
+
+private func matchedCloudColor(
+    _ cloud: VizCloudLayer,
+    matched: VizCloudLayer?,
+    source: CloudStyleBandsLayer.Source
+) -> Color {
+    switch source {
+    case .dd:
+        let dd = average(cloud.meanDewpointDepressionC, matched?.meanDewpointDepressionC)
+        return ColorScales.cloudFill(dewpointDepressionC: dd, coverage: cloud.coverage)
+    case .nwp:
+        let coverA = cloud.meanCloudCoverPct ?? ColorScales.coverageToPct(cloud.coverage)
+        let coverB = matched?.meanCloudCoverPct ?? matched.map { ColorScales.coverageToPct($0.coverage) } ?? coverA
+        return ColorScales.nwpCloudFill(pct: (coverA + coverB) / 2)
+    }
+}
+
+private func naturalFillFraction(
+    _ cloud: VizCloudLayer,
+    matched: VizCloudLayer?,
+    config: NaturalCloudConfig
+) -> Double {
+    if let coverA = cloud.meanCloudCoverPct {
+        let coverB = matched?.meanCloudCoverPct ?? coverA
+        return max(config.minFillFraction, min(1, ((coverA + coverB) / 2) / 100))
+    }
+    let coverA = config.fillFraction[coverageBucket(cloud.coverage), default: 1]
+    let coverB = matched.map { config.fillFraction[coverageBucket($0.coverage), default: coverA] } ?? coverA
+    return max(config.minFillFraction, (coverA + coverB) / 2)
+}
+
+private func coverageBucket(_ coverage: String) -> String {
+    let value = coverage.uppercased()
+    if value == "OVC" || value == "BKN" || value == "SCT" || value == "FEW" {
+        return value
+    }
+    return "BKN"
+}
+
+private func bandSeed(_ cloud: VizCloudLayer, source: CloudStyleBandsLayer.Source) -> Int {
+    let sourceSalt = source == .nwp ? 0xdeadbeef : 0
+    return (Int((cloud.baseFt / 100).rounded()) ^ 0x4d36e96) ^ sourceSalt
+}
+
+private func average(_ a: Double?, _ b: Double?) -> Double? {
+    if let a, let b { return (a + b) / 2 }
+    return a ?? b
+}
+
+private func hash01(_ n: Int) -> Double {
+    var h = UInt32(truncatingIfNeeded: n)
+    h &+= 0x9e3779b9
+    h = (h ^ (h >> 16)) &* 0x85ebca6b
+    h = (h ^ (h >> 13)) &* 0xc2b2ae35
+    h = h ^ (h >> 16)
+    return Double(h) / 4_294_967_296.0
+}

--- a/app/flyfun-weather/flyfun-weather/Views/CrossSection/Layers/CrossSectionLayer.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/CrossSection/Layers/CrossSectionLayer.swift
@@ -52,8 +52,10 @@ enum CrossSectionLayer {
     static let allLayers: [any CrossSectionLayerProtocol] = [
         SoftCloudBandsLayer(source: .nwp),
         SoftCloudBandsLayer(source: .dd),
-        NwpCloudBandsLayer(),
-        CloudBandsLayer(),
+        CloudStyleBandsLayer(source: .nwp, style: .square),
+        CloudStyleBandsLayer(source: .dd, style: .square),
+        CloudStyleBandsLayer(source: .nwp, style: .natural),
+        CloudStyleBandsLayer(source: .dd, style: .natural),
         ThermoConvectiveBgLayer(),
         NwpConvectiveBgLayer(),
         IcingBandsLayer(),
@@ -65,6 +67,9 @@ enum CrossSectionLayer {
         TemperatureLinesLayer(metric: .freezingLevel),
         TemperatureLinesLayer(metric: .minus10c),
         TemperatureLinesLayer(metric: .minus20c),
+        StabilityLinesLayer(metric: .lcl),
+        StabilityLinesLayer(metric: .lfc),
+        StabilityLinesLayer(metric: .el),
         ReferenceLinesLayer(),
     ]
 
@@ -74,6 +79,8 @@ enum CrossSectionLayer {
     static let defaultEnabled: [String: Bool] = [
         "soft-nwp-cloud-bands": true,
         "soft-cloud-bands": false,
+        "square-nwp-cloud-bands": false,
+        "square-cloud-bands": false,
         "nwp-cloud-bands": false,
         "cloud-bands": false,
         "thermo-convective-bg": false,
@@ -87,6 +94,9 @@ enum CrossSectionLayer {
         "freezing-level": true,
         "minus-10c": false,
         "minus-20c": false,
+        "lcl": true,
+        "lfc": true,
+        "el": true,
         "reference-lines": true,
     ]
 
@@ -94,7 +104,11 @@ enum CrossSectionLayer {
     /// Used by the dropdown picker UI: "None" + each method, in this display order.
     /// Mirrors web's PREFERRED_METHOD_LAYER mapping in layer-registry.ts.
     static let methodGroupOrder: [LayerGroup: [String]] = [
-        .clouds: ["soft-nwp-cloud-bands", "soft-cloud-bands", "nwp-cloud-bands", "cloud-bands"],
+        .clouds: [
+            "soft-nwp-cloud-bands", "soft-cloud-bands",
+            "square-nwp-cloud-bands", "square-cloud-bands",
+            "nwp-cloud-bands", "cloud-bands",
+        ],
         .icing: ["icing-ogimet-nwp-bands", "icing-bands", "sfip-bands"],
         .turbulence: ["cat-bands"],
         .convection: ["nwp-convective-bg", "thermo-convective-bg"],
@@ -104,8 +118,10 @@ enum CrossSectionLayer {
     static let methodLabels: [String: String] = [
         "soft-nwp-cloud-bands": "Soft NWP",
         "soft-cloud-bands": "Soft DD",
-        "nwp-cloud-bands": "NWP",
-        "cloud-bands": "DD",
+        "square-nwp-cloud-bands": "Square NWP",
+        "square-cloud-bands": "Square DD",
+        "nwp-cloud-bands": "Natural NWP",
+        "cloud-bands": "Natural DD",
         "icing-ogimet-nwp-bands": "Ogimet-NWP",
         "icing-bands": "Ogimet-DD",
         "sfip-bands": "SFIP",

--- a/app/flyfun-weather/flyfun-weather/Views/CrossSection/Layers/StabilityLinesLayer.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/CrossSection/Layers/StabilityLinesLayer.swift
@@ -1,0 +1,77 @@
+import SwiftUI
+
+/// LCL, LFC, and EL lines as smooth route-following stability references.
+struct StabilityLinesLayer: CrossSectionLayerProtocol {
+    enum Metric {
+        case lcl
+        case lfc
+        case el
+    }
+
+    let metric: Metric
+
+    var id: String {
+        switch metric {
+        case .lcl: "lcl"
+        case .lfc: "lfc"
+        case .el: "el"
+        }
+    }
+
+    var name: String {
+        switch metric {
+        case .lcl: "LCL"
+        case .lfc: "LFC"
+        case .el: "EL"
+        }
+    }
+
+    let group: LayerGroup = .stability
+
+    private var color: Color {
+        switch metric {
+        case .lcl: ColorScales.lclColor
+        case .lfc: ColorScales.lfcColor
+        case .el: ColorScales.elColor
+        }
+    }
+
+    private var lineWidth: CGFloat {
+        switch metric {
+        case .lcl: 2.0
+        case .lfc, .el: 1.5
+        }
+    }
+
+    func render(context: inout GraphicsContext, transform: CoordTransform, data: VizRouteData) {
+        var xs: [CGFloat] = []
+        var ys: [CGFloat] = []
+
+        for pt in data.points {
+            let alt: Double?
+            switch metric {
+            case .lcl: alt = pt.altitudeLines.lclAltitudeFt
+            case .lfc: alt = pt.altitudeLines.lfcAltitudeFt
+            case .el: alt = pt.altitudeLines.elAltitudeFt
+            }
+            guard let alt else { continue }
+            xs.append(transform.distanceToX(pt.distanceNm))
+            ys.append(transform.altitudeToY(alt))
+        }
+
+        guard xs.count >= 2 else { return }
+
+        let tangents = monotoneCubicTangents(xs: xs, ys: ys)
+        var path = Path()
+        path.move(to: CGPoint(x: xs[0], y: ys[0]))
+
+        for i in 0..<(xs.count - 1) {
+            let dx = xs[i + 1] - xs[i]
+            let cp1 = CGPoint(x: xs[i] + dx / 3, y: ys[i] + tangents[i] * dx / 3)
+            let cp2 = CGPoint(x: xs[i + 1] - dx / 3, y: ys[i + 1] - tangents[i + 1] * dx / 3)
+            path.addCurve(to: CGPoint(x: xs[i + 1], y: ys[i + 1]), control1: cp1, control2: cp2)
+        }
+
+        context.stroke(path, with: .color(color), style: StrokeStyle(lineWidth: lineWidth, dash: [6, 4]))
+    }
+}

--- a/app/flyfun-weather/flyfun-weather/Views/CrossSection/SkewTDetailView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/CrossSection/SkewTDetailView.swift
@@ -1,3 +1,4 @@
+import Charts
 import RZSkewT
 import SwiftUI
 
@@ -17,21 +18,29 @@ extension SoundingProfileResponse {
 
         let skewTIndices = indices.map {
             SkewTIndices(
-                lclPressureHPa: $0.lclAltitudeFt != nil ? nil : nil, // pressure not in ThermodynamicIndices
+                lclPressureHPa: $0.lclPressureHpa,
+                lfcPressureHPa: $0.lfcPressureHpa,
+                elPressureHPa: $0.elPressureHpa,
                 capeSurfaceJkg: $0.capeSurfaceJkg,
-                freezingLevelFt: $0.freezingLevelFt
+                cinSurfaceJkg: $0.cinSurfaceJkg,
+                freezingLevelFt: $0.freezingLevelFt,
+                liftedIndex: $0.liftedIndex
             )
         }
 
-        let overlayCloudLayers = (cloudLayers ?? []).map {
+        // Match the cross-section default: NWP cloud envelope and Ogimet-NWP icing
+        // when available, with DD/Ogimet as fallback for older packs.
+        let overlayCloudLayers = (nwpCloudLayers ?? cloudLayers ?? []).map {
             OverlayBand(baseFt: $0.baseFt, topFt: $0.topFt, label: $0.coverage)
         }
-        let overlayIcing = (icingZones ?? []).map {
+        let overlayIcing = (icingOgimetNwpZones ?? icingZones ?? []).map {
             OverlayBand(baseFt: $0.baseFt, topFt: $0.topFt, label: $0.risk)
         }
         let overlayInversions = (inversionLayers ?? []).map {
             InversionBand(baseFt: $0.baseFt, topFt: $0.topFt, strengthC: $0.strengthC)
         }
+        let convectiveLfcFt = indices?.lfcAltitudeFt ?? convective?.baseFt
+        let convectiveElFt = indices?.elAltitudeFt ?? convective?.topFt
 
         return SoundingProfile(
             levels: levels,
@@ -40,7 +49,9 @@ extension SoundingProfileResponse {
                 cloudLayers: overlayCloudLayers,
                 icingZones: overlayIcing,
                 inversions: overlayInversions,
-                cruiseAltitudeFt: cruiseAltitudeFt.map(Double.init)
+                cruiseAltitudeFt: cruiseAltitudeFt.map(Double.init),
+                convectiveLfcFt: convectiveLfcFt,
+                convectiveElFt: convectiveElFt
             )
         )
     }
@@ -89,6 +100,10 @@ struct SkewTDetailView: View {
                         config: SkewTConfiguration(pTop: 250)
                     )
                     .aspectRatio(9.0 / 5.0, contentMode: .fit)
+
+                    Divider()
+                    SkewTVariableProfileView(response: response)
+                        .frame(minHeight: 160)
                 }
             case .error(let error):
                 ContentUnavailableView("Sounding Unavailable",
@@ -96,13 +111,13 @@ struct SkewTDetailView: View {
                                        description: Text(error.localizedDescription))
             }
         }
-        .task(id: pointIndex) {
+        .task(id: "\(pointIndex)-\(viewModel.selectedModel)") {
             await loadProfile()
         }
     }
 
     private func loadProfile() async {
-        guard let pack = viewModel.pack else { return }
+        guard viewModel.pack != nil else { return }
         profileState = .loading
         do {
             let response = try await viewModel.fetchSoundingProfile(pointIndex: pointIndex)
@@ -110,5 +125,132 @@ struct SkewTDetailView: View {
         } catch {
             profileState = .error(error)
         }
+    }
+}
+
+private struct SkewTVariableProfileView: View {
+    let response: SoundingProfileResponse
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+    @State private var primaryMetricId = "relative-humidity"
+    @State private var secondaryMetricId = "theta-e"
+
+    private var primaryMetric: SkewTVariableMetric {
+        SkewTVariableMetrics.metric(byId: primaryMetricId) ?? SkewTVariableMetrics.all[0]
+    }
+
+    private var secondaryMetric: SkewTVariableMetric {
+        SkewTVariableMetrics.metric(byId: secondaryMetricId) ?? SkewTVariableMetrics.all[1]
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: WeatherTheme.Spacing.sm) {
+            HStack {
+                metricMenu(title: "Variable", selection: $primaryMetricId)
+                Spacer()
+                if horizontalSizeClass == .regular {
+                    metricMenu(title: "Compare", selection: $secondaryMetricId)
+                }
+            }
+
+            if horizontalSizeClass == .regular {
+                HStack(spacing: WeatherTheme.Spacing.lg) {
+                    variableChart(metric: primaryMetric)
+                    variableChart(metric: secondaryMetric)
+                }
+            } else {
+                variableChart(metric: primaryMetric)
+            }
+        }
+        .padding(.horizontal)
+        .padding(.vertical, WeatherTheme.Spacing.sm)
+    }
+
+    private func metricMenu(title: String, selection: Binding<String>) -> some View {
+        Menu {
+            ForEach(SkewTVariableMetrics.all) { metric in
+                Button {
+                    selection.wrappedValue = metric.id
+                } label: {
+                    if selection.wrappedValue == metric.id {
+                        Label(metric.label, systemImage: "checkmark")
+                    } else {
+                        Text(metric.label)
+                    }
+                }
+            }
+        } label: {
+            Label(SkewTVariableMetrics.metric(byId: selection.wrappedValue)?.label ?? title,
+                  systemImage: "waveform.path.ecg")
+                .font(.caption.bold())
+        }
+        .buttonStyle(.bordered)
+    }
+
+    private func variableChart(metric: SkewTVariableMetric) -> some View {
+        let data = chartData(for: metric)
+        return VStack(alignment: .leading, spacing: WeatherTheme.Spacing.xs) {
+            Text("\(metric.label) \(metric.unit)")
+                .font(.caption.bold())
+                .foregroundStyle(metric.color)
+
+            if data.isEmpty {
+                ContentUnavailableView("No \(metric.label)", systemImage: "chart.line.uptrend.xyaxis")
+                    .frame(height: 120)
+            } else {
+                Chart(data) { point in
+                    LineMark(
+                        x: .value(metric.label, point.value),
+                        y: .value("Altitude", point.altitudeFt)
+                    )
+                    .foregroundStyle(metric.color)
+                    .lineStyle(StrokeStyle(lineWidth: 2))
+                }
+                .chartYAxisLabel("ft")
+                .chartXAxisLabel(metric.unit)
+                .frame(height: 120)
+            }
+        }
+    }
+
+    private func chartData(for metric: SkewTVariableMetric) -> [SkewTVariablePoint] {
+        response.levels.compactMap { level in
+            guard let altitudeFt = level.altitudeFt,
+                  let value = metric.value(level)
+            else { return nil }
+            return SkewTVariablePoint(pressureHpa: Double(level.pressureHpa), altitudeFt: altitudeFt, value: value)
+        }
+        .sorted { $0.altitudeFt < $1.altitudeFt }
+    }
+}
+
+private struct SkewTVariablePoint: Identifiable {
+    let pressureHpa: Double
+    let altitudeFt: Double
+    let value: Double
+
+    var id: String { "\(Int(pressureHpa))-\(Int(altitudeFt))" }
+}
+
+private struct SkewTVariableMetric: Identifiable {
+    let id: String
+    let label: String
+    let unit: String
+    let color: Color
+    let value: (SoundingProfileLevel) -> Double?
+}
+
+private enum SkewTVariableMetrics {
+    static let all: [SkewTVariableMetric] = [
+        .init(id: "relative-humidity", label: "RH", unit: "%", color: .blue) { $0.relativeHumidityPct },
+        .init(id: "theta-e", label: "Theta-e", unit: "K", color: .orange) { $0.thetaEK },
+        .init(id: "lapse-rate", label: "Lapse", unit: "C/km", color: .purple) { $0.lapseRateCPerKm },
+        .init(id: "icing-index", label: "Icing", unit: "", color: .cyan) { $0.icingIndexNwp ?? $0.icingIndex },
+        .init(id: "cloud-fraction", label: "Cloud", unit: "%", color: .gray) { $0.cloudAreaFractionPct },
+        .init(id: "richardson", label: "Ri", unit: "", color: .green) { $0.richardsonNumber },
+        .init(id: "vertical-motion", label: "w", unit: "fpm", color: .red) { $0.wFpm },
+    ]
+
+    static func metric(byId id: String) -> SkewTVariableMetric? {
+        all.first { $0.id == id }
     }
 }

--- a/app/flyfun-weather/flyfun-weather/Views/CrossSection/SkewTTabView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/CrossSection/SkewTTabView.swift
@@ -1,0 +1,127 @@
+import SwiftUI
+
+/// Full-screen Skew-T instrument tab linked to the briefing active route point.
+struct SkewTTabView: View {
+    @Bindable var viewModel: BriefingViewModel
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        VStack(spacing: 0) {
+            controlStrip
+            Divider()
+
+            if let activePoint = viewModel.activePoint {
+                SkewTDetailView(viewModel: viewModel, pointIndex: activePoint.pointIndex)
+                    .id("\(activePoint.pointIndex)-\(viewModel.selectedModel)")
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                ContentUnavailableView(
+                    "Select a Route Point",
+                    systemImage: "chart.line.uptrend.xyaxis",
+                    description: Text("Load the route analysis or choose a point from the cross-section.")
+                )
+            }
+        }
+        .background(WeatherTheme.background(colorScheme))
+        .onAppear {
+            if viewModel.activePoint == nil,
+               case .loaded(let analyses) = viewModel.routeAnalysesState {
+                viewModel.setActivePoint(analyses.analyses.first)
+            }
+        }
+    }
+
+    private var controlStrip: some View {
+        HStack(spacing: WeatherTheme.Spacing.sm) {
+            Button {
+                moveSelection(by: -1)
+            } label: {
+                Image(systemName: "chevron.left")
+            }
+            .disabled(!canMove(by: -1))
+            .accessibilityLabel("Previous route point")
+
+            Menu {
+                ForEach(routePoints, id: \.pointIndex) { point in
+                    Button {
+                        viewModel.setActivePoint(point)
+                    } label: {
+                        HStack {
+                            Text(label(for: point))
+                            if point.pointIndex == viewModel.activePoint?.pointIndex {
+                                Image(systemName: "checkmark")
+                            }
+                        }
+                    }
+                }
+            } label: {
+                Label(activePointLabel, systemImage: "scope")
+                    .font(.caption.bold())
+                    .lineLimit(1)
+                    .padding(.horizontal, WeatherTheme.Spacing.sm)
+                    .padding(.vertical, WeatherTheme.Spacing.xs)
+                    .background(
+                        WeatherTheme.primary(colorScheme).opacity(0.10),
+                        in: RoundedRectangle(cornerRadius: WeatherTheme.Radius.control)
+                    )
+            }
+            .buttonStyle(.plain)
+            .disabled(routePoints.isEmpty)
+
+            Button {
+                moveSelection(by: 1)
+            } label: {
+                Image(systemName: "chevron.right")
+            }
+            .disabled(!canMove(by: 1))
+            .accessibilityLabel("Next route point")
+
+            Spacer()
+
+            ModelSelectorView(
+                selectedModel: Binding(
+                    get: { viewModel.selectedModel },
+                    set: { viewModel.selectedModel = $0 }
+                ),
+                models: viewModel.availableModels
+            )
+        }
+        .padding(.horizontal, WeatherTheme.Spacing.lg)
+        .padding(.vertical, WeatherTheme.Spacing.sm)
+        .background(WeatherTheme.surface(colorScheme))
+    }
+
+    private var routePoints: [RoutePointAnalysis] {
+        guard case .loaded(let analyses) = viewModel.routeAnalysesState else { return [] }
+        return analyses.analyses
+    }
+
+    private var activePointLabel: String {
+        guard let point = viewModel.routePoint(for: viewModel.activePoint) else {
+            return "Point"
+        }
+        return label(for: point)
+    }
+
+    private func label(for point: RoutePointAnalysis) -> String {
+        let name = point.waypointIcao ?? "Pt \(point.pointIndex)"
+        return "\(name) · \(Int(point.distanceFromOriginNm)) nm"
+    }
+
+    private func canMove(by offset: Int) -> Bool {
+        guard let index = activeRouteIndex else { return false }
+        return routePoints.indices.contains(index + offset)
+    }
+
+    private func moveSelection(by offset: Int) {
+        guard let index = activeRouteIndex else { return }
+        let nextIndex = index + offset
+        guard routePoints.indices.contains(nextIndex) else { return }
+        viewModel.setActivePoint(routePoints[nextIndex])
+    }
+
+    private var activeRouteIndex: Int? {
+        guard let activePoint = viewModel.activePoint else { return nil }
+        return routePoints.firstIndex { $0.pointIndex == activePoint.pointIndex }
+    }
+}

--- a/app/flyfun-weather/flyfun-weather/Views/Flights/AddFlightView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Flights/AddFlightView.swift
@@ -5,22 +5,29 @@ struct AddFlightView: View {
     @Environment(\.dismiss) private var dismiss
     @State private var viewModel: AddFlightViewModel
     @State private var showFplSheet = false
+    @State private var showRebriefConfirmation = false
 
-    let onCreated: (FlightResponse) -> Void
+    let onSaved: (FlightResponse) -> Void
 
-    init(repository: any BriefingRepository, onCreated: @escaping (FlightResponse) -> Void) {
-        _viewModel = State(initialValue: AddFlightViewModel(repository: repository))
-        self.onCreated = onCreated
+    init(
+        repository: any BriefingRepository,
+        editing flight: FlightResponse? = nil,
+        onSaved: @escaping (FlightResponse) -> Void
+    ) {
+        _viewModel = State(initialValue: AddFlightViewModel(repository: repository, editing: flight))
+        self.onSaved = onSaved
     }
 
     var body: some View {
         NavigationStack {
             Form {
                 fplSection
+                aircraftSection
                 waypointsSection
                 departureSection
                 altitudeSection
                 durationSection
+                statusSection
 
                 if let error = viewModel.errorMessage {
                     Section {
@@ -29,23 +36,29 @@ struct AddFlightView: View {
                     }
                 }
             }
-            .navigationTitle("New Flight")
+            .navigationTitle(viewModel.navigationTitle)
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Cancel") { dismiss() }
                 }
                 ToolbarItem(placement: .confirmationAction) {
-                    Button("Create") {
-                        Task {
-                            if let flight = await viewModel.createFlight() {
-                                onCreated(flight)
-                                dismiss()
-                            }
-                        }
+                    Button(viewModel.submitTitle) {
+                        submit()
                     }
                     .disabled(!viewModel.canSubmit)
                 }
+            }
+            .alert("Regenerate briefing?", isPresented: $showRebriefConfirmation) {
+                Button("Continue") {
+                    Task { await submitEdit(regenerate: true) }
+                }
+                Button("Cancel", role: .cancel) {}
+            } message: {
+                Text("This will regenerate the briefing. Continue?")
+            }
+            .task {
+                await viewModel.loadAircraft()
             }
         }
     }
@@ -69,6 +82,36 @@ struct AddFlightView: View {
         }
     }
 
+    private var aircraftSection: some View {
+        Section {
+            Picker("Aircraft", selection: Binding(
+                get: { viewModel.selectedAircraftId ?? 0 },
+                set: { viewModel.selectedAircraftId = $0 == 0 ? nil : $0 }
+            )) {
+                Text("No aircraft").tag(0)
+                ForEach(viewModel.aircraftOptions) { aircraft in
+                    VStack(alignment: .leading) {
+                        Text(aircraft.displayName)
+                        Text(aircraft.detailText)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    .tag(aircraft.id)
+                }
+            }
+
+            if viewModel.isLoadingAircraft {
+                HStack {
+                    ProgressView()
+                    Text("Loading aircraft…")
+                        .foregroundStyle(.secondary)
+                }
+            }
+        } header: {
+            Text("Aircraft")
+        }
+    }
+
     private var waypointsSection: some View {
         Section {
             TextField("LFBO TOU LFMT", text: $viewModel.waypointsText)
@@ -89,7 +132,11 @@ struct AddFlightView: View {
 
     private var departureSection: some View {
         Section {
-            DatePicker("Date & Time", selection: $viewModel.departureDate)
+            if let range = viewModel.departureRange {
+                DatePicker("Date & Time", selection: $viewModel.departureDate, in: range)
+            } else {
+                DatePicker("Date & Time", selection: $viewModel.departureDate)
+            }
         } header: {
             Text("Departure")
         }
@@ -128,6 +175,45 @@ struct AddFlightView: View {
             )
         } header: {
             Text("Duration")
+        }
+    }
+
+    @ViewBuilder
+    private var statusSection: some View {
+        if viewModel.isSubmitting || viewModel.statusMessage != nil {
+            Section {
+                HStack(spacing: 12) {
+                    if viewModel.isSubmitting {
+                        ProgressView()
+                    }
+                    Text(viewModel.statusMessage ?? "Working…")
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+    }
+
+    private func submit() {
+        if viewModel.isEditing {
+            if viewModel.requiresRebriefConfirmation {
+                showRebriefConfirmation = true
+            } else {
+                Task { await submitEdit(regenerate: false) }
+            }
+        } else {
+            Task {
+                if let flight = await viewModel.createFlight() {
+                    onSaved(flight)
+                    dismiss()
+                }
+            }
+        }
+    }
+
+    private func submitEdit(regenerate: Bool) async {
+        if let flight = await viewModel.saveEditedFlight(regenerate: regenerate) {
+            onSaved(flight)
+            dismiss()
         }
     }
 }

--- a/app/flyfun-weather/flyfun-weather/Views/Flights/AddFlightView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Flights/AddFlightView.swift
@@ -5,6 +5,7 @@ struct AddFlightView: View {
     @Environment(\.dismiss) private var dismiss
     @State private var viewModel: AddFlightViewModel
     @State private var showFplSheet = false
+    @State private var showAircraftSheet = false
     @State private var showRebriefConfirmation = false
 
     let onSaved: (FlightResponse) -> Void
@@ -60,6 +61,11 @@ struct AddFlightView: View {
             .task {
                 await viewModel.loadAircraft()
             }
+            .sheet(isPresented: $showAircraftSheet) {
+                AircraftFormSheet(viewModel: viewModel) {
+                    showAircraftSheet = false
+                }
+            }
         }
     }
 
@@ -84,19 +90,25 @@ struct AddFlightView: View {
 
     private var aircraftSection: some View {
         Section {
-            Picker("Aircraft", selection: Binding(
-                get: { viewModel.selectedAircraftId ?? 0 },
-                set: { viewModel.selectedAircraftId = $0 == 0 ? nil : $0 }
-            )) {
-                Text("No aircraft").tag(0)
-                ForEach(viewModel.aircraftOptions) { aircraft in
-                    VStack(alignment: .leading) {
-                        Text(aircraft.displayName)
-                        Text(aircraft.detailText)
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
+            if viewModel.aircraftOptions.isEmpty && !viewModel.isLoadingAircraft {
+                Label("No saved aircraft", systemImage: "airplane")
+                    .foregroundStyle(.secondary)
+            } else {
+                Picker("Aircraft", selection: Binding(
+                    get: { viewModel.selectedAircraftId ?? 0 },
+                    set: { viewModel.selectedAircraftId = $0 == 0 ? nil : $0 }
+                )) {
+                    Text("No aircraft").tag(0)
+                    ForEach(viewModel.aircraftOptions) { aircraft in
+                        Text(aircraft.pickerTitle).tag(aircraft.id)
                     }
-                    .tag(aircraft.id)
+                }
+                .pickerStyle(.menu)
+
+                if let aircraft = viewModel.selectedAircraft {
+                    Text(aircraft.detailText)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
                 }
             }
 
@@ -106,6 +118,13 @@ struct AddFlightView: View {
                     Text("Loading aircraft…")
                         .foregroundStyle(.secondary)
                 }
+            }
+
+            Button {
+                viewModel.prepareNewAircraftForm()
+                showAircraftSheet = true
+            } label: {
+                Label("Add Aircraft", systemImage: "plus")
             }
         } header: {
             Text("Aircraft")
@@ -271,6 +290,104 @@ private struct FplPasteSheet: View {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Cancel") { onDone() }
                 }
+            }
+        }
+    }
+}
+
+// MARK: - Aircraft Sheet
+
+/// Compact aircraft create flow used by the flight form when no presets exist yet.
+private struct AircraftFormSheet: View {
+    @Bindable var viewModel: AddFlightViewModel
+    let onDone: () -> Void
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    TextField("ICAO type, e.g. C172", text: $viewModel.newAircraftIcaoType)
+                        .textInputAutocapitalization(.characters)
+                        .autocorrectionDisabled()
+
+                    if viewModel.isSearchingAircraftTypes {
+                        HStack {
+                            ProgressView()
+                            Text("Searching aircraft types…")
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                } header: {
+                    Text("Aircraft Type")
+                }
+
+                if !viewModel.aircraftTypeSuggestions.isEmpty {
+                    Section {
+                        ForEach(viewModel.aircraftTypeSuggestions) { type in
+                            Button {
+                                viewModel.selectAircraftType(type)
+                            } label: {
+                                VStack(alignment: .leading, spacing: 2) {
+                                    Text(type.displayName)
+                                    if let category = type.category, !category.isEmpty {
+                                        Text(category)
+                                            .font(.caption)
+                                            .foregroundStyle(.secondary)
+                                    }
+                                }
+                            }
+                        }
+                    } header: {
+                        Text("Matches")
+                    }
+                }
+
+                Section {
+                    TextField("Tail number", text: $viewModel.newAircraftTailNumber)
+                        .textInputAutocapitalization(.characters)
+                        .autocorrectionDisabled()
+                    TextField("Nickname", text: $viewModel.newAircraftNickname)
+                    TextField("Cruise speed (kt)", text: $viewModel.newAircraftCruiseSpeedKt)
+                        .keyboardType(.numberPad)
+                    TextField("Ceiling (ft)", text: $viewModel.newAircraftCeilingFt)
+                        .keyboardType(.numberPad)
+                } header: {
+                    Text("Details")
+                }
+
+                Section {
+                    Toggle("IFR equipped", isOn: $viewModel.newAircraftIsIfr)
+                    Toggle("FIKI", isOn: $viewModel.newAircraftIsFiki)
+                    Toggle("Make default", isOn: $viewModel.newAircraftIsDefault)
+                }
+
+                if let error = viewModel.aircraftFormError {
+                    Section {
+                        Text(error)
+                            .foregroundStyle(.red)
+                    }
+                }
+            }
+            .navigationTitle("Add Aircraft")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { onDone() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") {
+                        Task {
+                            if await viewModel.createAircraft() {
+                                onDone()
+                            }
+                        }
+                    }
+                    .disabled(!viewModel.canSaveAircraft)
+                }
+            }
+            .task(id: viewModel.newAircraftIcaoType) {
+                try? await Task.sleep(nanoseconds: 250_000_000)
+                await viewModel.searchAircraftTypes()
             }
         }
     }

--- a/app/flyfun-weather/flyfun-weather/Views/Flights/FlightCardView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Flights/FlightCardView.swift
@@ -7,10 +7,20 @@ struct FlightCardView: View {
     var isOffline: Bool = false
 
     var body: some View {
-        HStack(spacing: 12) {
+        HStack(alignment: .top, spacing: 12) {
             VStack(alignment: .leading, spacing: 4) {
-                Text(flight.shortTitle)
-                    .font(.headline)
+                HStack(spacing: 6) {
+                    Text(flight.shortTitle)
+                        .font(.headline)
+                        .lineLimit(1)
+
+                    if flight.role == .subscriber {
+                        Image(systemName: "person.2")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .accessibilityLabel("Shared flight")
+                    }
+                }
 
                 Text(flight.waypoints.joined(separator: " - "))
                     .font(.subheadline)
@@ -19,7 +29,8 @@ struct FlightCardView: View {
 
                 HStack(spacing: 8) {
                     if let date = flight.departureDate {
-                        Label(DateFormatter.shortDate.string(from: date), systemImage: "calendar")
+                        Label("\(DateFormatter.shortDate.string(from: date)) \(DateFormatter.utcTime.string(from: date))",
+                              systemImage: "calendar")
                             .font(.caption)
                             .foregroundStyle(.secondary)
                     }
@@ -27,28 +38,57 @@ struct FlightCardView: View {
                     Label("FL\(flight.cruiseAltitudeFt / 100)", systemImage: "arrow.up.right")
                         .font(.caption)
                         .foregroundStyle(.secondary)
+
+                    Label(String(format: "%.1fh", flight.flightDurationHours), systemImage: "timer")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                HStack(spacing: 6) {
+                    if let aircraft = flight.aircraft {
+                        Label(aircraft.displayName, systemImage: "airplane")
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                    }
+
+                    if let summary = flight.latestBriefing?.advisorySummary,
+                       (summary.red ?? 0) + (summary.amber ?? 0) > 0 {
+                        Text("\(summary.red ?? 0) RED · \(summary.amber ?? 0) AMBER")
+                            .font(.caption2.monospacedDigit())
+                            .foregroundStyle(.secondary)
+                    }
+
+                    if let debrief = flight.debrief {
+                        Label(debrief.decision.capitalized, systemImage: "checkmark.circle")
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                    } else if flight.displaySection == .recent {
+                        Label("Debrief", systemImage: "checklist")
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                    }
                 }
             }
 
             Spacer()
 
             if hasCachedData {
-                Image(systemName: "arrow.down.circle.fill")
+                Image(systemName: "circle.fill")
                     .foregroundStyle(.green)
-                    .font(.caption)
+                    .font(.system(size: 8))
+                    .padding(.top, 6)
             }
 
-            if let assessment = flight.assessment {
+            if let assessment = flight.latestBriefing?.displayAssessment {
                 AssessmentStringBadge(status: assessment)
+            } else if flight.latestBriefing?.hasDigest == false {
+                Text("PENDING")
+                    .font(.caption.bold())
+                    .foregroundStyle(.secondary)
             }
         }
         .padding(.vertical, 4)
         .opacity(isOffline && !hasCachedData ? 0.4 : 1.0)
     }
-}
-
-// Extension to get assessment from a FlightResponse — not in server response for flights,
-// but will be available after we fetch the pack meta. For now, this is nil.
-extension FlightResponse {
-    var assessment: String? { nil }
 }

--- a/app/flyfun-weather/flyfun-weather/Views/Flights/FlightListView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Flights/FlightListView.swift
@@ -9,6 +9,7 @@ struct FlightListView: View {
     @State private var selectedFlight: FlightResponse?
     @State private var columnVisibility: NavigationSplitViewVisibility = .automatic
     @State private var showAddFlight = false
+    @State private var editingFlight: FlightResponse?
     @State private var showSettings = false
     @State private var showSignOutWarning = false
 
@@ -20,13 +21,16 @@ struct FlightListView: View {
                         if flights.isEmpty {
                             emptyStateView
                         } else {
-                            List(flights, selection: $selectedFlight) { flight in
-                                let hasCached = viewModel.cachedFlightIds.contains(flight.id)
-                                NavigationLink(value: flight) {
-                                    FlightCardView(flight: flight, hasCachedData: hasCached,
-                                                   isOffline: viewModel.isOffline)
+                            List(selection: $selectedFlight) {
+                                ForEach(viewModel.sectionedFlights) { group in
+                                    Section {
+                                        ForEach(group.flights) { flight in
+                                            flightRow(flight, viewModel: viewModel)
+                                        }
+                                    } header: {
+                                        Label(group.section.title, systemImage: group.section.systemImage)
+                                    }
                                 }
-                                .disabled(viewModel.isOffline && !hasCached)
                             }
                             .refreshable {
                                 await viewModel.loadFlights()
@@ -108,6 +112,16 @@ struct FlightListView: View {
                     }
                 }
             }
+            .sheet(item: $editingFlight) { flight in
+                if let repo = appState.repository {
+                    AddFlightView(repository: repo, editing: flight) { updated in
+                        Task {
+                            await viewModel?.loadFlights()
+                            selectedFlight = updated
+                        }
+                    }
+                }
+            }
             .sheet(isPresented: $showSettings) {
                 SettingsView()
             }
@@ -120,7 +134,7 @@ struct FlightListView: View {
         } detail: {
             if let selectedFlight {
                 BriefingContainerView(flight: selectedFlight)
-                    .id(selectedFlight.id)
+                    .id(selectedFlight.briefingIdentity)
             } else {
                 ContentUnavailableView("Select a Flight", systemImage: "airplane",
                                        description: Text("Choose a flight from the list to view its briefing."))
@@ -135,6 +149,33 @@ struct FlightListView: View {
         .onChange(of: scenePhase) {
             if scenePhase == .active {
                 Task { await viewModel?.loadFlights() }
+            }
+        }
+    }
+
+    private func flightRow(_ flight: FlightResponse, viewModel: FlightListViewModel) -> some View {
+        let hasCached = viewModel.cachedFlightIds.contains(flight.id)
+        return NavigationLink(value: flight) {
+            FlightCardView(flight: flight, hasCachedData: hasCached, isOffline: viewModel.isOffline)
+        }
+        .disabled(viewModel.isOffline && !hasCached)
+        .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+            if !viewModel.isOffline && flight.role != .subscriber {
+                Button {
+                    editingFlight = flight
+                } label: {
+                    Label("Edit", systemImage: "pencil")
+                }
+                .tint(.blue)
+            }
+        }
+        .contextMenu {
+            if !viewModel.isOffline && flight.role != .subscriber {
+                Button {
+                    editingFlight = flight
+                } label: {
+                    Label("Edit Flight", systemImage: "pencil")
+                }
             }
         }
     }

--- a/app/flyfun-weather/flyfun-weather/Views/Map/RouteMapView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Map/RouteMapView.swift
@@ -1,11 +1,18 @@
 import SwiftUI
 import MapKit
 
-/// Native map showing route polyline and waypoint annotations.
+/// Native map showing route polyline, metric-colored segments, waypoint callouts, and live aircraft.
 struct RouteMapView: View {
     let viewModel: BriefingViewModel
     var trackingService: FlightTrackingService
+
     @State private var mapVM = RouteMapViewModel()
+    @State private var selectedColorMetric: RouteMapMetric = .convectiveRisk
+    @State private var selectedWidthMetric: RouteMapMetric = .convectiveRisk
+    @State private var altitudeFt: Double = 0
+    @State private var selectedWaypoint: RouteMapViewModel.WaypointAnnotation?
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+    @Environment(\.colorScheme) private var colorScheme
 
     var body: some View {
         Group {
@@ -19,81 +26,418 @@ struct RouteMapView: View {
                     ProgressView()
                 }
             } else {
-                // Read observable values in view body — Map content builder is @escaping.
-                // locationUpdateCount forces re-evaluation since CLLocation is a reference type.
-                let _ = trackingService.locationUpdateCount
-                let isTracking = trackingService.isTracking
-                let aircraftLocation = trackingService.currentLocation
-                let aircraftOpacity = trackingService.projectedPosition?.opacity ?? 0.3
-                let aircraftHeading = trackingService.projectedPosition?.headingDeg ?? 0
-                let activeRoutePoint = viewModel.routePoint(for: viewModel.activePoint)
-                Map(initialPosition: .region(mapVM.mapRegion)) {
-                    MapPolyline(coordinates: mapVM.routeCoordinates)
-                        .stroke(.blue, lineWidth: 3)
-
-                    ForEach(mapVM.waypoints) { wp in
-                        Annotation(wp.id, coordinate: wp.coordinate) {
-                            VStack(spacing: 2) {
-                                Text(wp.id)
-                                    .font(.caption2.bold())
-                                    .padding(.horizontal, 4)
-                                    .padding(.vertical, 2)
-                                    .background(.ultraThinMaterial, in: Capsule())
-                                Circle()
-                                    .fill(.blue)
-                                    .frame(width: 8, height: 8)
-                            }
-                        }
-                    }
-
-                    if let activeRoutePoint {
-                        Annotation("", coordinate: .init(latitude: activeRoutePoint.lat, longitude: activeRoutePoint.lon), anchor: .center) {
-                            ZStack {
-                                Circle()
-                                    .fill(.orange.opacity(0.20))
-                                Circle()
-                                    .stroke(.orange, lineWidth: 3)
-                            }
-                                .frame(width: 22, height: 22)
-                        }
-                        .annotationTitles(.hidden)
-                    }
-
-                    // Live aircraft position — drawn last so it renders on top
-                    if isTracking, let location = aircraftLocation {
-                        Annotation("", coordinate: location.coordinate, anchor: .center) {
-                            Image(systemName: "airplane")
-                                .font(.system(size: 28, weight: .bold))
-                                .foregroundStyle(.orange)
-                                // SF Symbol "airplane" points right (90°); rotate so 0° = north
-                                .rotationEffect(.degrees(aircraftHeading - 90))
-                                .opacity(aircraftOpacity)
-                                .shadow(color: .black.opacity(0.5), radius: 3)
-                        }
-                        .annotationTitles(.hidden)
-                    }
-                }
-                .mapStyle(.standard(elevation: .realistic))
+                loadedMap
             }
+        }
+        .onChange(of: selectedColorMetric) {
+            if !usesDualMetrics {
+                selectedWidthMetric = selectedColorMetric
+            }
+        }
+        .onChange(of: horizontalSizeClass) {
+            if !usesDualMetrics {
+                selectedWidthMetric = selectedColorMetric
+            }
+        }
+        .onChange(of: viewModel.focusIntent) {
+            applyFocusIntent(viewModel.focusIntent)
         }
         .onChange(of: viewModel.snapshotState.isLoaded) {
             if case .loaded(let snapshot) = viewModel.snapshotState {
                 mapVM.update(from: snapshot)
+                ensureAltitudeInitialized()
             }
         }
         .onChange(of: viewModel.routeAnalysesState.isLoaded) {
             if case .loaded(let analyses) = viewModel.routeAnalysesState {
                 mapVM.update(from: analyses)
+                ensureAltitudeInitialized()
             }
         }
         .task {
-            // Immediate update if data already loaded
+            ensureAltitudeInitialized()
             if case .loaded(let analyses) = viewModel.routeAnalysesState {
                 mapVM.update(from: analyses)
             } else if case .loaded(let snapshot) = viewModel.snapshotState {
                 mapVM.update(from: snapshot)
             }
+            applyFocusIntent(viewModel.focusIntent)
         }
+    }
+
+    private var loadedMap: some View {
+        // Read observable values in view body — Map content builder is @escaping.
+        let _ = trackingService.locationUpdateCount
+        let isTracking = trackingService.isTracking
+        let aircraftLocation = trackingService.currentLocation
+        let aircraftOpacity = trackingService.projectedPosition?.opacity ?? 0.3
+        let aircraftHeading = trackingService.projectedPosition?.headingDeg ?? 0
+        let activeRoutePoint = viewModel.routePoint(for: viewModel.activePoint)
+        let widthMetric = usesDualMetrics ? selectedWidthMetric : selectedColorMetric
+        let segments = mapVM.segments(
+            colorMetric: selectedColorMetric,
+            widthMetric: widthMetric,
+            model: viewModel.selectedModel,
+            altitudeFt: effectiveAltitudeFt
+        )
+
+        return ZStack(alignment: .bottom) {
+            Map(initialPosition: .region(mapVM.mapRegion)) {
+                if segments.isEmpty {
+                    MapPolyline(coordinates: mapVM.routeCoordinates)
+                        .stroke(.blue, lineWidth: 3)
+                } else {
+                    ForEach(segments) { segment in
+                        MapPolyline(coordinates: segment.coordinates)
+                            .stroke(segment.color, lineWidth: segment.width)
+                    }
+                }
+
+                ForEach(segments) { segment in
+                    Annotation("", coordinate: segment.midpoint, anchor: .center) {
+                        Button {
+                            viewModel.setActivePoint(segment.targetPoint)
+                        } label: {
+                            Circle()
+                                .fill(Color.white.opacity(0.001))
+                                .frame(width: 34, height: 34)
+                        }
+                        .accessibilityLabel(segment.valueDescription ?? "Route segment")
+                    }
+                    .annotationTitles(.hidden)
+                }
+
+                ForEach(mapVM.waypoints) { waypoint in
+                    Annotation(waypoint.id, coordinate: waypoint.coordinate) {
+                        Button {
+                            selectWaypoint(waypoint)
+                        } label: {
+                            VStack(spacing: 2) {
+                                Text(waypoint.id)
+                                    .font(.caption2.bold())
+                                    .foregroundStyle(.primary)
+                                    .padding(.horizontal, 4)
+                                    .padding(.vertical, 2)
+                                    .background(.ultraThinMaterial, in: Capsule())
+                                Circle()
+                                    .fill(waypointColor(waypoint))
+                                    .frame(width: 10, height: 10)
+                                    .overlay(Circle().stroke(.white, lineWidth: 1.5))
+                            }
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+
+                if let activeRoutePoint {
+                    Annotation("", coordinate: .init(latitude: activeRoutePoint.lat, longitude: activeRoutePoint.lon), anchor: .center) {
+                        ZStack {
+                            Circle()
+                                .fill(.orange.opacity(0.20))
+                            Circle()
+                                .stroke(.orange, lineWidth: 3)
+                        }
+                        .frame(width: 22, height: 22)
+                    }
+                    .annotationTitles(.hidden)
+                }
+
+                if isTracking, let location = aircraftLocation {
+                    Annotation("", coordinate: location.coordinate, anchor: .center) {
+                        Image(systemName: "airplane")
+                            .font(.system(size: 28, weight: .bold))
+                            .foregroundStyle(.orange)
+                            .rotationEffect(.degrees(aircraftHeading - 90))
+                            .opacity(aircraftOpacity)
+                            .shadow(color: .black.opacity(0.5), radius: 3)
+                    }
+                    .annotationTitles(.hidden)
+                }
+            }
+            .mapStyle(.standard(elevation: .realistic))
+
+            VStack(spacing: WeatherTheme.Spacing.sm) {
+                RouteMapControls(
+                    selectedColorMetric: $selectedColorMetric,
+                    selectedWidthMetric: $selectedWidthMetric,
+                    altitudeFt: $altitudeFt,
+                    usesDualMetrics: usesDualMetrics,
+                    needsAltitude: selectedColorMetric.altitudeDependent || widthMetric.altitudeDependent,
+                    ceilingFt: viewModel.flight.flightCeilingFt,
+                    selectedModel: viewModel.selectedModel
+                )
+
+                RouteMapLegend(
+                    colorMetric: selectedColorMetric,
+                    widthMetric: usesDualMetrics && widthMetric != selectedColorMetric ? widthMetric : nil
+                )
+            }
+            .padding(WeatherTheme.Spacing.md)
+        }
+        .popover(item: $selectedWaypoint) { waypoint in
+            RouteWaypointConditionPopover(
+                waypoint: waypoint,
+                condition: airportCondition(for: waypoint),
+                selectedModel: viewModel.selectedModel
+            )
+            .presentationCompactAdaptation(.popover)
+        }
+    }
+
+    private var usesDualMetrics: Bool {
+        horizontalSizeClass == .regular
+    }
+
+    private var effectiveAltitudeFt: Double {
+        altitudeFt > 0 ? altitudeFt : Double(viewModel.flight.cruiseAltitudeFt)
+    }
+
+    private func ensureAltitudeInitialized() {
+        guard altitudeFt == 0 else { return }
+        altitudeFt = Double(viewModel.flight.cruiseAltitudeFt)
+    }
+
+    private func applyFocusIntent(_ intent: BriefingFocusIntent?) {
+        guard intent?.target == .map else { return }
+        if let metricId = intent?.metricId, let metric = RouteMapMetric(rawValue: metricId) {
+            selectedColorMetric = metric
+            if !usesDualMetrics {
+                selectedWidthMetric = metric
+            }
+        }
+        if let altitude = intent?.altitudeFt {
+            altitudeFt = min(Double(viewModel.flight.flightCeilingFt), max(0, altitude))
+        }
+    }
+
+    private func selectWaypoint(_ waypoint: RouteMapViewModel.WaypointAnnotation) {
+        if let point = mapVM.routePoints.first(where: { $0.waypointIcao == waypoint.id }) {
+            viewModel.setActivePoint(point)
+        }
+        selectedWaypoint = waypoint
+    }
+
+    private func airportCondition(for waypoint: RouteMapViewModel.WaypointAnnotation) -> AirportConditionsSummary? {
+        guard case .loaded(let advisories) = viewModel.advisoriesState,
+              let conditions = advisories.airportConditions
+        else { return nil }
+        if conditions.departure.icao == waypoint.id {
+            return conditions.departure
+        }
+        if conditions.arrival.icao == waypoint.id {
+            return conditions.arrival
+        }
+        return nil
+    }
+
+    private func waypointColor(_ waypoint: RouteMapViewModel.WaypointAnnotation) -> Color {
+        guard let condition = airportCondition(for: waypoint) else { return .blue }
+        let category = condition.conditions
+            .map { $0.flightCategory.uppercased() }
+            .sorted { flightCategorySeverity($0) > flightCategorySeverity($1) }
+            .first ?? "UNKNOWN"
+        return flightCategoryColor(category)
+    }
+}
+
+private struct RouteMapControls: View {
+    @Binding var selectedColorMetric: RouteMapMetric
+    @Binding var selectedWidthMetric: RouteMapMetric
+    @Binding var altitudeFt: Double
+    let usesDualMetrics: Bool
+    let needsAltitude: Bool
+    let ceilingFt: Int
+    let selectedModel: String
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: WeatherTheme.Spacing.sm) {
+            HStack(spacing: WeatherTheme.Spacing.sm) {
+                Picker("Color", selection: $selectedColorMetric) {
+                    ForEach(RouteMapMetric.allCases) { metric in
+                        Text(metric.label).tag(metric)
+                    }
+                }
+                .pickerStyle(.menu)
+
+                if usesDualMetrics {
+                    Picker("Width", selection: $selectedWidthMetric) {
+                        ForEach(RouteMapMetric.allCases) { metric in
+                            Text(metric.label).tag(metric)
+                        }
+                    }
+                    .pickerStyle(.menu)
+                }
+
+                Spacer()
+
+                Label(selectedModel.shortModelName.uppercased(), systemImage: "square.stack.3d.up")
+                    .font(.caption.bold())
+                    .foregroundStyle(WeatherTheme.mutedText(colorScheme))
+            }
+
+            if needsAltitude {
+                VStack(alignment: .leading, spacing: WeatherTheme.Spacing.xs) {
+                    HStack {
+                        Label("FL\(Int(altitudeFt / 100))", systemImage: "arrow.up.to.line.compact")
+                            .font(.caption.monospacedDigit())
+                        Spacer()
+                        Text("0-FL\(ceilingFt / 100)")
+                            .font(.caption2.monospacedDigit())
+                            .foregroundStyle(WeatherTheme.mutedText(colorScheme))
+                    }
+                    Slider(value: $altitudeFt, in: 0...Double(max(ceilingFt, 500)), step: 500)
+                }
+            }
+        }
+        .padding(WeatherTheme.Spacing.md)
+        .background(WeatherTheme.surface(colorScheme).opacity(0.92), in: RoundedRectangle(cornerRadius: WeatherTheme.Radius.card))
+        .overlay {
+            RoundedRectangle(cornerRadius: WeatherTheme.Radius.card)
+                .stroke(WeatherTheme.border(colorScheme), lineWidth: 0.5)
+        }
+    }
+}
+
+private struct RouteMapLegend: View {
+    let colorMetric: RouteMapMetric
+    let widthMetric: RouteMapMetric?
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: WeatherTheme.Spacing.xs) {
+            HStack {
+                Text(colorMetric.label)
+                    .font(.caption.bold())
+                    .foregroundStyle(WeatherTheme.text(colorScheme))
+                Spacer()
+                if colorMetric.altitudeDependent {
+                    Image(systemName: "arrow.up.to.line.compact")
+                        .font(.caption2)
+                        .foregroundStyle(WeatherTheme.mutedText(colorScheme))
+                }
+            }
+
+            LinearGradient(
+                colors: colorMetric.legendStops.map(\.color),
+                startPoint: .leading,
+                endPoint: .trailing
+            )
+            .frame(height: 8)
+            .clipShape(Capsule())
+
+            HStack {
+                ForEach(colorMetric.legendStops) { stop in
+                    Text(stop.label)
+                        .font(.caption2)
+                        .foregroundStyle(WeatherTheme.mutedText(colorScheme))
+                    if stop.id != colorMetric.legendStops.last?.id {
+                        Spacer(minLength: 2)
+                    }
+                }
+            }
+
+            if let widthMetric {
+                Label("Width: \(widthMetric.label)", systemImage: "lineweight")
+                    .font(.caption2)
+                    .foregroundStyle(WeatherTheme.mutedText(colorScheme))
+            }
+        }
+        .padding(WeatherTheme.Spacing.md)
+        .background(WeatherTheme.surface(colorScheme).opacity(0.92), in: RoundedRectangle(cornerRadius: WeatherTheme.Radius.card))
+        .overlay {
+            RoundedRectangle(cornerRadius: WeatherTheme.Radius.card)
+                .stroke(WeatherTheme.border(colorScheme), lineWidth: 0.5)
+        }
+    }
+}
+
+private struct RouteWaypointConditionPopover: View {
+    let waypoint: RouteMapViewModel.WaypointAnnotation
+    let condition: AirportConditionsSummary?
+    let selectedModel: String
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: WeatherTheme.Spacing.md) {
+            HStack {
+                VStack(alignment: .leading, spacing: WeatherTheme.Spacing.xs) {
+                    Text(waypoint.id)
+                        .font(.headline)
+                    Text(waypoint.name)
+                        .font(.caption)
+                        .foregroundStyle(WeatherTheme.mutedText(colorScheme))
+                }
+                Spacer()
+                if let modelCondition {
+                    Text(modelCondition.flightCategory.uppercased())
+                        .font(.caption.bold())
+                        .foregroundStyle(.white)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 4)
+                        .background(flightCategoryColor(modelCondition.flightCategory), in: Capsule())
+                }
+            }
+
+            if let modelCondition {
+                VStack(alignment: .leading, spacing: WeatherTheme.Spacing.xs) {
+                    Label(modelCondition.model.uppercased(), systemImage: "square.stack.3d.up")
+                    if let windSpeed = modelCondition.windSpeedKt {
+                        Label(windText(modelCondition, windSpeed: windSpeed), systemImage: "wind")
+                    }
+                    if let ceiling = modelCondition.ceilingFt {
+                        Label("\(ceiling) ft ceiling", systemImage: "cloud")
+                    }
+                    if let visibility = modelCondition.visibilitySm {
+                        Label(String(format: "%.1f sm visibility", visibility), systemImage: "eye")
+                    }
+                    if let runway = modelCondition.bestRunway {
+                        Label("RWY \(runway.runwayId) · XW \(Int(abs(runway.crosswindKt).rounded())) kt", systemImage: "arrow.triangle.branch")
+                    }
+                }
+                .font(.caption)
+                .foregroundStyle(WeatherTheme.text(colorScheme))
+            } else {
+                Text("Airport condition data is not available in this briefing pack.")
+                    .font(.caption)
+                    .foregroundStyle(WeatherTheme.mutedText(colorScheme))
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .frame(width: 260, alignment: .leading)
+        .padding(WeatherTheme.Spacing.md)
+    }
+
+    private var modelCondition: AirportModelCondition? {
+        guard let condition else { return nil }
+        return condition.conditions.first { $0.model == selectedModel }
+            ?? condition.conditions.first
+    }
+
+    private func windText(_ condition: AirportModelCondition, windSpeed: Double) -> String {
+        let direction = condition.windDirectionDeg.map { "\(Int($0.rounded())) deg" } ?? "VRB"
+        let gust = condition.windGustKt.map { "G\(Int($0.rounded()))" } ?? ""
+        return "\(direction) \(Int(windSpeed.rounded()))\(gust) kt"
+    }
+}
+
+private func flightCategorySeverity(_ category: String) -> Int {
+    switch category.uppercased() {
+    case "LIFR": 4
+    case "IFR": 3
+    case "MVFR": 2
+    case "VFR": 1
+    default: 0
+    }
+}
+
+private func flightCategoryColor(_ category: String) -> Color {
+    switch category.uppercased() {
+    case "VFR": .green
+    case "MVFR": .orange
+    case "IFR": .red
+    case "LIFR": .purple
+    default: .gray
     }
 }
 

--- a/app/flyfun-weather/flyfun-weather/Views/Map/RouteMapView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Map/RouteMapView.swift
@@ -26,6 +26,7 @@ struct RouteMapView: View {
                 let aircraftLocation = trackingService.currentLocation
                 let aircraftOpacity = trackingService.projectedPosition?.opacity ?? 0.3
                 let aircraftHeading = trackingService.projectedPosition?.headingDeg ?? 0
+                let activeRoutePoint = viewModel.routePoint(for: viewModel.activePoint)
                 Map(initialPosition: .region(mapVM.mapRegion)) {
                     MapPolyline(coordinates: mapVM.routeCoordinates)
                         .stroke(.blue, lineWidth: 3)
@@ -43,6 +44,19 @@ struct RouteMapView: View {
                                     .frame(width: 8, height: 8)
                             }
                         }
+                    }
+
+                    if let activeRoutePoint {
+                        Annotation("", coordinate: .init(latitude: activeRoutePoint.lat, longitude: activeRoutePoint.lon), anchor: .center) {
+                            ZStack {
+                                Circle()
+                                    .fill(.orange.opacity(0.20))
+                                Circle()
+                                    .stroke(.orange, lineWidth: 3)
+                            }
+                                .frame(width: 22, height: 22)
+                        }
+                        .annotationTitles(.hidden)
                     }
 
                     // Live aircraft position — drawn last so it renders on top

--- a/app/flyfun-weather/flyfun-weather/Views/RouteGraph/RouteGraphView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/RouteGraph/RouteGraphView.swift
@@ -12,19 +12,24 @@ private struct ChartDataPoint: Identifiable {
 struct RouteGraphView: View {
     let viewModel: BriefingViewModel
     let vizData: VizRouteData?
-
-    @State private var leftMetricId = "headwind"
-    @State private var rightMetricId = "cloud-cover"
+    let selectedDistanceNm: Double?
+    @Binding var leftMetricId: String
+    @Binding var rightMetricId: String
+    var onScrubDistance: (Double) -> Void = { _ in }
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
 
     private var leftMetric: RouteGraphMetric? { RouteGraphMetrics.metric(byId: leftMetricId) }
     private var rightMetric: RouteGraphMetric? { RouteGraphMetrics.metric(byId: rightMetricId) }
+    private var allowsRightMetric: Bool { horizontalSizeClass == .regular }
 
     var body: some View {
         VStack(spacing: 4) {
             HStack {
                 metricPicker(selection: $leftMetricId, label: "Left")
                 Spacer()
-                metricPicker(selection: $rightMetricId, label: "Right")
+                if allowsRightMetric {
+                    metricPicker(selection: $rightMetricId, label: "Right")
+                }
             }
             .padding(.horizontal, 12)
 
@@ -38,7 +43,7 @@ struct RouteGraphView: View {
     private func chartView(vizData: VizRouteData, leftMetric: RouteGraphMetric) -> some View {
         let leftData = extractData(points: vizData.points, metric: leftMetric)
         let rightData: [ChartDataPoint] = {
-            guard rightMetricId != "none", let rm = rightMetric else { return [] }
+            guard allowsRightMetric, rightMetricId != "none", let rm = rightMetric else { return [] }
             return extractData(points: vizData.points, metric: rm)
         }()
 
@@ -54,7 +59,7 @@ struct RouteGraphView: View {
                 }
             }
 
-            if let rm = rightMetric, rightMetricId != "none" {
+            if allowsRightMetric, let rm = rightMetric, rightMetricId != "none" {
                 ForEach(rightData) { pt in
                     if rm.renderType == .bar {
                         BarMark(x: .value("Distance", pt.distance), y: .value(rm.label, pt.value))
@@ -72,6 +77,12 @@ struct RouteGraphView: View {
                     .foregroundStyle(.gray.opacity(0.3))
                     .lineStyle(StrokeStyle(dash: [4, 4]))
             }
+
+            if let selectedDistanceNm {
+                RuleMark(x: .value("Selected", selectedDistanceNm))
+                    .foregroundStyle(.orange)
+                    .lineStyle(StrokeStyle(lineWidth: 1.5))
+            }
         }
         .chartXAxisLabel("Distance (nm)")
         .chartYAxis {
@@ -83,6 +94,22 @@ struct RouteGraphView: View {
         }
         .frame(height: 150)
         .padding(.horizontal, 12)
+        .chartOverlay { proxy in
+            GeometryReader { geometry in
+                Rectangle()
+                    .fill(.clear)
+                    .contentShape(Rectangle())
+                    .gesture(
+                        DragGesture(minimumDistance: 0)
+                            .onChanged { value in
+                                scrubGraph(at: value.location, proxy: proxy, geometry: geometry)
+                            }
+                            .onEnded { value in
+                                scrubGraph(at: value.location, proxy: proxy, geometry: geometry)
+                            }
+                    )
+            }
+        }
     }
 
     private func extractData(points: [VizPoint], metric: RouteGraphMetric) -> [ChartDataPoint] {
@@ -113,5 +140,14 @@ struct RouteGraphView: View {
             }
         }
         .buttonStyle(.plain)
+    }
+
+    private func scrubGraph(at location: CGPoint, proxy: ChartProxy, geometry: GeometryProxy) {
+        let plotFrame = geometry[proxy.plotAreaFrame]
+        let x = location.x - plotFrame.origin.x
+        guard x >= 0, x <= plotFrame.width,
+              let distance: Double = proxy.value(atX: x)
+        else { return }
+        onScrubDistance(distance)
     }
 }

--- a/app/flyfun-weather/flyfun-weather/Views/Shared/WeatherTheme.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Shared/WeatherTheme.swift
@@ -1,0 +1,56 @@
+import SwiftUI
+
+enum WeatherTheme {
+    enum Spacing {
+        static let xs: CGFloat = 4
+        static let sm: CGFloat = 8
+        static let md: CGFloat = 12
+        static let lg: CGFloat = 16
+        static let section: CGFloat = 24
+    }
+
+    enum Radius {
+        static let card: CGFloat = 8
+        static let control: CGFloat = 8
+    }
+
+    static func background(_ scheme: ColorScheme) -> Color {
+        scheme == .dark
+            ? Color(.sRGB, red: 18 / 255, green: 18 / 255, blue: 24 / 255, opacity: 1)
+            : Color(.sRGB, red: 248 / 255, green: 249 / 255, blue: 250 / 255, opacity: 1)
+    }
+
+    static func surface(_ scheme: ColorScheme) -> Color {
+        scheme == .dark
+            ? Color(.sRGB, red: 30 / 255, green: 30 / 255, blue: 42 / 255, opacity: 1)
+            : .white
+    }
+
+    static func border(_ scheme: ColorScheme) -> Color {
+        scheme == .dark
+            ? Color(.sRGB, red: 45 / 255, green: 45 / 255, blue: 58 / 255, opacity: 1)
+            : Color(.sRGB, red: 222 / 255, green: 226 / 255, blue: 230 / 255, opacity: 1)
+    }
+
+    static func mutedText(_ scheme: ColorScheme) -> Color {
+        scheme == .dark
+            ? Color(.sRGB, red: 156 / 255, green: 163 / 255, blue: 175 / 255, opacity: 1)
+            : Color(.sRGB, red: 108 / 255, green: 117 / 255, blue: 125 / 255, opacity: 1)
+    }
+
+    static func text(_ scheme: ColorScheme) -> Color {
+        scheme == .dark
+            ? Color(.sRGB, red: 228 / 255, green: 228 / 255, blue: 232 / 255, opacity: 1)
+            : Color(.sRGB, red: 26 / 255, green: 26 / 255, blue: 46 / 255, opacity: 1)
+    }
+
+    static func primary(_ scheme: ColorScheme) -> Color {
+        scheme == .dark
+            ? Color(.sRGB, red: 96 / 255, green: 165 / 255, blue: 250 / 255, opacity: 1)
+            : Color(.sRGB, red: 37 / 255, green: 99 / 255, blue: 235 / 255, opacity: 1)
+    }
+
+    static func shadow(_ scheme: ColorScheme) -> Color {
+        .black.opacity(scheme == .dark ? 0.28 : 0.08)
+    }
+}

--- a/app/flyfun-weather/flyfun-weatherTests/flyfun_weatherTests.swift
+++ b/app/flyfun-weather/flyfun-weatherTests/flyfun_weatherTests.swift
@@ -5,12 +5,181 @@
 //  Created by Brice Rosenzweig on 01/03/2026.
 //
 
+import Foundation
 import Testing
+@testable import flyfun_weather
 
 struct flyfun_weatherTests {
 
-    @Test func example() async throws {
-        // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+    @Test func soundingProfileDecodesExtendedLevelFields() throws {
+        let json = """
+        {
+          "point_index": 3,
+          "lat": 51.1,
+          "lon": -0.6,
+          "distance_from_origin_nm": 42.5,
+          "waypoint_icao": "EGTF",
+          "model": "gfs",
+          "time": "2026-06-24T12:00:00Z",
+          "levels": [
+            {
+              "pressure_hpa": 850,
+              "altitude_ft": 4780.0,
+              "temperature_c": 4.2,
+              "dewpoint_c": 1.4,
+              "wind_speed_kt": 27.0,
+              "wind_direction_deg": 245.0,
+              "relative_humidity_pct": 82.0,
+              "dewpoint_depression_c": 2.8,
+              "wet_bulb_c": 2.9,
+              "theta_e_k": 303.4,
+              "lapse_rate_c_per_km": 6.1,
+              "icing_index": 21.0,
+              "icing_index_nwp": 37.0,
+              "sfip_100": 44.0,
+              "cloud_liquid_water_g_m3": 0.18,
+              "ice_mixing_ratio_g_kg": 0.05,
+              "cloud_area_fraction_pct": 73.0,
+              "richardson_number": 0.21,
+              "omega_pa_s": -0.32,
+              "w_fpm": 52.0
+            }
+          ],
+          "cruise_altitude_ft": 8000,
+          "track_deg": 132.0,
+          "label": "EGTF",
+          "indices": {
+            "freezing_level_ft": 5200.0,
+            "minus10c_level_ft": 11800.0,
+            "minus20c_level_ft": 17200.0,
+            "lcl_pressure_hpa": 910.0,
+            "lcl_altitude_ft": 2900.0,
+            "lfc_pressure_hpa": 710.0,
+            "lfc_altitude_ft": 9800.0,
+            "el_pressure_hpa": 360.0,
+            "el_altitude_ft": 27000.0,
+            "cape_surface_jkg": 850.0,
+            "cape_most_unstable_jkg": 920.0,
+            "cape_mixed_layer_jkg": 610.0,
+            "cin_surface_jkg": -42.0,
+            "lifted_index": -3.2,
+            "showalter_index": 0.8,
+            "k_index": 28.5,
+            "total_totals": 49.0,
+            "precipitable_water_mm": 24.0,
+            "nwp_cape_jkg": 700.0,
+            "nwp_cape_type": "ml",
+            "nwp_cin_jkg": -20.0,
+            "nwp_lifted_index": -2.1,
+            "nwp_freezing_level_ft": 5400.0,
+            "cape_raw_vs_calc_divergent": true
+          },
+          "parcel_path": [{"pressure_hpa": 850.0, "temperature_c": 7.0}],
+          "cloud_layers": [],
+          "nwp_cloud_layers": [],
+          "icing_zones": [],
+          "icing_ogimet_nwp_zones": [],
+          "sfip_zones": [],
+          "inversion_layers": [],
+          "convective": {"risk_level": "low", "base_ft": 9000.0, "top_ft": 25000.0}
+        }
+        """.data(using: .utf8)!
+
+        let response = try JSONDecoder.weatherBrief.decode(SoundingProfileResponse.self, from: json)
+        let level = try #require(response.levels.first)
+
+        #expect(response.trackDeg == 132.0)
+        #expect(response.label == "EGTF")
+        #expect(response.parcelPath?.first?.pressureHpa == 850.0)
+        #expect(response.indices?.lclPressureHpa == 910.0)
+        #expect(response.indices?.liftedIndex == -3.2)
+        #expect(response.indices?.nwpCapeType == "ml")
+        #expect(response.indices?.capeRawVsCalcDivergent == true)
+        #expect(response.convective?.riskLevel == "low")
+        #expect(level.relativeHumidityPct == 82.0)
+        #expect(level.dewpointDepressionC == 2.8)
+        #expect(level.wetBulbC == 2.9)
+        #expect(level.thetaEK == 303.4)
+        #expect(level.lapseRateCPerKm == 6.1)
+        #expect(level.icingIndex == 21.0)
+        #expect(level.icingIndexNwp == 37.0)
+        #expect(level.sfip100 == 44.0)
+        #expect(level.cloudLiquidWaterGM3 == 0.18)
+        #expect(level.iceMixingRatioGKg == 0.05)
+        #expect(level.cloudAreaFractionPct == 73.0)
+        #expect(level.richardsonNumber == 0.21)
+        #expect(level.omegaPaS == -0.32)
+        #expect(level.wFpm == 52.0)
+    }
+
+    @Test func advisoriesDecodeParametersAndCrossCheck() throws {
+        let json = """
+        {
+          "advisories": [
+            {
+              "advisory_id": "convective",
+              "aggregate_status": "red",
+              "aggregate_detail": "High CAPE near EGTF",
+              "per_model": [
+                {
+                  "model": "gfs",
+                  "status": "red",
+                  "detail": "HIGH risk over 20nm",
+                  "affected_points": 3,
+                  "total_points": 5,
+                  "affected_pct": 60.0,
+                  "affected_nm": 20.0,
+                  "total_nm": 33.3,
+                  "cross_check": "Thermodynamic risk high while NWP cover is quiet"
+                }
+              ],
+              "parameters_used": {
+                "affected_pct_red": 50.0,
+                "min_risk": 2.0
+              }
+            }
+          ],
+          "catalog": [
+            {
+              "id": "convective",
+              "name": "Convective Activity",
+              "short_description": "Can fly around convective activity",
+              "description": "Uses convective risk assessment per point.",
+              "category": "convective",
+              "default_enabled": true,
+              "altitude_dependent": false,
+              "parameters": [
+                {
+                  "key": "affected_pct_red",
+                  "label": "Route % (red)",
+                  "description": "Route percentage affected for red",
+                  "type": "percent",
+                  "unit": "%",
+                  "default": 50.0,
+                  "min": 10.0,
+                  "max": 100.0,
+                  "step": 5.0
+                }
+              ]
+            }
+          ],
+          "route_name": "egtf-eglf",
+          "cruise_altitude_ft": 8000,
+          "flight_ceiling_ft": 18000,
+          "total_distance_nm": 33.3,
+          "models": ["gfs"],
+          "aggregation": "worst",
+          "airport_conditions": null
+        }
+        """.data(using: .utf8)!
+
+        let response = try JSONDecoder.weatherBrief.decode(AdvisoriesResponse.self, from: json)
+        let advisory = try #require(response.advisories.first)
+        let model = try #require(advisory.perModel.first)
+
+        #expect(advisory.parametersUsed["affected_pct_red"] == 50.0)
+        #expect(response.catalog.first?.parameters.first?.key == "affected_pct_red")
+        #expect(model.crossCheck == "Thermodynamic risk high while NWP cover is quiet")
     }
 
 }

--- a/app/flyfun-weather/flyfun-weatherTests/flyfun_weatherTests.swift
+++ b/app/flyfun-weather/flyfun-weatherTests/flyfun_weatherTests.swift
@@ -182,4 +182,62 @@ struct flyfun_weatherTests {
         #expect(model.crossCheck == "Thermodynamic risk high while NWP cover is quiet")
     }
 
+    @Test func advisoryDetailDecodesStructuredCrossCheckAndConvectiveBlock() throws {
+        let json = """
+        {
+          "advisory_id": "convective",
+          "aggregate_status": "red",
+          "aggregate_detail": "High CAPE along the middle third of the route",
+          "name": "Convective Activity",
+          "description": "Can fly around convective activity.",
+          "flight_id": "flight-1",
+          "briefing_timestamp": "2026-06-24T12:00:00+00:00",
+          "route_name": "egtf-eglf",
+          "total_distance_nm": 50.0,
+          "per_model": [
+            {
+              "model": "gfs",
+              "status": "red",
+              "detail": "HIGH risk near EGTF",
+              "affected_pct": 44.0,
+              "affected_nm": 22.0,
+              "total_nm": 50.0,
+              "cross_check": {"note": "NWP scheme remains quiet"}
+            }
+          ],
+          "parameters_used": {"affected_pct_red": 40.0},
+          "cross_check_note": "Cross-checks explain the grade.",
+          "convective_note": "Convective split is explanatory.",
+          "convective": {
+            "gfs": {
+              "assessment_method": "thermo",
+              "method_counts": {"thermo": 1},
+              "thermo": {
+                "cape_range_jkg": [1840, 1840],
+                "peak": {
+                  "cape_jkg": 1840,
+                  "el_top_ft": 27000,
+                  "risk_level": "high",
+                  "distance_nm": 19.5,
+                  "waypoint_icao": "EGTF"
+                }
+              },
+              "nwp": {"max_cover_pct": 0, "peak_top_ft": null}
+            }
+          }
+        }
+        """.data(using: .utf8)!
+
+        let response = try JSONDecoder.weatherBrief.decode(AdvisoryDetailResponse.self, from: json)
+        let model = try #require(response.perModel.first)
+        let convective = try #require(response.convective?["gfs"])
+
+        #expect(response.name == "Convective Activity")
+        #expect(response.totalDistanceNm == 50.0)
+        #expect(model.crossCheck == "note: NWP scheme remains quiet")
+        #expect(convective.assessmentMethod == "thermo")
+        #expect(convective.thermo?.peak?.elTopFt == 27000)
+        #expect(convective.nwp?.maxCoverPct == 0)
+    }
+
 }

--- a/app/flyfun-weather/flyfun-weatherTests/flyfun_weatherTests.swift
+++ b/app/flyfun-weather/flyfun-weatherTests/flyfun_weatherTests.swift
@@ -364,4 +364,149 @@ struct flyfun_weatherTests {
         #expect(RouteMapMetric.tempAtLevel.value(for: firstPoint, model: "gfs", altitudeFt: 8000) == -6)
     }
 
+    @MainActor
+    @Test func flightListDecodesOperationalSectionsAndUpdateInvalidation() throws {
+        let flightsJson = """
+        [
+          {
+            "id": "future-flight",
+            "user_id": "user-1",
+            "profile_id": null,
+            "aircraft_id": 7,
+            "aircraft": {
+              "id": 7,
+              "icao_type": "SR22",
+              "type_name": "Cirrus SR22",
+              "tail_number": "N123AB",
+              "nickname": "N123AB"
+            },
+            "route_name": "egtf_eglf",
+            "waypoints": ["EGTF", "EGLF"],
+            "departure_time": "2099-06-24T12:00:00+00:00",
+            "alt_departure_time": null,
+            "target_date": "2099-06-24",
+            "target_time_utc": 12,
+            "cruise_altitude_ft": 8000,
+            "flight_ceiling_ft": 18000,
+            "flight_duration_hours": 1.5,
+            "private": false,
+            "auto_refresh": false,
+            "auto_refresh_hour": null,
+            "created_at": "2026-06-24T08:00:00+00:00",
+            "latest_briefing": {
+              "assessment": "green",
+              "assessment_reason": "Fine",
+              "outlook": null,
+              "outlook_reason": null,
+              "has_digest": true,
+              "days_out": 1,
+              "fetch_timestamp": "2026-06-24T09:00:00+00:00",
+              "has_advisories": true,
+              "advisory_summary": {
+                "red": 1,
+                "amber": 2,
+                "top": [{"status": "RED", "name": "Convection"}]
+              }
+            },
+            "role": "owner",
+            "owner_display_name": null,
+            "is_subscribed": false,
+            "debrief": null,
+            "section": "future",
+            "raw_route": null,
+            "parser_version": null,
+            "share_code": "abc123xy"
+          },
+          {
+            "id": "recent-flight",
+            "user_id": "user-1",
+            "profile_id": null,
+            "aircraft_id": null,
+            "aircraft": null,
+            "route_name": "egll_egkk",
+            "waypoints": ["EGLL", "EGKK"],
+            "departure_time": "2020-06-24T10:00:00+00:00",
+            "alt_departure_time": null,
+            "target_date": "2020-06-24",
+            "target_time_utc": 10,
+            "cruise_altitude_ft": 5000,
+            "flight_ceiling_ft": 12000,
+            "flight_duration_hours": 0.8,
+            "private": false,
+            "auto_refresh": false,
+            "auto_refresh_hour": null,
+            "created_at": "2020-06-23T08:00:00+00:00",
+            "latest_briefing": null,
+            "role": "owner",
+            "owner_display_name": null,
+            "is_subscribed": false,
+            "debrief": {
+              "flight_id": "recent-flight",
+              "decision": "flown",
+              "reasons": [],
+              "outcomes": {},
+              "note": null,
+              "created_at": "2020-06-24T12:00:00+00:00",
+              "updated_at": "2020-06-24T12:00:00+00:00"
+            },
+            "section": "recent",
+            "raw_route": null,
+            "parser_version": null,
+            "share_code": null
+          }
+        ]
+        """.data(using: .utf8)!
+
+        let flights = try JSONDecoder.weatherBrief.decode([FlightResponse].self, from: flightsJson)
+        let grouped = FlightListViewModel.groupFlights(flights)
+
+        #expect(grouped.map(\.section) == [.future, .recent])
+        #expect(grouped.first?.flights.first?.latestBriefing?.advisorySummary?.red == 1)
+        #expect(grouped.first?.flights.first?.aircraft?.displayName == "N123AB")
+        #expect(grouped.last?.flights.first?.debrief?.decision == "flown")
+
+        let updateJson = """
+        {
+          "id": "future-flight",
+          "user_id": "user-1",
+          "profile_id": null,
+          "aircraft_id": null,
+          "aircraft": null,
+          "route_name": "egtf_eglf",
+          "waypoints": ["EGTF", "EGLF"],
+          "departure_time": "2099-06-24T13:00:00+00:00",
+          "alt_departure_time": null,
+          "target_date": "2099-06-24",
+          "target_time_utc": 13,
+          "cruise_altitude_ft": 8000,
+          "flight_ceiling_ft": 18000,
+          "flight_duration_hours": 1.5,
+          "private": false,
+          "auto_refresh": false,
+          "auto_refresh_hour": null,
+          "created_at": "2026-06-24T08:00:00+00:00",
+          "latest_briefing": null,
+          "role": "owner",
+          "owner_display_name": null,
+          "is_subscribed": false,
+          "debrief": null,
+          "section": "future",
+          "raw_route": null,
+          "parser_version": null,
+          "share_code": null,
+          "invalidation": "refetch_needed"
+        }
+        """.data(using: .utf8)!
+
+        let update = try JSONDecoder.weatherBrief.decode(UpdateFlightResponse.self, from: updateJson)
+        #expect(update.flight.departureTime == "2099-06-24T13:00:00+00:00")
+        #expect(update.invalidation == .refetchNeeded)
+
+        let request = UpdateFlightRequest(aircraftId: 0, cruiseAltitudeFt: 9000)
+        let encoded = try JSONSerialization.jsonObject(with: JSONEncoder.weatherBrief.encode(request)) as? [String: Any]
+        #expect(encoded?["aircraft_id"] as? Int == 0)
+        #expect(encoded?["cruise_altitude_ft"] as? Int == 9000)
+        #expect(encoded?["departure_time"] == nil)
+    }
+
 }

--- a/app/flyfun-weather/flyfun-weatherTests/flyfun_weatherTests.swift
+++ b/app/flyfun-weather/flyfun-weatherTests/flyfun_weatherTests.swift
@@ -240,4 +240,128 @@ struct flyfun_weatherTests {
         #expect(convective.nwp?.maxCoverPct == 0)
     }
 
+    @MainActor
+    @Test func routeMapMetricsStyleSegmentsAndAltitudeLayers() throws {
+        let json = """
+        {
+          "route_name": "egtf-eglf",
+          "target_date": "2026-06-24",
+          "departure_time": "2026-06-24T12:00:00Z",
+          "flight_duration_hours": 1.0,
+          "total_distance_nm": 20.0,
+          "cruise_altitude_ft": 8000,
+          "models": ["gfs"],
+          "analyses": [
+            {
+              "point_index": 0,
+              "lat": 51.3,
+              "lon": -0.55,
+              "distance_from_origin_nm": 0.0,
+              "waypoint_icao": "EGTF",
+              "waypoint_name": "Fairoaks",
+              "interpolated_time": "2026-06-24T12:00:00Z",
+              "track_deg": 120.0,
+              "wind_components": {
+                "gfs": {
+                  "wind_speed_kt": 30.0,
+                  "wind_direction_deg": 270.0,
+                  "track_deg": 120.0,
+                  "headwind_kt": 18.0,
+                  "crosswind_kt": 12.0
+                }
+              },
+              "sounding": {
+                "gfs": {
+                  "indices": {
+                    "freezing_level_ft": 5000.0,
+                    "minus10c_level_ft": 10000.0,
+                    "minus20c_level_ft": 16000.0,
+                    "cape_surface_jkg": 1800.0
+                  },
+                  "cloud_layers": [
+                    {"base_ft": 7000.0, "top_ft": 9000.0, "coverage": "bkn"}
+                  ],
+                  "icing_zones": [
+                    {"base_ft": 6500.0, "top_ft": 9500.0, "risk": "moderate", "icing_type": "rime"}
+                  ],
+                  "sfip_zones": [
+                    {"base_ft": 6500.0, "top_ft": 9500.0, "risk": "moderate", "icing_type": "sfip", "mean_sfip100": 65.0, "variant": "sfip"}
+                  ],
+                  "vertical_motion": {
+                    "classification": "moderate",
+                    "cat_risk_layers": [
+                      {"base_ft": 7500.0, "top_ft": 9000.0, "risk": "moderate"}
+                    ]
+                  },
+                  "convective": {"risk_level": "high", "base_ft": 6000.0, "top_ft": 24000.0, "cape_jkg": 1800.0},
+                  "cloud_cover_low_pct": 40.0,
+                  "cloud_cover_mid_pct": 20.0,
+                  "cloud_cover_high_pct": 10.0,
+                  "nwp_cloud_diagnostics": {
+                    "low": {"cover_pct": 40.0, "base_ft": 4000.0, "top_ft": 8000.0},
+                    "mid": {"cover_pct": 20.0, "base_ft": 8000.0, "top_ft": 14000.0},
+                    "high": {"cover_pct": 10.0, "base_ft": 18000.0, "top_ft": 24000.0},
+                    "ceiling_ft": 2200.0
+                  }
+                }
+              },
+              "model_divergence": [{"variable": "temperature", "model_values": {"gfs": -6.0}, "mean": -6.0, "spread": 0.0, "agreement": "poor"}]
+            },
+            {
+              "point_index": 1,
+              "lat": 51.28,
+              "lon": -0.76,
+              "distance_from_origin_nm": 20.0,
+              "waypoint_icao": "EGLF",
+              "waypoint_name": "Farnborough",
+              "interpolated_time": "2026-06-24T12:20:00Z",
+              "track_deg": 120.0,
+              "wind_components": {
+                "gfs": {
+                  "wind_speed_kt": 24.0,
+                  "wind_direction_deg": 250.0,
+                  "track_deg": 120.0,
+                  "headwind_kt": 12.0,
+                  "crosswind_kt": 9.0
+                }
+              },
+              "sounding": {
+                "gfs": {
+                  "indices": {
+                    "freezing_level_ft": 6000.0,
+                    "minus10c_level_ft": 11000.0,
+                    "minus20c_level_ft": 17000.0,
+                    "cape_surface_jkg": 900.0
+                  },
+                  "cloud_layers": [],
+                  "icing_zones": [],
+                  "sfip_zones": [],
+                  "vertical_motion": {"classification": "smooth", "cat_risk_layers": []},
+                  "convective": {"risk_level": "moderate", "base_ft": 7000.0, "top_ft": 18000.0, "cape_jkg": 900.0},
+                  "cloud_cover_low_pct": 10.0,
+                  "cloud_cover_mid_pct": 10.0,
+                  "cloud_cover_high_pct": 0.0
+                }
+              },
+              "model_divergence": [{"variable": "temperature", "model_values": {"gfs": -4.0}, "mean": -4.0, "spread": 0.0, "agreement": "good"}]
+            }
+          ]
+        }
+        """.data(using: .utf8)!
+
+        let response = try JSONDecoder.weatherBrief.decode(RouteAnalysesResponse.self, from: json)
+        let routeMap = RouteMapViewModel()
+        routeMap.update(from: response)
+        let firstPoint = try #require(response.analyses.first)
+        let segments = routeMap.segments(colorMetric: .convectiveRisk, widthMetric: .headwind, model: "gfs", altitudeFt: 8000)
+
+        #expect(segments.count == 1)
+        #expect(segments.first?.valueDescription == "high")
+        #expect((segments.first?.width ?? 0) > 3)
+        #expect(RouteMapMetric.icingRiskAtLevel.value(for: firstPoint, model: "gfs", altitudeFt: 8000) == 2)
+        #expect(RouteMapMetric.sfipAtLevel.value(for: firstPoint, model: "gfs", altitudeFt: 8000) == 65)
+        #expect(RouteMapMetric.cloudAtLevel.value(for: firstPoint, model: "gfs", altitudeFt: 8000) == 70)
+        #expect(RouteMapMetric.tempAtLevel.value(for: firstPoint, model: "gfs", altitudeFt: 8000) == -6)
+    }
+
 }

--- a/src/weatherbrief/api/packs.py
+++ b/src/weatherbrief/api/packs.py
@@ -46,6 +46,7 @@ def _validate_model(model: str) -> str:
     return model
 from weatherbrief.api.flights import _load_flight_or_404, _load_owned_flight
 from flyfun_common.db import current_user_id, get_db, SessionLocal
+from weatherbrief.connectors import views
 from weatherbrief.digest.llm_digest import LongRangeDigest, ecmwf_grib_horizon_days
 from weatherbrief.fetch.freshness import registry as freshness_registry
 from weatherbrief.fetch.model_status import fetch_model_metadata
@@ -2861,6 +2862,67 @@ def altitude_table(
     return result.model_dump()
 
 
+@router.get("/{timestamp}/advisories/{advisory_id}/detail")
+def get_advisory_detail(
+    flight_id: str,
+    timestamp: str,
+    advisory_id: str,
+    user_id: str = Depends(current_user_id),
+    db: Session = Depends(get_db),
+):
+    """Get a structured per-advisory drill-down for native clients."""
+    pack_dir = _get_pack_dir(db, flight_id, timestamp, viewer_id=user_id)
+    adv_path = pack_dir / "route_advisories.json"
+    if not adv_path.exists():
+        raise HTTPException(status_code=404, detail="Route advisories not available")
+
+    advisories = json_mod.loads(adv_path.read_text())
+    adv = next(
+        (
+            item
+            for item in advisories.get("advisories", [])
+            if item.get("advisory_id") == advisory_id
+        ),
+        None,
+    )
+    if adv is None:
+        available = [
+            item.get("advisory_id")
+            for item in advisories.get("advisories", [])
+            if item.get("advisory_id")
+        ]
+        listed = ", ".join(available)
+        raise HTTPException(
+            status_code=404,
+            detail=f"Advisory '{advisory_id}' not found. Available: {listed}",
+        )
+
+    catalog = {entry.get("id"): entry for entry in advisories.get("catalog", [])}
+    result = views.advisory_detail(adv, catalog.get(advisory_id))
+    result.update(
+        {
+            "flight_id": flight_id,
+            "briefing_timestamp": timestamp,
+            "route_name": advisories.get("route_name"),
+            "cruise_altitude_ft": advisories.get("cruise_altitude_ft"),
+            "flight_ceiling_ft": advisories.get("flight_ceiling_ft"),
+            "total_distance_nm": advisories.get("total_distance_nm"),
+            "models": advisories.get("models", []),
+            "aggregation": advisories.get("aggregation"),
+        }
+    )
+
+    if advisory_id == "convective":
+        route_analyses_path = pack_dir / "route_analyses.json"
+        if route_analyses_path.exists():
+            route_analyses = json_mod.loads(route_analyses_path.read_text())
+            models = [m.get("model") for m in adv.get("per_model", []) if m.get("model")]
+            result["convective"] = views.convective_detail(route_analyses, models)
+            result["convective_note"] = views.CONVECTIVE_NOTE
+
+    return result
+
+
 @router.get("/{timestamp}/elevation")
 def get_elevation(
     flight_id: str,
@@ -3497,5 +3559,4 @@ def _get_pack_dir(db: Session, flight_id: str, timestamp: str, *, viewer_id: str
     if not pack_path.exists():
         raise HTTPException(status_code=404, detail="Pack not found")
     return pack_path
-
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -713,6 +713,100 @@ class TestPacksAPI:
         assert resp.status_code == 404
 
 
+class TestAdvisoryDetailAPI:
+    @pytest.fixture
+    def pack_with_advisory_detail(self, tmp_path, sample_pack, monkeypatch):
+        monkeypatch.setenv("DATA_DIR", str(tmp_path / "data"))
+        pack_dir = pack_dir_for(
+            DEV_USER_ID,
+            sample_pack.flight_id,
+            sample_pack.fetch_timestamp,
+        )
+        pack_dir.mkdir(parents=True, exist_ok=True)
+        (pack_dir / "route_advisories.json").write_text(json.dumps({
+            "advisories": [
+                {
+                    "advisory_id": "convective",
+                    "aggregate_status": "red",
+                    "aggregate_detail": "High CAPE along the middle third of the route",
+                    "per_model": [
+                        {
+                            "model": "gfs",
+                            "status": "red",
+                            "detail": "HIGH risk near EGTF",
+                            "affected_pct": 44.0,
+                            "affected_nm": 22.0,
+                            "total_nm": 50.0,
+                            "cross_check": {"note": "NWP scheme remains quiet"},
+                        }
+                    ],
+                    "parameters_used": {"affected_pct_red": 40.0},
+                }
+            ],
+            "catalog": [
+                {
+                    "id": "convective",
+                    "name": "Convective Activity",
+                    "category": "convective",
+                    "description": "Can fly around convective activity.",
+                }
+            ],
+            "route_name": "egtk-lsgs",
+            "cruise_altitude_ft": 8000,
+            "flight_ceiling_ft": 18000,
+            "total_distance_nm": 50.0,
+            "models": ["gfs"],
+            "aggregation": "worst",
+        }))
+        (pack_dir / "route_analyses.json").write_text(json.dumps({
+            "analyses": [
+                {
+                    "distance_from_origin_nm": 19.5,
+                    "waypoint_icao": "EGTF",
+                    "forecast_hour": 15,
+                    "interpolated_time": "2026-06-24T15:00:00Z",
+                    "sounding": {
+                        "gfs": {
+                            "convective": {"method": "thermo"},
+                            "convective_thermo": {
+                                "cape_jkg": 1840,
+                                "top_ft": 27000,
+                                "risk_level": "high",
+                            },
+                            "convective_nwp": {"cover_pct": 0, "top_ft": None},
+                        }
+                    },
+                }
+            ]
+        }))
+        return sample_pack
+
+    def test_get_advisory_detail_success(self, client, pack_with_advisory_detail):
+        ts = pack_with_advisory_detail.fetch_timestamp.isoformat()
+        fid = pack_with_advisory_detail.flight_id
+        resp = client.get(f"/api/flights/{fid}/packs/{ts}/advisories/convective/detail")
+        assert resp.status_code == 200, resp.text
+
+        body = resp.json()
+        assert body["advisory_id"] == "convective"
+        assert body["aggregate_status"] == "red"
+        assert body["name"] == "Convective Activity"
+        assert body["briefing_timestamp"] == ts
+        assert body["total_distance_nm"] == 50.0
+        assert body["per_model"][0]["affected_nm"] == 22.0
+        assert body["per_model"][0]["cross_check"] == {"note": "NWP scheme remains quiet"}
+        assert "downgrade signal" in body["cross_check_note"]
+        assert "convective_note" in body
+        assert body["convective"]["gfs"]["thermo"]["peak"]["el_top_ft"] == 27000
+
+    def test_get_advisory_detail_missing_id_is_404(self, client, pack_with_advisory_detail):
+        ts = pack_with_advisory_detail.fetch_timestamp.isoformat()
+        fid = pack_with_advisory_detail.flight_id
+        resp = client.get(f"/api/flights/{fid}/packs/{ts}/advisories/icing_escape/detail")
+        assert resp.status_code == 404, resp.text
+        assert "convective" in resp.json()["detail"]
+
+
 class TestPackArtifacts:
     """Test artifact serving (snapshot, gramet, skewt, digest)."""
 


### PR DESCRIPTION
## Summary
- Implements the iOS modernisation epic tracked by #285 across the phase commits for #286 through #293.
- Adds the modern iOS briefing/data backbone, cross-section parity, touch interaction, Skew-T overlays, advisory drilldown, map metric overlays, and flight management polish.
- Adds a follow-up iOS fix so dev users can add aircraft from the new-flight flow, create flights, and see precise API/SSE authorization errors.

## Verification
- Built the iOS app on the Mac with Xcode 26.3:
  `xcodebuild -project flyfun-weather/flyfun-weather.xcodeproj -scheme flyfun-weather -configuration Debug -destination "platform=iOS Simulator,id=A2381A35-36C7-490E-AADE-EEFE8A003588" -derivedDataPath /Users/qianzhao/DerivedData/flyfun-weather-epic-285-build build`
- Result: `BUILD SUCCEEDED`.

## Notes
- PR branch contains the committed epic/fix work only. Local uncommitted Xcode project/scheme edits in the NFS worktree were left out.

Closes #285.
