### PR TITLE
fix(ios): testing-feedback batch — flight list, advisory/departure cards, discussion nav, cross-section/Skew-T

### DIFF
--- a/app/flyfun-weather/flyfun-weather/Models/API/FlightResponse.swift
+++ b/app/flyfun-weather/flyfun-weather/Models/API/FlightResponse.swift
@@ -18,6 +18,11 @@ struct FlightResponse: Codable, Identifiable, Sendable {
     let autoRefresh: Bool
     let autoRefreshHour: Int?
     let createdAt: String
+    /// Latest briefing pack summary (assessment / outlook / advisory chips),
+    /// inlined by `/api/flights` so the list card shows a traffic-light tag
+    /// without a per-flight round-trip — same payload the web card reads. nil
+    /// for a flight that has never been briefed.
+    let latestBriefing: BriefingStatusInfo?
     /// Owner vs subscriber. Absent on older servers — treated as owner.
     let role: FlightRole?
 
@@ -60,4 +65,36 @@ struct AircraftInfo: Codable, Hashable, Sendable {
         if let tailNumber, !tailNumber.isEmpty { return tailNumber }
         return typeName
     }
+}
+
+/// Summary of a flight's latest briefing pack, inlined in the flights list so
+/// each card can render a status tag from the single `/api/flights` response
+/// (mirrors the web `BriefingStatusInfo`). Scalar fields are optional so a
+/// partial/legacy payload decodes rather than failing the whole flight.
+struct BriefingStatusInfo: Codable, Sendable {
+    /// GREEN / AMBER / RED traffic-light verdict (short-range, within the GRIB
+    /// horizon). nil when only a long-range `outlook` is available.
+    let assessment: String?
+    let assessmentReason: String?
+    /// Long-range early outlook (beyond the GRIB horizon), e.g.
+    /// TRENDING_SETTLED / MIXED_SIGNALS / TRENDING_UNSETTLED. Mutually
+    /// exclusive with `assessment` — a tendency, not a verdict.
+    let outlook: String?
+    let outlookReason: String?
+    let hasAdvisories: Bool?
+    let advisorySummary: AdvisorySummary?
+}
+
+/// Compact RED/AMBER advisory breakdown for the flights-list card chips.
+struct AdvisorySummary: Codable, Sendable {
+    let red: Int
+    let amber: Int
+    /// Severity-ordered named concerns, capped at 3 server-side.
+    let top: [AdvisoryChip]
+}
+
+/// One named advisory concern for the summary chips.
+struct AdvisoryChip: Codable, Sendable {
+    let status: String  // "RED" | "AMBER"
+    let name: String
 }

--- a/app/flyfun-weather/flyfun-weather/Services/FixtureBriefingRepository.swift
+++ b/app/flyfun-weather/flyfun-weather/Services/FixtureBriefingRepository.swift
@@ -67,7 +67,7 @@ actor FixtureBriefingRepository: BriefingRepository {
             flightCeilingFt: request.flightCeilingFt ?? 13000,
             flightDurationHours: request.flightDurationHours ?? 2.0,
             private: false, autoRefresh: false, autoRefreshHour: nil,
-            createdAt: "2099-06-25T09:00:00Z", role: nil
+            createdAt: "2099-06-25T09:00:00Z", latestBriefing: nil, role: nil
         )
         createdFlights.append(flight)
         return flight

