### PR TITLE
feat(convective): anchor advisory headline on MODERATE+, peak, and cross-model range (#300)

### DIFF
--- a/src/weatherbrief/analysis/advisories/convective.py
+++ b/src/weatherbrief/analysis/advisories/convective.py
@@ -26,6 +26,11 @@ _RISK_ORDER = [
     ConvectiveRisk.EXTREME,
 ]
 
+# Threshold for "actual convective concern" — the headline extent is anchored
+# here (MODERATE+), separate from the LOW min_risk floor that drives the colour
+# (#300).
+_MOD_IDX = _RISK_ORDER.index(ConvectiveRisk.MODERATE)
+
 
 def _coverage_suffix(max_cover_pct: float | None) -> str:
     """Append coverage label when NWP convective cover data is available."""
@@ -117,10 +122,12 @@ class ConvectiveEvaluator:
         cruise_ft = ctx.cruise_altitude_ft
 
         per_model: list[ModelAdvisoryResult] = []
+        peak_by_model: dict[str, ConvectiveRisk] = {}
 
         for model in ctx.models:
             total = 0
-            affected = 0
+            affected = 0  # >= min_risk (LOW floor) — drives the colour
+            affected_mod = 0  # >= MODERATE — anchors the headline extent (#300)
             has_high = False
             worst_risk = ConvectiveRisk.NONE
             below_cruise_count = 0  # risky points skipped because tops below cruise
@@ -208,6 +215,8 @@ class ConvectiveEvaluator:
                     continue
 
                 affected += 1
+                if risk_idx >= _MOD_IDX:
+                    affected_mod += 1
                 if risk_idx > _RISK_ORDER.index(worst_risk):
                     worst_risk = graded_risk
 
@@ -218,14 +227,12 @@ class ConvectiveEvaluator:
                     max_cover_pct = max(max_cover_pct or 0, conv.cover_pct)
 
             ext = format_extent(affected, total, ctx.total_distance_nm)
+            ext_mod = format_extent(affected_mod, total, ctx.total_distance_nm)
             loc = ctx.locale
             cover_suffix = _coverage_suffix(max_cover_pct)
             if total == 0:
                 status = AdvisoryStatus.UNAVAILABLE
                 detail = adv_t("no_data", loc)
-            elif has_high:
-                status = AdvisoryStatus.RED
-                detail = adv_t("convective.risk_over", loc, risk=worst_risk.value.upper(), extent=ext) + cover_suffix
             elif affected == 0:
                 status = AdvisoryStatus.GREEN
                 if below_cruise_count > 0:
@@ -233,11 +240,27 @@ class ConvectiveEvaluator:
                 else:
                     detail = adv_t("convective.none", loc)
             else:
-                status = pct_above_threshold(affected, total, affected_pct_amber, affected_pct_red)
-                # LOW risk alone can't escalate to RED — cap at AMBER
-                if worst_risk == ConvectiveRisk.LOW and status == AdvisoryStatus.RED:
-                    status = AdvisoryStatus.AMBER
-                detail = adv_t("convective.risk_over", loc, risk=worst_risk.value.upper(), extent=ext) + cover_suffix
+                # Colour grade is unchanged (#300 is display-only): HIGH/EXTREME
+                # anywhere → RED; otherwise threshold on the LOW-floor extent,
+                # capped at AMBER when the peak is only LOW.
+                if has_high:
+                    status = AdvisoryStatus.RED
+                else:
+                    status = pct_above_threshold(affected, total, affected_pct_amber, affected_pct_red)
+                    if worst_risk == ConvectiveRisk.LOW and status == AdvisoryStatus.RED:
+                        status = AdvisoryStatus.AMBER
+                # Headline anchors on the MODERATE+ extent + named peak, so the
+                # severity word (peak) and the coverage (MODERATE+ extent) are
+                # never conflated. When nothing reaches MODERATE (LOW-only floor),
+                # fall back to "primed, not firing" so favorable-but-quiet CAPE
+                # doesn't masquerade as active convection (#300).
+                if affected_mod > 0:
+                    detail = adv_t(
+                        "convective.risk_over_mod", loc,
+                        extent=ext_mod, peak=worst_risk.value.upper(),
+                    ) + cover_suffix
+                else:
+                    detail = adv_t("convective.favorability", loc, extent=ext) + cover_suffix
 
             cross_check: str | None = None
             if xcheck_fired > 0:
@@ -261,7 +284,49 @@ class ConvectiveEvaluator:
                 model=model, status=status, detail=detail,
                 affected=affected, total=total,
                 total_distance_nm=ctx.total_distance_nm,
+                affected_mod=affected_mod,
                 cross_check=cross_check,
             ))
