### PR TITLE
ECMWF cp fires NWP convective track without a tower; character prefers native cp

### DIFF
--- a/designs/meteorology-decisions.md
+++ b/designs/meteorology-decisions.md
@@ -1384,6 +1384,79 @@ a yes/no firing gate.
 - `tests/test_convective.py` — native-top tiering, cover modifier + cap,
   cover-only scale, CIN suppression, quiet-native NONE, CAPE-fallback path, and
   the Reims regression anchors.
+
+### Phase 3 — `cp` fires the NWP track without a tower; character prefers native `cp`
+
+**Date:** 2026-06-26
+**Status:** Implemented.
+**Context:** EGTF→BIG→LFAT→LFQA 2026-06-27 (D-1). Over the Channel, ECMWF's own
+scheme is precipitating convectively — `cp` peaks **4.26 mm/h at ~52 nm**, with
+0.4–1.2 mm/h either side — matching what Windy shows. But the NWP track read
+**NONE** the whole way across, and the convective-character advisory read ECMWF
+**GREEN**. Two Phase-1/2 assumptions broke here:
+
+1. **"No tower top ⇒ quiet scheme ⇒ NONE."** Phase 1 made `convective_top_ft`
+   (`hcct`) the primary native scale on the premise that a firing scheme emits a
+   tower top. ECMWF violates it: `hcct` is sentinel/absent across the entire
+   Channel *even where `cp` = 4 mm/h*, and ECMWF has no convective-cover field.
+   So `assess_convective_nwp` fell through to the quiet branch → NONE, with the
+   `cp` we already decode sitting unused on the same diagnostics object. The
+   Phase-2 firing gate only ever *holds a tower down*; there was no symmetric
+   path to *lift NONE up* when `cp` fires without geometry. This is the marine /
+   **elevated** convection case — the surface parcel has zero CAPE (DD quiet),
+   so neither track saw it.
+2. **Character "realized" read Open-Meteo `showers`, which is structurally 0.0
+   for ECMWF IFS.** `showers_at_point()` returns Open-Meteo's convective-only
+   precip, which Open-Meteo does not populate for ECMWF (verified: 0.00 at every
+   point while total precip was 4.38 mm/h). So no ECMWF point could ever be
+   "realized" by precip → GREEN.
+
+**The decisions:**
+
+- **`cp` is a first-class native firing signal, not just a binary gate.** When a
+  native model has no tower top and no cover fraction but `convective_precip_mm_h
+  > 0.1`, derive the NWP risk from a **convective-precip-rate ladder**
+  (`_CONV_PRECIP_MM_H_THRESHOLDS`: ≥2.0 → MODERATE, ≥0.5 → LOW, ≥0.1 →
+  MARGINAL), method `"nwp_precip"`. **Tower top stays primary whenever present** —
+  this is the geometry-absent fallback only. Depth is unknown from rate alone, so
+  the ladder is **capped at MODERATE** (same rationale as the cover-only scale),
+  and a precip-derived tier skips the firing-gate hold-down and the precip
+  corroboration (which would double-count `cp`).
+  - *Why a ladder and not a binary floor:* the user explicitly chose to revisit
+    the Phase-1 "precip is yes/no only" stance. Rate still carries real intensity
+    information; the MODERATE cap and the resolution caveat below keep it honest.
+  - *Resolution caveat (unchanged from Phase-1 reasoning 1):* convective-precip
+    rate is resolution-dependent. These thresholds are calibrated for
+    synoptic-scale GRIB (ECMWF ~9–25 km); a convection-permitting model whose
+    `cp` gets wired later needs its own ladder. Defensible v1 — tune against the
+    eval-digest corpus.
+- **Convective-character "realized" prefers GRIB-native `cp` over Open-Meteo
+  `showers`** for any model carrying `nwp_cloud_diagnostics`. A native value of
+  `0.0` is a real "not firing" reading and is used as-is; only absent native
+  diagnostics (non-GRIB models — AROME/UKMO/MF) fall back to the Open-Meteo
+  `showers` cross-section field. This is the "ECMWF should use the GRIB variable,
+  not Open-Meteo" principle (the documented intended direction for ECMWF surface
+  fields, weather-engine-specs §Future-1).
+
+**Effect on the EGTF→LFQA case:** ECMWF convective character GREEN → **AMBER
+"Scattered cells" (20% of route)** under the shipped default; the NWP track now
+reads MODERATE over the Channel `cp` cores, so the inline cross-check and the
+per-model NWP cross-section reflect the firing the model actually forecasts. The
+**graded severity colour is unchanged** over the Channel — §14's DD-floor
+(`max(native, thermo)`) already graded it MODERATE off the elevated MU-CAPE — so
+this is a narrative / character / track-independence fix, not a colour change
+there. Safety asymmetry preserved: `cp` can only *add* a firing signal, never
+downgrade a DD red.
+
+**Files changed (Phase 3):**
+- `src/weatherbrief/analysis/sounding/convective.py` —
+  `_CONV_PRECIP_MM_H_THRESHOLDS`, `_risk_from_conv_precip`, `"nwp_precip"` branch
+  in `assess_convective_nwp`.
+- `src/weatherbrief/analysis/advisories/convective_character.py` — realized
+  signal prefers native `convective_precip_mm_h` over Open-Meteo `showers`.
+- `tests/test_convective.py` — precip-rate tiering, the ECMWF Channel regression
+  (`cp` fires when `hcct` absent), and tower-top-stays-primary guard.
+
 ## 15. Convective character: a VFR-avoidability axis separate from severity
 
 **Date:** 2026-06-24

