### PR TITLE
ios(skew-t): Tier 2 linked cursor + Tier 3 side-panel variables (§4.8)

### DIFF
--- a/app/flyfun-weather/flyfun-weather.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/app/flyfun-weather/flyfun-weather.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -52,7 +52,7 @@
       "location" : "https://github.com/roznet/rzskewt.git",
       "state" : {
         "branch" : "main",
-        "revision" : "c7e7764e0a19f5967df58231c62ebb49f5a1f80d"
+        "revision" : "315d3be2175d363e4fec4d24e88277f21cb24217"
       }
     },
     {

--- a/app/flyfun-weather/flyfun-weather/Views/CrossSection/SkewTDetailView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/CrossSection/SkewTDetailView.swift
@@ -85,6 +85,18 @@ struct SkewTDetailView: View {
     let pointIndex: Int
 
     @State private var profileState: LoadingState<SoundingProfileResponse> = .idle
+    /// Shared crosshair pressure (§4.8 Tier 2): two-way with the Skew-T and read
+    /// by the side-panel so both views show one linked cursor + readout.
+    @State private var selectedPressureHPa: Double?
+    /// Selected side-panel variable(s) (§4.8 Tier 3): one on iPhone, up to two on iPad.
+    @State private var primaryVarId: String?
+    @State private var secondaryVarId: String?
+    @Environment(\.horizontalSizeClass) private var hSizeClass
+
+    // Web app pressure range (1050–250 hPa); shared by the plot and the panel so
+    // their pressure rows line up (the panel requires an identical config).
+    private let config = SkewTConfiguration(pTop: 250)
+    private var isPad: Bool { hSizeClass == .regular }
 
     var body: some View {
         Group {
@@ -93,45 +105,114 @@ struct SkewTDetailView: View {
                 ProgressView("Loading sounding...")
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             case .loaded(let response):
-                VStack(spacing: 0) {
-                    // Header
-                    HStack {
-                        if let icao = response.waypointIcao {
-                            Text(icao).font(.headline)
-                        }
-                        Text("\(Int(response.distanceFromOriginNm)) nm")
-                            .font(.subheadline)
-                            .foregroundStyle(.secondary)
-                        Text(response.model.uppercased())
-                            .font(.caption.bold())
-                            .padding(.horizontal, 6)
-                            .padding(.vertical, 2)
-                            .background(.blue.opacity(0.15), in: Capsule())
-                        Spacer()
-                        Text("\(response.levels.count) levels")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                    }
-                    .padding(.horizontal)
-                    .padding(.vertical, 4)
-
-                    // Skew-T plot — match web app's pressure range (1050–250 hPa)
-                    // Landscape aspect ~9:5 to match metpy figsize
-                    SkewTView(
-                        profile: response.toSoundingProfile(),
-                        config: SkewTConfiguration(pTop: 250)
-                    )
-                    .aspectRatio(9.0 / 5.0, contentMode: .fit)
-                }
+                plotSection(response)
             case .error(let error):
                 ContentUnavailableView("Sounding Unavailable",
                                        systemImage: "chart.xyaxis.line",
                                        description: Text(error.localizedDescription))
             }
         }
+        // New point → drop the stale cursor before its sounding loads.
+        .onChange(of: pointIndex) { selectedPressureHPa = nil }
         .task(id: pointIndex) {
             await loadProfile()
         }
+    }
+
+    @ViewBuilder
+    private func plotSection(_ response: SoundingProfileResponse) -> some View {
+        let profile = response.toSoundingProfile()
+        let available = SkewTVariableCatalog.variables(for: response, levels: profile.levels)
+        let shown = shownVariables(available)
+        VStack(spacing: Theme.spacingXS) {
+            header(response)
+            if !available.isEmpty {
+                variablePicker(available)
+            }
+            HStack(spacing: 0) {
+                SkewTView(profile: profile, config: config, selectedPressureHPa: $selectedPressureHPa)
+                if !shown.isEmpty {
+                    SkewTVariablePanel(profile: profile, variables: shown, config: config,
+                                       selectedPressureHPa: selectedPressureHPa)
+                        .frame(width: isPad ? 220 : 96)
+                }
+            }
+        }
+        .onAppear { ensureDefaults(available) }
+        .onChange(of: isPad) { ensureDefaults(available) }
+    }
+
+    private func header(_ response: SoundingProfileResponse) -> some View {
+        HStack {
+            if let icao = response.waypointIcao {
+                Text(icao).font(.headline)
+            }
+            Text("\(Int(response.distanceFromOriginNm)) nm")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+            Text(response.model.uppercased())
+                .font(.caption.bold())
+                .padding(.horizontal, 6)
+                .padding(.vertical, 2)
+                .background(.blue.opacity(0.15), in: Capsule())
+            Spacer()
+            Text("\(response.levels.count) levels")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .padding(.horizontal)
+        .padding(.vertical, 4)
+    }
+
+    // MARK: Side-panel variable selection (§4.8 Tier 3)
+
+    private func shownVariables(_ available: [SkewTVariable]) -> [SkewTVariable] {
+        let ids = isPad ? [primaryVarId, secondaryVarId] : [primaryVarId]
+        // compactMap also de-dups nils; allow the same id twice to collapse to one.
+        var seen = Set<String>()
+        return ids.compactMap { id -> SkewTVariable? in
+            guard let id, seen.insert(id).inserted else { return nil }
+            return available.first { $0.id == id }
+        }
+    }
+
+    private func ensureDefaults(_ available: [SkewTVariable]) {
+        guard !available.isEmpty else { return }
+        if primaryVarId == nil || !available.contains(where: { $0.id == primaryVarId }) {
+            primaryVarId = available.first?.id
+        }
+        if isPad, secondaryVarId == nil || !available.contains(where: { $0.id == secondaryVarId }) {
+            secondaryVarId = available.dropFirst().first?.id ?? available.first?.id
+        }
+    }
+
+    @ViewBuilder
+    private func variablePicker(_ available: [SkewTVariable]) -> some View {
+        HStack(spacing: Theme.spacingS) {
+            varMenu(fallback: "Variable", selection: $primaryVarId, available: available)
+            if isPad {
+                varMenu(fallback: "2nd", selection: $secondaryVarId, available: available)
+            }
+            Spacer()
+        }
+        .padding(.horizontal, Theme.cardPadding)
+    }
+
+    private func varMenu(fallback: String, selection: Binding<String?>, available: [SkewTVariable]) -> some View {
+        let current = available.first { $0.id == selection.wrappedValue }
+        return Menu {
+            ForEach(available) { v in
+                Button(v.unit.isEmpty ? v.label : "\(v.label) (\(v.unit))") { selection.wrappedValue = v.id }
+            }
+        } label: {
+            HStack(spacing: 4) {
+                Circle().fill(current?.color ?? .clear).frame(width: 8, height: 8)
+                Text(current?.label ?? fallback).font(.caption)
+                Image(systemName: "chevron.down").font(.caption2)
+            }
+            .foregroundStyle(Theme.text)
+        }
+        .buttonStyle(.plain)
     }
 
     private func loadProfile() async {

--- a/app/flyfun-weather/flyfun-weather/Views/CrossSection/SkewTVariableCatalog.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/CrossSection/SkewTVariableCatalog.swift
@@ -1,0 +1,39 @@
+import RZSkewT
+import SwiftUI
+
+/// Host-supplied Skew-T side-panel variables (§4.8 Tier 3).
+///
+/// Per the §1E split, derivations and units stay on the host: the RZSkewT package
+/// only plots a `value` closure against pressure. The package's `SoundingLevel`
+/// carries just pressure/altitude/T/Td/wind, so closures that need an extended
+/// field (RH, θe, Ri, ω, cloud, icing…) look it up by pressure from the host
+/// response — keyed on `pressureHpa`, exactly how the package level's
+/// `pressureHPa` was built in `toSoundingProfile()`.
+enum SkewTVariableCatalog {
+    /// Offerable variables for a sounding, in display order. Variables with no
+    /// data for *this* sounding are dropped so the picker only lists ones that
+    /// actually plot. `levels` are the package levels of the built profile, used
+    /// both for the closures' key space and the presence filter.
+    static func variables(for response: SoundingProfileResponse, levels: [SoundingLevel]) -> [SkewTVariable] {
+        let byPressure = Dictionary(
+            response.levels.map { (Int($0.pressureHpa), $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+        func ext(_ level: SoundingLevel) -> SoundingProfileLevel? { byPressure[Int(level.pressureHPa.rounded())] }
+
+        let all: [SkewTVariable] = [
+            SkewTVariable(id: "rh", label: "RH", unit: "%", color: .blue, range: 0...100) { ext($0)?.relativeHumidityPct },
+            SkewTVariable(id: "thetae", label: "θe", unit: "K", color: .orange) { ext($0)?.thetaEK },
+            SkewTVariable(id: "wind", label: "Wind", unit: "kt", color: .purple) { $0.windSpeedKt },
+            SkewTVariable(id: "lapse", label: "Lapse", unit: "°C/km", color: .teal) { ext($0)?.lapseRateCPerKm },
+            SkewTVariable(id: "ri", label: "Ri", color: .brown) { ext($0)?.richardsonNumber },
+            SkewTVariable(id: "omega", label: "ω", unit: "Pa/s", color: .indigo) { ext($0)?.omegaPaS },
+            SkewTVariable(id: "cloud", label: "Cloud", unit: "%", color: .gray, range: 0...100) { ext($0)?.cloudAreaFractionPct },
+            SkewTVariable(id: "icing", label: "Icing", color: .cyan) { ext($0).flatMap { $0.icingIndexNwp ?? $0.icingIndex } },
+            SkewTVariable(id: "clw", label: "CLW", unit: "g/m³", color: .mint) { ext($0)?.cloudLiquidWaterGM3 },
+        ]
+        // Reuse each variable's own closure for the presence check (no duplicated
+        // field mapping): keep it only if some level yields a value.
+        return all.filter { v in levels.contains { v.value($0) != nil } }
+    }
+}


### PR DESCRIPTION
## Summary
Wires the host side of the now-merged rzskewt package work (roznet/rzskewt#1) so the Skew-T tab gets the §4.8 features that were deferred to the package.

- **Bump rzskewt pin** `c7e7764` → `315d3be` in `Package.resolved`. The committed lockfile was stale — SPM resolved `branch: main` to latest at build time, but the pin lagged (pre-overlay-bands).
- **Tier 2 — linked cursor + interpolated readout.** `SkewTDetailView` now passes a shared `selectedPressureHPa` binding to `SkewTView` (drag → crosshair + interpolated readout, package-drawn) and the same value to a `SkewTVariablePanel` beside it, so both share one cursor. Cursor resets on point change.
- **Tier 3 — side-panel variables.** New `SkewTVariableCatalog` builds host-supplied `SkewTVariable`s (RH, θe, wind, lapse, Ri, ω, cloud, icing, CLW). Per the §1E split the package only plots a closure against pressure; closures look the extended field up by pressure from the host response, so **derivations/units stay host-side**. iPhone shows one variable, iPad shows up to two (dual-axis) via a picker. Variables with no data for a given sounding are filtered out of the picker.
- **Tier 1** overlay bands were already wired in `toSoundingProfile()`; **Tier 4** compare stays deferred, matching the plan.

## Verification
- `xcodebuild` (iPhone 17 sim): **BUILD SUCCEEDED**.

## Notes
- The package's `SoundingLevel` carries only p/alt/T/Td/wind; the variable closures key on `pressureHpa` (exactly how the package level's `pressureHPa` is built) to reach the host's extended fields.
- Follow-ups from the #297 review tracked separately: #303 (cross-section scrub redraw perf), #304 (offline indicator §1D).

🤖 Generated with [Claude Code](https://claude.com/claude-code)