--- a/app/flyfun-weather/flyfun-weather/ViewModels/BriefingViewModel.swift
+++ b/app/flyfun-weather/flyfun-weather/ViewModels/BriefingViewModel.swift
@@ -105,7 +105,10 @@ final class BriefingViewModel {
 
     // UI state
     var selectedTab: BriefingTab = .advisory
-    var selectedModel: String = "gfs"
+    /// Default to ECMWF (#8, iOS feedback). The effective choice is reconciled
+    /// against the models a given flight actually carries via `preferredModel`;
+    /// a user's explicit pick is remembered across flights/launches (#9).
+    var selectedModel: String = BriefingViewModel.storedPreferredModel ?? "ecmwf"
     var availableModels: [String] = []
 
     /// Shared active route point (§4.7) — the scrub/selected point on the
@@ -498,9 +501,35 @@ final class BriefingViewModel {
         if !models.isEmpty {
             availableModels = models
             if !models.contains(selectedModel) {
-                selectedModel = models.first ?? "gfs"
+                selectedModel = preferredModel(from: models)
             }
         }
+    }
+
+    /// `UserDefaults` key for the sticky model preference.
+    private static let preferredModelKey = "preferredCrossSectionModel"
+
+    /// The user's last explicit model pick, if any.
+    static var storedPreferredModel: String? {
+        UserDefaults.standard.string(forKey: preferredModelKey)
+    }
+
+    /// Choose which model to show for a flight whose current selection isn't
+    /// available: the user's sticky preference when this flight carries it, else
+    /// ECMWF (the #8 default), else GFS, else whatever's first. Never persists —
+    /// a fallback for an ECMWF-less flight must not clobber the saved preference.
+    private func preferredModel(from available: [String]) -> String {
+        if let pref = Self.storedPreferredModel, available.contains(pref) { return pref }
+        if available.contains("ecmwf") { return "ecmwf" }
+        if available.contains("gfs") { return "gfs" }
+        return available.first ?? selectedModel
+    }
+
+    /// Record an explicit user model choice so it sticks across flights and
+    /// launches (#8/#9, iOS feedback). Programmatic fallbacks must NOT call this.
+    func selectModel(_ model: String) {
+        selectedModel = model
+        UserDefaults.standard.set(model, forKey: Self.preferredModelKey)
     }
 
     // MARK: - Section loaders
@@ -544,7 +573,7 @@ final class BriefingViewModel {
                 let raModels = response.models.sorted()
                 availableModels = raModels
                 if !raModels.contains(selectedModel) {
-                    selectedModel = raModels.first ?? selectedModel
+                    selectedModel = preferredModel(from: raModels)
                     Self.logger.info("Switched model to \(self.selectedModel) (previous not in route analyses)")
                 }
             }

--- a/app/flyfun-weather/flyfun-weather/ViewModels/CrossSectionViewModel.swift
+++ b/app/flyfun-weather/flyfun-weather/ViewModels/CrossSectionViewModel.swift
@@ -19,12 +19,15 @@ final class CrossSectionViewModel {
     /// booted GRAMET layer preset above, so the chart and the preset agree on
     /// boot. Theme is orthogonal to the layer preset (changing one doesn't reset
     /// the other) — mirrors the web, where `setVizTheme` leaves the preset alone.
-    /// Persisted across launches via `UserDefaults` (the layer preset itself
-    /// isn't persisted yet, so a restart keeps your colours but resets layers).
+    /// Persisted across launches via `UserDefaults`.
     private(set) var themeId: CrossSectionThemeID
 
     /// `UserDefaults` key for the persisted theme choice.
     private static let themeDefaultsKey = "crossSectionThemeId"
+    /// `UserDefaults` key for the persisted layer enablement map.
+    private static let layersDefaultsKey = "crossSectionEnabledLayers"
+    /// `UserDefaults` key for the persisted advisory-lens id (absent when none).
+    private static let advisoryPresetDefaultsKey = "crossSectionAdvisoryPreset"
 
     init() {
         // Restore the last-chosen theme; fall back to GRAMET (the boot preset's
@@ -35,6 +38,22 @@ final class CrossSectionViewModel {
         // config sheet's legend swatches) render in the right palette even before
         // the renderer runs.
         CrossSectionTheme.setActive(themeId)
+
+        // Restore the last layer config so a relaunch keeps the user's layers
+        // (not just colours) — mirrors the web, which persists the whole viz
+        // config (#9, iOS testing feedback). Keep only ids the current build
+        // still knows about (a renamed/removed layer can't resurrect a stale id),
+        // and merge restored values over the GRAMET defaults so a newly-added
+        // layer gets its default state rather than vanishing.
+        if let data = UserDefaults.standard.data(forKey: Self.layersDefaultsKey),
+           let decoded = try? JSONDecoder().decode([String: Bool].self, from: data) {
+            var merged = CrossSectionPresets.gramet
+            for (id, on) in decoded where merged[id] != nil {
+                merged[id] = on
+            }
+            enabledLayers = merged
+        }
+        activeAdvisoryPreset = UserDefaults.standard.string(forKey: Self.advisoryPresetDefaultsKey)
     }
 
     /// Switch the colour theme. Independent of the layer preset. Persisted.
@@ -42,6 +61,19 @@ final class CrossSectionViewModel {
         themeId = id
         CrossSectionTheme.setActive(id)
         UserDefaults.standard.set(id.rawValue, forKey: Self.themeDefaultsKey)
+    }
+
+    /// Persist the current layer set + active advisory lens. Called after every
+    /// mutation so the config survives relaunch (#9, iOS testing feedback).
+    private func persistLayerConfig() {
+        if let data = try? JSONEncoder().encode(enabledLayers) {
+            UserDefaults.standard.set(data, forKey: Self.layersDefaultsKey)
+        }
+        if let id = activeAdvisoryPreset {
+            UserDefaults.standard.set(id, forKey: Self.advisoryPresetDefaultsKey)
+        } else {
+            UserDefaults.standard.removeObject(forKey: Self.advisoryPresetDefaultsKey)
+        }
     }
 
     func update(routeAnalyses: RouteAnalysesResponse, elevation: ElevationResponse?, model: String) {
@@ -52,6 +84,7 @@ final class CrossSectionViewModel {
     func toggleLayer(_ id: String) {
         enabledLayers[id] = !(enabledLayers[id] ?? false)
         activeAdvisoryPreset = nil  // a manual edit is no longer a named lens
+        persistLayerConfig()
     }
 
     /// Force-enable a known layer (e.g. a deep-link focus intent turning on the
@@ -59,6 +92,7 @@ final class CrossSectionViewModel {
     func enableLayer(_ id: String) {
         guard enabledLayers[id] != nil else { return }
         enabledLayers[id] = true
+        persistLayerConfig()
     }
 
     // MARK: - Layer presets (§4.5; ported from web — see CrossSectionPresets).
@@ -89,6 +123,7 @@ final class CrossSectionViewModel {
         if !map.isEmpty { enabledLayers = map }
         if let tid = preset.themeId { setTheme(tid) }
         activeAdvisoryPreset = nil
+        persistLayerConfig()
     }
 
     /// The preset matching the current layer set, or `.custom` if it's been
@@ -129,12 +164,14 @@ final class CrossSectionViewModel {
         }
         enabledLayers = m
         activeAdvisoryPreset = preset.id
+        persistLayerConfig()
     }
 
     /// Clear the active lens (the picker's "None") without otherwise touching the
     /// layer config.
     func clearAdvisoryPreset() {
         activeAdvisoryPreset = nil
+        persistLayerConfig()
     }
 
     // MARK: - Methods (clouds/icing/turbulence/convection — one method per group)
@@ -154,6 +191,7 @@ final class CrossSectionViewModel {
             enabledLayers[id] = (id == layerId)
         }
         activeAdvisoryPreset = nil
+        persistLayerConfig()
     }
 
     // MARK: - Cloud axes (source × style — two independent controls, #7)

--- a/app/flyfun-weather/flyfun-weather/ViewModels/FlightListViewModel.swift
+++ b/app/flyfun-weather/flyfun-weather/ViewModels/FlightListViewModel.swift
@@ -14,6 +14,9 @@ enum LoadingState<T> {
 @MainActor
 final class FlightListViewModel {
     private(set) var state: LoadingState<[FlightResponse]> = .idle
+    /// True while a refresh runs *over an already-loaded list* — drives a subtle
+    /// in-place indicator instead of replacing the list with a spinner (#1).
+    private(set) var isRefreshing = false
     /// True when the flight list was served from cache (server unreachable).
     private(set) var isOffline = false
     /// Flight IDs that have downloaded pack data available offline.
@@ -31,7 +34,19 @@ final class FlightListViewModel {
         guard !isLoading else { return }
         isLoading = true
         defer { isLoading = false }
-        state = .loading
+        // Only show the full-screen spinner on the very first load. A refresh
+        // (scene re-activation, pull-to-refresh, post-edit) keeps the current
+        // list on screen and swaps in fresh data when it arrives, so reopening
+        // the app no longer flashes the list to empty (#1, iOS feedback).
+        let hadList: Bool
+        if case .loaded = state {
+            hadList = true
+            isRefreshing = true
+        } else {
+            hadList = false
+            state = .loading
+        }
+        defer { isRefreshing = false }
         do {
             let flights = try await repository.flights()
             // Check offline/cache status
@@ -43,8 +58,15 @@ final class FlightListViewModel {
             state = .loaded(flights)
             Self.logger.info("Loaded \(flights.count) flights (offline=\(self.isOffline), cached=\(self.cachedFlightIds.count))")
         } catch {
-            state = .error(error)
-            Self.logger.error("Failed to load flights: \(error)")
+            // Keep an already-loaded list on screen if a refresh fails — the
+            // stale list beats an error wall. Only surface the error when we
+            // have nothing to show.
+            if hadList {
+                Self.logger.error("Flight-list refresh failed, keeping current list: \(error)")
+            } else {
+                state = .error(error)
+                Self.logger.error("Failed to load flights: \(error)")
+            }
         }
     }
 }

--- a/app/flyfun-weather/flyfun-weather/Views/Briefing/AdvisoryCardView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Briefing/AdvisoryCardView.swift
@@ -168,12 +168,9 @@ struct AdvisoryCardView: View {
                             .foregroundStyle(.secondary)
                     }
                 }
-                if let entry = catalogEntry {
-                    Text(entry.description)
-                        .font(.caption)
-                        .foregroundStyle(.tertiary)
-                        .padding(.top, 4)
-                }
+                // The advisory description is intentionally NOT repeated here —
+                // it's one tap away via the (i) HelpInfoButton in the header (#311),
+                // and duplicating it just consumed vertical space (iOS testing feedback).
             }
         }
         .padding()

--- a/app/flyfun-weather/flyfun-weather/Views/Briefing/AirportConditionsView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Briefing/AirportConditionsView.swift
@@ -39,13 +39,13 @@ private struct AirportConditionCard: View {
     /// top-line rating. Defaults expanded.
     @State private var isExpanded = true
 
-    /// Worst (most restrictive) flight category across the models, for the
-    /// collapsed summary badge. Severity: LIFR > IFR > MVFR > VFR.
-    private var worstCategory: String? {
+    /// The worst (most restrictive) per-model condition — drives the collapsed
+    /// summary line. Severity: LIFR > IFR > MVFR > VFR.
+    private var worstCondition: AirportModelCondition? {
         let order = ["lifr": 3, "ifr": 2, "mvfr": 1, "vfr": 0]
-        return summary.conditions
-            .map(\.flightCategory)
-            .max { (order[$0.lowercased()] ?? -1) < (order[$1.lowercased()] ?? -1) }
+        return summary.conditions.max {
+            (order[$0.flightCategory.lowercased()] ?? -1) < (order[$1.flightCategory.lowercased()] ?? -1)
+        }
     }
 
     var body: some View {
@@ -66,11 +66,6 @@ private struct AirportConditionCard: View {
                             .lineLimit(1)
                     }
                     Spacer()
-                    // Collapsed: surface the worst rating so the card is still
-                    // glanceable without expanding.
-                    if !isExpanded, let worst = worstCategory {
-                        FlightCategoryBadge(category: worst)
-                    }
                     Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
                         .font(.caption)
                         .foregroundStyle(.secondary)
@@ -81,31 +76,44 @@ private struct AirportConditionCard: View {
 
             if isExpanded {
                 ForEach(summary.conditions) { condition in
-                    HStack(spacing: 12) {
-                        Text(condition.model.shortModelName)
-                            .font(.caption.bold())
-                            .frame(width: 60, alignment: .leading)
-
-                        FlightCategoryBadge(category: condition.flightCategory)
-
-                        if let wind = condition.windSpeedKt, let dir = condition.windDirectionDeg {
-                            Label("\(Int(dir))@\(Int(wind))kt", systemImage: "wind")
-                                .font(.caption)
-                        }
-
-                        if let rw = condition.bestRunway {
-                            Text("Rwy \(rw.runwayId)")
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                        }
-
-                        Spacer()
-                    }
+                    conditionRow(condition)
                 }
+            } else if let worst = worstCondition {
+                // Collapsed: keep the card glanceable — worst rating + its wind
+                // and runway, like the web's top-line summary (#4, iOS feedback).
+                conditionRow(worst, showModel: false)
             }
         }
         .padding()
         .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 12))
+    }
+
+    /// One condition line: model (optional) · category · wind · best runway.
+    /// Shared by the expanded per-model list and the collapsed summary line.
+    @ViewBuilder
+    private func conditionRow(_ condition: AirportModelCondition, showModel: Bool = true) -> some View {
+        HStack(spacing: 12) {
+            if showModel {
+                Text(condition.model.shortModelName)
+                    .font(.caption.bold())
+                    .frame(width: 60, alignment: .leading)
+            }
+
+            FlightCategoryBadge(category: condition.flightCategory)
+
+            if let wind = condition.windSpeedKt, let dir = condition.windDirectionDeg {
+                Label("\(Int(dir))@\(Int(wind))kt", systemImage: "wind")
+                    .font(.caption)
+            }
+
+            if let rw = condition.bestRunway {
+                Text("Rwy \(rw.runwayId)")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+        }
     }
 }
 

--- a/app/flyfun-weather/flyfun-weather/Views/Briefing/AirportConditionsView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Briefing/AirportConditionsView.swift
@@ -34,43 +34,73 @@ struct AirportConditionsView: View {
 private struct AirportConditionCard: View {
     let title: String
     let summary: AirportConditionsSummary
+    /// Collapsible (#4, iOS feedback): expanded shows one line per model;
+    /// collapsed shows just the worst-category summary badge — like the web's
+    /// top-line rating. Defaults expanded.
+    @State private var isExpanded = true
+
+    /// Worst (most restrictive) flight category across the models, for the
+    /// collapsed summary badge. Severity: LIFR > IFR > MVFR > VFR.
+    private var worstCategory: String? {
+        let order = ["lifr": 3, "ifr": 2, "mvfr": 1, "vfr": 0]
+        return summary.conditions
+            .map(\.flightCategory)
+            .max { (order[$0.lowercased()] ?? -1) < (order[$1.lowercased()] ?? -1) }
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
-            HStack {
-                Text(title)
-                    .font(.caption.bold())
-                    .foregroundStyle(.secondary)
-                Text(summary.icao)
-                    .font(.headline)
-                if !summary.name.isEmpty {
-                    Text(summary.name)
-                        .font(.subheadline)
+            Button {
+                withAnimation { isExpanded.toggle() }
+            } label: {
+                HStack {
+                    Text(title)
+                        .font(.caption.bold())
+                        .foregroundStyle(.secondary)
+                    Text(summary.icao)
+                        .font(.headline)
+                    if !summary.name.isEmpty {
+                        Text(summary.name)
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                    }
+                    Spacer()
+                    // Collapsed: surface the worst rating so the card is still
+                    // glanceable without expanding.
+                    if !isExpanded, let worst = worstCategory {
+                        FlightCategoryBadge(category: worst)
+                    }
+                    Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
+                        .font(.caption)
                         .foregroundStyle(.secondary)
                 }
-                Spacer()
+                .contentShape(Rectangle())
             }
+            .buttonStyle(.plain)
 
-            ForEach(summary.conditions) { condition in
-                HStack(spacing: 12) {
-                    Text(condition.model.shortModelName)
-                        .font(.caption.bold())
-                        .frame(width: 60, alignment: .leading)
+            if isExpanded {
+                ForEach(summary.conditions) { condition in
+                    HStack(spacing: 12) {
+                        Text(condition.model.shortModelName)
+                            .font(.caption.bold())
+                            .frame(width: 60, alignment: .leading)
 
-                    FlightCategoryBadge(category: condition.flightCategory)
+                        FlightCategoryBadge(category: condition.flightCategory)
 
-                    if let wind = condition.windSpeedKt, let dir = condition.windDirectionDeg {
-                        Label("\(Int(dir))@\(Int(wind))kt", systemImage: "wind")
-                            .font(.caption)
+                        if let wind = condition.windSpeedKt, let dir = condition.windDirectionDeg {
+                            Label("\(Int(dir))@\(Int(wind))kt", systemImage: "wind")
+                                .font(.caption)
+                        }
+
+                        if let rw = condition.bestRunway {
+                            Text("Rwy \(rw.runwayId)")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+
+                        Spacer()
                     }
-
-                    if let rw = condition.bestRunway {
-                        Text("Rwy \(rw.runwayId)")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                    }
-
-                    Spacer()
                 }
             }
         }

--- a/app/flyfun-weather/flyfun-weather/Views/Briefing/DiscussionTabView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Briefing/DiscussionTabView.swift
@@ -4,11 +4,16 @@ import SwiftUI
 /// the digest's four narrative sections — Synoptic, Specific Concerns, Trend and
 /// Watch Items — as markdown. Watch is repeated here from the Advisory tab on
 /// purpose (it reads as the "what to keep an eye on" close of the discussion).
+///
+/// A sticky scroll-spy pill bar (the same `ScrollSpyScroll` the Advisory tab
+/// uses) lets the pilot jump straight to a section instead of hunting through
+/// the prose (#5, iOS feedback). The bar auto-suppresses when only one section
+/// is present.
 struct DiscussionTabView: View {
     let viewModel: BriefingViewModel
 
     var body: some View {
-        ScrollView {
+        ScrollSpyScroll(sections: spySections) {
             VStack(alignment: .leading, spacing: Theme.sectionSpacing) {
                 content
             }
@@ -16,6 +21,13 @@ struct DiscussionTabView: View {
             .padding(.vertical, Theme.cardPadding)
         }
         .background(Theme.bg)
+    }
+
+    /// Spy-bar sections — only the populated narrative sections, in order. Empty
+    /// for the loading/error/empty states, so the bar hides itself there.
+    private var spySections: [SpySection] {
+        guard case .loaded(let digest) = viewModel.digestState else { return [] }
+        return Self.sections(from: digest).map { SpySection($0.id, $0.title) }
     }
 
     @ViewBuilder
@@ -32,7 +44,7 @@ struct DiscussionTabView: View {
                                        description: Text("No discussion is available for this briefing."))
                     .padding(.top, Theme.sectionSpacing)
             } else {
-                ForEach(sections, id: \.title) { section in
+                ForEach(sections, id: \.id) { section in
                     VStack(alignment: .leading, spacing: Theme.spacingS) {
                         Text(section.title)
                             .font(.headline)
@@ -41,6 +53,7 @@ struct DiscussionTabView: View {
                     }
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding(.horizontal, Theme.cardPadding)
+                    .spyAnchor(section.id)
                 }
             }
         case .error(let error):
@@ -51,18 +64,19 @@ struct DiscussionTabView: View {
     }
 
     /// The discussion's four narrative sections, in order, dropping any the
-    /// digest didn't populate.
-    private static func sections(from digest: DigestResponse) -> [(title: String, text: String)] {
-        var result: [(String, String)] = []
-        func add(_ title: String, _ text: String?) {
+    /// digest didn't populate. Each carries a stable id used both as the
+    /// `ForEach` key and the scroll-spy anchor/pill id.
+    private static func sections(from digest: DigestResponse) -> [(id: String, title: String, text: String)] {
+        var result: [(String, String, String)] = []
+        func add(_ id: String, _ title: String, _ text: String?) {
             if let text, !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                result.append((title, text))
+                result.append((id, title, text))
             }
         }
-        add("Synoptic Overview", digest.synoptic)
-        add("Specific Concerns", digest.specificConcerns)
-        add("Trend", digest.trend)
-        add("Watch Items", digest.watchItemsMarkdown)
+        add("synoptic", "Synoptic Overview", digest.synoptic)
+        add("concerns", "Specific Concerns", digest.specificConcerns)
+        add("trend", "Trend", digest.trend)
+        add("watch", "Watch Items", digest.watchItemsMarkdown)
         return result
     }
 }

--- a/app/flyfun-weather/flyfun-weather/Views/CrossSection/CrossSectionView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/CrossSection/CrossSectionView.swift
@@ -17,8 +17,9 @@ struct CrossSectionView: View {
     @State private var chromeHidden = false
     /// Route-graph metric selection, lifted here so the readout strip and the
     /// graph share one cursor + one metric choice (§4.7 unified cursor).
-    @State private var graphLeftMetricId = "headwind"
-    @State private var graphRightMetricId = "cloud-cover"
+    /// Persisted (#9) so the chosen metrics survive relaunch, like the web.
+    @AppStorage("crossSectionGraphLeftMetric") private var graphLeftMetricId = "headwind"
+    @AppStorage("crossSectionGraphRightMetric") private var graphRightMetricId = "cloud-cover"
     /// Scroll-to target inside the tab (#310): the "Sounding ›" deep-link and a
     /// `FocusIntent.target == .skewT` set this to "skewt"; the ScrollViewReader
     /// scrolls to the embedded Skew-T and resets it to nil.
@@ -159,7 +160,7 @@ struct CrossSectionView: View {
         HStack(spacing: Theme.spacingM) {
             ModelSelectorView(selectedModel: Binding(
                 get: { viewModel.selectedModel },
-                set: { viewModel.selectedModel = $0 }
+                set: { viewModel.selectModel($0) }  // sticky pick (#8/#9)
             ), models: viewModel.availableModels)
             Spacer()
             layersPill

--- a/app/flyfun-weather/flyfun-weather/Views/CrossSection/SkewTDetailView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/CrossSection/SkewTDetailView.swift
@@ -117,12 +117,24 @@ struct SkewTDetailView: View {
     // Web app pressure range (1050–250 hPa); shared by the plot and the panel so
     // their pressure rows line up (the panel requires an identical config). Wind
     // barbs are off (#310 — wind is surfaced via the HW/XW side-panel variable),
-    // so the right margin is trimmed to just fit the FL labels.
-    private let config = SkewTConfiguration(
-        pTop: 250,
-        margins: .init(left: 40, right: 46, top: 20, bottom: 25),
-        showWindBarbs: false
-    )
+    // so the right margin is trimmed to just fit the FL labels. On a narrow
+    // iPhone the axis gutters are trimmed further so the plot interior doesn't
+    // collapse to a sliver (#7, iOS feedback).
+    private var config: SkewTConfiguration {
+        if isPad {
+            return SkewTConfiguration(
+                pTop: 250,
+                margins: .init(left: 40, right: 46, top: 20, bottom: 25),
+                showWindBarbs: false
+            )
+        } else {
+            return SkewTConfiguration(
+                pTop: 250,
+                margins: .init(left: 32, right: 36, top: 16, bottom: 22),
+                showWindBarbs: false
+            )
+        }
+    }
     private var isPad: Bool { hSizeClass == .regular }
 
     /// Track (°true) at this route point, for the HW/XW side-panel variable.
@@ -171,10 +183,14 @@ struct SkewTDetailView: View {
             }
             HStack(spacing: 0) {
                 SkewTView(profile: profile, config: config, selectedPressureHPa: $selectedPressureHPa)
+                    // Deterministically take the remaining width so the plot
+                    // can't collapse to a sliver next to the fixed side panel on
+                    // a narrow iPhone (#7).
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
                 if !shown.isEmpty {
                     SkewTVariablePanel(profile: profile, variables: shown, config: config,
                                        selectedPressureHPa: selectedPressureHPa)
-                        .frame(width: isPad ? 220 : 96)
+                        .frame(width: isPad ? 220 : 84)
                 }
             }
         }

--- a/app/flyfun-weather/flyfun-weather/Views/CrossSection/SkewTDetailView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/CrossSection/SkewTDetailView.swift
@@ -1,3 +1,4 @@
+import OSLog
 import RZSkewT
 import SwiftUI
 
@@ -86,6 +87,7 @@ extension SoundingProfileResponse {
 
 /// Shows a Skew-T plot for a selected route point, loaded from the API.
 struct SkewTDetailView: View {
+    private static let logger = Logger(subsystem: "aero.flyfun.weather", category: "SkewT")
     let viewModel: BriefingViewModel
     let pointIndex: Int
 
@@ -350,6 +352,15 @@ struct SkewTDetailView: View {
             availableGroups = SkewTVariableCatalog.grouped(for: response, levels: profile.levels, trackDeg: trackDeg)
             ensureDefaults(availableVars)
             profileState = .loaded(response)
+        } catch let apiError as APIError where apiError.isCancellation {
+            // Scrubbing the cross-section changes the active point, which
+            // cancels this in-flight sounding fetch via `.task(id:)`. That's
+            // benign — a fresh task is already loading the new point — so don't
+            // flash a "network error cancelled" wall (mirrors loadPireps). Leave
+            // state as .loading; the superseding task publishes the result.
+            Self.logger.debug("Sounding load cancelled — ignoring")
+        } catch is CancellationError {
+            Self.logger.debug("Sounding load cancelled — ignoring")
         } catch {
             profileState = .error(error)
         }

--- a/app/flyfun-weather/flyfun-weather/Views/CrossSection/SkewTDetailView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/CrossSection/SkewTDetailView.swift
@@ -116,26 +116,31 @@ struct SkewTDetailView: View {
     @Environment(\.horizontalSizeClass) private var hSizeClass
     @Environment(AppState.self) private var appState
 
-    // Web app pressure range (1050–250 hPa); shared by the plot and the panel so
-    // their pressure rows line up (the panel requires an identical config). Wind
-    // barbs are off (#310 — wind is surfaced via the HW/XW side-panel variable),
-    // so the right margin is trimmed to just fit the FL labels. On a narrow
-    // iPhone the axis gutters are trimmed further so the plot interior doesn't
-    // collapse to a sliver (#7, iOS feedback).
-    private var config: SkewTConfiguration {
-        if isPad {
-            return SkewTConfiguration(
-                pTop: 250,
-                margins: .init(left: 40, right: 46, top: 20, bottom: 25),
-                showWindBarbs: false
-            )
-        } else {
-            return SkewTConfiguration(
-                pTop: 250,
-                margins: .init(left: 32, right: 36, top: 16, bottom: 22),
-                showWindBarbs: false
-            )
-        }
+    // Axis margins — trimmed on a narrow iPhone so the plot interior keeps room.
+    // Wind barbs are off (#310 — wind is surfaced via the HW/XW side-panel
+    // variable), so the right margin is just enough for the FL labels.
+    private var margins: SkewTConfiguration.Margins {
+        isPad ? .init(left: 40, right: 46, top: 20, bottom: 25)
+              : .init(left: 32, right: 36, top: 16, bottom: 22)
+    }
+
+    /// Build the Skew-T config for a concrete plot box (1050–250 hPa range,
+    /// shared identically by the plot and the side panel so their pressure rows
+    /// line up). The skew angle is the fix for #7: RZSkewT aspect-corrects the
+    /// skew to keep a true visual 45°, which on a tall/narrow iPhone plot (h≫w)
+    /// makes `skewFactor = tan45·h/w` large and pushes the cold upper-air data
+    /// off the right edge. Capping the effective skew factor at the classic
+    /// square-aspect value (1.0) keeps the diagram readable: `tan(θ)·h/w = 1 ⇒
+    /// θ = atan(w/h)`. Wide plots (iPad/landscape) keep the full 45°.
+    private func skewConfig(plotWidth: CGFloat, plotHeight: CGFloat) -> SkewTConfiguration {
+        let m = margins
+        let interiorW = max(plotWidth - m.left - m.right, 1)
+        let interiorH = max(plotHeight - m.top - m.bottom, 1)
+        let angleDeg = interiorH > interiorW
+            ? atan(Double(interiorW / interiorH)) * 180 / .pi
+            : 45
+        return SkewTConfiguration(pTop: 250, tMin: -40, tMax: 50,
+                                  skewAngle: angleDeg, margins: m, showWindBarbs: false)
     }
     private var isPad: Bool { hSizeClass == .regular }
 
@@ -183,17 +188,22 @@ struct SkewTDetailView: View {
             if !availableVars.isEmpty {
                 variablePicker(availableVars)
             }
-            HStack(spacing: 0) {
-                SkewTView(profile: profile, config: config, selectedPressureHPa: $selectedPressureHPa)
-                    // Deterministically take the remaining width so the plot
-                    // can't collapse to a sliver next to the fixed side panel on
-                    // a narrow iPhone (#7).
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-                if !shown.isEmpty {
-                    SkewTVariablePanel(profile: profile, variables: shown, config: config,
-                                       selectedPressureHPa: selectedPressureHPa)
-                        .frame(width: isPad ? 220 : 84)
+            GeometryReader { geo in
+                // Side panel is a fixed-width strip; the plot takes the rest.
+                // The config (and its aspect-aware skew angle) is derived from
+                // the real plot box so the diagram fits the available space (#7).
+                let panelW: CGFloat = shown.isEmpty ? 0 : (isPad ? 220 : 100)
+                let cfg = skewConfig(plotWidth: geo.size.width - panelW, plotHeight: geo.size.height)
+                HStack(spacing: 0) {
+                    SkewTView(profile: profile, config: cfg, selectedPressureHPa: $selectedPressureHPa)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    if !shown.isEmpty {
+                        SkewTVariablePanel(profile: profile, variables: shown, config: cfg,
+                                           selectedPressureHPa: selectedPressureHPa)
+                            .frame(width: panelW)
+                    }
                 }
+                .frame(width: geo.size.width, height: geo.size.height)
             }
         }
         // Re-pick defaults only when the size class flips (iPad gains a 2nd axis).

--- a/app/flyfun-weather/flyfun-weather/Views/Flights/FlightCardView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Flights/FlightCardView.swift
@@ -55,18 +55,56 @@ struct FlightCardView: View {
                     .font(.caption)
             }
 
-            if let assessment = flight.assessment {
-                AssessmentStringBadge(status: assessment)
-            }
+            statusBadge
         }
         .padding(.vertical, 4)
         .opacity(isOffline && !hasCachedData ? 0.4 : 1.0)
         .accessibilityIdentifier("flightCard-\(flight.id)")
     }
+
+    /// Trailing status tag: the GREEN/AMBER/RED traffic light when a short-range
+    /// assessment exists, otherwise the soft long-range outlook badge (matches
+    /// the web flights card). Nothing when the flight hasn't been briefed.
+    @ViewBuilder
+    private var statusBadge: some View {
+        if let assessment = flight.latestBriefing?.assessment {
+            AssessmentStringBadge(status: assessment)
+        } else if let outlook = flight.latestBriefing?.outlook {
+            OutlookBadge(outlook: outlook)
+        }
+    }
 }
 
-// Extension to get assessment from a FlightResponse — not in server response for flights,
-// but will be available after we fetch the pack meta. For now, this is nil.
-extension FlightResponse {
-    var assessment: String? { nil }
+/// Soft tinted badge for a flight's long-range outlook (beyond the GRIB
+/// horizon). Deliberately softer than the assessment traffic light — an
+/// outlook is a tendency ("what to expect"), not a verdict.
+private struct OutlookBadge: View {
+    let outlook: String
+
+    private var label: String {
+        switch outlook.uppercased() {
+        case "TRENDING_SETTLED": "Settled"
+        case "TRENDING_UNSETTLED": "Unsettled"
+        default: "Mixed"
+        }
+    }
+
+    private var tint: Color {
+        switch outlook.uppercased() {
+        case "TRENDING_SETTLED": Theme.green
+        case "TRENDING_UNSETTLED": Theme.red
+        default: Theme.amber
+        }
+    }
+
+    var body: some View {
+        Text(label)
+            .font(.caption2.weight(.semibold))
+            .foregroundStyle(tint)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 3)
+            .background(tint.opacity(0.15), in: Capsule())
+            .overlay(Capsule().stroke(tint.opacity(0.4), lineWidth: 0.5))
+            .accessibilityLabel("Outlook: \(label)")
+    }
 }

--- a/app/flyfun-weather/flyfun-weather/Views/Flights/FlightListView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Flights/FlightListView.swift
@@ -72,6 +72,13 @@ struct FlightListView: View {
             }
             .navigationTitle("Flights")
             .toolbar {
+                ToolbarItem(placement: .principal) {
+                    // Subtle in-place refresh indicator — the list stays visible
+                    // underneath instead of being replaced by a spinner (#1).
+                    if viewModel?.isRefreshing == true {
+                        ProgressView().controlSize(.small)
+                    }
+                }
                 #if DEBUG
                 ToolbarItem(placement: .topBarLeading) {
                     Menu {

--- a/app/flyfun-weather/flyfun-weather/Views/RouteGraph/RouteGraphView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/RouteGraph/RouteGraphView.swift
@@ -85,16 +85,38 @@ struct RouteGraphView: View {
                     .lineStyle(StrokeStyle(lineWidth: 1.5))
             }
         }
+        // Pin the X domain to the full route (0…total) so a given distance maps
+        // to the SAME fraction of the plot width the cross-section uses — without
+        // this, Charts auto-domains to the data's min/max distance and the cursor
+        // drifts out of register with the cross-section above (#6, iOS feedback).
+        .chartXScale(domain: 0...max(vizData.totalDistanceNm, 1))
         .chartXAxisLabel("Distance (nm)")
         .chartYAxis {
-            AxisMarks(position: .leading) { _ in
+            AxisMarks(position: .leading) { value in
                 AxisGridLine()
-                AxisValueLabel()
-                    .foregroundStyle(leftMetric.color)
+                AxisValueLabel {
+                    if let v = value.as(Double.self) {
+                        // Fixed-width label pins the leading gutter to the
+                        // cross-section's left margin so the two plot areas share
+                        // the same left edge (#6). Right-aligned in the gutter.
+                        Text(Self.axisLabel(v))
+                            .frame(width: CoordTransform.margins.left - 6, alignment: .trailing)
+                    }
+                }
+                .foregroundStyle(leftMetric.color)
             }
         }
         .frame(height: 150)
-        .padding(.horizontal, 12)
+        // Reserve the cross-section's right margin so the plot's right edge lines
+        // up too; the leading edge is handled by the fixed-width Y label above.
+        .padding(.trailing, CoordTransform.margins.right)
+    }
+
+    /// Compact Y-axis number: integer-valued metrics (kt, %, °C) print clean;
+    /// fractional ones (precip mm) keep one decimal. Keeps the fixed-width
+    /// gutter narrow enough to match the cross-section's left margin.
+    private static func axisLabel(_ v: Double) -> String {
+        v == v.rounded() ? String(Int(v)) : String(format: "%.1f", v)
     }
 
     private func extractData(points: [VizPoint], metric: RouteGraphMetric) -> [ChartDataPoint] {

--- a/app/flyfun-weather/flyfun-weatherTests/TestSupport.swift
+++ b/app/flyfun-weather/flyfun-weatherTests/TestSupport.swift
@@ -111,6 +111,7 @@ func makeFlight(
         autoRefresh: false,
         autoRefreshHour: nil,
         createdAt: "2026-06-20T09:00:00Z",
+        latestBriefing: nil,
         role: role
     )
 }


### PR DESCRIPTION
On-device testing feedback batch (9 items). Builds clean (`xcodebuild … build` succeeds).

## Flight list
1. **No more flash to empty on reopen.** `FlightListViewModel.loadFlights()` only shows the full-screen spinner on the first load; a refresh (scene-active, pull-to-refresh, post-edit) keeps the current list on screen and swaps in fresh data when it arrives. Refresh failures keep the stale list rather than showing an error wall. A subtle nav-bar `ProgressView` signals the in-place refresh. Freshness is preserved — it always converges to the latest server list.
2. **Status tag on each card.** The `/api/flights` response **already inlines** `latest_briefing` (assessment / outlook / advisory summary) — the web card reads it; iOS just wasn't decoding it. Added the `BriefingStatusInfo`/`AdvisorySummary` models and wired the card to the existing `AssessmentStringBadge`, plus a soft outlook badge for long-range flights. **No backend change.**

## Briefing cards
3. **Advisory card** drops the redundant description text when expanded — it's one tap away via the (i) button.
4. **Departure/arrival conditions card** is now collapsible: expanded shows one line per model (unchanged), collapsed shows just the worst-flight-category badge (web top-line behavior). Default expanded.
5. **Discussion tab** gets the same scroll-spy section nav band as the Advisory tab. The four narrative sections (Synoptic / Specific Concerns / Trend / Watch) were already structured in the data — just not anchored. Reuses `ScrollSpyScroll` + `.spyAnchor`.

## Cross-section / Skew-T
6. **Route graph ↔ cross-section X-axis alignment.** Pinned the chart's X domain to `0…totalDistanceNm` (Charts was auto-domaining to data min/max) and matched the plot insets to the cross-section's left/right margins, so a given distance lands at the same x and the shared cursor stays in register.
7. **Skew-T responsive on narrow iPhone width.** Plot now deterministically fills the remaining width next to the side panel; trimmed axis margins + panel width on compact so the plot can't collapse to a sliver.
8. **Defaults to ECMWF** (was GFS via alphabetical fallback). `preferredModel()` = sticky preference → ECMWF → GFS → first.
9. **Settings persist across launches** — layers, advisory lens, route-graph metrics, and the model pick now persist (joining the already-persisted theme), mirroring the web.

## Verification
- `xcodebuild -scheme flyfun-weather … build` → **BUILD SUCCEEDED**.
- ⚠️ **#6 and #7 are visual and need an on-device check** — the mock-mode sim can't render the cross-section / Skew-T (`FixtureBriefingRepository` throws `.notProvided`). The alignment insets in #6 and the trimmed margins in #7 are principled starting points that may want a small px nudge on device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)