### PR TITLE
ios: revamp flight-create flow (loading fix, autocomplete, TZ, profiles, autorouter, interpret)

### DIFF
--- a/app/flyfun-weather/.gitignore
+++ b/app/flyfun-weather/.gitignore
@@ -1,0 +1,4 @@
+
+# Slim airports DB is downloaded from the server at runtime, never committed (churns per AIRAC cycle)
+airports.db
+*.airportsdb

--- a/app/flyfun-weather/flyfun-weather/App/AppState.swift
+++ b/app/flyfun-weather/flyfun-weather/App/AppState.swift
@@ -237,5 +237,9 @@ final class AppState {
         repository = CachingBriefingRepository(client: client, online: online, cache: cache)
         Task { await userPreferences.refresh(using: client) }
         Task { await helpCatalog.refresh(using: client) }
+        // Open any cached airports DB immediately (offline-safe), then refresh it
+        // from the server if the AIRAC copy changed (ETag → usually a 304 no-op).
+        AirportDatabase.shared.loadCached()
+        Task { await AirportDatabase.shared.refresh(using: client) }
     }
 }

--- a/app/flyfun-weather/flyfun-weather/Models/API/AutorouterRoute.swift
+++ b/app/flyfun-weather/flyfun-weather/Models/API/AutorouterRoute.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+/// One recent route from the user's linked Autorouter account
+/// (`GET /api/flights/autorouter-routes`). Selecting one feeds its ICAO flight
+/// plan through the same parse→fill path as "Paste Flight Plan".
+struct AutorouterRoute: Codable, Identifiable, Hashable, Sendable {
+    var id: String { routeid }
+
+    let routeid: String
+    let departure: String
+    let destination: String
+    let departureName: String?
+    let destinationName: String?
+    let departureTime: String?
+    let fplan: String
+    let routeDistanceNm: Int?
+    let aircraftDescription: String?
+    let callsign: String?
+
+    /// "EGTF → LSGS" headline for the picker row.
+    var title: String { "\(departure) \u{2192} \(destination)" }
+
+    /// Secondary line: date · distance · aircraft, omitting any missing parts.
+    var subtitle: String {
+        var parts: [String] = []
+        if let departureTime, let date = Self.isoParser.date(from: departureTime) {
+            parts.append(Self.dayFormatter.string(from: date))
+        }
+        if let routeDistanceNm { parts.append("\(routeDistanceNm) nm") }
+        if let aircraftDescription, !aircraftDescription.isEmpty { parts.append(aircraftDescription) }
+        else if let callsign, !callsign.isEmpty { parts.append(callsign) }
+        return parts.joined(separator: " \u{00b7} ")
+    }
+
+    private static let isoParser = ISO8601DateFormatter()
+    private static let dayFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "d MMM"
+        f.timeZone = TimeZone(identifier: "UTC")
+        return f
+    }()
+}
+
+struct AutorouterRoutesResponse: Codable, Sendable {
+    let routes: [AutorouterRoute]
+}

--- a/app/flyfun-weather/flyfun-weather/Models/API/CreateFlightRequest.swift
+++ b/app/flyfun-weather/flyfun-weather/Models/API/CreateFlightRequest.swift
@@ -9,6 +9,9 @@ struct CreateFlightRequest: Encodable {
     var flightCeilingFt: Int?
     var flightDurationHours: Double?
     var aircraftId: Int? = nil
+    /// Flight profile to associate; the server fills any unspecified flight
+    /// fields (ceiling, speed, model choices) from this profile's settings.
+    var profileId: Int? = nil
 }
 
 /// Request body for editing an existing flight via PATCH /api/flights/{id}.
@@ -22,6 +25,7 @@ struct UpdateFlightRequest: Encodable {
     var cruiseAltitudeFt: Int? = nil
     var flightCeilingFt: Int? = nil
     var flightDurationHours: Double? = nil
+    var profileId: Int? = nil
 }
 
 /// How much of the briefing an edit invalidated, returned alongside the updated

--- a/app/flyfun-weather/flyfun-weather/Models/API/ProfileResponse.swift
+++ b/app/flyfun-weather/flyfun-weather/Models/API/ProfileResponse.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+/// A flight profile from `GET /api/user/profiles`. A profile presets the flight
+/// parameters (cruise altitude, ceiling, speed) and the weather-model choices.
+/// The create/edit form only needs identity + the flight parameters; the decoder
+/// ignores the many other settings keys (model selection, methods, advisories).
+struct ProfileResponse: Codable, Identifiable, Hashable, Sendable {
+    let id: Int
+    let name: String
+    let isDefault: Bool
+    let settings: ProfileSettings
+}
+
+/// The subset of profile settings the flight form applies. Property names rely on
+/// the shared decoder's `.convertFromSnakeCase`; unlisted keys are ignored.
+struct ProfileSettings: Codable, Hashable, Sendable {
+    let cruiseAltitudeFt: Int?
+    let flightCeilingFt: Int?
+    let speedKt: Int?
+}
+
+extension [ProfileResponse] {
+    /// Default profile first, then alphabetical — matches the web selector order.
+    func sortedForPicker() -> [ProfileResponse] {
+        sorted { lhs, rhs in
+            if lhs.isDefault != rhs.isDefault { return lhs.isDefault && !rhs.isDefault }
+            return lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
+        }
+    }
+}

--- a/app/flyfun-weather/flyfun-weather/Models/API/RouteInterpretation.swift
+++ b/app/flyfun-weather/flyfun-weather/Models/API/RouteInterpretation.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+/// A resolved waypoint with coordinates and timezone (server `WaypointInfo`).
+struct RouteWaypointInfo: Codable, Hashable, Sendable, Identifiable {
+    let icao: String
+    let name: String
+    let lat: Double
+    let lon: Double
+    let timezone: String?
+
+    var id: String { icao }
+}
+
+/// Result of `POST /api/flights/interpret-route` — what the server understood
+/// from a free-typed route, what it skipped, and what it dropped as off-route.
+struct InterpretRouteResponse: Codable, Sendable {
+    let originalTokens: [String]
+    let interpreted: [String]
+    /// Tokens the server couldn't place at all (typos / unsupported formats).
+    let skipped: [String]
+    /// Tokens recognised but rejected as too far off the direct leg.
+    let offRoute: [String]
+    let waypoints: [RouteWaypointInfo]
+
+    /// True when everything the user typed was understood — nothing skipped or
+    /// dropped — so the save flow can accept silently (mirrors the web).
+    var isClean: Bool { skipped.isEmpty && offRoute.isEmpty }
+}
+
+/// Request body for `interpret-route`.
+struct InterpretRouteRequest: Encodable {
+    let rawRoute: String
+}
+
+/// Result of `POST /api/flights/route-distance`.
+struct RouteDistanceResponse: Codable, Sendable {
+    let totalDistanceNm: Double
+    let waypoints: [RouteWaypointInfo]
+}
+
+/// Request body for `route-distance`.
+struct RouteDistanceRequest: Encodable {
+    let waypoints: [String]
+}

--- a/app/flyfun-weather/flyfun-weather/Services/APIClient.swift
+++ b/app/flyfun-weather/flyfun-weather/Services/APIClient.swift
@@ -113,6 +113,46 @@ actor APIClient {
         return .updated(data: data, etag: http.value(forHTTPHeaderField: "ETag"))
     }
 
+    // MARK: - Airports DB (ETag-cached)
+
+    /// Outcome of a conditional airports-DB fetch (mirrors the help-catalog flow).
+    enum AirportsDBFetchResult: Sendable {
+        case notModified
+        case updated(data: Data, etag: String?)
+    }
+
+    /// Conditionally download the slim airports SQLite used for local ICAO
+    /// autocomplete. Pass the cached `ETag`; a `304` returns `.notModified` and
+    /// the caller keeps its on-disk copy. The DB is a few MB and changes only on
+    /// an AIRAC cycle, so this is a rare full download.
+    func fetchAirportsDB(ifNoneMatch etag: String? = nil) async throws -> AirportsDBFetchResult {
+        let url = baseURL.appendingPathComponent("/api/nav/airports-db")
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.timeoutInterval = 120   // multi-MB body on a slow link
+        if let etag { request.setValue(etag, forHTTPHeaderField: "If-None-Match") }
+
+        let data: Data
+        let http: HTTPURLResponse
+        do {
+            (data, http) = try await rollingSession.data(for: request)
+        } catch FlyFunAPIError.unauthorized {
+            throw APIError.unauthorized
+        } catch let FlyFunAPIError.networkError(inner) {
+            throw APIError.networkError(inner)
+        } catch {
+            throw APIError.networkError(error)
+        }
+
+        if http.statusCode == 304 {
+            return .notModified
+        }
+        guard (200...299).contains(http.statusCode) else {
+            throw APIError.serverError(http.statusCode, String(data: data, encoding: .utf8))
+        }
+        return .updated(data: data, etag: http.value(forHTTPHeaderField: "ETag"))
+    }
+
     // MARK: - Generic request methods
 
     /// Fetch and decode a JSON response.

--- a/app/flyfun-weather/flyfun-weather/Services/AirportDatabase.swift
+++ b/app/flyfun-weather/flyfun-weather/Services/AirportDatabase.swift
@@ -13,8 +13,14 @@ import FMDB
 ///
 /// Wraps RZFlight's `KnownAirports` (`rankedSearch` is an in-memory tiered
 /// ICAO/name search), so lookups never touch the network or block typing.
+///
+/// `@MainActor`-isolated: all access to the stored DB handles happens on the main
+/// actor (the only off-main work — file IO + opening the SQLite — runs inside
+/// `Task.detached` blocks that hop back via `MainActor.run` before assigning), so
+/// there's no data race on `knownAirports`/`isLoaded`.
 @Observable
