### PR TITLE
ios(cross-section): split static scene from scrub cursor overlay (#303)

### DIFF
--- a/app/flyfun-weather/flyfun-weather/ViewModels/CrossSectionViewModel.swift
+++ b/app/flyfun-weather/flyfun-weather/ViewModels/CrossSectionViewModel.swift
@@ -9,9 +9,16 @@ final class CrossSectionViewModel {
     private(set) var enabledLayers: [String: Bool] = CrossSectionPresets.gramet
     /// Currently-applied advisory lens id (e.g. "icing"), or nil when none/Custom.
     private(set) var activeAdvisoryPreset: String?
+    /// Monotonic identity for `vizData`: bumped only when the data is rebuilt
+    /// (model/route/elevation change). `VizRouteData` is a deep value type with no
+    /// `Equatable` conformance, so the static cross-section scene keys its
+    /// `Equatable` redraw gate on this counter instead of diffing the whole struct
+    /// each scrub tick (#303).
+    private(set) var dataVersion: Int = 0
 
     func update(routeAnalyses: RouteAnalysesResponse, elevation: ElevationResponse?, model: String) {
         vizData = Self.extractVizData(from: routeAnalyses, model: model, elevation: elevation)
+        dataVersion += 1
     }
 
     func toggleLayer(_ id: String) {

--- a/app/flyfun-weather/flyfun-weather/Views/CrossSection/CrossSectionRenderer.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/CrossSection/CrossSectionRenderer.swift
@@ -14,7 +14,20 @@ struct CrossSectionRenderer {
         let opacity: Double
     }
 
+    /// Convenience: render the whole scene in one pass (static scene + dynamic
+    /// cursor/aircraft overlay). The live view splits these into two separate
+    /// Canvases so a scrub tick redraws only the cheap overlay (#303); this stays
+    /// for any single-pass caller (previews, snapshots).
     func render(context: inout GraphicsContext, size: CGSize) {
+        renderStatic(context: &context, size: size)
+        renderCursor(context: &context, size: size)
+    }
+
+    /// The static scene: sky, all enabled data layers, and the axes/grid. This is
+    /// the expensive pass (O(n_slots × subBlobs) gradient fills for the natural
+    /// cloud style) and must only re-run on data/model/layer/size change — never
+    /// on a scrub tick (#303). Does NOT draw the cursor or aircraft.
+    func renderStatic(context: inout GraphicsContext, size: CGSize) {
         let transform = CoordTransform(
             size: size,
             maxDistanceNm: data.totalDistanceNm,
@@ -42,6 +55,29 @@ struct CrossSectionRenderer {
             }
         }
 
+        // Axes and grid (drawn outside clip)
+        drawAxes(context: &context, transform: transform, data: data)
+    }
+
+    /// The dynamic overlay: the scrub cursor rule + the live aircraft marker.
+    /// Cheap (O(1)) so it can redraw every drag tick / GPS update without jank
+    /// (#303). Both are clipped to the plot area, matching the static pass.
+    func renderCursor(context: inout GraphicsContext, size: CGSize) {
+        guard selectedDistanceNm != nil || aircraftPosition != nil else { return }
+        let transform = CoordTransform(
+            size: size,
+            maxDistanceNm: data.totalDistanceNm,
+            maxAltitudeFt: data.flightCeilingFt
+        )
+        let skyRect = CGRect(
+            x: transform.plotArea.left,
+            y: transform.plotArea.top,
+            width: transform.plotArea.width,
+            height: transform.plotArea.height
+        )
+        var clipped = context
+        clipped.clip(to: Path(skyRect))
+
         // Selected-point indicator (drawn inside clip so it stays in plot area)
         if let selectedNm = selectedDistanceNm {
             let x = transform.distanceToX(selectedNm)
@@ -55,9 +91,6 @@ struct CrossSectionRenderer {
         if let aircraft = aircraftPosition {
             drawAircraft(context: &clipped, transform: transform, position: aircraft)
         }
-
-        // Axes and grid (drawn outside clip)
-        drawAxes(context: &context, transform: transform, data: data)
     }
 
     // MARK: - Axes drawing

--- a/app/flyfun-weather/flyfun-weather/Views/CrossSection/CrossSectionScene.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/CrossSection/CrossSectionScene.swift
@@ -1,0 +1,56 @@
+import SwiftUI
+
+/// The static cross-section scene: sky, all enabled data layers, and axes/grid.
+///
+/// This is the heavy render pass — the natural cloud style alone draws
+/// O(n_slots × subBlobsPerSlot) radial-gradient fills per band per segment
+/// (~400+ gradient fills on a typical route). It must redraw only when the data,
+/// model, layer set, or canvas size changes — NOT on every scrub drag tick
+/// (~60 fps), which used to re-run the whole stack and jank older A-series chips
+/// (#303).
+///
+/// The redraw gate is `Equatable`: SwiftUI skips re-evaluating this view (and so
+/// re-running the inner `Canvas` closure) when `==` reports no change. We key on
+/// the view model's monotonic `dataVersion` rather than diffing the deep
+/// `VizRouteData` value each tick. A frame/size change still re-runs the closure
+/// — the `Canvas`'s own `size` input changes — which is exactly the "rebuild on
+/// size change" behaviour we want. The cursor and aircraft are deliberately NOT
+/// drawn here; they live in `CrossSectionCursorOverlay`.
+struct StaticCrossSectionScene: View, Equatable {
+    let data: VizRouteData
+    let enabledLayers: [String: Bool]
+    /// Identity for `data` (bumped by `CrossSectionViewModel.update`). Comparing
+    /// this int + the small layer dict is cheap; diffing `VizRouteData` is not.
+    let dataVersion: Int
+
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.dataVersion == rhs.dataVersion && lhs.enabledLayers == rhs.enabledLayers
+    }
+
+    var body: some View {
+        Canvas { context, size in
+            CrossSectionRenderer(data: data, enabledLayers: enabledLayers)
+                .renderStatic(context: &context, size: size)
+        }
+    }
+}
+
+/// The dynamic cross-section overlay: the scrub cursor rule + the live aircraft
+/// marker. Drawn in its own `Canvas` so a scrub tick or GPS update redraws only
+/// these O(1) primitives, leaving the cached static scene untouched (#303).
+/// Non-interactive — the scrub gesture lives on the static scene beneath it.
+struct CrossSectionCursorOverlay: View {
+    let data: VizRouteData
+    let cursorDistanceNm: Double?
+    let aircraft: CrossSectionRenderer.AircraftPosition?
+
+    var body: some View {
+        Canvas { context, size in
+            CrossSectionRenderer(data: data, enabledLayers: [:],
+                                 selectedDistanceNm: cursorDistanceNm,
+                                 aircraftPosition: aircraft)
+                .renderCursor(context: &context, size: size)
+        }
+        .allowsHitTesting(false)
+    }
+}

--- a/app/flyfun-weather/flyfun-weather/Views/CrossSection/CrossSectionScene.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/CrossSection/CrossSectionScene.swift
@@ -9,13 +9,16 @@ import SwiftUI
 /// (~60 fps), which used to re-run the whole stack and jank older A-series chips
 /// (#303).
 ///
-/// The redraw gate is `Equatable`: SwiftUI skips re-evaluating this view (and so
-/// re-running the inner `Canvas` closure) when `==` reports no change. We key on
-/// the view model's monotonic `dataVersion` rather than diffing the deep
-/// `VizRouteData` value each tick. A frame/size change still re-runs the closure
-/// — the `Canvas`'s own `size` input changes — which is exactly the "rebuild on
-/// size change" behaviour we want. The cursor and aircraft are deliberately NOT
-/// drawn here; they live in `CrossSectionCursorOverlay`.
+/// The redraw gate is `Equatable` + `.equatable()` at the call site: that pairing
+/// forces SwiftUI to skip re-evaluating this view (and so re-running the inner
+/// `Canvas` closure) when `==` reports no change. Conformance alone is not enough
+/// — without `.equatable()` the reconciler reflects the stored properties, can't
+/// compare the non-`Equatable` `VizRouteData`, and treats the view as changed
+/// every tick. We key `==` on the view model's monotonic `dataVersion` rather than
+/// diffing the deep `VizRouteData` value each tick. A frame/size change still
+/// re-runs the closure — the `Canvas`'s own `size` input changes — which is
+/// exactly the "rebuild on size change" behaviour we want. The cursor and aircraft
+/// are deliberately NOT drawn here; they live in `CrossSectionCursorOverlay`.
 struct StaticCrossSectionScene: View, Equatable {
     let data: VizRouteData
     let enabledLayers: [String: Bool]

--- a/app/flyfun-weather/flyfun-weather/Views/CrossSection/CrossSectionView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/CrossSection/CrossSectionView.swift
@@ -193,22 +193,25 @@ struct CrossSectionView: View {
             let cursor = scrubDistanceNm ?? activePointDistanceNm
             let layers = csVM.enabledLayers
 
-            Canvas { context, size in
-                CrossSectionRenderer(data: vizData, enabledLayers: layers,
-                                     selectedDistanceNm: cursor,
-                                     aircraftPosition: aircraft)
-                    .render(context: &context, size: size)
-            }
-            .frame(minHeight: 300)
-            // Portrait constrains to a 2:1 artifact; landscape fills the screen.
-            // (Passing `nil` to aspectRatio means "use intrinsic ratio" — a
-            // Canvas has none, which collapsed the chart to a sliver. #9)
-            .modifier(CanvasAspectModifier(landscape: isLandscapeFocus))
-            .background(GeometryReader { geo in
-                Color.clear.onAppear { canvasSize = geo.size }
-                    .onChange(of: geo.size) { _, newSize in canvasSize = newSize }
-            })
-            .gesture(scrubGesture)
+            // Static scene (sky + cloud bands + axes) is the expensive pass and is
+            // gated behind an `Equatable` key so a scrub tick — which only changes
+            // `cursor`/`aircraft` — does NOT re-run its ~400 gradient fills. The
+            // thin cursor rule + aircraft marker live in a cheap overlay Canvas
+            // that redraws every tick instead (#303).
+            StaticCrossSectionScene(data: vizData, enabledLayers: layers, dataVersion: csVM.dataVersion)
+                .frame(minHeight: 300)
+                // Portrait constrains to a 2:1 artifact; landscape fills the screen.
+                // (Passing `nil` to aspectRatio means "use intrinsic ratio" — a
+                // Canvas has none, which collapsed the chart to a sliver. #9)
+                .modifier(CanvasAspectModifier(landscape: isLandscapeFocus))
+                .overlay {
+                    CrossSectionCursorOverlay(data: vizData, cursorDistanceNm: cursor, aircraft: aircraft)
+                }
+                .background(GeometryReader { geo in
+                    Color.clear.onAppear { canvasSize = geo.size }
+                        .onChange(of: geo.size) { _, newSize in canvasSize = newSize }
+                })
+                .gesture(scrubGesture)
         } else {
             switch viewModel.routeAnalysesState {
             case .idle, .loading:

--- a/app/flyfun-weather/flyfun-weather/Views/CrossSection/CrossSectionView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/CrossSection/CrossSectionView.swift
@@ -199,6 +199,12 @@ struct CrossSectionView: View {
             // thin cursor rule + aircraft marker live in a cheap overlay Canvas
             // that redraws every tick instead (#303).
             StaticCrossSectionScene(data: vizData, enabledLayers: layers, dataVersion: csVM.dataVersion)
+                // `.equatable()` is load-bearing: it forces SwiftUI to gate the
+                // redraw on the custom `==` (dataVersion + layers). Without it the
+                // reconciler falls back to reflecting the stored properties, can't
+                // compare the non-Equatable `VizRouteData`, and redraws every scrub
+                // tick — defeating the split (#303). Do not remove.
+                .equatable()
                 .frame(minHeight: 300)
                 // Portrait constrains to a 2:1 artifact; landscape fills the screen.
                 // (Passing `nil` to aspectRatio means "use intrinsic ratio" — a


### PR DESCRIPTION
Fixes the cross-section scrub jank from #303 (deferred from the PR #297 review).

## Problem
`CrossSectionView`'s single `Canvas` re-rendered the **whole** layer stack whenever `scrubDistanceNm` changed — i.e. every drag tick (~60fps). The natural cloud style draws O(n_slots × subBlobsPerSlot) radial-gradient fills per band per segment (~400+ gradient fills/tick on a typical route). The scrub cursor is a thin dynamic overlay over an otherwise static scene, but everything repainted each tick → jank on older A-series chips.

## Fix
Separate the static layer from the dynamic cursor overlay, as the issue suggested:

- **`StaticCrossSectionScene`** (`View & Equatable`) — sky + all enabled data layers + axes/grid. The expensive pass. Its `Equatable` gate keys on a new monotonic `dataVersion` (bumped only in `CrossSectionViewModel.update`, i.e. model/route/elevation change) plus the layer dict, so SwiftUI skips re-running the `Canvas` closure on a scrub tick. `VizRouteData` is a deep value type with no `Equatable`, hence the cheap version int instead of diffing the struct each tick. A frame/size change still re-runs the closure (the `Canvas`'s own `size` input changes) — exactly the "rebuild on resize" behaviour we want.
- **`CrossSectionCursorOverlay`** — the scrub cursor rule + live aircraft marker. O(1), `allowsHitTesting(false)` so the scrub gesture on the static scene beneath still works. Redraws every tick — but it's now cheap.

`CrossSectionRenderer.render` is split into `renderStatic` / `renderCursor`; the combined `render` stays for any single-pass caller (previews/snapshots).

Note (from the issue): this cursor-in-the-layer-Canvas pattern was shared with the alternative #299 implementation too.

## Verification
- `xcodebuild` (generic iOS Simulator, Debug) — **BUILD SUCCEEDED**.
- No data-path/logic change beyond the `dataVersion` bump; no test references the renderer or the counter.
- Visual parity (static scene identical, cursor/aircraft unchanged) wants a device/simulator eyeball — flagged as a human checkpoint since mock mode can't render the cross-section.

Closes #303.

🤖 Generated with [Claude Code](https://claude.com/claude-code)