--- a/src/weatherbrief/analysis/advisories/convective_character.py
+++ b/src/weatherbrief/analysis/advisories/convective_character.py
@@ -234,6 +234,11 @@ class ConvectiveCharacterEvaluator:
                         diag.convective_precip_mm_h if diag is not None else None
                     )
                     if native_cp is not None:
+                        # `native_cp` is mm/h; `showers_mm` (the threshold) and
+                        # showers_at_point() are mm-over-step. For the hourly
+                        # cross-section step these are numerically equal, so the
+                        # >= showers_mm test holds. If showers_mm is ever
+                        # recalibrated, revisit this mm/h-vs-mm equivalence.
                         showers = native_cp
                     else:
                         showers = showers_at_point(

--- a/src/weatherbrief/analysis/advisories/convective_character.py
+++ b/src/weatherbrief/analysis/advisories/convective_character.py
@@ -221,9 +221,24 @@ class ConvectiveCharacterEvaluator:
                 realized = False
                 embedded = False
                 if is_conv:
-                    showers = showers_at_point(
-                        ctx.cross_sections, model, rpa.point_index, rpa.forecast_hour
+                    # Prefer the model's own GRIB-native convective precip (`cp`)
+                    # over Open-Meteo `showers`: Open-Meteo does not populate
+                    # `showers` for ECMWF IFS (it is structurally 0.0), so the
+                    # native field is the only realized-firing precip signal for
+                    # ECMWF over marine / elevated convection. A native value of
+                    # 0.0 is a real "not firing" reading and is used as-is; only
+                    # absent native diagnostics (non-GRIB models — AROME/UKMO/MF)
+                    # fall back to the Open-Meteo `showers` cross-section field.
+                    diag = sounding.nwp_cloud_diagnostics
+                    native_cp = (
+                        diag.convective_precip_mm_h if diag is not None else None
                     )
+                    if native_cp is not None:
+                        showers = native_cp
+                    else:
+                        showers = showers_at_point(
+                            ctx.cross_sections, model, rpa.point_index, rpa.forecast_hour
+                        )
                     nwp = sounding.convective_nwp
                     cover = nwp.cover_pct if nwp is not None else None
                     has_geom = (

--- a/src/weatherbrief/analysis/sounding/convective.py
+++ b/src/weatherbrief/analysis/sounding/convective.py
@@ -603,6 +603,40 @@ _CORROB_K_INDEX = 35.0
 _CORROB_TOTAL_TOTALS = 50.0
 _CORROB_PRECIP_MM_H = 0.5
 
+# Convective-precip-rate → tier (§14 Phase 3, #283 follow-up). Used ONLY when a
+# native model is precipitating convectively but emitted neither a tower top nor
+# a cover fraction — the ECMWF marine / elevated-convection case, where `cp`
+# lands but `hcct` is sentinel/absent. The Phase-1 design collapsed "no geometry"
+# to NONE, which hid a plainly-firing scheme (e.g. 4 mm/h convective rain over
+# the Channel read NONE). Tower top stays the primary, resolution-robust scale
+# whenever it IS present; this ladder is the geometry-absent fallback only.
+#
+# Depth is unknown from rate alone, so the ladder is capped at MODERATE (same
+# rationale as the cover-only scale). Precip *rate* is resolution-dependent (§14
+# reasoning 1: 0.8 mm/h at ECMWF ~9–25 km ≈ 3–5 mm/h at convection-permitting
+# scale), so these thresholds are calibrated for synoptic-scale GRIB; a finer
+# model whose convective precip gets wired later needs its own ladder. Defensible
+# v1 — tune against the eval-digest corpus.
+_CONV_PRECIP_MM_H_THRESHOLDS = [
+    (2.0, ConvectiveRisk.MODERATE),               # active shower / storm core
+    (0.5, ConvectiveRisk.LOW),                    # light convective showers
+    (_FIRING_PRECIP_MM_H, ConvectiveRisk.MARGINAL),  # isolated / weak (firing floor)
+]
+
+
+def _risk_from_conv_precip(precip_mm_h: float) -> ConvectiveRisk:
+    """Depth-unknown native risk tier from convective precip rate (§14 Phase 3).
+
+    Fallback for a native model firing convective precip with no tower top and no
+    cover fraction (ECMWF marine / elevated convection). NOT used when geometry is
+    present — tower top remains the primary, resolution-robust scale. Capped at
+    MODERATE by ``_CONV_PRECIP_MM_H_THRESHOLDS`` (depth unknown).
+    """
+    for min_mm_h, level in _CONV_PRECIP_MM_H_THRESHOLDS:
+        if precip_mm_h >= min_mm_h:
+            return level
+    return ConvectiveRisk.NONE
+
 
 def _convection_realized_nwp(diag: NWPCloudDiagnostics) -> bool:
     """True when the model's convective scheme actually fired here (#283).
@@ -756,7 +790,11 @@ def assess_convective_nwp(
             method="nwp_cape_fallback",
         )
 
-    # Native path. Determine which convective geometry this model exposes
+    precip = nwp_diagnostics.convective_precip_mm_h
+    drivers: list[str] = []
+    suppressors: list[str] = []
+
+    # Native path. Determine which convective signal this model exposes
     # (preserving the method strings consumed by dd_nwp_agreement / front
     # co-location) and the base/top envelope to attach.
     if cover is not None:
@@ -772,22 +810,34 @@ def assess_convective_nwp(
         # still keep the tower rather than silently discard a real cell (#283
         # review) — the base is then unknown (None), but the tower drives risk.
         method, base_ft, top_ft = "nwp_lcl_top", lcl, top
+    elif precip is not None and precip > _FIRING_PRECIP_MM_H:
+        # §14 Phase 3: no tower top and no cover fraction, but the scheme is
+        # precipitating convectively (ECMWF marine / elevated convection — `cp`
+        # present, `hcct` sentinel). Tier from the precip rate rather than the
+        # old false NONE. Realized by construction, so it skips the firing-gate
+        # hold-down and the precip corroboration (which would double-count `cp`).
+        method, base_ft, top_ft = "nwp_precip", None, None
     else:
         # Native model, quiet convective scheme at this point (no cover, no
-        # usable geometry, or a sub-LCL hcct artefact). Keep a real NONE
-        # assessment — not None — so the DD-vs-NWP comparison can still fire.
+        # usable geometry, no convective precip). Keep a real NONE assessment —
+        # not None — so the DD-vs-NWP comparison can still fire.
         method, base_ft, top_ft = "nwp", None, None
 
-    # Risk from the validated native fields (NOT CAPE).
-    risk = _native_convective_risk(top_ft, cover)
+    if method == "nwp_precip":
+        risk = _risk_from_conv_precip(precip)
+        drivers.append(
+            f"Model convective scheme precipitating ({precip:.1f} mm/h) with no "
+            "diagnosed tower top — tier from precip rate (depth unknown, capped MODERATE)"
+        )
+    else:
+        # Risk from the validated native geometry (NOT CAPE).
+        risk = _native_convective_risk(top_ft, cover)
 
-    # Firing gate + native corroboration (#283 Phase 2): hold a deep-but-dry
-    # tower down one level, or bump a realized cell up on strong native indices.
-    drivers: list[str] = []
-    suppressors: list[str] = []
-    risk, gate_note, gate_is_driver = _apply_firing_gate(risk, nwp_diagnostics)
-    if gate_note is not None:
-        (drivers if gate_is_driver else suppressors).append(gate_note)
+        # Firing gate + native corroboration (#283 Phase 2): hold a deep-but-dry
+        # tower down one level, or bump a realized cell up on strong native indices.
+        risk, gate_note, gate_is_driver = _apply_firing_gate(risk, nwp_diagnostics)
+        if gate_note is not None:
+            (drivers if gate_is_driver else suppressors).append(gate_note)
 
     # Keep the strong-CIN suppression (#283: partially handles a capped tower the
     # scheme reports but won't realize; CIN < -200 → one level down). Prefer the

--- a/src/weatherbrief/analysis/sounding/convective.py
+++ b/src/weatherbrief/analysis/sounding/convective.py
@@ -620,7 +620,7 @@ _CORROB_PRECIP_MM_H = 0.5
 _CONV_PRECIP_MM_H_THRESHOLDS = [
     (2.0, ConvectiveRisk.MODERATE),               # active shower / storm core
     (0.5, ConvectiveRisk.LOW),                    # light convective showers
-    (_FIRING_PRECIP_MM_H, ConvectiveRisk.MARGINAL),  # isolated / weak (firing floor)
+    (_FIRING_PRECIP_MM_H, ConvectiveRisk.MARGINAL),  # MARGINAL lower bound (entry gate requires precip > 0.1)
 ]
 
 
@@ -849,10 +849,17 @@ def assess_convective_nwp(
     # physical suppressors (no realized convection AND a strong inhibition) — and
     # is bounded at NONE. Tune either threshold with the combined effect in mind.
     # See tests/test_convective.py::test_nwp_firing_gate_and_cin_double_suppression.
-    eff_cin = nwp_diagnostics.ml_cin_jkg if nwp_diagnostics.ml_cin_jkg is not None else cin
-    if eff_cin is not None and eff_cin < CIN_CAP_THRESHOLD and risk != ConvectiveRisk.NONE:
-        risk = _down_one(risk)
-        suppressors.append(f"Strong cap (CIN {eff_cin:.0f} J/kg) holds the tower down")
+    #
+    # NOT applied on the "nwp_precip" path (§14 Phase 3): `cp` proves the scheme
+    # already fired, so penalising it on surface/ML CIN is circular — the
+    # parameterisation overcame whatever inhibition existed at the (typically
+    # elevated) triggering level, which a negative surface/ML CIN does not
+    # describe. CIN suppression is for the deep-but-dry tower, not a firing cell.
+    if method != "nwp_precip":
+        eff_cin = nwp_diagnostics.ml_cin_jkg if nwp_diagnostics.ml_cin_jkg is not None else cin
+        if eff_cin is not None and eff_cin < CIN_CAP_THRESHOLD and risk != ConvectiveRisk.NONE:
+            risk = _down_one(risk)
+            suppressors.append(f"Strong cap (CIN {eff_cin:.0f} J/kg) holds the tower down")
 
     return ConvectiveAssessment(
         drivers=drivers,

--- a/src/weatherbrief/models/analysis.py
+++ b/src/weatherbrief/models/analysis.py
@@ -690,7 +690,7 @@ class ConvectiveAssessment(BaseModel):
     top_ft: Optional[float] = None  # thermo: el_altitude_ft; NWP: convective_top_ft
     cover_pct: Optional[float] = None  # NWP only; thermo: None
     convective_precip_mm_h: Optional[float] = None  # NWP native firing signal (#283); thermo: None
-    method: str = "thermo"  # "thermo", "nwp", "nwp_hybrid", "nwp_lcl_top", "nwp_cape_fallback"
+    method: str = "thermo"  # "thermo", "nwp", "nwp_hybrid", "nwp_lcl_top", "nwp_precip", "nwp_cape_fallback"
 
 
 class CATRiskLayer(BaseModel):

--- a/tests/test_convective.py
+++ b/tests/test_convective.py
@@ -717,6 +717,32 @@ def test_nwp_ecmwf_channel_precip_fires_when_hcct_absent():
     assert result.convective_precip_mm_h == 4.26
 
 
+def test_nwp_precip_not_suppressed_by_strong_cin():
+    """§14 Phase 3: CIN suppression must NOT downgrade a firing nwp_precip cell.
+
+    `cp` proves the scheme fired; penalising it on surface/ML CIN is circular (the
+    parameterisation already overcame the inhibition at the elevated triggering
+    level). Both a strong negative ML-CIN and a strong negative surface CIN must
+    leave the precip-derived tier intact.
+    """
+    # Strong negative ML-CIN — preferred over surface CIN — must not suppress.
+    indices = ThermodynamicIndices(cape_surface_jkg=0.0, cin_surface_jkg=0.0)
+    diag = NWPCloudDiagnostics(
+        total_cover_pct=70.0, convective_precip_mm_h=4.26, ml_cin_jkg=-300.0
+    )
+    result = assess_convective_nwp(indices, diag)
+    assert result is not None
+    assert result.method == "nwp_precip"
+    assert result.risk_level == ConvectiveRisk.MODERATE  # not knocked to LOW
+
+    # Strong negative surface CIN (no ML-CIN) — also must not suppress.
+    indices2 = ThermodynamicIndices(cape_surface_jkg=0.0, cin_surface_jkg=-300.0)
+    diag2 = NWPCloudDiagnostics(total_cover_pct=70.0, convective_precip_mm_h=4.26)
+    result2 = assess_convective_nwp(indices2, diag2)
+    assert result2 is not None
+    assert result2.risk_level == ConvectiveRisk.MODERATE
+
+
 def test_nwp_precip_not_used_when_tower_top_present():
     """Tower top stays primary: a precip rate never overrides a diagnosed top."""
     indices = ThermodynamicIndices(cape_surface_jkg=40.0, lcl_altitude_ft=3000.0)

--- a/tests/test_convective.py
+++ b/tests/test_convective.py
@@ -668,6 +668,66 @@ def test_nwp_cover_only_scale_when_no_top():
         assert result.risk_level == expected, f"cover={cover}: want {expected}, got {result.risk_level}"
 
 
+def test_nwp_precip_fired_tiering_when_no_geometry():
+    """§14 Phase 3: convective precip with no tower top / cover → rate-based tier.
+
+    Depth unknown from rate alone, so the ladder is capped at MODERATE.
+    """
+    for precip, expected in [
+        (4.26, ConvectiveRisk.MODERATE),   # active shower core (>=2.0)
+        (2.0, ConvectiveRisk.MODERATE),
+        (1.24, ConvectiveRisk.LOW),        # light showers (>=0.5)
+        (0.5, ConvectiveRisk.LOW),
+        (0.45, ConvectiveRisk.MARGINAL),   # isolated/weak (>=0.1)
+        (0.1, ConvectiveRisk.NONE),        # at/below the firing gate (> 0.1 required)
+        (0.0, ConvectiveRisk.NONE),
+    ]:
+        indices = ThermodynamicIndices(cape_surface_jkg=40.0)
+        # total_cover marks it native; no convective top, no convective cover.
+        diag = NWPCloudDiagnostics(
+            total_cover_pct=70.0, convective_precip_mm_h=precip
+        )
+        result = assess_convective_nwp(indices, diag)
+        assert result is not None
+        assert result.risk_level == expected, (
+            f"precip={precip}: want {expected}, got {result.risk_level}"
+        )
+        if precip > 0.1:
+            assert result.method == "nwp_precip"
+
+
+def test_nwp_ecmwf_channel_precip_fires_when_hcct_absent():
+    """Regression: ECMWF over the Channel — cp 4.26 mm/h, hcct sentinel (no top),
+    no convective-cover field → MODERATE via the precip rate, not a false NONE.
+
+    EGTF→LFAT 2026-06-27 @ ~52 nm: elevated marine convection. Surface parcel has
+    no CAPE (instability is elevated), so DD is quiet, but the model's own scheme
+    is precipitating convectively — Windy shows it; we used to read NONE.
+    """
+    indices = ThermodynamicIndices(cape_surface_jkg=0.0, cin_surface_jkg=0.0)
+    diag = NWPCloudDiagnostics(
+        total_cover_pct=81.0,          # native cloud content (not the CAPE fallback)
+        convective_precip_mm_h=4.26,   # ECMWF `cp`, de-accumulated
+        # convective_top_ft / convective_cover_pct absent (hcct sentinel, no cc field)
+    )
+    result = assess_convective_nwp(indices, diag)
+    assert result is not None
+    assert result.method == "nwp_precip"
+    assert result.risk_level == ConvectiveRisk.MODERATE
+    assert result.convective_precip_mm_h == 4.26
+
+
+def test_nwp_precip_not_used_when_tower_top_present():
+    """Tower top stays primary: a precip rate never overrides a diagnosed top."""
+    indices = ThermodynamicIndices(cape_surface_jkg=40.0, lcl_altitude_ft=3000.0)
+    # ECMWF hcct present (FL150 → LOW) with light precip; top wins, method nwp_lcl_top.
+    diag = NWPCloudDiagnostics(convective_top_ft=15000.0, convective_precip_mm_h=4.0)
+    result = assess_convective_nwp(indices, diag)
+    assert result is not None
+    assert result.method == "nwp_lcl_top"
+    assert result.risk_level == ConvectiveRisk.LOW
+
+
 def test_nwp_gfs_sun_reims_high():
     """Regression (#283): GFS Sun LFQA — cover 46.8%, top FL332 → HIGH.
 


### PR DESCRIPTION
## Why

Investigating EGTF→BIG→LFAT→LFQA 2026-06-27 (D-1): Windy showed vigorous convection over the Channel on ECMWF, but our briefing read it as benign (NWP convective track NONE, convective-character GREEN) while flagging Reims. Root cause — ECMWF's own scheme **is** precipitating convectively over the Channel (`cp` peaks **4.26 mm/h @ ~52 nm**, with 0.4–1.2 mm/h either side), but two §14 Phase-1/2 assumptions broke:

1. **"No tower top ⇒ quiet scheme ⇒ NONE."** ECMWF's `hcct` (convective top) is sentinel/absent across the whole Channel *even where `cp` fires*, and ECMWF has no convective-cover field. So `assess_convective_nwp` fell through to the quiet branch → NONE, with the `cp` we already decode sitting unused. The Phase-2 firing gate only ever *holds a tower down* — no symmetric path to *lift NONE up*. This is the marine/**elevated** convection case (surface parcel has zero CAPE, so the DD/parcel track is also quiet).
2. **Character "realized" read Open-Meteo `showers`, which is structurally 0.0 for ECMWF IFS** (verified: 0.00 at every point while total precip was 4.38 mm/h). So no ECMWF point could ever be "realized" by precip → GREEN.

## What

- **`cp` is now a first-class native firing signal** (`convective.py`). No tower top + no cover + `cp > 0.1` → tier from a convective-precip-rate ladder (`method="nwp_precip"`): ≥2.0 → MODERATE, ≥0.5 → LOW, ≥0.1 → MARGINAL. **Tower top stays primary whenever present** — ladder is the geometry-absent fallback only. Capped at MODERATE (depth unknown from rate); skips the firing-gate hold-down + precip-corroboration (would double-count `cp`). Rate is resolution-dependent → thresholds are a synoptic-scale v1.
- **Convective-character "realized" prefers GRIB-native `convective_precip_mm_h` over Open-Meteo `showers`** for any model carrying NWP diagnostics; Open-Meteo fallback only for non-GRIB models (AROME/UKMO/MF). The "use the GRIB variable, not Open-Meteo" principle.

## Effect (validated on the real pack)

- **NWP track over the Channel: NONE → fires** — 52 nm `cp` 4.26 → **MODERATE**, 72 nm → LOW, 42/62/82 nm → MARGINAL; tower-top points (10–22 nm) still `nwp_lcl_top` (geometry primary).
- **ECMWF convective character: GREEN → AMBER "Scattered cells" (20% of route)** under the shipped default method.
- **Graded severity colour over the Channel is unchanged** — §14's DD-floor (`max(native, thermo)`) already graded it MODERATE off elevated MU-CAPE. This is a narrative / character / track-independence fix, plus it lets the inline cross-check reflect the firing the model actually forecasts.
- **Safety asymmetry preserved:** `cp` can only *add* a firing signal, never downgrade a DD red.

## Tests / docs

- 3 new regression tests in `tests/test_convective.py`: precip-rate tiering, the ECMWF Channel case (`cp` fires when `hcct` absent → MODERATE), tower-top-stays-primary guard.
- Full suite: **2984 passed, 9 skipped, 0 failed**.
- Logged as meteorology-decisions **§14 Phase 3** (reasoning + the revisited Phase-1 "precip is yes/no only" stance).

> Note: visible effect reaches users only after a refresh recomputes packs — existing packs hold the pre-computed soundings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)