### PR TITLE
Cross-section: depth-unresolved ghost column for NWP convective without a tower

### DIFF
--- a/designs/visualization.md
+++ b/designs/visualization.md
@@ -65,7 +65,7 @@ Rendering order: **night shading → obscuration → clouds → convection → i
 | Natural DD clouds | DD Natural | clouds | `cloud-bands-factory.ts` | off | Same puff rendering using DD-derived cloud layers |
 | Square NWP clouds | Square NWP | clouds | `cloud-bands-factory.ts` | off | Solid filled cells per zone, opacity from cover% (ForeFlight-like) |
 | Square DD clouds | Square DD | clouds | `cloud-bands-factory.ts` | off | Same square cells using DD-derived cloud layers |
-| NWP Convective | NWP Convective | convection | `nwp-convective-bg.ts` | **on** | Model convective scheme output (base/top/coverage) |
+| NWP Convective | NWP Convective | convection | `nwp-convective-bg.ts` | **on** | Model convective scheme output (base/top/coverage); full-height **depth-unresolved ghost column** when risk ≥ LOW but no base/top (ECMWF `nwp_precip` / GFS cover-only) |
 | Thermo Convective | Thermo Convective | convection | `thermo-convective-bg.ts` | off | CAPE/CIN tower columns LFC→EL (LCL fallback), hatching, TCU/CB/+TS labels |
 | Icing bands | Ogimet-DD | icing | `icing-bands.ts` | off | DD-attenuated Ogimet index |
 | Ogimet-NWP bands | Ogimet-NWP | icing | `icing-ogimet-nwp-bands.ts` | **on** | NWP cloud-fraction-scaled Ogimet index with glaciation |
