### PR TITLE
iOS test suite: unit (Tier A/B/C) + XCUITest seam & first journeys (#314)

### DIFF
--- a/app/flyfun-weather/flyfun-weather/App/AppState.swift
+++ b/app/flyfun-weather/flyfun-weather/App/AppState.swift
@@ -122,7 +122,9 @@ final class AppState {
         if Self.isUITestMockMode {
             repository = FixtureBriefingRepository()
         } else {
-            applyToken("uitest-token")
+            // Live-dev mode: don't write to the keychain — reuse whatever real
+            // token the developer already has, so we never leave a fake token
+            // behind that would 401 the real app on next launch.
             setupClient()
         }
     }

--- a/app/flyfun-weather/flyfun-weather/App/AppState.swift
+++ b/app/flyfun-weather/flyfun-weather/App/AppState.swift
@@ -76,6 +76,16 @@ final class AppState {
 
     var isAuthenticated: Bool { jwt != nil }
 
+    #if DEBUG
+    /// Launched by a UI test (`FLYFUN_UITEST=1`) — skip the auth gate so the app
+    /// renders past `LoginView` without a real sign-in.
+    static var isUITesting: Bool { ProcessInfo.processInfo.environment["FLYFUN_UITEST"] == "1" }
+    /// Serve bundled fixtures instead of the network (`FLYFUN_MOCK=1`) so UI tests
+    /// are deterministic and offline. Stub at the app boundary — XCUITest can't
+    /// intercept network the way Playwright can.
+    static var isUITestMockMode: Bool { ProcessInfo.processInfo.environment["FLYFUN_MOCK"] == "1" }
+    #endif
+
     // MARK: - Lifecycle
 
     init() {
@@ -90,10 +100,33 @@ final class AppState {
             }
         )
 
+        #if DEBUG
+        if Self.isUITesting {
+            setupUITestSession()
+            return
+        }
+        #endif
+
         if store.token?.isEmpty == false {
             setupClient()
         }
     }
+
+    #if DEBUG
+    /// Wire up a fake authenticated session for UI tests. In mock mode the
+    /// repository serves fixtures; otherwise it points at the selected server so
+    /// tests can also run against a live dev backend. The fake JWT is set on the
+    /// observable mirror only — it is never written to the keychain.
+    private func setupUITestSession() {
+        jwt = "uitest-token"
+        if Self.isUITestMockMode {
+            repository = FixtureBriefingRepository()
+        } else {
+            applyToken("uitest-token")
+            setupClient()
+        }
+    }
+    #endif
 
     // MARK: - Auth
 

--- a/app/flyfun-weather/flyfun-weather/Services/BriefingCacheStore.swift
+++ b/app/flyfun-weather/flyfun-weather/Services/BriefingCacheStore.swift
@@ -30,9 +30,16 @@ actor BriefingCacheStore {
     private var index: [String: CachedPackEntry] = [:] // keyed by "flightId/timestamp"
     private var loaded = false
 
-    init() {
+    /// Designated initializer — the cache root is injectable so tests can point
+    /// it at a temp directory instead of the shared Application Support container.
+    init(cacheDir: URL) {
+        self.cacheDir = cacheDir
+    }
+
+    /// Production initializer — Application Support/BriefingCache.
+    convenience init() {
         let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
-        cacheDir = appSupport.appendingPathComponent("BriefingCache", isDirectory: true)
+        self.init(cacheDir: appSupport.appendingPathComponent("BriefingCache", isDirectory: true))
     }
 
     // MARK: - Read / Write

--- a/app/flyfun-weather/flyfun-weather/Services/FixtureBriefingRepository.swift
+++ b/app/flyfun-weather/flyfun-weather/Services/FixtureBriefingRepository.swift
@@ -36,7 +36,10 @@ final class FixtureBriefingRepository: BriefingRepository, @unchecked Sendable {
           }
         ]
         """
-        return (try? JSONDecoder.weatherBrief.decode([FlightResponse].self, from: Data(json.utf8))) ?? []
+        // try! on purpose: this fixture must always decode. If a model change
+        // breaks it, fail loudly here rather than silently emptying the list and
+        // making every UI journey fail with a misleading "no flights" message.
+        return try! JSONDecoder.weatherBrief.decode([FlightResponse].self, from: Data(json.utf8))
     }
 
     private let flightsFixture = decodeFlights()

--- a/app/flyfun-weather/flyfun-weather/Services/FixtureBriefingRepository.swift
+++ b/app/flyfun-weather/flyfun-weather/Services/FixtureBriefingRepository.swift
@@ -40,10 +40,31 @@ final class FixtureBriefingRepository: BriefingRepository, @unchecked Sendable {
     }
 
     private let flightsFixture = decodeFlights()
+    /// Flights created during a journey via `createFlight`, so the new flight
+    /// shows up on the next `flights()` reload.
+    private var createdFlights: [FlightResponse] = []
 
     // MARK: Served
 
-    func flights() async throws -> [FlightResponse] { flightsFixture }
+    func flights() async throws -> [FlightResponse] { flightsFixture + createdFlights }
+
+    func createFlight(_ request: CreateFlightRequest) async throws -> FlightResponse {
+        let flight = FlightResponse(
+            id: "created-\(createdFlights.count + 1)",
+            userId: "uitest", profileId: nil, aircraftId: request.aircraftId, aircraft: nil,
+            routeName: request.waypoints.joined(separator: " "),
+            waypoints: request.waypoints,
+            departureTime: request.departureTime,
+            targetDate: "2099-07-05", targetTimeUtc: 1000,
+            cruiseAltitudeFt: request.cruiseAltitudeFt ?? 8000,
+            flightCeilingFt: request.flightCeilingFt ?? 13000,
+            flightDurationHours: request.flightDurationHours ?? 2.0,
+            private: false, autoRefresh: false, autoRefreshHour: nil,
+            createdAt: "2099-06-25T09:00:00Z", role: nil
+        )
+        createdFlights.append(flight)
+        return flight
+    }
     func aircraft() async throws -> [AircraftResponse] { [] }
     func searchAircraftTypes(_ query: String) async throws -> [AircraftTypeResponse] { [] }
     func packs(flightId: String) async throws -> [PackMetaResponse] { [] }
@@ -54,7 +75,6 @@ final class FixtureBriefingRepository: BriefingRepository, @unchecked Sendable {
 
     // MARK: Not yet needed by a journey
 
-    func createFlight(_ request: CreateFlightRequest) async throws -> FlightResponse { throw FixtureError.notProvided("createFlight") }
     func updateFlight(flightId: String, request: UpdateFlightRequest) async throws -> UpdateFlightResponse { throw FixtureError.notProvided("updateFlight") }
     func createAircraft(_ request: CreateAircraftRequest) async throws -> AircraftResponse { throw FixtureError.notProvided("createAircraft") }
     func parseFpl(_ text: String) async throws -> ParseFplResponse { throw FixtureError.notProvided("parseFpl") }

--- a/app/flyfun-weather/flyfun-weather/Services/FixtureBriefingRepository.swift
+++ b/app/flyfun-weather/flyfun-weather/Services/FixtureBriefingRepository.swift
@@ -1,0 +1,76 @@
+#if DEBUG
+import Foundation
+
+/// Deterministic, offline `BriefingRepository` for UI tests (`FLYFUN_MOCK=1`).
+///
+/// Serves canned fixtures so XCUITest journeys run with no backend, no network,
+/// and no ~2-minute briefing wait. Endpoints a journey doesn't need yet throw
+/// `FixtureError.notProvided` — wire them up as the journeys grow rather than
+/// faking a whole briefing up front.
+///
+/// Flights use far-future departures so they land in the list's "Future" group
+/// regardless of when the test runs.
+final class FixtureBriefingRepository: BriefingRepository, @unchecked Sendable {
+
+    enum FixtureError: Error, CustomStringConvertible {
+        case notProvided(String)
+        var description: String { if case .notProvided(let m) = self { "fixture not provided: \(m)" } else { "" } }
+    }
+
+    private static func decodeFlights() -> [FlightResponse] {
+        let json = """
+        [
+          {
+            "id": "fixture-1", "user_id": "uitest", "route_name": "LFMD LFML",
+            "waypoints": ["LFMD", "LFML"], "departure_time": "2099-07-01T09:00:00Z",
+            "target_date": "2099-07-01", "target_time_utc": 900,
+            "cruise_altitude_ft": 8000, "flight_ceiling_ft": 13000, "flight_duration_hours": 1.5,
+            "private": false, "auto_refresh": false, "created_at": "2099-06-25T09:00:00Z"
+          },
+          {
+            "id": "fixture-2", "user_id": "uitest", "route_name": "EGTF LFAT",
+            "waypoints": ["EGTF", "LFAT"], "departure_time": "2099-07-03T13:00:00Z",
+            "target_date": "2099-07-03", "target_time_utc": 1300,
+            "cruise_altitude_ft": 6000, "flight_ceiling_ft": 11000, "flight_duration_hours": 2.0,
+            "private": false, "auto_refresh": false, "created_at": "2099-06-25T09:00:00Z"
+          }
+        ]
+        """
+        return (try? JSONDecoder.weatherBrief.decode([FlightResponse].self, from: Data(json.utf8))) ?? []
+    }
+
+    private let flightsFixture = decodeFlights()
+
+    // MARK: Served
+
+    func flights() async throws -> [FlightResponse] { flightsFixture }
+    func aircraft() async throws -> [AircraftResponse] { [] }
+    func searchAircraftTypes(_ query: String) async throws -> [AircraftTypeResponse] { [] }
+    func packs(flightId: String) async throws -> [PackMetaResponse] { [] }
+    func fetchPireps(flightId: String) async throws -> PirepListResponse { PirepListResponse(items: [], count: 0) }
+    func refreshStream(flightId: String) async -> AsyncThrowingStream<RefreshEvent, Error> {
+        AsyncThrowingStream { $0.finish() }
+    }
+
+    // MARK: Not yet needed by a journey
+
+    func createFlight(_ request: CreateFlightRequest) async throws -> FlightResponse { throw FixtureError.notProvided("createFlight") }
+    func updateFlight(flightId: String, request: UpdateFlightRequest) async throws -> UpdateFlightResponse { throw FixtureError.notProvided("updateFlight") }
+    func createAircraft(_ request: CreateAircraftRequest) async throws -> AircraftResponse { throw FixtureError.notProvided("createAircraft") }
+    func parseFpl(_ text: String) async throws -> ParseFplResponse { throw FixtureError.notProvided("parseFpl") }
+    func latestPack(flightId: String) async throws -> PackMetaResponse { throw FixtureError.notProvided("latestPack") }
+    func advisories(flightId: String, timestamp: String) async throws -> AdvisoriesResponse { throw FixtureError.notProvided("advisories") }
+    func advisoryDetail(flightId: String, timestamp: String, advisoryId: String) async throws -> AdvisoryDetailResponse { throw FixtureError.notProvided("advisoryDetail") }
+    func recalculateAdvisories(flightId: String, timestamp: String, cruiseAltitudeFt: Int?) async throws { throw FixtureError.notProvided("recalculateAdvisories") }
+    func digest(flightId: String, timestamp: String) async throws -> DigestResponse { throw FixtureError.notProvided("digest") }
+    func snapshot(flightId: String, timestamp: String) async throws -> SnapshotResponse { throw FixtureError.notProvided("snapshot") }
+    func routeAnalyses(flightId: String, timestamp: String) async throws -> RouteAnalysesResponse { throw FixtureError.notProvided("routeAnalyses") }
+    func elevation(flightId: String, timestamp: String) async throws -> ElevationResponse { throw FixtureError.notProvided("elevation") }
+    func skewtImage(flightId: String, timestamp: String, icao: String, model: String) async throws -> Data { throw FixtureError.notProvided("skewtImage") }
+    func grametImage(flightId: String, timestamp: String) async throws -> Data { throw FixtureError.notProvided("grametImage") }
+    func soundingProfile(flightId: String, timestamp: String, pointIndex: Int, model: String) async throws -> SoundingProfileResponse { throw FixtureError.notProvided("soundingProfile") }
+    func refreshStatus(flightId: String) async throws -> RefreshStatusResponse { throw FixtureError.notProvided("refreshStatus") }
+    func submitPirep(_ request: SubmitPirepRequest) async throws -> PirepResponse { throw FixtureError.notProvided("submitPirep") }
+    func submitPirepsBatch(_ requests: [SubmitPirepRequest]) async throws -> [PirepResponse] { throw FixtureError.notProvided("submitPirepsBatch") }
+}
+#endif

--- a/app/flyfun-weather/flyfun-weather/Services/PirepOfflineStore.swift
+++ b/app/flyfun-weather/flyfun-weather/Services/PirepOfflineStore.swift
@@ -9,9 +9,16 @@ actor PirepOfflineStore {
 
     private static let logger = Logger(subsystem: "aero.flyfun.weather", category: "PirepOffline")
 
-    init() {
+    /// Designated initializer — the queue file is injectable so tests can point
+    /// it at a temp file instead of the shared Documents container.
+    init(fileURL: URL) {
+        self.fileURL = fileURL
+    }
+
+    /// Production initializer — Documents/pending_pireps.json.
+    convenience init() {
         let docs = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
-        fileURL = docs.appendingPathComponent("pending_pireps.json")
+        self.init(fileURL: docs.appendingPathComponent("pending_pireps.json"))
     }
 
     /// Load pending PIREPs from disk.

--- a/app/flyfun-weather/flyfun-weather/Views/Flights/AddFlightView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Flights/AddFlightView.swift
@@ -45,6 +45,7 @@ struct AddFlightView: View {
                 ToolbarItem(placement: .confirmationAction) {
                     Button(viewModel.submitTitle) { submit() }
                         .disabled(!viewModel.canSubmit)
+                        .accessibilityIdentifier("submitFlightButton")
                 }
             }
             .confirmationDialog(
@@ -165,6 +166,7 @@ struct AddFlightView: View {
             TextField("LFBO TOU LFMT", text: $viewModel.waypointsText)
                 .textInputAutocapitalization(.characters)
                 .autocorrectionDisabled()
+                .accessibilityIdentifier("waypointsField")
 
             if !viewModel.waypoints.isEmpty {
                 Text(viewModel.waypoints.joined(separator: " \u{2192} "))

--- a/app/flyfun-weather/flyfun-weather/Views/Flights/FlightCardView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Flights/FlightCardView.swift
@@ -61,6 +61,7 @@ struct FlightCardView: View {
         }
         .padding(.vertical, 4)
         .opacity(isOffline && !hasCachedData ? 0.4 : 1.0)
+        .accessibilityIdentifier("flightCard-\(flight.id)")
     }
 }
 

--- a/app/flyfun-weather/flyfun-weather/Views/Flights/FlightListView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Flights/FlightListView.swift
@@ -60,6 +60,7 @@ struct FlightListView: View {
                             .refreshable {
                                 await viewModel.loadFlights()
                             }
+                            .accessibilityIdentifier("flightList")
                         }
                     }
                 } else {
@@ -94,6 +95,7 @@ struct FlightListView: View {
                         } label: {
                             Label("Add Flight", systemImage: "plus")
                         }
+                        .accessibilityIdentifier("addFlightButton")
                         Menu {
                             Button {
                                 showSettings = true

--- a/app/flyfun-weather/flyfun-weatherTests/PureLogicTests.swift
+++ b/app/flyfun-weather/flyfun-weatherTests/PureLogicTests.swift
@@ -1,0 +1,322 @@
+//
+//  PureLogicTests.swift
+//  flyfun-weatherTests
+//
+//  Tier A (#314) — pure-function unit tests for the math/colour/geometry that
+//  draws every chart. These are the silent-regression class: wrong colours or
+//  positions never crash, so we pin the boundaries here.
+//
+//  Style note: colour-threshold logic is tested by *bucket identity* — values
+//  inside one bucket resolve to the same colour, values across a boundary do
+//  not — so the tests survive palette tweaks and only fail if the *thresholds*
+//  move. The continuous-scale clamps are tested the same way (out-of-range
+//  inputs collapse to the endpoint colour).
+//
+
+import Testing
+import SwiftUI
+import UIKit
+@testable import flyfun_weather
+
+// MARK: - Colour helpers
+
+/// Resolve a SwiftUI `Color` to sRGB components so two colours can be compared
+/// for equality with a tolerance (SwiftUI `Color`'s own `==` is unreliable
+/// across the semantic vs `.sRGB` providers we mix here).
+private func rgba(_ color: Color) -> (r: Double, g: Double, b: Double, a: Double) {
+    var r: CGFloat = 0, g: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0
+    UIColor(color).getRed(&r, green: &g, blue: &b, alpha: &a)
+    return (Double(r), Double(g), Double(b), Double(a))
+}
+
+private func sameColor(_ a: Color, _ b: Color, tol: Double = 0.001) -> Bool {
+    let x = rgba(a), y = rgba(b)
+    return abs(x.r - y.r) < tol && abs(x.g - y.g) < tol && abs(x.b - y.b) < tol && abs(x.a - y.a) < tol
+}
+
+// MARK: - CoordTransform (cross-section pixel mapping)
+
+@Suite struct CoordTransformTests {
+    // 400×200 plot, margins L50/R40/T20/B30 → plotArea left50 top20 width310 height150.
+    private let t = CoordTransform(size: CGSize(width: 400, height: 200), maxDistanceNm: 100, maxAltitudeFt: 10000)
+
+    @Test func distanceMapsLeftToRight() {
+        #expect(abs(t.distanceToX(0) - 50) < 1e-6)        // origin at plot left
+        #expect(abs(t.distanceToX(100) - 360) < 1e-6)     // max distance at plot right (50+310)
+        #expect(abs(t.distanceToX(50) - 205) < 1e-6)      // midpoint
+    }
+
+    @Test func altitudeAxisIsInverted() {
+        // High altitude = top (small y), ground = bottom (large y).
+        #expect(abs(t.altitudeToY(10000) - 20) < 1e-6)    // ceiling at plot top
+        #expect(abs(t.altitudeToY(0) - 170) < 1e-6)       // ground at plot bottom (20+150)
+        #expect(t.altitudeToY(10000) < t.altitudeToY(0))
+    }
+
+    @Test func roundTripsBothAxes() {
+        for d in [0.0, 12.5, 47.3, 100.0] {
+            #expect(abs(t.xToDistance(t.distanceToX(d)) - d) < 1e-6)
+        }
+        for a in [0.0, 1234.0, 8000.0, 10000.0] {
+            #expect(abs(t.yToAltitude(t.altitudeToY(a)) - a) < 1e-6)
+        }
+    }
+}
+
+// MARK: - Assessment / severityRank
+
+@Suite struct AssessmentTests {
+    @Test func severityOrdersRedWorstThenAmberThenGreen() {
+        #expect(severityRank("red") == 3)
+        #expect(severityRank("amber") == 2)
+        #expect(severityRank("green") == 1)
+        #expect(severityRank("unavailable") == 0)
+        #expect(severityRank("") == 0)
+        #expect(severityRank("red") > severityRank("amber"))
+        #expect(severityRank("amber") > severityRank("green"))
+        #expect(severityRank("green") > severityRank("bogus"))
+    }
+
+    @Test func colourMapping() {
+        #expect(sameColor(Assessment.green.color, .green))
+        #expect(sameColor(Assessment.amber.color, .orange))
+        #expect(sameColor(Assessment.red.color, .red))
+        #expect(sameColor(Assessment.unavailable.color, .gray))
+    }
+
+    @Test func labelIsUppercased() {
+        #expect(Assessment.green.label == "GREEN")
+        #expect(Assessment.unavailable.label == "UNAVAILABLE")
+    }
+}
+
+// MARK: - Extensions
+
+@Suite struct ExtensionsTests {
+    @Test func shortModelName() {
+        #expect("meteofrance".shortModelName == "MF")
+        #expect("best_match".shortModelName == "BEST")
+        #expect("ecmwf".shortModelName == "ECMWF")
+        #expect("ECMWF".shortModelName == "ECMWF")   // case-insensitive
+        #expect("gfs".shortModelName == "GFS")        // default → uppercased
+        #expect("icon".shortModelName == "ICON")
+    }
+
+    @Test func queryParamExtraction() {
+        let url = URL(string: "https://weather.flyfun.aero/brief?flight=42&model=ecmwf")!
+        #expect(url.queryParam("flight") == "42")
+        #expect(url.queryParam("model") == "ecmwf")
+        #expect(url.queryParam("missing") == nil)
+    }
+}
+
+// MARK: - MapColors (segment colour scales — threshold buckets)
+
+@Suite struct MapColorsTests {
+    @Test func ceilingMatchesFlightCategoryBoundaries() {
+        #expect(sameColor(MapColors.ceiling(200), MapColors.flightCategory("LIFR")))
+        #expect(sameColor(MapColors.ceiling(700), MapColors.flightCategory("IFR")))
+        #expect(sameColor(MapColors.ceiling(2000), MapColors.flightCategory("MVFR")))
+        #expect(sameColor(MapColors.ceiling(5000), MapColors.flightCategory("VFR")))
+        // Boundaries flip the category exactly at 500 / 1000 / 3000.
+        #expect(!sameColor(MapColors.ceiling(499), MapColors.ceiling(500)))
+        #expect(!sameColor(MapColors.ceiling(999), MapColors.ceiling(1000)))
+        #expect(!sameColor(MapColors.ceiling(2999), MapColors.ceiling(3000)))
+    }
+
+    @Test func flightCategoryPalette() {
+        #expect(sameColor(MapColors.flightCategory("VFR"), .green))
+        #expect(sameColor(MapColors.flightCategory("MVFR"), .blue))
+        #expect(sameColor(MapColors.flightCategory("IFR"), .red))
+        #expect(sameColor(MapColors.flightCategory("LIFR"), .purple))
+        #expect(sameColor(MapColors.flightCategory("???"), .gray))
+    }
+
+    @Test func sfipBucketBoundariesAt20_50_80() {
+        // Within a bucket → same colour; across the 20/50/80 lines → different.
+        #expect(sameColor(MapColors.sfip(0), MapColors.sfip(20)))
+        #expect(!sameColor(MapColors.sfip(20), MapColors.sfip(20.1)))
+        #expect(sameColor(MapColors.sfip(21), MapColors.sfip(50)))
+        #expect(!sameColor(MapColors.sfip(50), MapColors.sfip(50.1)))
+        #expect(sameColor(MapColors.sfip(51), MapColors.sfip(80)))
+        #expect(!sameColor(MapColors.sfip(80), MapColors.sfip(80.1)))
+    }
+
+    @Test func riskRanksAreFiveDistinctColours() {
+        let colours = [MapColors.risk(0), MapColors.risk(1), MapColors.risk(2), MapColors.risk(3), MapColors.risk(4)]
+        for i in colours.indices {
+            for j in colours.indices where j > i {
+                #expect(!sameColor(colours[i], colours[j]))
+            }
+        }
+        // Rank is rounded: 0.4 → 0 (none), 0.6 → 1 (light).
+        #expect(sameColor(MapColors.risk(0.4), MapColors.risk(0)))
+        #expect(sameColor(MapColors.risk(0.6), MapColors.risk(1)))
+    }
+
+    @Test func headwindSignSplitsTailwindFromHeadwind() {
+        // All tailwind/calm (kt ≤ 0) is one constant green; headwind scales away from it.
+        #expect(sameColor(MapColors.headwind(0), MapColors.headwind(-30)))
+        #expect(!sameColor(MapColors.headwind(0), MapColors.headwind(15)))
+    }
+
+    @Test func continuousScalesClampAtEnds() {
+        // CAPE / temperature / cloud-cover saturate outside their domain.
+        #expect(sameColor(MapColors.cape(-100), MapColors.cape(0)))
+        #expect(sameColor(MapColors.cape(3000), MapColors.cape(2000)))
+        #expect(sameColor(MapColors.temperature(-30), MapColors.temperature(-20)))
+        #expect(sameColor(MapColors.temperature(50), MapColors.temperature(40)))
+        #expect(sameColor(MapColors.cloudCover(-10), MapColors.cloudCover(0)))
+        #expect(sameColor(MapColors.cloudCover(150), MapColors.cloudCover(100)))
+        // …but the endpoints themselves are visibly different.
+        #expect(!sameColor(MapColors.cape(0), MapColors.cape(2000)))
+        #expect(!sameColor(MapColors.temperature(-20), MapColors.temperature(40)))
+        #expect(!sameColor(MapColors.cloudCover(0), MapColors.cloudCover(100)))
+    }
+}
+
+// MARK: - MapMetrics registry (exercises the private altitude helpers + linearWidth)
+
+@Suite struct MapMetricsTests {
+
+    private func metric(_ id: String) -> MapMetric {
+        MapMetrics.metric(byId: id)!
+    }
+
+    @Test func linearWidthClampsAndScales() {
+        // cloud-cover width = linearWidth(value, 100, 3, 18).
+        let w = metric("cloud-cover-total").width
+        #expect(abs(w(0) - 3) < 1e-6)       // min width
+        #expect(abs(w(50) - 10.5) < 1e-6)   // midpoint
+        #expect(abs(w(100) - 18) < 1e-6)    // max width
+        #expect(abs(w(200) - 18) < 1e-6)    // clamped above max
+        #expect(abs(w(-50) - 10.5) < 1e-6)  // uses |value|
+    }
+
+    @Test func segmentValueAveragesContinuousFields() {
+        let m = metric("cloud-cover-total")  // aggregation .average
+        let a = makeVizPoint(cloudCoverTotalPct: 20)
+        let b = makeVizPoint(cloudCoverTotalPct: 60)
+        #expect(m.segmentValue(a, b, altitudeFt: nil) == 40)
+    }
+
+    @Test func segmentValueTakesWorstForOrdinalRisk() {
+        let m = metric("convective-risk")  // aggregation .worst, riskRank lookup
+        let calm = makeVizPoint(convectiveRisk: "none")    // 0
+        let bad = makeVizPoint(convectiveRisk: "severe")   // 3
+        #expect(m.segmentValue(calm, bad, altitudeFt: nil) == 3)
+    }
+
+    @Test func segmentValueFallsBackWhenOneEndpointNil() {
+        // temp-at-level returns nil without a freezing level; the segment should
+        // then report the other endpoint's value, not nil.
+        let m = metric("temp-at-level")
+        let known = makeVizPoint(freezingLevelFt: 10000)   // 0°C at 10000 ft
+        let unknown = makeVizPoint()                        // no freezing level → nil
+        let v = m.segmentValue(known, unknown, altitudeFt: 10000)
+        #expect(v != nil)
+        #expect(abs((v ?? .nan) - 0) < 1e-6)
+    }
+
+    @Test func tempAtAltitudeInterpolatesAndExtrapolates() {
+        let m = metric("temp-at-level")
+        let p = makeVizPoint(freezingLevelFt: 10000, minus10cLevelFt: 20000, minus20cLevelFt: 30000)
+        #expect(abs((m.getValue(p, 10000) ?? .nan) - 0) < 1e-6)     // at freezing level
+        #expect(abs((m.getValue(p, 15000) ?? .nan) - -5) < 1e-6)    // half-way 0 → -10
+        #expect(abs((m.getValue(p, 5000) ?? .nan) - 10) < 1e-6)     // below: +2°C/1000ft warmer
+        #expect(abs((m.getValue(p, 35000) ?? .nan) - -30) < 1e-6)   // above: extrapolated colder
+        #expect(m.getValue(makeVizPoint(), 10000) == nil)           // no freezing level → nil
+    }
+
+    @Test func icingRiskPrefersOgimetEnvelopeAndRespectsAltitudeSpan() {
+        let m = metric("icing-risk-at-level")
+        let diag = VizIcingZone(baseFt: 5000, topFt: 15000, risk: "moderate", type: "diag")  // rank 2
+        let ogimet = VizIcingZone(baseFt: 0, topFt: 40000, risk: "severe", type: "nwp")       // rank 3
+        // When OGIMET-NWP zones are present they win over the diagnostic zones.
+        let p = makeVizPoint(icingZones: [diag], icingOgimetNwpZones: [ogimet])
+        #expect((m.getValue(p, 10000) ?? -1) == 3)
+        // Fall back to diagnostic zones when no OGIMET envelope.
+        let pDiag = makeVizPoint(icingZones: [diag])
+        #expect((m.getValue(pDiag, 10000) ?? -1) == 2)
+        #expect((m.getValue(pDiag, 20000) ?? -1) == 0)   // above the zone → no risk
+    }
+
+    @Test func sfipPeaksWithinSpanAndIsNilOutside() {
+        let m = metric("sfip-at-level")
+        let zone = VizSfipZone(baseFt: 5000, topFt: 15000, risk: "moderate", type: "nwp", meanSfip100: 65, variant: "x")
+        let p = makeVizPoint(sfipZones: [zone])
+        #expect(m.getValue(p, 10000) == 65)
+        #expect(m.getValue(p, 20000) == nil)   // outside the zone
+        #expect(m.getValue(p, nil) == nil)     // no altitude
+    }
+
+    @Test func cloudAtAltitudeUsesCoverageWeight() {
+        let m = metric("cloud-at-level")
+        let ovc = makeVizPoint(cloudLayers: [makeCloud(3000, 8000, "ovc")])  // weight 1.0 → 100
+        #expect(m.getValue(ovc, 5000) == 100)
+        let sct = makeVizPoint(cloudLayers: [makeCloud(3000, 8000, "sct")])  // weight 0.3 → 30
+        #expect(abs((sct.cloudLayers.isEmpty ? .nan : (m.getValue(sct, 5000) ?? .nan)) - 30) < 1e-6)
+        let unknown = makeVizPoint(cloudLayers: [makeCloud(3000, 8000, "xyz")])  // default 0.5 → 50
+        #expect((m.getValue(unknown, 5000) ?? -1) == 50)
+        #expect((m.getValue(ovc, 12000) ?? -1) == 0)   // above the layer → clear
+    }
+}
+
+// MARK: - VizPoint stub factory (only the fields under test need overriding)
+
+private func makeCloud(_ baseFt: Double, _ topFt: Double, _ coverage: String) -> VizCloudLayer {
+    VizCloudLayer(baseFt: baseFt, topFt: topFt, coverage: coverage, meanDewpointDepressionC: nil, meanCloudCoverPct: nil)
+}
+
+private func makeVizPoint(
+    distanceNm: Double = 0,
+    freezingLevelFt: Double? = nil,
+    minus10cLevelFt: Double? = nil,
+    minus20cLevelFt: Double? = nil,
+    cloudLayers: [VizCloudLayer] = [],
+    icingZones: [VizIcingZone] = [],
+    icingOgimetNwpZones: [VizIcingZone] = [],
+    sfipZones: [VizSfipZone] = [],
+    catLayers: [VizCATLayer] = [],
+    convectiveRisk: String = "none",
+    cloudCoverTotalPct: Double = 0,
+    cloudCoverLowPct: Double = 0,
+    headwindKt: Double = 0,
+    capeSurfaceJkg: Double = 0,
+    worstModelAgreement: String = "good"
+) -> VizPoint {
+    VizPoint(
+        distanceNm: distanceNm,
+        lat: 0, lon: 0,
+        time: "2026-06-24T12:00:00Z",
+        altitudeLines: AltitudeLines(
+            freezingLevelFt: freezingLevelFt,
+            minus10cLevelFt: minus10cLevelFt,
+            minus20cLevelFt: minus20cLevelFt,
+            lclAltitudeFt: nil, lfcAltitudeFt: nil, elAltitudeFt: nil
+        ),
+        cloudLayers: cloudLayers,
+        nwpCloudLayers: nil,
+        icingZones: icingZones,
+        icingOgimetNwpZones: icingOgimetNwpZones,
+        sfipZones: sfipZones,
+        catLayers: catLayers,
+        inversions: [],
+        convectiveRisk: convectiveRisk,
+        convectiveBaseFt: nil, convectiveTopFt: nil,
+        nwpConvectiveRisk: "none",
+        nwpConvectiveBaseFt: nil, nwpConvectiveTopFt: nil,
+        nwpConvectiveCoverPct: nil, nwpConvectiveMethod: nil,
+        hasNwpConvective: false,
+        cloudCoverTotalPct: cloudCoverTotalPct,
+        cloudCoverLowPct: cloudCoverLowPct,
+        cloudCoverMidPct: 0,
+        headwindKt: headwindKt,
+        crosswindKt: 0,
+        capeSurfaceJkg: capeSurfaceJkg,
+        worstModelAgreement: worstModelAgreement,
+        nwpCloudDiag: nil,
+        temperatureC: nil,
+        precipitationMm: nil
+    )
+}

--- a/app/flyfun-weather/flyfun-weatherTests/ServiceTests.swift
+++ b/app/flyfun-weather/flyfun-weatherTests/ServiceTests.swift
@@ -119,12 +119,9 @@ import Foundation
 
 @Suite struct PirepOfflineStoreTests {
 
-    private func store() -> PirepOfflineStore {
-        PirepOfflineStore(fileURL: makeTempDir().appendingPathComponent("pending.json"))
-    }
-
     @Test func enqueueIncrementsPendingCount() async {
-        let s = store()
+        let dir = makeTempDir(); defer { try? FileManager.default.removeItem(at: dir) }
+        let s = PirepOfflineStore(fileURL: dir.appendingPathComponent("pending.json"))
         #expect(await s.pendingCount == 0)
         await s.enqueue(makePirepRequest(remarks: "a"))
         await s.enqueue(makePirepRequest(remarks: "b"))
@@ -132,7 +129,8 @@ import Foundation
     }
 
     @Test func syncDrainsOnSuccess() async {
-        let s = store()
+        let dir = makeTempDir(); defer { try? FileManager.default.removeItem(at: dir) }
+        let s = PirepOfflineStore(fileURL: dir.appendingPathComponent("pending.json"))
         await s.enqueue(makePirepRequest())
         await s.enqueue(makePirepRequest())
         let repo = MockBriefingRepository()
@@ -145,7 +143,8 @@ import Foundation
     }
 
     @Test func syncKeepsQueueOnFailure() async {
-        let s = store()
+        let dir = makeTempDir(); defer { try? FileManager.default.removeItem(at: dir) }
+        let s = PirepOfflineStore(fileURL: dir.appendingPathComponent("pending.json"))
         await s.enqueue(makePirepRequest())
         let repo = MockBriefingRepository()
         repo.submitPirepsBatchResult = .failure(MockError.injected("offline"))
@@ -156,7 +155,8 @@ import Foundation
     }
 
     @Test func syncEmptyQueueIsNoOp() async {
-        let s = store()
+        let dir = makeTempDir(); defer { try? FileManager.default.removeItem(at: dir) }
+        let s = PirepOfflineStore(fileURL: dir.appendingPathComponent("pending.json"))
         let repo = MockBriefingRepository()
         let synced = await s.sync(using: repo)
         #expect(synced == 0)
@@ -164,7 +164,8 @@ import Foundation
     }
 
     @Test func queuePersistsAcrossStoreInstances() async {
-        let file = makeTempDir().appendingPathComponent("pending.json")
+        let dir = makeTempDir(); defer { try? FileManager.default.removeItem(at: dir) }
+        let file = dir.appendingPathComponent("pending.json")
         let s1 = PirepOfflineStore(fileURL: file)
         await s1.enqueue(makePirepRequest(remarks: "persisted"))
         // A fresh store on the same file must load the queued PIREP.

--- a/app/flyfun-weather/flyfun-weatherTests/ServiceTests.swift
+++ b/app/flyfun-weather/flyfun-weatherTests/ServiceTests.swift
@@ -1,0 +1,175 @@
+//
+//  ServiceTests.swift
+//  flyfun-weatherTests
+//
+//  Tier C (#314) — cache/offline service logic.
+//
+//  CachedPackEntry rules are pure (no I/O). The two on-disk actors are tested
+//  against an injected temp directory (the `init(cacheDir:)` / `init(fileURL:)`
+//  seams added for testability), so they never touch the shared app container
+//  and can't pollute each other.
+//
+//  Deferred: CachingBriefingRepository's online→cache fallback chain wraps a
+//  *concrete* OnlineBriefingRepository(APIClient), so faulting the online layer
+//  needs a protocol-injection refactor — tracked as a follow-up, not done here.
+//
+
+import Testing
+import Foundation
+@testable import flyfun_weather
+
+// MARK: - CachedPackEntry (pure "complete pack" rule + cache key)
+
+@Suite struct CachedPackEntryTests {
+
+    private func entry(_ endpoints: Set<String>) -> CachedPackEntry {
+        CachedPackEntry(
+            flightId: "flt-1", timestamp: "2026-06-24T09:00:00Z",
+            flightTitle: "LFMD → LFML", assessment: "green",
+            downloadedAt: Date(timeIntervalSince1970: 0),
+            endpoints: endpoints, totalBytes: 1024
+        )
+    }
+
+    @Test func isCompleteRequiresAllFiveEndpoints() {
+        #expect(entry(CachedPackEntry.requiredEndpoints).isComplete)
+        // Superset (extra endpoint) is still complete.
+        #expect(entry(CachedPackEntry.requiredEndpoints.union(["gramet"])).isComplete)
+        // Missing any one required endpoint → incomplete.
+        for missing in CachedPackEntry.requiredEndpoints {
+            #expect(entry(CachedPackEntry.requiredEndpoints.subtracting([missing])).isComplete == false)
+        }
+        #expect(entry([]).isComplete == false)
+    }
+
+    @Test func idIsFlightSlashTimestamp() {
+        #expect(entry([]).id == "flt-1/2026-06-24T09:00:00Z")
+    }
+}
+
+// MARK: - BriefingCacheStore (on-disk index + pack data, temp dir)
+
+@Suite struct BriefingCacheStoreTests {
+
+    private let all = CachedPackEntry.requiredEndpoints
+
+    @Test func registerThenIsPackCachedReflectsCompleteness() async {
+        let dir = makeTempDir(); defer { try? FileManager.default.removeItem(at: dir) }
+        let store = BriefingCacheStore(cacheDir: dir)
+
+        await store.registerDownload(flightId: "f1", timestamp: "t1", flightTitle: "T",
+                                     assessment: "green", endpoints: all, totalBytes: 10)
+        #expect(await store.isPackCached(flightId: "f1", timestamp: "t1"))
+
+        await store.registerDownload(flightId: "f2", timestamp: "t2", flightTitle: "T",
+                                     assessment: nil, endpoints: ["advisories"], totalBytes: 5)
+        #expect(await store.isPackCached(flightId: "f2", timestamp: "t2") == false)  // incomplete
+    }
+
+    @Test func dataRoundTrips() async throws {
+        let dir = makeTempDir(); defer { try? FileManager.default.removeItem(at: dir) }
+        let store = BriefingCacheStore(cacheDir: dir)
+        let payload = Data("{\"x\":1}".utf8)
+
+        try await store.writeData(payload, flightId: "f1", timestamp: "2026:01", endpoint: "advisories")
+        let back = await store.readData(flightId: "f1", timestamp: "2026:01", endpoint: "advisories")
+        #expect(back == payload)
+        #expect(await store.readData(flightId: "f1", timestamp: "2026:01", endpoint: "digest") == nil)
+    }
+
+    @Test func metadataRoundTrips() async throws {
+        let dir = makeTempDir(); defer { try? FileManager.default.removeItem(at: dir) }
+        let store = BriefingCacheStore(cacheDir: dir)
+        let payload = Data("[]".utf8)
+        try await store.writeMetadata(payload, name: "flights")
+        #expect(await store.readMetadata(name: "flights") == payload)
+        #expect(await store.readMetadata(name: "missing") == nil)
+    }
+
+    @Test func indexPersistsAcrossStoreInstances() async {
+        let dir = makeTempDir(); defer { try? FileManager.default.removeItem(at: dir) }
+        let store1 = BriefingCacheStore(cacheDir: dir)
+        await store1.registerDownload(flightId: "f1", timestamp: "t1", flightTitle: "T",
+                                      assessment: "amber", endpoints: all, totalBytes: 99)
+        // A fresh store reading the same dir must load the persisted index.
+        let store2 = BriefingCacheStore(cacheDir: dir)
+        #expect(await store2.isPackCached(flightId: "f1", timestamp: "t1"))
+        #expect(await store2.totalCacheSize() == 99)
+    }
+
+    @Test func deleteAndClearRemoveEntries() async {
+        let dir = makeTempDir(); defer { try? FileManager.default.removeItem(at: dir) }
+        let store = BriefingCacheStore(cacheDir: dir)
+        await store.registerDownload(flightId: "f1", timestamp: "t1", flightTitle: "T",
+                                     assessment: nil, endpoints: all, totalBytes: 1)
+        await store.registerDownload(flightId: "f2", timestamp: "t2", flightTitle: "T",
+                                     assessment: nil, endpoints: all, totalBytes: 1)
+        #expect(await store.cachedPacks().count == 2)
+
+        await store.deletePack(flightId: "f1", timestamp: "t1")
+        #expect(await store.isPackCached(flightId: "f1", timestamp: "t1") == false)
+        #expect(await store.cachedPacks().count == 1)
+
+        await store.clearAll()
+        #expect(await store.cachedPacks().isEmpty)
+    }
+}
+
+// MARK: - PirepOfflineStore (offline queue, temp file)
+
+@Suite struct PirepOfflineStoreTests {
+
+    private func store() -> PirepOfflineStore {
+        PirepOfflineStore(fileURL: makeTempDir().appendingPathComponent("pending.json"))
+    }
+
+    @Test func enqueueIncrementsPendingCount() async {
+        let s = store()
+        #expect(await s.pendingCount == 0)
+        await s.enqueue(makePirepRequest(remarks: "a"))
+        await s.enqueue(makePirepRequest(remarks: "b"))
+        #expect(await s.pendingCount == 2)
+    }
+
+    @Test func syncDrainsOnSuccess() async {
+        let s = store()
+        await s.enqueue(makePirepRequest())
+        await s.enqueue(makePirepRequest())
+        let repo = MockBriefingRepository()
+        repo.submitPirepsBatchResult = .success([PirepResponse.offline, PirepResponse.offline])
+
+        let synced = await s.sync(using: repo)
+        #expect(synced == 2)
+        #expect(await s.pendingCount == 0)            // queue cleared
+        #expect(repo.submitPirepsBatchCallCount == 1) // single batch call
+    }
+
+    @Test func syncKeepsQueueOnFailure() async {
+        let s = store()
+        await s.enqueue(makePirepRequest())
+        let repo = MockBriefingRepository()
+        repo.submitPirepsBatchResult = .failure(MockError.injected("offline"))
+
+        let synced = await s.sync(using: repo)
+        #expect(synced == 0)
+        #expect(await s.pendingCount == 1)            // unsent, still queued
+    }
+
+    @Test func syncEmptyQueueIsNoOp() async {
+        let s = store()
+        let repo = MockBriefingRepository()
+        let synced = await s.sync(using: repo)
+        #expect(synced == 0)
+        #expect(repo.submitPirepsBatchCallCount == 0) // never hits the network
+    }
+
+    @Test func queuePersistsAcrossStoreInstances() async {
+        let file = makeTempDir().appendingPathComponent("pending.json")
+        let s1 = PirepOfflineStore(fileURL: file)
+        await s1.enqueue(makePirepRequest(remarks: "persisted"))
+        // A fresh store on the same file must load the queued PIREP.
+        let s2 = PirepOfflineStore(fileURL: file)
+        await s2.load()
+        #expect(await s2.pendingCount == 1)
+    }
+}

--- a/app/flyfun-weather/flyfun-weatherTests/TestSupport.swift
+++ b/app/flyfun-weather/flyfun-weatherTests/TestSupport.swift
@@ -32,9 +32,11 @@ final class MockBriefingRepository: BriefingRepository, @unchecked Sendable {
     var flightsResult: Result<[FlightResponse], Error> = .success([])
     var aircraftResult: Result<[AircraftResponse], Error> = .success([])
     var createFlightResult: Result<FlightResponse, Error> = .failure(MockError.notStubbed("createFlight"))
+    var submitPirepsBatchResult: Result<[PirepResponse], Error> = .success([PirepResponse.offline])
 
     // Call counters for behaviour assertions.
     private(set) var flightsCallCount = 0
+    private(set) var submitPirepsBatchCallCount = 0
 
     func flights() async throws -> [FlightResponse] {
         flightsCallCount += 1
@@ -63,7 +65,10 @@ final class MockBriefingRepository: BriefingRepository, @unchecked Sendable {
     }
     func refreshStatus(flightId: String) async throws -> RefreshStatusResponse { throw MockError.notStubbed("refreshStatus") }
     func submitPirep(_ request: SubmitPirepRequest) async throws -> PirepResponse { throw MockError.notStubbed("submitPirep") }
-    func submitPirepsBatch(_ requests: [SubmitPirepRequest]) async throws -> [PirepResponse] { throw MockError.notStubbed("submitPirepsBatch") }
+    func submitPirepsBatch(_ requests: [SubmitPirepRequest]) async throws -> [PirepResponse] {
+        submitPirepsBatchCallCount += 1
+        return try submitPirepsBatchResult.get()
+    }
     func fetchPireps(flightId: String) async throws -> PirepListResponse { throw MockError.notStubbed("fetchPireps") }
 }
 
@@ -98,4 +103,20 @@ func makeFlight(
         createdAt: "2026-06-20T09:00:00Z",
         role: role
     )
+}
+
+func makePirepRequest(remarks: String = "test") -> SubmitPirepRequest {
+    let json = """
+    {"observed_at": "2026-06-24T12:00:00Z", "latitude": 43.5, "longitude": 6.95,
+     "remarks": "\(remarks)", "source": "inflight"}
+    """
+    return try! JSONDecoder.weatherBrief.decode(SubmitPirepRequest.self, from: Data(json.utf8))
+}
+
+/// A unique temp directory for a test, auto-created. Caller removes it.
+func makeTempDir() -> URL {
+    let dir = FileManager.default.temporaryDirectory
+        .appendingPathComponent("wbtests-\(UUID().uuidString)", isDirectory: true)
+    try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    return dir
 }

--- a/app/flyfun-weather/flyfun-weatherTests/TestSupport.swift
+++ b/app/flyfun-weather/flyfun-weatherTests/TestSupport.swift
@@ -106,11 +106,14 @@ func makeFlight(
 }
 
 func makePirepRequest(remarks: String = "test") -> SubmitPirepRequest {
+    // Base is a fixed, safe JSON literal; set caller-controlled `remarks` on the
+    // decoded value so a string with quotes/backslashes can't break the JSON.
     let json = """
-    {"observed_at": "2026-06-24T12:00:00Z", "latitude": 43.5, "longitude": 6.95,
-     "remarks": "\(remarks)", "source": "inflight"}
+    {"observed_at": "2026-06-24T12:00:00Z", "latitude": 43.5, "longitude": 6.95, "source": "inflight"}
     """
-    return try! JSONDecoder.weatherBrief.decode(SubmitPirepRequest.self, from: Data(json.utf8))
+    var request = try! JSONDecoder.weatherBrief.decode(SubmitPirepRequest.self, from: Data(json.utf8))
+    request.remarks = remarks
+    return request
 }
 
 /// A unique temp directory for a test, auto-created. Caller removes it.

--- a/app/flyfun-weather/flyfun-weatherTests/TestSupport.swift
+++ b/app/flyfun-weather/flyfun-weatherTests/TestSupport.swift
@@ -1,0 +1,101 @@
+//
+//  TestSupport.swift
+//  flyfun-weatherTests
+//
+//  Shared test doubles + fixture factories (#314).
+//
+//  `MockBriefingRepository` conforms to the full `BriefingRepository` protocol
+//  but only the handful of calls a given ViewModel actually makes are stubbable;
+//  everything else throws `notStubbed` so an unexpected call fails loudly rather
+//  than returning silent garbage. ViewModels inject `any BriefingRepository`, so
+//  this is the seam that lets the whole logic layer be tested with no network.
+//
+
+import Foundation
+@testable import flyfun_weather
+
+enum MockError: Error, CustomStringConvertible {
+    case notStubbed(String)
+    case injected(String)
+    var description: String {
+        switch self {
+        case .notStubbed(let m): "MockBriefingRepository.\(m) was called but not stubbed"
+        case .injected(let m): "injected failure: \(m)"
+        }
+    }
+}
+
+/// In-memory `BriefingRepository`. Configure the few results a test needs; the
+/// rest throw `notStubbed`.
+final class MockBriefingRepository: BriefingRepository, @unchecked Sendable {
+    // Configurable results (set per-test).
+    var flightsResult: Result<[FlightResponse], Error> = .success([])
+    var aircraftResult: Result<[AircraftResponse], Error> = .success([])
+    var createFlightResult: Result<FlightResponse, Error> = .failure(MockError.notStubbed("createFlight"))
+
+    // Call counters for behaviour assertions.
+    private(set) var flightsCallCount = 0
+
+    func flights() async throws -> [FlightResponse] {
+        flightsCallCount += 1
+        return try flightsResult.get()
+    }
+    func createFlight(_ request: CreateFlightRequest) async throws -> FlightResponse { try createFlightResult.get() }
+    func updateFlight(flightId: String, request: UpdateFlightRequest) async throws -> UpdateFlightResponse { throw MockError.notStubbed("updateFlight") }
+    func aircraft() async throws -> [AircraftResponse] { try aircraftResult.get() }
+    func searchAircraftTypes(_ query: String) async throws -> [AircraftTypeResponse] { throw MockError.notStubbed("searchAircraftTypes") }
+    func createAircraft(_ request: CreateAircraftRequest) async throws -> AircraftResponse { throw MockError.notStubbed("createAircraft") }
+    func parseFpl(_ text: String) async throws -> ParseFplResponse { throw MockError.notStubbed("parseFpl") }
+    func packs(flightId: String) async throws -> [PackMetaResponse] { throw MockError.notStubbed("packs") }
+    func latestPack(flightId: String) async throws -> PackMetaResponse { throw MockError.notStubbed("latestPack") }
+    func advisories(flightId: String, timestamp: String) async throws -> AdvisoriesResponse { throw MockError.notStubbed("advisories") }
+    func advisoryDetail(flightId: String, timestamp: String, advisoryId: String) async throws -> AdvisoryDetailResponse { throw MockError.notStubbed("advisoryDetail") }
+    func recalculateAdvisories(flightId: String, timestamp: String, cruiseAltitudeFt: Int?) async throws { throw MockError.notStubbed("recalculateAdvisories") }
+    func digest(flightId: String, timestamp: String) async throws -> DigestResponse { throw MockError.notStubbed("digest") }
+    func snapshot(flightId: String, timestamp: String) async throws -> SnapshotResponse { throw MockError.notStubbed("snapshot") }
+    func routeAnalyses(flightId: String, timestamp: String) async throws -> RouteAnalysesResponse { throw MockError.notStubbed("routeAnalyses") }
+    func elevation(flightId: String, timestamp: String) async throws -> ElevationResponse { throw MockError.notStubbed("elevation") }
+    func skewtImage(flightId: String, timestamp: String, icao: String, model: String) async throws -> Data { throw MockError.notStubbed("skewtImage") }
+    func grametImage(flightId: String, timestamp: String) async throws -> Data { throw MockError.notStubbed("grametImage") }
+    func soundingProfile(flightId: String, timestamp: String, pointIndex: Int, model: String) async throws -> SoundingProfileResponse { throw MockError.notStubbed("soundingProfile") }
+    func refreshStream(flightId: String) async -> AsyncThrowingStream<RefreshEvent, Error> {
+        AsyncThrowingStream { $0.finish() }
+    }
+    func refreshStatus(flightId: String) async throws -> RefreshStatusResponse { throw MockError.notStubbed("refreshStatus") }
+    func submitPirep(_ request: SubmitPirepRequest) async throws -> PirepResponse { throw MockError.notStubbed("submitPirep") }
+    func submitPirepsBatch(_ requests: [SubmitPirepRequest]) async throws -> [PirepResponse] { throw MockError.notStubbed("submitPirepsBatch") }
+    func fetchPireps(flightId: String) async throws -> PirepListResponse { throw MockError.notStubbed("fetchPireps") }
+}
+
+// MARK: - Fixture factories
+
+func makeFlight(
+    id: String = "flt-1",
+    aircraftId: Int? = nil,
+    waypoints: [String] = ["LFMD", "LFML"],
+    departureTime: String = "2026-06-24T12:00:00Z",
+    cruiseAltitudeFt: Int = 8000,
+    flightDurationHours: Double = 2.0,
+    role: FlightRole? = nil
+) -> FlightResponse {
+    FlightResponse(
+        id: id,
+        userId: "user-1",
+        profileId: nil,
+        aircraftId: aircraftId,
+        aircraft: nil,
+        routeName: waypoints.joined(separator: " "),
+        waypoints: waypoints,
+        departureTime: departureTime,
+        targetDate: "2026-06-24",
+        targetTimeUtc: 1200,
+        cruiseAltitudeFt: cruiseAltitudeFt,
+        flightCeilingFt: 13000,
+        flightDurationHours: flightDurationHours,
+        private: false,
+        autoRefresh: false,
+        autoRefreshHour: nil,
+        createdAt: "2026-06-20T09:00:00Z",
+        role: role
+    )
+}

--- a/app/flyfun-weather/flyfun-weatherTests/ViewModelTests.swift
+++ b/app/flyfun-weather/flyfun-weatherTests/ViewModelTests.swift
@@ -9,6 +9,7 @@
 
 import Testing
 import Foundation
+import MapKit
 @testable import flyfun_weather
 
 // MARK: - AddFlightViewModel (form validation + change detection)
@@ -139,5 +140,90 @@ import Foundation
             Issue.record("expected .error, got \(vm.state)")
             return
         }
+    }
+}
+
+// MARK: - RouteMapViewModel (waypoint extraction + fit-region math)
+
+@MainActor
+@Suite struct RouteMapViewModelTests {
+
+    /// Minimal snapshot with three waypoints at clean lat/lon for exact math.
+    private func snapshot() throws -> SnapshotResponse {
+        let json = """
+        {
+          "route": {
+            "name": "TEST",
+            "waypoints": [
+              {"icao": "AAAA", "name": "Alpha", "lat": 40.0, "lon": 2.0},
+              {"icao": "BBBB", "name": "Bravo", "lat": 42.0, "lon": 4.0},
+              {"icao": "CCCC", "name": "Charlie", "lat": 44.0, "lon": 6.0}
+            ],
+            "cruise_altitude_ft": 8000,
+            "flight_ceiling_ft": 13000,
+            "flight_duration_hours": 2.0
+          },
+          "target_date": "2026-06-24",
+          "days_out": 1
+        }
+        """
+        return try JSONDecoder.weatherBrief.decode(SnapshotResponse.self, from: Data(json.utf8))
+    }
+
+    @Test func extractsWaypointsAndRouteLine() throws {
+        let vm = RouteMapViewModel()
+        vm.update(from: try snapshot())
+        #expect(vm.waypoints.count == 3)
+        #expect(vm.routeCoordinates.count == 3)
+        #expect(vm.waypoints.first?.id == "AAAA")
+        #expect(vm.waypoints.first?.name == "Alpha")
+    }
+
+    @Test func fitRegionCentersAndPadsBy1_4Plus0_5() throws {
+        let vm = RouteMapViewModel()
+        vm.update(from: try snapshot())
+        // center = midpoint of the bounding box
+        #expect(abs(vm.mapRegion.center.latitude - 42.0) < 1e-6)
+        #expect(abs(vm.mapRegion.center.longitude - 4.0) < 1e-6)
+        // span = range * 1.4 + 0.5 padding
+        #expect(abs(vm.mapRegion.span.latitudeDelta - ((44.0 - 40.0) * 1.4 + 0.5)) < 1e-6)
+        #expect(abs(vm.mapRegion.span.longitudeDelta - ((6.0 - 2.0) * 1.4 + 0.5)) < 1e-6)
+    }
+}
+
+// MARK: - BriefingViewModel (pack history labels)
+
+@MainActor
+@Suite struct BriefingViewModelTests {
+
+    private func vm() -> BriefingViewModel {
+        BriefingViewModel(flight: makeFlight(), repository: MockBriefingRepository())
+    }
+
+    private func pack(daysOut: Int, timestamp: String = "2026-06-24T09:00:00Z") throws -> PackMetaResponse {
+        let json = """
+        {
+          "flight_id": "flt-1",
+          "fetch_timestamp": "\(timestamp)",
+          "days_out": \(daysOut),
+          "is_historical": false,
+          "has_gramet": true, "has_skewt": true, "has_digest": true, "has_advisories": true,
+          "model_init_times": {}, "grib_init_times": {}, "models_skipped_region": []
+        }
+        """
+        return try JSONDecoder.weatherBrief.decode(PackMetaResponse.self, from: Data(json.utf8))
+    }
+
+    @Test func dayLabelSignsForecastVsHistorical() throws {
+        let m = vm()
+        #expect(m.packDayLabel(for: try pack(daysOut: 3)) == "D-3")
+        #expect(m.packDayLabel(for: try pack(daysOut: 0)) == "D-0")
+        #expect(m.packDayLabel(for: try pack(daysOut: -2)) == "D+2")
+    }
+
+    @Test func packLabelFormatsUtcDateTime() throws {
+        let m = vm()
+        let label = m.packLabel(for: try pack(daysOut: 1, timestamp: "2026-06-24T09:00:00Z"))
+        #expect(label == "D-1 · Jun 24 09:00 UTC")
     }
 }

--- a/app/flyfun-weather/flyfun-weatherTests/ViewModelTests.swift
+++ b/app/flyfun-weather/flyfun-weatherTests/ViewModelTests.swift
@@ -1,0 +1,143 @@
+//
+//  ViewModelTests.swift
+//  flyfun-weatherTests
+//
+//  Tier B (#314) — ViewModel logic via the injected `MockBriefingRepository`.
+//  These cover the highest-risk-of-user-facing-bug logic: form validation,
+//  change detection, and the list state machine — all without a network.
+//
+
+import Testing
+import Foundation
+@testable import flyfun_weather
+
+// MARK: - AddFlightViewModel (form validation + change detection)
+
+@MainActor
+@Suite struct AddFlightViewModelTests {
+
+    private func makeVM(flight: FlightResponse? = nil) -> AddFlightViewModel {
+        AddFlightViewModel(repository: MockBriefingRepository(), flight: flight)
+    }
+
+    @Test func waypointsParseUppercaseSplitOnSpaceDashComma() {
+        let vm = makeVM()
+        vm.waypointsText = "lfmd-lfml, lfat  egtf"
+        #expect(vm.waypoints == ["LFMD", "LFML", "LFAT", "EGTF"])
+    }
+
+    @Test func waypointsDropsEmptyTokens() {
+        let vm = makeVM()
+        vm.waypointsText = "  ,, lfmd  -  lfml , "
+        #expect(vm.waypoints == ["LFMD", "LFML"])
+    }
+
+    @Test func canSubmitNeedsAtLeastTwoWaypointsWhenCreating() {
+        let vm = makeVM()
+        vm.waypointsText = "LFMD"
+        #expect(vm.canSubmit == false)
+        vm.waypointsText = "LFMD LFML"
+        #expect(vm.canSubmit == true)
+        vm.isSubmitting = true            // in-flight submit blocks re-submit
+        #expect(vm.canSubmit == false)
+    }
+
+    @Test func canSubmitWhenEditingRequiresAChange() {
+        let vm = makeVM(flight: makeFlight())
+        // Loaded from the flight verbatim → no changes → cannot save.
+        #expect(vm.isEditing)
+        #expect(vm.canSubmit == false)
+        vm.cruiseAltitudeFt += 1000
+        #expect(vm.canSubmit == true)
+    }
+
+    @Test func hasChangesDetectsEachEditedField() {
+        // Route
+        var vm = makeVM(flight: makeFlight(waypoints: ["LFMD", "LFML"]))
+        vm.waypointsText = "LFMD LFAT"
+        #expect(vm.hasChanges)
+        // Altitude
+        vm = makeVM(flight: makeFlight(cruiseAltitudeFt: 8000))
+        vm.cruiseAltitudeFt = 6000
+        #expect(vm.hasChanges)
+        // Duration
+        vm = makeVM(flight: makeFlight(flightDurationHours: 2.0))
+        vm.flightDurationHours = 3.0
+        #expect(vm.hasChanges)
+        // Aircraft
+        vm = makeVM(flight: makeFlight(aircraftId: nil))
+        vm.selectedAircraftId = 5
+        #expect(vm.hasChanges)
+        // Unchanged
+        vm = makeVM(flight: makeFlight())
+        #expect(vm.hasChanges == false)
+    }
+
+    @Test func aircraftOnlyEditIsNotForecastAffecting() {
+        let vm = makeVM(flight: makeFlight(aircraftId: nil))
+        vm.selectedAircraftId = 7
+        #expect(vm.hasChanges)                       // it IS a change…
+        #expect(vm.hasForecastAffectingChange == false)  // …but doesn't re-brief
+        // A route change, by contrast, is forecast-affecting.
+        vm.waypointsText = "LFMD LFAT"
+        #expect(vm.hasForecastAffectingChange)
+    }
+
+    @Test func canSaveAircraftReflectsIcaoTypeRegex() {
+        let vm = makeVM()
+        vm.newAircraftIcaoType = "C172"
+        #expect(vm.canSaveAircraft)            // 1–4 alphanumerics
+        vm.newAircraftIcaoType = "a1"          // lowercased → uppercased, valid
+        #expect(vm.canSaveAircraft)
+        vm.newAircraftIcaoType = "TOOLONG"     // > 4 chars
+        #expect(vm.canSaveAircraft == false)
+        vm.newAircraftIcaoType = "C-72"        // illegal character
+        #expect(vm.canSaveAircraft == false)
+        vm.newAircraftIcaoType = ""            // empty
+        #expect(vm.canSaveAircraft == false)
+    }
+}
+
+// MARK: - FlightListViewModel (async load state machine)
+
+@MainActor
+@Suite struct FlightListViewModelTests {
+
+    @Test func startsIdle() {
+        let vm = FlightListViewModel(repository: MockBriefingRepository())
+        guard case .idle = vm.state else {
+            Issue.record("expected .idle, got \(vm.state)")
+            return
+        }
+    }
+
+    @Test func loadSuccessTransitionsToLoaded() async {
+        let repo = MockBriefingRepository()
+        repo.flightsResult = .success([makeFlight(id: "a"), makeFlight(id: "b")])
+        let vm = FlightListViewModel(repository: repo)
+
+        await vm.loadFlights()
+
+        guard case .loaded(let flights) = vm.state else {
+            Issue.record("expected .loaded, got \(vm.state)")
+            return
+        }
+        #expect(flights.count == 2)
+        #expect(vm.isOffline == false)            // plain mock isn't a caching repo
+        #expect(vm.cachedFlightIds.isEmpty)
+        #expect(repo.flightsCallCount == 1)
+    }
+
+    @Test func loadFailureTransitionsToError() async {
+        let repo = MockBriefingRepository()
+        repo.flightsResult = .failure(MockError.injected("server down"))
+        let vm = FlightListViewModel(repository: repo)
+
+        await vm.loadFlights()
+
+        guard case .error = vm.state else {
+            Issue.record("expected .error, got \(vm.state)")
+            return
+        }
+    }
+}

--- a/app/flyfun-weather/flyfun-weatherUITests/flyfun_weatherUITests.swift
+++ b/app/flyfun-weather/flyfun-weatherUITests/flyfun_weatherUITests.swift
@@ -2,7 +2,10 @@
 //  flyfun_weatherUITests.swift
 //  flyfun-weatherUITests
 //
-//  Created by Brice Rosenzweig on 01/03/2026.
+//  XCUITest journeys (#314). Launched in mock mode (FLYFUN_UITEST + FLYFUN_MOCK)
+//  so they skip the auth gate and serve fixtures — deterministic, offline, no
+//  backend or OAuth. Selectors key off accessibilityIdentifiers, not visible
+//  text, so they survive copy/localization changes.
 //
 
 import XCTest
@@ -10,30 +13,54 @@ import XCTest
 final class flyfun_weatherUITests: XCTestCase {
 
     override func setUpWithError() throws {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
-
-        // In UI tests it is usually best to stop immediately when a failure occurs.
         continueAfterFailure = false
-
-        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
     }
 
-    override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-    }
-
+    /// Launch the app as a UI test would: fake-authenticated + fixture-backed.
     @MainActor
-    func testExample() throws {
-        // UI tests must launch the application that they test.
+    private func launchMockApp() -> XCUIApplication {
         let app = XCUIApplication()
+        app.launchEnvironment["FLYFUN_UITEST"] = "1"
+        app.launchEnvironment["FLYFUN_MOCK"] = "1"
         app.launch()
+        return app
+    }
 
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    /// iPhone collapses the split view to show the flight list directly; iPad in
+    /// portrait collapses to the detail pane with the list behind a "Show Sidebar"
+    /// toggle. Reveal it so the list is reachable on both idioms.
+    @MainActor
+    private func revealFlightList(_ app: XCUIApplication) {
+        if app.staticTexts["LFMD → LFML"].waitForExistence(timeout: 5) { return }
+        let showSidebar = app.buttons["Show Sidebar"]
+        if showSidebar.exists { showSidebar.tap() }
+    }
+
+    /// Journey 1 — launch in mock mode lands past the login gate on the flight
+    /// list, and the seeded fixtures render (iPhone + iPad).
+    @MainActor
+    func testFlightListRendersSeededFlights() throws {
+        let app = launchMockApp()
+        revealFlightList(app)
+
+        // Both fixture flights' route titles appear (proves the list rendered
+        // from the fixture repository, not the login screen).
+        XCTAssertTrue(app.staticTexts["LFMD → LFML"].waitForExistence(timeout: 10),
+                      "first fixture flight should be listed")
+        XCTAssertTrue(app.staticTexts["EGTF → LFAT"].waitForExistence(timeout: 5),
+                      "second fixture flight should be listed")
+
+        // The primary action is reachable.
+        XCTAssertTrue(app.buttons["addFlightButton"].exists, "Add Flight button should be present")
+
+        let shot = XCTAttachment(screenshot: app.screenshot())
+        shot.name = "FlightList-Mock"
+        shot.lifetime = .keepAlways
+        add(shot)
     }
 
     @MainActor
     func testLaunchPerformance() throws {
-        // This measures how long it takes to launch your application.
         measure(metrics: [XCTApplicationLaunchMetric()]) {
             XCUIApplication().launch()
         }

--- a/app/flyfun-weather/flyfun-weatherUITests/flyfun_weatherUITests.swift
+++ b/app/flyfun-weather/flyfun-weatherUITests/flyfun_weatherUITests.swift
@@ -59,6 +59,36 @@ final class flyfun_weatherUITests: XCTestCase {
         add(shot)
     }
 
+    /// Journey 2 — add-flight form: submit is gated until ≥2 waypoints, then a
+    /// create round-trips and the new flight appears in the list.
+    @MainActor
+    func testAddFlightValidationAndCreate() throws {
+        let app = launchMockApp()
+        revealFlightList(app)
+
+        app.buttons["addFlightButton"].tap()
+
+        let waypoints = app.textFields["waypointsField"]
+        XCTAssertTrue(waypoints.waitForExistence(timeout: 5), "add-flight form should appear")
+        let submit = app.buttons["submitFlightButton"]
+
+        // One waypoint → submit disabled.
+        waypoints.tap()
+        waypoints.typeText("EGLL")
+        XCTAssertFalse(submit.isEnabled, "one waypoint is not enough to submit")
+
+        // Second waypoint → submit enabled.
+        waypoints.typeText(" EGKK")
+        XCTAssertTrue(submit.isEnabled, "two waypoints should enable submit")
+
+        submit.tap()
+
+        // Form dismisses and the created flight appears in the list.
+        revealFlightList(app)
+        XCTAssertTrue(app.staticTexts["EGLL → EGKK"].waitForExistence(timeout: 10),
+                      "newly created flight should appear in the list")
+    }
+
     @MainActor
     func testLaunchPerformance() throws {
         measure(metrics: [XCTApplicationLaunchMetric()]) {

--- a/app/flyfun-weather/flyfun-weatherUITests/flyfun_weatherUITests.swift
+++ b/app/flyfun-weather/flyfun-weatherUITests/flyfun_weatherUITests.swift
@@ -31,7 +31,10 @@ final class flyfun_weatherUITests: XCTestCase {
     /// toggle. Reveal it so the list is reachable on both idioms.
     @MainActor
     private func revealFlightList(_ app: XCUIApplication) {
-        if app.staticTexts["LFMD → LFML"].waitForExistence(timeout: 5) { return }
+        // Already on screen (iPhone, or iPad landscape) — keyed off the list's
+        // accessibility identifier, not fixture content, so renaming a fixture
+        // route can't silently break iPad handling.
+        if app.descendants(matching: .any)["flightList"].waitForExistence(timeout: 5) { return }
         let showSidebar = app.buttons["Show Sidebar"]
         if showSidebar.exists { showSidebar.tap() }
     }


### PR DESCRIPTION
## Summary

Builds out the iOS app's automated test suite (#314): a full unit-test layer plus the XCUITest launch seam and the first two UI journeys. ~51 unit tests + 2 UI journeys, all green on iPhone 17 and iPad Pro 11.

**Part 1 (unit) — complete. Part 2 (XCUITest) — seam + journeys 1–2.** The remaining three journeys (briefing drill-down, cross-section, offline), which all need a coherent briefing fixture set, are split into **#318** so this PR stays reviewable.

## Part 1 — unit tests (`flyfun-weatherTests`)

- **Tier A — pure logic:** `CoordTransform` (axis mapping, inverted-Y, round-trip), `Assessment`/`severityRank`, `Extensions`, `MapColors` (ceiling/SFIP/risk threshold buckets + continuous-scale clamps), `MapMetrics` (`linearWidth`, segment aggregation, and the private altitude helpers via the public registry + a `VizPoint` stub).
- **Tier B — ViewModels** via a new `MockBriefingRepository`: `AddFlightViewModel` (waypoint parse, `canSubmit`, change detection, ICAO regex), `FlightListViewModel` (state machine), `RouteMapViewModel` (fit-region math), `BriefingViewModel` (pack labels).
- **Tier C — cache/offline:** `CachedPackEntry` rule, `BriefingCacheStore` (index/persistence/data round-trips), `PirepOfflineStore` (enqueue/sync/persist).

**Colour thresholds are tested by bucket identity** (same-bucket equal, cross-boundary unequal) so they survive palette tweaks and only fail if a threshold moves.

## Part 2 — XCUITest

- **Launch seam** (`AppState`, `#if DEBUG`): `FLYFUN_UITEST=1` skips the auth gate (fake JWT on the observable mirror only — never written to the keychain); `FLYFUN_MOCK=1` serves `FixtureBriefingRepository` instead of the network — deterministic, offline, no backend/OAuth.
- **`FixtureBriefingRepository`** (DEBUG, app target): serves `flights()` + a stateful `createFlight`; briefing endpoints throw `notProvided` until #318 wires them up.
- **`accessibilityIdentifier`s:** `flightList`, `flightCard-<id>`, `addFlightButton`, `waypointsField`, `submitFlightButton`.
- **Journey 1** — flight list renders seeded fixtures.
- **Journey 2** — add-flight: submit gated until ≥2 waypoints, create, new flight appears.
- Both journeys pass on **iPhone + iPad**; `revealFlightList` handles the iPad-portrait split-view collapse (taps "Show Sidebar").

## Minimal production changes (all test-motivated)
- `BriefingCacheStore` / `PirepOfflineStore`: added designated `init(cacheDir:)` / `init(fileURL:)` overloads (production `init()` delegates) so the on-disk actors test against a temp dir.
- `AppState`: the `#if DEBUG` UITest seam.
- `FixtureBriefingRepository`: new DEBUG-only file.
- `accessibilityIdentifier`s on a few controls. No behaviour change.

## How files are added
The project uses Xcode 16 synchronized folder groups, so new test/source files compile automatically — no `project.pbxproj` edits.

## Verification
- Unit suite: `** TEST SUCCEEDED **` on iPhone 17.
- UI journeys: green on iPhone 17 **and** iPad Pro 11.
- Rebased onto latest `origin/main` (app-icon + #311 help-content commits); re-ran unit + UI post-rebase — still green.

## Deferred (tracked in #318)
- Briefing/cross-section/offline journeys + the briefing fixture set.
- `CrossSectionViewModel.extractVizData` unit test.
- `CachingBriefingRepository` fallback test (needs a protocol-injection refactor of the concrete `OnlineBriefingRepository`).

Part of #314. Remaining journeys: #318. CI/release-gate wiring: #315.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
