### PR TITLE
ios(cross-section): color Theme system ported from web (#320)

### DIFF
--- a/app/flyfun-weather/flyfun-weather/ViewModels/CrossSectionViewModel.swift
+++ b/app/flyfun-weather/flyfun-weather/ViewModels/CrossSectionViewModel.swift
@@ -15,6 +15,24 @@ final class CrossSectionViewModel {
     /// `Equatable` redraw gate on this counter instead of diffing the whole struct
     /// each scrub tick (#303).
     private(set) var dataVersion: Int = 0
+    /// Active cross-section colour theme (#320). Defaults to GRAMET to match the
+    /// booted GRAMET layer preset above, so the chart and the preset agree on
+    /// boot. Theme is orthogonal to the layer preset (changing one doesn't reset
+    /// the other) — mirrors the web, where `setVizTheme` leaves the preset alone.
+    private(set) var themeId: CrossSectionThemeID = .gramet
+
+    init() {
+        // Sync the module-level active theme to our boot default so the very
+        // first frame (and the config sheet's legend swatches) render in the
+        // right palette even before the renderer runs.
+        CrossSectionTheme.setActive(themeId)
+    }
+
+    /// Switch the colour theme. Independent of the layer preset.
+    func setTheme(_ id: CrossSectionThemeID) {
+        themeId = id
+        CrossSectionTheme.setActive(id)
+    }
 
     func update(routeAnalyses: RouteAnalysesResponse, elevation: ElevationResponse?, model: String) {
         vizData = Self.extractVizData(from: routeAnalyses, model: model, elevation: elevation)
@@ -42,11 +60,24 @@ final class CrossSectionViewModel {
         case foreFlight = "ForeFlight"
         case custom = "Custom"
         var id: String { rawValue }
+
+        /// The colour theme each preset carries (#320). Mirrors the web preset
+        /// `themeId` mapping (gramet→gramet, windy→light, foreflight→high-contrast);
+        /// Custom carries none (leave the current theme as-is).
+        var themeId: CrossSectionThemeID? {
+            switch self {
+            case .gramet: .gramet
+            case .windy: .light
+            case .foreFlight: .highContrast
+            case .custom: nil
+            }
+        }
     }
 
     func applyPreset(_ preset: Preset) {
         let map = presetMap(preset)
         if !map.isEmpty { enabledLayers = map }
+        if let tid = preset.themeId { setTheme(tid) }
         activeAdvisoryPreset = nil
     }
 

--- a/app/flyfun-weather/flyfun-weather/Views/CrossSection/ColorScales.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/CrossSection/ColorScales.swift
@@ -14,46 +14,47 @@ struct RGBA: Sendable {
     func withAlpha(_ alpha: Double) -> Color { Color(.sRGB, red: r, green: g, blue: b, opacity: alpha) }
 }
 
-/// Color functions for cross-section layers. Port of web's scales.ts.
+/// Colour functions for cross-section layers. Port of web's scales.ts.
+///
+/// Every colour reads through `CrossSectionTheme.active` so a single theme
+/// switch recolours the whole chart (mirrors web's `getActiveTheme()`). The
+/// function/property names and signatures are unchanged from the pre-theme
+/// version so all call sites stay put — only the bodies now defer to the theme.
 nonisolated enum ColorScales {
+    private static var theme: CrossSectionTheme { CrossSectionTheme.active }
+
     // MARK: - Icing risk
 
     static func icingRiskColor(_ risk: String) -> Color {
-        switch risk {
-        case "light": Color(.sRGB, red: 0.4, green: 0.6, blue: 1.0, opacity: 0.35)
-        case "moderate": Color(.sRGB, red: 1.0, green: 0.6, blue: 0.2, opacity: 0.45)
-        case "severe": Color(.sRGB, red: 1.0, green: 0.2, blue: 0.2, opacity: 0.55)
-        default: .clear
-        }
+        theme.icing[risk] ?? .clear
     }
 
     // MARK: - CAT risk
 
     static func catRiskColor(_ risk: String) -> Color {
-        switch risk {
-        case "light": Color(.sRGB, red: 1.0, green: 0.75, blue: 0.0, opacity: 0.20)
-        case "moderate": Color(.sRGB, red: 1.0, green: 0.65, blue: 0.0, opacity: 0.40)
-        case "severe": Color(.sRGB, red: 1.0, green: 0.2, blue: 0.2, opacity: 0.55)
-        default: .clear
-        }
+        theme.cat[risk] ?? .clear
     }
 
     // MARK: - Cloud fill from dewpoint depression
 
     /// RGBA components (0–1) for a DD-sourced cloud fill. Faithful port of the
-    /// web Standard theme `cloudFillFromDD`: dense gray (saturated, low DD) →
-    /// near-white (dry, high DD), interpolated by DD; alpha per coverage class.
+    /// web `cloudFillFromDD`: dense (saturated, low DD) → thin (dry, high DD),
+    /// interpolated by DD; alpha per coverage class.
     static func cloudRGBA(dewpointDepressionC: Double?, coverage: String) -> RGBA {
+        let t = theme
+        let (lo, hi) = t.cloudCoverageAlpha[coverage.lowercased()] ?? (0.30, 0.65)
         guard let dd = dewpointDepressionC else {
             // fallbackGray + the class's upper alpha (web behaviour for nil DD).
-            return RGBA(r: 180 / 255.0, g: 180 / 255.0, b: 185 / 255.0, a: coverageAlphaRange(coverage).hi)
+            let g = t.cloudFallbackGray
+            return RGBA(r: g.r / 255.0, g: g.g / 255.0, b: g.b / 255.0, a: hi)
         }
-        let t = min(max(dd / 3.0, 0), 1.0)
+        let f = min(max(dd / 3.0, 0), 1.0)
+        let d = t.cloudDense, th = t.cloudThin
         return RGBA(
-            r: (140 + 110 * t) / 255.0,   // denseRgb[140,140,150] → thinRgb[250,250,255]
-            g: (140 + 110 * t) / 255.0,
-            b: (150 + 105 * t) / 255.0,
-            a: coverageAlpha(coverage, t: t)
+            r: (d.r + (th.r - d.r) * f) / 255.0,
+            g: (d.g + (th.g - d.g) * f) / 255.0,
+            b: (d.b + (th.b - d.b) * f) / 255.0,
+            a: hi - (hi - lo) * f   // denser (hi) when saturated, lighter (lo) when dry
         )
     }
 
@@ -61,58 +62,45 @@ nonisolated enum ColorScales {
         cloudRGBA(dewpointDepressionC: dewpointDepressionC, coverage: coverage).color
     }
 
-    /// Per-coverage [lo, hi] alpha bounds (web Standard theme `clouds.coverageAlpha`).
-    private static func coverageAlphaRange(_ coverage: String) -> (lo: Double, hi: Double) {
-        switch coverage.lowercased() {
-        case "few": return (0.20, 0.35)
-        case "sct": return (0.50, 0.65)
-        case "bkn": return (0.60, 0.88)
-        case "ovc": return (0.70, 0.95)
-        default: return (0.30, 0.65)
-        }
-    }
-
-    /// Alpha from coverage class, denser (hi) when saturated, lighter (lo) when
-    /// dry. Mirrors web `coverageAlpha`: `hi - (hi - lo) * t`.
-    private static func coverageAlpha(_ coverage: String, t: Double) -> Double {
-        let r = coverageAlphaRange(coverage)
-        return r.hi - (r.hi - r.lo) * t
-    }
-
     // MARK: - Inversion
 
     static func inversionOpacity(_ strengthC: Double) -> Double {
-        let clamped = min(max(strengthC / 3.0, 0), 1.0)
-        return 0.15 + 0.50 * clamped
+        let t = theme
+        let clamped = min(max(strengthC / t.inversionMaxStrengthC, 0), 1.0)
+        return min(t.inversionFloor + t.inversionScale * clamped, t.inversionCap)
     }
 
-    static let inversionColor = Color(.sRGB, red: 233 / 255.0, green: 30 / 255.0, blue: 99 / 255.0)
+    static var inversionColor: Color { theme.inversionBase.color() }
 
     // MARK: - Terrain
 
-    static let terrainFill = Color(.sRGB, red: 139 / 255.0, green: 115 / 255.0, blue: 85 / 255.0)
-    static let terrainStroke = Color(.sRGB, red: 107 / 255.0, green: 91 / 255.0, blue: 69 / 255.0)
+    static var terrainFill: Color { theme.terrainFill.color() }
+    static var terrainStroke: Color { theme.terrainStroke.color() }
 
     // MARK: - Temperature lines
 
-    static let freezingLevelColor = Color(.sRGB, red: 0, green: 188 / 255.0, blue: 212 / 255.0)
-    static let minus10cColor = Color(.sRGB, red: 33 / 255.0, green: 150 / 255.0, blue: 243 / 255.0)
-    static let minus20cColor = Color(.sRGB, red: 26 / 255.0, green: 35 / 255.0, blue: 126 / 255.0)
+    static var freezingLevelColor: Color { theme.freezingLevel }
+    static var minus10cColor: Color { theme.minus10c }
+    static var minus20cColor: Color { theme.minus20c }
 
     // MARK: - Reference
 
-    static let cruiseAltitudeColor = Color(.sRGB, red: 0.2, green: 0.2, blue: 0.2, opacity: 0.7)
+    static var cruiseAltitudeColor: Color { theme.cruise }
+    static var ceilingColor: Color { theme.ceiling }
+
+    // MARK: - Axes (grid + waypoint lines drawn over the sky)
+
+    static var gridColor: Color { theme.axisGrid }
+    static var waypointLineColor: Color { theme.axisWaypoint }
 
     // MARK: - Sky background
 
-    /// Web Standard theme sky (#7395DB). The previous light-cyan (#87CEEB) sky
-    /// washed out the whitish clouds — the Standard palette's cloud colours are
-    /// tuned for this periwinkle blue.
-    static let skyBlue = Color(.sRGB, red: 115 / 255.0, green: 149 / 255.0, blue: 219 / 255.0)
+    static var skyBlue: Color { theme.skyBackground }
 
-    // MARK: - NWP cloud (model-percentage-derived, blue-tinted)
+    // MARK: - NWP cloud (model-percentage-derived)
 
-    /// Map METAR coverage class to a representative percentage.
+    /// Map METAR coverage class to a representative percentage. (Not themed —
+    /// this is a data mapping, not a colour.)
     static func coverageToPct(_ coverage: String) -> Double {
         switch coverage.uppercased() {
         case "OVC": return 90
@@ -124,128 +112,80 @@ nonisolated enum ColorScales {
     }
 
     /// RGBA components (0–1) for an NWP cover%-derived cloud fill. Mirrors web
-    /// `nwpCloudFill`.
+    /// `nwpCloudFill`: bright (low cover) → bright−delta (high cover).
     static func nwpCloudRGBA(pct: Double) -> RGBA {
-        // Web Standard theme `nwpCloudFill`: near-white (low cover) → gray (high
-        // cover); alpha 0.30→0.85. brightRgb[245,245,255] − deltaRgb[105,105,100]·t.
-        let t = min(1.0, max(0.0, pct / 100.0))
+        let t = theme
+        let f = min(1.0, max(0.0, pct / 100.0))
         return RGBA(
-            r: (245 - 105 * t) / 255.0,
-            g: (245 - 105 * t) / 255.0,
-            b: (255 - 100 * t) / 255.0,
-            a: 0.30 + 0.55 * t
+            r: (t.nwpBright.r - t.nwpDelta.r * f) / 255.0,
+            g: (t.nwpBright.g - t.nwpDelta.g * f) / 255.0,
+            b: (t.nwpBright.b - t.nwpDelta.b * f) / 255.0,
+            a: t.nwpOpacityFloor + t.nwpOpacityScale * f
         )
     }
 
-    /// Blue-tinted fill from coverage percentage. Distinct hue from DD cloud layers
-    /// so users can tell NWP and DD methods apart at a glance.
+    /// Distinct hue from DD cloud layers so users can tell NWP and DD methods apart.
     static func nwpCloudFill(pct: Double) -> Color {
         nwpCloudRGBA(pct: pct).color
     }
 
     // MARK: - Stability lines (LCL / LFC / EL)
-    // Colours mirror the web cross-section theme `stability` block so parcel
-    // levels read identically across clients.
 
-    static let lclColor = Color(.sRGB, red: 76 / 255.0, green: 175 / 255.0, blue: 80 / 255.0)   // #4caf50
-    static let lfcColor = Color(.sRGB, red: 255 / 255.0, green: 152 / 255.0, blue: 0 / 255.0)   // #ff9800
-    static let elColor = Color(.sRGB, red: 244 / 255.0, green: 67 / 255.0, blue: 54 / 255.0)    // #f44336
+    static var lclColor: Color { theme.lcl }
+    static var lfcColor: Color { theme.lfc }
+    static var elColor: Color { theme.el }
 
     // MARK: - Soft cloud (GRAMET-style feathered fill)
 
     /// Coverage → fill alpha at the band's solid centre.
     static func softCloudCenterAlpha(_ coverage: String) -> Double {
-        switch coverage.uppercased() {
-        case "OVC": return 0.85
-        case "BKN": return 0.65
-        case "SCT": return 0.45
-        case "FEW": return 0.15
-        default: return 0.50
-        }
+        theme.softCloudCoverageAlpha[coverage.uppercased()] ?? 0.50
     }
 
     /// Fade fraction at top and bottom edges for soft-cloud bands.
-    static let softCloudFeatherFraction: Double = 0.15
+    static var softCloudFeatherFraction: Double { theme.softCloudFeather }
 
-    /// Base RGB for soft cloud fills (white-ish).
-    static let softCloudFillRGB: (Double, Double, Double) = (255 / 255.0, 255 / 255.0, 255 / 255.0)
+    /// Base RGB (0–1) for soft cloud fills.
+    static var softCloudFillRGB: (Double, Double, Double) {
+        let f = theme.softCloudFill
+        return (f.r / 255.0, f.g / 255.0, f.b / 255.0)
+    }
 
     // MARK: - SFIP icing
 
     static func sfipRiskColor(_ risk: String) -> Color {
-        switch risk {
-        case "light": Color(.sRGB, red: 0.45, green: 0.7, blue: 1.0, opacity: 0.40)
-        case "moderate": Color(.sRGB, red: 1.0, green: 0.55, blue: 0.0, opacity: 0.50)
-        case "severe": Color(.sRGB, red: 0.85, green: 0.1, blue: 0.55, opacity: 0.55)
-        default: .clear
-        }
+        theme.sfipIcing[risk] ?? .clear
     }
 
     // MARK: - Convective tower palette
 
     /// Subtle full-height column wash behind the tower for situational awareness.
     static func convectiveBgWash(_ risk: String) -> Color {
-        switch risk {
-        case "low": Color(.sRGB, red: 1.0, green: 0.95, blue: 0.6, opacity: 0.08)
-        case "moderate": Color(.sRGB, red: 1.0, green: 0.7, blue: 0.0, opacity: 0.10)
-        case "high": Color(.sRGB, red: 1.0, green: 0.2, blue: 0.2, opacity: 0.12)
-        case "extreme": Color(.sRGB, red: 0.6, green: 0.0, blue: 0.5, opacity: 0.15)
-        default: .clear
-        }
+        theme.convBgWash[risk] ?? .clear
     }
 
     /// Tower body fill colour (LCL/base → EL/top).
     static func convectiveTowerFill(_ risk: String) -> Color {
-        switch risk {
-        case "low": Color(.sRGB, red: 1.0, green: 0.9, blue: 0.4, opacity: 0.30)
-        case "moderate": Color(.sRGB, red: 1.0, green: 0.6, blue: 0.0, opacity: 0.40)
-        case "high": Color(.sRGB, red: 1.0, green: 0.2, blue: 0.2, opacity: 0.50)
-        case "extreme": Color(.sRGB, red: 0.55, green: 0.0, blue: 0.45, opacity: 0.55)
-        default: .clear
-        }
+        theme.convTowerFill[risk] ?? .clear
     }
 
     /// Diagonal hatching colour, drawn inside the tower.
     static func convectiveHatchColor(_ risk: String) -> Color {
-        switch risk {
-        case "low": Color(.sRGB, red: 0.85, green: 0.65, blue: 0.0, opacity: 0.35)
-        case "moderate": Color(.sRGB, red: 0.85, green: 0.40, blue: 0.0, opacity: 0.50)
-        case "high": Color(.sRGB, red: 0.7, green: 0.05, blue: 0.05, opacity: 0.60)
-        case "extreme": Color(.sRGB, red: 0.35, green: 0.0, blue: 0.35, opacity: 0.65)
-        default: .clear
-        }
+        theme.convHatch[risk] ?? .clear
     }
 
     /// Rectangle outline around the tower body.
     static func convectiveEdgeColor(_ risk: String) -> Color {
-        switch risk {
-        case "low": Color(.sRGB, red: 0.7, green: 0.55, blue: 0.0, opacity: 0.6)
-        case "moderate": Color(.sRGB, red: 0.85, green: 0.4, blue: 0.0, opacity: 0.7)
-        case "high": Color(.sRGB, red: 0.7, green: 0.1, blue: 0.1, opacity: 0.8)
-        case "extreme": Color(.sRGB, red: 0.4, green: 0.0, blue: 0.4, opacity: 0.85)
-        default: .clear
-        }
+        theme.convEdge[risk] ?? .clear
     }
 
     /// Anvil strip colour at tower top.
     static func convectiveStripColor(_ risk: String) -> Color {
-        switch risk {
-        case "low": Color(.sRGB, red: 0.85, green: 0.7, blue: 0.0, opacity: 0.6)
-        case "moderate": Color(.sRGB, red: 0.85, green: 0.45, blue: 0.0, opacity: 0.75)
-        case "high": Color(.sRGB, red: 0.7, green: 0.1, blue: 0.1, opacity: 0.8)
-        case "extreme": Color(.sRGB, red: 0.4, green: 0.0, blue: 0.4, opacity: 0.85)
-        default: .clear
-        }
+        theme.convStrip[risk] ?? .clear
     }
 
     /// Pill-label text colour (TCU/CB/+TS).
     static func convectiveCBLabelColor(_ risk: String) -> Color {
-        switch risk {
-        case "low": Color(.sRGB, red: 0.6, green: 0.45, blue: 0.0, opacity: 0.9)
-        case "moderate": Color(.sRGB, red: 0.7, green: 0.35, blue: 0.0, opacity: 0.95)
-        case "high": Color(.sRGB, red: 0.65, green: 0.1, blue: 0.1, opacity: 1.0)
-        case "extreme": Color(.sRGB, red: 0.4, green: 0.0, blue: 0.4, opacity: 1.0)
-        default: .gray
-        }
+        theme.convCBLabel[risk] ?? .gray
     }
 }

--- a/app/flyfun-weather/flyfun-weather/Views/CrossSection/CrossSectionConfigSheet.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/CrossSection/CrossSectionConfigSheet.swift
@@ -15,6 +15,7 @@ struct CrossSectionConfigSheet: View {
         NavigationStack {
             List {
                 presetSection
+                themeSection
                 advisoryLensSection
                 methodSection
                 referenceSection
@@ -53,6 +54,30 @@ struct CrossSectionConfigSheet: View {
             Text("Preset")
         } footer: {
             Text("A preset sets every layer. Changing any control below switches to Custom.")
+        }
+    }
+
+    // MARK: Theme — colours only (orthogonal to the layer Preset, #320)
+
+    private var themeSection: some View {
+        Section {
+            Picker("Theme", selection: Binding(
+                get: { csVM.themeId },
+                set: { csVM.setTheme($0) }
+            )) {
+                ForEach(CrossSectionThemeID.allCases) { id in
+                    HStack {
+                        swatch(id.theme.skyBackground)
+                        Text(id.theme.label)
+                    }
+                    .tag(id)
+                }
+            }
+            .pickerStyle(.menu)
+        } header: {
+            Text("Theme")
+        } footer: {
+            Text("Colours only — independent of the Preset. Selecting a Preset also sets its matching theme.")
         }
     }
 

--- a/app/flyfun-weather/flyfun-weather/Views/CrossSection/CrossSectionRenderer.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/CrossSection/CrossSectionRenderer.swift
@@ -6,6 +6,10 @@ struct CrossSectionRenderer {
     let enabledLayers: [String: Bool]
     var selectedDistanceNm: Double?
     var aircraftPosition: AircraftPosition?
+    /// Active colour theme (#320). The renderer pins the module-level active
+    /// theme to this before drawing so every `ColorScales` lookup in the layer
+    /// stack resolves against the same theme for the whole frame.
+    var themeId: CrossSectionThemeID = .gramet
 
     /// Lightweight position data for rendering the aircraft icon on the cross-section.
     struct AircraftPosition {
@@ -28,6 +32,13 @@ struct CrossSectionRenderer {
     /// cloud style) and must only re-run on data/model/layer/size change — never
     /// on a scrub tick (#303). Does NOT draw the cursor or aircraft.
     func renderStatic(context: inout GraphicsContext, size: CGSize) {
+        // Writing the shared active theme is only safe on the main actor (see the
+        // `_active` note in CrossSectionTheme). The Canvas closure always runs on
+        // the main actor; this asserts that invariant in debug so a future
+        // off-main caller (e.g. a background snapshot render) trips immediately
+        // rather than racing silently. (#320)
+        MainActor.assertIsolated("CrossSectionRenderer.renderStatic must run on the main actor")
+        CrossSectionTheme.setActive(themeId)
         let transform = CoordTransform(
             size: size,
             maxDistanceNm: data.totalDistanceNm,
@@ -97,7 +108,11 @@ struct CrossSectionRenderer {
 
     private func drawAxes(context: inout GraphicsContext, transform: CoordTransform, data: VizRouteData) {
         let plot = transform.plotArea
-        let gridColor = Color.gray.opacity(0.2)
+        // Grid lines cross the (themed) sky, so the grid colour is theme-driven
+        // — white-ish on the coloured skies, dark on the Light theme. Tick
+        // labels sit outside the plot on the app background, so they stay
+        // `.primary`.
+        let gridColor = ColorScales.gridColor
         let textColor = Color.primary
 
         // Plot border
@@ -152,7 +167,7 @@ struct CrossSectionRenderer {
             var wpPath = Path()
             wpPath.move(to: CGPoint(x: x, y: plot.top))
             wpPath.addLine(to: CGPoint(x: x, y: plot.bottom))
-            context.stroke(wpPath, with: .color(Color.gray.opacity(0.4)), style: StrokeStyle(lineWidth: 0.5, dash: [4, 4]))
+            context.stroke(wpPath, with: .color(ColorScales.waypointLineColor), style: StrokeStyle(lineWidth: 0.5, dash: [4, 4]))
 
             let text = context.resolve(Text(wp.icao).font(.system(size: 8, weight: .bold)).foregroundColor(textColor))
             context.draw(text, at: CGPoint(x: x, y: plot.top - 4), anchor: .bottom)

--- a/app/flyfun-weather/flyfun-weather/Views/CrossSection/CrossSectionScene.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/CrossSection/CrossSectionScene.swift
@@ -24,6 +24,10 @@ struct StaticCrossSectionScene: View, Equatable {
     /// Identity for `data` (bumped by `CrossSectionViewModel.update`). Comparing
     /// this int + the small layer dict is cheap; diffing `VizRouteData` is not.
     let dataVersion: Int
+    /// Active colour theme (#320). Part of `==` so switching themes repaints the
+    /// static layers/sky/axes — otherwise the gate would skip the redraw and only
+    /// the cursor overlay (which doesn't read the theme) would update.
+    let themeId: CrossSectionThemeID
     /// Rendered canvas size, fed from the call site's `GeometryReader`. Included
     /// in `==` so a rotation/resize is a real change and forces a redraw, rather
     /// than relying on the undocumented behaviour of `Canvas` re-running its
@@ -32,13 +36,14 @@ struct StaticCrossSectionScene: View, Equatable {
 
     static func == (lhs: Self, rhs: Self) -> Bool {
         lhs.dataVersion == rhs.dataVersion
+            && lhs.themeId == rhs.themeId
             && lhs.renderSize == rhs.renderSize
             && lhs.enabledLayers == rhs.enabledLayers
     }
 
     var body: some View {
         Canvas { context, size in
-            CrossSectionRenderer(data: data, enabledLayers: enabledLayers)
+            CrossSectionRenderer(data: data, enabledLayers: enabledLayers, themeId: themeId)
                 .renderStatic(context: &context, size: size)
         }
     }

--- a/app/flyfun-weather/flyfun-weather/Views/CrossSection/CrossSectionTheme.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/CrossSection/CrossSectionTheme.swift
@@ -1,0 +1,468 @@
+import SwiftUI
+
+// =============================================================================
+// SYNC — mirrors web/ts/visualization/cross-section/theme.ts
+//   • Keep theme IDs identical ("standard" / "high-contrast" / "gramet" /
+//     "light") so a route renders with visually matching colours on both
+//     platforms and the two files can be diffed.
+//   • Port colour VALUES verbatim from the web themes. Widths/dashes for the
+//     temperature/stability/reference lines are NOT themed on iOS (the line
+//     layers hardcode them) — only colours are, per #320.
+//   • Web-only theme fields with no iOS layer yet are intentionally not ported:
+//     nightShading, obscuration, compareModelColors, coverageOpacity, sld.
+//     Add them here (and the matching layer) when iOS grows those layers.
+// =============================================================================
+
+/// 0–255 RGB triple, the unit the web theme stores cloud / terrain / inversion
+/// colours in (cloud fills interpolate between two RGBs, so the raw channels are
+/// kept rather than pre-baked `Color`s).
+struct RGB: Sendable {
+    let r: Double
+    let g: Double
+    let b: Double
+    func color(_ alpha: Double = 1) -> Color {
+        Color(.sRGB, red: r / 255, green: g / 255, blue: b / 255, opacity: alpha)
+    }
+}
+
+/// Built-in cross-section colour themes. Raw values match the web `ThemeId`
+/// union so persisted prefs and the preset `themeId` map cross platforms.
+enum CrossSectionThemeID: String, CaseIterable, Identifiable, Sendable {
+    case standard
+    case highContrast = "high-contrast"
+    case gramet
+    case light
+    var id: String { rawValue }
+
+    /// The theme for this ID. Always present — `CrossSectionTheme.all` is keyed
+    /// by every case — so call sites don't need to unwrap. Falls back to
+    /// `.standard` only to stay total.
+    var theme: CrossSectionTheme { CrossSectionTheme.all[self] ?? .standard }
+}
+
+/// A complete cross-section colour theme. Mirrors the web `CrossSectionTheme`
+/// interface, trimmed to the fields iOS layers actually render. Fields are `var`
+/// so derived themes can be built by copy-and-override (the web `{...STANDARD}`
+/// spread pattern).
+struct CrossSectionTheme: Sendable {
+    var id: CrossSectionThemeID
+    var label: String
+
+    // Sky + axes
+    var skyBackground: Color
+    var axisGrid: Color
+    var axisWaypoint: Color
+
+    // Terrain
+    var terrainFill: RGB
+    var terrainStroke: RGB
+
+    // Temperature isotherm line colours
+    var freezingLevel: Color
+    var minus10c: Color
+    var minus20c: Color
+
+    // Stability parcel-level line colours
+    var lcl: Color
+    var lfc: Color
+    var el: Color
+
+    // Reference lines
+    var cruise: Color
+    var ceiling: Color
+
+    // DD-sourced cloud fill (dense → thin interpolation, per-coverage alpha)
+    var cloudDense: RGB
+    var cloudThin: RGB
+    var cloudCoverageAlpha: [String: (lo: Double, hi: Double)]  // keyed "few/sct/bkn/ovc"
+    var cloudFallbackGray: RGB
+
+    // NWP cover%-sourced cloud fill
+    var nwpBright: RGB
+    var nwpDelta: RGB
+    var nwpOpacityFloor: Double
+    var nwpOpacityScale: Double
+
+    // Soft (GRAMET-style feathered) cloud fill
+    var softCloudFill: RGB
+    var softCloudCoverageAlpha: [String: Double]  // keyed "OVC/BKN/SCT/FEW"
+    var softCloudFeather: Double
+
+    // Hazard band palettes (keyed by risk class)
+    var icing: [String: Color]
+    var sfipIcing: [String: Color]
+    var cat: [String: Color]
+    var convBgWash: [String: Color]
+    var convTowerFill: [String: Color]
+    var convHatch: [String: Color]
+    var convEdge: [String: Color]
+    var convStrip: [String: Color]
+    var convCBLabel: [String: Color]
+
+    // Inversion band
+    var inversionBase: RGB
+    var inversionFloor: Double
+    var inversionScale: Double
+    var inversionMaxStrengthC: Double
+    var inversionCap: Double
+}
+
+// MARK: - Theme registry (ported from web theme.ts)
+
+extension CrossSectionTheme {
+    /// Convenience for an rgba() colour given 0–255 channels.
+    private static func c(_ r: Double, _ g: Double, _ b: Double, _ a: Double = 1) -> Color {
+        Color(.sRGB, red: r / 255, green: g / 255, blue: b / 255, opacity: a)
+    }
+
+    // --- Standard (current production values) ---
+    static let standard = CrossSectionTheme(
+        id: .standard,
+        label: "Standard",
+        skyBackground: c(115, 149, 219),                 // #7395DB
+        axisGrid: c(255, 255, 255, 0.35),
+        axisWaypoint: c(255, 255, 255, 0.45),
+        terrainFill: RGB(r: 139, g: 115, b: 85),         // #8B7355
+        terrainStroke: RGB(r: 107, g: 91, b: 69),        // #6B5B45
+        freezingLevel: c(0, 188, 212),                   // #00bcd4
+        minus10c: c(33, 150, 243),                       // #2196f3
+        minus20c: c(26, 35, 126),                        // #1a237e
+        lcl: c(76, 175, 80),                             // #4caf50
+        lfc: c(255, 152, 0),                             // #ff9800
+        el: c(244, 67, 54),                              // #f44336
+        cruise: c(55, 65, 81),                           // #374151
+        ceiling: c(148, 103, 189),                       // #9467bd
+        cloudDense: RGB(r: 140, g: 140, b: 150),
+        cloudThin: RGB(r: 250, g: 250, b: 255),
+        cloudCoverageAlpha: [
+            "few": (0.20, 0.35), "sct": (0.50, 0.65),
+            "bkn": (0.60, 0.88), "ovc": (0.70, 0.95),
+        ],
+        cloudFallbackGray: RGB(r: 180, g: 180, b: 185),
+        nwpBright: RGB(r: 245, g: 245, b: 255),
+        nwpDelta: RGB(r: 105, g: 105, b: 100),
+        nwpOpacityFloor: 0.30,
+        nwpOpacityScale: 0.55,
+        softCloudFill: RGB(r: 255, g: 255, b: 255),
+        softCloudCoverageAlpha: ["OVC": 0.85, "BKN": 0.65, "SCT": 0.45, "FEW": 0.15],
+        softCloudFeather: 0.15,
+        icing: [
+            "none": .clear,
+            "light": c(185, 170, 230, 0.70),
+            "moderate": c(120, 100, 215, 0.85),
+            "severe": c(65, 35, 155, 0.93),
+        ],
+        sfipIcing: [
+            "none": .clear,
+            "light": c(185, 170, 230, 0.78),
+            "moderate": c(120, 100, 215, 0.92),
+            "severe": c(65, 35, 155, 1.00),
+        ],
+        cat: [
+            "none": .clear,
+            "light": c(255, 193, 7, 0.20),
+            "moderate": c(255, 152, 0, 0.40),
+            "severe": c(220, 53, 69, 0.55),
+        ],
+        convBgWash: [
+            "marginal": c(200, 200, 200, 0.04),
+            "low": c(255, 235, 59, 0.06),
+            "moderate": c(255, 152, 0, 0.08),
+            "high": c(220, 53, 69, 0.10),
+            "extreme": c(183, 28, 28, 0.14),
+        ],
+        convTowerFill: [
+            "marginal": c(180, 180, 180, 0.15),
+            "low": c(255, 235, 59, 0.18),
+            "moderate": c(255, 152, 0, 0.25),
+            "high": c(220, 53, 69, 0.30),
+            "extreme": c(183, 28, 28, 0.35),
+        ],
+        convHatch: [
+            "marginal": c(140, 140, 140, 0.15),
+            "low": c(180, 160, 0, 0.20),
+            "moderate": c(200, 100, 0, 0.35),
+            "high": c(200, 40, 40, 0.40),
+            "extreme": c(150, 20, 20, 0.50),
+        ],
+        convEdge: [
+            "marginal": c(140, 140, 140, 0.25),
+            "low": c(180, 160, 0, 0.30),
+            "moderate": c(200, 100, 0, 0.50),
+            "high": c(200, 40, 40, 0.60),
+            "extreme": c(150, 20, 20, 0.70),
+        ],
+        convStrip: [
+            "marginal": c(160, 160, 160, 0.40),
+            "low": c(255, 235, 59, 0.50),
+            "moderate": c(255, 152, 0, 0.75),
+            "high": c(220, 53, 69, 0.85),
+            "extreme": c(183, 28, 28, 0.90),
+        ],
+        convCBLabel: [
+            "moderate": c(200, 100, 0, 0.80),
+            "high": c(200, 40, 40, 0.90),
+            "extreme": c(150, 20, 20, 0.95),
+        ],
+        inversionBase: RGB(r: 233, g: 30, b: 99),
+        inversionFloor: 0.15,
+        inversionScale: 0.50,
+        inversionMaxStrengthC: 3,
+        inversionCap: 0.65
+    )
+
+    // --- High contrast (deep-navy sky) ---
+    static let highContrast: CrossSectionTheme = {
+        var t = standard
+        t.id = .highContrast
+        t.label = "High Contrast"
+        t.skyBackground = c(27, 48, 96)                  // #1B3060
+        t.axisGrid = c(255, 255, 255, 0.30)
+        t.axisWaypoint = c(255, 255, 255, 0.40)
+        t.terrainFill = RGB(r: 74, g: 58, b: 40)         // #4A3A28
+        t.terrainStroke = RGB(r: 107, g: 91, b: 69)      // #6B5B45
+        t.freezingLevel = c(0, 229, 255)                 // #00e5ff
+        t.minus10c = c(66, 165, 245)                     // #42a5f5
+        t.minus20c = c(124, 77, 255)                     // #7c4dff
+        t.lcl = c(105, 240, 174)                         // #69f0ae
+        t.lfc = c(255, 171, 64)                          // #ffab40
+        t.el = c(255, 82, 82)                            // #ff5252
+        t.cruise = c(224, 224, 224)                      // #e0e0e0
+        t.ceiling = c(206, 147, 216)                     // #ce93d8
+        t.cloudDense = RGB(r: 70, g: 70, b: 70)
+        t.cloudThin = RGB(r: 230, g: 230, b: 230)
+        t.cloudCoverageAlpha = [
+            "few": (0.15, 0.30), "sct": (0.45, 0.60),
+            "bkn": (0.55, 0.85), "ovc": (0.65, 0.95),
+        ]
+        t.cloudFallbackGray = RGB(r: 120, g: 120, b: 120)
+        t.nwpBright = RGB(r: 230, g: 230, b: 230)
+        t.nwpDelta = RGB(r: 150, g: 150, b: 150)
+        // softClouds inherited (web omits → factory default white fill)
+        t.icing = [
+            "none": .clear,
+            "light": c(200, 220, 240, 0.70),
+            "moderate": c(154, 176, 224, 0.80),
+            "severe": c(132, 112, 216, 0.90),
+        ]
+        t.sfipIcing = [
+            "none": .clear,
+            "light": c(200, 220, 240, 0.80),
+            "moderate": c(154, 176, 224, 0.90),
+            "severe": c(132, 112, 216, 1.00),
+        ]
+        t.cat = [
+            "none": .clear,
+            "light": c(24, 136, 72, 0.40),
+            "moderate": c(152, 184, 48, 0.55),
+            "severe": c(200, 208, 16, 0.70),
+        ]
+        t.convBgWash = [
+            "marginal": c(248, 160, 32, 0.06),
+            "low": c(248, 160, 32, 0.10),
+            "moderate": c(240, 120, 32, 0.14),
+            "high": c(216, 80, 32, 0.18),
+            "extreme": c(232, 24, 24, 0.22),
+        ]
+        t.convTowerFill = [
+            "marginal": c(248, 160, 32, 0.20),
+            "low": c(248, 160, 32, 0.28),
+            "moderate": c(240, 120, 32, 0.38),
+            "high": c(216, 80, 32, 0.48),
+            "extreme": c(232, 24, 24, 0.55),
+        ]
+        t.convHatch = [
+            "marginal": c(248, 160, 32, 0.25),
+            "low": c(248, 160, 32, 0.35),
+            "moderate": c(240, 120, 32, 0.50),
+            "high": c(216, 80, 32, 0.60),
+            "extreme": c(232, 24, 24, 0.70),
+        ]
+        t.convEdge = [
+            "marginal": c(248, 160, 32, 0.30),
+            "low": c(248, 160, 32, 0.40),
+            "moderate": c(240, 120, 32, 0.55),
+            "high": c(216, 80, 32, 0.65),
+            "extreme": c(232, 24, 24, 0.75),
+        ]
+        t.convStrip = [
+            "marginal": c(248, 160, 32, 0.45),
+            "low": c(248, 160, 32, 0.55),
+            "moderate": c(240, 120, 32, 0.75),
+            "high": c(216, 80, 32, 0.85),
+            "extreme": c(232, 24, 24, 0.92),
+        ]
+        t.convCBLabel = [
+            "moderate": c(240, 120, 32, 0.85),
+            "high": c(216, 80, 32, 0.92),
+            "extreme": c(232, 24, 24, 0.95),
+        ]
+        t.inversionBase = RGB(r: 255, g: 82, b: 82)
+        t.inversionFloor = 0.25
+        t.inversionScale = 0.55
+        t.inversionCap = 0.80
+        return t
+    }()
+
+    // --- GRAMET (CloudPath-inspired deep blue) ---
+    static let gramet: CrossSectionTheme = {
+        var t = standard
+        t.id = .gramet
+        t.label = "GRAMET"
+        t.skyBackground = c(43, 93, 168)                 // #2B5DA8
+        t.axisGrid = c(255, 255, 255, 0.25)
+        t.axisWaypoint = c(255, 255, 255, 0.35)
+        t.terrainFill = RGB(r: 139, g: 105, b: 20)       // #8B6914
+        t.terrainStroke = RGB(r: 107, g: 80, b: 16)      // #6B5010
+        t.freezingLevel = c(255, 68, 68)                 // #FF4444
+        t.minus10c = c(34, 204, 68)                      // #22CC44
+        t.minus20c = c(34, 204, 68)                      // #22CC44
+        t.cruise = c(224, 224, 224)                      // #e0e0e0
+        t.ceiling = c(206, 147, 216)                     // #ce93d8
+        // clouds / nwpClouds / cat / inversion inherited from standard
+        t.icing = [
+            "none": .clear,
+            "light": c(170, 230, 205, 0.45),
+            "moderate": c(110, 200, 165, 0.60),
+            "severe": c(45, 130, 100, 0.75),
+        ]
+        t.sfipIcing = [
+            "none": .clear,
+            "light": c(170, 230, 205, 0.55),
+            "moderate": c(110, 200, 165, 0.70),
+            "severe": c(45, 130, 100, 0.85),
+        ]
+        // Convective inherits standard except the CB pill label.
+        t.convCBLabel = [
+            "moderate": c(255, 180, 40, 1.0),
+            "high": c(255, 80, 60, 1.0),
+            "extreme": c(255, 50, 30, 1.0),
+        ]
+        t.softCloudFill = RGB(r: 255, g: 255, b: 255)
+        t.softCloudCoverageAlpha = ["OVC": 0.85, "BKN": 0.65, "SCT": 0.45, "FEW": 0.15]
+        t.softCloudFeather = 0.15
+        return t
+    }()
+
+    // --- Light (Windy-inspired white sky, gray clouds) ---
+    static let light: CrossSectionTheme = {
+        var t = standard
+        t.id = .light
+        t.label = "Light"
+        t.skyBackground = c(248, 249, 251)               // #F8F9FB
+        t.axisGrid = c(20, 30, 50, 0.18)
+        t.axisWaypoint = c(20, 30, 50, 0.32)
+        t.terrainFill = RGB(r: 164, g: 130, b: 86)       // #A48256
+        t.terrainStroke = RGB(r: 122, g: 94, b: 61)      // #7A5E3D
+        t.freezingLevel = c(2, 119, 189)                 // #0277BD
+        t.minus10c = c(21, 101, 192)                     // #1565C0
+        t.minus20c = c(13, 71, 161)                      // #0D47A1
+        t.lcl = c(46, 125, 50)                           // #2E7D32
+        t.lfc = c(230, 81, 0)                            // #E65100
+        t.el = c(198, 40, 40)                            // #C62828
+        t.cruise = c(33, 33, 33)                         // #212121
+        t.ceiling = c(106, 27, 154)                      // #6A1B9A
+        t.cloudDense = RGB(r: 70, g: 80, b: 95)
+        t.cloudThin = RGB(r: 195, g: 200, b: 210)
+        t.cloudCoverageAlpha = [
+            "few": (0.15, 0.30), "sct": (0.40, 0.55),
+            "bkn": (0.55, 0.80), "ovc": (0.70, 0.90),
+        ]
+        t.cloudFallbackGray = RGB(r: 150, g: 155, b: 165)
+        t.nwpBright = RGB(r: 225, g: 228, b: 232)
+        t.nwpDelta = RGB(r: 155, g: 160, b: 165)
+        t.nwpOpacityFloor = 0.35
+        t.nwpOpacityScale = 0.70
+        t.icing = [
+            "none": .clear,
+            "light": c(170, 140, 220, 0.55),
+            "moderate": c(110, 80, 200, 0.72),
+            "severe": c(60, 30, 145, 0.88),
+        ]
+        t.sfipIcing = [
+            "none": .clear,
+            "light": c(170, 140, 220, 0.65),
+            "moderate": c(110, 80, 200, 0.82),
+            "severe": c(60, 30, 145, 0.95),
+        ]
+        t.cat = [
+            "none": .clear,
+            "light": c(255, 152, 0, 0.30),
+            "moderate": c(245, 124, 0, 0.50),
+            "severe": c(198, 40, 40, 0.65),
+        ]
+        t.convBgWash = [
+            "marginal": c(120, 120, 120, 0.05),
+            "low": c(255, 193, 7, 0.10),
+            "moderate": c(245, 124, 0, 0.14),
+            "high": c(220, 53, 69, 0.18),
+            "extreme": c(136, 14, 79, 0.22),
+        ]
+        t.convTowerFill = [
+            "marginal": c(120, 120, 120, 0.20),
+            "low": c(255, 193, 7, 0.28),
+            "moderate": c(245, 124, 0, 0.40),
+            "high": c(220, 53, 69, 0.50),
+            "extreme": c(136, 14, 79, 0.55),
+        ]
+        t.convHatch = [
+            "marginal": c(100, 100, 100, 0.25),
+            "low": c(180, 130, 0, 0.35),
+            "moderate": c(200, 80, 0, 0.50),
+            "high": c(180, 30, 30, 0.60),
+            "extreme": c(100, 10, 50, 0.70),
+        ]
+        t.convEdge = [
+            "marginal": c(100, 100, 100, 0.35),
+            "low": c(180, 130, 0, 0.45),
+            "moderate": c(200, 80, 0, 0.60),
+            "high": c(180, 30, 30, 0.70),
+            "extreme": c(100, 10, 50, 0.80),
+        ]
+        t.convStrip = [
+            "marginal": c(120, 120, 120, 0.50),
+            "low": c(255, 193, 7, 0.65),
+            "moderate": c(245, 124, 0, 0.80),
+            "high": c(220, 53, 69, 0.88),
+            "extreme": c(136, 14, 79, 0.92),
+        ]
+        t.convCBLabel = [
+            "moderate": c(200, 80, 0, 0.92),
+            "high": c(180, 30, 30, 0.95),
+            "extreme": c(100, 10, 50, 1.00),
+        ]
+        t.inversionBase = RGB(r: 194, g: 24, b: 91)
+        t.inversionFloor = 0.20
+        t.inversionScale = 0.55
+        t.inversionCap = 0.75
+        t.softCloudFill = RGB(r: 70, g: 80, b: 95)
+        t.softCloudCoverageAlpha = ["OVC": 0.55, "BKN": 0.40, "SCT": 0.25, "FEW": 0.10]
+        t.softCloudFeather = 0.15
+        return t
+    }()
+
+    /// Registry keyed by ID. Mirrors web `THEMES`.
+    static let all: [CrossSectionThemeID: CrossSectionTheme] = [
+        .standard: standard,
+        .highContrast: highContrast,
+        .gramet: gramet,
+        .light: light,
+    ]
+
+    // MARK: - Active theme (module-level indirection, mirrors web get/setActiveTheme)
+    //
+    // The cross-section renders synchronously on the main actor (SwiftUI Canvas)
+    // and the only writers are the main-actor view model / renderer, so a single
+    // shared value is safe. Marked `nonisolated(unsafe)` so the nonisolated
+    // `ColorScales` lookups can read it without hopping actors. Defaults to
+    // `.standard` as a safe fallback; the view model sets it to the booted
+    // theme (GRAMET) before the first frame.
+
+    nonisolated(unsafe) private static var _active: CrossSectionTheme = standard
+
+    static var active: CrossSectionTheme { _active }
+
+    static func setActive(_ id: CrossSectionThemeID) {
+        _active = all[id] ?? standard
+    }
+}

--- a/app/flyfun-weather/flyfun-weather/Views/CrossSection/CrossSectionView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/CrossSection/CrossSectionView.swift
@@ -192,17 +192,22 @@ struct CrossSectionView: View {
             let aircraft = aircraftPosition
             let cursor = scrubDistanceNm ?? activePointDistanceNm
             let layers = csVM.enabledLayers
+            // Read themeId here so the Canvas re-renders when the theme changes
+            // (it's an @Observable dependency, like `layers`). (#320)
+            let themeId = csVM.themeId
 
             // Static scene (sky + cloud bands + axes) is the expensive pass and is
             // gated behind an `Equatable` key so a scrub tick — which only changes
             // `cursor`/`aircraft` — does NOT re-run its ~400 gradient fills. The
             // thin cursor rule + aircraft marker live in a cheap overlay Canvas
-            // that redraws every tick instead (#303).
+            // that redraws every tick instead (#303). `themeId` is part of the gate
+            // so a theme switch repaints the static layers, not just the overlay (#320).
             StaticCrossSectionScene(data: vizData, enabledLayers: layers,
-                                    dataVersion: csVM.dataVersion, renderSize: canvasSize)
+                                    dataVersion: csVM.dataVersion, themeId: themeId,
+                                    renderSize: canvasSize)
                 // `.equatable()` is load-bearing: it forces SwiftUI to gate the
-                // redraw on the custom `==` (dataVersion + layers + size). Without it the
-                // reconciler falls back to reflecting the stored properties, can't
+                // redraw on the custom `==` (dataVersion + layers + themeId + size). Without
+                // it the reconciler falls back to reflecting the stored properties, can't
                 // compare the non-Equatable `VizRouteData`, and redraws every scrub
                 // tick — defeating the split (#303). Do not remove.
                 .equatable()

--- a/app/flyfun-weather/flyfun-weather/Views/CrossSection/Layers/CrossSectionPresets.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/CrossSection/Layers/CrossSectionPresets.swift
@@ -18,9 +18,10 @@ import Foundation
 // the web side (both files carry the reciprocal SYNC comment).
 // =============================================================================
 
-/// One-click layer configuration. Port of web `LayerPreset`. `themeId` is kept
-/// for parity (the web preset also picks a color theme); iOS has no cross-section
-/// color-theme system yet (tracked in #320), so it's informational for now.
+/// One-click layer configuration. Port of web `LayerPreset`. `themeId` mirrors
+/// the web preset's colour theme; the live wiring (selecting a preset also sets
+/// its theme, #320) lives on `CrossSectionViewModel.Preset.themeId`. This struct
+/// stays as a parity mirror of the web `PRESETS` table.
 struct LayerPreset: Identifiable, Equatable {
     let id: String
     let label: String

--- a/app/flyfun-weather/flyfun-weather/Views/CrossSection/Layers/ReferenceLinesLayer.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/CrossSection/Layers/ReferenceLinesLayer.swift
@@ -20,7 +20,7 @@ struct ReferenceLinesLayer: CrossSectionLayerProtocol {
             let ceilingY = transform.altitudeToY(data.ceilingAltitudeFt)
             drawRefLine(&context, y: ceilingY, left: plot.left, right: plot.right,
                         label: "Ceiling \(Int(data.ceilingAltitudeFt))'",
-                        color: .gray.opacity(0.5))
+                        color: ColorScales.ceilingColor)
         }
     }
 

--- a/app/flyfun-weather/flyfun-weatherTests/CrossSectionThemeTests.swift
+++ b/app/flyfun-weather/flyfun-weatherTests/CrossSectionThemeTests.swift
@@ -1,0 +1,110 @@
+//
+//  CrossSectionThemeTests.swift
+//  flyfun-weatherTests
+//
+//  #320 — cross-section colour-theme system: registry completeness, the
+//  module-level active-theme indirection, and the preset→theme wiring on
+//  CrossSectionViewModel. Asserts on theme IDs and the raw RGB/Double fields
+//  (SwiftUI `Color` equality across independently-built instances is unreliable,
+//  so the ported values are checked via the 0–255 `RGB` channels).
+//
+//  All tests live in ONE `@MainActor @Suite(.serialized)`: they read and write
+//  the shared `CrossSectionTheme._active` global, and Swift Testing parallelises
+//  suites by default. Serializing (and pinning to the main actor, which is where
+//  the renderer/view model mutate the global in production) removes the cross-
+//  test race the active-theme assertions would otherwise hit.
+//
+
+import Testing
+@testable import flyfun_weather
+
+@MainActor
+@Suite(.serialized) struct CrossSectionThemeTests {
+
+    // MARK: Registry
+
+    @Test func registryHasAllFourThemesMatchingWeb() {
+        // IDs (and their raw values) mirror the web `ThemeId` union so a route
+        // renders identically and the two files diff cleanly.
+        #expect(Set(CrossSectionTheme.all.keys) == Set(CrossSectionThemeID.allCases))
+        #expect(CrossSectionThemeID.standard.rawValue == "standard")
+        #expect(CrossSectionThemeID.highContrast.rawValue == "high-contrast")
+        #expect(CrossSectionThemeID.gramet.rawValue == "gramet")
+        #expect(CrossSectionThemeID.light.rawValue == "light")
+    }
+
+    @Test func eachThemeHasItsOwnIdAndLabel() {
+        for id in CrossSectionThemeID.allCases {
+            #expect(id.theme.id == id)
+            #expect(id.theme.label.isEmpty == false)
+        }
+    }
+
+    @Test func standardThemePortsWebRgbValuesVerbatim() {
+        let std = CrossSectionTheme.standard
+        // Cloud ramp: dense [140,140,150] → thin [250,250,255] (web Standard).
+        #expect((std.cloudDense.r, std.cloudDense.g, std.cloudDense.b) == (140, 140, 150))
+        #expect((std.cloudThin.r, std.cloudThin.g, std.cloudThin.b) == (250, 250, 255))
+        // Inversion base #e91e63 with floor/cap.
+        #expect((std.inversionBase.r, std.inversionBase.g, std.inversionBase.b) == (233, 30, 99))
+        #expect(std.inversionFloor == 0.15)
+        #expect(std.inversionCap == 0.65)
+    }
+
+    @Test func grametInheritsStandardCloudRampLightOverridesNwpOpacity() {
+        // Derived themes are built by copy-and-override, so GRAMET keeps the
+        // Standard cloud ramp (only sky/terrain/icing/etc. change)…
+        #expect(CrossSectionTheme.gramet.cloudDense.r == CrossSectionTheme.standard.cloudDense.r)
+        // …while Light bumps the NWP cloud opacity scale (0.55 → 0.70).
+        #expect(CrossSectionTheme.light.nwpOpacityScale == 0.70)
+        #expect(CrossSectionTheme.standard.nwpOpacityScale == 0.55)
+    }
+
+    // MARK: Active-theme indirection
+
+    @Test func setActiveSwitchesTheThemeColorScalesResolvesAgainst() {
+        let original = CrossSectionTheme.active.id
+        defer { CrossSectionTheme.setActive(original) }
+
+        CrossSectionTheme.setActive(.light)
+        #expect(CrossSectionTheme.active.id == .light)
+
+        CrossSectionTheme.setActive(.gramet)
+        #expect(CrossSectionTheme.active.id == .gramet)
+    }
+
+    // MARK: Preset → theme wiring (CrossSectionViewModel)
+
+    @Test func bootDefaultsToGrametThemeMatchingTheGrametLayerPreset() {
+        let vm = CrossSectionViewModel()
+        // The booted layer preset is GRAMET, so the theme agrees on boot.
+        #expect(vm.themeId == .gramet)
+        #expect(vm.currentPreset == .gramet)
+        #expect(CrossSectionTheme.active.id == .gramet)
+    }
+
+    @Test func selectingALayerPresetAlsoAppliesItsTheme() {
+        let vm = CrossSectionViewModel()
+
+        vm.applyPreset(.windy)
+        #expect(vm.themeId == .light)          // web mapping: windy → light
+        #expect(CrossSectionTheme.active.id == .light)
+
+        vm.applyPreset(.foreFlight)
+        #expect(vm.themeId == .highContrast)   // web mapping: foreflight → high-contrast
+        #expect(CrossSectionTheme.active.id == .highContrast)
+
+        vm.applyPreset(.gramet)
+        #expect(vm.themeId == .gramet)
+    }
+
+    @Test func setThemeIsOrthogonalToTheLayerPreset() {
+        let vm = CrossSectionViewModel()
+        // Changing the theme alone must NOT disturb the layer set / preset label
+        // (mirrors web `setVizTheme`, which leaves the preset alone).
+        vm.setTheme(.standard)
+        #expect(vm.themeId == .standard)
+        #expect(CrossSectionTheme.active.id == .standard)
+        #expect(vm.currentPreset == .gramet)   // layers untouched → still GRAMET
+    }
+}

--- a/web/ts/visualization/cross-section/theme.ts
+++ b/web/ts/visualization/cross-section/theme.ts
@@ -7,6 +7,12 @@
  * Usage: import { getActiveTheme } from './theme';
  *        const t = getActiveTheme();
  *        ctx.fillStyle = t.terrain.fillColor;
+ *
+ * SYNC: the iOS app mirrors these themes (color values + IDs) in
+ * app/flyfun-weather/flyfun-weather/Views/CrossSection/CrossSectionTheme.swift.
+ * iOS ports only the fields its layers render (no nightShading / obscuration /
+ * compareModelColors / sld yet) and themes colors but not line widths/dashes.
+ * Keep the two in lockstep when editing palettes (#320).
  */
 
 // --- Theme interface ---


### PR DESCRIPTION
## Summary

Introduces a cross-section **color-theme system** on iOS, separate from the layer **Preset** picker — closes #320. Mirrors the web `THEMES` registry so a given route/model renders with visually matching colors on web and iOS.

`ColorScales` now resolves every color through a module-level active theme (web's `getActiveTheme()` pattern), so one switch recolors the whole chart and all 45 existing call sites stay untouched.

## What changed

- **`CrossSectionTheme.swift` (new)** — struct + registry porting **all four** web themes verbatim (`standard` / `high-contrast` / `gramet` / `light`). The web selector exposes all four and the Windy preset maps to `light`, so the full set is ported (not just three). Colors only — line widths/dashes stay in the layers. Web fields with no iOS layer yet (nightShading / obscuration / compareModelColors / sld) are intentionally not ported, documented in the SYNC header.
- **`ColorScales`** rewritten to read through `CrossSectionTheme.active`.
- **Theme picker** in `CrossSectionConfigSheet`, distinct from the layer Preset.
- **`CrossSectionViewModel`** gains `themeId` + `setTheme`; `applyPreset` also applies the preset's `themeId` (gramet→gramet, windy→light, foreflight→high-contrast). Theme is orthogonal to the layer preset, matching web `setVizTheme`.
- **Renderer** pins the active theme per frame; axes grid/waypoint + ceiling line are now theme-driven; the Canvas re-renders on `themeId` change.
- Reciprocal SYNC comment added to web `theme.ts`.

## Behavior note

Boot theme = **GRAMET** to agree with iOS's booted GRAMET layer preset, so the default chart now renders in the GRAMET palette (matching web). The `standard` theme's icing/CAT/SFIP/convective colors also now match web verbatim.

## Testing

- `xcodebuild build` (iOS Simulator) — succeeds.
- New `CrossSectionThemeTests` (8 tests, green): registry completeness, active-theme switch, boot default, preset→theme wiring, theme/preset orthogonality.
- Manually verified on iPad: default GRAMET look, live theme switching + legend recolor, preset→theme flips.

## Acceptance criteria
- [x] Four selectable cross-section color themes matching the web palettes.
- [x] Theme selector in the config sheet, separate from the layer Preset.
- [x] Selecting a layer Preset also applies its `themeId`.
- [x] Cross-section + legends re-render correctly on theme change.
- [x] A given route/model renders with visually matching colors on web and iOS for the same theme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)