+            peak_by_model[model] = worst_risk
 
-        return RouteAdvisoryResult.from_per_model("convective", per_model, params)
+        result = RouteAdvisoryResult.from_per_model("convective", per_model, params)
+        # Override the generic representative-model detail with a cross-model
+        # MODERATE+ range + peak, built here where the locale is available
+        # (from_per_model is locale-agnostic). GREEN/UNAVAILABLE keep the
+        # representative wording (none / below-cruise / no-data). (#300)
+        agg = result.aggregate_status
+        if agg in (AdvisoryStatus.AMBER, AdvisoryStatus.RED):
+            loc = ctx.locale
+            matching = [m for m in per_model if m.status == agg]
+            mod_models = [m for m in matching if m.affected_mod_points > 0]
+            if mod_models:
+                peak = max(
+                    (peak_by_model[m.model] for m in mod_models),
+                    key=lambda r: _RISK_ORDER.index(r),
+                ).value.upper()
+                pcts = sorted(round(m.affected_mod_pct) for m in mod_models)
+                lo, hi = pcts[0], pcts[-1]
+                if lo == hi:
+                    result.aggregate_detail = adv_t(
+                        "convective.risk_over_mod_pct", loc, pct=lo, peak=peak
+                    )
+                else:
+                    result.aggregate_detail = adv_t(
+                        "convective.risk_over_range", loc, min=lo, max=hi, peak=peak
+                    )
+            else:
+                # LOW-only across every supporting model — favorability range.
+                pcts = sorted(
+                    round(m.affected_pct) for m in matching if m.total_points > 0
+                )
+                if pcts:
+                    lo, hi = pcts[0], pcts[-1]
+                    if lo == hi:
+                        result.aggregate_detail = adv_t(
+                            "convective.favorability_pct", loc, pct=lo
+                        )
+                    else:
+                        result.aggregate_detail = adv_t(
+                            "convective.favorability_range", loc, min=lo, max=hi
+                        )
+        return result

--- a/src/weatherbrief/analysis/advisories/strings.py
+++ b/src/weatherbrief/analysis/advisories/strings.py
@@ -58,11 +58,48 @@ _STRINGS: dict[str, dict[str, str]] = {
     },
 
     # --- convective ---
