### PR TITLE
ios(tips): native TipKit contextual coachmarks for the briefing detail views (#312)

### DIFF
--- a/app/flyfun-weather/flyfun-weather/App/WeatherBriefApp.swift
+++ b/app/flyfun-weather/flyfun-weather/App/WeatherBriefApp.swift
@@ -1,9 +1,20 @@
 import SwiftUI
+import TipKit
 
 @main
 struct WeatherBriefApp: App {
     @State private var appState = AppState()
     @Environment(\.scenePhase) private var scenePhase
+
+    init() {
+        // Contextual coachmarks for the briefing detail views (#312). Guarded
+        // `try?` — a tip-store failure must never block app launch. Revisit
+        // `.daily` later if the tips ever feel noisy.
+        try? Tips.configure([
+            .displayFrequency(.immediate),
+            .datastoreLocation(.applicationDefault),
+        ])
+    }
 
     var body: some Scene {
         WindowGroup {

--- a/app/flyfun-weather/flyfun-weather/Tips/BriefingTips.swift
+++ b/app/flyfun-weather/flyfun-weather/Tips/BriefingTips.swift
@@ -54,7 +54,9 @@ struct RefreshBriefingTip: Tip {
 /// so it never fires while the Advisory (or any other) tab is on screen.
 struct CrossSectionLayersTip: Tip {
     /// Set from `CrossSectionView`'s appear/disappear so the tip is eligible
-    /// only while that tab is the visible one.
+    /// only while that tab is the visible one. TipKit requires each `@Parameter`
+    /// to live on its own Tip type, so this is written in tandem with
+    /// `CrossSectionScrubTip.crossSectionVisible` — update both together.
     @Parameter static var crossSectionVisible: Bool = false
 
     var title: Text { Text("Choose what to show") }
@@ -71,6 +73,8 @@ struct CrossSectionLayersTip: Tip {
 /// the canvas the first time the tab is opened; invalidated once the user
 /// scrubs once. Shares the visibility gate with the Layers tip.
 struct CrossSectionScrubTip: Tip {
+    /// Written in tandem with `CrossSectionLayersTip.crossSectionVisible` from
+    /// `CrossSectionView`'s appear/disappear — update both together.
     @Parameter static var crossSectionVisible: Bool = false
 
     var title: Text { Text("Tap or drag anywhere") }

--- a/app/flyfun-weather/flyfun-weather/Tips/BriefingTips.swift
+++ b/app/flyfun-weather/flyfun-weather/Tips/BriefingTips.swift
@@ -1,0 +1,84 @@
+import SwiftUI
+import TipKit
+
+/// Contextual coachmarks for the briefing detail views (#312).
+///
+/// TipKit (iOS 17+) surfaces each tip at its point of use, then persists the
+/// dismissal so a tip never nags twice — no storage code on our side. This is
+/// the native, non-blocking counterpart to the web app's driver.js tour: tips
+/// appear next to the control they describe, the user dismisses them, and the
+/// framework remembers. There is no forced linear walkthrough.
+///
+/// Scope (per #312): buttons/controls *inside* the detail views, not the tab
+/// bar (`.popoverTip` cannot cleanly anchor to a SwiftUI `Tab`). Add more tips
+/// incrementally — keep each one short and action-oriented.
+
+// MARK: - Events
+
+/// Donated when the user acts on the download tip, so the refresh tip can
+/// sequence *after* it. The two controls sit side by side and the whole point
+/// is the contrast — offline-save vs. fetch-new — so they should read as a pair.
+enum BriefingTipEvents {
+    static let downloadTipSeen = Tips.Event(id: "briefing.downloadTipSeen")
+}
+
+// MARK: - Toolbar tips
+
+/// 1. Download button (`arrow.down.circle`, `.notDownloaded`).
+struct DownloadBriefingTip: Tip {
+    var title: Text { Text("Save for offline") }
+    var message: Text? {
+        Text("Downloads this briefing so you can view it without a connection. Stays put until you refresh or remove it.")
+    }
+    var image: Image? { Image(systemName: "arrow.down.circle") }
+}
+
+/// 2. Refresh button (`arrow.clockwise`). Sequenced after the download tip via
+/// the `downloadTipSeen` event so the offline-save / fetch-new pair reads in
+/// order. If the user ignores the download tip, this one simply waits — it is
+/// still non-forced.
+struct RefreshBriefingTip: Tip {
+    var title: Text { Text("Get the latest forecast") }
+    var message: Text? {
+        Text("Re-fetches the newest model run from the server. Download saves what you have now; refresh pulls new data.")
+    }
+    var image: Image? { Image(systemName: "arrow.clockwise") }
+    var rules: [Rule] {
+        #Rule(BriefingTipEvents.downloadTipSeen) { $0.donations.count > 0 }
+    }
+}
+
+// MARK: - Cross-section tips
+
+/// 3. Cross-section "Layers" pill. Gated on the Cross-Section tab being visible
+/// so it never fires while the Advisory (or any other) tab is on screen.
+struct CrossSectionLayersTip: Tip {
+    /// Set from `CrossSectionView`'s appear/disappear so the tip is eligible
+    /// only while that tab is the visible one.
+    @Parameter static var crossSectionVisible: Bool = false
+
+    var title: Text { Text("Choose what to show") }
+    var message: Text? {
+        Text("Toggle cloud, icing, wind and other layers on the cross-section.")
+    }
+    var image: Image? { Image(systemName: "slider.horizontal.3") }
+    var rules: [Rule] {
+        #Rule(Self.$crossSectionVisible) { $0 }
+    }
+}
+
+/// 4. Cross-section canvas — "tap any point". An inline `TipView` banner above
+/// the canvas the first time the tab is opened; invalidated once the user
+/// scrubs once. Shares the visibility gate with the Layers tip.
+struct CrossSectionScrubTip: Tip {
+    @Parameter static var crossSectionVisible: Bool = false
+
+    var title: Text { Text("Tap or drag anywhere") }
+    var message: Text? {
+        Text("Read exact values at any point along the route and altitude. Double-tap to hide the controls.")
+    }
+    var image: Image? { Image(systemName: "hand.point.up.left") }
+    var rules: [Rule] {
+        #Rule(Self.$crossSectionVisible) { $0 }
+    }
+}

--- a/app/flyfun-weather/flyfun-weather/Views/Briefing/BriefingContainerView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Briefing/BriefingContainerView.swift
@@ -1,5 +1,6 @@
 import CoreLocation
 import SwiftUI
+import TipKit
 
 /// Tab-based briefing viewer for a single flight.
 struct BriefingContainerView: View {
@@ -122,6 +123,11 @@ private struct BriefingToolbarView: View {
     var isInFlightWindow: Bool
     var startTracking: () -> Void
 
+    // Contextual tips (#312): the download/refresh pair reads side by side, so
+    // the refresh tip is sequenced after the download tip donates its event.
+    private let downloadTip = DownloadBriefingTip()
+    private let refreshTip = RefreshBriefingTip()
+
     var body: some View {
         HStack(spacing: 12) {
             // Start / Stop Flight button
@@ -146,10 +152,20 @@ private struct BriefingToolbarView: View {
             switch viewModel.downloadState {
             case .notDownloaded:
                 Button {
-                    Task { await viewModel.downloadCurrentPack() }
+                    Task {
+                        await viewModel.downloadCurrentPack()
+                        // Retire the tip on a successful download. The refresh
+                        // tip's sequencing is driven by the dismissal watcher
+                        // below, so it fires whether the user downloads or just
+                        // closes the tip.
+                        if case .downloaded = viewModel.downloadState {
+                            downloadTip.invalidate(reason: .actionPerformed)
+                        }
+                    }
                 } label: {
                     Image(systemName: "arrow.down.circle")
                 }
+                .popoverTip(downloadTip)
             case .downloading(let progress, _, _):
                 ProgressView(value: progress)
                     .progressViewStyle(.circular)
@@ -177,7 +193,10 @@ private struct BriefingToolbarView: View {
 
             // Refresh button
             Button {
-                Task { await viewModel.refresh() }
+                Task {
+                    await viewModel.refresh()
+                    refreshTip.invalidate(reason: .actionPerformed)
+                }
             } label: {
                 if viewModel.refreshState.isRefreshing {
                     ProgressView()
@@ -187,6 +206,19 @@ private struct BriefingToolbarView: View {
                 }
             }
             .disabled(viewModel.refreshState.isRefreshing)
+            .popoverTip(refreshTip)
+        }
+        // Sequence the refresh tip after the download tip: when the download tip
+        // is dismissed — closed via its × OR acted on by downloading — donate the
+        // event that makes the refresh tip eligible, so the offline-save /
+        // fetch-new pair reads in order (#312).
+        .task {
+            for await status in downloadTip.statusUpdates {
+                if case .invalidated = status {
+                    await BriefingTipEvents.downloadTipSeen.donate()
+                    break
+                }
+            }
         }
     }
 }

--- a/app/flyfun-weather/flyfun-weather/Views/Briefing/BriefingContainerView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Briefing/BriefingContainerView.swift
@@ -195,7 +195,13 @@ private struct BriefingToolbarView: View {
             Button {
                 Task {
                     await viewModel.refresh()
-                    refreshTip.invalidate(reason: .actionPerformed)
+                    // Don't burn the coaching tip on a failed refresh — keep it
+                    // visible so the user can retry with the coaching present
+                    // (mirrors the download-tip guard). `.completed`/`.noRefresh`
+                    // are the successful terminal states; `.error` is failure.
+                    if case .error = viewModel.refreshState {} else {
+                        refreshTip.invalidate(reason: .actionPerformed)
+                    }
                 }
             } label: {
                 if viewModel.refreshState.isRefreshing {

--- a/app/flyfun-weather/flyfun-weather/Views/CrossSection/CrossSectionView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/CrossSection/CrossSectionView.swift
@@ -28,6 +28,11 @@ struct CrossSectionView: View {
     // Contextual tips (#312), gated on this tab being visible.
     private let layersTip = CrossSectionLayersTip()
     private let scrubTip = CrossSectionScrubTip()
+    /// One-shot guard so the scrub tip is retired exactly once — and only in
+    /// portrait, where its `TipView` is actually rendered. Landscape focus has
+    /// no scrub `TipView` (distraction-free by design), so a landscape drag must
+    /// not consume the tip before the user ever sees it.
+    @State private var scrubTipInvalidated = false
 
     /// iPhone landscape → immersive full-bleed focus mode (§4.7): cross-section
     /// is a wide artifact, so landscape gives it the right aspect ratio.
@@ -221,9 +226,13 @@ struct CrossSectionView: View {
 
     private func updateScrub(at location: CGPoint) {
         guard let vizData = csVM.vizData, canvasSize.width > 0, !vizData.points.isEmpty else { return }
-        // First real scrub retires the "tap any point" tip (idempotent — the
-        // drag fires this many times).
-        scrubTip.invalidate(reason: .actionPerformed)
+        // First real scrub retires the "tap any point" tip — but only in
+        // portrait, where the tip is shown. The drag fires this repeatedly, so
+        // short-circuit after the first to avoid hammering TipKit.
+        if !scrubTipInvalidated && !isLandscapeFocus {
+            scrubTipInvalidated = true
+            scrubTip.invalidate(reason: .actionPerformed)
+        }
         let transform = CoordTransform(size: canvasSize,
                                        maxDistanceNm: vizData.totalDistanceNm,
                                        maxAltitudeFt: vizData.flightCeilingFt)

--- a/app/flyfun-weather/flyfun-weather/Views/CrossSection/CrossSectionView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/CrossSection/CrossSectionView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import TipKit
 
 /// SwiftUI Canvas wrapper for the cross-section visualization (§4.7 interaction).
 /// Touch model (a): tap/drag = scrub → moves a continuous cursor that drives the
@@ -24,6 +25,10 @@ struct CrossSectionView: View {
     @State private var scrollTarget: String?
     @Environment(\.verticalSizeClass) private var vSizeClass
 
+    // Contextual tips (#312), gated on this tab being visible.
+    private let layersTip = CrossSectionLayersTip()
+    private let scrubTip = CrossSectionScrubTip()
+
     /// iPhone landscape → immersive full-bleed focus mode (§4.7): cross-section
     /// is a wide artifact, so landscape gives it the right aspect ratio.
     private var isLandscapeFocus: Bool { vSizeClass == .compact }
@@ -44,6 +49,16 @@ struct CrossSectionView: View {
         .sheet(isPresented: $showingConfig) {
             CrossSectionConfigSheet(csVM: csVM)
         }
+        // Gate the cross-section tips on this tab being on screen so they never
+        // fire from the Advisory/Map tabs (#312).
+        .onAppear {
+            CrossSectionLayersTip.crossSectionVisible = true
+            CrossSectionScrubTip.crossSectionVisible = true
+        }
+        .onDisappear {
+            CrossSectionLayersTip.crossSectionVisible = false
+            CrossSectionScrubTip.crossSectionVisible = false
+        }
     }
 
     // MARK: Portrait layout
@@ -60,6 +75,10 @@ struct CrossSectionView: View {
                         onSounding: goToSounding,
                         routeGraphMetricIds: [graphLeftMetricId, graphRightMetricId]
                     )
+                    // "Tap any point" coachmark above the canvas (#312); cleared
+                    // on the first scrub via `updateScrub`.
+                    TipView(scrubTip)
+                        .padding(.horizontal, Theme.cardPadding)
                     crossSectionCanvas
                     RouteGraphView(viewModel: viewModel, vizData: csVM.vizData, scrubDistanceNm: scrubDistanceNm,
                                    leftMetricId: $graphLeftMetricId, rightMetricId: $graphRightMetricId)
@@ -139,6 +158,7 @@ struct CrossSectionView: View {
     private var layersPill: some View {
         Button {
             showingConfig = true
+            layersTip.invalidate(reason: .actionPerformed)
         } label: {
             Label("Layers", systemImage: "slider.horizontal.3")
                 .font(.caption.weight(.medium))
@@ -147,6 +167,7 @@ struct CrossSectionView: View {
                 .foregroundStyle(Theme.primary)
         }
         .buttonStyle(.plain)
+        .popoverTip(layersTip)
     }
 
     // MARK: Canvas
@@ -195,6 +216,9 @@ struct CrossSectionView: View {
 
     private func updateScrub(at location: CGPoint) {
         guard let vizData = csVM.vizData, canvasSize.width > 0, !vizData.points.isEmpty else { return }
+        // First real scrub retires the "tap any point" tip (idempotent — the
+        // drag fires this many times).
+        scrubTip.invalidate(reason: .actionPerformed)
         let transform = CoordTransform(size: canvasSize,
                                        maxDistanceNm: vizData.totalDistanceNm,
                                        maxAltitudeFt: vizData.flightCeilingFt)

--- a/app/flyfun-weather/flyfun-weather/Views/CrossSection/CrossSectionView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/CrossSection/CrossSectionView.swift
@@ -76,9 +76,14 @@ struct CrossSectionView: View {
                         routeGraphMetricIds: [graphLeftMetricId, graphRightMetricId]
                     )
                     // "Tap any point" coachmark above the canvas (#312); cleared
-                    // on the first scrub via `updateScrub`.
-                    TipView(scrubTip)
-                        .padding(.horizontal, Theme.cardPadding)
+                    // on the first scrub via `updateScrub`. Only render once
+                    // there's a canvas to interact with — otherwise the tip
+                    // would be consumed coaching against a loading/error
+                    // placeholder.
+                    if csVM.vizData != nil {
+                        TipView(scrubTip)
+                            .padding(.horizontal, Theme.cardPadding)
+                    }
                     crossSectionCanvas
                     RouteGraphView(viewModel: viewModel, vizData: csVM.vizData, scrubDistanceNm: scrubDistanceNm,
                                    leftMetricId: $graphLeftMetricId, rightMetricId: $graphRightMetricId)

--- a/app/flyfun-weather/flyfun-weather/Views/SettingsView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/SettingsView.swift
@@ -1,4 +1,7 @@
 import SwiftUI
+#if DEBUG
+import TipKit
+#endif
 
 /// App settings: account management, links, and legal.
 struct SettingsView: View {
@@ -11,6 +14,9 @@ struct SettingsView: View {
     @State private var showFinalConfirmation = false
     @State private var isDeleting = false
     @State private var errorMessage: String?
+    #if DEBUG
+    @State private var tipsResetConfirmation: String?
+    #endif
 
     var body: some View {
         NavigationStack {
@@ -77,6 +83,36 @@ struct SettingsView: View {
                             .font(.caption)
                     }
                 }
+
+                #if DEBUG
+                // Developer-only: TipKit persists which coachmarks have been
+                // seen, so they never reappear once dismissed. `resetDatastore()`
+                // can only run *before* `Tips.configure()` (it throws
+                // `tipsDatastoreAlreadyConfigured` at runtime), so for in-app
+                // testing we use the session overrides instead: "Show All"
+                // force-displays every tip ignoring seen-state and eligibility
+                // gates; "Reset" clears that override. Mirrors the debug server
+                // picker — present only in DEBUG builds.
+                Section {
+                    Button {
+                        Tips.showAllTipsForTesting()
+                        tipsResetConfirmation = "Showing all tips — open the briefing / Cross-Section tab to see them."
+                    } label: {
+                        Label("Show All Tips", systemImage: "lightbulb")
+                    }
+                    Button {
+                        Tips.hideAllTipsForTesting()
+                        tipsResetConfirmation = "Override cleared — tips follow their normal seen-state and gates again."
+                    } label: {
+                        Label("Reset Tips Override", systemImage: "lightbulb.slash")
+                    }
+                } header: {
+                    Text("Developer")
+                } footer: {
+                    Text(tipsResetConfirmation
+                         ?? "Force-show the briefing coachmarks (#312) for testing. Session-only — overrides reset on relaunch.")
+                }
+                #endif
             }
             .navigationTitle("Settings")
             .toolbar {


### PR DESCRIPTION
## What

Native iOS/iPad equivalent of the web app's guided tour, using Apple's **TipKit** (iOS 17+) instead of a forced linear walkthrough. Tips surface at the point of use, the user dismisses them, and the framework persists the seen-state — non-blocking, cockpit-friendly. Establishes the pattern + scaffolding and ships **four example tips**; more are added incrementally.

Closes #312. Part of the iOS modernisation epic #285.

## Changes

- **Launch config** (`WeatherBriefApp.swift`) — `Tips.configure([.displayFrequency(.immediate), .datastoreLocation(.applicationDefault)])` in a guarded `try?`.
- **`Tips/BriefingTips.swift`** (new) — four `Tip` structs + the download→refresh sequencing event. The two cross-section tips carry a `@Parameter` visibility gate.
- **Four attachment points** wired into existing views (no structural changes):
  1. **Download button** → `.popoverTip` "Save for offline".
  2. **Refresh button** → `.popoverTip` "Get the latest forecast", **sequenced after** the download tip. A `statusUpdates` watcher donates the sequencing event the moment the download tip is dismissed (closed via × *or* downloaded), so the offline-save / fetch-new pair reads in order.
  3. **Cross-section "Layers" pill** → `.popoverTip` "Choose what to show"; gated to the Cross-Section tab; invalidated when the config sheet opens.
  4. **Cross-section canvas** → inline `TipView` "Tap or drag anywhere"; gated to the tab; invalidated on first scrub.
- **Settings** (`SettingsView.swift`) — DEBUG-only "Developer" section with **Show All Tips** / **Reset Tips Override** (`showAllTipsForTesting` / `hideAllTipsForTesting`) for visual QA, mirroring the existing debug server picker. (`resetDatastore()` can't run post-`configure()`, so the session overrides are the correct runtime tools.)

## Testing

- Builds clean for iPad Pro 11" (M5) simulator, iOS 26.
- Verified on iPad simulator: "Save for offline" → close → "Get the latest forecast" sequences correctly; Cross-Section "Layers" tip appears on that tab only.

## Out of scope (per issue)

Forced/linear tour, tab-bar popover anchoring, the #311 deep help catalog, and tip-copy localization beyond English.

🤖 Generated with [Claude Code](https://claude.com/claude-code)