### PR TITLE
iOS: briefing & cross-section UI tweaks

### DIFF
--- a/app/flyfun-weather/flyfun-weather/Models/API/DigestResponse.swift
+++ b/app/flyfun-weather/flyfun-weather/Models/API/DigestResponse.swift
@@ -6,6 +6,9 @@ struct DigestResponse: Codable, Sendable {
     let assessment: String?
     let assessmentReason: String?
     let synoptic: String?
+    /// Hazard-by-hazard concerns (digest `specific_concerns`). Decoded via the
+    /// client's `.convertFromSnakeCase` strategy. Markdown.
+    let specificConcerns: String?
     let winds: String?
     let icing: String?
     let turbulence: String?
@@ -54,6 +57,14 @@ struct DigestResponse: Codable, Sendable {
     /// Watch items as an array of strings.
     var watchItemsList: [String] {
         watchItems?.values ?? []
+    }
+
+    /// Watch items reconstructed as a single markdown string (the server sends
+    /// `watch_items` as one markdown block; `FlexibleStringArray` splits it on
+    /// newlines, so re-join to render the original list). Empty → nil.
+    var watchItemsMarkdown: String? {
+        let joined = watchItemsList.joined(separator: "\n")
+        return joined.isEmpty ? nil : joined
     }
 }
 

--- a/app/flyfun-weather/flyfun-weather/ViewModels/BriefingViewModel.swift
+++ b/app/flyfun-weather/flyfun-weather/ViewModels/BriefingViewModel.swift
@@ -50,6 +50,9 @@ struct FocusIntent: Equatable {
     var layerId: String?
     /// Map metric id to select.
     var mapMetricId: String?
+    /// Advisory lens id to apply on the cross-section (e.g. "icing"); see
+    /// `CrossSectionPresets`.
+    var advisoryPresetId: String?
     var pointIndex: Int?
     var distanceNm: Double?
     var altitudeFt: Double?
@@ -210,13 +213,43 @@ final class BriefingViewModel {
     func packLabel(for pack: PackMetaResponse) -> String {
         let prefix = packDayLabel(for: pack)
         // Extract date/time from fetchTimestamp
-        if let date = ISO8601DateFormatter().date(from: pack.fetchTimestamp) {
-            let fmt = DateFormatter()
-            fmt.dateFormat = "MMM d HH:mm"
-            fmt.timeZone = TimeZone(identifier: "UTC")
-            return "\(prefix) · \(fmt.string(from: date)) UTC"
+        if let date = Self.isoParser.date(from: pack.fetchTimestamp) {
+            return "\(prefix) · \(Self.dayTimeUTC.string(from: date)) UTC"
         }
         return prefix
+    }
+
+    /// Compact toolbar-chip label. Normally just the day code ("D-0"), but when
+    /// another pack in history shares the same UTC day it appends the time
+    /// ("D-0 · 14:05") so same-day runs are distinguishable at a glance — like
+    /// the web history dropdown.
+    func packChipLabel(for pack: PackMetaResponse) -> String {
+        let day = packDayLabel(for: pack)
+        guard hasSameDaySibling(pack),
+              let date = Self.isoParser.date(from: pack.fetchTimestamp) else { return day }
+        return "\(day) · \(Self.timeUTC.string(from: date))"
+    }
+
+    /// Whether another pack in history was fetched on the same UTC calendar day.
+    private func hasSameDaySibling(_ pack: PackMetaResponse) -> Bool {
+        guard let day = Self.utcDayKey(pack.fetchTimestamp) else { return false }
+        return packHistory.filter { Self.utcDayKey($0.fetchTimestamp) == day }.count > 1
+    }
+
+    private static func utcDayKey(_ timestamp: String) -> String? {
+        guard let date = isoParser.date(from: timestamp) else { return nil }
+        return dayKeyUTC.string(from: date)
+    }
+
+    private static let isoParser = ISO8601DateFormatter()
+    private static let dayTimeUTC: DateFormatter = utcFormatter("MMM d HH:mm")
+    private static let timeUTC: DateFormatter = utcFormatter("HH:mm")
+    private static let dayKeyUTC: DateFormatter = utcFormatter("yyyy-MM-dd")
+    private static func utcFormatter(_ format: String) -> DateFormatter {
+        let fmt = DateFormatter()
+        fmt.dateFormat = format
+        fmt.timeZone = TimeZone(identifier: "UTC")
+        return fmt
     }
 
     // MARK: - Advisory detail

--- a/app/flyfun-weather/flyfun-weather/ViewModels/BriefingViewModel.swift
+++ b/app/flyfun-weather/flyfun-weather/ViewModels/BriefingViewModel.swift
@@ -213,7 +213,7 @@ final class BriefingViewModel {
     func packLabel(for pack: PackMetaResponse) -> String {
         let prefix = packDayLabel(for: pack)
         // Extract date/time from fetchTimestamp
-        if let date = Self.isoParser.date(from: pack.fetchTimestamp) {
+        if let date = Self.parseISO(pack.fetchTimestamp) {
             return "\(prefix) · \(Self.dayTimeUTC.string(from: date)) UTC"
         }
         return prefix
@@ -226,7 +226,7 @@ final class BriefingViewModel {
     func packChipLabel(for pack: PackMetaResponse) -> String {
         let day = packDayLabel(for: pack)
         guard hasSameDaySibling(pack),
-              let date = Self.isoParser.date(from: pack.fetchTimestamp) else { return day }
+              let date = Self.parseISO(pack.fetchTimestamp) else { return day }
         return "\(day) · \(Self.timeUTC.string(from: date))"
     }
 
@@ -237,11 +237,25 @@ final class BriefingViewModel {
     }
 
     private static func utcDayKey(_ timestamp: String) -> String? {
-        guard let date = isoParser.date(from: timestamp) else { return nil }
+        guard let date = parseISO(timestamp) else { return nil }
         return dayKeyUTC.string(from: date)
     }
 
-    private static let isoParser = ISO8601DateFormatter()
+    /// Parse an ISO-8601 timestamp. The server sends `datetime.isoformat()`,
+    /// which includes microseconds (e.g. `2026-06-28T08:46:00.123456+00:00`),
+    /// so try the fractional-seconds parser first, then plain. (Default
+    /// `ISO8601DateFormatter` rejects fractional seconds — that was why the time
+    /// never appeared.)
+    private static func parseISO(_ s: String) -> Date? {
+        isoParserFrac.date(from: s) ?? isoParserPlain.date(from: s)
+    }
+
+    private static let isoParserFrac: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return f
+    }()
+    private static let isoParserPlain = ISO8601DateFormatter()
     private static let dayTimeUTC: DateFormatter = utcFormatter("MMM d HH:mm")
     private static let timeUTC: DateFormatter = utcFormatter("HH:mm")
     private static let dayKeyUTC: DateFormatter = utcFormatter("yyyy-MM-dd")

--- a/app/flyfun-weather/flyfun-weather/ViewModels/CrossSectionViewModel.swift
+++ b/app/flyfun-weather/flyfun-weather/ViewModels/CrossSectionViewModel.swift
@@ -6,7 +6,9 @@ import Foundation
 @MainActor
 final class CrossSectionViewModel {
     private(set) var vizData: VizRouteData?
-    private(set) var enabledLayers: [String: Bool] = CrossSectionLayer.defaultEnabled
+    private(set) var enabledLayers: [String: Bool] = CrossSectionPresets.gramet
+    /// Currently-applied advisory lens id (e.g. "icing"), or nil when none/Custom.
+    private(set) var activeAdvisoryPreset: String?
 
     func update(routeAnalyses: RouteAnalysesResponse, elevation: ElevationResponse?, model: String) {
         vizData = Self.extractVizData(from: routeAnalyses, model: model, elevation: elevation)
@@ -14,6 +16,7 @@ final class CrossSectionViewModel {
 
     func toggleLayer(_ id: String) {
         enabledLayers[id] = !(enabledLayers[id] ?? false)
+        activeAdvisoryPreset = nil  // a manual edit is no longer a named lens
     }
 
     /// Force-enable a known layer (e.g. a deep-link focus intent turning on the
@@ -23,8 +26,8 @@ final class CrossSectionViewModel {
         enabledLayers[id] = true
     }
 
-    // MARK: - Presets (§4.5 — preset collapses every method/toggle; cloud STYLE
-    // is preset-driven appearance. Touching any control flips to Custom.)
+    // MARK: - Layer presets (§4.5; ported from web — see CrossSectionPresets).
+    // A preset sets every layer; touching any control flips to Custom.
 
     enum Preset: String, CaseIterable, Identifiable {
         case gramet = "GRAMET"
@@ -35,12 +38,9 @@ final class CrossSectionViewModel {
     }
 
     func applyPreset(_ preset: Preset) {
-        switch preset {
-        case .gramet: enabledLayers = CrossSectionLayer.defaultEnabled
-        case .windy: enabledLayers = Self.preset(cloudMethod: "nwp-cloud-bands")       // natural
-        case .foreFlight: enabledLayers = Self.preset(cloudMethod: "square-nwp-cloud-bands") // square
-        case .custom: break
-        }
+        let map = presetMap(preset)
+        if !map.isEmpty { enabledLayers = map }
+        activeAdvisoryPreset = nil
     }
 
     /// The preset matching the current layer set, or `.custom` if it's been
@@ -54,21 +54,36 @@ final class CrossSectionViewModel {
 
     private func presetMap(_ p: Preset) -> [String: Bool] {
         switch p {
-        case .gramet: return CrossSectionLayer.defaultEnabled
-        case .windy: return Self.preset(cloudMethod: "nwp-cloud-bands")
-        case .foreFlight: return Self.preset(cloudMethod: "square-nwp-cloud-bands")
+        case .gramet: return CrossSectionPresets.gramet
+        case .windy: return CrossSectionPresets.windy
+        case .foreFlight: return CrossSectionPresets.foreflight
         case .custom: return [:]
         }
     }
 
-    /// GRAMET defaults with the clouds method group swapped to `cloudMethod`.
-    private static func preset(cloudMethod: String) -> [String: Bool] {
-        var m = CrossSectionLayer.defaultEnabled
-        for id in CrossSectionLayer.methodGroupOrder[.clouds] ?? [] {
-            m[id] = (id == cloudMethod)
+    // MARK: - Advisory lenses (ported from web ADVISORY_PRESETS)
+
+    /// Apply a hazard lens: clean-slate the managed groups, enable the preferred
+    /// layer of each named method group, then force the lens's explicit lines on.
+    /// Terrain + cruise reference stay (always-on / not in resetGroups).
+    func applyAdvisoryPreset(_ preset: AdvisoryPreset) {
+        var m = enabledLayers
+        for layer in CrossSectionLayer.allLayers where CrossSectionPresets.resetGroups.contains(layer.group) {
+            m[layer.id] = false
         }
-        return m
+        for group in preset.groups {
+            if let preferred = CrossSectionLayer.methodGroupOrder[group]?.first {
+                m[preferred] = true
+            }
+        }
+        for id in preset.lines where m[id] != nil {  // drop ids iOS doesn't have
+            m[id] = true
+        }
+        enabledLayers = m
+        activeAdvisoryPreset = preset.id
     }
+
+    // MARK: - Methods (clouds/icing/turbulence/convection — one method per group)
 
     /// Currently-active method layer ID for a method group (clouds/icing/etc),
     /// or nil if all methods in the group are off.
@@ -84,6 +99,33 @@ final class CrossSectionViewModel {
         for id in order {
             enabledLayers[id] = (id == layerId)
         }
+        activeAdvisoryPreset = nil
+    }
+
+    // MARK: - Cloud axes (source × style — two independent controls, #7)
+
+    /// Active cloud source/style, or nil when clouds are off.
+    var cloudAxes: (source: CloudSource, style: CloudStyle)? {
+        activeMethod(for: .clouds).flatMap { CrossSectionPresets.parseCloudLayerId($0) }
+    }
+
+    /// Turn the cloud layer on (defaulting to Soft NWP) or off.
+    func setCloudEnabled(_ on: Bool) {
+        if on {
+            let axes = cloudAxes ?? (.nwp, .soft)
+            setMethod(CrossSectionPresets.cloudLayerId(source: axes.source, style: axes.style), for: .clouds)
+        } else {
+            setMethod(nil, for: .clouds)
+        }
+    }
+
+    /// Change one cloud axis, keeping the other (and keeping clouds on).
+    func setCloud(source: CloudSource? = nil, style: CloudStyle? = nil) {
+        let current = cloudAxes ?? (.nwp, .soft)
+        let newId = CrossSectionPresets.cloudLayerId(
+            source: source ?? current.source,
+            style: style ?? current.style)
+        setMethod(newId, for: .clouds)
     }
 
     // MARK: - Data extraction (port of data-extract.ts)

--- a/app/flyfun-weather/flyfun-weather/ViewModels/CrossSectionViewModel.swift
+++ b/app/flyfun-weather/flyfun-weather/ViewModels/CrossSectionViewModel.swift
@@ -83,6 +83,12 @@ final class CrossSectionViewModel {
         activeAdvisoryPreset = preset.id
     }
 
+    /// Clear the active lens (the picker's "None") without otherwise touching the
+    /// layer config.
+    func clearAdvisoryPreset() {
+        activeAdvisoryPreset = nil
+    }
+
     // MARK: - Methods (clouds/icing/turbulence/convection — one method per group)
 
     /// Currently-active method layer ID for a method group (clouds/icing/etc),

--- a/app/flyfun-weather/flyfun-weather/Views/Briefing/AdvisoryCardView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Briefing/AdvisoryCardView.swift
@@ -49,6 +49,50 @@ struct AdvisoryCardView: View {
         catalog.first { $0.id == advisory.advisoryId }
     }
 
+    /// CTA row: "Why it's RED ›" (AMBER/RED only) + "On cross-section" lens chip
+    /// (advisories that map to a cross-section lens, #6). Rendered only when at
+    /// least one button is present, so GREEN/no-lens cards add no empty node.
+    @ViewBuilder
+    private var ctaRow: some View {
+        let showWhy = viewModel != nil && (advisory.aggregateStatus == "amber" || advisory.aggregateStatus == "red")
+        let lensPreset = viewModel != nil ? CrossSectionPresets.preset(forAdvisory: advisory.advisoryId) : nil
+        if showWhy || lensPreset != nil {
+            HStack(spacing: 14) {
+                if showWhy {
+                    Button {
+                        showingDetail = true
+                    } label: {
+                        HStack(spacing: 2) {
+                            Text("Why it's \(advisory.aggregateStatus.uppercased())")
+                            Image(systemName: "chevron.right")
+                        }
+                        .font(.caption.weight(.semibold))
+                    }
+                    .buttonStyle(.plain)
+                    .foregroundStyle(Color.accentColor)
+                }
+                if let viewModel, let preset = lensPreset {
+                    Button {
+                        viewModel.setFocusIntent(FocusIntent(
+                            target: .crossSection,
+                            model: viewModel.selectedModel,
+                            advisoryPresetId: preset.id,
+                            pointIndex: viewModel.activePointIndex
+                        ))
+                    } label: {
+                        HStack(spacing: 3) {
+                            Image(systemName: "chart.xyaxis.line")
+                            Text("On cross-section")
+                        }
+                        .font(.caption.weight(.semibold))
+                    }
+                    .buttonStyle(.plain)
+                    .foregroundStyle(Color.accentColor)
+                }
+            }
+        }
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             // Header
@@ -95,41 +139,7 @@ struct AdvisoryCardView: View {
                 }
             }
 
-            // CTA row: "Why it's RED ›" (AMBER/RED only) + "On cross-section" lens
-            // chip for advisories that map to a cross-section lens (#6).
-            HStack(spacing: 14) {
-                if viewModel != nil, advisory.aggregateStatus == "amber" || advisory.aggregateStatus == "red" {
-                    Button {
-                        showingDetail = true
-                    } label: {
-                        HStack(spacing: 2) {
-                            Text("Why it's \(advisory.aggregateStatus.uppercased())")
-                            Image(systemName: "chevron.right")
-                        }
-                        .font(.caption.weight(.semibold))
-                    }
-                    .buttonStyle(.plain)
-                    .foregroundStyle(Color.accentColor)
-                }
-                if let viewModel, let preset = CrossSectionPresets.preset(forAdvisory: advisory.advisoryId) {
-                    Button {
-                        viewModel.setFocusIntent(FocusIntent(
-                            target: .crossSection,
-                            model: viewModel.selectedModel,
-                            advisoryPresetId: preset.id,
-                            pointIndex: viewModel.activePointIndex
-                        ))
-                    } label: {
-                        HStack(spacing: 3) {
-                            Image(systemName: "chart.xyaxis.line")
-                            Text("On cross-section")
-                        }
-                        .font(.caption.weight(.semibold))
-                    }
-                    .buttonStyle(.plain)
-                    .foregroundStyle(Color.accentColor)
-                }
-            }
+            ctaRow
 
             // Expanded detail
             if isExpanded {

--- a/app/flyfun-weather/flyfun-weather/Views/Briefing/AdvisoryCardView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Briefing/AdvisoryCardView.swift
@@ -85,29 +85,50 @@ struct AdvisoryCardView: View {
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
 
-            // Per-model badges
+            // Per-model badges — FlowLayout packs them tightly and wraps to a
+            // second row instead of stretching across evenly-spaced columns.
             if !advisory.perModel.isEmpty {
-                let columns = Array(repeating: GridItem(.flexible(), spacing: 4), count: min(advisory.perModel.count, 4))
-                LazyVGrid(columns: columns, spacing: 4) {
+                FlowLayout(spacing: 4) {
                     ForEach(advisory.perModel) { modelResult in
                         ModelStatusBadge(model: modelResult.model, status: modelResult.status)
                     }
                 }
             }
 
-            // "Why it's RED ›" CTA — only when AMBER/RED (GREEN cards stay calm, §4.6 Rung 1).
-            if viewModel != nil, advisory.aggregateStatus == "amber" || advisory.aggregateStatus == "red" {
-                Button {
-                    showingDetail = true
-                } label: {
-                    HStack(spacing: 2) {
-                        Text("Why it's \(advisory.aggregateStatus.uppercased())")
-                        Image(systemName: "chevron.right")
+            // CTA row: "Why it's RED ›" (AMBER/RED only) + "On cross-section" lens
+            // chip for advisories that map to a cross-section lens (#6).
+            HStack(spacing: 14) {
+                if viewModel != nil, advisory.aggregateStatus == "amber" || advisory.aggregateStatus == "red" {
+                    Button {
+                        showingDetail = true
+                    } label: {
+                        HStack(spacing: 2) {
+                            Text("Why it's \(advisory.aggregateStatus.uppercased())")
+                            Image(systemName: "chevron.right")
+                        }
+                        .font(.caption.weight(.semibold))
                     }
-                    .font(.caption.weight(.semibold))
+                    .buttonStyle(.plain)
+                    .foregroundStyle(Color.accentColor)
                 }
-                .buttonStyle(.plain)
-                .foregroundStyle(Color.accentColor)
+                if let viewModel, let preset = CrossSectionPresets.preset(forAdvisory: advisory.advisoryId) {
+                    Button {
+                        viewModel.setFocusIntent(FocusIntent(
+                            target: .crossSection,
+                            model: viewModel.selectedModel,
+                            advisoryPresetId: preset.id,
+                            pointIndex: viewModel.activePointIndex
+                        ))
+                    } label: {
+                        HStack(spacing: 3) {
+                            Image(systemName: "chart.xyaxis.line")
+                            Text("On cross-section")
+                        }
+                        .font(.caption.weight(.semibold))
+                    }
+                    .buttonStyle(.plain)
+                    .foregroundStyle(Color.accentColor)
+                }
             }
 
             // Expanded detail

--- a/app/flyfun-weather/flyfun-weather/Views/Briefing/AdvisoryTabView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Briefing/AdvisoryTabView.swift
@@ -13,7 +13,6 @@ struct AdvisoryTabView: View {
             VStack(alignment: .leading, spacing: Theme.sectionSpacing) {
                 heroSection
                     .spyAnchor("hero")
-                watchSection
                 advisoriesSection
                     .spyAnchor("advisories")
                 AirportConditionsView(viewModel: viewModel)
@@ -22,6 +21,9 @@ struct AdvisoryTabView: View {
                     AlternatesView(viewModel: viewModel)
                         .spyAnchor("alternates")
                 }
+                // Watch reads as the "keep an eye on this" close, so it sits at
+                // the very end (#4); anchored internally.
+                watchSection
             }
             .padding(.vertical, Theme.cardPadding)
         }
@@ -42,10 +44,10 @@ struct AdvisoryTabView: View {
 
     private var spySections: [SpySection] {
         var sections = [SpySection("hero", "Summary")]
-        if hasWatchItems { sections.append(SpySection("watch", "Watch")) }
         sections.append(SpySection("advisories", "Advisories"))
         sections.append(SpySection("conditions", "Conditions"))
         if hasAlternates { sections.append(SpySection("alternates", "Alternates")) }
+        if hasWatchItems { sections.append(SpySection("watch", "Watch")) }
         return sections
     }
 
@@ -79,51 +81,21 @@ struct AdvisoryTabView: View {
 
     // MARK: Watch chips
 
+    /// Watch items as readable markdown text (no deep-link — these are just a
+    /// list of things to keep an eye on, #4). Rendered last in the tab.
     @ViewBuilder
     private var watchSection: some View {
-        if case .loaded(let digest) = viewModel.digestState {
-            let items = digest.watchItemsList
-            if !items.isEmpty {
-                VStack(alignment: .leading, spacing: Theme.spacingS) {
-                    Text("Watch")
-                        .font(.headline)
-                        .foregroundStyle(Theme.text)
-                    FlowLayout(spacing: Theme.spacingS) {
-                        ForEach(items, id: \.self) { item in
-                            Button {
-                                viewModel.setFocusIntent(FocusIntent(
-                                    target: .crossSection,
-                                    model: viewModel.selectedModel,
-                                    layerId: Self.watchLayerId(for: item),
-                                    pointIndex: viewModel.activePointIndex
-                                ))
-                            } label: {
-                                HStack(spacing: Theme.spacingXS) {
-                                    Label(item, systemImage: "exclamationmark.circle")
-                                    Image(systemName: "chevron.right").font(.caption2)
-                                }
-                                .font(.subheadline)
-                                .foregroundStyle(Theme.amber)
-                                .padding(.horizontal, 10).padding(.vertical, 6)
-                                .background(Theme.amber.opacity(0.12), in: Capsule())
-                            }
-                            .buttonStyle(.plain)
-                        }
-                    }
-                }
-                .padding(.horizontal, Theme.cardPadding)
-                .spyAnchor("watch")
+        if case .loaded(let digest) = viewModel.digestState, let watch = digest.watchItemsMarkdown {
+            VStack(alignment: .leading, spacing: Theme.spacingS) {
+                Text("Watch")
+                    .font(.headline)
+                    .foregroundStyle(Theme.text)
+                DigestMarkdownText(markdown: watch)
             }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, Theme.cardPadding)
+            .spyAnchor("watch")
         }
-    }
-
-    /// Map a watch-item phrase to the cross-section layer it most relates to.
-    private static func watchLayerId(for item: String) -> String? {
-        let s = item.lowercased()
-        if s.contains("ice") || s.contains("icing") { return "icing-ogimet-nwp-bands" }
-        if s.contains("conv") || s.contains("storm") || s.contains("cb") || s.contains("cape") { return "thermo-convective-bg" }
-        if s.contains("turb") || s.contains("shear") { return "cat-bands" }
-        return nil
     }
 
     // MARK: Advisories — responsive grid (#310 item 2)

--- a/app/flyfun-weather/flyfun-weather/Views/Briefing/BriefingContainerView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Briefing/BriefingContainerView.swift
@@ -516,7 +516,7 @@ private struct BriefingPackToolbar: View {
 
     private var currentPackLabel: String {
         if let pack = viewModel.pack {
-            return viewModel.packDayLabel(for: pack)
+            return viewModel.packChipLabel(for: pack)
         }
         return "History"
     }

--- a/app/flyfun-weather/flyfun-weather/Views/Briefing/DiscussionTabView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Briefing/DiscussionTabView.swift
@@ -1,9 +1,9 @@
 import SwiftUI
 
-/// The **Discussion** tab (#310): the big-picture synoptic narrative. v1 ships
-/// synopsis text only — surface-pressure & front charts are a deferred
-/// fast-follow (see the issue's Phasing). Per-hazard digest narrative lives on
-/// the matching advisory card (Advisory tab), keeping Discussion big-picture.
+/// The **Discussion** tab (#310): the big-picture synoptic narrative. Renders
+/// the digest's four narrative sections — Synoptic, Specific Concerns, Trend and
+/// Watch Items — as markdown. Watch is repeated here from the Advisory tab on
+/// purpose (it reads as the "what to keep an eye on" close of the discussion).
 struct DiscussionTabView: View {
     let viewModel: BriefingViewModel
 
@@ -26,26 +26,43 @@ struct DiscussionTabView: View {
                 .frame(maxWidth: .infinity)
                 .padding(.top, Theme.sectionSpacing)
         case .loaded(let digest):
-            if let synopsis = digest.synopsis, !synopsis.isEmpty {
-                VStack(alignment: .leading, spacing: Theme.spacingS) {
-                    Text("Synoptic Overview")
-                        .font(.headline)
-                        .foregroundStyle(Theme.text)
-                    Text(synopsis)
-                        .font(.body)
-                        .foregroundStyle(Theme.textMuted)
-                        .fixedSize(horizontal: false, vertical: true)
-                }
-                .padding(.horizontal, Theme.cardPadding)
-            } else {
+            let sections = Self.sections(from: digest)
+            if sections.isEmpty {
                 ContentUnavailableView("No Discussion", systemImage: "text.alignleft",
-                                       description: Text("No synoptic overview is available for this briefing."))
+                                       description: Text("No discussion is available for this briefing."))
                     .padding(.top, Theme.sectionSpacing)
+            } else {
+                ForEach(sections, id: \.title) { section in
+                    VStack(alignment: .leading, spacing: Theme.spacingS) {
+                        Text(section.title)
+                            .font(.headline)
+                            .foregroundStyle(Theme.text)
+                        DigestMarkdownText(markdown: section.text)
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal, Theme.cardPadding)
+                }
             }
         case .error(let error):
             ContentUnavailableView("Discussion Unavailable", systemImage: "text.alignleft",
                                    description: Text(error.localizedDescription))
                 .padding(.top, Theme.sectionSpacing)
         }
+    }
+
+    /// The discussion's four narrative sections, in order, dropping any the
+    /// digest didn't populate.
+    private static func sections(from digest: DigestResponse) -> [(title: String, text: String)] {
+        var result: [(String, String)] = []
+        func add(_ title: String, _ text: String?) {
+            if let text, !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                result.append((title, text))
+            }
+        }
+        add("Synoptic Overview", digest.synoptic)
+        add("Specific Concerns", digest.specificConcerns)
+        add("Trend", digest.trend)
+        add("Watch Items", digest.watchItemsMarkdown)
+        return result
     }
 }

--- a/app/flyfun-weather/flyfun-weather/Views/CrossSection/ColorScales.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/CrossSection/ColorScales.swift
@@ -40,16 +40,19 @@ nonisolated enum ColorScales {
 
     // MARK: - Cloud fill from dewpoint depression
 
-    /// RGBA components (0–1) for a DD-sourced cloud fill. Mirrors web
-    /// `cloudFillFromDD`. Returned as a tuple so the natural style can build
-    /// both a solid and a fully-transparent gradient stop from the same colour.
+    /// RGBA components (0–1) for a DD-sourced cloud fill. Faithful port of the
+    /// web Standard theme `cloudFillFromDD`: dense gray (saturated, low DD) →
+    /// near-white (dry, high DD), interpolated by DD; alpha per coverage class.
     static func cloudRGBA(dewpointDepressionC: Double?, coverage: String) -> RGBA {
-        let dd = dewpointDepressionC ?? 1.5
+        guard let dd = dewpointDepressionC else {
+            // fallbackGray + the class's upper alpha (web behaviour for nil DD).
+            return RGBA(r: 180 / 255.0, g: 180 / 255.0, b: 185 / 255.0, a: coverageAlphaRange(coverage).hi)
+        }
         let t = min(max(dd / 3.0, 0), 1.0)
         return RGBA(
-            r: (170 + 75 * t) / 255.0,
-            g: (170 + 75 * t) / 255.0,
-            b: (175 + 73 * t) / 255.0,
+            r: (140 + 110 * t) / 255.0,   // denseRgb[140,140,150] → thinRgb[250,250,255]
+            g: (140 + 110 * t) / 255.0,
+            b: (150 + 105 * t) / 255.0,
             a: coverageAlpha(coverage, t: t)
         )
     }
@@ -58,13 +61,22 @@ nonisolated enum ColorScales {
         cloudRGBA(dewpointDepressionC: dewpointDepressionC, coverage: coverage).color
     }
 
-    private static func coverageAlpha(_ coverage: String, t: Double) -> Double {
-        switch coverage {
-        case "sct": 0.40 + 0.15 * (1 - t)
-        case "bkn": 0.50 + 0.30 * (1 - t)
-        case "ovc": 0.60 + 0.32 * (1 - t)
-        default: 0.30
+    /// Per-coverage [lo, hi] alpha bounds (web Standard theme `clouds.coverageAlpha`).
+    private static func coverageAlphaRange(_ coverage: String) -> (lo: Double, hi: Double) {
+        switch coverage.lowercased() {
+        case "few": return (0.20, 0.35)
+        case "sct": return (0.50, 0.65)
+        case "bkn": return (0.60, 0.88)
+        case "ovc": return (0.70, 0.95)
+        default: return (0.30, 0.65)
         }
+    }
+
+    /// Alpha from coverage class, denser (hi) when saturated, lighter (lo) when
+    /// dry. Mirrors web `coverageAlpha`: `hi - (hi - lo) * t`.
+    private static func coverageAlpha(_ coverage: String, t: Double) -> Double {
+        let r = coverageAlphaRange(coverage)
+        return r.hi - (r.hi - r.lo) * t
     }
 
     // MARK: - Inversion
@@ -93,7 +105,10 @@ nonisolated enum ColorScales {
 
     // MARK: - Sky background
 
-    static let skyBlue = Color(.sRGB, red: 135 / 255.0, green: 206 / 255.0, blue: 235 / 255.0)
+    /// Web Standard theme sky (#7395DB). The previous light-cyan (#87CEEB) sky
+    /// washed out the whitish clouds — the Standard palette's cloud colours are
+    /// tuned for this periwinkle blue.
+    static let skyBlue = Color(.sRGB, red: 115 / 255.0, green: 149 / 255.0, blue: 219 / 255.0)
 
     // MARK: - NWP cloud (model-percentage-derived, blue-tinted)
 
@@ -111,13 +126,14 @@ nonisolated enum ColorScales {
     /// RGBA components (0–1) for an NWP cover%-derived cloud fill. Mirrors web
     /// `nwpCloudFill`.
     static func nwpCloudRGBA(pct: Double) -> RGBA {
+        // Web Standard theme `nwpCloudFill`: near-white (low cover) → gray (high
+        // cover); alpha 0.30→0.85. brightRgb[245,245,255] − deltaRgb[105,105,100]·t.
         let t = min(1.0, max(0.0, pct / 100.0))
-        // Brighter blue at low cover, darker at high cover.
         return RGBA(
-            r: (210 - 60 * t) / 255.0,
-            g: (220 - 50 * t) / 255.0,
-            b: (235 - 20 * t) / 255.0,
-            a: 0.30 + 0.50 * t
+            r: (245 - 105 * t) / 255.0,
+            g: (245 - 105 * t) / 255.0,
+            b: (255 - 100 * t) / 255.0,
+            a: 0.30 + 0.55 * t
         )
     }
 

--- a/app/flyfun-weather/flyfun-weather/Views/CrossSection/CrossSectionConfigSheet.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/CrossSection/CrossSectionConfigSheet.swift
@@ -62,7 +62,13 @@ struct CrossSectionConfigSheet: View {
         Section {
             Picker("Lens", selection: Binding(
                 get: { csVM.activeAdvisoryPreset ?? "" },
-                set: { id in if let p = CrossSectionPresets.advisory[id] { csVM.applyAdvisoryPreset(p) } }
+                set: { id in
+                    if id.isEmpty {
+                        csVM.clearAdvisoryPreset()  // "None" — deselect the lens
+                    } else if let p = CrossSectionPresets.advisory[id] {
+                        csVM.applyAdvisoryPreset(p)
+                    }
+                }
             )) {
                 Text("None").tag("")
                 ForEach(CrossSectionPresets.advisoryList) { Text($0.label).tag($0.id) }

--- a/app/flyfun-weather/flyfun-weather/Views/CrossSection/CrossSectionConfigSheet.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/CrossSection/CrossSectionConfigSheet.swift
@@ -15,6 +15,7 @@ struct CrossSectionConfigSheet: View {
         NavigationStack {
             List {
                 presetSection
+                advisoryLensSection
                 methodSection
                 referenceSection
                 if showMore { moreSection }
@@ -55,13 +56,70 @@ struct CrossSectionConfigSheet: View {
         }
     }
 
+    // MARK: Advisory lens — focus the chart on one hazard (ported from web)
+
+    private var advisoryLensSection: some View {
+        Section {
+            Picker("Lens", selection: Binding(
+                get: { csVM.activeAdvisoryPreset ?? "" },
+                set: { id in if let p = CrossSectionPresets.advisory[id] { csVM.applyAdvisoryPreset(p) } }
+            )) {
+                Text("None").tag("")
+                ForEach(CrossSectionPresets.advisoryList) { Text($0.label).tag($0.id) }
+            }
+        } header: {
+            Text("Advisory view")
+        } footer: {
+            if let id = csVM.activeAdvisoryPreset, let p = CrossSectionPresets.advisory[id] {
+                Text(p.caption)
+            } else {
+                Text("Focus the chart on one hazard (icing, clouds, convection…).")
+            }
+        }
+    }
+
     // MARK: Method groups — one row per concern (pick-one method)
 
     private var methodSection: some View {
         Section("Conditions") {
-            ForEach(LayerGroup.allCases.filter(\.isMethodGroup), id: \.self) { group in
+            // Clouds get two independent axes (source + style); the other method
+            // groups stay single dropdowns. (#7)
+            cloudControl
+            ForEach(LayerGroup.allCases.filter { $0.isMethodGroup && $0 != .clouds }, id: \.self) { group in
                 methodRow(for: group)
             }
+        }
+    }
+
+    // MARK: Cloud control — Source (DD/NWP) × Style (Soft/Natural/Square)
+
+    @ViewBuilder
+    private var cloudControl: some View {
+        let axes = csVM.cloudAxes
+        Toggle(isOn: Binding(
+            get: { axes != nil },
+            set: { csVM.setCloudEnabled($0) }
+        )) {
+            HStack {
+                swatch(LegendColors.color(forGroup: .clouds))
+                Text("Clouds")
+            }
+        }
+        if let axes {
+            Picker("Source", selection: Binding(
+                get: { axes.source },
+                set: { csVM.setCloud(source: $0) }
+            )) {
+                ForEach(CloudSource.allCases) { Text($0.label).tag($0) }
+            }
+            .pickerStyle(.segmented)
+            Picker("Style", selection: Binding(
+                get: { axes.style },
+                set: { csVM.setCloud(style: $0) }
+            )) {
+                ForEach(CloudStyle.allCases) { Text($0.label).tag($0) }
+            }
+            .pickerStyle(.segmented)
         }
     }
 
@@ -117,11 +175,13 @@ struct CrossSectionConfigSheet: View {
         }
     }
 
-    /// Reference + temperature toggle layers (terrain / freezing / -10 / -20),
-    /// excluding the stability lines which live under "More".
+    /// Reference + temperature toggle layers (freezing / -10 / -20 / cruise),
+    /// excluding the stability lines which live under "More". Terrain is
+    /// intentionally omitted — it always renders (force-on in the renderer),
+    /// mirroring the web panel which has no terrain toggle.
     private var referenceLayers: [any CrossSectionLayerProtocol] {
         CrossSectionLayer.allLayers.filter {
-            ($0.group == .reference || $0.group == .temperature || $0.group == .terrain)
+            ($0.group == .reference || $0.group == .temperature)
         }
     }
 
@@ -140,9 +200,6 @@ struct CrossSectionConfigSheet: View {
                     }
                 }
             }
-            Text("Cloud style (soft / natural / square) follows the preset; pick a method above to override.")
-                .font(.caption)
-                .foregroundStyle(Theme.textMuted)
         }
     }
 

--- a/app/flyfun-weather/flyfun-weather/Views/CrossSection/CrossSectionRenderer.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/CrossSection/CrossSectionRenderer.swift
@@ -34,7 +34,10 @@ struct CrossSectionRenderer {
         var clipped = context
         clipped.clip(to: Path(skyRect))
         for layer in CrossSectionLayer.allLayers {
-            if enabledLayers[layer.id] ?? false {
+            // Terrain always renders (force-on, no UI toggle — mirrors the web
+            // panel which omits the terrain group). Its position in `allLayers`
+            // keeps the correct mid-stack z-order (after bands, before lines).
+            if layer.id == "terrain" || (enabledLayers[layer.id] ?? false) {
                 layer.render(context: &clipped, transform: transform, data: data)
             }
         }

--- a/app/flyfun-weather/flyfun-weather/Views/CrossSection/CrossSectionView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/CrossSection/CrossSectionView.swift
@@ -200,7 +200,10 @@ struct CrossSectionView: View {
                     .render(context: &context, size: size)
             }
             .frame(minHeight: 300)
-            .aspectRatio(isLandscapeFocus ? nil : 2.0, contentMode: .fit)
+            // Portrait constrains to a 2:1 artifact; landscape fills the screen.
+            // (Passing `nil` to aspectRatio means "use intrinsic ratio" — a
+            // Canvas has none, which collapsed the chart to a sliver. #9)
+            .modifier(CanvasAspectModifier(landscape: isLandscapeFocus))
             .background(GeometryReader { geo in
                 Color.clear.onAppear { canvasSize = geo.size }
                     .onChange(of: geo.size) { _, newSize in canvasSize = newSize }
@@ -260,6 +263,12 @@ struct CrossSectionView: View {
     private func applyFocusIntent() {
         guard let intent = viewModel.focusIntent,
               intent.target == .crossSection || intent.target == .skewT else { return }
+        // An advisory lens configures the whole view; a single layerId just
+        // force-enables one layer. Apply the lens first so a layerId can refine it.
+        if let presetId = intent.advisoryPresetId,
+           let preset = CrossSectionPresets.advisory[presetId] {
+            csVM.applyAdvisoryPreset(preset)
+        }
         if let layerId = intent.layerId { csVM.enableLayer(layerId) }
         if let dist = intent.distanceNm {
             scrubDistanceNm = dist
@@ -311,6 +320,22 @@ struct CrossSectionView: View {
             var elevation: ElevationResponse? = nil
             if case .loaded(let elev) = viewModel.elevationState { elevation = elev }
             csVM.update(routeAnalyses: analyses, elevation: elevation, model: viewModel.selectedModel)
+        }
+    }
+}
+
+/// Sizes the cross-section canvas per orientation: portrait keeps a 2:1
+/// artifact (`.fit`), landscape fills the screen. Kept as a modifier (not an
+/// inline `.aspectRatio(landscape ? nil : 2.0, ...)`) because passing `nil`
+/// makes SwiftUI use the view's *intrinsic* ratio — a Canvas has none, which
+/// collapsed the chart to a vertical sliver in iPhone landscape. (#9)
+private struct CanvasAspectModifier: ViewModifier {
+    let landscape: Bool
+    func body(content: Content) -> some View {
+        if landscape {
+            content.frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else {
+            content.aspectRatio(2.0, contentMode: .fit)
         }
     }
 }

--- a/app/flyfun-weather/flyfun-weather/Views/CrossSection/Layers/CloudBandsNatural.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/CrossSection/Layers/CloudBandsNatural.swift
@@ -345,27 +345,34 @@ struct SquareCloudBandsLayer: CrossSectionLayerProtocol {
             let xL = transform.distanceToX(band.left.distanceNm)
             let xR = transform.distanceToX(band.right.distanceNm)
             let xMid = (xL + xR) / 2
-            let color = source.matchedRGBA(band.cl, band.matched).color
+            let rgba = source.matchedRGBA(band.cl, band.matched)
             fillFlatCell(&context, x0: xL, x1: xMid, baseFt: band.left.baseFt, topFt: band.left.topFt,
-                         transform: transform, color: color)
+                         transform: transform, fill: rgba)
             fillFlatCell(&context, x0: xMid, x1: xR, baseFt: band.right.baseFt, topFt: band.right.topFt,
-                         transform: transform, color: color)
+                         transform: transform, fill: rgba)
         }
     }
 }
 
 /// One flat (horizontal top/base) rectangular cloud cell. Skips tapered
 /// zero-height ends produced for unmatched zones.
+///
+/// Square has no blobs/feathering to add structure, so a faint cover-based fill
+/// dissolves into the (light) sky. Bump the fill to a visible floor and stroke a
+/// darker border so cells read as crisp ForeFlight-style blocks on any sky. (#7)
 private func fillFlatCell(
     _ context: inout GraphicsContext,
     x0: CGFloat, x1: CGFloat, baseFt: Double, topFt: Double,
-    transform: CoordTransform, color: Color
+    transform: CoordTransform, fill rgba: RGBA
 ) {
     guard x1 > x0 else { return }
     let yTop = transform.altitudeToY(topFt)
     let yBase = transform.altitudeToY(baseFt)
     guard yBase > yTop else { return }
-    context.fill(Path(CGRect(x: x0, y: yTop, width: x1 - x0, height: yBase - yTop)), with: .color(color))
+    let rect = CGRect(x: x0, y: yTop, width: x1 - x0, height: yBase - yTop)
+    context.fill(Path(rect), with: .color(rgba.withAlpha(max(rgba.a, 0.55))))
+    let border = RGBA(r: rgba.r * 0.55, g: rgba.g * 0.55, b: rgba.b * 0.65, a: 0.9)
+    context.stroke(Path(rect), with: .color(border.color), lineWidth: 0.75)
 }
 
 // MARK: - Shared single-point column fallback

--- a/app/flyfun-weather/flyfun-weather/Views/CrossSection/Layers/CloudBandsNatural.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/CrossSection/Layers/CloudBandsNatural.swift
@@ -337,18 +337,35 @@ struct SquareCloudBandsLayer: CrossSectionLayerProtocol {
         }
 
         forEachCloudBand(data, source: source) { band in
-            // Straight-edged trapezoid cell (ForeFlight-like), solid fill.
+            // Flat rectangular cells (ForeFlight-like): each endpoint contributes
+            // a flat cell at its own base/top, split at the segment midpoint — so
+            // adjacent cells step vertically instead of sloping. A single sloped
+            // trapezoid read as a soft/smooth band; this mirrors web
+            // drawColumnBand's per-point fillRect. (#7)
             let xL = transform.distanceToX(band.left.distanceNm)
             let xR = transform.distanceToX(band.right.distanceNm)
-            var path = Path()
-            path.move(to: CGPoint(x: xL, y: transform.altitudeToY(band.left.topFt)))
-            path.addLine(to: CGPoint(x: xR, y: transform.altitudeToY(band.right.topFt)))
-            path.addLine(to: CGPoint(x: xR, y: transform.altitudeToY(band.right.baseFt)))
-            path.addLine(to: CGPoint(x: xL, y: transform.altitudeToY(band.left.baseFt)))
-            path.closeSubpath()
-            context.fill(path, with: .color(source.matchedRGBA(band.cl, band.matched).color))
+            let xMid = (xL + xR) / 2
+            let color = source.matchedRGBA(band.cl, band.matched).color
+            fillFlatCell(&context, x0: xL, x1: xMid, baseFt: band.left.baseFt, topFt: band.left.topFt,
+                         transform: transform, color: color)
+            fillFlatCell(&context, x0: xMid, x1: xR, baseFt: band.right.baseFt, topFt: band.right.topFt,
+                         transform: transform, color: color)
         }
     }
+}
+
+/// One flat (horizontal top/base) rectangular cloud cell. Skips tapered
+/// zero-height ends produced for unmatched zones.
+private func fillFlatCell(
+    _ context: inout GraphicsContext,
+    x0: CGFloat, x1: CGFloat, baseFt: Double, topFt: Double,
+    transform: CoordTransform, color: Color
+) {
+    guard x1 > x0 else { return }
+    let yTop = transform.altitudeToY(topFt)
+    let yBase = transform.altitudeToY(baseFt)
+    guard yBase > yTop else { return }
+    context.fill(Path(CGRect(x: x0, y: yTop, width: x1 - x0, height: yBase - yTop)), with: .color(color))
 }
 
 // MARK: - Shared single-point column fallback

--- a/app/flyfun-weather/flyfun-weather/Views/CrossSection/Layers/CloudBandsNatural.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/CrossSection/Layers/CloudBandsNatural.swift
@@ -354,12 +354,9 @@ struct SquareCloudBandsLayer: CrossSectionLayerProtocol {
     }
 }
 
-/// One flat (horizontal top/base) rectangular cloud cell. Skips tapered
-/// zero-height ends produced for unmatched zones.
-///
-/// Square has no blobs/feathering to add structure, so a faint cover-based fill
-/// dissolves into the (light) sky. Bump the fill to a visible floor and stroke a
-/// darker border so cells read as crisp ForeFlight-style blocks on any sky. (#7)
+/// One flat (horizontal top/base) rectangular cloud cell, solid fill (no border
+/// — ForeFlight-like). Skips tapered zero-height ends produced for unmatched
+/// zones. Visibility comes from the Standard-theme cloud colour + sky contrast.
 private func fillFlatCell(
     _ context: inout GraphicsContext,
     x0: CGFloat, x1: CGFloat, baseFt: Double, topFt: Double,
@@ -369,10 +366,7 @@ private func fillFlatCell(
     let yTop = transform.altitudeToY(topFt)
     let yBase = transform.altitudeToY(baseFt)
     guard yBase > yTop else { return }
-    let rect = CGRect(x: x0, y: yTop, width: x1 - x0, height: yBase - yTop)
-    context.fill(Path(rect), with: .color(rgba.withAlpha(max(rgba.a, 0.55))))
-    let border = RGBA(r: rgba.r * 0.55, g: rgba.g * 0.55, b: rgba.b * 0.65, a: 0.9)
-    context.stroke(Path(rect), with: .color(border.color), lineWidth: 0.75)
+    context.fill(Path(CGRect(x: x0, y: yTop, width: x1 - x0, height: yBase - yTop)), with: .color(rgba.color))
 }
 
 // MARK: - Shared single-point column fallback

--- a/app/flyfun-weather/flyfun-weather/Views/CrossSection/Layers/CrossSectionLayer.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/CrossSection/Layers/CrossSectionLayer.swift
@@ -73,34 +73,9 @@ enum CrossSectionLayer {
         ReferenceLinesLayer(),
     ]
 
-    /// GRAMET-aligned defaults (matches web's GRAMET preset, the production default):
-    /// Soft NWP clouds + Ogimet-NWP icing + CAT (Ri) + NWP convective + freezing
-    /// level + terrain + cruise altitude.
-    static let defaultEnabled: [String: Bool] = [
-        "soft-nwp-cloud-bands": true,
-        "soft-cloud-bands": false,
-        "nwp-cloud-bands": false,
-        "cloud-bands": false,
-        "square-nwp-cloud-bands": false,
-        "square-cloud-bands": false,
-        "thermo-convective-bg": false,
-        "nwp-convective-bg": true,
-        "icing-bands": false,
-        "icing-ogimet-nwp-bands": true,
-        "sfip-bands": false,
-        "cat-bands": true,
-        "inversion-bands": false,
-        "terrain": true,
-        "freezing-level": true,
-        "minus-10c": false,
-        "minus-20c": false,
-        // Stability lines stay default-off (design §4.5 buries them as expert
-        // toggles / clean default view); IDs match web for prefs sync + presets.
-        "lcl": false,
-        "lfc": false,
-        "el": false,
-        "reference-lines": true,
-    ]
+    // The default enabled-layer set now lives in `CrossSectionPresets.gramet`
+    // (the boot state and the GRAMET preset are the same map). The old
+    // `defaultEnabled` static was removed once both its uses moved there.
 
     /// For each method group, ordered list of layer IDs (from preferred to alternates).
     /// Used by the dropdown picker UI: "None" + each method, in this display order.

--- a/app/flyfun-weather/flyfun-weather/Views/CrossSection/Layers/CrossSectionPresets.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/CrossSection/Layers/CrossSectionPresets.swift
@@ -1,0 +1,180 @@
+import Foundation
+
+// =============================================================================
+// SYNC — keep this file in lockstep with the web preset definitions:
+//   • Layer presets (GRAMET / Windy / ForeFlight):
+//       web/ts/visualization/cross-section/layer-registry.ts  (PRESETS, *_ENABLED)
+//   • Advisory lenses (Basic / Icing / Clouds / Convective / Turbulence / VFR / IFR):
+//       web/ts/visualization/cross-section/advisory-presets.ts (ADVISORY_PRESETS,
+//       ADVISORY_TO_PRESET, getPresetForAdvisory)
+//   • Cloud source×style axes:
+//       web/ts/visualization/cross-section/cloud-bands-factory.ts (CLOUD_LAYER_BY_AXES,
+//       parseCloudLayerId)
+//
+// iOS uses its own layer IDs and lacks a few web layers (ieng-icing-bands,
+// e-shear-bands, sld-bands, surface-obscuration-bands). The maps below translate
+// the web intent to iOS IDs; line IDs that don't exist on iOS are simply dropped
+// when applied. When the web presets change, update this file — and add a note on
+// the web side (both files carry the reciprocal SYNC comment).
+// =============================================================================
+
+/// One-click layer configuration. Port of web `LayerPreset`. `themeId` is kept
+/// for parity (the web preset also picks a color theme); iOS has no cross-section
+/// color-theme system yet (tracked in #320), so it's informational for now.
+struct LayerPreset: Identifiable, Equatable {
+    let id: String
+    let label: String
+    let themeId: String
+    let enabledLayers: [String: Bool]
+}
+
+/// Hazard-oriented lens. Port of web `AdvisoryPreset` (cross-section directives
+/// only — the web's route-graph / map / Skew-T directives are not yet wired on
+/// iOS). `groups` enables the preferred layer of each method group on a clean
+/// slate; `lines` force-enables explicit layer IDs.
+struct AdvisoryPreset: Identifiable, Equatable {
+    let id: String
+    let label: String
+    let caption: String
+    var groups: [LayerGroup] = []
+    var lines: [String] = []
+}
+
+/// Cloud rendering axes (orthogonal): which data feed, and how it's drawn.
+/// Mirrors web's `cloud-bands-factory.ts`.
+enum CloudSource: String, CaseIterable, Identifiable {
+    case nwp, dd
+    var id: String { rawValue }
+    var label: String { self == .nwp ? "NWP" : "DD" }
+}
+
+enum CloudStyle: String, CaseIterable, Identifiable {
+    case soft, natural, square
+    var id: String { rawValue }
+    var label: String {
+        switch self {
+        case .soft: "Soft"
+        case .natural: "Natural"
+        case .square: "Square"
+        }
+    }
+}
+
+enum CrossSectionPresets {
+    // MARK: - Layer presets (ported from web *_ENABLED, translated to iOS IDs)
+
+    /// Builds a complete enabled-map (every layer present) with the given IDs on.
+    private static func layers(on onIds: Set<String>) -> [String: Bool] {
+        var m: [String: Bool] = [:]
+        for layer in CrossSectionLayer.allLayers { m[layer.id] = onIds.contains(layer.id) }
+        return m
+    }
+
+    /// GRAMET — Natural NWP clouds + Ogimet-NWP icing + CAT (Ri) + NWP convective.
+    static let gramet = layers(on: [
+        "nwp-cloud-bands", "nwp-convective-bg", "icing-ogimet-nwp-bands",
+        "cat-bands", "terrain", "freezing-level", "reference-lines",
+    ])
+
+    /// Windy — Natural NWP clouds + SFIP-NWP icing + CAT (Ri) + NWP convective.
+    static let windy = layers(on: [
+        "nwp-cloud-bands", "nwp-convective-bg", "sfip-bands",
+        "cat-bands", "terrain", "freezing-level", "reference-lines",
+    ])
+
+    /// ForeFlight — Square DD clouds + Ogimet-DD icing + CAT (Ri) + NWP convective.
+    static let foreflight = layers(on: [
+        "square-cloud-bands", "nwp-convective-bg", "icing-bands",
+        "cat-bands", "terrain", "freezing-level", "reference-lines",
+    ])
+
+    static let all: [LayerPreset] = [
+        LayerPreset(id: "gramet", label: "GRAMET", themeId: "gramet", enabledLayers: gramet),
+        LayerPreset(id: "windy", label: "Windy", themeId: "light", enabledLayers: windy),
+        LayerPreset(id: "foreflight", label: "ForeFlight", themeId: "high-contrast", enabledLayers: foreflight),
+    ]
+
+    // MARK: - Advisory lenses (ported from web ADVISORY_PRESETS)
+
+    /// Groups reset to OFF before applying a lens, so the view shows only what the
+    /// lens specifies (plus always-on terrain + cruise reference).
+    static let resetGroups: Set<LayerGroup> = [
+        .clouds, .icing, .convection, .turbulence, .stability, .temperature,
+    ]
+
+    /// Display order for the lens picker.
+    static let advisoryOrder = ["basic", "icing", "clouds", "convective", "turbulence", "vfr", "ifr"]
+
+    static let advisory: [String: AdvisoryPreset] = [
+        "basic": AdvisoryPreset(
+            id: "basic", label: "Basic / Learn",
+            caption: "Temperature, dewpoint, and the parcel path with LCL/LFC/EL — no hazard bands.",
+            groups: [], lines: ["freezing-level"]),
+        "icing": AdvisoryPreset(
+            id: "icing", label: "Icing",
+            caption: "Icing bands vs the 0 °C line and terrain — is there an ice-free descent?",
+            groups: [.icing, .clouds], lines: ["freezing-level"]),
+        "clouds": AdvisoryPreset(
+            id: "clouds", label: "Clouds",
+            caption: "Cloud tops & coverage vs your cruise level.",
+            groups: [.clouds], lines: ["freezing-level"]),
+        "convective": AdvisoryPreset(
+            id: "convective", label: "Convective",
+            caption: "Towers framed by LCL→LFC→EL and instability along route.",
+            groups: [.convection, .clouds],
+            lines: ["lcl", "lfc", "el", "freezing-level", "minus-10c", "minus-20c"]),
+        "turbulence": AdvisoryPreset(
+            id: "turbulence", label: "Turbulence",
+            caption: "CAT/shear layers near cruise; terrain + wind for orographic risk.",
+            groups: [.turbulence], lines: ["inversion-bands"]),
+        "vfr": AdvisoryPreset(
+            id: "vfr", label: "VFR feasibility",
+            caption: "VMC picture: clouds & obscuration vs cruise and airports.",
+            groups: [.clouds], lines: ["freezing-level"]),
+        "ifr": AdvisoryPreset(
+            id: "ifr", label: "IFR feasibility",
+            caption: "IFR hazards: icing + convection + cloud along route.",
+            groups: [.icing, .convection, .clouds], lines: ["freezing-level", "minus-10c"]),
+    ]
+
+    static var advisoryList: [AdvisoryPreset] { advisoryOrder.compactMap { advisory[$0] } }
+
+    /// advisory_id → lens id (card chips). Mirrors web ADVISORY_TO_PRESET.
+    static let advisoryToPreset: [String: String] = [
+        "icing_escape": "icing", "fiki_icing": "icing",
+        "cloud_top": "clouds", "vmc_cruise": "clouds",
+        "convective": "convective",
+        "turbulence": "turbulence", "mountain_wind": "turbulence",
+        "vfr_feasibility": "vfr", "ifr_feasibility": "ifr",
+    ]
+
+    /// The lens a given advisory's chip should apply, or nil if it has no chip.
+    static func preset(forAdvisory advisoryId: String) -> AdvisoryPreset? {
+        guard let presetId = advisoryToPreset[advisoryId] else { return nil }
+        return advisory[presetId]
+    }
+
+    // MARK: - Cloud axes (source × style ⇄ layer id)
+
+    /// (source, style) → cloud layer id.
+    static func cloudLayerId(source: CloudSource, style: CloudStyle) -> String {
+        switch (style, source) {
+        case (.soft, .nwp): "soft-nwp-cloud-bands"
+        case (.soft, .dd): "soft-cloud-bands"
+        case (.natural, .nwp): "nwp-cloud-bands"
+        case (.natural, .dd): "cloud-bands"
+        case (.square, .nwp): "square-nwp-cloud-bands"
+        case (.square, .dd): "square-cloud-bands"
+        }
+    }
+
+    /// cloud layer id → (source, style), or nil if not a cloud layer.
+    static func parseCloudLayerId(_ id: String) -> (source: CloudSource, style: CloudStyle)? {
+        for source in CloudSource.allCases {
+            for style in CloudStyle.allCases where cloudLayerId(source: source, style: style) == id {
+                return (source, style)
+            }
+        }
+        return nil
+    }
+}

--- a/app/flyfun-weather/flyfun-weather/Views/CrossSection/Layers/CrossSectionPresets.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/CrossSection/Layers/CrossSectionPresets.swift
@@ -6,7 +6,7 @@ import Foundation
 //       web/ts/visualization/cross-section/layer-registry.ts  (PRESETS, *_ENABLED)
 //   • Advisory lenses (Basic / Icing / Clouds / Convective / Turbulence / VFR / IFR):
 //       web/ts/visualization/cross-section/advisory-presets.ts (ADVISORY_PRESETS,
-//       ADVISORY_TO_PRESET, getPresetForAdvisory)
+//       ADVISORY_TO_PRESET, ADVISORY_OVERRIDES, getPresetForAdvisory)
 //   • Cloud source×style axes:
 //       web/ts/visualization/cross-section/cloud-bands-factory.ts (CLOUD_LAYER_BY_AXES,
 //       parseCloudLayerId)
@@ -148,10 +148,24 @@ enum CrossSectionPresets {
         "vfr_feasibility": "vfr", "ifr_feasibility": "ifr",
     ]
 
+    /// Per-advisory extras unioned onto the base lens. Mirrors web
+    /// `ADVISORY_OVERRIDES`: e.g. FIKI icing adds warm-nose isotherms. iOS-missing
+    /// line ids (e.g. `sld-bands`) are kept here for parity and dropped at apply
+    /// time by `applyAdvisoryPreset`'s `m[id] != nil` guard.
+    static let advisoryOverrides: [String: (groups: [LayerGroup], lines: [String])] = [
+        "fiki_icing": (groups: [], lines: ["minus-10c", "minus-20c", "sld-bands"]),
+    ]
+
     /// The lens a given advisory's chip should apply, or nil if it has no chip.
+    /// Unions `advisoryOverrides` onto the base lens (mirrors web
+    /// `getPresetForAdvisory`).
     static func preset(forAdvisory advisoryId: String) -> AdvisoryPreset? {
-        guard let presetId = advisoryToPreset[advisoryId] else { return nil }
-        return advisory[presetId]
+        guard let presetId = advisoryToPreset[advisoryId], var p = advisory[presetId] else { return nil }
+        if let o = advisoryOverrides[advisoryId] {
+            p.groups += o.groups
+            p.lines += o.lines
+        }
+        return p
     }
 
     // MARK: - Cloud axes (source × style ⇄ layer id)

--- a/app/flyfun-weather/flyfun-weather/Views/Flights/FlightListView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Flights/FlightListView.swift
@@ -12,6 +12,9 @@ struct FlightListView: View {
     @State private var showSettings = false
     @State private var showSignOutWarning = false
     @State private var editingFlight: FlightResponse?
+    /// "Past" flights start collapsed (like the web app) so the list opens on
+    /// what's upcoming/recent.
+    @State private var pastExpanded = false
 
     var body: some View {
         NavigationSplitView(columnVisibility: $columnVisibility) {
@@ -22,36 +25,36 @@ struct FlightListView: View {
                             emptyStateView
                         } else {
                             // Utility logbook (§4.4): Future · Recent · Past.
+                            // Past is collapsible (collapsed by default).
                             List(selection: $selectedFlight) {
                                 ForEach(Self.groupedFlights(flights), id: \.title) { group in
-                                    Section(group.title) {
-                                        ForEach(group.flights) { flight in
-                                            let hasCached = viewModel.cachedFlightIds.contains(flight.id)
-                                            NavigationLink(value: flight) {
-                                                FlightCardView(flight: flight, hasCachedData: hasCached,
-                                                               isOffline: viewModel.isOffline)
-                                            }
-                                            .disabled(viewModel.isOffline && !hasCached)
-                                            .swipeActions(edge: .trailing, allowsFullSwipe: false) {
-                                                // Subscribers can't edit shared flights, and editing
-                                                // is online-only (it regenerates the briefing).
-                                                if !viewModel.isOffline && flight.isEditable {
-                                                    Button {
-                                                        editingFlight = flight
-                                                    } label: {
-                                                        Label("Edit", systemImage: "pencil")
-                                                    }
-                                                    .tint(.blue)
+                                    if group.title == "Past" {
+                                        Section {
+                                            if pastExpanded {
+                                                ForEach(group.flights) { flight in
+                                                    flightRow(flight, viewModel: viewModel)
                                                 }
                                             }
-                                            .contextMenu {
-                                                if !viewModel.isOffline && flight.isEditable {
-                                                    Button {
-                                                        editingFlight = flight
-                                                    } label: {
-                                                        Label("Edit Flight", systemImage: "pencil")
-                                                    }
+                                        } header: {
+                                            Button {
+                                                withAnimation { pastExpanded.toggle() }
+                                            } label: {
+                                                HStack {
+                                                    Text("Past")
+                                                    Spacer()
+                                                    Text("\(group.flights.count)")
+                                                        .foregroundStyle(.secondary)
+                                                    Image(systemName: pastExpanded ? "chevron.down" : "chevron.right")
+                                                        .foregroundStyle(.secondary)
                                                 }
+                                                .contentShape(Rectangle())
+                                            }
+                                            .buttonStyle(.plain)
+                                        }
+                                    } else {
+                                        Section(group.title) {
+                                            ForEach(group.flights) { flight in
+                                                flightRow(flight, viewModel: viewModel)
                                             }
                                         }
                                     }
@@ -177,6 +180,39 @@ struct FlightListView: View {
         .onChange(of: scenePhase) {
             if scenePhase == .active {
                 Task { await viewModel?.loadFlights() }
+            }
+        }
+    }
+
+    /// One flight row (navigation + edit swipe/context menu). Shared by every
+    /// section so the collapsible Past section renders identical rows.
+    @ViewBuilder
+    private func flightRow(_ flight: FlightResponse, viewModel: FlightListViewModel) -> some View {
+        let hasCached = viewModel.cachedFlightIds.contains(flight.id)
+        NavigationLink(value: flight) {
+            FlightCardView(flight: flight, hasCachedData: hasCached,
+                           isOffline: viewModel.isOffline)
+        }
+        .disabled(viewModel.isOffline && !hasCached)
+        .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+            // Subscribers can't edit shared flights, and editing is online-only
+            // (it regenerates the briefing).
+            if !viewModel.isOffline && flight.isEditable {
+                Button {
+                    editingFlight = flight
+                } label: {
+                    Label("Edit", systemImage: "pencil")
+                }
+                .tint(.blue)
+            }
+        }
+        .contextMenu {
+            if !viewModel.isOffline && flight.isEditable {
+                Button {
+                    editingFlight = flight
+                } label: {
+                    Label("Edit Flight", systemImage: "pencil")
+                }
             }
         }
     }

--- a/app/flyfun-weather/flyfun-weather/Views/Shared/DigestMarkdownText.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Shared/DigestMarkdownText.swift
@@ -30,18 +30,21 @@ struct DigestMarkdownText: View {
 
     /// Force each list item onto its own line. The LLM often emits watch items /
     /// concerns as one run-on string ("1. … 2. … 3. …" or "- … - …"), so insert a
-    /// newline before any numbered ("N. ") or bulleted ("- ", "• ") marker that
-    /// isn't already at the start of a line. `\d+\.\s` (digit-dot-space) won't
-    /// match decimals like "10.5" (no space after the dot).
+    /// newline before any numbered ("N. ") or bulleted ("- ", "• ") marker.
+    ///
+    /// The marker must be preceded by a clause/sentence terminator (`. , : ; )`)
+    /// so we break between list items but NOT before a sentence-final integer
+    /// (e.g. "gusts to 25. Expect…" stays one line) or a range ("5 - 10 kt").
+    /// `\d+\.\s` won't match decimals like "10.5" (no space after the dot).
     static func normalize(_ s: String) -> String {
         var out = s
-        // Break before "N. " markers that follow other text on the same line.
+        // Break before "N. " markers that close a previous clause/item.
         out = out.replacingOccurrences(
-            of: "(?<=\\S)[ \\t]+(?=\\d+\\.\\s)",
+            of: "(?<=[.,:;)])[ \\t]+(?=\\d+\\.\\s)",
             with: "\n", options: .regularExpression)
-        // Break before "- " / "• " bullets mid-line.
+        // Break before "- " / "• " bullets that close a previous clause/item.
         out = out.replacingOccurrences(
-            of: "(?<=\\S)[ \\t]+(?=[-•]\\s)",
+            of: "(?<=[.,:;)])[ \\t]+(?=[-•]\\s)",
             with: "\n", options: .regularExpression)
         return out
     }

--- a/app/flyfun-weather/flyfun-weather/Views/Shared/DigestMarkdownText.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Shared/DigestMarkdownText.swift
@@ -1,0 +1,39 @@
+import SwiftUI
+
+/// Renders an LLM-digest markdown string (synoptic / specific concerns / trend /
+/// watch items). SwiftUI `Text` markdown is inline-only, so we parse each line
+/// for inline emphasis/links while preserving line breaks and blank-line
+/// paragraph gaps — good enough for the digest's bold-led numbered lists and
+/// paragraphs without pulling in a full markdown renderer.
+struct DigestMarkdownText: View {
+    let markdown: String
+    var font: Font = .body
+    var color: Color = Theme.textMuted
+
+    var body: some View {
+        let lines = markdown.split(separator: "\n", omittingEmptySubsequences: false)
+        VStack(alignment: .leading, spacing: Theme.spacingXS) {
+            ForEach(Array(lines.enumerated()), id: \.offset) { _, raw in
+                let line = String(raw)
+                if line.trimmingCharacters(in: .whitespaces).isEmpty {
+                    Color.clear.frame(height: 4)  // paragraph gap
+                } else {
+                    Text(Self.attributed(line))
+                        .font(font)
+                        .foregroundStyle(color)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+            }
+        }
+    }
+
+    /// Inline-only markdown parse, preserving whitespace; falls back to the raw
+    /// string if the line isn't valid markdown.
+    private static func attributed(_ line: String) -> AttributedString {
+        (try? AttributedString(
+            markdown: line,
+            options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)
+        )) ?? AttributedString(line)
+    }
+}

--- a/app/flyfun-weather/flyfun-weather/Views/Shared/DigestMarkdownText.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Shared/DigestMarkdownText.swift
@@ -11,7 +11,7 @@ struct DigestMarkdownText: View {
     var color: Color = Theme.textMuted
 
     var body: some View {
-        let lines = markdown.split(separator: "\n", omittingEmptySubsequences: false)
+        let lines = Self.normalize(markdown).split(separator: "\n", omittingEmptySubsequences: false)
         VStack(alignment: .leading, spacing: Theme.spacingXS) {
             ForEach(Array(lines.enumerated()), id: \.offset) { _, raw in
                 let line = String(raw)
@@ -26,6 +26,24 @@ struct DigestMarkdownText: View {
                 }
             }
         }
+    }
+
+    /// Force each list item onto its own line. The LLM often emits watch items /
+    /// concerns as one run-on string ("1. … 2. … 3. …" or "- … - …"), so insert a
+    /// newline before any numbered ("N. ") or bulleted ("- ", "• ") marker that
+    /// isn't already at the start of a line. `\d+\.\s` (digit-dot-space) won't
+    /// match decimals like "10.5" (no space after the dot).
+    static func normalize(_ s: String) -> String {
+        var out = s
+        // Break before "N. " markers that follow other text on the same line.
+        out = out.replacingOccurrences(
+            of: "(?<=\\S)[ \\t]+(?=\\d+\\.\\s)",
+            with: "\n", options: .regularExpression)
+        // Break before "- " / "• " bullets mid-line.
+        out = out.replacingOccurrences(
+            of: "(?<=\\S)[ \\t]+(?=[-•]\\s)",
+            with: "\n", options: .regularExpression)
+        return out
     }
 
     /// Inline-only markdown parse, preserving whitespace; falls back to the raw

--- a/app/flyfun-weather/flyfun-weather/Views/Shared/SectionSpyBar.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Shared/SectionSpyBar.swift
@@ -30,9 +30,13 @@ private struct SpyOffsetKey: PreferenceKey {
 extension View {
     /// Mark a scroll target and report its top offset for scroll-spy tracking.
     /// Pair with `ScrollSpyScroll`; the `id` must match a `SpySection.id`.
+    ///
+    /// `.id()` is applied LAST (outermost): `ScrollViewReader.scrollTo` only
+    /// finds a target whose `.id` is on the outermost layout view, so applying it
+    /// before `.background(GeometryReader…)` left tap-to-scroll a silent no-op
+    /// (scroll-position tracking still worked, masking it). (#3)
     func spyAnchor(_ id: String) -> some View {
         self
-            .id(id)
             .background(
                 GeometryReader { geo in
                     Color.clear.preference(
@@ -41,6 +45,7 @@ extension View {
                     )
                 }
             )
+            .id(id)
     }
 }
 

--- a/app/flyfun-weather/flyfun-weather/Views/Shared/SectionSpyBar.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Shared/SectionSpyBar.swift
@@ -109,23 +109,34 @@ struct ScrollSpyScroll<Content: View>: View {
     @ViewBuilder var content: () -> Content
 
     @State private var active: String = ""
+    @State private var scrollTarget: String?
 
     var body: some View {
-        ScrollViewReader { proxy in
-            VStack(spacing: 0) {
-                if sections.count > 1 {
-                    SectionSpyBar(sections: sections, active: active.isEmpty ? (sections.first?.id ?? "") : active) { id in
-                        withAnimation(.easeInOut(duration: 0.25)) {
-                            proxy.scrollTo(id, anchor: .top)
-                        }
-                    }
+        // The pill bar sits OUTSIDE the ScrollViewReader; the reader wraps only
+        // the ScrollView and consumes a `scrollTarget` trigger via `.onChange`.
+        // (Driving `proxy.scrollTo` directly from a tap handler on a sibling of
+        // the ScrollView inside the same reader silently did nothing — this is
+        // the same reader+trigger shape CrossSectionView uses successfully.) (#3)
+        VStack(spacing: 0) {
+            if sections.count > 1 {
+                SectionSpyBar(sections: sections, active: active.isEmpty ? (sections.first?.id ?? "") : active) { id in
+                    scrollTarget = id
                 }
+            }
+            ScrollViewReader { proxy in
                 ScrollView {
                     content()
                 }
                 .coordinateSpace(name: Self.coordSpace)
                 .onPreferenceChange(SpyOffsetKey.self) { offsets in
                     active = Self.activeSection(sections: sections, offsets: offsets)
+                }
+                .onChange(of: scrollTarget) { _, target in
+                    guard let target else { return }
+                    withAnimation(.easeInOut(duration: 0.25)) {
+                        proxy.scrollTo(target, anchor: .top)
+                    }
+                    scrollTarget = nil
                 }
             }
         }

--- a/web/ts/visualization/cross-section/advisory-presets.ts
+++ b/web/ts/visualization/cross-section/advisory-presets.ts
@@ -16,6 +16,12 @@
  * effect later (highlight a band, emphasize layers, pre-enable a Skew-T
  * overlay) is: add one optional field here + one field on {@link ResolvedView}
  * + one branch in the store applier — existing presets and call sites untouched.
+ *
+ * SYNC: the iOS app mirrors ADVISORY_PRESETS + ADVISORY_TO_PRESET (cross-section
+ * directives only) in
+ * app/flyfun-weather/flyfun-weather/Views/CrossSection/Layers/CrossSectionPresets.swift.
+ * Keep the lens set, labels/captions, groups/lines, and advisory→lens mapping in
+ * lockstep when editing here.
  */
 
 import type { LayerGroup } from '../types';

--- a/web/ts/visualization/cross-section/layer-registry.ts
+++ b/web/ts/visualization/cross-section/layer-registry.ts
@@ -256,6 +256,9 @@ const FOREFLIGHT_ENABLED: Record<string, boolean> = {
   'cruise-altitude': true,
 };
 
+// SYNC: the iOS app mirrors these layer presets (GRAMET / Windy / ForeFlight) in
+// app/flyfun-weather/flyfun-weather/Views/CrossSection/Layers/CrossSectionPresets.swift
+// (translated to iOS layer IDs). Keep the two in lockstep when editing presets.
 const PRESETS: Record<string, LayerPreset> = {
   gramet: {
     id: 'gramet',

--- a/web/ts/visualization/cross-section/layers/cloud-bands-factory.ts
+++ b/web/ts/visualization/cross-section/layers/cloud-bands-factory.ts
@@ -566,6 +566,8 @@ export const squareNwpCloudBandsLayer = cloudLayer({
   defaultEnabled: true,
 });
 
+// SYNC: the iOS app mirrors this source×style → layer-id mapping (and
+// parseCloudLayerId) in CrossSectionPresets.swift (cloudLayerId/parseCloudLayerId).
 /** Lookup table: which layer id corresponds to a given (source, style) combo. */
 export const CLOUD_LAYER_BY_AXES: Record<CloudSource, Record<CloudStyle, string>> = {
   dd: {


### PR DESCRIPTION
Nine UI tweaks to the iOS briefing viewer + cross-section, ported to match web behaviour where relevant. Color themes for the cross-section are split out into #320 for an independent agent.

## Changes
1. **Pack picker** — chip shows the run time (`D-0 · 14:05`) when another pack shares the same UTC day, so same-day runs are distinguishable (menu rows already showed full time).
2. **Advisory model badges** — `FlowLayout` instead of an evenly-spaced `LazyVGrid`; badges pack tightly and wrap to a second row instead of stretching one row.
3. **Scroll-spy nav** — tap-to-scroll was a silent no-op: `.id()` wasn't the outermost modifier on the anchor, so `ScrollViewReader.scrollTo` couldn't find it (scroll-position highlight still worked, masking it). `.id()` now applied last.
4. **Watch** — moved to the end of the Advisory tab, rendered as **markdown** (was an unreadable one-line chip row); dropped the cross-section deep-link (watch items are just a list to keep an eye on).
5. **Discussion** — decode `specific_concerns` and render **Synoptic / Specific Concerns / Trend / Watch** as markdown (was synoptic-only).
6. **Cross-section presets** — layer presets now carry real per-preset `enabledLayers` ported from the web (GRAMET/Windy/ForeFlight); added the advisory-lens family (Basic/Icing/Clouds/Convective/Turbulence/VFR/IFR) ported from the web, selectable in the config sheet and via an "On cross-section" chip on advisory cards.
7. **Cloud controls** — split the single 6-option dropdown into two independent controls: **Source** (DD/NWP) and **Style** (Soft/Natural/Square).
8. **Terrain** — always renders (force-on in the renderer); removed its config toggle, mirroring the web panel.
9. **iPhone landscape** — cross-section collapsed to a vertical sliver because `.aspectRatio(nil, .fit)` uses a Canvas's (nonexistent) intrinsic ratio. Portrait keeps 2:1; landscape fills.

## Sync / duplication note (item 6)
There is no shared runtime config for presets — the web presets are bundled TypeScript. The tables are **ported into Swift** (`CrossSectionPresets.swift`), the same pattern already used for the layer registry, translated to iOS layer IDs. Both sides carry reciprocal `SYNC:` comments:
- `CrossSectionPresets.swift` ↔ `web/ts/visualization/cross-section/layer-registry.ts` (PRESETS), `advisory-presets.ts` (ADVISORY_PRESETS / mapping), `layers/cloud-bands-factory.ts` (cloud source×style).

## Verification
- `xcodebuild` (Debug, iOS Simulator) **succeeds**, no warnings.
- ⚠️ **Items 3 and 9 are code-fixed but not live-tested**: the fixture repository doesn't provide digest/advisories/routeAnalyses/elevation, so mock mode can't render the advisory scroll-spy or the cross-section. Both fixes are canonical SwiftUI patterns; please confirm on device (scroll-spy pill tap jumps to section; iPhone landscape cross-section fills width).

🤖 Generated with [Claude Code](https://claude.com/claude-code)