-final class AirportDatabase: @unchecked Sendable {
+@MainActor
+final class AirportDatabase {
     static let shared = AirportDatabase()
 
     /// True once a usable database is open. Drives whether autocomplete can offer
@@ -30,8 +36,9 @@ final class AirportDatabase: @unchecked Sendable {
 
     private init() {}
 
-    /// On-disk cache location (persisted, not purgeable like Caches).
-    private static var cacheURL: URL {
+    /// On-disk cache location (persisted, not purgeable like Caches). `nonisolated`
+    /// so the off-main `Task.detached` blocks can read it (it only uses FileManager).
+    nonisolated private static var cacheURL: URL {
         let base = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
         return base.appendingPathComponent("airports.db")
     }
@@ -60,7 +67,6 @@ final class AirportDatabase: @unchecked Sendable {
                 self.isLoaded = true
             }
         }
-        Task { await loadTask?.value }
     }
 
     /// Conditionally download the latest airports DB and swap it in. Uses

--- a/app/flyfun-weather/flyfun-weather/Services/AirportDatabase.swift
+++ b/app/flyfun-weather/flyfun-weather/Services/AirportDatabase.swift
@@ -1,0 +1,136 @@
+import Foundation
+import OSLog
+import RZFlight
+import FMDB
+
+/// Local airport database for fast, offline ICAO autocomplete.
+///
+/// The slim `airports.db` is **not** bundled — it churns every AIRAC cycle, so
+/// instead the app downloads it from the server (`GET /api/nav/airports-db`),
+/// caches it in Application Support, and refreshes it via ETag when the server's
+/// copy changes. With no cached copy yet (first launch / offline) `search()`
+/// simply returns nothing — autocomplete is empty, never broken.
+///
+/// Wraps RZFlight's `KnownAirports` (`rankedSearch` is an in-memory tiered
+/// ICAO/name search), so lookups never touch the network or block typing.
+@Observable
+final class AirportDatabase: @unchecked Sendable {
+    static let shared = AirportDatabase()
+
+    /// True once a usable database is open. Drives whether autocomplete can offer
+    /// anything; the UI degrades gracefully to "no suggestions" when false.
+    private(set) var isLoaded: Bool = false
+
+    private var knownAirports: KnownAirports?
+    private var db: FMDatabase?
+    private var loadTask: Task<Void, Never>?
+
+    private static let logger = Logger(subsystem: "aero.flyfun.weather", category: "AirportDatabase")
+    private static let etagKey = "airportsDB.etag"
+
+    private init() {}
+
+    /// On-disk cache location (persisted, not purgeable like Caches).
+    private static var cacheURL: URL {
+        let base = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+        return base.appendingPathComponent("airports.db")
+    }
+
+    /// Open the locally-cached DB if one was previously downloaded. Cheap, runs
+    /// off the main thread, and is safe to call at launch. No-op when there's no
+    /// cache yet.
+    func loadCached() {
+        guard !isLoaded, loadTask == nil else { return }
+        loadTask = Task.detached(priority: .userInitiated) { [weak self] in
+            guard let self else { return }
+            let url = Self.cacheURL
+            guard FileManager.default.fileExists(atPath: url.path) else {
+                Self.logger.debug("No cached airports DB yet")
+                return
+            }
+            let database = FMDatabase(path: url.path)
+            guard database.open() else {
+                Self.logger.error("Failed to open cached airports DB")
+                return
+            }
+            let known = KnownAirports(db: database)
+            await MainActor.run {
+                self.db = database
+                self.knownAirports = known
+                self.isLoaded = true
+            }
+        }
+        Task { await loadTask?.value }
+    }
+
+    /// Conditionally download the latest airports DB and swap it in. Uses
+    /// ETag/`If-None-Match`, so an unchanged DB costs only a 304. Failures
+    /// (offline, server down) are non-fatal — whatever is already loaded stays.
+    func refresh(using client: APIClient) async {
+        let hasCache = FileManager.default.fileExists(atPath: Self.cacheURL.path)
+        let etagToSend = hasCache ? UserDefaults.standard.string(forKey: Self.etagKey) : nil
+        do {
+            let result = try await client.fetchAirportsDB(ifNoneMatch: etagToSend)
+            switch result {
+            case .notModified:
+                Self.logger.debug("Airports DB already current")
+                if !isLoaded { loadCached() }
+            case .updated(let data, let etag):
+                await install(data: data, etag: etag)
+                Self.logger.info("Airports DB updated (\(data.count) bytes)")
+            }
+        } catch {
+            Self.logger.debug("Airports DB refresh skipped: \(error.localizedDescription)")
+        }
+    }
+
+    /// Ranked ICAO/name search. Empty until a DB is loaded.
+    func search(needle: String, limit: Int = 12) -> [Airport] {
+        guard let knownAirports, !needle.isEmpty else { return [] }
+        return knownAirports.rankedSearch(needle: needle, limit: limit)
+    }
+
+    /// Look up a single airport by ICAO (no runway hydration — autocomplete only
+    /// needs identity + coordinates).
+    func airport(icao: String) -> Airport? {
+        knownAirports?.airport(icao: icao, ensureRunway: false)
+    }
+
+    // MARK: - Private
+
+    /// Write the downloaded bytes to the cache path and open the new DB, all off
+    /// the main thread; assign the handles on the main actor.
+    private func install(data: Data, etag: String?) async {
+        let url = Self.cacheURL
+        await Task.detached(priority: .userInitiated) { [weak self] in
+            guard let self else { return }
+            do {
+                let dir = url.deletingLastPathComponent()
+                try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+                let tmp = url.appendingPathExtension("download")
+                try? FileManager.default.removeItem(at: tmp)
+                try data.write(to: tmp, options: .atomic)
+                if FileManager.default.fileExists(atPath: url.path) {
+                    try FileManager.default.removeItem(at: url)
+                }
+                try FileManager.default.moveItem(at: tmp, to: url)
+            } catch {
+                Self.logger.error("Failed to persist airports DB: \(error.localizedDescription)")
+                return
+            }
+            let database = FMDatabase(path: url.path)
+            guard database.open() else {
+                Self.logger.error("Failed to open downloaded airports DB")
+                return
+            }
+            let known = KnownAirports(db: database)
+            await MainActor.run {
+                self.db?.close()
+                self.db = database
+                self.knownAirports = known
+                self.isLoaded = true
+                if let etag { UserDefaults.standard.set(etag, forKey: Self.etagKey) }
+            }
+        }.value
+    }
+}

--- a/app/flyfun-weather/flyfun-weather/Services/BriefingRepository.swift
+++ b/app/flyfun-weather/flyfun-weather/Services/BriefingRepository.swift
@@ -6,9 +6,13 @@ protocol BriefingRepository: Sendable {
     func createFlight(_ request: CreateFlightRequest) async throws -> FlightResponse
     func updateFlight(flightId: String, request: UpdateFlightRequest) async throws -> UpdateFlightResponse
     func aircraft() async throws -> [AircraftResponse]
+    func profiles() async throws -> [ProfileResponse]
     func searchAircraftTypes(_ query: String) async throws -> [AircraftTypeResponse]
     func createAircraft(_ request: CreateAircraftRequest) async throws -> AircraftResponse
     func parseFpl(_ text: String) async throws -> ParseFplResponse
+    func interpretRoute(rawRoute: String) async throws -> InterpretRouteResponse
+    func routeDistance(waypoints: [String]) async throws -> RouteDistanceResponse
+    func autorouterRoutes(limit: Int) async throws -> [AutorouterRoute]
     func packs(flightId: String) async throws -> [PackMetaResponse]
     func latestPack(flightId: String) async throws -> PackMetaResponse
     func advisories(flightId: String, timestamp: String) async throws -> AdvisoriesResponse
@@ -58,6 +62,10 @@ final class OnlineBriefingRepository: BriefingRepository {
         try await client.request("/api/aircraft")
     }
 
+    func profiles() async throws -> [ProfileResponse] {
+        try await client.request("/api/user/profiles")
+    }
+
     func searchAircraftTypes(_ query: String) async throws -> [AircraftTypeResponse] {
         return try await client.requestURL("/api/aircraft/types?q=\(Self.queryValueEncoded(query))")
     }
@@ -70,6 +78,23 @@ final class OnlineBriefingRepository: BriefingRepository {
     func parseFpl(_ text: String) async throws -> ParseFplResponse {
         let body = try JSONEncoder.weatherBrief.encode(ParseFplRequest(fplText: text))
         return try await client.request("/api/flights/parse-fpl", method: "POST", body: body)
+    }
+
+    func interpretRoute(rawRoute: String) async throws -> InterpretRouteResponse {
+        let body = try JSONEncoder.weatherBrief.encode(InterpretRouteRequest(rawRoute: rawRoute))
+        return try await client.request("/api/flights/interpret-route", method: "POST", body: body)
+    }
+
+    func routeDistance(waypoints: [String]) async throws -> RouteDistanceResponse {
+        let body = try JSONEncoder.weatherBrief.encode(RouteDistanceRequest(waypoints: waypoints))
+        return try await client.request("/api/flights/route-distance", method: "POST", body: body)
+    }
+
+    func autorouterRoutes(limit: Int) async throws -> [AutorouterRoute] {
+        let response: AutorouterRoutesResponse = try await client.requestURL(
+            "/api/flights/autorouter-routes?limit=\(limit)"
+        )
+        return response.routes
     }
 
     func packs(flightId: String) async throws -> [PackMetaResponse] {

--- a/app/flyfun-weather/flyfun-weather/Services/CachingBriefingRepository.swift
+++ b/app/flyfun-weather/flyfun-weather/Services/CachingBriefingRepository.swift
@@ -52,6 +52,22 @@ final class CachingBriefingRepository: BriefingRepository {
         try await online.aircraft()
     }
 
+    func profiles() async throws -> [ProfileResponse] {
+        try await online.profiles()
+    }
+
+    func interpretRoute(rawRoute: String) async throws -> InterpretRouteResponse {
+        try await online.interpretRoute(rawRoute: rawRoute)
+    }
+
+    func routeDistance(waypoints: [String]) async throws -> RouteDistanceResponse {
+        try await online.routeDistance(waypoints: waypoints)
+    }
+
+    func autorouterRoutes(limit: Int) async throws -> [AutorouterRoute] {
+        try await online.autorouterRoutes(limit: limit)
+    }
+
     func searchAircraftTypes(_ query: String) async throws -> [AircraftTypeResponse] {
         try await online.searchAircraftTypes(query)
     }

--- a/app/flyfun-weather/flyfun-weather/Services/FixtureBriefingRepository.swift
+++ b/app/flyfun-weather/flyfun-weather/Services/FixtureBriefingRepository.swift
@@ -73,6 +73,7 @@ actor FixtureBriefingRepository: BriefingRepository {
         return flight
     }
     func aircraft() async throws -> [AircraftResponse] { [] }
+    func profiles() async throws -> [ProfileResponse] { [] }
     func searchAircraftTypes(_ query: String) async throws -> [AircraftTypeResponse] { [] }
     func packs(flightId: String) async throws -> [PackMetaResponse] { [] }
     func fetchPireps(flightId: String) async throws -> PirepListResponse { PirepListResponse(items: [], count: 0) }
@@ -85,6 +86,9 @@ actor FixtureBriefingRepository: BriefingRepository {
     func updateFlight(flightId: String, request: UpdateFlightRequest) async throws -> UpdateFlightResponse { throw FixtureError.notProvided("updateFlight") }
     func createAircraft(_ request: CreateAircraftRequest) async throws -> AircraftResponse { throw FixtureError.notProvided("createAircraft") }
     func parseFpl(_ text: String) async throws -> ParseFplResponse { throw FixtureError.notProvided("parseFpl") }
+    func interpretRoute(rawRoute: String) async throws -> InterpretRouteResponse { throw FixtureError.notProvided("interpretRoute") }
+    func routeDistance(waypoints: [String]) async throws -> RouteDistanceResponse { throw FixtureError.notProvided("routeDistance") }
+    func autorouterRoutes(limit: Int) async throws -> [AutorouterRoute] { [] }
     func latestPack(flightId: String) async throws -> PackMetaResponse { throw FixtureError.notProvided("latestPack") }
     func advisories(flightId: String, timestamp: String) async throws -> AdvisoriesResponse { throw FixtureError.notProvided("advisories") }
     func advisoryDetail(flightId: String, timestamp: String, advisoryId: String) async throws -> AdvisoryDetailResponse { throw FixtureError.notProvided("advisoryDetail") }

--- a/app/flyfun-weather/flyfun-weather/ViewModels/AddFlightViewModel.swift
+++ b/app/flyfun-weather/flyfun-weather/ViewModels/AddFlightViewModel.swift
@@ -7,10 +7,28 @@ import OSLog
 final class AddFlightViewModel {
     // Form fields
     var waypointsText: String = ""
-    var departureDate: Date = Calendar.current.date(byAdding: .hour, value: 1, to: Date()) ?? Date()
+    /// TZ-aware departure time. `departureDate` below bridges to its instant so
+    /// the rest of the VM keeps working with a plain `Date`.
+    let departureTime: DepartureTimeModel
     var cruiseAltitudeFt: Int = 5500
     var flightDurationHours: Double = 2.0
     var selectedAircraftId: Int?
+
+    /// Absolute departure instant — the single source of truth lives in
+    /// `departureTime`; this is the bridge the existing create/edit code uses.
+    var departureDate: Date {
+        get { departureTime.instant }
+        set { departureTime.instant = newValue }
+    }
+
+    // Route interpretation (#5) — also feeds the timezone dropdown (#4).
+    private(set) var routeInterpretation: InterpretRouteResponse?
+    private(set) var isInterpreting: Bool = false
+
+    // Flight profile picker
+    private(set) var profileOptions: [ProfileResponse] = []
+    private(set) var isLoadingProfiles: Bool = false
+    var selectedProfileId: Int?
 
     // FPL paste
     var fplText: String = ""
@@ -47,12 +65,14 @@ final class AddFlightViewModel {
     init(repository: any BriefingRepository, flight: FlightResponse? = nil) {
         self.repository = repository
         self.editingFlight = flight
+        let defaultInstant = Calendar.current.date(byAdding: .hour, value: 1, to: Date()) ?? Date()
+        self.departureTime = DepartureTimeModel(instant: flight?.departureDate ?? defaultInstant)
         if let flight {
             waypointsText = flight.waypoints.joined(separator: " ")
-            if let date = flight.departureDate { departureDate = date }
             cruiseAltitudeFt = flight.cruiseAltitudeFt
             flightDurationHours = flight.flightDurationHours
             selectedAircraftId = flight.aircraftId
+            selectedProfileId = flight.profileId
         }
     }
 
@@ -61,6 +81,19 @@ final class AddFlightViewModel {
     var navigationTitle: String { isEditing ? "Edit Flight" : "New Flight" }
 
     var submitTitle: String { isEditing ? "Save" : "Create" }
+
+    /// Replace the trailing (still-being-typed) token with a chosen ICAO and add
+    /// a trailing space so the user can keep typing the next waypoint. Preserves
+    /// whatever separator the user was using before the last token.
+    func completeLastToken(with icao: String) {
+        let separators: Set<Character> = [" ", "-", ","]
+        if let lastSep = waypointsText.lastIndex(where: { separators.contains($0) }) {
+            let prefix = waypointsText[...lastSep]
+            waypointsText = String(prefix) + icao + " "
+        } else {
+            waypointsText = icao + " "
+        }
+    }
 
     /// Parsed waypoints from the text field.
     var waypoints: [String] {
@@ -82,6 +115,7 @@ final class AddFlightViewModel {
         if cruiseAltitudeFt != original.cruiseAltitudeFt { return true }
         if abs(flightDurationHours - original.flightDurationHours) > 0.01 { return true }
         if selectedAircraftId != original.aircraftId { return true }
+        if selectedProfileId != original.profileId { return true }
         guard let originalDate = original.departureDate else { return true }
         return abs(departureDate.timeIntervalSince(originalDate)) > 1
     }
@@ -94,8 +128,115 @@ final class AddFlightViewModel {
         if waypoints != original.waypoints.map({ $0.uppercased() }) { return true }
         if cruiseAltitudeFt != original.cruiseAltitudeFt { return true }
         if abs(flightDurationHours - original.flightDurationHours) > 0.01 { return true }
+        // A profile carries model/method choices, so changing it can change the
+        // forecast — treat it like a forecast-affecting field (rebrief confirm).
+        if selectedProfileId != original.profileId { return true }
         guard let originalDate = original.departureDate else { return true }
         return abs(departureDate.timeIntervalSince(originalDate)) > 1
+    }
+
+    // MARK: - Route interpretation + timezone resolution
+
+    /// Whether the latest interpretation dropped any tokens (skipped / off-route),
+    /// so the save flow should confirm before committing (mirrors the web).
+    var routeHasDroppedTokens: Bool {
+        guard let interpretation = routeInterpretation else { return false }
+        return !interpretation.isClean
+    }
+
+    /// Resolve the typed route on the server: validates/normalises waypoints,
+    /// returns what was understood / skipped / off-route, and per-waypoint
+    /// timezones. Feeds both the interpret popup (#5) and the TZ dropdown (#4).
+    /// Debounced by the caller; non-fatal on failure (e.g. a half-typed route).
+    func resolveRoute() async {
+        let route = waypointsText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard waypoints.count >= 2 else {
+            routeInterpretation = nil
+            return
+        }
+        isInterpreting = true
+        defer { isInterpreting = false }
+        do {
+            let result = try await repository.interpretRoute(rawRoute: route)
+            routeInterpretation = result
+            applyRouteTimeZones(from: result.waypoints)
+        } catch {
+            // Half-typed or out-of-coverage route — keep the field usable, just
+            // don't offer interpretation/timezones yet.
+            Self.logger.debug("Route interpret unavailable: \(error)")
+        }
+    }
+
+    /// Populate the timezone dropdown from resolved waypoints and default the
+    /// display zone to the departure airport's timezone (first waypoint).
+    private func applyRouteTimeZones(from waypoints: [RouteWaypointInfo]) {
+        let zones = waypoints.compactMap(\.timezone)
+        departureTime.setRouteTimeZones(zones, preferred: waypoints.first?.timezone)
+    }
+
+    // MARK: - Autorouter import + recent routes
+
+    private(set) var autorouterRoutes: [AutorouterRoute] = []
+    private(set) var isLoadingAutorouter: Bool = false
+    /// User-facing message when Autorouter import can't proceed (not linked, empty,
+    /// or unreachable). Nil when routes loaded successfully.
+    var autorouterError: String?
+
+    /// Recently-flown routes, derived client-side from the flight list (most recent
+    /// distinct waypoint sequences) — same source as the web's recent-route dropdown.
+    private(set) var recentRoutes: [[String]] = []
+
+    func loadAutorouterRoutes() async {
+        isLoadingAutorouter = true
+        autorouterError = nil
+        defer { isLoadingAutorouter = false }
+        do {
+            autorouterRoutes = try await repository.autorouterRoutes(limit: 25)
+            if autorouterRoutes.isEmpty {
+                autorouterError = "No recent routes found in your Autorouter account."
+            }
+        } catch let APIError.serverError(code, message)
+            where code == 409 || (message?.contains("autorouter_not_linked") ?? false) {
+            autorouterRoutes = []
+            autorouterError = "Link your Autorouter account on the web app to import routes here."
+        } catch {
+            autorouterRoutes = []
+            autorouterError = "Could not load Autorouter routes: \(error.localizedDescription)"
+            Self.logger.debug("Autorouter routes unavailable: \(error)")
+        }
+    }
+
+    /// Import a selected Autorouter route by running its ICAO flight plan through
+    /// the same parse→fill path as "Paste Flight Plan".
+    func importAutorouterRoute(_ route: AutorouterRoute) async {
+        fplText = route.fplan
+        await parseFpl()
+    }
+
+    func loadRecentRoutes() async {
+        do {
+            let flights = try await repository.flights()
+            // `createdAt` is an ISO-8601 string, so a lexicographic sort orders by
+            // recency. Keep up to 8 distinct waypoint sequences.
+            let sorted = flights.sorted { $0.createdAt > $1.createdAt }
+            var seen = Set<String>()
+            var result: [[String]] = []
+            for flight in sorted {
+                let wps = flight.waypoints.map { $0.uppercased() }
+                guard wps.count >= 2 else { continue }
+                if seen.insert(wps.joined(separator: " ")).inserted {
+                    result.append(wps)
+                    if result.count >= 8 { break }
+                }
+            }
+            recentRoutes = result
+        } catch {
+            Self.logger.debug("Recent routes unavailable: \(error)")
+        }
+    }
+
+    func applyRecentRoute(_ waypoints: [String]) {
+        waypointsText = waypoints.joined(separator: " ")
     }
 
     // MARK: - Aircraft picker
@@ -125,6 +266,45 @@ final class AddFlightViewModel {
             // Non-fatal: the form still works without saved aircraft.
             Self.logger.debug("Aircraft list unavailable: \(error)")
         }
+    }
+
+    // MARK: - Profile picker
+
+    var selectedProfile: ProfileResponse? {
+        guard let selectedProfileId else { return nil }
+        return profileOptions.first { $0.id == selectedProfileId }
+    }
+
+    func loadProfiles() async {
+        guard !isLoadingProfiles else { return }
+        isLoadingProfiles = true
+        defer { isLoadingProfiles = false }
+        do {
+            let profiles = try await repository.profiles()
+            profileOptions = profiles.sortedForPicker()
+            // Ensure the picker always reflects a valid selection. If none is set
+            // (new flight, or an older flight saved before profiles existed), fall
+            // back to the account default. Apply the preset's altitude only when
+            // creating — on edit we must not silently rewrite the flight's values.
+            let known = selectedProfileId.flatMap { id in profiles.contains { $0.id == id } } ?? false
+            if !known {
+                selectedProfileId = profiles.first(where: \.isDefault)?.id ?? profiles.first?.id
+                if !isEditing, let id = selectedProfileId { applyProfile(id) }
+            }
+        } catch {
+            // Non-fatal: the form still works without a profile (server uses the
+            // account default).
+            Self.logger.debug("Profile list unavailable: \(error)")
+        }
+    }
+
+    /// Apply a selected profile's preset flight parameters to the form. Mirrors
+    /// the web: choosing a profile fills cruise altitude (and the server fills
+    /// ceiling/speed from the same profile on save).
+    func applyProfile(_ id: Int?) {
+        selectedProfileId = id
+        guard let profile = profileOptions.first(where: { $0.id == id }) else { return }
+        if let alt = profile.settings.cruiseAltitudeFt { cruiseAltitudeFt = alt }
     }
 
     func prepareNewAircraftForm() {
@@ -299,7 +479,8 @@ final class AddFlightViewModel {
             departureTime: formatter.string(from: departureDate),
             cruiseAltitudeFt: cruiseAltitudeFt,
             flightDurationHours: flightDurationHours,
-            aircraftId: selectedAircraftId
+            aircraftId: selectedAircraftId,
+            profileId: selectedProfileId
         )
 
         do {
@@ -337,7 +518,8 @@ final class AddFlightViewModel {
             waypoints: waypoints,
             departureTime: formatter.string(from: departureDate),
             cruiseAltitudeFt: cruiseAltitudeFt,
-            flightDurationHours: flightDurationHours
+            flightDurationHours: flightDurationHours,
+            profileId: selectedProfileId
         )
 
         do {

--- a/app/flyfun-weather/flyfun-weather/ViewModels/BriefingViewModel.swift
+++ b/app/flyfun-weather/flyfun-weather/ViewModels/BriefingViewModel.swift
@@ -184,11 +184,31 @@ final class BriefingViewModel {
             async let dataTask: () = loadPackData(timestamp: pack.fetchTimestamp)
             _ = await (historyTask, dataTask)
             await checkCacheStatus()
+        } catch APIError.notFound {
+            // No briefing pack exists yet — this is the normal state right after a
+            // flight is created (POST /api/flights only saves the flight; it does
+            // not generate a briefing). Rather than dead-ending on a "not found"
+            // error, kick off the first briefing and stream its progress through
+            // the existing refresh banner (stage/detail/percent).
+            await generateFirstBriefing()
         } catch {
             Self.logger.error("Failed to load pack meta: \(error)")
             advisoriesState = .error(error)
             digestState = .error(error)
             snapshotState = .error(error)
+        }
+    }
+
+    /// Generate the briefing for a flight that has no pack yet (e.g. just created).
+    /// If the server already has a refresh in flight (started from the web or
+    /// another device), adopt and poll it; otherwise start a fresh streamed run.
+    /// Either way the refresh UI reports progress and the data loads on completion.
+    private func generateFirstBriefing() async {
+        let active = (try? await repository.refreshStatus(flightId: flight.id))?.active ?? false
+        if active {
+            await checkActiveRefresh()
+        } else {
+            await refresh()
         }
     }
 

--- a/app/flyfun-weather/flyfun-weather/ViewModels/DepartureTimeModel.swift
+++ b/app/flyfun-weather/flyfun-weather/ViewModels/DepartureTimeModel.swift
@@ -1,0 +1,144 @@
+import Foundation
+
+/// One selectable timezone for the departure-time picker.
+struct DepartureTimeZoneOption: Identifiable, Hashable, Sendable {
+    var id: String { identifier }
+    let identifier: String   // IANA id, e.g. "Europe/Paris" or "UTC"
+    let label: String        // e.g. "Paris (GMT+2)"
+}
+
+/// TZ-aware departure-time model (port of the web's `timezone.ts` behaviour).
+///
+/// The single source of truth is an absolute `instant` (UTC). The form edits a
+/// wall-clock (date + hour + minute) *interpreted in the selected timezone*, and
+/// the displayed values are always derived from `instant` in that zone — so
+/// switching the timezone keeps the same instant and re-displays it (exactly the
+/// web's "preserve the instant" behaviour), while editing the wall-clock rebuilds
+/// the instant in the selected zone.
+///
+/// DST is handled natively: `Calendar.date(from:)` and
+/// `TimeZone.secondsFromGMT(for:)` both resolve the offset for the actual date,
+/// so a summer "Europe/Paris" shows GMT+2 and a winter one GMT+1 with no special
+/// casing (the bug flyfun-forms' fixed-offset picker has).
+@Observable
+@MainActor
+final class DepartureTimeModel {
+    /// Absolute departure instant (UTC). Everything else is derived from this.
+    var instant: Date
+
+    /// IANA timezone the wall-clock is shown/edited in. Defaults to UTC until the
+    /// route resolves a departure-airport timezone.
+    var timeZoneId: String = "UTC" {
+        didSet { /* instant unchanged → displayed wall-clock re-derives */ }
+    }
+
+    /// IANA timezones offered in the dropdown, in route order. UTC is always first.
+    private var routeTimeZoneIds: [String] = []
+
+    init(instant: Date) {
+        self.instant = instant
+    }
+
+    var timeZone: TimeZone { TimeZone(identifier: timeZoneId) ?? .gmt }
+
+    private var calendar: Calendar {
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = timeZone
+        return cal
+    }
+
+    // MARK: - Displayed wall-clock (in the selected zone)
+
+    var hour: Int { calendar.component(.hour, from: instant) }
+    var minute: Int { calendar.component(.minute, from: instant) }
+
+    /// Minute snapped to the 15-minute options the picker offers.
+    var minuteOption: Int { Self.nearestMinuteOption(minute) }
+
+    /// A proxy `Date` for a device-timezone `DatePicker` (date component only):
+    /// it carries the selected-zone calendar day re-expressed in the device zone,
+    /// so the picker shows the right Y/M/D no matter the device's own timezone.
+    var dateProxy: Date {
+        get {
+            let c = calendar.dateComponents([.year, .month, .day], from: instant)
+            var deviceComps = DateComponents()
+            deviceComps.year = c.year; deviceComps.month = c.month; deviceComps.day = c.day
+            deviceComps.hour = 12   // noon avoids DST/midnight edge cases in the device zone
+            return Calendar.current.date(from: deviceComps) ?? instant
+        }
+        set {
+            let c = Calendar.current.dateComponents([.year, .month, .day], from: newValue)
+            rebuild(year: c.year, month: c.month, day: c.day)
+        }
+    }
+
+    func setHour(_ newHour: Int) { rebuild(hour: newHour) }
+    func setMinute(_ newMinute: Int) { rebuild(minute: newMinute) }
+
+    /// Rebuild `instant` from the current wall-clock with the given overrides,
+    /// interpreting the result in the selected timezone (DST-correct).
+    private func rebuild(year: Int? = nil, month: Int? = nil, day: Int? = nil,
+                         hour: Int? = nil, minute: Int? = nil) {
+        var c = calendar.dateComponents([.year, .month, .day, .hour, .minute], from: instant)
+        if let year { c.year = year }
+        if let month { c.month = month }
+        if let day { c.day = day }
+        if let hour { c.hour = hour }
+        if let minute { c.minute = minute }
+        c.second = 0
+        if let rebuilt = calendar.date(from: c) { instant = rebuilt }
+    }
+
+    // MARK: - Timezone options
+
+    /// Build the dropdown from resolved route waypoint timezones. UTC is always
+    /// offered; route zones follow in order, de-duplicated. When the current
+    /// selection is still the UTC default, switch to `preferred` (typically the
+    /// departure airport) — this only changes the *display* zone, never the
+    /// instant.
+    func setRouteTimeZones(_ identifiers: [String], preferred: String?) {
+        routeTimeZoneIds = identifiers
+        if timeZoneId == "UTC", let preferred, identifiers.contains(preferred) {
+            timeZoneId = preferred
+        }
+    }
+
+    /// Options shown in the picker, with DST-correct offset labels for the
+    /// currently-selected date (recomputed as the date changes).
+    var options: [DepartureTimeZoneOption] {
+        var seen = Set<String>()
+        var result: [DepartureTimeZoneOption] = []
+        for id in ["UTC"] + routeTimeZoneIds where !seen.contains(id) {
+            seen.insert(id)
+            result.append(DepartureTimeZoneOption(identifier: id, label: label(for: id)))
+        }
+        return result
+    }
+
+    private func label(for identifier: String) -> String {
+        if identifier == "UTC" { return "UTC" }
+        let zone = TimeZone(identifier: identifier) ?? .gmt
+        let offsetMin = zone.secondsFromGMT(for: instant) / 60
+        let city = identifier.split(separator: "/").last
+            .map { $0.replacingOccurrences(of: "_", with: " ") } ?? identifier
+        return "\(city) (\(Self.formatOffset(offsetMin)))"
+    }
+
+    // MARK: - Pure helpers (unit-tested)
+
+    /// Minute options the picker offers.
+    static let minuteOptions = [0, 15, 30, 45]
+
+    static func nearestMinuteOption(_ m: Int) -> Int {
+        minuteOptions.min(by: { abs($0 - m) < abs($1 - m) }) ?? 0
+    }
+
+    /// Format a signed minute offset as "GMT+2" / "GMT-5:30".
+    static func formatOffset(_ offsetMinutes: Int) -> String {
+        let sign = offsetMinutes >= 0 ? "+" : "-"
+        let abs = Swift.abs(offsetMinutes)
+        let h = abs / 60
+        let m = abs % 60
+        return m != 0 ? String(format: "GMT%@%d:%02d", sign, h, m) : "GMT\(sign)\(h)"
+    }
+}

--- a/app/flyfun-weather/flyfun-weather/ViewModels/DepartureTimeModel.swift
+++ b/app/flyfun-weather/flyfun-weather/ViewModels/DepartureTimeModel.swift
@@ -98,7 +98,12 @@ final class DepartureTimeModel {
     /// instant.
     func setRouteTimeZones(_ identifiers: [String], preferred: String?) {
         routeTimeZoneIds = identifiers
-        if timeZoneId == "UTC", let preferred, identifiers.contains(preferred) {
+        let available = Set(["UTC"] + identifiers)
+        if !available.contains(timeZoneId) {
+            // The route changed and the selected zone is no longer offered —
+            // reset so the picker never shows a blank selected row.
+            timeZoneId = preferred ?? "UTC"
+        } else if timeZoneId == "UTC", let preferred, identifiers.contains(preferred) {
             timeZoneId = preferred
         }
     }

--- a/app/flyfun-weather/flyfun-weather/ViewModels/RouteAutocompleteController.swift
+++ b/app/flyfun-weather/flyfun-weather/ViewModels/RouteAutocompleteController.swift
@@ -1,0 +1,55 @@
+import Foundation
+import RZFlight
+
+/// One ICAO autocomplete suggestion (Sendable projection of RZFlight's `Airport`).
+struct AirportSuggestion: Identifiable, Hashable, Sendable {
+    var id: String { icao }
+    let icao: String
+    let name: String
+}
+
+/// Drives dynamic ICAO autocomplete for the route field.
+///
+/// Design notes (matching the "fast to type" requirement):
+/// - The *keystroke* never does work — the view debounces (`.task(id:)` cancels
+///   the superseded run), so typing is never blocked.
+/// - We only ever complete the **last** token in the field. If the user keeps
+///   typing past the pause, the debounce fires again for the new last token, so
+///   stale results can't appear for an already-finished waypoint.
+/// - `rankedSearch` is an in-memory tiered ICAO/name lookup over ~8.5k airports
+///   (sub-millisecond), so it runs on the main actor after the debounce — no
+///   background hop needed, and no chance of a data race on the shared DB.
+@Observable
+@MainActor
+final class RouteAutocompleteController {
+    /// Suggestions for the current last token (empty when nothing matches, the
+    /// token is too short, or the DB hasn't been downloaded yet).
+    private(set) var suggestions: [AirportSuggestion] = []
+
+    /// Token separators must match `AddFlightViewModel.waypoints` parsing.
+    private static let separators = CharacterSet(charactersIn: " -,")
+
+    /// The trailing, still-being-typed identifier (uppercased). Empty when the
+    /// field is empty or ends with a separator (i.e. the previous token is done).
+    static func lastToken(in text: String) -> String {
+        text.uppercased().components(separatedBy: separators).last ?? ""
+    }
+
+    /// Recompute suggestions for the field's current last token. Cheap; intended
+    /// to be called from a debounced `.task(id:)`.
+    func update(for text: String) {
+        let token = Self.lastToken(in: text)
+        // Need at least 2 chars to keep the list tight (a single letter matches
+        // hundreds of ICAOs and isn't useful).
+        guard token.count >= 2 else {
+            suggestions = []
+            return
+        }
+        suggestions = AirportDatabase.shared.search(needle: token, limit: 8)
+            .map { AirportSuggestion(icao: $0.icao, name: $0.name) }
+    }
+
+    func clear() {
+        suggestions = []
+    }
+}

--- a/app/flyfun-weather/flyfun-weather/Views/Flights/AddFlightView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Flights/AddFlightView.swift
@@ -185,12 +185,12 @@ struct AddFlightView: View {
     private var profileSection: some View {
         if !viewModel.profileOptions.isEmpty {
             Section {
-                Picker("Profile", selection: Binding(
-                    get: { viewModel.selectedProfileId ?? 0 },
-                    set: { viewModel.applyProfile($0 == 0 ? nil : $0) }
+                Picker("Profile", selection: Binding<Int?>(
+                    get: { viewModel.selectedProfileId },
+                    set: { viewModel.applyProfile($0) }
                 )) {
                     ForEach(viewModel.profileOptions) { profile in
-                        Text(profile.name).tag(profile.id)
+                        Text(profile.name).tag(Optional(profile.id))
                     }
                 }
                 .pickerStyle(.menu)

--- a/app/flyfun-weather/flyfun-weather/Views/Flights/AddFlightView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Flights/AddFlightView.swift
@@ -5,9 +5,16 @@ import SwiftUI
 struct AddFlightView: View {
     @Environment(\.dismiss) private var dismiss
     @State private var viewModel: AddFlightViewModel
+    @State private var autocomplete = RouteAutocompleteController()
+    @FocusState private var routeFieldFocused: Bool
     @State private var showFplSheet = false
     @State private var showAircraftSheet = false
     @State private var showRebriefConfirm = false
+    @State private var showInterpretSheet = false
+    @State private var showAutorouterSheet = false
+    /// True when the interpret sheet is shown as a pre-create confirmation
+    /// (because the route dropped tokens), so "Accept" proceeds to create.
+    @State private var confirmingInterpretBeforeCreate = false
 
     /// Called with the created OR updated flight.
     let onCreated: (FlightResponse) -> Void
@@ -21,7 +28,8 @@ struct AddFlightView: View {
     var body: some View {
         NavigationStack {
             Form {
-                fplSection
+                importSection
+                profileSection
                 aircraftSection
                 waypointsSection
                 departureSection
@@ -63,10 +71,37 @@ struct AddFlightView: View {
             .task {
                 await viewModel.loadAircraft()
             }
+            .task {
+                await viewModel.loadProfiles()
+            }
+            .task {
+                await viewModel.loadRecentRoutes()
+            }
             .sheet(isPresented: $showAircraftSheet) {
                 AircraftFormSheet(viewModel: viewModel) {
                     showAircraftSheet = false
                 }
+            }
+            .sheet(isPresented: $showAutorouterSheet) {
+                AutorouterPickerSheet(viewModel: viewModel) { route in
+                    showAutorouterSheet = false
+                    Task { await viewModel.importAutorouterRoute(route) }
+                } onCancel: {
+                    showAutorouterSheet = false
+                }
+            }
+            .sheet(isPresented: $showInterpretSheet) {
+                RouteInterpretSheet(
+                    interpretation: viewModel.routeInterpretation,
+                    rawRoute: viewModel.waypointsText,
+                    isResolving: viewModel.isInterpreting,
+                    acceptTitle: confirmingInterpretBeforeCreate ? "Accept & Create" : nil,
+                    onAccept: {
+                        showInterpretSheet = false
+                        Task { await performCreate() }
+                    },
+                    onResolve: { await viewModel.resolveRoute() }
+                )
             }
         }
     }
@@ -82,13 +117,20 @@ struct AddFlightView: View {
             } else {
                 Task { await submitEdit(regenerate: false) }
             }
+        } else if viewModel.routeHasDroppedTokens {
+            // The route dropped tokens — show the interpretation so the pilot can
+            // confirm what we understood before creating (mirrors the web).
+            confirmingInterpretBeforeCreate = true
+            showInterpretSheet = true
         } else {
-            Task {
-                if let flight = await viewModel.createFlight() {
-                    onCreated(flight)
-                    dismiss()
-                }
-            }
+            Task { await performCreate() }
+        }
+    }
+
+    private func performCreate() async {
+        if let flight = await viewModel.createFlight() {
+            onCreated(flight)
+            dismiss()
         }
     }
 
@@ -101,20 +143,69 @@ struct AddFlightView: View {
 
     // MARK: - Sections
 
-    private var fplSection: some View {
+    private var importSection: some View {
         Section {
+            if !viewModel.recentRoutes.isEmpty {
+                Menu {
+                    ForEach(Array(viewModel.recentRoutes.enumerated()), id: \.offset) { _, route in
+                        Button(route.joined(separator: " ")) {
+                            viewModel.applyRecentRoute(route)
+                        }
+                    }
+                } label: {
+                    Label("Recent routes", systemImage: "clock.arrow.circlepath")
+                }
+            }
+
             Button {
                 showFplSheet = true
             } label: {
                 Label("Paste Flight Plan", systemImage: "doc.on.clipboard")
             }
-            .sheet(isPresented: $showFplSheet) {
-                FplPasteSheet(viewModel: viewModel) {
-                    showFplSheet = false
+
+            Button {
+                showAutorouterSheet = true
+                Task { await viewModel.loadAutorouterRoutes() }
+            } label: {
+                Label("Import from Autorouter", systemImage: "arrow.down.doc")
+            }
+        } header: {
+            Text("Import")
+        } footer: {
+            Text("Start from a recent route, an ICAO flight plan, or your Autorouter history.")
+        }
+        .sheet(isPresented: $showFplSheet) {
+            FplPasteSheet(viewModel: viewModel) {
+                showFplSheet = false
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var profileSection: some View {
+        if !viewModel.profileOptions.isEmpty {
+            Section {
+                Picker("Profile", selection: Binding(
+                    get: { viewModel.selectedProfileId ?? 0 },
+                    set: { viewModel.applyProfile($0 == 0 ? nil : $0) }
+                )) {
+                    ForEach(viewModel.profileOptions) { profile in
+                        Text(profile.name).tag(profile.id)
+                    }
+                }
+                .pickerStyle(.menu)
+            } header: {
+                Text("Profile")
+            } footer: {
+                Text("Presets cruise altitude and the weather models used for the briefing.")
+            }
+        } else if viewModel.isLoadingProfiles {
+            Section {
+                HStack {
+                    ProgressView()
+                    Text("Loading profiles\u{2026}").foregroundStyle(.secondary)
                 }
             }
-        } footer: {
-            Text("Paste an ICAO flight plan to auto-fill all fields.")
         }
     }
 
@@ -166,25 +257,134 @@ struct AddFlightView: View {
             TextField("LFBO TOU LFMT", text: $viewModel.waypointsText)
                 .textInputAutocapitalization(.characters)
                 .autocorrectionDisabled()
+                .focused($routeFieldFocused)
                 .accessibilityIdentifier("waypointsField")
+                // Debounced autocomplete: the keystroke only cancels the prior
+                // pending search, so typing is never blocked. After a short pause
+                // we look up completions for the *last* token.
+                .task(id: viewModel.waypointsText) {
+                    try? await Task.sleep(for: .milliseconds(140))
+                    guard !Task.isCancelled else { return }
+                    autocomplete.update(for: viewModel.waypointsText)
+                }
+
+            if routeFieldFocused, !autocomplete.suggestions.isEmpty {
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 8) {
+                        ForEach(autocomplete.suggestions) { suggestion in
+                            Button {
+                                viewModel.completeLastToken(with: suggestion.icao)
+                                autocomplete.clear()
+                            } label: {
+                                VStack(alignment: .leading, spacing: 1) {
+                                    Text(suggestion.icao)
+                                        .font(.caption.bold().monospaced())
+                                    Text(suggestion.name)
+                                        .font(.caption2)
+                                        .foregroundStyle(.secondary)
+                                        .lineLimit(1)
+                                }
+                                .padding(.horizontal, 10)
+                                .padding(.vertical, 6)
+                                .background(Color.accentColor.opacity(0.12), in: Capsule())
+                            }
+                            .buttonStyle(.plain)
+                        }
+                    }
+                    .padding(.vertical, 2)
+                }
+                .listRowInsets(EdgeInsets(top: 4, leading: 12, bottom: 4, trailing: 12))
+            }
 
             if !viewModel.waypoints.isEmpty {
                 Text(viewModel.waypoints.joined(separator: " \u{2192} "))
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
+
+            if viewModel.waypoints.count >= 2 {
+                Button {
+                    confirmingInterpretBeforeCreate = false
+                    showInterpretSheet = true
+                } label: {
+                    HStack {
+                        Label("Interpret route", systemImage: "map")
+                        if viewModel.isInterpreting {
+                            Spacer()
+                            ProgressView()
+                        } else if viewModel.routeHasDroppedTokens {
+                            Spacer()
+                            Image(systemName: "exclamationmark.triangle.fill")
+                                .foregroundStyle(.orange)
+                                .font(.caption)
+                        }
+                    }
+                }
+            }
         } header: {
             Text("Route")
         } footer: {
-            Text("Enter waypoints separated by spaces (ICAO codes, navaids, or fixes).")
+            Text("Enter waypoints separated by spaces (ICAO codes, navaids, or fixes). Tap Interpret to see what was understood and view it on the map.")
+        }
+        // Resolve the route (interpretation + timezones) a bit after typing
+        // settles. Longer debounce than autocomplete since it's a network call.
+        .task(id: viewModel.waypointsText) {
+            try? await Task.sleep(for: .milliseconds(500))
+            guard !Task.isCancelled else { return }
+            await viewModel.resolveRoute()
         }
     }
 
     private var departureSection: some View {
         Section {
-            DatePicker("Date & Time", selection: $viewModel.departureDate)
+            DatePicker(
+                "Date",
+                selection: Binding(
+                    get: { viewModel.departureTime.dateProxy },
+                    set: { viewModel.departureTime.dateProxy = $0 }
+                ),
+                displayedComponents: .date
+            )
+
+            HStack {
+                Text("Time")
+                Spacer()
+                Picker("Hour", selection: Binding(
+                    get: { viewModel.departureTime.hour },
+                    set: { viewModel.departureTime.setHour($0) }
+                )) {
+                    ForEach(0..<24, id: \.self) { h in
+                        Text(String(format: "%02d", h)).tag(h)
+                    }
+                }
+                .labelsHidden()
+                .pickerStyle(.menu)
+                Text(":").foregroundStyle(.secondary)
+                Picker("Minute", selection: Binding(
+                    get: { viewModel.departureTime.minuteOption },
+                    set: { viewModel.departureTime.setMinute($0) }
+                )) {
+                    ForEach(DepartureTimeModel.minuteOptions, id: \.self) { m in
+                        Text(String(format: "%02d", m)).tag(m)
+                    }
+                }
+                .labelsHidden()
+                .pickerStyle(.menu)
+            }
+
+            Picker("Timezone", selection: Binding(
+                get: { viewModel.departureTime.timeZoneId },
+                set: { viewModel.departureTime.timeZoneId = $0 }
+            )) {
+                ForEach(viewModel.departureTime.options) { option in
+                    Text(option.label).tag(option.identifier)
+                }
+            }
+            .pickerStyle(.menu)
         } header: {
             Text("Departure")
+        } footer: {
+            Text("The time is interpreted in the selected timezone. Enter a route to offer each airport's local time.")
         }
     }
 
@@ -397,6 +597,56 @@ private struct AircraftFormSheet: View {
                 try? await Task.sleep(nanoseconds: 250_000_000)
                 guard !Task.isCancelled else { return }
                 await viewModel.searchAircraftTypes()
+            }
+        }
+    }
+}
+
+// MARK: - Autorouter Picker Sheet
+
+/// Lists the user's recent Autorouter routes; selecting one imports its flight
+/// plan. Shows a helpful message when the account isn't linked or has no routes.
+private struct AutorouterPickerSheet: View {
+    @Bindable var viewModel: AddFlightViewModel
+    let onSelect: (AutorouterRoute) -> Void
+    let onCancel: () -> Void
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if viewModel.isLoadingAutorouter {
+                    ProgressView("Loading routes\u{2026}")
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                } else if let error = viewModel.autorouterError {
+                    ContentUnavailableView {
+                        Label("Autorouter", systemImage: "arrow.down.doc")
+                    } description: {
+                        Text(error)
+                    }
+                } else {
+                    List(viewModel.autorouterRoutes) { route in
+                        Button {
+                            onSelect(route)
+                        } label: {
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(route.title)
+                                    .font(.headline)
+                                if !route.subtitle.isEmpty {
+                                    Text(route.subtitle)
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            .navigationTitle("Import from Autorouter")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { onCancel() }
+                }
             }
         }
     }

--- a/app/flyfun-weather/flyfun-weather/Views/Flights/RouteInterpretSheet.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Flights/RouteInterpretSheet.swift
@@ -1,0 +1,168 @@
+import MapKit
+import SwiftUI
+
+/// Sheet that shows how the server interpreted a typed route: what was understood,
+/// what was skipped or dropped as off-route, and the resolved route on a map
+/// (#5 — parity with the web's "Interpret" popup).
+struct RouteInterpretSheet: View {
+    let interpretation: InterpretRouteResponse?
+    let rawRoute: String
+    let isResolving: Bool
+    /// When non-nil, shows a confirmation button (e.g. "Accept & Create").
+    let acceptTitle: String?
+    let onAccept: () -> Void
+    let onResolve: () async -> Void
+
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if let interpretation {
+                    RouteInterpretContent(interpretation: interpretation, rawRoute: rawRoute)
+                } else if isResolving {
+                    ProgressView("Interpreting route\u{2026}")
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                } else {
+                    ContentUnavailableView(
+                        "Could not interpret route",
+                        systemImage: "map",
+                        description: Text("Check the waypoints and try again.")
+                    )
+                }
+            }
+            .navigationTitle("Route")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(acceptTitle == nil ? "Done" : "Cancel") { dismiss() }
+                }
+                if let acceptTitle {
+                    ToolbarItem(placement: .confirmationAction) {
+                        Button(acceptTitle) { onAccept() }
+                    }
+                }
+            }
+            .task {
+                if interpretation == nil { await onResolve() }
+            }
+        }
+    }
+}
+
+/// The understood/skipped/off-route summary plus the route map.
+private struct RouteInterpretContent: View {
+    let interpretation: InterpretRouteResponse
+    let rawRoute: String
+
+    private var coordinates: [CLLocationCoordinate2D] {
+        interpretation.waypoints.map { CLLocationCoordinate2D(latitude: $0.lat, longitude: $0.lon) }
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                routeMap
+                    .frame(height: 240)
+                    .clipShape(RoundedRectangle(cornerRadius: 12))
+
+                if !interpretation.interpreted.isEmpty {
+                    summaryBlock(
+                        title: "Understood",
+                        systemImage: "checkmark.circle.fill",
+                        tint: .green,
+                        text: interpretation.interpreted.joined(separator: " \u{2192} ")
+                    )
+                }
+
+                if !interpretation.skipped.isEmpty {
+                    chipBlock(
+                        title: "Skipped (not recognized)",
+                        systemImage: "questionmark.circle.fill",
+                        tint: .orange,
+                        tokens: interpretation.skipped
+                    )
+                }
+
+                if !interpretation.offRoute.isEmpty {
+                    chipBlock(
+                        title: "Off route (too far)",
+                        systemImage: "arrow.uturn.left.circle.fill",
+                        tint: .secondary,
+                        tokens: interpretation.offRoute
+                    )
+                }
+            }
+            .padding()
+        }
+    }
+
+    @ViewBuilder
+    private var routeMap: some View {
+        if coordinates.count >= 2 {
+            Map(initialPosition: .region(Self.boundingRegion(coordinates))) {
+                MapPolyline(coordinates: coordinates)
+                    .stroke(.blue, lineWidth: 3)
+                ForEach(interpretation.waypoints) { wp in
+                    Marker(wp.icao, coordinate: CLLocationCoordinate2D(latitude: wp.lat, longitude: wp.lon))
+                }
+            }
+        } else {
+            ContentUnavailableView("No mappable waypoints", systemImage: "mappin.slash")
+        }
+    }
+
+    private func summaryBlock(title: String, systemImage: String, tint: Color, text: String) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Label(title, systemImage: systemImage)
+                .font(.subheadline.bold())
+                .foregroundStyle(tint)
+            Text(text)
+                .font(.callout)
+                .foregroundStyle(.primary)
+        }
+    }
+
+    private func chipBlock(title: String, systemImage: String, tint: Color, tokens: [String]) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Label(title, systemImage: systemImage)
+                .font(.subheadline.bold())
+                .foregroundStyle(tint)
+            FlowChips(tokens: tokens, tint: tint)
+        }
+    }
+
+    /// Region that fits all coordinates with a little padding.
+    static func boundingRegion(_ coords: [CLLocationCoordinate2D]) -> MKCoordinateRegion {
+        let lats = coords.map(\.latitude)
+        let lons = coords.map(\.longitude)
+        let minLat = lats.min() ?? 0, maxLat = lats.max() ?? 0
+        let minLon = lons.min() ?? 0, maxLon = lons.max() ?? 0
+        let center = CLLocationCoordinate2D(latitude: (minLat + maxLat) / 2, longitude: (minLon + maxLon) / 2)
+        let span = MKCoordinateSpan(
+            latitudeDelta: max((maxLat - minLat) * 1.4, 0.5),
+            longitudeDelta: max((maxLon - minLon) * 1.4, 0.5)
+        )
+        return MKCoordinateRegion(center: center, span: span)
+    }
+}
+
+/// Simple wrapping row of token chips.
+private struct FlowChips: View {
+    let tokens: [String]
+    let tint: Color
+
+    var body: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 6) {
+                ForEach(tokens, id: \.self) { token in
+                    Text(token)
+                        .font(.caption.monospaced())
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 4)
+                        .background(tint.opacity(0.15), in: Capsule())
+                }
+            }
+        }
+    }
+}

--- a/app/flyfun-weather/flyfun-weatherTests/RouteCreateLogicTests.swift
+++ b/app/flyfun-weather/flyfun-weatherTests/RouteCreateLogicTests.swift
@@ -1,0 +1,106 @@
+//
+//  RouteCreateLogicTests.swift
+//  flyfun-weatherTests
+//
+//  Pure-logic tests for the flight-create revamp: TZ-aware departure time
+//  (#4) and route autocomplete token parsing (#6). These are silent-regression
+//  prone — wrong timezone math sends the wrong UTC instant to the server, and
+//  wrong tokenisation completes the wrong waypoint, neither of which crashes.
+//
+
+import Testing
+import Foundation
+@testable import flyfun_weather
+
+private func iso(_ s: String) -> Date {
+    let f = ISO8601DateFormatter()
+    return f.date(from: s)!
+}
+
+/// A device-timezone date at noon for the given Y/M/D (matches how
+/// `DepartureTimeModel.dateProxy` reads the date component).
+private func deviceDate(_ y: Int, _ m: Int, _ d: Int) -> Date {
+    var c = DateComponents()
+    c.year = y; c.month = m; c.day = d; c.hour = 12
+    return Calendar.current.date(from: c)!
+}
+
+@MainActor
+@Suite struct DepartureTimeModelTests {
+    @Test func formatOffsetSignAndMinutes() {
+        #expect(DepartureTimeModel.formatOffset(120) == "GMT+2")
+        #expect(DepartureTimeModel.formatOffset(0) == "GMT+0")
+        #expect(DepartureTimeModel.formatOffset(-330) == "GMT-5:30")
+        #expect(DepartureTimeModel.formatOffset(330) == "GMT+5:30")
+    }
+
+    @Test func nearestMinuteSnapsToQuarter() {
+        #expect(DepartureTimeModel.nearestMinuteOption(7) == 0)
+        #expect(DepartureTimeModel.nearestMinuteOption(8) == 15)
+        #expect(DepartureTimeModel.nearestMinuteOption(22) == 15)
+        #expect(DepartureTimeModel.nearestMinuteOption(23) == 30)
+        #expect(DepartureTimeModel.nearestMinuteOption(45) == 45)
+    }
+
+    @Test func wallClockBuildsCorrectUtcInSummerDst() {
+        // 09:00 on 2026-07-15 in Paris is CEST (GMT+2) → 07:00Z.
+        let model = DepartureTimeModel(instant: iso("2026-01-01T00:00:00Z"))
+        model.timeZoneId = "Europe/Paris"
+        model.dateProxy = deviceDate(2026, 7, 15)
+        model.setHour(9)
+        model.setMinute(0)
+        #expect(model.instant == iso("2026-07-15T07:00:00Z"))
+    }
+
+    @Test func wallClockBuildsCorrectUtcInWinterStandardTime() {
+        // 09:00 on 2026-01-15 in Paris is CET (GMT+1) → 08:00Z — the DST case
+        // flyfun-forms' fixed-offset picker gets wrong.
+        let model = DepartureTimeModel(instant: iso("2026-07-01T00:00:00Z"))
+        model.timeZoneId = "Europe/Paris"
+        model.dateProxy = deviceDate(2026, 1, 15)
+        model.setHour(9)
+        model.setMinute(0)
+        #expect(model.instant == iso("2026-01-15T08:00:00Z"))
+    }
+
+    @Test func switchingTimeZonePreservesTheInstant() {
+        let model = DepartureTimeModel(instant: iso("2026-01-01T00:00:00Z"))
+        model.timeZoneId = "Europe/Paris"
+        model.dateProxy = deviceDate(2026, 7, 15)
+        model.setHour(9)
+        model.setMinute(0)
+        let fixed = model.instant            // 07:00Z
+
+        model.timeZoneId = "UTC"
+        #expect(model.instant == fixed)      // instant unchanged
+        #expect(model.hour == 7)             // same moment, displayed in UTC
+        #expect(model.minute == 0)
+    }
+
+    @Test func optionsAlwaysIncludeUtcFirst() {
+        let model = DepartureTimeModel(instant: iso("2026-07-15T12:00:00Z"))
+        model.setRouteTimeZones(["Europe/Paris", "Europe/London"], preferred: "Europe/Paris")
+        let ids = model.options.map(\.identifier)
+        #expect(ids.first == "UTC")
+        #expect(ids.contains("Europe/Paris"))
+        #expect(ids.contains("Europe/London"))
+        // Preferred departure zone becomes the selection (was the UTC default).
+        #expect(model.timeZoneId == "Europe/Paris")
+    }
+}
+
+@MainActor
+@Suite struct RouteAutocompleteTests {
+    @Test func lastTokenIsTheTrailingIdentifier() {
+        #expect(RouteAutocompleteController.lastToken(in: "EGTF LFQ") == "LFQ")
+        #expect(RouteAutocompleteController.lastToken(in: "egtf lfq") == "LFQ")
+        #expect(RouteAutocompleteController.lastToken(in: "EGTF-LF") == "LF")
+        #expect(RouteAutocompleteController.lastToken(in: "EGTF,LO") == "LO")
+    }
+
+    @Test func lastTokenEmptyAfterSeparatorOrEmptyField() {
+        // A trailing separator means the previous token is finished.
+        #expect(RouteAutocompleteController.lastToken(in: "EGTF ") == "")
+        #expect(RouteAutocompleteController.lastToken(in: "") == "")
+    }
+}

--- a/app/flyfun-weather/flyfun-weatherTests/RouteCreateLogicTests.swift
+++ b/app/flyfun-weather/flyfun-weatherTests/RouteCreateLogicTests.swift
@@ -87,6 +87,16 @@ private func deviceDate(_ y: Int, _ m: Int, _ d: Int) -> Date {
         // Preferred departure zone becomes the selection (was the UTC default).
         #expect(model.timeZoneId == "Europe/Paris")
     }
+
+    @Test func resetsSelectionWhenRouteDropsTheCurrentZone() {
+        let model = DepartureTimeModel(instant: iso("2026-07-15T12:00:00Z"))
+        model.setRouteTimeZones(["Europe/Paris"], preferred: "Europe/Paris")
+        #expect(model.timeZoneId == "Europe/Paris")
+        // Route changes to a zone set that no longer offers Paris — the picker
+        // must not end up on a value absent from its options.
+        model.setRouteTimeZones(["America/New_York"], preferred: "America/New_York")
+        #expect(model.timeZoneId == "America/New_York")
+    }
 }
 
 @MainActor

--- a/app/flyfun-weather/flyfun-weatherTests/TestSupport.swift
+++ b/app/flyfun-weather/flyfun-weatherTests/TestSupport.swift
@@ -51,6 +51,10 @@ final class MockBriefingRepository: BriefingRepository, @unchecked Sendable {
     func createFlight(_ request: CreateFlightRequest) async throws -> FlightResponse { try createFlightResult.get() }
     func updateFlight(flightId: String, request: UpdateFlightRequest) async throws -> UpdateFlightResponse { throw MockError.notStubbed("updateFlight") }
     func aircraft() async throws -> [AircraftResponse] { try aircraftResult.get() }
+    func profiles() async throws -> [ProfileResponse] { [] }
+    func interpretRoute(rawRoute: String) async throws -> InterpretRouteResponse { throw MockError.notStubbed("interpretRoute") }
+    func routeDistance(waypoints: [String]) async throws -> RouteDistanceResponse { throw MockError.notStubbed("routeDistance") }
+    func autorouterRoutes(limit: Int) async throws -> [AutorouterRoute] { [] }
     func searchAircraftTypes(_ query: String) async throws -> [AircraftTypeResponse] { throw MockError.notStubbed("searchAircraftTypes") }
     func createAircraft(_ request: CreateAircraftRequest) async throws -> AircraftResponse { throw MockError.notStubbed("createAircraft") }
     func parseFpl(_ text: String) async throws -> ParseFplResponse { throw MockError.notStubbed("parseFpl") }

--- a/designs/future/ios-flight-create-overhaul.md
+++ b/designs/future/ios-flight-create-overhaul.md
@@ -1,0 +1,216 @@
+# iOS Flight-Create Overhaul — Implementation Plan
+
+> Status: IMPLEMENTED on branch `ios-flight-create-revamp` (worktree). All six items
+> built + compiling; pure TZ/tokenisation logic unit-tested; server endpoint tested.
+> Bring the iOS flight-creation flow to parity with the web flight-create page, fix the
+> stuck "Loading Briefing" screen, and add dynamic ICAO autocomplete.
+
+## As-built deviations from the original plan
+
+- **#6 airports DB is downloaded, not bundled.** A bundled SQLite churns every AIRAC
+  cycle and would bloat the repo, so instead a new server endpoint
+  `GET /api/nav/airports-db` serves a slim (~3.5 MB, airports+runways only) SQLite
+  built from `nav.db` and cached server-side, with an `ETag`/`If-None-Match` refresh.
+  The iOS `AirportDatabase` caches it in Application Support and refreshes on launch.
+  With no cached copy (first run / offline) autocomplete is simply empty — never broken.
+  The DB is gitignored, never committed.
+- **#4 TZ math uses Swift `TimeZone.secondsFromGMT(for:)`** (DST-correct natively)
+  rather than re-implementing the web's Intl-based offset computation. The single
+  source of truth is the absolute instant; switching zones preserves it and re-displays
+  (web behaviour). `DepartureTimeModel` carries this, unit-tested for summer/winter DST.
+- **Sharing:** all new code is app-local in flyfun-weather (reusing RZFlight's existing
+  `KnownAirports.rankedSearch`). Promoting the pure TZ helpers + a `KnownAirports.bundled`
+  loader into RZFlight remains a deliberate follow-up (both apps track rzflight `main`).
+
+---
+
+> Original plan retained below for reference.
+
+## Guiding insight
+
+The web backend already exposes every endpoint we need. This is almost entirely
+**iOS client-side work** — wire up SwiftUI to APIs the web already calls and iOS
+currently ignores. Server changes: none expected (verify only).
+
+Reference files:
+- iOS create: `app/flyfun-weather/flyfun-weather/Views/Flights/AddFlightView.swift`,
+  `ViewModels/AddFlightViewModel.swift`, `Models/API/CreateFlightRequest.swift`
+- iOS briefing/SSE: `Views/Briefing/BriefingContainerView.swift`,
+  `ViewModels/BriefingViewModel.swift` (`refresh()` already streams progress)
+- Web reference: `web/ts/flights-main.ts`, `web/ts/components/route-interpret.ts`,
+  `web/ts/utils/timezone.ts`
+- Proven autocomplete pattern: `flyfun-forms/.../Services/AirportDatabase.swift`
+
+---
+
+## Item 1 — Fix the stuck "Loading Briefing" (the real bug)
+
+**Root cause.** `POST /api/flights` only *saves* the flight; it does not generate a
+briefing. After create, `FlightListView` sets `selectedFlight = flight`, the briefing
+container loads, calls `latestPack()`, gets 404 (no pack yet), and sits on
+`ProgressView("Loading briefing...")` / `.error`. The web kicks off a refresh after
+create; iOS never does. All progress machinery already exists in
+`BriefingViewModel.refresh()` (streams `/packs/refresh/stream` with stage/detail/%).
+
+**Plan.**
+- In `BriefingViewModel.loadBriefing()`: when `latestPack()` indicates *no pack exists*
+  (distinguish 404 / empty from a real network error), call `refresh()` instead of
+  setting `.error`. This reuses the existing progress-bar UI end to end.
+- Distinguish "no pack yet" from transient errors so we don't auto-refresh-loop on a
+  genuine network failure. Add a `noPackYet` path (check the `APIError`/status).
+- `BriefingContainerView` already shows the refresh progress overlay during
+  `refreshState == .refreshing`; confirm it renders during the initial auto-refresh
+  (it should, since it's the same state).
+- Optional nicety: pass a hint from the create completion so the container knows this
+  is a brand-new flight and shows "Generating briefing…" immediately rather than
+  "Loading…".
+
+**Files:** `BriefingViewModel.swift`, `BriefingContainerView.swift` (minor),
+possibly `FlightListView.swift` (pass new-flight hint).
+**Effort:** small. **Risk:** low. Ship-first candidate.
+
+---
+
+## Item 6 — Dynamic ICAO autocomplete (infrastructure first; enables local validation)
+
+**Feasibility.** Proven. RZFlight ships `KnownAirports.rankedSearch(needle:limit:)`
+(in-memory, tiered: ICAO prefix → ICAO contains → name prefix → name contains).
+flyfun-forms already wraps it in `AirportDatabase` (singleton, loads a bundled
+`airports.db` on a `Task.detached`). No network → typing never blocks.
+
+**Plan.**
+- **Bundle the DB.** Add an `airports.db` to the iOS app bundle. forms ships a 10 MB
+  airports-only DB (vs the 33 MB full `nav.db`). Decision: reuse forms' airports-only
+  DB build so we add ~10 MB, not 33 MB. (Confirm the build step that produces forms'
+  `airports.db`; replicate it from `data/nav.db` if needed.)
+- **Copy the singleton.** Port `AirportDatabase.swift` verbatim (it's generic RZFlight
+  glue): `load()` on app launch, `ready()`, `search(needle:limit:)`,
+  `airport(icao:)`.
+- **Suggestions UI.** A `RouteAutocompleteController` (small `@Observable`) that:
+  - watches the waypoints text field,
+  - extracts the **current last token** (after the last space/dash/comma),
+  - debounces ~150 ms, runs `search()` on a background queue,
+  - publishes results *only if the last token is still the same one searched*
+    (drop stale results — this is exactly the "if the user already typed the next
+    word, autocomplete that one instead" behaviour),
+  - renders a horizontal suggestions bar above the keyboard; tapping a suggestion
+    replaces the last token with its ICAO + a trailing space.
+- Min token length 1–2 chars before searching to avoid huge result sets.
+
+**Why early in the sequence:** the bundled DB also gives us local ICAO validation,
+which strengthens the interpret feedback (#5) and lets us pre-validate before calling
+the server.
+
+**Files (new):** `Services/AirportDatabase.swift`, `Views/Flights/RouteAutocomplete*`,
+bundle resource `airports.db`. **Effort:** medium. **Risk:** bundle-size; otherwise low.
+
+---
+
+## Item 3 — Profile selector
+
+**Backend:** `GET /user/profiles` → `[ProfileResponse]`. A profile presets
+`cruise_altitude_ft`, `flight_ceiling_ft`, `speed_kt`, plus model/method choices.
+On create, web sends `profile_id`; server fills unspecified fields from the profile.
+
+**Plan.**
+- New iOS models: `ProfileResponse` + `ProfileSettings` (Decodable) mirroring
+  `profiles.py`. Repository: `fetchProfiles() -> [ProfileResponse]`.
+- Add `profileId: Int?` to `CreateFlightRequest` (and `UpdateFlightRequest` if edit
+  should carry it). **Coding key:** `profile_id`.
+- `AddFlightView`: a `Picker` for profile (default-first). On selection, override the
+  altitude/ceiling fields with the profile's values (matching web behaviour), and feed
+  `speed_kt` into the duration auto-calc.
+- Load profiles in `AddFlightViewModel` alongside aircraft.
+
+**Files:** `CreateFlightRequest.swift`, new `Models/API/ProfileResponse.swift`,
+`BriefingRepository.swift`, `AddFlightView.swift`, `AddFlightViewModel.swift`.
+**Effort:** small–medium.
+
+---
+
+## Item 2 — Autorouter import + recent-route dropdown (+ FPL already exists)
+
+iOS already has FPL paste import (parses via `POST /flights/parse-fpl`). Two additions:
+
+**2a. Autorouter import.**
+- Backend: `GET /flights/autorouter-routes?limit=25` → `{ routes: [...] }`. Gated by
+  linked autorouter credentials (`hasAutorouterCreds` in `/user/preferences`).
+- Plan: repository `fetchAutorouterRoutes(limit:)`; a picker sheet listing routes
+  (dep→dest, date, distance, aircraft). On select, run the route's `fplan` through the
+  **existing** FPL parse → apply path (reuse current `applyParsedFpl` equivalent).
+- If not linked: show a sheet pointing to settings/web to link autorouter (iOS does not
+  own the OAuth link flow — same as today's credential model).
+
+**2b. Recent-route dropdown.**
+- **No API.** Web builds this client-side from the flight list: sort by created, take up
+  to 8 distinct waypoint sequences. iOS already loads the flight list — derive the same
+  list in `AddFlightViewModel`, expose a `Menu`/`Picker` near the waypoints field that
+  fills the field on selection. Hide when <2 distinct routes.
+
+**Files:** `BriefingRepository.swift`, new picker view for autorouter,
+`AddFlightView.swift`, `AddFlightViewModel.swift`. **Effort:** medium (autorouter),
+small (recent routes).
+
+---
+
+## Items 4 + 5 — Timezone handling and "Interpret" feedback (share one backend call)
+
+Both rely on `POST /flights/interpret-route` (returns `interpreted` / `skipped` /
+`off_route` + per-waypoint `{icao,name,lat,lon,timezone}`). `POST /flights/route-distance`
+returns the same waypoint+timezone shape plus `total_distance_nm` for duration calc.
+
+### Item 5 — Interpret popup
+- After the route field settles (debounced) or on an explicit **Interpret** button,
+  call `interpret-route`.
+- Show a popup/sheet: the understood chain (`interpreted`), `skipped` chips (amber,
+  "not recognized"), `off_route` chips (muted, "too far"), and a **MapKit** map drawing
+  the resolved polyline + waypoint pins (iOS already uses MapKit in `RouteMapView`).
+- On save, mirror web: if nothing skipped/off-route, accept silently; otherwise show the
+  confirmation popup with Accept/Cancel.
+- Local pre-filter: with the bundled DB (#6) we can flag obviously-unknown tokens before
+  the server call, but the server stays the source of truth (handles airways, coords,
+  detour geometry).
+
+### Item 4 — Timezone (port the web logic; do NOT copy flyfun-forms' buggy version)
+The web approach is correct and DST-safe; flyfun-forms' `TimeEntryView` has DST-naive
+labels and date-wrap bugs — port the web, not forms.
+
+- Keep weatherbrief's existing nicer time-entry UX; **add a timezone dropdown**.
+- Populate the dropdown from the route's waypoint timezones (the `timezone` fields from
+  `interpret-route`/`route-distance`), plus UTC always. De-dup; label with the DST-correct
+  offset **for the selected date**.
+- Port `web/ts/utils/timezone.ts`:
+  - `getUtcOffsetMinutes(tz, refDate)` → Swift `TimeZone(identifier:)?.secondsFromGMT(for: refDate)`
+    (DST-aware by date — this is the key correctness win over forms).
+  - `buildTimezoneOptions`, `localToUtc`, `utcToLocal`, `nearestMinuteOption`,
+    `formatUtcOffset` → small Swift helpers.
+- Model: keep a single **internal UTC** instant; display it in the selected zone;
+  re-render on zone change (preserve the instant). On submit, send UTC ISO-8601
+  (fixes today's bug where the iOS `DatePicker` local time is force-stamped `Z`).
+- Duration auto-calc: use `total_distance_nm` (route-distance) + profile/aircraft
+  `speed_kt` (IAS→TAS at altitude), unless the user manually edited duration (lock flag),
+  matching web.
+
+**Files:** new `Utils/Timezone.swift`, new `Views/Flights/RouteInterpretView.swift`
+(map popup), changes to `AddFlightView.swift` / `AddFlightViewModel.swift`, repository
+methods `interpretRoute` + `routeDistance`. **Effort:** medium each.
+
+---
+
+## Recommended build sequence
+
+1. **#1** — fix stuck Loading Briefing (smallest, biggest UX win).
+2. **#6 infra** — bundle `airports.db` + `AirportDatabase` + autocomplete bar.
+3. **#3** — profile selector.
+4. **#2** — autorouter import + recent-route dropdown.
+5. **#4 + #5** — timezone port + interpret popup (shared `interpret-route` call).
+
+## Open decisions / confirmations before coding
+- **Bundle size:** OK to add ~10 MB `airports.db`? (forms already does.) Confirm the
+  build step that produces the airports-only DB from `nav.db`.
+- **Profiles on iOS:** new models needed (no `ProfileResponse` exists on iOS today).
+- **Edit parity:** apply the same TZ/interpret/profile UX to the *edit* flight sheet
+  (same `AddFlightView`), or create-only for v1?
+- **Server:** confirm `/flights/interpret-route`, `/flights/route-distance`,
+  `/flights/autorouter-routes`, `/user/profiles` are all reachable by the iOS auth
+  context (token vs cookie) — expected yes, verify.

--- a/src/weatherbrief/api/app.py
+++ b/src/weatherbrief/api/app.py
@@ -60,6 +60,7 @@ from weatherbrief.api.airport_profile import router as airport_profile_router
 from weatherbrief.api.hewson_map import router as hewson_map_router
 from weatherbrief.api.synoptic_charts import router as synoptic_charts_router
 from weatherbrief.api.data_sources import router as data_sources_router
+from weatherbrief.api.nav import router as nav_router
 from weatherbrief.api.models import router as models_router
 from weatherbrief.api.tokens import router as tokens_router
 from weatherbrief.api.account_export import router as account_export_router
@@ -550,6 +551,7 @@ def create_app() -> FastAPI:
     app.include_router(models_router, prefix="/api")
     app.include_router(help_router, prefix="/api")
     app.include_router(data_sources_router, prefix="/api")
+    app.include_router(nav_router, prefix="/api")
     app.include_router(refresh_router, prefix="/api")
     app.include_router(transparency_router, prefix="/api")
     app.include_router(donations_router, prefix="/api")

--- a/src/weatherbrief/api/nav.py
+++ b/src/weatherbrief/api/nav.py
@@ -11,9 +11,10 @@ The slim DB keeps only the ``airports`` + ``runways`` tables (what
 ``KnownAirports`` reads), dropping procedures / AIP / waypoints / change-log
 tables — ~3.5 MB instead of the full ~33 MB nav DB.
 
-No auth: airport data is public, descriptive reference data (same stance as the
-data-sources catalogue). The build is cached on disk next to the nav DB and
-rebuilt only when the nav DB's mtime advances.
+Requires a bearer token (the iOS client is always authenticated when it fetches
+this), to keep the API's security posture consistent and avoid an unauthenticated
+scraping vector. The build is cached on disk next to the nav DB and rebuilt only
+when the nav DB's mtime advances.
 """
 
 from __future__ import annotations
@@ -24,8 +25,9 @@ import sqlite3
 import threading
 from pathlib import Path
 
-from fastapi import APIRouter, HTTPException, Request, Response
+from fastapi import APIRouter, Depends, HTTPException, Request, Response
 from fastapi.responses import FileResponse
+from flyfun_common.db import current_user_id
 
 router = APIRouter(prefix="/nav", tags=["nav"])
 
@@ -96,7 +98,10 @@ def ensure_slim_db(nav_db_path: str) -> tuple[Path, str]:
 
 
 @router.get("/airports-db")
-def download_airports_db(request: Request):
+def download_airports_db(
+    request: Request,
+    user_id: str = Depends(current_user_id),  # gate only; not used in the body
+):
     """Stream the slim airports SQLite, honoring ``If-None-Match`` (ETag)."""
     nav_db_path = getattr(request.app.state, "db_path", "") or ""
     if not nav_db_path or not os.path.exists(nav_db_path):

--- a/src/weatherbrief/api/nav.py
+++ b/src/weatherbrief/api/nav.py
@@ -1,0 +1,117 @@
+"""Slim airports SQLite download for native clients (iOS autocomplete).
+
+The iOS app does fast, offline ICAO autocomplete against a *local* copy of the
+airport table (via RZFlight's ``KnownAirports``). Rather than bundling a SQLite
+file into the app — which would churn every AIRAC cycle and bloat the repo — the
+client downloads a slimmed-down copy here and refreshes it only when the source
+nav DB changes (ETag / ``If-None-Match``). With no local copy yet (first launch
+or offline) the client simply has an empty autocomplete; nothing breaks.
+
+The slim DB keeps only the ``airports`` + ``runways`` tables (what
+``KnownAirports`` reads), dropping procedures / AIP / waypoints / change-log
+tables — ~3.5 MB instead of the full ~33 MB nav DB.
+
+No auth: airport data is public, descriptive reference data (same stance as the
+data-sources catalogue). The build is cached on disk next to the nav DB and
+rebuilt only when the nav DB's mtime advances.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import sqlite3
+import threading
+from pathlib import Path
+
+from fastapi import APIRouter, HTTPException, Request, Response
+from fastapi.responses import FileResponse
+
+router = APIRouter(prefix="/nav", tags=["nav"])
+
+# Serialise concurrent rebuilds (the freshness loop or multiple clients could
+# race the first build after an AIRAC update).
+_build_lock = threading.Lock()
+
+
+def _slim_path(nav_db_path: str) -> Path:
+    return Path(str(nav_db_path) + ".airports_slim.db")
+
+
+def _etag_path(nav_db_path: str) -> Path:
+    return Path(str(nav_db_path) + ".airports_slim.etag")
+
+
+def _build_slim_db(nav_db_path: str, out_path: Path) -> None:
+    """Copy just airports + runways into a fresh SQLite at ``out_path``."""
+    tmp = Path(str(out_path) + ".tmp")
+    if tmp.exists():
+        tmp.unlink()
+    con = sqlite3.connect(str(tmp))
+    try:
+        con.execute("ATTACH DATABASE ? AS src", (nav_db_path,))
+        con.execute("CREATE TABLE airports AS SELECT * FROM src.airports")
+        con.execute("CREATE TABLE runways AS SELECT * FROM src.runways")
+        # KnownAirports looks runways up by airport_icao; index keeps that O(log n).
+        con.execute("CREATE INDEX idx_runways_airport_icao ON runways(airport_icao)")
+        con.commit()
+        con.execute("DETACH DATABASE src")
+    finally:
+        con.close()
+    tmp.replace(out_path)
+
+
+def _content_etag(path: Path) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as fh:
+        for chunk in iter(lambda: fh.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()[:16]
+
+
+def ensure_slim_db(nav_db_path: str) -> tuple[Path, str]:
+    """Return ``(slim_path, etag)``, rebuilding when the nav DB is newer.
+
+    Exposed (not underscore-prefixed) so tests and any future warm-up loop can
+    trigger the build without going through the HTTP layer.
+    """
+    slim_path = _slim_path(nav_db_path)
+    etag_path = _etag_path(nav_db_path)
+    nav_mtime = os.path.getmtime(nav_db_path)
+    is_fresh = slim_path.exists() and os.path.getmtime(slim_path) >= nav_mtime
+    if not is_fresh:
+        with _build_lock:
+            # Re-check under the lock — another request may have just built it.
+            is_fresh = slim_path.exists() and os.path.getmtime(slim_path) >= nav_mtime
+            if not is_fresh:
+                _build_slim_db(nav_db_path, slim_path)
+                etag = _content_etag(slim_path)
+                etag_path.write_text(etag)
+                return slim_path, etag
+    if etag_path.exists():
+        return slim_path, etag_path.read_text().strip()
+    etag = _content_etag(slim_path)
+    etag_path.write_text(etag)
+    return slim_path, etag
+
+
+@router.get("/airports-db")
+def download_airports_db(request: Request):
+    """Stream the slim airports SQLite, honoring ``If-None-Match`` (ETag)."""
+    nav_db_path = getattr(request.app.state, "db_path", "") or ""
+    if not nav_db_path or not os.path.exists(nav_db_path):
+        raise HTTPException(status_code=503, detail="Airport database unavailable")
+
+    slim_path, etag = ensure_slim_db(nav_db_path)
+    quoted = f'"{etag}"'
+
+    if_none_match = request.headers.get("if-none-match")
+    if if_none_match and if_none_match.strip() in (etag, quoted):
+        return Response(status_code=304, headers={"ETag": quoted, "Cache-Control": "no-cache"})
+
+    return FileResponse(
+        str(slim_path),
+        media_type="application/octet-stream",
+        filename="airports.db",
+        headers={"ETag": quoted, "Cache-Control": "no-cache"},
+    )

--- a/tests/test_nav_airports_db.py
+++ b/tests/test_nav_airports_db.py
@@ -10,6 +10,7 @@ import sqlite3
 
 import pytest
 from fastapi.testclient import TestClient
+from flyfun_common.db import DEV_USER_ID, current_user_id
 
 from weatherbrief.api.app import create_app
 
@@ -56,6 +57,7 @@ def client(tmp_path, monkeypatch) -> TestClient:
     monkeypatch.setenv("JWT_SECRET", "test-jwt-secret")
     monkeypatch.setenv("AIRPORTS_DB", str(nav_db))
     app = create_app()
+    app.dependency_overrides[current_user_id] = lambda: DEV_USER_ID
     return TestClient(app, raise_server_exceptions=False)
 
 

--- a/tests/test_nav_airports_db.py
+++ b/tests/test_nav_airports_db.py
@@ -1,0 +1,87 @@
+"""Tests for the slim airports-DB download endpoint (iOS autocomplete source).
+
+The iOS app downloads a slimmed airports SQLite here and refreshes it via ETag
+when the source nav DB changes. See ``weatherbrief.api.nav``.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+from fastapi.testclient import TestClient
+
+from weatherbrief.api.app import create_app
+
+
+def _make_nav_db(path: str) -> None:
+    """Build a minimal nav DB with the columns KnownAirports reads."""
+    con = sqlite3.connect(path)
+    con.execute(
+        """
+        CREATE TABLE airports (
+            icao_code TEXT NOT NULL PRIMARY KEY,
+            name TEXT,
+            type TEXT,
+            latitude_deg REAL,
+            longitude_deg REAL,
+            elevation_ft REAL
+        )
+        """
+    )
+    con.execute(
+        "CREATE TABLE runways (id INTEGER PRIMARY KEY, airport_icao TEXT NOT NULL, le_ident TEXT)"
+    )
+    # Tables the slim build must drop.
+    con.execute("CREATE TABLE waypoints (ident TEXT)")
+    con.execute("CREATE TABLE procedures (airport_icao TEXT)")
+    con.executemany(
+        "INSERT INTO airports VALUES (?, ?, ?, ?, ?, ?)",
+        [
+            ("EGTF", "Fairoaks", "small_airport", 51.35, -0.56, 80.0),
+            ("LFQA", "Reims", "small_airport", 49.31, 4.05, 312.0),
+        ],
+    )
+    con.execute("INSERT INTO runways VALUES (1, 'EGTF', '06')")
+    con.commit()
+    con.close()
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch) -> TestClient:
+    nav_db = tmp_path / "nav.db"
+    _make_nav_db(str(nav_db))
+    monkeypatch.setenv("DATA_DIR", str(tmp_path / "data"))
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.setenv("JWT_SECRET", "test-jwt-secret")
+    monkeypatch.setenv("AIRPORTS_DB", str(nav_db))
+    app = create_app()
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def test_download_returns_slim_sqlite(client, tmp_path):
+    resp = client.get("/api/nav/airports-db")
+    assert resp.status_code == 200
+    assert resp.headers.get("ETag")
+    assert len(resp.content) > 0
+
+    # The payload is a real SQLite with only airports + runways (no waypoints).
+    out = tmp_path / "downloaded.db"
+    out.write_bytes(resp.content)
+    con = sqlite3.connect(str(out))
+    tables = {r[0] for r in con.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+    assert "airports" in tables
+    assert "runways" in tables
+    assert "waypoints" not in tables
+    assert "procedures" not in tables
+    icaos = {r[0] for r in con.execute("SELECT icao_code FROM airports")}
+    assert icaos == {"EGTF", "LFQA"}
+    con.close()
+
+
+def test_if_none_match_returns_304(client):
+    first = client.get("/api/nav/airports-db")
+    etag = first.headers["ETag"]
+    second = client.get("/api/nav/airports-db", headers={"If-None-Match": etag})
+    assert second.status_code == 304
+    assert second.headers["ETag"] == etag


### PR DESCRIPTION
Brings the iOS flight-create flow to parity with the web flight-create page and fixes the stuck **"Loading Briefing"** screen. Almost entirely iOS client work — the web backend already had the endpoints; one new server endpoint was added for the autocomplete DB.

## What's in it

| # | Change |
|---|--------|
| **1** | **Stuck loading fixed.** Creating a flight only saved it (no briefing). `BriefingViewModel.loadBriefing()` now detects the no-pack `404` and routes into the existing streamed `refresh()`, so the progress banner (stage/detail/%) drives first-briefing generation instead of a dead spinner. |
| **6** | **Dynamic ICAO autocomplete** on the route field (debounced, last-token, never blocks typing), backed by RZFlight `KnownAirports.rankedSearch`. The airports DB is **downloaded**, not bundled: new `GET /api/nav/airports-db` serves a slim ~3.5 MB SQLite (airports+runways from `nav.db`), cached server-side, ETag-refreshed. iOS caches it in Application Support and refreshes on launch; with no copy (first run / offline) autocomplete is simply empty. **The DB is gitignored — never committed** (it churns every AIRAC cycle). |
| **3** | **Profile selector** (create + edit). `GET /api/user/profiles`; applies the profile's cruise altitude; sends `profile_id`. |
| **2** | **Import from Autorouter** (`/autorouter-routes`, reuses the FPL parse path; `409` → "link on the web app") + **recent-routes menu** (client-side from flight history). |
| **4** | **TZ-aware departure time**: date + hour/minute + **timezone dropdown** populated from route waypoints, DST-correct via `TimeZone.secondsFromGMT(for:)`. Also fixes a latent bug where a device-local `DatePicker` value was force-stamped `Z`. |
| **5** | **"Interpret route" sheet**: understood / skipped / off-route chips + a MapKit route polyline; confirm-on-create when tokens were dropped. Shares the one `interpret-route` call with #4. |

Edit parity applied throughout (same `AddFlightView`).

## Tests
- Swift: `DepartureTimeModelTests` (summer/winter DST instant math, tz-switch-preserves-instant, offset formatting) + `RouteAutocompleteTests` (last-token parsing) — pass.
- Python: `test_nav_airports_db.py` (slim-DB shape + ETag/304) — pass; existing flights-API tests still green.
- 6 clean `xcodebuild` builds. On-device visual verification done by the author.

## Notes / follow-ups
- Sharing: all new iOS code is app-local, reusing RZFlight's existing primitives. Promoting the pure TZ helpers + a `KnownAirports.bundled` loader into RZFlight (so flyfun-forms can drop its DST-buggy `TimeEntryView`) is a deliberate follow-up — both apps track rzflight `main`.
- Design notes: `designs/future/ios-flight-create-overhaul.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)