### PR TITLE
Make flight duration an hours/minutes dropdown on the web

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -85,8 +85,32 @@
             <input type="number" id="input-ceiling" value="18000" min="1000" max="45000" step="500">
           </div>
           <div class="form-group">
-            <label for="input-duration">Duration (hrs)</label>
-            <input type="number" id="input-duration" value="0" min="0" max="24" step="0.5">
+            <label for="input-duration-hours">Duration</label>
+            <div class="time-input-group">
+              <select id="input-duration-hours">
+                <option value="0">0</option>
+                <option value="1">1</option>
+                <option value="2">2</option>
+                <option value="3">3</option>
+                <option value="4">4</option>
+                <option value="5">5</option>
+                <option value="6">6</option>
+                <option value="7">7</option>
+                <option value="8">8</option>
+                <option value="9">9</option>
+                <option value="10">10</option>
+                <option value="11">11</option>
+                <option value="12">12</option>
+              </select>
+              <span class="time-separator">h</span>
+              <select id="input-duration-minutes">
+                <option value="0">00</option>
+                <option value="15">15</option>
+                <option value="30">30</option>
+                <option value="45">45</option>
+              </select>
+              <span class="time-separator">m</span>
+            </div>
           </div>
           <div class="form-group">
             <label>&nbsp;</label>

--- a/web/index.html
+++ b/web/index.html
@@ -87,28 +87,10 @@
           <div class="form-group">
             <label for="input-duration-hours">Duration</label>
             <div class="time-input-group">
-              <select id="input-duration-hours">
-                <option value="0">0</option>
-                <option value="1">1</option>
-                <option value="2">2</option>
-                <option value="3">3</option>
-                <option value="4">4</option>
-                <option value="5">5</option>
-                <option value="6">6</option>
-                <option value="7">7</option>
-                <option value="8">8</option>
-                <option value="9">9</option>
-                <option value="10">10</option>
-                <option value="11">11</option>
-                <option value="12">12</option>
-              </select>
+              <!-- Options populated from duration.ts helpers in flights-main.ts -->
+              <select id="input-duration-hours"></select>
               <span class="time-separator">h</span>
-              <select id="input-duration-minutes">
-                <option value="0">00</option>
-                <option value="15">15</option>
-                <option value="30">30</option>
-                <option value="45">45</option>
-              </select>
+              <select id="input-duration-minutes"></select>
               <span class="time-separator">m</span>
             </div>
           </div>