@@ -199,7 +199,11 @@ Three-way page theme support via `web/ts/theme.ts` (separate from cross-section 
 
 ## Convective Tower Rendering
 
-Convective towers are rendered by two layers — `thermo-convective-bg.ts` (CAPE/CIN thermodynamic scheme) and `nwp-convective-bg.ts` (model convective scheme base/top). The thermo layer is the more complex:
+Convective towers are rendered by two layers — `thermo-convective-bg.ts` (CAPE/CIN thermodynamic scheme) and `nwp-convective-bg.ts` (model convective scheme base/top).
+
+**NWP depth-unresolved ghost column.** The NWP layer needs a model base/top to draw a tower. The `nwp_precip` path (ECMWF firing on `cp` with `hcct` sentinel) and a GFS cover-only point both carry a real risk (≥ LOW) but *no* drawable base/top. Rather than skip them (which silently dropped real convection from the section while the route map + advisory still flagged it), `drawUnresolvedColumn()` renders a full-height **ghost column**: the risk-tinted `bgWash` spanning terrain→section-top, **dashed vertical sides**, and a **"?" marker** near the top — deliberately distinct from a resolved tower (no solid body / anvil / edge box) so it never reads as a known full-height CB. The tooltip row shows `Tower: depth unresolved (cp X mm/h)` with the firing evidence. `convective_precip_mm_h` is plumbed through `VizPoint.nwpConvectivePrecipMmH` for that evidence string.
+
+The thermo layer is the more complex:
 - **Marginal risk skipped**: points with `convectiveRisk === 'none' | 'marginal'` skip tower rendering entirely (marginal CAPE <100 J/kg produces misleading visual towers for noise-level instability)
 - **Tower columns**: drawn from base (LFC, falling back to LCL) → estimated tower top for each route point with risk ≥ LOW
 - **Tower top estimation**: uses thermodynamic EL if available and reliable (>3000ft above LCL), else estimates from `max(freezingLevel, −10°C, −20°C)` altitude lines as fallbacks
@@ -251,7 +255,7 @@ The registry includes 14 entries: cloud DD, cloud NWP, Ogimet-DD, Ogimet-NWP, SF
 - SFIP: `SFIP nn/100 type (T n°C)` plus trailing `[proxy]` for any non-`full` variant.
 - CAT / E-Shear: `(Ri n.nn)` when populated.
 - Thermo Conv: `(CAPE x, CIN -y)` plus `LCL→EL: FLxxx–FLyyy` (or `Tower:` fallback).
-- NWP Conv: `(nn% cover)` plus `Tower: FLxxx–FLyyy [method-tag]` where method-tag is `nwp` / `nwp_lcl_top` / `nwp_hybrid`.
+- NWP Conv: `(nn% cover)` plus `Tower: FLxxx–FLyyy [method-tag]` where method-tag is `nwp` / `nwp_lcl_top` / `nwp_hybrid` / `nwp_precip`. When depth is unresolved (no base/top) the row reads `Tower: depth unresolved (cp X mm/h)` and matches the full ghost column at any cursor altitude.
 - Inversions: ` (sfc)` suffix for surface-based.
 
 Header/terrain/temperature/stability rows stay inline in `interaction.ts` (different shape — proximity-based not band-based).

--- a/web/tests/unit/fixtures/viz-point.ts
+++ b/web/tests/unit/fixtures/viz-point.ts
@@ -45,6 +45,7 @@ export function makeVizPoint(overrides: Partial<VizPoint> = {}): VizPoint {
     nwpConvectiveBaseFt: null,
     nwpConvectiveTopFt: null,
     nwpConvectiveCoverPct: null,
+    nwpConvectivePrecipMmH: null,
     nwpConvectiveMethod: null,
     hasNwpConvective: false,
     cloudCoverTotalPct: 0,

--- a/web/tests/unit/tooltip-formatters.test.ts
+++ b/web/tests/unit/tooltip-formatters.test.ts
@@ -259,6 +259,38 @@ describe('convective layers', () => {
     expect(out).toContain('Tower: 3,000 ft–FL250');
     expect(out).toContain('[nwp_lcl_top]');
   });
+
+  it('nwp-convective shows "depth unresolved" + cp when base/top absent (nwp_precip)', () => {
+    const point = makeVizPoint({
+      nwpConvectiveRisk: 'moderate',
+      nwpConvectiveBaseFt: null,
+      nwpConvectiveTopFt: null,
+      nwpConvectiveCoverPct: null,
+      nwpConvectivePrecipMmH: 4.26,
+      nwpConvectiveMethod: 'nwp_precip',
+    });
+    // Full-height ghost column → row shows at any cursor altitude.
+    const out = format('nwp-convective-bg', point, 35000)!;
+    expect(out).toContain('NWP Conv: moderate');
+    expect(out).toContain('depth unresolved');
+    expect(out).toContain('cp 4.3 mm/h');
+    expect(out).toContain('[nwp_precip]');
+    expect(out).not.toContain('FL'); // no fabricated tower range
+  });
+
+  it('nwp-convective falls back to cover% evidence when no cp (cover-only)', () => {
+    const point = makeVizPoint({
+      nwpConvectiveRisk: 'moderate',
+      nwpConvectiveBaseFt: null,
+      nwpConvectiveTopFt: null,
+      nwpConvectiveCoverPct: 70,
+      nwpConvectivePrecipMmH: null,
+      nwpConvectiveMethod: 'nwp',
+    });
+    const out = format('nwp-convective-bg', point, 12000)!;
+    expect(out).toContain('depth unresolved');
+    expect(out).toContain('70% cover');
+  });
 });
 
 describe('inversion-bands', () => {

--- a/web/ts/adapters/airport-profile-adapter.ts
+++ b/web/ts/adapters/airport-profile-adapter.ts
@@ -87,7 +87,7 @@ export interface SoundingPayload {
   inversion_layers?: any[];
   vertical_motion?: { cat_risk_layers?: any[]; e_shear_layers?: any[] } | null;
   convective?: { risk_level?: string; base_ft?: number | null; top_ft?: number | null; cin_jkg?: number } | null;
-  convective_nwp?: { risk_level?: string; base_ft?: number | null; top_ft?: number | null; cover_pct?: number | null; method?: string | null } | null;
+  convective_nwp?: { risk_level?: string; base_ft?: number | null; top_ft?: number | null; cover_pct?: number | null; convective_precip_mm_h?: number | null; method?: string | null } | null;
   cloud_cover_low_pct?: number | null;
   cloud_cover_mid_pct?: number | null;
   cloud_cover_high_pct?: number | null;
@@ -386,6 +386,7 @@ function synthesizeVizPoint(
     nwpConvectiveBaseFt: sounding?.convective_nwp?.base_ft ?? null,
     nwpConvectiveTopFt: sounding?.convective_nwp?.top_ft ?? null,
     nwpConvectiveCoverPct: sounding?.convective_nwp?.cover_pct ?? null,
+    nwpConvectivePrecipMmH: sounding?.convective_nwp?.convective_precip_mm_h ?? null,
     nwpConvectiveMethod: sounding?.convective_nwp?.method ?? null,
     hasNwpConvective: sounding?.convective_nwp != null,
     cloudCoverTotalPct: randomOverlapPct(low, mid, high),

--- a/web/ts/store/types.ts
+++ b/web/ts/store/types.ts
@@ -337,6 +337,7 @@ export interface ConvectiveAssessment {
   base_ft: number | null;
   top_ft: number | null;
   cover_pct: number | null;
+  convective_precip_mm_h: number | null;
   method: string;
 }
 

--- a/web/ts/visualization/cross-section/layers/nwp-convective-bg.ts
+++ b/web/ts/visualization/cross-section/layers/nwp-convective-bg.ts
@@ -6,10 +6,72 @@
  */
 
 import type { CrossSectionLayer, CoordTransform, VizRouteData } from '../../types';
+import { getActiveTheme } from '../theme';
 import {
   getBgWash, getTowerFill, getHatchColor, getStripColor, getEdgeColor, STRIP_HEIGHT,
   drawHatching, drawCBLabel,
 } from './thermo-convective-bg';
+
+/** Draw a full-height "ghost" column for a convective point whose depth the
+ *  model did not resolve (risk ≥ LOW but no base/top — ECMWF `nwp_precip` firing
+ *  on `cp`, or a GFS cover-only point with no tower top). Deliberately distinct
+ *  from a resolved tower: a risk-tinted wash spanning the whole column with
+ *  dashed sides and a "?" marker, so it never reads as a known full-height CB.
+ *  The honest tooltip ("depth unresolved") carries the detail. */
+function drawUnresolvedColumn(
+  ctx: CanvasRenderingContext2D,
+  xLeft: number,
+  xRight: number,
+  plotTop: number,
+  plotHeight: number,
+  risk: string,
+): void {
+  const colWidth = xRight - xLeft;
+
+  // Risk-tinted full-height wash (terrain layer masks the below-surface part).
+  const bgWash = getBgWash()[risk];
+  if (bgWash) {
+    ctx.fillStyle = bgWash;
+    ctx.fillRect(xLeft, plotTop, colWidth, plotHeight);
+  }
+
+  // Dashed vertical sides — signals "column, depth unknown" vs a solid tower box.
+  const edgeColor = getEdgeColor()[risk];
+  if (edgeColor) {
+    ctx.save();
+    ctx.strokeStyle = edgeColor;
+    ctx.lineWidth = 1;
+    ctx.setLineDash([4, 4]);
+    ctx.beginPath();
+    ctx.moveTo(xLeft + 0.5, plotTop);
+    ctx.lineTo(xLeft + 0.5, plotTop + plotHeight);
+    ctx.moveTo(xRight - 0.5, plotTop);
+    ctx.lineTo(xRight - 0.5, plotTop + plotHeight);
+    ctx.stroke();
+    ctx.restore();
+  }
+
+  // "?" marker near the top — depth-unresolved cue.
+  if (colWidth > 14) {
+    const cx = (xLeft + xRight) / 2;
+    const cy = plotTop + 12;
+    const colors = getActiveTheme().convective.cbLabelColor;
+    const theme = getActiveTheme();
+    ctx.save();
+    ctx.font = 'bold 11px -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif';
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    const pw = ctx.measureText('?').width + 8;
+    const ph = 15;
+    ctx.fillStyle = theme.sky.background + 'e6';
+    ctx.beginPath();
+    ctx.roundRect(cx - pw / 2, cy - ph / 2, pw, ph, 3);
+    ctx.fill();
+    ctx.fillStyle = colors[risk] ?? 'rgba(200, 100, 0, 0.8)';
+    ctx.fillText('?', cx, cy);
+    ctx.restore();
+  }
+}
 
 export const nwpConvectiveBgLayer: CrossSectionLayer = {
   id: 'nwp-convective-bg',
@@ -36,8 +98,14 @@ export const nwpConvectiveBgLayer: CrossSectionLayer = {
         : (x + transform.distanceToX(data.points[i + 1].distanceNm)) / 2;
       const colWidth = xRight - xLeft;
 
-      // NWP bounds are model-computed — skip if absent (no full-height fallback)
-      if (p.nwpConvectiveBaseFt == null || p.nwpConvectiveTopFt == null) continue;
+      // Depth unresolved: risk ≥ LOW but the model gave no tower base/top
+      // (ECMWF `nwp_precip` on `cp`, or GFS cover-only). Draw a distinct
+      // ghost column rather than skipping — the risk is real, only the
+      // geometry is unknown.
+      if (p.nwpConvectiveBaseFt == null || p.nwpConvectiveTopFt == null) {
+        drawUnresolvedColumn(ctx, xLeft, xRight, plotArea.top, plotArea.height, risk);
+        continue;
+      }
 
       {
         const baseFt = p.nwpConvectiveBaseFt;

--- a/web/ts/visualization/cross-section/tooltip-formatters.ts
+++ b/web/ts/visualization/cross-section/tooltip-formatters.ts
@@ -215,26 +215,42 @@ interface NwpConvZone {
   topFt: number;
   risk: string;
   coverPct: number | null;
+  precipMmH: number | null;
   method: string | null;
+  unresolved: boolean;
 }
 
 const nwpConv: LayerTooltipDef = {
   id: 'nwp-convective-bg',
   getZones: (p): NwpConvZone[] => {
-    if (p.nwpConvectiveRisk === 'none') return [];
+    if (p.nwpConvectiveRisk === 'none' || p.nwpConvectiveRisk === 'marginal') return [];
     const baseFt = p.nwpConvectiveBaseFt;
     const topFt = p.nwpConvectiveTopFt;
-    if (baseFt === null || topFt === null) return [];
-    return [{
-      baseFt, topFt,
+    const common = {
       risk: p.nwpConvectiveRisk,
       coverPct: p.nwpConvectiveCoverPct,
+      precipMmH: p.nwpConvectivePrecipMmH,
       method: p.nwpConvectiveMethod,
-    }];
+    };
+    // Depth unresolved (no model base/top): match the full column so the row
+    // shows wherever the cursor is in the ghost column.
+    if (baseFt === null || topFt === null) {
+      return [{ ...common, baseFt: 0, topFt: Number.MAX_SAFE_INTEGER, unresolved: true }];
+    }
+    return [{ ...common, baseFt, topFt, unresolved: false }];
   },
   formatLine: (z: NwpConvZone) => {
-    const cover = z.coverPct !== null ? `${Math.round(z.coverPct)}% cover` : '';
     const tag = z.method ? ` [${z.method}]` : '';
+    if (z.unresolved) {
+      // Evidence the scheme fired even though it gave no tower geometry.
+      const ev = z.precipMmH !== null
+        ? `cp ${z.precipMmH.toFixed(1)} mm/h`
+        : (z.coverPct !== null ? `${Math.round(z.coverPct)}% cover` : '');
+      let line = `NWP Conv: ${z.risk}`;
+      line += `<br>Tower: depth unresolved${ev ? ` (${ev})` : ''}${tag}`;
+      return line;
+    }
+    const cover = z.coverPct !== null ? `${Math.round(z.coverPct)}% cover` : '';
     let line = `NWP Conv: ${z.risk}` + extras([cover]);
     line += `<br>Tower: ${fmtFL(z.baseFt)}–${fmtFL(z.topFt)}${tag}`;
     return line;

--- a/web/ts/visualization/data-extract.ts
+++ b/web/ts/visualization/data-extract.ts
@@ -419,6 +419,7 @@ function extractPoint(
     nwpConvectiveBaseFt: sounding?.convective_nwp?.base_ft ?? null,
     nwpConvectiveTopFt: sounding?.convective_nwp?.top_ft ?? null,
     nwpConvectiveCoverPct: sounding?.convective_nwp?.cover_pct ?? null,
+    nwpConvectivePrecipMmH: sounding?.convective_nwp?.convective_precip_mm_h ?? null,
     nwpConvectiveMethod: sounding?.convective_nwp?.method ?? null,
     hasNwpConvective: sounding?.convective_nwp != null,
     cloudCoverTotalPct,

--- a/web/ts/visualization/types.ts
+++ b/web/ts/visualization/types.ts
@@ -259,7 +259,10 @@ export interface VizPoint {
   nwpConvectiveBaseFt: number | null;
   nwpConvectiveTopFt: number | null;
   nwpConvectiveCoverPct: number | null;
-  /** Method tag: "nwp", "nwp_lcl_top", "nwp_hybrid", etc. */
+  /** Native convective precip rate (mm/h) — the firing evidence on the
+   *  "nwp_precip" path, where base/top are unresolved. Null otherwise. */
+  nwpConvectivePrecipMmH: number | null;
+  /** Method tag: "nwp", "nwp_lcl_top", "nwp_hybrid", "nwp_precip", etc. */
   nwpConvectiveMethod: string | null;
   /**
    * True when the model produced a convective_nwp assessment (regardless


### PR DESCRIPTION
## Why

Follow-up to PR #306 (§14 Phase 3). That change made ECMWF's `cp` fire the NWP convective track even when the model gives no tower top (`method="nwp_precip"`, `base_ft`/`top_ft` both null). But the cross-section's NWP convective layer **needs** a base/top to draw a tower, so it skipped those points entirely (`nwp-convective-bg.ts:40` `if (base==null||top==null) continue`) and the tooltip returned no row. Result: a real MODERATE convective risk that the **route map and advisory both flag** was invisible on the cross-section. The same null-geometry skip also dropped GFS **cover-only** points (depth-unknown).

## What

Render a full-height **depth-unresolved ghost column** (`drawUnresolvedColumn`) for any NWP convective point with risk ≥ LOW but no drawable base/top:
- risk-tinted `bgWash` spanning terrain→section-top,
- **dashed vertical sides** + a **"?" marker** near the top,
- deliberately distinct from a resolved tower — no solid body / anvil / edge box — so it never reads as a *known* full-height CB.

Tooltip row now shows `Tower: depth unresolved (cp X mm/h)` (or `… (NN% cover)` for cover-only) instead of an absent row, matching the full ghost column at any cursor altitude. `convective_precip_mm_h` is plumbed through `VizPoint.nwpConvectivePrecipMmH` for the evidence string.

```
ceil ┊▒▒▒┊   risk-tinted wash
     ┊▒?▒┊   dashed sides + '?'
     ┊▒▒▒┊   (no solid body/anvil)
terr ┊▒▒▒┊
  ▔▔▔▔▔▔▔▔▔▔
hover: NWP Conv MODERATE — depth unresolved (cp 4.3 mm/h) [nwp_precip]
```

## Validation

- `tsc --noEmit` clean (the 2 pre-existing `eval/label-panel.ts` errors are unrelated, present on `main`).
- esbuild bundles build.
- Web suite **391 passing** (+2 new tooltip cases: `cp` evidence + cover-only fallback).
- `designs/visualization.md` updated (layer table, Convective Tower Rendering section, tooltip extras).

> Visual note: existing packs hold pre-Phase-3 soundings (`convective_nwp` = NONE over the Channel), so the ghost column appears only once a pack is refreshed with the new backend. Happy to spin up the devserver against a freshly-refreshed flight for a screenshot if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)