-    "convective.risk_over": {
-        "en": "{risk} convective risk over {extent}",
-        "fr": "Risque convectif {risk} sur {extent}",
-        "de": "{risk} Konvektionsrisiko über {extent}",
-        "es": "Riesgo convectivo {risk} sobre {extent}",
+    # Headline anchors on MODERATE+ extent (actual convective concern) and names
+    # the peak separately, so the severity word (peak) and the extent (MODERATE+
+    # coverage) are never conflated into one number (#300). "MODERATE+" is kept
+    # as a literal threshold label across locales — like the {peak}/{risk} enum
+    # values, which are intentionally not localized.
+    "convective.risk_over_mod": {
+        "en": "MODERATE+ over {extent} — peak {peak}",
+        "fr": "MODERATE+ sur {extent} — pic {peak}",
+        "de": "MODERATE+ über {extent} — Spitze {peak}",
+        "es": "MODERATE+ sobre {extent} — pico {peak}",
+    },
+    "convective.risk_over_mod_pct": {
+        "en": "MODERATE+ over {pct}% — peak {peak}",
+        "fr": "MODERATE+ sur {pct}% — pic {peak}",
+        "de": "MODERATE+ über {pct}% — Spitze {peak}",
+        "es": "MODERATE+ sobre {pct}% — pico {peak}",
+    },
+    "convective.risk_over_range": {
+        "en": "MODERATE+ over {min}–{max}% across models — peak {peak}",
+        "fr": "MODERATE+ sur {min}–{max}% selon les modèles — pic {peak}",
+        "de": "MODERATE+ über {min}–{max}% je nach Modell — Spitze {peak}",
+        "es": "MODERATE+ sobre {min}–{max}% entre modelos — pico {peak}",
+    },
+    # LOW-only case: CAPE is present (primed) but no MODERATE+ firing — worded so
+    # it can't masquerade as active convection (#300).
+    "convective.favorability": {
+        "en": "Low-end CAPE primed, not firing, over {extent}",
+        "fr": "CAPE de bas niveau amorcée, sans déclenchement, sur {extent}",
+        "de": "CAPE im unteren Bereich vorhanden, nicht ausgelöst, über {extent}",
+        "es": "CAPE de gama baja preparada, sin disparo, sobre {extent}",
+    },
+    "convective.favorability_pct": {
+        "en": "Low-end CAPE primed, not firing, over {pct}%",
+        "fr": "CAPE de bas niveau amorcée, sans déclenchement, sur {pct}%",
+        "de": "CAPE im unteren Bereich vorhanden, nicht ausgelöst, über {pct}%",
+        "es": "CAPE de gama baja preparada, sin disparo, sobre {pct}%",
+    },
+    "convective.favorability_range": {
+        "en": "Low-end CAPE primed, not firing, over {min}–{max}% across models",
+        "fr": "CAPE de bas niveau amorcée, sans déclenchement, sur {min}–{max}% selon les modèles",
+        "de": "CAPE im unteren Bereich vorhanden, nicht ausgelöst, über {min}–{max}% je nach Modell",
+        "es": "CAPE de gama baja preparada, sin disparo, sobre {min}–{max}% entre modelos",
     },
     "convective.none": {
         "en": "No significant convective activity",

--- a/src/weatherbrief/models/advisories.py
+++ b/src/weatherbrief/models/advisories.py
@@ -95,6 +95,13 @@ class ModelAdvisoryResult(BaseModel):
     affected_pct: float = 0.0
     affected_nm: float = 0.0
     total_nm: float = 0.0
+    # Optional second extent at a higher threshold (e.g. convective MODERATE+ vs
+    # the LOW-floor primary extent), so the aggregate can anchor its headline on
+    # actual concern rather than the min-threshold union (#300). Stays 0 for
+    # evaluators that don't populate it; convective sets it explicitly.
+    affected_mod_points: int = 0
+    affected_mod_pct: float = 0.0
+    affected_mod_nm: float = 0.0
     # Optional details-only metadata: divergence between the chosen method and
     # an independent second derivation (e.g. convective DD-vs-model scheme).
     # Never affects the grade; surfaced only in the info popup and LLM digest.
@@ -110,9 +117,15 @@ class ModelAdvisoryResult(BaseModel):
         affected: int,
         total: int,
         total_distance_nm: float,
+        affected_mod: int | None = None,
         cross_check: str | None = None,
     ) -> ModelAdvisoryResult:
-        """Build a result, computing pct and nm from point counts."""
+        """Build a result, computing pct and nm from point counts.
+
+        ``affected_mod`` is an optional higher-threshold count (e.g. convective
+        MODERATE+); its pct/nm are derived the same way as the primary extent.
+        """
+        mod = affected_mod or 0
         return cls(
             model=model,
             status=status,
@@ -122,6 +135,9 @@ class ModelAdvisoryResult(BaseModel):
             affected_pct=round(100 * affected / total, 1) if total > 0 else 0,
             affected_nm=round(total_distance_nm * affected / total, 1) if total > 0 else 0,
             total_nm=round(total_distance_nm, 1),
+            affected_mod_points=mod,
+            affected_mod_pct=round(100 * mod / total, 1) if total > 0 else 0,
+            affected_mod_nm=round(total_distance_nm * mod / total, 1) if total > 0 else 0,
             cross_check=cross_check,
         )
 

--- a/tests/analysis/advisories/test_evaluators.py
+++ b/tests/analysis/advisories/test_evaluators.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from datetime import datetime
+
 from weatherbrief.analysis.advisories import RouteContext
 from weatherbrief.analysis.advisories.fiki_icing import FIKIIcingEvaluator
 from weatherbrief.analysis.advisories.icing_escape import IcingEscapeEvaluator
@@ -12,7 +14,72 @@ from weatherbrief.analysis.advisories.cloud_top import CloudTopEvaluator
 from weatherbrief.analysis.advisories.model_agreement import ModelAgreementEvaluator
 from weatherbrief.analysis.advisories.vfr_feasibility import VFRFeasibilityEvaluator
 from weatherbrief.analysis.advisories.ifr_feasibility import IFRFeasibilityEvaluator
-from weatherbrief.models import AdvisoryStatus
+from weatherbrief.models import (
+    AdvisoryStatus,
+    ConvectiveAssessment,
+    ConvectiveRisk,
+    RoutePointAnalysis,
+    SoundingAnalysis,
+    ThermodynamicIndices,
+)
+
+# Default convective params (LOW floor drives colour, MODERATE+ anchors headline).
+_CONV_PARAMS = {
+    "min_risk": 2,
+    "affected_pct_amber": 20,
+    "affected_pct_red": 50,
+    "top_clearance_ft": 2000,
+}
+
+
+def _conv_route(
+    per_model_risks: dict[str, list[ConvectiveRisk]],
+    *,
+    total_nm: float = 200.0,
+    cruise_ft: int = 8000,
+) -> RouteContext:
+    """Build a RouteContext where each model carries an explicit per-point risk
+    list. All lists must share the same length (= number of route points).
+
+    Each point's convective assessment is a bare thermo-less CAPE risk (no
+    convective_thermo/convective_nwp), so the DD-floor and cross-check paths stay
+    inert — isolating the headline-wording logic under test.
+    """
+    lengths = {len(v) for v in per_model_risks.values()}
+    assert len(lengths) == 1, "all per-model risk lists must be the same length"
+    n = lengths.pop()
+    analyses = []
+    for i in range(n):
+        sounding = {
+            model: SoundingAnalysis(
+                indices=ThermodynamicIndices(),
+                convective=ConvectiveAssessment(
+                    risk_level=risks[i], cape_jkg=1000.0
+                ),
+            )
+            for model, risks in per_model_risks.items()
+        }
+        analyses.append(
+            RoutePointAnalysis(
+                point_index=i,
+                lat=48.0 + i * 0.5,
+                lon=2.0 + i * 0.5,
+                distance_from_origin_nm=i * (total_nm / max(n - 1, 1)),
+                interpolated_time=datetime(2026, 3, 1, 10, 0),
+                forecast_hour=datetime(2026, 3, 1, 9, 0),
+                track_deg=135.0,
+                sounding=sounding,
+            )
+        )
+    return RouteContext(
+        analyses=analyses,
+        cross_sections=[],
+        elevation=None,
+        models=list(per_model_risks.keys()),
+        cruise_altitude_ft=cruise_ft,
+        flight_ceiling_ft=18000,
+        total_distance_nm=total_nm,
+    )
 
 
 class TestIcingEscape:
@@ -276,6 +343,89 @@ class TestConvective:
         res = ConvectiveEvaluator.evaluate(ctx, params)
         # DD EL FL350 reaches FL300 cruise → not filtered → HIGH → RED.
         assert res.aggregate_status == AdvisoryStatus.RED
+
+
+class TestConvectiveHeadline:
+    """Headline wording (#300): anchor extent on MODERATE+, name the peak, and
+    show a cross-model range — never the LOW-floor union as one number."""
+
+    def test_moderate_plus_anchoring_not_low_union(self):
+        """6 HIGH + 18 LOW of 24 points: every point clears the LOW floor (100%)
+        but only 25% reaches MODERATE+. The headline extent must reflect the
+        MODERATE+ 25%, not the 100% LOW union, with the peak named separately."""
+        risks = [ConvectiveRisk.HIGH] * 6 + [ConvectiveRisk.LOW] * 18
+        ctx = _conv_route({"gfs": risks})
+        res = ConvectiveEvaluator.evaluate(ctx, _CONV_PARAMS)
+
+        assert res.aggregate_status == AdvisoryStatus.RED  # colour unchanged
+        m = res.per_model[0]
+        assert m.affected_points == 24
+        assert m.affected_mod_points == 6
+        # Per-model detail anchors on the MODERATE+ extent (25%) + peak HIGH.
+        assert "MODERATE+" in m.detail
+        assert "25%" in m.detail
+        assert "peak HIGH" in m.detail
+        assert "100%" not in m.detail  # the LOW union must not be the headline
+        # Single model → aggregate collapses to a single % (no range).
+        assert "25%" in res.aggregate_detail
+        assert "peak HIGH" in res.aggregate_detail
+        assert "across models" not in res.aggregate_detail
+
+    def test_cross_model_range(self):
+        """Three RED models with differing MODERATE+ coverage (25/50/75%) →
+        aggregate shows the range across the supporting models + peak."""
+        ctx = _conv_route(
+            {
+                "gfs": [ConvectiveRisk.HIGH] * 2 + [ConvectiveRisk.LOW] * 6,  # 25%
+                "icon": [ConvectiveRisk.HIGH] * 4 + [ConvectiveRisk.LOW] * 4,  # 50%
+                "ecmwf": [ConvectiveRisk.HIGH] * 6 + [ConvectiveRisk.LOW] * 2,  # 75%
+            }
+        )
+        res = ConvectiveEvaluator.evaluate(ctx, _CONV_PARAMS)
+
+        assert res.aggregate_status == AdvisoryStatus.RED
+        assert "MODERATE+" in res.aggregate_detail
+        assert "25–75%" in res.aggregate_detail
+        assert "across models" in res.aggregate_detail
+        assert "peak HIGH" in res.aggregate_detail
+
+    def test_low_only_favorability_fallback(self):
+        """4 LOW + 6 NONE of 10: 40% clears the LOW floor (AMBER) but nothing
+        reaches MODERATE. Wording must be 'primed, not firing' favorability —
+        never 'MODERATE+ over 0%'."""
+        risks = [ConvectiveRisk.LOW] * 4 + [ConvectiveRisk.NONE] * 6
+        ctx = _conv_route({"gfs": risks})
+        res = ConvectiveEvaluator.evaluate(ctx, _CONV_PARAMS)
+
+        assert res.aggregate_status == AdvisoryStatus.AMBER
+        m = res.per_model[0]
+        assert m.affected_points == 4
+        assert m.affected_mod_points == 0
+        assert "primed" in m.detail.lower()
+        assert "MODERATE+" not in m.detail
+        assert "40%" in m.detail
+        # Aggregate (single model) → favorability single %, no range/peak.
+        assert "primed" in res.aggregate_detail.lower()
+        assert "40%" in res.aggregate_detail
+        assert "across models" not in res.aggregate_detail
+        assert "peak" not in res.aggregate_detail.lower()
+
+    def test_range_collapses_when_models_agree(self):
+        """Two RED models with identical MODERATE+ coverage (50%) → the range
+        collapses to a single number; no '–' range, no 'across models'."""
+        ctx = _conv_route(
+            {
+                "gfs": [ConvectiveRisk.HIGH] * 4 + [ConvectiveRisk.LOW] * 4,  # 50%
+                "icon": [ConvectiveRisk.HIGH] * 4 + [ConvectiveRisk.LOW] * 4,  # 50%
+            }
+        )
+        res = ConvectiveEvaluator.evaluate(ctx, _CONV_PARAMS)
+
+        assert res.aggregate_status == AdvisoryStatus.RED
+        assert "MODERATE+ over 50%" in res.aggregate_detail
+        assert "peak HIGH" in res.aggregate_detail
+        assert "across models" not in res.aggregate_detail
+        assert "–" not in res.aggregate_detail  # no en-dash range
 
 
 class TestCloudTop:


### PR DESCRIPTION
Closes #300.

## Problem

The convective advisory headline conflated three different things into one number. Concrete case — `lfqa_lfat_egtf-2026-06-28`, ECMWF: **"HIGH convective risk over 92%"**. Decoded, that was *"peak HIGH at one point; 92% of the route has at least LOW risk (mostly non-firing low-end CAPE); and 92% is ECMWF alone (GFS/ICON much lower)."* The severity word was the **peak**, the extent was at the **LOW floor**, and the % was **one arbitrary model**.

## Change (display-only — colour grade unchanged)

Option (b) from the issue:

- Tally `affected_mod` (≥ MODERATE) alongside `affected` (≥ LOW floor, still drives colour).
- **Per-model detail** now anchors on the MODERATE+ extent + named peak: `MODERATE+ over {extent} — peak {peak}`. The LOW-only AMBER case (nothing reaches MODERATE) reads `Low-end CAPE primed, not firing, over {extent}` so favorable-but-quiet CAPE can't masquerade as active convection.
- **Aggregate detail** is composed in the evaluator (locale available; `from_per_model` is locale-agnostic) as a MODERATE+ range across the models supporting the displayed colour: `MODERATE+ over {min}–{max}% across models — peak {peak}`. Collapses to a single number for single-model / agreeing models.
- `ModelAdvisoryResult` gains `affected_mod_points/pct/nm`; `build()` takes an optional `affected_mod`.
- New en/fr/de/es templates; the now-dead `convective.risk_over` removed.

### Before / after (reference case)

```
before:  HIGH convective risk over 92%        (ECMWF alone)
after:   MODERATE+ over 8–33% across models — peak HIGH
```

The RED colour (3/3 consensus, driven by the HIGH peak) is unchanged.

## Scope

Convective only — turbulence's `risk_over` left as-is (issue open question). The colour grade is deliberately untouched here; the follow-up question of anchoring the **colour** coverage thresholds on MODERATE+ (a recalibration with a validation gate) is tracked separately in #301.

## Tests

`tests/analysis/advisories/test_evaluators.py` — new `TestConvectiveHeadline`:
1. MODERATE+ anchoring (headline reflects MODERATE+ %, not the LOW union)
2. cross-model range
3. LOW-only favorability fallback
4. single-value range collapse

Full suite green (2968 passed, 8 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)