--- a/web/tests/flight-lifecycle.spec.ts
+++ b/web/tests/flight-lifecycle.spec.ts
@@ -358,7 +358,7 @@ test('flight lifecycle: create → view → save settings → altitude overlay �
   await page.selectOption('#input-minute', '0');
   await page.fill('#input-altitude', '2000');
   // Provide a non-zero duration so the zero-duration confirm popup doesn't fire
-  await page.fill('#input-duration', '1');
+  await page.selectOption('#input-duration-hours', '1');
 
   // Submit the form — triggers POST and navigates to briefing
   await page.click('#create-flight-form button[type="submit"]');

--- a/web/tests/unit/duration.test.ts
+++ b/web/tests/unit/duration.test.ts
@@ -65,6 +65,12 @@ describe('formatDurationHM', () => {
     expect(formatDurationHM(12.75)).toBe('12h45');
   });
 
+  it('rounds up to the 15-min grid so view matches the edit dropdowns', () => {
+    // 2.1h -> 2h15 (ceil), agreeing with splitDurationCeil rather than 2h06.
+    expect(formatDurationHM(2.1)).toBe('2h15');
+    expect(formatDurationHM(1 + 1 / 60)).toBe('1h15');
+  });
+
   it('handles non-positive / invalid input as 0h', () => {
     expect(formatDurationHM(-1)).toBe('0h');
     expect(formatDurationHM(NaN)).toBe('0h');

--- a/web/tests/unit/duration.test.ts
+++ b/web/tests/unit/duration.test.ts
@@ -1,0 +1,93 @@
+/** Tests for the flight-duration dropdown helpers. */
+
+import { describe, it, expect } from 'vitest';
+import {
+  splitDurationCeil, combineDuration, formatDurationHM,
+  buildDurationHourOptions, buildDurationMinuteOptions,
+  MAX_DURATION_HOURS,
+} from '../../ts/utils/duration';
+
+describe('splitDurationCeil', () => {
+  it('keeps exact 15-minute multiples unchanged', () => {
+    expect(splitDurationCeil(0)).toEqual({ hours: 0, minutes: 0 });
+    expect(splitDurationCeil(0.25)).toEqual({ hours: 0, minutes: 15 });
+    expect(splitDurationCeil(0.5)).toEqual({ hours: 0, minutes: 30 });
+    expect(splitDurationCeil(0.75)).toEqual({ hours: 0, minutes: 45 });
+    expect(splitDurationCeil(1)).toEqual({ hours: 1, minutes: 0 });
+    expect(splitDurationCeil(2.5)).toEqual({ hours: 2, minutes: 30 });
+  });
+
+  it('rounds up to the next 15-minute unit (never shorter)', () => {
+    // 1h02m -> 1h15m
+    expect(splitDurationCeil(1 + 2 / 60)).toEqual({ hours: 1, minutes: 15 });
+    // 1h16m -> 1h30m
+    expect(splitDurationCeil(1 + 16 / 60)).toEqual({ hours: 1, minutes: 30 });
+    // 59m -> 1h00m
+    expect(splitDurationCeil(59 / 60)).toEqual({ hours: 1, minutes: 0 });
+    // just over 45m -> 1h00m
+    expect(splitDurationCeil(0.76)).toEqual({ hours: 1, minutes: 0 });
+  });
+
+  it('clamps to the 12h45m ceiling', () => {
+    expect(splitDurationCeil(13)).toEqual({ hours: 12, minutes: 45 });
+    expect(splitDurationCeil(100)).toEqual({ hours: 12, minutes: 45 });
+    expect(splitDurationCeil(MAX_DURATION_HOURS + 0.75)).toEqual({ hours: 12, minutes: 45 });
+  });
+
+  it('treats non-positive / invalid input as zero', () => {
+    expect(splitDurationCeil(-1)).toEqual({ hours: 0, minutes: 0 });
+    expect(splitDurationCeil(NaN)).toEqual({ hours: 0, minutes: 0 });
+    // Non-finite is rejected by the guard rather than clamped.
+    expect(splitDurationCeil(Infinity)).toEqual({ hours: 0, minutes: 0 });
+  });
+});
+
+describe('combineDuration', () => {
+  it('combines hours and minutes into decimal hours', () => {
+    expect(combineDuration(0, 0)).toBe(0);
+    expect(combineDuration(1, 15)).toBe(1.25);
+    expect(combineDuration(2, 30)).toBe(2.5);
+    expect(combineDuration(12, 45)).toBe(12.75);
+  });
+
+  it('round-trips with splitDurationCeil for grid values', () => {
+    const { hours, minutes } = splitDurationCeil(3.5);
+    expect(combineDuration(hours, minutes)).toBe(3.5);
+  });
+});
+
+describe('formatDurationHM', () => {
+  it('formats whole and partial hours compactly', () => {
+    expect(formatDurationHM(0)).toBe('0h');
+    expect(formatDurationHM(2)).toBe('2h');
+    expect(formatDurationHM(1.25)).toBe('1h15');
+    expect(formatDurationHM(2.5)).toBe('2h30');
+    expect(formatDurationHM(12.75)).toBe('12h45');
+  });
+
+  it('handles non-positive / invalid input as 0h', () => {
+    expect(formatDurationHM(-1)).toBe('0h');
+    expect(formatDurationHM(NaN)).toBe('0h');
+  });
+});
+
+describe('buildDurationHourOptions', () => {
+  it('offers 0..MAX_DURATION_HOURS with the selected one marked', () => {
+    const html = buildDurationHourOptions(2);
+    expect(html).toContain('<option value="0">0</option>');
+    expect(html).toContain('<option value="2" selected>2</option>');
+    expect(html).toContain(`<option value="${MAX_DURATION_HOURS}">${MAX_DURATION_HOURS}</option>`);
+    // 13 options for 0..12
+    expect(html.match(/<option/g)?.length).toBe(MAX_DURATION_HOURS + 1);
+  });
+});
+
+describe('buildDurationMinuteOptions', () => {
+  it('offers the four quarter-hour values, zero-padded', () => {
+    const html = buildDurationMinuteOptions(30);
+    expect(html).toContain('<option value="0">00</option>');
+    expect(html).toContain('<option value="30" selected>30</option>');
+    expect(html).toContain('<option value="45">45</option>');
+    expect(html.match(/<option/g)?.length).toBe(4);
+  });
+});

--- a/web/ts/components/duration-confirm.ts
+++ b/web/ts/components/duration-confirm.ts
@@ -7,6 +7,7 @@
 import { fetchRouteDistance } from '../adapters/api-adapter';
 import { escapeHtml } from '../utils';
 import { t } from '../i18n/i18n';
+import { buildDurationHourOptions, buildDurationMinuteOptions, combineDuration, MAX_DURATION_HOURS } from '../utils/duration';
 
 export interface DurationConfirmResult {
   confirmed: boolean;
@@ -40,12 +41,15 @@ export async function confirmZeroDuration(waypoints: string[]): Promise<Duration
       <h3>${escapeHtml(t('flights.form.zeroDurationTitle'))}</h3>
       <p style="margin-top:0.5rem;">${escapeHtml(t('flights.form.zeroDurationMessage'))}</p>
       <div style="margin-top:0.75rem;display:flex;align-items:center;gap:0.5rem;">
-        <label for="zero-duration-input" style="font-weight:600;">
+        <label for="zero-duration-hours" style="font-weight:600;">
           ${escapeHtml(t('flights.form.zeroDurationLabel'))}
         </label>
-        <input id="zero-duration-input" type="number" min="0" max="24" step="0.5" value="0"
-               style="width:5rem;padding:0.35rem;font-size:1rem;" />
-        <span style="color:var(--text-muted,#6b7280);">${escapeHtml(t('flights.form.zeroDurationHoursUnit'))}</span>
+        <div class="time-input-group">
+          <select id="zero-duration-hours">${buildDurationHourOptions(0)}</select>
+          <span class="time-separator">h</span>
+          <select id="zero-duration-minutes">${buildDurationMinuteOptions(0)}</select>
+          <span class="time-separator">m</span>
+        </div>
       </div>
       ${buildSuggestionsHtml(distanceNm)}
       <div style="margin-top:1rem;display:flex;gap:0.5rem;justify-content:flex-end;">
@@ -63,9 +67,9 @@ export async function confirmZeroDuration(waypoints: string[]): Promise<Duration
 
     modal.addEventListener('click', (e) => e.stopPropagation());
 
-    const input = modal.querySelector('#zero-duration-input') as HTMLInputElement | null;
-    input?.focus();
-    input?.select();
+    const hoursSel = modal.querySelector('#zero-duration-hours') as HTMLSelectElement | null;
+    const minutesSel = modal.querySelector('#zero-duration-minutes') as HTMLSelectElement | null;
+    hoursSel?.focus();
 
     const cleanup = () => {
       document.removeEventListener('keydown', onEsc);
@@ -78,32 +82,36 @@ export async function confirmZeroDuration(waypoints: string[]): Promise<Duration
     };
 
     const accept = () => {
-      const raw = parseFloat(input?.value || '0');
-      const duration = isNaN(raw) ? 0 : Math.max(0, raw);
+      const hours = parseInt(hoursSel?.value || '0', 10) || 0;
+      const minutes = parseInt(minutesSel?.value || '0', 10) || 0;
       cleanup();
-      resolve({ confirmed: true, duration });
+      resolve({ confirmed: true, duration: combineDuration(hours, minutes) });
     };
 
     const onEsc = (e: KeyboardEvent) => {
       if (e.key === 'Escape') cancel();
     };
 
-    // Enter inside the field commits the value (matches form-submit muscle memory)
-    input?.addEventListener('keydown', (e) => {
-      if (e.key === 'Enter') {
-        e.preventDefault();
-        accept();
-      }
+    // Enter inside the dropdowns commits the value (matches form-submit muscle memory)
+    [hoursSel, minutesSel].forEach((sel) => {
+      sel?.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter') {
+          e.preventDefault();
+          accept();
+        }
+      });
     });
 
-    // Suggestion chips fill the input but don't auto-submit — the pilot
-    // still sees the value before clicking Continue.
+    // Suggestion chips fill the hour dropdown but don't auto-submit — the pilot
+    // still sees the value before clicking Continue. Suggestions are whole hours,
+    // so the minute dropdown resets to 00.
     modal.querySelectorAll<HTMLButtonElement>('.zero-duration-suggestion').forEach((btn) => {
       btn.addEventListener('click', () => {
         const hours = btn.dataset.hours;
-        if (hours && input) {
-          input.value = hours;
-          input.focus();
+        if (hours && hoursSel) {
+          hoursSel.value = hours;
+          if (minutesSel) minutesSel.value = '0';
+          hoursSel.focus();
         }
       });
     });
@@ -119,10 +127,10 @@ export async function confirmZeroDuration(waypoints: string[]): Promise<Duration
 function buildSuggestionsHtml(distanceNm: number | null): string {
   if (distanceNm == null || distanceNm <= 0) return '';
   // Whole-hour suggestions — conservative (rounded up, never shorter) and they
-  // land on valid 15-min dropdown values. The caller snaps the chosen value to
-  // the duration dropdowns via setDurationControls/splitDurationCeil.
-  const at120 = Math.ceil(distanceNm / 120);
-  const at150 = Math.ceil(distanceNm / 150);
+  // land on valid 15-min dropdown values. Clamped to the hour dropdown's ceiling
+  // so the chip can actually be applied on very long routes.
+  const at120 = Math.min(Math.ceil(distanceNm / 120), MAX_DURATION_HOURS);
+  const at150 = Math.min(Math.ceil(distanceNm / 150), MAX_DURATION_HOURS);
   const distLabel = t('flights.form.zeroDurationDistance', { dist: distanceNm.toFixed(0) });
   const hint = t('flights.form.zeroDurationSuggestionsHint');
   return `

--- a/web/ts/components/duration-confirm.ts
+++ b/web/ts/components/duration-confirm.ts
@@ -141,9 +141,10 @@ function buildSuggestionsHtml(distanceNm: number | null): string {
         <button type="button" class="zero-duration-suggestion btn btn-outline btn-sm" data-hours="${at120}">
           120 kt &rarr; ${at120} h
         </button>
+        ${at150 !== at120 ? `
         <button type="button" class="zero-duration-suggestion btn btn-outline btn-sm" data-hours="${at150}">
           150 kt &rarr; ${at150} h
-        </button>
+        </button>` : ''}
       </div>
     </div>
   `;

--- a/web/ts/components/duration-confirm.ts
+++ b/web/ts/components/duration-confirm.ts
@@ -118,8 +118,9 @@ export async function confirmZeroDuration(waypoints: string[]): Promise<Duration
 
 function buildSuggestionsHtml(distanceNm: number | null): string {
   if (distanceNm == null || distanceNm <= 0) return '';
-  // Round up to whole hours — the model's duration unit is hours and the
-  // existing waypoint-blur auto-calc (flights-main.ts) does the same.
+  // Whole-hour suggestions — conservative (rounded up, never shorter) and they
+  // land on valid 15-min dropdown values. The caller snaps the chosen value to
+  // the duration dropdowns via setDurationControls/splitDurationCeil.
   const at120 = Math.ceil(distanceNm / 120);
   const at150 = Math.ceil(distanceNm / 150);
   const distLabel = t('flights.form.zeroDurationDistance', { dist: distanceNm.toFixed(0) });

--- a/web/ts/flight-main.ts
+++ b/web/ts/flight-main.ts
@@ -10,6 +10,7 @@ import { copyFlightShareLink, redirectToLogin, renderUserInfo } from './utils';
 import { initTheme } from './theme';
 import { initI18n, t } from './i18n/i18n';
 import { localToUtc, utcToLocal } from './utils/timezone';
+import { combineDuration } from './utils/duration';
 import { interpretAndConfirmRoute, previewRoute } from './components/route-interpret';
 import { createFlight, fetchRouteAdvisories, moveFlight } from './adapters/api-adapter';
 import { flaggedTagsFromAdvisories } from './components/debrief-taxonomy';
@@ -293,7 +294,8 @@ async function init(): Promise<void> {
       const aircraftEl = document.getElementById('edit-aircraft') as HTMLSelectElement;
       const altEl = document.getElementById('edit-altitude') as HTMLInputElement;
       const ceilEl = document.getElementById('edit-ceiling') as HTMLInputElement;
-      const durEl = document.getElementById('edit-duration') as HTMLInputElement;
+      const durHoursEl = document.getElementById('edit-duration-hours') as HTMLSelectElement;
+      const durMinutesEl = document.getElementById('edit-duration-minutes') as HTMLSelectElement;
       const altEnabledEl = document.getElementById('edit-alt-enabled') as HTMLInputElement;
 
       syncUtcFromLocal();
@@ -302,7 +304,10 @@ async function init(): Promise<void> {
       const aircraftId = aircraftEl?.value ? parseInt(aircraftEl.value, 10) : undefined;
       const altitude = parseInt(altEl.value, 10);
       const ceiling = parseInt(ceilEl.value, 10);
-      const duration = parseFloat(durEl.value);
+      const duration = combineDuration(
+        parseInt(durHoursEl?.value || '0', 10) || 0,
+        parseInt(durMinutesEl?.value || '0', 10) || 0,
+      );
 
       // Save handles non-structural changes only — date/origin/dest stay the same.
       const departureTime = `${flight.target_date}T${editUtcHour.toString().padStart(2, '0')}:${editUtcMinute.toString().padStart(2, '0')}:00Z`;

--- a/web/ts/flights-main.ts
+++ b/web/ts/flights-main.ts
@@ -26,6 +26,7 @@ import { initTheme } from './theme';
 import { initI18n, t } from './i18n/i18n';
 import { initInfoPopup } from './components/info-popup';
 import { iasToTasISA, resolveCruiseSpeedIAS } from './utils/atmo';
+import { splitDurationCeil, combineDuration } from './utils/duration';
 import {
   buildTimezoneOptions, localToUtc, utcToLocal, nearestMinuteOption,
 } from './utils/timezone';
@@ -161,11 +162,33 @@ async function fetchRouteAndUpdateUI(): Promise<void> {
   }
 }
 
+/** Read the duration hour/minute dropdowns as decimal hours. */
+function getDurationHours(): number {
+  const hoursSel = document.getElementById('input-duration-hours') as HTMLSelectElement | null;
+  const minsSel = document.getElementById('input-duration-minutes') as HTMLSelectElement | null;
+  const hours = parseInt(hoursSel?.value || '0', 10) || 0;
+  const minutes = parseInt(minsSel?.value || '0', 10) || 0;
+  return combineDuration(hours, minutes);
+}
+
+/** Populate the duration hour/minute dropdowns from a decimal-hours value,
+ *  rounding UP to the nearest 15-minute unit (never shorter — see
+ *  splitDurationCeil). Setting ``.value`` does not fire a change event, so the
+ *  durationManuallyEdited guard stays untouched on programmatic updates. */
+function setDurationControls(decimalHours: number): void {
+  const { hours, minutes } = splitDurationCeil(decimalHours);
+  const hoursSel = document.getElementById('input-duration-hours') as HTMLSelectElement | null;
+  const minsSel = document.getElementById('input-duration-minutes') as HTMLSelectElement | null;
+  if (hoursSel) hoursSel.value = String(hours);
+  if (minsSel) minsSel.value = String(minutes);
+}
+
 /** Auto-calculate the duration field from the cached route distance and the
  *  resolved cruise speed (aircraft IAS first, then flight-default profile —
  *  see getCruiseSpeedIAS), unless the user has edited it manually. The speed is
  *  cruise IAS; we convert it to TAS at the selected cruise altitude (ISA
- *  standard atmosphere) so distance ÷ TAS = still-air duration. */
+ *  standard atmosphere) so distance ÷ TAS = still-air duration. The estimate is
+ *  rounded UP to the next 15-minute unit when populating the dropdowns. */
 function recalcDurationEstimate(): void {
   if (durationManuallyEdited || lastTotalDistanceNm <= 0) return;
   const iasKt = getCruiseSpeedIAS();
@@ -173,9 +196,7 @@ function recalcDurationEstimate(): void {
   const altFt = parseInt(
     (document.getElementById('input-altitude') as HTMLInputElement)?.value || '8000', 10);
   const tasKt = iasToTasISA(iasKt, altFt);
-  const durationHours = Math.ceil(lastTotalDistanceNm / tasKt);
-  const durationInput = document.getElementById('input-duration') as HTMLInputElement;
-  if (durationInput) durationInput.value = String(durationHours);
+  setDurationControls(lastTotalDistanceNm / tasKt);
 }
 
 /** Populate the Recent Routes dropdown from the user's flight history.
@@ -242,7 +263,7 @@ function translateStaticElements(): void {
   set('label[for="input-hour"]', 'page.flights.time');
   set('label[for="input-altitude"]', 'page.flights.altitude');
   set('label[for="input-ceiling"]', 'page.flights.ceiling');
-  set('label[for="input-duration"]', 'page.flights.duration');
+  set('label[for="input-duration-hours"]', 'page.flights.duration');
   set('#loading-spinner', 'page.flights.loading');
   const submitBtn = document.querySelector('#create-flight-form button[type="submit"]');
   if (submitBtn) submitBtn.textContent = t('page.flights.createFlight');
@@ -296,11 +317,8 @@ async function applyParsedFpl(text: string): Promise<void> {
 
     // Duration
     if (parsed.duration_hours != null) {
-      const durInput = document.getElementById('input-duration') as HTMLInputElement;
-      if (durInput) {
-        durInput.value = String(parsed.duration_hours);
-        durationManuallyEdited = true; // prevent auto-calc from overwriting
-      }
+      setDurationControls(parsed.duration_hours);
+      durationManuallyEdited = true; // prevent auto-calc from overwriting
     }
 
     // Trigger route distance fetch to populate timezones and validate
@@ -688,7 +706,7 @@ async function init(): Promise<void> {
       const { hour: utcHour, minute: utcMinute } = localTimeToUtc();
       const altitude = parseInt((document.getElementById('input-altitude') as HTMLInputElement).value || '8000', 10);
       const ceiling = parseInt((document.getElementById('input-ceiling') as HTMLInputElement).value || '18000', 10);
-      let duration = parseFloat((document.getElementById('input-duration') as HTMLInputElement).value || '0');
+      let duration = getDurationHours();
       const profileSelect = document.getElementById('input-profile') as HTMLSelectElement;
       const profileId = profileSelect?.value ? parseInt(profileSelect.value, 10) : undefined;
       const aircraftSelect = document.getElementById('input-aircraft') as HTMLSelectElement;
@@ -719,9 +737,10 @@ async function init(): Promise<void> {
       if (!duration || duration <= 0) {
         const confirm = await confirmZeroDuration(waypoints);
         if (!confirm.confirmed) return;
-        duration = confirm.duration;
-        const durationInput = document.getElementById('input-duration') as HTMLInputElement;
-        if (durationInput) durationInput.value = String(duration);
+        // Reflect the confirmed value in the dropdowns (rounded up to the next
+        // 15-min unit) and re-read so the submitted value matches what's shown.
+        setDurationControls(confirm.duration);
+        duration = getDurationHours();
       }
 
       try {
@@ -809,10 +828,9 @@ async function init(): Promise<void> {
   });
 
   // --- Track manual duration edits ---
-  const durationInput = document.getElementById('input-duration') as HTMLInputElement;
-  durationInput?.addEventListener('input', () => {
-    durationManuallyEdited = true;
-  });
+  const onDurationEdit = () => { durationManuallyEdited = true; };
+  document.getElementById('input-duration-hours')?.addEventListener('change', onDurationEdit);
+  document.getElementById('input-duration-minutes')?.addEventListener('change', onDurationEdit);
 
   // --- Recompute the duration estimate when cruise altitude changes ---
   // TAS (and therefore still-air duration) depends on altitude. Recompute from

--- a/web/ts/flights-main.ts
+++ b/web/ts/flights-main.ts
@@ -26,7 +26,10 @@ import { initTheme } from './theme';
 import { initI18n, t } from './i18n/i18n';
 import { initInfoPopup } from './components/info-popup';
 import { iasToTasISA, resolveCruiseSpeedIAS } from './utils/atmo';
-import { splitDurationCeil, combineDuration } from './utils/duration';
+import {
+  splitDurationCeil, combineDuration,
+  buildDurationHourOptions, buildDurationMinuteOptions,
+} from './utils/duration';
 import {
   buildTimezoneOptions, localToUtc, utcToLocal, nearestMinuteOption,
 } from './utils/timezone';
@@ -678,6 +681,12 @@ async function init(): Promise<void> {
       hourSelect.appendChild(opt);
     }
   }
+
+  // --- Populate duration dropdowns from the shared helpers (default 0h00) ---
+  const durHoursSelect = document.getElementById('input-duration-hours') as HTMLSelectElement | null;
+  if (durHoursSelect) durHoursSelect.innerHTML = buildDurationHourOptions(0);
+  const durMinutesSelect = document.getElementById('input-duration-minutes') as HTMLSelectElement | null;
+  if (durMinutesSelect) durMinutesSelect.innerHTML = buildDurationMinuteOptions(0);
 
   // --- First-login welcome wizard ---
   if (!user.setup_completed) {

--- a/web/ts/i18n/locales/de.json
+++ b/web/ts/i18n/locales/de.json
@@ -627,7 +627,7 @@
   "page.flights.time": "Uhrzeit",
   "page.flights.altitude": "Flughöhe (ft)",
   "page.flights.ceiling": "Gipfelhöhe (ft)",
-  "page.flights.duration": "Dauer (Std.)",
+  "page.flights.duration": "Dauer",
   "page.flights.createFlight": "Flug erstellen",
   "page.flights.loading": "Flüge werden geladen...",
   "page.settings.title": "Einstellungen",

--- a/web/ts/i18n/locales/de.json
+++ b/web/ts/i18n/locales/de.json
@@ -63,7 +63,6 @@
   "flights.form.zeroDurationTitle": "Flugdauer best\u00e4tigen",
   "flights.form.zeroDurationMessage": "Sie haben eine Dauer von 0 Stunden eingegeben. Das ist ungew\u00f6hnlich \u2014 es erzeugt eine Momentaufnahme der Wetterlage statt eines Flugfensters. Wollten Sie das Feld wirklich leer lassen?",
   "flights.form.zeroDurationLabel": "Dauer:",
-  "flights.form.zeroDurationHoursUnit": "Stunden",
   "flights.form.zeroDurationDistance": "Streckenl\u00e4nge: {dist} NM",
   "flights.form.zeroDurationSuggestionsHint": "Vorgeschlagene Dauer nach Reisegeschwindigkeit:",
   "flights.form.zeroDurationContinue": "Weiter",

--- a/web/ts/i18n/locales/en.json
+++ b/web/ts/i18n/locales/en.json
@@ -66,7 +66,6 @@
   "flights.form.zeroDurationTitle": "Confirm flight duration",
   "flights.form.zeroDurationMessage": "You entered a duration of 0 hours. That's unusual \u2014 it produces a snapshot-in-time briefing rather than a flight window. Did you mean to leave it blank?",
   "flights.form.zeroDurationLabel": "Duration:",
-  "flights.form.zeroDurationHoursUnit": "hours",
   "flights.form.zeroDurationDistance": "Route distance: {dist} NM",
   "flights.form.zeroDurationSuggestionsHint": "Suggested durations based on cruise speed:",
   "flights.form.zeroDurationContinue": "Continue",

--- a/web/ts/i18n/locales/en.json
+++ b/web/ts/i18n/locales/en.json
@@ -748,7 +748,7 @@
   "page.flights.time": "Time",
   "page.flights.altitude": "Altitude (ft)",
   "page.flights.ceiling": "Ceiling (ft)",
-  "page.flights.duration": "Duration (hrs)",
+  "page.flights.duration": "Duration",
   "page.flights.createFlight": "Create Flight",
   "page.flights.loading": "Loading flights...",
 

--- a/web/ts/i18n/locales/es.json
+++ b/web/ts/i18n/locales/es.json
@@ -63,7 +63,6 @@
   "flights.form.zeroDurationTitle": "Confirmar la duraci\u00f3n del vuelo",
   "flights.form.zeroDurationMessage": "Ha introducido una duraci\u00f3n de 0 horas. Es inusual \u2014 produce una instant\u00e1nea meteorol\u00f3gica en lugar de una ventana de vuelo. \u00bfQuer\u00eda dejarlo en blanco?",
   "flights.form.zeroDurationLabel": "Duraci\u00f3n:",
-  "flights.form.zeroDurationHoursUnit": "horas",
   "flights.form.zeroDurationDistance": "Distancia de la ruta: {dist} NM",
   "flights.form.zeroDurationSuggestionsHint": "Duraciones sugeridas seg\u00fan la velocidad de crucero:",
   "flights.form.zeroDurationContinue": "Continuar",

--- a/web/ts/i18n/locales/es.json
+++ b/web/ts/i18n/locales/es.json
@@ -627,7 +627,7 @@
   "page.flights.time": "Hora",
   "page.flights.altitude": "Altitud (ft)",
   "page.flights.ceiling": "Techo (ft)",
-  "page.flights.duration": "Duración (hrs)",
+  "page.flights.duration": "Duración",
   "page.flights.createFlight": "Crear vuelo",
   "page.flights.loading": "Cargando vuelos...",
   "page.settings.title": "Configuración",

--- a/web/ts/i18n/locales/fr.json
+++ b/web/ts/i18n/locales/fr.json
@@ -63,7 +63,6 @@
   "flights.form.zeroDurationTitle": "Confirmer la dur\u00e9e du vol",
   "flights.form.zeroDurationMessage": "Vous avez saisi une dur\u00e9e de 0 heure. C'est inhabituel \u2014 cela produit une \u00e9tude m\u00e9t\u00e9o \u00e0 un instant donn\u00e9 plut\u00f4t que sur une fen\u00eatre de vol. Vouliez-vous vraiment laisser ce champ vide ?",
   "flights.form.zeroDurationLabel": "Dur\u00e9e :",
-  "flights.form.zeroDurationHoursUnit": "heures",
   "flights.form.zeroDurationDistance": "Distance de la route : {dist} NM",
   "flights.form.zeroDurationSuggestionsHint": "Dur\u00e9es sugg\u00e9r\u00e9es selon la vitesse de croisi\u00e8re :",
   "flights.form.zeroDurationContinue": "Continuer",

--- a/web/ts/i18n/locales/fr.json
+++ b/web/ts/i18n/locales/fr.json
@@ -627,7 +627,7 @@
   "page.flights.time": "Heure",
   "page.flights.altitude": "Altitude (ft)",
   "page.flights.ceiling": "Plafond (ft)",
-  "page.flights.duration": "Durée (h)",
+  "page.flights.duration": "Durée",
   "page.flights.createFlight": "Créer un vol",
   "page.flights.loading": "Chargement des vols...",
   "page.settings.title": "Paramètres",

--- a/web/ts/managers/flight-detail-ui.ts
+++ b/web/ts/managers/flight-detail-ui.ts
@@ -7,6 +7,7 @@ import type { ProfileResponse } from '../adapters/profiles-adapter';
 import { $, escapeHtml, formatDate, formatDepartureTime, formatAlt, flightTitle, flightRouteCompact, isFlightPast } from '../utils';
 import { getDateLocale, t } from '../i18n/i18n';
 import { buildTimezoneOptions, utcToLocal } from '../utils/timezone';
+import { splitDurationCeil, buildDurationHourOptions, buildDurationMinuteOptions, formatDurationHM } from '../utils/duration';
 import { renderDebriefForm } from '../components/debrief-form';
 import { renderDebriefSummary } from '../components/debrief-summary';
 import { showRoutePopup } from '../components/route-interpret';
@@ -126,6 +127,12 @@ export function renderFlightInfo(
       return `<option value="${m}"${sel}>${m.toString().padStart(2, '0')}</option>`;
     }).join('');
 
+    // Build duration hour/minute options (split stored decimal hours, rounding
+    // up to the next 15-min unit so the dropdowns never show less than stored).
+    const durParts = splitDurationCeil(flight.flight_duration_hours);
+    const durationHourOptions = buildDurationHourOptions(durParts.hours);
+    const durationMinuteOptions = buildDurationMinuteOptions(durParts.minutes);
+
     // Build profile options
     const profileOptions = profiles.map(p => {
       const sel = p.id === flight.profile_id ? ' selected' : '';
@@ -213,7 +220,12 @@ export function renderFlightInfo(
         <div class="info-row">
           <span class="info-label">Duration</span>
           <span class="info-value">
-            <input type="number" id="edit-duration" class="edit-input" value="${flight.flight_duration_hours}" min="0" max="24" step="0.5" style="width:70px"> hrs
+            <div class="time-input-group">
+              <select id="edit-duration-hours" class="edit-input">${durationHourOptions}</select>
+              <span class="time-separator">h</span>
+              <select id="edit-duration-minutes" class="edit-input">${durationMinuteOptions}</select>
+              <span class="time-separator">m</span>
+            </div>
           </span>
         </div>
         <div class="info-row edit-actions">
@@ -336,7 +348,7 @@ export function renderFlightInfo(
         </div>
         <div class="info-row">
           <span class="info-label">Duration</span>
-          <span class="info-value">${flight.flight_duration_hours}h</span>
+          <span class="info-value">${formatDurationHM(flight.flight_duration_hours)}</span>
         </div>
         <div class="info-row">
           <span class="info-label">End time</span>

--- a/web/ts/managers/flight-detail-ui.ts
+++ b/web/ts/managers/flight-detail-ui.ts
@@ -7,7 +7,7 @@ import type { ProfileResponse } from '../adapters/profiles-adapter';
 import { $, escapeHtml, formatDate, formatDepartureTime, formatAlt, flightTitle, flightRouteCompact, isFlightPast } from '../utils';
 import { getDateLocale, t } from '../i18n/i18n';
 import { buildTimezoneOptions, utcToLocal } from '../utils/timezone';
-import { splitDurationCeil, buildDurationHourOptions, buildDurationMinuteOptions, formatDurationHM } from '../utils/duration';
+import { splitDurationCeil, combineDuration, buildDurationHourOptions, buildDurationMinuteOptions, formatDurationHM } from '../utils/duration';
 import { renderDebriefForm } from '../components/debrief-form';
 import { renderDebriefSummary } from '../components/debrief-summary';
 import { showRoutePopup } from '../components/route-interpret';
@@ -73,7 +73,10 @@ export function renderFlightInfo(
   const dt = new Date(flight.departure_time);
   const utcHour = dt.getUTCHours();
   const utcMinute = dt.getUTCMinutes();
-  const endTime = new Date(dt.getTime() + flight.flight_duration_hours * 3600_000);
+  // End time uses the same ceil-to-15-min duration as the read-only Duration
+  // label so the two never disagree for legacy non-15-min stored values.
+  const endParts = splitDurationCeil(flight.flight_duration_hours);
+  const endTime = new Date(dt.getTime() + combineDuration(endParts.hours, endParts.minutes) * 3600_000);
   const endTimeStr = `${endTime.getUTCHours().toString().padStart(2, '0')}:${endTime.getUTCMinutes().toString().padStart(2, '0')}Z`;
 
   // Profile display name

--- a/web/ts/utils/duration.ts
+++ b/web/ts/utils/duration.ts
@@ -36,13 +36,12 @@ export function combineDuration(hours: number, minutes: number): number {
   return hours + minutes / 60;
 }
 
-/** Format decimal hours as a compact "1h15" / "2h" label for read-only display,
- *  rounding to the nearest minute. "0h" for non-positive / invalid input. */
+/** Format decimal hours as a compact "1h15" / "2h" label for read-only display.
+ *  Rounds UP to the next 15-minute unit (via splitDurationCeil) so the label
+ *  agrees with what the edit dropdowns show for the same stored value. "0h" for
+ *  non-positive / invalid input. */
 export function formatDurationHM(decimalHours: number): string {
-  if (!Number.isFinite(decimalHours) || decimalHours <= 0) return '0h';
-  const totalMinutes = Math.round(decimalHours * 60);
-  const hours = Math.floor(totalMinutes / 60);
-  const minutes = totalMinutes % 60;
+  const { hours, minutes } = splitDurationCeil(decimalHours);
   return minutes ? `${hours}h${minutes.toString().padStart(2, '0')}` : `${hours}h`;
 }
 

--- a/web/ts/utils/duration.ts
+++ b/web/ts/utils/duration.ts
@@ -1,0 +1,65 @@
+/** Shared helpers for the flight-duration hour/minute dropdown controls used on
+ *  the flight setup form (index.html) and the flight-detail edit form. The model
+ *  stores ``flight_duration_hours`` as decimal hours; the UI presents it as a
+ *  whole-hour select (0–12) plus a 15-minute select. */
+
+/** Selectable minute values — quarter-hour granularity. */
+export const DURATION_MINUTE_OPTIONS = [0, 15, 30, 45] as const;
+
+/** Largest whole-hour the hour dropdown offers. */
+export const MAX_DURATION_HOURS = 12;
+
+/** Largest duration the dropdowns can represent, in decimal hours (12h45m). */
+const MAX_DURATION_DECIMAL = MAX_DURATION_HOURS + 45 / 60;
+
+export interface DurationParts {
+  hours: number;
+  minutes: number;
+}
+
+/** Split decimal hours into {hours, minutes}, rounding UP to the next 15-minute
+ *  unit (never shorter) and clamping to the 12h45m dropdown ceiling. A still-air
+ *  estimate of 1h02m therefore becomes 1h15m — we never advertise a flight
+ *  window shorter than the computed time. Non-positive / invalid input → 0h00. */
+export function splitDurationCeil(decimalHours: number): DurationParts {
+  if (!Number.isFinite(decimalHours) || decimalHours <= 0) return { hours: 0, minutes: 0 };
+  const capped = Math.min(decimalHours, MAX_DURATION_DECIMAL);
+  // Count 15-minute units, rounding up. The epsilon absorbs float error so exact
+  // multiples (e.g. 0.75h → 3.0 quarters) don't tip into the next unit.
+  const quarters = Math.ceil(capped * 4 - 1e-9);
+  const totalMinutes = quarters * 15;
+  return { hours: Math.floor(totalMinutes / 60), minutes: totalMinutes % 60 };
+}
+
+/** Combine whole hours + minutes back into decimal hours for the model. */
+export function combineDuration(hours: number, minutes: number): number {
+  return hours + minutes / 60;
+}
+
+/** Format decimal hours as a compact "1h15" / "2h" label for read-only display,
+ *  rounding to the nearest minute. "0h" for non-positive / invalid input. */
+export function formatDurationHM(decimalHours: number): string {
+  if (!Number.isFinite(decimalHours) || decimalHours <= 0) return '0h';
+  const totalMinutes = Math.round(decimalHours * 60);
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  return minutes ? `${hours}h${minutes.toString().padStart(2, '0')}` : `${hours}h`;
+}
+
+/** Build ``<option>`` markup for the hour select (0…MAX_DURATION_HOURS). */
+export function buildDurationHourOptions(selectedHours: number): string {
+  let html = '';
+  for (let h = 0; h <= MAX_DURATION_HOURS; h++) {
+    const sel = h === selectedHours ? ' selected' : '';
+    html += `<option value="${h}"${sel}>${h}</option>`;
+  }
+  return html;
+}
+
+/** Build ``<option>`` markup for the 15-minute select. */
+export function buildDurationMinuteOptions(selectedMinutes: number): string {
+  return DURATION_MINUTE_OPTIONS.map(m => {
+    const sel = m === selectedMinutes ? ' selected' : '';
+    return `<option value="${m}"${sel}>${m.toString().padStart(2, '0')}</option>`;
+  }).join('');
+}


### PR DESCRIPTION
Replace the decimal duration number entry on the flight setup form (and the
flight-detail edit form) with two dropdowns: whole hours (0–12) and minutes in
15-minute units. The model still stores flight_duration_hours as decimal hours;
the UI splits/combines it.

Auto-computed durations (route distance ÷ TAS, FPL import, zero-duration
confirm) now round UP to the next 15-minute unit so the advertised flight
window is never shorter than the still-air estimate. All duration-update paths
go through shared helpers in web/ts/utils/duration.ts (splitDurationCeil,
combineDuration, option builders, formatDurationHM) covered by unit tests.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HTgd7DWoWYqYc9dzLmAvJK