### PR TITLE
feat(advisories): generic mitigation concept + VFR worked example (#328)

### DIFF
--- a/src/weatherbrief/analysis/advisories/strings.py
+++ b/src/weatherbrief/analysis/advisories/strings.py
@@ -414,6 +414,12 @@ _STRINGS: dict[str, dict[str, str]] = {
         "de": "VMC verfügbar auf {alt:,} ft",
         "es": "VMC disponible a {alt:,} ft",
     },
+    "vfr.mitigation.altitude_marginal": {
+        "en": "Marginal VMC at {alt:,} ft",
+        "fr": "VMC marginale à {alt:,} ft",
+        "de": "Marginale VMC auf {alt:,} ft",
+        "es": "VMC marginal a {alt:,} ft",
+    },
     "vfr.mitigation.climb_after": {
         "en": "VMC climb to cruise possible after ~{dist} nm from departure",
         "fr": "Montée VMC vers la croisière possible après ~{dist} nm du départ",

--- a/src/weatherbrief/analysis/advisories/strings.py
+++ b/src/weatherbrief/analysis/advisories/strings.py
@@ -408,6 +408,24 @@ _STRINGS: dict[str, dict[str, str]] = {
         "de": "{cov}-Schicht im Sinkflug bei {icao}",
         "es": "Capa {cov} en descenso en {icao}",
     },
+    "vfr.mitigation.altitude": {
+        "en": "VMC available at {alt:,} ft",
+        "fr": "VMC possible à {alt:,} ft",
+        "de": "VMC verfügbar auf {alt:,} ft",
+        "es": "VMC disponible a {alt:,} ft",
+    },
+    "vfr.mitigation.climb_after": {
+        "en": "VMC climb to cruise possible after ~{dist} nm from departure",
+        "fr": "Montée VMC vers la croisière possible après ~{dist} nm du départ",
+        "de": "VMC-Steigflug auf Reiseflughöhe ab ~{dist} nm nach dem Start möglich",
+        "es": "Ascenso VMC a crucero posible tras ~{dist} nm desde la salida",
+    },
+    "vfr.mitigation.descend_before": {
+        "en": "VMC descent possible until ~{dist} nm before arrival",
+        "fr": "Descente VMC possible jusqu'à ~{dist} nm avant l'arrivée",
+        "de": "VMC-Sinkflug bis ~{dist} nm vor der Ankunft möglich",
+        "es": "Descenso VMC posible hasta ~{dist} nm antes de la llegada",
+    },
 
     # --- ifr_feasibility ---
     "ifr.lifr_below_min": {

--- a/src/weatherbrief/analysis/advisories/vfr_feasibility.py
+++ b/src/weatherbrief/analysis/advisories/vfr_feasibility.py
@@ -287,6 +287,9 @@ def _check_corridor_vfr(
     return worst, parts
 
 
+# Only the graded statuses are mapped: `_vertical_mitigation` guards on
+# AMBER/RED cruise status and the candidate statuses come from
+# `_enroute_vfr_status` (always GREEN/AMBER/RED), so UNAVAILABLE is never indexed.
 _SEVERITY = {AdvisoryStatus.GREEN: 0, AdvisoryStatus.AMBER: 1, AdvisoryStatus.RED: 2}
 
 
@@ -313,7 +316,11 @@ def _vertical_mitigation(
     chosen altitude — NOT the overall advisory status (a corridor deck or
     airport issue can still hold the grade higher).
     """
-    if cruise_status == AdvisoryStatus.GREEN:
+    # Only compute a mitigation for an axis that is actually flagged (#328
+    # decision 6). Restricting to AMBER/RED also keeps every `_SEVERITY[...]`
+    # lookup below provably safe — both `cruise_status` and the candidate
+    # statuses are then graded (never GREEN-skip or UNAVAILABLE).
+    if cruise_status not in (AdvisoryStatus.AMBER, AdvisoryStatus.RED):
         return None
 
     cruise = ctx.cruise_altitude_ft
@@ -341,10 +348,18 @@ def _vertical_mitigation(
     if best_alt is None or best_status is None:
         return None
 
+    # Honest phrasing: a GREEN band is clear VMC; an AMBER band (offered only
+    # when cruise is RED and no clear band clears the terrain floor) is merely
+    # *less* IMC — say "marginal" so the detail doesn't contradict the badge.
+    detail_key = (
+        "vfr.mitigation.altitude"
+        if best_status == AdvisoryStatus.GREEN
+        else "vfr.mitigation.altitude_marginal"
+    )
     return Mitigation(
         kind=MitigationKind.ALTITUDE,
         addresses="cruise_imc",
-        detail=adv_t("vfr.mitigation.altitude", loc, alt=best_alt),
+        detail=adv_t(detail_key, loc, alt=best_alt),
         mitigated_status=best_status,
         altitude_ft=best_alt,
     )

--- a/src/weatherbrief/analysis/advisories/vfr_feasibility.py
+++ b/src/weatherbrief/analysis/advisories/vfr_feasibility.py
@@ -183,8 +183,8 @@ def _corridor_points(
     model: str,
     corridor_nm: float,
     phase: str,
-) -> Iterator[tuple[float, bool, bool]]:
-    """Yield ``(distance_nm, has_ovc, has_bkn)`` for each climb/descent corridor point.
+) -> Iterator[tuple[float, bool, bool, float | None]]:
+    """Yield ``(distance_nm, has_ovc, has_bkn, base_agl_ft)`` for each corridor point.
 
     Single source of truth for both corridor membership and the transitable-deck
     condition, shared by the corridor grade (``_check_corridor_vfr``) and the
@@ -198,6 +198,11 @@ def _corridor_points(
       (``floor < top_ft < cruise``) is one the flight must climb/descend through.
       A layer whose top reaches cruise is cruise-in-cloud and is left to
       ``_check_enroute_vfr`` rather than double-counted here.
+
+    ``base_agl_ft`` is the height **above terrain** of the lowest blocking deck's
+    base (``None`` when the point carries no deck) — the VFR room available
+    *beneath* the deck, used by the mitigation's reachability gate. The grade
+    ignores it.
 
     Points are yielded in ``ctx.analyses`` order (callers that need distance order
     sort the result).
@@ -219,6 +224,7 @@ def _corridor_points(
         floor = _field_elevation_ft(ctx, d)
         has_ovc = False
         has_bkn = False
+        lowest_base_ft: float | None = None
         for cl in sounding.cloud_layers:
             if cl.coverage not in (CloudCoverage.BKN, CloudCoverage.OVC):
                 continue
@@ -227,7 +233,10 @@ def _corridor_points(
                     has_ovc = True
                 else:
                     has_bkn = True
-        yield d, has_ovc, has_bkn
+                if lowest_base_ft is None or cl.base_ft < lowest_base_ft:
+                    lowest_base_ft = cl.base_ft
+        base_agl_ft = (lowest_base_ft - floor) if lowest_base_ft is not None else None
+        yield d, has_ovc, has_bkn, base_agl_ft
 
 
 def _check_corridor_vfr(
@@ -264,7 +273,7 @@ def _check_corridor_vfr(
     for phase, key, icao, fallback in phases:
         has_ovc = False
         has_bkn = False
-        for _d, p_ovc, p_bkn in _corridor_points(ctx, model, corridor_nm, phase):
+        for _d, p_ovc, p_bkn, _base in _corridor_points(ctx, model, corridor_nm, phase):
             has_ovc = has_ovc or p_ovc
             has_bkn = has_bkn or p_bkn
 
@@ -346,26 +355,47 @@ def _corridor_blocked_profile(
     model: str,
     corridor_nm: float,
     phase: str,
-) -> list[tuple[float, bool]]:
-    """Per-point (distance, blocked) for a corridor phase, sorted by distance.
+) -> list[tuple[float, bool, float | None]]:
+    """Per-point (distance, blocked, base_agl_ft) for a corridor phase, sorted by distance.
 
     A point is *blocked* when it carries a transitable BKN/OVC deck (see
     ``_corridor_points`` for the membership + deck condition). Collapses the
-    per-point OVC/BKN split to a single ``blocked`` bool so a mitigation can
-    locate where the deck breaks.
+    per-point OVC/BKN split to a single ``blocked`` bool and carries the
+    lowest-deck base height above terrain (``base_agl_ft``) so the mitigation can
+    both locate where the deck breaks and check there is VFR room beneath it.
     """
     profile = [
-        (d, p_ovc or p_bkn)
-        for d, p_ovc, p_bkn in _corridor_points(ctx, model, corridor_nm, phase)
+        (d, p_ovc or p_bkn, base_agl)
+        for d, p_ovc, p_bkn, base_agl in _corridor_points(ctx, model, corridor_nm, phase)
     ]
     profile.sort(key=lambda t: t[0])
     return profile
+
+
+def _under_deck_flyable(
+    blocked_points: list[tuple[float, float | None]],
+    min_base_agl_ft: float,
+) -> bool:
+    """True if every blocked corridor point has VFR room beneath its deck.
+
+    The along-route mitigation tells the pilot to stay *below* the deck until it
+    breaks, then climb (or to descend below it before it starts). That only works
+    if there is flyable VFR airspace under the deck along the whole blocked
+    stretch — i.e. each blocked point's lowest deck base sits at least
+    ``min_base_agl_ft`` above terrain. If the deck scrapes the ground anywhere on
+    that stretch, the clear air can't be reached and the RED/AMBER is genuine.
+    """
+    return all(
+        base_agl is not None and base_agl >= min_base_agl_ft
+        for _d, base_agl in blocked_points
+    )
 
 
 def _corridor_mitigation(
     ctx: RouteContext,
     model: str,
     corridor_nm: float,
+    min_base_agl_ft: float,
     loc: str | None,
 ) -> list[Mitigation]:
     """Find along-route repositioning mitigations for blocked corridor decks.
@@ -373,9 +403,14 @@ def _corridor_mitigation(
     Climb-out: if the corridor points nearest departure are blocked but farther
     ones clear, offer "climb to cruise after ~d* nm from departure" (``d*`` is
     the nearest confirmed-clear distance beyond the blocked region). Descent is
-    symmetric near the arrival end. Only offered when there is a genuine
-    clear/blocked split — a uniformly blocked corridor cannot be repositioned
-    around, so no mitigation (the RED/AMBER is genuine).
+    symmetric near the arrival end. Two gates must BOTH hold:
+
+    1. A genuine clear/blocked split — a uniformly blocked corridor cannot be
+       repositioned around.
+    2. The deck is flyable underneath along the blocked stretch
+       (``_under_deck_flyable``) — otherwise the clear air is unreachable.
+
+    If either fails, no mitigation (the RED/AMBER is genuine).
 
     ``mitigated_status`` is GREEN: repositioning clears that phase's deck. It
     speaks only for the corridor axis, not the overall advisory.
@@ -385,10 +420,10 @@ def _corridor_mitigation(
 
     # --- Climb-out: deck near departure, clear beyond d* ---
     climb = _corridor_blocked_profile(ctx, model, corridor_nm, "climb")
-    blocked = [d for d, b in climb if b]
-    clear = [d for d, b in climb if not b]
-    if blocked and clear:
-        max_blocked = max(blocked)
+    blocked = [(d, base_agl) for d, b, base_agl in climb if b]
+    clear = [d for d, b, _ in climb if not b]
+    if blocked and clear and _under_deck_flyable(blocked, min_base_agl_ft):
+        max_blocked = max(d for d, _ in blocked)
         beyond = [d for d in clear if d > max_blocked]
         if beyond:
             # Round once: the phrasing is qualitative ("~X nm"), so detail and
@@ -405,10 +440,10 @@ def _corridor_mitigation(
 
     # --- Descent: deck near arrival, clear before it ---
     descent = _corridor_blocked_profile(ctx, model, corridor_nm, "descent")
-    blocked = [d for d, b in descent if b]
-    clear = [d for d, b in descent if not b]
-    if blocked and clear:
-        min_blocked = min(blocked)
+    blocked = [(d, base_agl) for d, b, base_agl in descent if b]
+    clear = [d for d, b, _ in descent if not b]
+    if blocked and clear and _under_deck_flyable(blocked, min_base_agl_ft):
+        min_blocked = min(d for d, _ in blocked)
         before = [d for d in clear if d < min_blocked]
         if before:
             d_star = max(before)
@@ -497,6 +532,17 @@ class VFRFeasibilityEvaluator:
                     max=20,
                     step=1,
                 ),
+                AdvisoryParameterDef(
+                    key="mitigation_min_base_agl_ft",
+                    label="Mitigation min deck base (AGL)",
+                    description="Minimum cloud-deck base above terrain for an along-route 'stay below the deck then climb/descend' mitigation to be offered — below this there isn't VFR room beneath the deck to reach the clear air",
+                    type="altitude",
+                    unit="ft",
+                    default=3000,
+                    min=1000,
+                    max=6000,
+                    step=500,
+                ),
             ],
         )
 
@@ -506,6 +552,7 @@ class VFRFeasibilityEvaluator:
         imc_pct_amber = params.get("imc_pct_amber", 15)
         imc_pct_red = params.get("imc_pct_red", 30)
         corridor_nm = params.get("terminal_corridor_nm", 5)
+        mitigation_min_base_agl_ft = params.get("mitigation_min_base_agl_ft", 3000)
 
         per_model: list[ModelAdvisoryResult] = []
 
@@ -608,7 +655,9 @@ class VFRFeasibilityEvaluator:
             )
             if vertical is not None:
                 mitigations.append(vertical)
-            mitigations.extend(_corridor_mitigation(ctx, model, corridor_nm, loc))
+            mitigations.extend(_corridor_mitigation(
+                ctx, model, corridor_nm, mitigation_min_base_agl_ft, loc,
+            ))
 
             per_model.append(ModelAdvisoryResult.build(
                 model=model, status=status, detail=detail,

--- a/src/weatherbrief/analysis/advisories/vfr_feasibility.py
+++ b/src/weatherbrief/analysis/advisories/vfr_feasibility.py
@@ -13,6 +13,8 @@ caution. The standalone advisory still grades it fully (snow can RED).
 
 from __future__ import annotations
 
+from collections.abc import Iterator
+
 from weatherbrief.analysis.advisories import RouteContext
 from weatherbrief.analysis.advisories._helpers import format_extent
 from weatherbrief.analysis.advisories.enroute_precip import classify_enroute_precip
@@ -176,6 +178,58 @@ def _field_elevation_ft(ctx: RouteContext, distance_nm: float) -> float:
     return nearest.elevation_ft
 
 
+def _corridor_points(
+    ctx: RouteContext,
+    model: str,
+    corridor_nm: float,
+    phase: str,
+) -> Iterator[tuple[float, bool, bool]]:
+    """Yield ``(distance_nm, has_ovc, has_bkn)`` for each climb/descent corridor point.
+
+    Single source of truth for both corridor membership and the transitable-deck
+    condition, shared by the corridor grade (``_check_corridor_vfr``) and the
+    corridor mitigation (``_corridor_blocked_profile``):
+
+    - **Membership**: within ``corridor_nm`` of the origin (climb) or destination
+      (descent), with a nearer-half tiebreak so the two corridors stay mutually
+      exclusive on short routes / large ``corridor_nm`` (a point at the midpoint
+      is attributed to the climb-out).
+    - **Deck**: a BKN/OVC layer lying entirely between field elevation and cruise
+      (``floor < top_ft < cruise``) is one the flight must climb/descend through.
+      A layer whose top reaches cruise is cruise-in-cloud and is left to
+      ``_check_enroute_vfr`` rather than double-counted here.
+
+    Points are yielded in ``ctx.analyses`` order (callers that need distance order
+    sort the result).
+    """
+    cruise = ctx.cruise_altitude_ft
+    total = ctx.total_distance_nm
+
+    for rpa in ctx.analyses:
+        d = rpa.distance_from_origin_nm or 0.0
+        if phase == "climb":
+            in_corridor = d <= corridor_nm and d <= total / 2
+        else:
+            in_corridor = (total - d) <= corridor_nm and d > total / 2
+        if not in_corridor:
+            continue
+        sounding = rpa.sounding.get(model)
+        if sounding is None:
+            continue
+        floor = _field_elevation_ft(ctx, d)
+        has_ovc = False
+        has_bkn = False
+        for cl in sounding.cloud_layers:
+            if cl.coverage not in (CloudCoverage.BKN, CloudCoverage.OVC):
+                continue
+            if floor < cl.top_ft < cruise:
+                if cl.coverage == CloudCoverage.OVC:
+                    has_ovc = True
+                else:
+                    has_bkn = True
+        yield d, has_ovc, has_bkn
+
+
 def _check_corridor_vfr(
     ctx: RouteContext,
     model: str,
@@ -195,8 +249,6 @@ def _check_corridor_vfr(
 
     Returns (worst_status, detail_fragments).
     """
-    cruise = ctx.cruise_altitude_ft
-    total = ctx.total_distance_nm
     worst = AdvisoryStatus.GREEN
     parts: list[str] = []
     loc = ctx.locale
@@ -212,33 +264,9 @@ def _check_corridor_vfr(
     for phase, key, icao, fallback in phases:
         has_ovc = False
         has_bkn = False
-        for rpa in ctx.analyses:
-            d = rpa.distance_from_origin_nm or 0.0
-            # Distance to this phase's airport, plus a nearer-half tiebreak so the
-            # climb and descent corridors stay mutually exclusive when they would
-            # otherwise overlap (short routes / large terminal_corridor_nm). A
-            # point exactly at the midpoint is attributed to the climb-out.
-            if phase == "climb":
-                in_corridor = d <= corridor_nm and d <= total / 2
-            else:
-                in_corridor = (total - d) <= corridor_nm and d > total / 2
-            if not in_corridor:
-                continue
-            sounding = rpa.sounding.get(model)
-            if sounding is None:
-                continue
-            floor = _field_elevation_ft(ctx, d)
-            for cl in sounding.cloud_layers:
-                if cl.coverage not in (CloudCoverage.BKN, CloudCoverage.OVC):
-                    continue
-                # A deck we must transit on climb/descent: lies entirely between
-                # the field and cruise. A layer whose top reaches cruise is
-                # cruise-in-cloud — left to _check_enroute_vfr, not double-counted.
-                if floor < cl.top_ft < cruise:
-                    if cl.coverage == CloudCoverage.OVC:
-                        has_ovc = True
-                    else:
-                        has_bkn = True
+        for _d, p_ovc, p_bkn in _corridor_points(ctx, model, corridor_nm, phase):
+            has_ovc = has_ovc or p_ovc
+            has_bkn = has_bkn or p_bkn
 
         if has_ovc:
             worst = _worst_status(worst, AdvisoryStatus.RED)
@@ -321,34 +349,15 @@ def _corridor_blocked_profile(
 ) -> list[tuple[float, bool]]:
     """Per-point (distance, blocked) for a corridor phase, sorted by distance.
 
-    A point is *blocked* when a BKN/OVC layer lies entirely between field
-    elevation and cruise (``floor < top_ft < cruise``) — the same deck condition
-    ``_check_corridor_vfr`` uses, but reported per point so a mitigation can
+    A point is *blocked* when it carries a transitable BKN/OVC deck (see
+    ``_corridor_points`` for the membership + deck condition). Collapses the
+    per-point OVC/BKN split to a single ``blocked`` bool so a mitigation can
     locate where the deck breaks.
     """
-    cruise = ctx.cruise_altitude_ft
-    total = ctx.total_distance_nm
-    profile: list[tuple[float, bool]] = []
-
-    for rpa in ctx.analyses:
-        d = rpa.distance_from_origin_nm or 0.0
-        if phase == "climb":
-            in_corridor = d <= corridor_nm and d <= total / 2
-        else:
-            in_corridor = (total - d) <= corridor_nm and d > total / 2
-        if not in_corridor:
-            continue
-        sounding = rpa.sounding.get(model)
-        if sounding is None:
-            continue
-        floor = _field_elevation_ft(ctx, d)
-        blocked = any(
-            cl.coverage in (CloudCoverage.BKN, CloudCoverage.OVC)
-            and floor < cl.top_ft < cruise
-            for cl in sounding.cloud_layers
-        )
-        profile.append((d, blocked))
-
+    profile = [
+        (d, p_ovc or p_bkn)
+        for d, p_ovc, p_bkn in _corridor_points(ctx, model, corridor_nm, phase)
+    ]
     profile.sort(key=lambda t: t[0])
     return profile
 
@@ -382,13 +391,15 @@ def _corridor_mitigation(
         max_blocked = max(blocked)
         beyond = [d for d in clear if d > max_blocked]
         if beyond:
-            d_star = min(beyond)
+            # Round once: the phrasing is qualitative ("~X nm"), so detail and
+            # the structured distance must report the same integer.
+            dist = round(min(beyond))
             mitigations.append(Mitigation(
                 kind=MitigationKind.ROUTE_POSITION,
                 addresses="climb_deck",
-                detail=adv_t("vfr.mitigation.climb_after", loc, dist=round(d_star)),
+                detail=adv_t("vfr.mitigation.climb_after", loc, dist=dist),
                 mitigated_status=AdvisoryStatus.GREEN,
-                distance_nm=round(d_star, 1),
+                distance_nm=dist,
                 reference="departure",
             ))
 
@@ -401,13 +412,14 @@ def _corridor_mitigation(
         before = [d for d in clear if d < min_blocked]
         if before:
             d_star = max(before)
-            dist_before_arrival = total - d_star
+            # Round once (see climb case): nm before arrival, same int in both.
+            dist = round(total - d_star)
             mitigations.append(Mitigation(
                 kind=MitigationKind.ROUTE_POSITION,
                 addresses="descent_deck",
-                detail=adv_t("vfr.mitigation.descend_before", loc, dist=round(dist_before_arrival)),
+                detail=adv_t("vfr.mitigation.descend_before", loc, dist=dist),
                 mitigated_status=AdvisoryStatus.GREEN,
-                distance_nm=round(dist_before_arrival, 1),
+                distance_nm=dist,
                 reference="arrival",
             ))
 

--- a/src/weatherbrief/analysis/advisories/vfr_feasibility.py
+++ b/src/weatherbrief/analysis/advisories/vfr_feasibility.py
@@ -23,10 +23,21 @@ from weatherbrief.models import (
     AdvisoryParameterDef,
     AdvisoryStatus,
     CloudCoverage,
+    Mitigation,
+    MitigationKind,
     ModelAdvisoryResult,
     RouteAdvisoryResult,
 )
 from weatherbrief.models.airport_conditions import FlightCategory
+
+# Minimum clearance above the highest terrain along the route for a lower cruise
+# altitude to be a valid VFR mitigation. Mirrors the icing-escape terrain gate
+# (``sounding/advisories.py:_TERRAIN_CLEARANCE_FT``): a clear band below MSA is
+# not a flyable option, so the RED is genuine and no mitigation is offered.
+_TERRAIN_CLEARANCE_FT = 1000
+
+# Step (ft) for the downward scan when searching for a clear lower altitude.
+_MITIGATION_STEP_FT = 500
 
 
 def _worst_status(*statuses: AdvisoryStatus) -> AdvisoryStatus:
@@ -77,18 +88,23 @@ def _check_enroute_vfr(
     ctx: RouteContext,
     model: str,
     cloud_clearance_ft: float,
+    altitude_ft: float,
 ) -> tuple[int, int, int, int]:
-    """Check en-route cloud clearance for VFR.
+    """Check en-route cloud clearance for VFR at ``altitude_ft``.
+
+    Takes the evaluated altitude explicitly (rather than reading
+    ``ctx.cruise_altitude_ft``) so it can be re-run at candidate altitudes when
+    searching for a lower-altitude mitigation.
 
     Returns (total, imc_count, marginal_count, clear_count).
-    - imc_count: points where cruise is inside BKN/OVC cloud
+    - imc_count: points where the altitude is inside BKN/OVC cloud
     - marginal_count: points where cloud clearance < threshold (but not in cloud)
     """
     total = 0
     imc_count = 0
     marginal_count = 0
     clear_count = 0
-    cruise = ctx.cruise_altitude_ft
+    cruise = altitude_ft
 
     for rpa in ctx.analyses:
         sounding = rpa.sounding.get(model)
@@ -121,6 +137,30 @@ def _check_enroute_vfr(
             clear_count += 1
 
     return total, imc_count, marginal_count, clear_count
+
+
+def _enroute_vfr_status(
+    total: int,
+    imc_count: int,
+    marginal_count: int,
+    imc_pct_amber: float,
+    imc_pct_red: float,
+) -> AdvisoryStatus:
+    """Grade the en-route cloud-clearance axis from point counts.
+
+    Shared by ``evaluate`` and the vertical-mitigation scan so a candidate
+    altitude is graded with exactly the same thresholds as cruise.
+    """
+    if total <= 0:
+        return AdvisoryStatus.GREEN
+    affected = imc_count + marginal_count
+    imc_pct = 100.0 * imc_count / total
+    affected_pct = 100.0 * affected / total
+    if imc_pct >= imc_pct_red:
+        return AdvisoryStatus.RED
+    if affected_pct >= imc_pct_amber:
+        return AdvisoryStatus.AMBER
+    return AdvisoryStatus.GREEN
 
 
 def _field_elevation_ft(ctx: RouteContext, distance_nm: float) -> float:
@@ -208,6 +248,170 @@ def _check_corridor_vfr(
             parts.append(adv_t(key, loc, cov="BKN", icao=icao or fallback))
 
     return worst, parts
+
+
+_SEVERITY = {AdvisoryStatus.GREEN: 0, AdvisoryStatus.AMBER: 1, AdvisoryStatus.RED: 2}
+
+
+def _vertical_mitigation(
+    ctx: RouteContext,
+    model: str,
+    cloud_clearance_ft: float,
+    imc_pct_amber: float,
+    imc_pct_red: float,
+    cruise_status: AdvisoryStatus,
+    loc: str | None,
+) -> Mitigation | None:
+    """Search for a lower cruise altitude that clears en-route cloud (cruise_imc).
+
+    Scans downward from ``cruise - step`` to a terrain floor
+    (``max terrain + _TERRAIN_CLEARANCE_FT``), re-grading the en-route axis at
+    each candidate. Returns an ALTITUDE mitigation reporting the **highest**
+    altitude whose status strictly improves on cruise, preferring a fully clear
+    (GREEN) band over a merely-better (AMBER) one. Returns None when the
+    en-route axis is already green, or when the only improving band lies below
+    the terrain floor (the RED is genuine).
+
+    ``mitigated_status`` is the status of the *cruise IMC axis alone* at the
+    chosen altitude — NOT the overall advisory status (a corridor deck or
+    airport issue can still hold the grade higher).
+    """
+    if cruise_status == AdvisoryStatus.GREEN:
+        return None
+
+    cruise = ctx.cruise_altitude_ft
+    max_terrain = ctx.elevation.max_elevation_ft if ctx.elevation else 0.0
+    floor = max_terrain + _TERRAIN_CLEARANCE_FT
+
+    best_alt: int | None = None
+    best_status: AdvisoryStatus | None = None
+
+    alt = cruise - _MITIGATION_STEP_FT
+    while alt >= floor:
+        total, imc, marg, _ = _check_enroute_vfr(ctx, model, cloud_clearance_ft, alt)
+        cand = _enroute_vfr_status(total, imc, marg, imc_pct_amber, imc_pct_red)
+        # Only an altitude that strictly improves on cruise is worth offering.
+        if _SEVERITY[cand] < _SEVERITY[cruise_status]:
+            if best_status is None or _SEVERITY[cand] < _SEVERITY[best_status]:
+                best_alt = int(alt)
+                best_status = cand
+            # Scanning high→low, the first GREEN is the highest GREEN and the
+            # best we can do — stop rather than descend further for no gain.
+            if cand == AdvisoryStatus.GREEN:
+                break
+        alt -= _MITIGATION_STEP_FT
+
+    if best_alt is None or best_status is None:
+        return None
+
+    return Mitigation(
+        kind=MitigationKind.ALTITUDE,
+        addresses="cruise_imc",
+        detail=adv_t("vfr.mitigation.altitude", loc, alt=best_alt),
+        mitigated_status=best_status,
+        altitude_ft=best_alt,
+    )
+
+
+def _corridor_blocked_profile(
+    ctx: RouteContext,
+    model: str,
+    corridor_nm: float,
+    phase: str,
+) -> list[tuple[float, bool]]:
+    """Per-point (distance, blocked) for a corridor phase, sorted by distance.
+
+    A point is *blocked* when a BKN/OVC layer lies entirely between field
+    elevation and cruise (``floor < top_ft < cruise``) — the same deck condition
+    ``_check_corridor_vfr`` uses, but reported per point so a mitigation can
+    locate where the deck breaks.
+    """
+    cruise = ctx.cruise_altitude_ft
+    total = ctx.total_distance_nm
+    profile: list[tuple[float, bool]] = []
+
+    for rpa in ctx.analyses:
+        d = rpa.distance_from_origin_nm or 0.0
+        if phase == "climb":
+            in_corridor = d <= corridor_nm and d <= total / 2
+        else:
+            in_corridor = (total - d) <= corridor_nm and d > total / 2
+        if not in_corridor:
+            continue
+        sounding = rpa.sounding.get(model)
+        if sounding is None:
+            continue
+        floor = _field_elevation_ft(ctx, d)
+        blocked = any(
+            cl.coverage in (CloudCoverage.BKN, CloudCoverage.OVC)
+            and floor < cl.top_ft < cruise
+            for cl in sounding.cloud_layers
+        )
+        profile.append((d, blocked))
+
+    profile.sort(key=lambda t: t[0])
+    return profile
+
+
+def _corridor_mitigation(
+    ctx: RouteContext,
+    model: str,
+    corridor_nm: float,
+    loc: str | None,
+) -> list[Mitigation]:
+    """Find along-route repositioning mitigations for blocked corridor decks.
+
+    Climb-out: if the corridor points nearest departure are blocked but farther
+    ones clear, offer "climb to cruise after ~d* nm from departure" (``d*`` is
+    the nearest confirmed-clear distance beyond the blocked region). Descent is
+    symmetric near the arrival end. Only offered when there is a genuine
+    clear/blocked split — a uniformly blocked corridor cannot be repositioned
+    around, so no mitigation (the RED/AMBER is genuine).
+
+    ``mitigated_status`` is GREEN: repositioning clears that phase's deck. It
+    speaks only for the corridor axis, not the overall advisory.
+    """
+    total = ctx.total_distance_nm
+    mitigations: list[Mitigation] = []
+
+    # --- Climb-out: deck near departure, clear beyond d* ---
+    climb = _corridor_blocked_profile(ctx, model, corridor_nm, "climb")
+    blocked = [d for d, b in climb if b]
+    clear = [d for d, b in climb if not b]
+    if blocked and clear:
+        max_blocked = max(blocked)
+        beyond = [d for d in clear if d > max_blocked]
+        if beyond:
+            d_star = min(beyond)
+            mitigations.append(Mitigation(
+                kind=MitigationKind.ROUTE_POSITION,
+                addresses="climb_deck",
+                detail=adv_t("vfr.mitigation.climb_after", loc, dist=round(d_star)),
+                mitigated_status=AdvisoryStatus.GREEN,
+                distance_nm=round(d_star, 1),
+                reference="departure",
+            ))
+
+    # --- Descent: deck near arrival, clear before it ---
+    descent = _corridor_blocked_profile(ctx, model, corridor_nm, "descent")
+    blocked = [d for d, b in descent if b]
+    clear = [d for d, b in descent if not b]
+    if blocked and clear:
+        min_blocked = min(blocked)
+        before = [d for d in clear if d < min_blocked]
+        if before:
+            d_star = max(before)
+            dist_before_arrival = total - d_star
+            mitigations.append(Mitigation(
+                kind=MitigationKind.ROUTE_POSITION,
+                addresses="descent_deck",
+                detail=adv_t("vfr.mitigation.descend_before", loc, dist=round(dist_before_arrival)),
+                mitigated_status=AdvisoryStatus.GREEN,
+                distance_nm=round(dist_before_arrival, 1),
+                reference="arrival",
+            ))
+
+    return mitigations
 
 
 @register
@@ -299,7 +503,7 @@ class VFRFeasibilityEvaluator:
 
             # 2. En-route cloud clearance
             total, imc_count, marginal_count, _ = _check_enroute_vfr(
-                ctx, model, cloud_clearance_ft
+                ctx, model, cloud_clearance_ft, ctx.cruise_altitude_ft
             )
 
             # 3. Climb-out / descent corridor decks (BKN/OVC below cruise near airports)
@@ -323,28 +527,24 @@ class VFRFeasibilityEvaluator:
 
             # 4. Determine en-route status
             affected = imc_count + marginal_count
-            enroute_status = AdvisoryStatus.GREEN
+            enroute_status = _enroute_vfr_status(
+                total, imc_count, marginal_count, imc_pct_amber, imc_pct_red
+            )
             enroute_detail = ""
 
-            if total > 0:
-                imc_pct = 100.0 * imc_count / total
-                affected_pct = 100.0 * affected / total
-
+            if total > 0 and affected > 0:
                 ext = format_extent(affected, total, ctx.total_distance_nm)
-
-                if imc_pct >= imc_pct_red:
-                    enroute_status = AdvisoryStatus.RED
+                if enroute_status == AdvisoryStatus.RED:
                     enroute_detail = adv_t("vfr.imc_over", loc, extent=ext)
-                elif affected_pct >= imc_pct_amber:
-                    enroute_status = AdvisoryStatus.AMBER
+                elif enroute_status == AdvisoryStatus.AMBER:
                     if marginal_count > 0 and imc_count > 0:
                         enroute_detail = adv_t("vfr.imc_marginal", loc, extent=ext)
                     elif imc_count > 0:
                         enroute_detail = adv_t("vfr.imc_over", loc, extent=ext)
                     else:
                         enroute_detail = adv_t("vfr.marginal", loc, extent=ext)
-                elif affected > 0:
-                    enroute_detail = adv_t("vfr.minor", loc, extent=format_extent(affected, total, ctx.total_distance_nm))
+                else:  # GREEN status but some points affected → minor clearance issues
+                    enroute_detail = adv_t("vfr.minor", loc, extent=ext)
 
             # 5. En-route precipitation (visibility proxy) — capped at AMBER
             # in the composite; the standalone advisory grades it fully.
@@ -386,10 +586,23 @@ class VFRFeasibilityEvaluator:
             else:
                 detail = " | ".join(detail_parts)
 
+            # 7. Mitigations (advice only — never change the grade). Vertical:
+            # a lower altitude that clears cruise IMC. Along-route: reposition
+            # the climb/descent to thread a corridor deck.
+            mitigations: list[Mitigation] = []
+            vertical = _vertical_mitigation(
+                ctx, model, cloud_clearance_ft,
+                imc_pct_amber, imc_pct_red, enroute_status, loc,
+            )
+            if vertical is not None:
+                mitigations.append(vertical)
+            mitigations.extend(_corridor_mitigation(ctx, model, corridor_nm, loc))
+
             per_model.append(ModelAdvisoryResult.build(
                 model=model, status=status, detail=detail,
                 affected=affected, total=total,
                 total_distance_nm=ctx.total_distance_nm,
+                mitigations=mitigations,
             ))
 
         return RouteAdvisoryResult.from_per_model("vfr_feasibility", per_model, params)

--- a/src/weatherbrief/models/__init__.py
+++ b/src/weatherbrief/models/__init__.py
@@ -88,6 +88,8 @@ from weatherbrief.models.advisories import (  # noqa: F401
     AltitudeAdvisoryDelta,
     AltitudeAdvisoryRow,
     AltitudeTableResult,
+    Mitigation,
+    MitigationKind,
     ModelAdvisoryResult,
     RouteAdvisoriesManifest,
     RouteAdvisoryResult,

--- a/src/weatherbrief/models/advisories.py
+++ b/src/weatherbrief/models/advisories.py
@@ -57,6 +57,37 @@ class AdvisoryStatus(str, Enum):
         return cls.worst(tied)
 
 
+class MitigationKind(str, Enum):
+    """Axis along which an advisory's flagged issue could be mitigated."""
+
+    ALTITUDE = "altitude"             # fly a different altitude
+    ROUTE_POSITION = "route_position"  # climb/descend at a different point along the route
+    TIMING = "timing"                 # reserved for future use
+
+
+class Mitigation(BaseModel):
+    """A decision that could improve a flagged sub-issue — advice only.
+
+    A mitigation never changes the advisory's grade (same contract as
+    ``cross_check``). It reports the status **of the specific sub-issue it
+    addresses** if applied (``mitigated_status``), NOT the overall advisory
+    status — an advisory grades several axes via ``worst`` and a mitigation
+    on one axis says nothing about the others. The ``addresses`` tag is a
+    stable English machine token (not localized); human phrasing lives in the
+    localized ``detail``.
+    """
+
+    kind: MitigationKind
+    addresses: str                    # stable tag of the sub-issue, e.g. "cruise_imc",
+                                      # "climb_deck", "descent_deck" (NOT localized)
+    detail: str                       # localized human phrasing (via adv_t)
+    mitigated_status: AdvisoryStatus  # status OF THE ADDRESSED ISSUE if applied —
+                                      # NOT the advisory overall status
+    altitude_ft: int | None = None    # set for ALTITUDE
+    distance_nm: float | None = None  # set for ROUTE_POSITION
+    reference: str | None = None      # e.g. "departure" / "arrival" — disambiguates distance
+
+
 class AdvisoryParameterDef(BaseModel):
     """Definition of a user-tunable parameter for an advisory."""
 
@@ -106,6 +137,10 @@ class ModelAdvisoryResult(BaseModel):
     # an independent second derivation (e.g. convective DD-vs-model scheme).
     # Never affects the grade; surfaced only in the info popup and LLM digest.
     cross_check: str | None = None
+    # Per-model mitigations: alternative/mitigating decisions that would improve
+    # a flagged sub-issue (advice only — never alters ``status``). Defaults empty
+    # so old packs deserialize cleanly.
+    mitigations: list[Mitigation] = Field(default_factory=list)
 
     @classmethod
     def build(
@@ -119,6 +154,7 @@ class ModelAdvisoryResult(BaseModel):
         total_distance_nm: float,
         affected_mod: int | None = None,
         cross_check: str | None = None,
+        mitigations: list[Mitigation] | None = None,
     ) -> ModelAdvisoryResult:
         """Build a result, computing pct and nm from point counts.
 
@@ -141,7 +177,26 @@ class ModelAdvisoryResult(BaseModel):
             affected_mod_pct=round(100 * mod / total, 1) if total > 0 else 0,
             affected_mod_nm=round(total_distance_nm * mod / total, 1) if total > 0 else 0,
             cross_check=cross_check,
+            mitigations=mitigations if mitigations is not None else [],
         )
+
+
+def _aggregate_mitigations(
+    per_model: list[ModelAdvisoryResult],
+    agg_status: AdvisoryStatus,
+) -> list[Mitigation]:
+    """Aggregate per-model mitigations (representative-model policy).
+
+    Returns the mitigations of the first per-model result whose status equals
+    the aggregate status — the same representative used to choose
+    ``aggregate_detail`` — else an empty list. Kept as a standalone module-level
+    function so the policy can later be swapped for a "conservative,
+    all-or-nothing per kind" merge by editing this one place.
+    """
+    for m in per_model:
+        if m.status == agg_status:
+            return list(m.mitigations)
+    return []
 
 
 class RouteAdvisoryResult(BaseModel):
@@ -152,6 +207,10 @@ class RouteAdvisoryResult(BaseModel):
     aggregate_detail: str = ""
     per_model: list[ModelAdvisoryResult] = Field(default_factory=list)
     parameters_used: dict[str, float] = Field(default_factory=dict)
+    # Aggregate mitigations chosen by ``_aggregate_mitigations`` (representative
+    # model). Advice only — never alters ``aggregate_status``. Defaults empty so
+    # old packs deserialize cleanly.
+    aggregate_mitigations: list[Mitigation] = Field(default_factory=list)
 
     @classmethod
     def from_per_model(
@@ -182,6 +241,7 @@ class RouteAdvisoryResult(BaseModel):
             aggregate_detail=representative.detail if representative else "",
             per_model=per_model,
             parameters_used=params,
+            aggregate_mitigations=_aggregate_mitigations(per_model, agg),
         )
 
 

--- a/tests/analysis/advisories/test_evaluators.py
+++ b/tests/analysis/advisories/test_evaluators.py
@@ -649,7 +649,7 @@ class TestVFRFeasibility:
         entry = VFRFeasibilityEvaluator.catalog_entry()
         assert entry.id == "vfr_feasibility"
         assert entry.category == "flight_rules"
-        assert len(entry.parameters) == 4
+        assert len(entry.parameters) == 5
 
     def test_tunable_clearance(self, vfr_marginal_clearance_context: RouteContext):
         """With 500ft clearance threshold, 800ft gap is comfortable → GREEN."""

--- a/tests/test_vfr_mitigation.py
+++ b/tests/test_vfr_mitigation.py
@@ -150,6 +150,29 @@ def test_vertical_blocked_by_terrain():
     assert not any(m.kind == MitigationKind.ALTITUDE for m in _mitigations(result))
 
 
+def test_vertical_amber_band_uses_marginal_phrasing():
+    """When the best reachable band is only AMBER (cruise RED, no clear band above
+    the floor), the detail must NOT claim 'VMC available' — it says 'marginal' to
+    match the AMBER axis status."""
+    # OVC 7000–12000 → cruise (8000) IMC/RED. Terrain 5200 → floor 6200: the
+    # clear band (6000) is below the floor, but the marginal band (6500, within
+    # 1000ft of base) clears it → best candidate is AMBER at 6500.
+    deck = EnhancedCloudLayer(base_ft=7000, top_ft=12000, coverage=CloudCoverage.OVC)
+    analyses = [_rpa(i, i * 20.0, {"gfs": [deck]}) for i in range(10)]
+    result = VFRFeasibilityEvaluator.evaluate(
+        _ctx(analyses, elevation=_elevation(max_elev_ft=5200)), _VFR_DEFAULTS
+    )
+
+    assert result.aggregate_status == AdvisoryStatus.RED
+    alt = [m for m in _mitigations(result) if m.kind == MitigationKind.ALTITUDE]
+    assert len(alt) == 1
+    m = alt[0]
+    assert m.mitigated_status == AdvisoryStatus.AMBER
+    assert m.altitude_ft == 6500
+    assert "marginal" in m.detail.lower()
+    assert "VMC available" not in m.detail  # the GREEN-only phrasing
+
+
 # ---------------------------------------------------------------------------
 # Along-route mitigation (addresses climb_deck / descent_deck)
 # ---------------------------------------------------------------------------

--- a/tests/test_vfr_mitigation.py
+++ b/tests/test_vfr_mitigation.py
@@ -1,0 +1,293 @@
+"""Tests for VFR Feasibility mitigations (issue #328).
+
+A mitigation surfaces a decision that would improve a flagged sub-issue
+(fly lower to clear cruise IMC, reposition the climb/descent around a corridor
+deck). Mitigations are **advice only** — they never change the advisory grade.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+
+from weatherbrief.analysis.advisories import RouteContext
+from weatherbrief.analysis.advisories.vfr_feasibility import VFRFeasibilityEvaluator
+from weatherbrief.models import (
+    AdvisoryStatus,
+    CloudCoverage,
+    ElevationPoint,
+    ElevationProfile,
+    EnhancedCloudLayer,
+    Mitigation,
+    MitigationKind,
+    ModelAdvisoryResult,
+    RouteAdvisoryResult,
+    RoutePointAnalysis,
+    SoundingAnalysis,
+    ThermodynamicIndices,
+)
+
+# Default VFR params (mirror the catalog defaults).
+_VFR_DEFAULTS = {
+    "cloud_clearance_ft": 1000,
+    "imc_pct_amber": 15,
+    "imc_pct_red": 30,
+    "terminal_corridor_nm": 5,
+}
+
+
+# ---------------------------------------------------------------------------
+# Builders (self-contained — the advisory conftest fixtures live in a
+# different test package and are not visible here).
+# ---------------------------------------------------------------------------
+
+def _sounding(layers: list[EnhancedCloudLayer] | None = None) -> SoundingAnalysis:
+    return SoundingAnalysis(
+        indices=ThermodynamicIndices(freezing_level_ft=5000),
+        cloud_layers=layers or [],
+    )
+
+
+def _rpa(
+    point_index: int,
+    distance_nm: float,
+    layers_by_model: dict[str, list[EnhancedCloudLayer]],
+) -> RoutePointAnalysis:
+    return RoutePointAnalysis(
+        point_index=point_index,
+        lat=48.0 + point_index * 0.1,
+        lon=2.0 + point_index * 0.1,
+        distance_from_origin_nm=distance_nm,
+        interpolated_time=datetime(2026, 3, 1, 10, 0),
+        forecast_hour=datetime(2026, 3, 1, 9, 0),
+        track_deg=90.0,
+        sounding={m: _sounding(layers) for m, layers in layers_by_model.items()},
+    )
+
+
+def _elevation(max_elev_ft: float = 500.0, n_points: int = 20, total_nm: float = 200.0) -> ElevationProfile:
+    points = [
+        ElevationPoint(
+            distance_nm=i * total_nm / (n_points - 1),
+            elevation_ft=max_elev_ft,
+            lat=48.0 + i * 0.1,
+            lon=2.0 + i * 0.1,
+        )
+        for i in range(n_points)
+    ]
+    return ElevationProfile(
+        route_name="test",
+        points=points,
+        max_elevation_ft=max_elev_ft,
+        total_distance_nm=total_nm,
+    )
+
+
+def _ctx(
+    analyses: list[RoutePointAnalysis],
+    *,
+    elevation: ElevationProfile | None = None,
+    models: tuple[str, ...] = ("gfs",),
+    cruise_altitude_ft: int = 8000,
+    total_distance_nm: float = 200.0,
+) -> RouteContext:
+    return RouteContext(
+        analyses=analyses,
+        cross_sections=[],
+        elevation=elevation if elevation is not None else _elevation(total_nm=total_distance_nm),
+        models=list(models),
+        cruise_altitude_ft=cruise_altitude_ft,
+        flight_ceiling_ft=18000,
+        total_distance_nm=total_distance_nm,
+    )
+
+
+def _mitigations(result: RouteAdvisoryResult, model: str = "gfs") -> list[Mitigation]:
+    per = next(m for m in result.per_model if m.model == model)
+    return per.mitigations
+
+
+# ---------------------------------------------------------------------------
+# Vertical mitigation (addresses cruise_imc)
+# ---------------------------------------------------------------------------
+
+def test_vertical_happy_path():
+    """Cruise inside an OVC deck, clear band below well above terrain.
+
+    One ALTITUDE mitigation reporting the highest clear altitude, GREEN, while
+    the advisory itself stays RED (the grade is independent of the mitigation).
+    """
+    # OVC 7000–12000 contains cruise (8000) at every point → IMC everywhere.
+    # Highest clear altitude = base 7000 − 1000 clearance = 6000ft (terrain 500).
+    deck = EnhancedCloudLayer(base_ft=7000, top_ft=12000, coverage=CloudCoverage.OVC)
+    analyses = [_rpa(i, i * 20.0, {"gfs": [deck]}) for i in range(10)]
+    result = VFRFeasibilityEvaluator.evaluate(_ctx(analyses), _VFR_DEFAULTS)
+
+    assert result.aggregate_status == AdvisoryStatus.RED  # grade unchanged
+    mits = _mitigations(result)
+    alt = [m for m in mits if m.kind == MitigationKind.ALTITUDE]
+    assert len(alt) == 1
+    m = alt[0]
+    assert m.addresses == "cruise_imc"
+    assert m.altitude_ft == 6000
+    assert m.mitigated_status == AdvisoryStatus.GREEN  # axis status, not overall
+    assert m.detail  # localized phrasing populated
+
+
+def test_vertical_blocked_by_terrain():
+    """The only clear band sits below the terrain floor → no vertical mitigation."""
+    # OVC 5000–12000 contains cruise; terrain 5500 → floor 6500, so every
+    # candidate altitude down to the floor is still inside the deck.
+    deck = EnhancedCloudLayer(base_ft=5000, top_ft=12000, coverage=CloudCoverage.OVC)
+    analyses = [_rpa(i, i * 20.0, {"gfs": [deck]}) for i in range(10)]
+    result = VFRFeasibilityEvaluator.evaluate(
+        _ctx(analyses, elevation=_elevation(max_elev_ft=5500)), _VFR_DEFAULTS
+    )
+
+    assert result.aggregate_status == AdvisoryStatus.RED
+    assert not any(m.kind == MitigationKind.ALTITUDE for m in _mitigations(result))
+
+
+# ---------------------------------------------------------------------------
+# Along-route mitigation (addresses climb_deck / descent_deck)
+# ---------------------------------------------------------------------------
+
+def test_along_route_climb_happy_path():
+    """OVC deck below cruise over the corridor points nearest departure,
+    clear beyond → one ROUTE_POSITION climb mitigation."""
+    deck = EnhancedCloudLayer(base_ft=3000, top_ft=5000, coverage=CloudCoverage.OVC)
+    # Wide corridor (60nm) so points 0,20,40,60 are in the climb corridor.
+    # Blocked at 0 & 20nm, clear at 40 & 60nm → climb after ~40nm.
+    analyses = [_rpa(i, i * 20.0, {"gfs": [deck] if i in (0, 1) else []}) for i in range(10)]
+    result = VFRFeasibilityEvaluator.evaluate(
+        _ctx(analyses), {**_VFR_DEFAULTS, "terminal_corridor_nm": 60}
+    )
+
+    assert result.aggregate_status == AdvisoryStatus.RED  # OVC corridor deck
+    climb = [m for m in _mitigations(result) if m.addresses == "climb_deck"]
+    assert len(climb) == 1
+    m = climb[0]
+    assert m.kind == MitigationKind.ROUTE_POSITION
+    assert m.distance_nm == 40.0
+    assert m.reference == "departure"
+    assert m.mitigated_status == AdvisoryStatus.GREEN
+    # Cruise is clear (deck top below cruise) → no vertical mitigation.
+    assert not any(m.kind == MitigationKind.ALTITUDE for m in _mitigations(result))
+
+
+def test_along_route_descent_happy_path():
+    """Symmetric to climb: deck near arrival, clear before → descent mitigation."""
+    deck = EnhancedCloudLayer(base_ft=3000, top_ft=5000, coverage=CloudCoverage.OVC)
+    # Blocked at 160 & 180nm (near arrival), clear at 140nm → descend before
+    # ~60nm from arrival (200 − 140).
+    analyses = [_rpa(i, i * 20.0, {"gfs": [deck] if i in (8, 9) else []}) for i in range(10)]
+    result = VFRFeasibilityEvaluator.evaluate(
+        _ctx(analyses), {**_VFR_DEFAULTS, "terminal_corridor_nm": 60}
+    )
+
+    assert result.aggregate_status == AdvisoryStatus.RED
+    descent = [m for m in _mitigations(result) if m.addresses == "descent_deck"]
+    assert len(descent) == 1
+    m = descent[0]
+    assert m.kind == MitigationKind.ROUTE_POSITION
+    assert m.distance_nm == 60.0
+    assert m.reference == "arrival"
+    assert m.mitigated_status == AdvisoryStatus.GREEN
+
+
+def test_along_route_uniformly_blocked():
+    """Deck over the whole climb corridor → no along-route mitigation
+    (the deck can't be avoided by repositioning)."""
+    deck = EnhancedCloudLayer(base_ft=3000, top_ft=5000, coverage=CloudCoverage.OVC)
+    analyses = [_rpa(i, i * 20.0, {"gfs": [deck] if i in (0, 1, 2, 3) else []}) for i in range(10)]
+    result = VFRFeasibilityEvaluator.evaluate(
+        _ctx(analyses), {**_VFR_DEFAULTS, "terminal_corridor_nm": 60}
+    )
+
+    assert result.aggregate_status == AdvisoryStatus.RED
+    assert not any(m.addresses == "climb_deck" for m in _mitigations(result))
+
+
+# ---------------------------------------------------------------------------
+# Co-occurrence
+# ---------------------------------------------------------------------------
+
+def test_cooccurrence_vertical_and_along_route():
+    """Cruise IMC AND a corridor deck → two mitigations; grade still RED."""
+    cruise_deck = EnhancedCloudLayer(base_ft=7000, top_ft=12000, coverage=CloudCoverage.OVC)
+    low_deck = EnhancedCloudLayer(base_ft=3000, top_ft=5000, coverage=CloudCoverage.OVC)
+    # Every point has the cruise-level deck (IMC); points 0,20 also carry a low
+    # corridor deck. Points 40,60 are clear in the corridor → climb after ~40nm.
+    analyses = [
+        _rpa(i, i * 20.0, {"gfs": [cruise_deck, low_deck] if i in (0, 1) else [cruise_deck]})
+        for i in range(10)
+    ]
+    result = VFRFeasibilityEvaluator.evaluate(
+        _ctx(analyses), {**_VFR_DEFAULTS, "terminal_corridor_nm": 60}
+    )
+
+    assert result.aggregate_status == AdvisoryStatus.RED  # worst(...) unchanged
+    mits = _mitigations(result)
+    addresses = {m.addresses for m in mits}
+    assert "cruise_imc" in addresses
+    assert "climb_deck" in addresses
+    assert len(mits) == 2
+
+
+# ---------------------------------------------------------------------------
+# Aggregation — representative-model policy
+# ---------------------------------------------------------------------------
+
+def test_aggregate_uses_representative_model_mitigations():
+    """``aggregate_mitigations`` = the mitigations of the FIRST per-model result
+    whose status equals the aggregate status (representative-model policy).
+
+    This is an explicit assertion of the current policy: a future switch to a
+    conservative all-or-nothing merge must change this test deliberately.
+    """
+    mit_a = Mitigation(
+        kind=MitigationKind.ALTITUDE, addresses="cruise_imc", detail="A",
+        mitigated_status=AdvisoryStatus.GREEN, altitude_ft=6000,
+    )
+    mit_b = Mitigation(
+        kind=MitigationKind.ALTITUDE, addresses="cruise_imc", detail="B",
+        mitigated_status=AdvisoryStatus.GREEN, altitude_ft=5000,
+    )
+    per_model = [
+        ModelAdvisoryResult.build(
+            model="gfs", status=AdvisoryStatus.RED, detail="", affected=5, total=10,
+            total_distance_nm=200, mitigations=[mit_a],
+        ),
+        ModelAdvisoryResult.build(
+            model="ecmwf", status=AdvisoryStatus.RED, detail="", affected=5, total=10,
+            total_distance_nm=200, mitigations=[mit_b],
+        ),
+        ModelAdvisoryResult.build(
+            model="icon", status=AdvisoryStatus.AMBER, detail="", affected=2, total=10,
+            total_distance_nm=200,
+        ),
+    ]
+    result = RouteAdvisoryResult.from_per_model("vfr_feasibility", per_model, {})
+
+    assert result.aggregate_status == AdvisoryStatus.RED
+    # Representative is the FIRST RED model (gfs) — NOT a merge of gfs+ecmwf.
+    assert result.aggregate_mitigations == [mit_a]
+
+
+# ---------------------------------------------------------------------------
+# Backward compatibility
+# ---------------------------------------------------------------------------
+
+def test_backward_compat_model_result_without_mitigations():
+    """An old ModelAdvisoryResult JSON without the field → empty mitigations."""
+    old = ModelAdvisoryResult.model_validate_json('{"model": "gfs", "status": "green"}')
+    assert old.mitigations == []
+
+
+def test_backward_compat_route_result_without_mitigations():
+    """An old RouteAdvisoryResult JSON without the field → empty aggregate."""
+    old = RouteAdvisoryResult.model_validate_json(
+        '{"advisory_id": "vfr_feasibility", "aggregate_status": "green"}'
+    )
+    assert old.aggregate_mitigations == []

--- a/tests/test_vfr_mitigation.py
+++ b/tests/test_vfr_mitigation.py
@@ -34,6 +34,7 @@ _VFR_DEFAULTS = {
     "imc_pct_amber": 15,
     "imc_pct_red": 30,
     "terminal_corridor_nm": 5,
+    "mitigation_min_base_agl_ft": 3000,
 }
 
 
@@ -156,7 +157,8 @@ def test_vertical_blocked_by_terrain():
 def test_along_route_climb_happy_path():
     """OVC deck below cruise over the corridor points nearest departure,
     clear beyond → one ROUTE_POSITION climb mitigation."""
-    deck = EnhancedCloudLayer(base_ft=3000, top_ft=5000, coverage=CloudCoverage.OVC)
+    # base 4000 over 500ft terrain = 3500ft AGL, clears the mitigation base gate.
+    deck = EnhancedCloudLayer(base_ft=4000, top_ft=5500, coverage=CloudCoverage.OVC)
     # Wide corridor (60nm) so points 0,20,40,60 are in the climb corridor.
     # Blocked at 0 & 20nm, clear at 40 & 60nm → climb after ~40nm.
     analyses = [_rpa(i, i * 20.0, {"gfs": [deck] if i in (0, 1) else []}) for i in range(10)]
@@ -178,7 +180,8 @@ def test_along_route_climb_happy_path():
 
 def test_along_route_descent_happy_path():
     """Symmetric to climb: deck near arrival, clear before → descent mitigation."""
-    deck = EnhancedCloudLayer(base_ft=3000, top_ft=5000, coverage=CloudCoverage.OVC)
+    # base 4000 over 500ft terrain = 3500ft AGL, clears the mitigation base gate.
+    deck = EnhancedCloudLayer(base_ft=4000, top_ft=5500, coverage=CloudCoverage.OVC)
     # Blocked at 160 & 180nm (near arrival), clear at 140nm → descend before
     # ~60nm from arrival (200 − 140).
     analyses = [_rpa(i, i * 20.0, {"gfs": [deck] if i in (8, 9) else []}) for i in range(10)]
@@ -199,7 +202,9 @@ def test_along_route_descent_happy_path():
 def test_along_route_uniformly_blocked():
     """Deck over the whole climb corridor → no along-route mitigation
     (the deck can't be avoided by repositioning)."""
-    deck = EnhancedCloudLayer(base_ft=3000, top_ft=5000, coverage=CloudCoverage.OVC)
+    # High enough base to clear the AGL gate, so the no-mitigation result is due
+    # to the uniformly-blocked corridor (no clear/blocked split), not the gate.
+    deck = EnhancedCloudLayer(base_ft=4000, top_ft=5500, coverage=CloudCoverage.OVC)
     analyses = [_rpa(i, i * 20.0, {"gfs": [deck] if i in (0, 1, 2, 3) else []}) for i in range(10)]
     result = VFRFeasibilityEvaluator.evaluate(
         _ctx(analyses), {**_VFR_DEFAULTS, "terminal_corridor_nm": 60}
@@ -209,6 +214,30 @@ def test_along_route_uniformly_blocked():
     assert not any(m.addresses == "climb_deck" for m in _mitigations(result))
 
 
+def test_along_route_low_base_not_reachable():
+    """A clear/blocked split exists, but the blocked-stretch deck base is too low
+    to fly under (1500ft base over 500ft terrain = 1000ft AGL < 3000 default) →
+    no along-route mitigation: the clear air beyond is unreachable VFR.
+
+    Tunable: lowering the threshold below the deck's AGL base re-enables it.
+    """
+    low_deck = EnhancedCloudLayer(base_ft=1500, top_ft=5000, coverage=CloudCoverage.OVC)
+    analyses = [_rpa(i, i * 20.0, {"gfs": [low_deck] if i in (0, 1) else []}) for i in range(10)]
+
+    blocked = VFRFeasibilityEvaluator.evaluate(
+        _ctx(analyses), {**_VFR_DEFAULTS, "terminal_corridor_nm": 60}
+    )
+    assert blocked.aggregate_status == AdvisoryStatus.RED  # deck still grades RED
+    assert not any(m.addresses == "climb_deck" for m in _mitigations(blocked))
+
+    # With the gate lowered below the deck's 1000ft AGL base, the mitigation returns.
+    relaxed = VFRFeasibilityEvaluator.evaluate(
+        _ctx(analyses),
+        {**_VFR_DEFAULTS, "terminal_corridor_nm": 60, "mitigation_min_base_agl_ft": 500},
+    )
+    assert any(m.addresses == "climb_deck" for m in _mitigations(relaxed))
+
+
 # ---------------------------------------------------------------------------
 # Co-occurrence
 # ---------------------------------------------------------------------------
@@ -216,7 +245,8 @@ def test_along_route_uniformly_blocked():
 def test_cooccurrence_vertical_and_along_route():
     """Cruise IMC AND a corridor deck → two mitigations; grade still RED."""
     cruise_deck = EnhancedCloudLayer(base_ft=7000, top_ft=12000, coverage=CloudCoverage.OVC)
-    low_deck = EnhancedCloudLayer(base_ft=3000, top_ft=5000, coverage=CloudCoverage.OVC)
+    # Low deck base 4000 over 500ft terrain = 3500ft AGL, clears the base gate.
+    low_deck = EnhancedCloudLayer(base_ft=4000, top_ft=5500, coverage=CloudCoverage.OVC)
     # Every point has the cruise-level deck (IMC); points 0,20 also carry a low
     # corridor deck. Points 40,60 are clear in the corridor → climb after ~40nm.
     analyses = [


### PR DESCRIPTION
Introduce a generic per-advisory "mitigation" — what different decision
could improve a flagged sub-issue (a lower altitude, a point where a deck
breaks). Mitigations are advice only: they never change the grade, same
contract as cross_check.

Data model (models/advisories.py):
- MitigationKind {ALTITUDE, ROUTE_POSITION, TIMING} + Mitigation
  (addresses tag, localized detail, axis-scoped mitigated_status,
  altitude_ft/distance_nm/reference). Exported from models/__init__.
- ModelAdvisoryResult.mitigations (+ build() param) and
  RouteAdvisoryResult.aggregate_mitigations, both default-empty so old
  packs deserialize cleanly.
- _aggregate_mitigations(per_model, agg_status): representative-model
  policy (mitigations of the first per-model result matching the aggregate
  status), isolated in one swappable helper. Wired into from_per_model.

VFR Feasibility worked example (vfr_feasibility.py):
- Vertical mitigation (addresses cruise_imc): terrain-gated downward scan
  for the highest altitude that improves the en-route cloud axis, preferring
  a fully clear band. Refactored _check_enroute_vfr to take an explicit
  altitude_ft and extracted _enroute_vfr_status so cruise and candidate
  altitudes grade identically.
- Along-route mitigation (addresses climb_deck / descent_deck): locate where
  a corridor deck breaks and offer "climb after ~X nm" / "descend before
  ~Y nm", only when there is a genuine clear/blocked split.
- mitigated_status is axis-scoped, never the overall grade.

Localization: vfr.mitigation.{altitude,climb_after,descend_before} in all
four locales (en/fr/de/es).

Tests: tests/test_vfr_mitigation.py covers vertical happy/terrain-blocked,
along-route climb/descent/uniformly-blocked, co-occurrence, representative-
model aggregation, and backward-compat deserialization.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CUkyaaJirjKDV25R8EG3GL