### PR TITLE
feat(auth): reviewer carve-out for hardened deep-link login (H8)

### DIFF
--- a/app/flyfun-weather/flyfun-weather/App/AppState.swift
+++ b/app/flyfun-weather/flyfun-weather/App/AppState.swift
@@ -140,14 +140,41 @@ final class AppState {
         setupClient()
     }
 
-    /// Handle a deep-link auth callback (`flyfunweather://auth?token=…` or
-    /// `https://weather.flyfun.aero/auth/callback?token=…`).
+    /// Handle a deep-link auth callback.
+    ///
+    /// The normal Google/Apple sign-in is captured *inside*
+    /// `ASWebAuthenticationSession` and never reaches `onOpenURL`, so the only
+    /// legitimate inbound deep link here is the **App Store reviewer** token
+    /// (`flyfunweather://auth?token=<jwt>`), which carries a `scope:"review"`
+    /// claim. Any other bare-token deep link is a login-CSRF attempt and is
+    /// ignored. The claim is read only to *route* — the server still verifies
+    /// the signature on every API call, so a forged review token is inert
+    /// (401s on first use) and never reaches a real account.
     func handleAuthCallback(url: URL) {
         guard let token = callbackParser.token(from: url) else {
             Self.logger.warning("Invalid auth callback URL: \(url)")
             return
         }
+        guard Self.unverifiedScope(of: token) == "review" else {
+            Self.logger.warning("Ignoring non-review bare-token deep link")
+            return
+        }
         signIn(token: token)
+    }
+
+    /// Reads the (unverified) `scope` claim from a JWT payload for routing only.
+    /// Never used for authorization — that stays with the server signature.
+    static func unverifiedScope(of jwt: String) -> String? {
+        let parts = jwt.split(separator: ".")
+        guard parts.count == 3 else { return nil }
+        var b64 = String(parts[1])
+            .replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+        while b64.count % 4 != 0 { b64 += "=" }
+        guard let data = Data(base64Encoded: b64),
+              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { return nil }
+        return obj["scope"] as? String
     }
 
     func logout() {

--- a/app/flyfun-weather/flyfun-weather/App/AppState.swift
+++ b/app/flyfun-weather/flyfun-weather/App/AppState.swift
@@ -146,13 +146,29 @@ final class AppState {
     /// `ASWebAuthenticationSession` and never reaches `onOpenURL`, so the only
     /// legitimate inbound deep link here is the **App Store reviewer** token
     /// (`flyfunweather://auth?token=<jwt>`), which carries a `scope:"review"`
-    /// claim. Any other bare-token deep link is a login-CSRF attempt and is
-    /// ignored. The claim is read only to *route* — the server still verifies
-    /// the signature on every API call, so a forged review token is inert
-    /// (401s on first use) and never reaches a real account.
+    /// claim.
+    ///
+    /// Two guards, in order:
+    /// 1. **Never overwrite an existing session.** The reviewer path is only for
+    ///    a fresh (signed-out) device. Bailing when already authenticated closes
+    ///    the residual forced-logout vector: the `scope` claim is read
+    ///    *unverified* (we can't check the signature client-side), so a spoofed
+    ///    `scope:"review"` token could otherwise be persisted over a logged-in
+    ///    user's real token and 401 them out on the next request.
+    /// 2. **Require `scope:"review"`.** Any other bare-token deep link is a
+    ///    login-CSRF attempt and is ignored.
+    ///
+    /// Account-takeover / session-fixation is closed regardless: the claim is a
+    /// routing hint only — the server verifies the signature on every API call,
+    /// so a forged review token is inert (401s on first use) and only a
+    /// genuinely server-signed reviewer token authenticates end-to-end.
     func handleAuthCallback(url: URL) {
         guard let token = callbackParser.token(from: url) else {
             Self.logger.warning("Invalid auth callback URL: \(url)")
+            return
+        }
+        guard jwt == nil else {
+            Self.logger.warning("Ignoring auth deep link while already authenticated")
             return
         }
         guard Self.unverifiedScope(of: token) == "review" else {
@@ -164,7 +180,7 @@ final class AppState {
 
     /// Reads the (unverified) `scope` claim from a JWT payload for routing only.
     /// Never used for authorization — that stays with the server signature.
-    static func unverifiedScope(of jwt: String) -> String? {
+    nonisolated static func unverifiedScope(of jwt: String) -> String? {
         let parts = jwt.split(separator: ".")
         guard parts.count == 3 else { return nil }
         var b64 = String(parts[1])

--- a/app/flyfun-weather/flyfun-weatherTests/ReviewTokenScopeTests.swift
+++ b/app/flyfun-weather/flyfun-weatherTests/ReviewTokenScopeTests.swift
@@ -1,0 +1,71 @@
+//
+//  ReviewTokenScopeTests.swift
+//  flyfun-weatherTests
+//
+//  Unit tests for AppState.unverifiedScope(of:) — the routing gate that decides
+//  whether an inbound bare-token deep link is the App Store reviewer link
+//  (scope:"review"). Security-critical: it's the only path that accepts a
+//  bare token in onOpenURL (H8 carve-out). The claim is read UNVERIFIED (no
+//  signature check), so this only routes — authorization stays server-side.
+//
+
+import Foundation
+import Testing
+@testable import flyfun_weather
+
+/// Build a JWT-shaped string with the given payload. The signature segment is
+/// irrelevant here — `unverifiedScope` never checks it (that's the point).
+private func makeJWT(payload: [String: Any]) -> String {
+    func b64url(_ d: Data) -> String {
+        d.base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+    let header = b64url(Data(#"{"alg":"HS256","typ":"JWT"}"#.utf8))
+    let body = b64url(try! JSONSerialization.data(withJSONObject: payload))
+    return "\(header).\(body).signature-not-checked"
+}
+
+@Suite("unverifiedScope")
+struct ReviewTokenScopeTests {
+
+    @Test func extractsReviewScope() {
+        let token = makeJWT(payload: ["sub": "u1", "scope": "review"])
+        #expect(AppState.unverifiedScope(of: token) == "review")
+    }
+
+    @Test func missingScopeReturnsNil() {
+        let token = makeJWT(payload: ["sub": "u1", "email": "a@b.com"])
+        #expect(AppState.unverifiedScope(of: token) == nil)
+    }
+
+    @Test func nonReviewScopeReturnsItsValue() {
+        // A different scope must not read as "review" (the caller gates on ==).
+        let token = makeJWT(payload: ["sub": "u1", "scope": "mcp"])
+        #expect(AppState.unverifiedScope(of: token) == "mcp")
+    }
+
+    @Test func nonJWTShapedStringReturnsNil() {
+        #expect(AppState.unverifiedScope(of: "not-a-jwt") == nil)
+        #expect(AppState.unverifiedScope(of: "only.two") == nil)
+    }
+
+    @Test func nonJSONPayloadReturnsNil() {
+        let token = "header.bm90LWpzb24.sig"  // "not-json" base64url, not JSON
+        #expect(AppState.unverifiedScope(of: token) == nil)
+    }
+
+    @Test func handlesBase64PayloadNeedingPadding() {
+        // A payload whose base64url length isn't a multiple of 4 exercises the
+        // padding loop. {"scope":"review"} encodes to a length needing padding.
+        let token = makeJWT(payload: ["scope": "review"])
+        #expect(AppState.unverifiedScope(of: token) == "review")
+    }
+
+    @Test func scopeWrongTypeReturnsNil() {
+        // A numeric `scope` is not a String → nil (never mistaken for "review").
+        let token = makeJWT(payload: ["sub": "u1", "scope": 42])
+        #expect(AppState.unverifiedScope(of: token) == nil)
+    }
+}

--- a/scripts/mint_reviewer_token.py
+++ b/scripts/mint_reviewer_token.py
@@ -80,8 +80,8 @@ def main() -> None:
         # scope:"review" is what lets the hardened app accept this as a
         # bare-token deep link (the App Store reviewer carve-out). It is a
         # routing hint only — the server verifies the signature on every call,
-        # so the claim confers no authority on its own. See
-        # designs/oauth-deeplink-hardening.md.
+        # so the claim confers no authority on its own. See the design doc in
+        # the companion repo: flyfun-common/designs/oauth-deeplink-hardening.md.
         {
             "sub": user_id,
             "email": email,

--- a/scripts/mint_reviewer_token.py
+++ b/scripts/mint_reviewer_token.py
@@ -77,7 +77,19 @@ def main() -> None:
     now = datetime.now(timezone.utc)
     exp = now + timedelta(days=args.days)
     token = jwt.encode(
-        {"sub": user_id, "email": email, "name": name, "iat": now, "exp": exp},
+        # scope:"review" is what lets the hardened app accept this as a
+        # bare-token deep link (the App Store reviewer carve-out). It is a
+        # routing hint only — the server verifies the signature on every call,
+        # so the claim confers no authority on its own. See
+        # designs/oauth-deeplink-hardening.md.
+        {
+            "sub": user_id,
+            "email": email,
+            "name": name,
+            "scope": "review",
+            "iat": now,
+            "exp": exp,
+        },
         secret,
         algorithm=JWT_ALGORITHM,
     )


### PR DESCRIPTION
## Summary

Companion to **roznet/flyfun-common#7** (native auth-code deep-link flow). Together they close **SECURITY_AUDIT.md H8**.

The normal Google/Apple sign-in is captured inside `ASWebAuthenticationSession` and never reaches `onOpenURL`, so the only legitimate inbound deep link is the **App Store reviewer** token. This PR hardens `AppState.handleAuthCallback` to accept a bare-token deep link **only** when it carries a `scope:"review"` claim:

- The claim is read (unverified) **for routing only** — the server verifies the JWT signature on every API call, so a forged `review` token is inert (401s on first use, never reaches a real account).
- Any other bare-token deep link (an attacker's own token) is ignored → the login-CSRF / session-fixation vector is closed.
- The one-tap reviewer link keeps working.

`scripts/mint_reviewer_token.py` now stamps `scope:"review"` so the minted token passes the carve-out.

## Release sequencing

The code-exchange login activates only after flyfun-common#7 is published (PyPI + SPM tag), the server is deployed, and this app bumps its flyfun-common SPM pin. This app-side carve-out is independently safe to ship (it doesn't depend on the new flyfun-common API). Beta testers re-authenticate on the new build.

## Test plan
- App builds clean.
- `mint_reviewer_token.py` runs and the minted token decodes with `scope:"review"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)