### PR TITLE
feat(timing): timing-scenario scan — background ECMWF departure-window discovery

### DIFF
--- a/src/weatherbrief/analysis/advisories/__init__.py
+++ b/src/weatherbrief/analysis/advisories/__init__.py
@@ -72,4 +72,4 @@ class AdvisoryEvaluator(Protocol):
     def evaluate(ctx: RouteContext, params: dict[str, float]) -> RouteAdvisoryResult: ...
 
 
-from weatherbrief.analysis.advisories.registry import evaluate_all, get_altitude_dependent_ids, get_catalog, resolve_enabled_ids  # noqa: E402, F401
+from weatherbrief.analysis.advisories.registry import evaluate_all, get_altitude_dependent_ids, get_catalog, get_scan_class_ids, get_timing_class_ids, resolve_enabled_ids  # noqa: E402, F401

--- a/src/weatherbrief/analysis/advisories/airport_wind.py
+++ b/src/weatherbrief/analysis/advisories/airport_wind.py
@@ -73,6 +73,7 @@ class AirportWindEvaluator:
     def catalog_entry() -> AdvisoryCatalogEntry:
         return AdvisoryCatalogEntry(
             id="airport_wind",
+            timing_class="cheap",
             name="Airport Wind",
             short_description="Crosswind and gusts at airports",
             description=(

--- a/src/weatherbrief/analysis/advisories/cloud_top.py
+++ b/src/weatherbrief/analysis/advisories/cloud_top.py
@@ -23,6 +23,7 @@ class CloudTopEvaluator:
     def catalog_entry() -> AdvisoryCatalogEntry:
         return AdvisoryCatalogEntry(
             id="cloud_top",
+            timing_class="scan",
             name="Cloud Tops",
             short_description="Can fly above cloud tops",
             description=(

--- a/src/weatherbrief/analysis/advisories/convective.py
+++ b/src/weatherbrief/analysis/advisories/convective.py
@@ -55,6 +55,7 @@ class ConvectiveEvaluator:
     def catalog_entry() -> AdvisoryCatalogEntry:
         return AdvisoryCatalogEntry(
             id="convective",
+            timing_class="scan",
             name="Convective Activity",
             short_description="Can fly around convective activity",
             description=(

--- a/src/weatherbrief/analysis/advisories/convective_character.py
+++ b/src/weatherbrief/analysis/advisories/convective_character.py
@@ -229,6 +229,7 @@ class ConvectiveCharacterEvaluator:
     def catalog_entry() -> AdvisoryCatalogEntry:
         return AdvisoryCatalogEntry(
             id="convective_character",
+            timing_class="scan",
             name="Convective Character",
             short_description="Is convection circumnavigable VFR?",
             description=(

--- a/src/weatherbrief/analysis/advisories/density_altitude.py
+++ b/src/weatherbrief/analysis/advisories/density_altitude.py
@@ -79,6 +79,7 @@ class DensityAltitudeEvaluator:
     def catalog_entry() -> AdvisoryCatalogEntry:
         return AdvisoryCatalogEntry(
             id="density_altitude",
+            timing_class="cheap",
             name="Density Altitude",
             short_description="Aircraft performance at departure and arrival",
             description=(

--- a/src/weatherbrief/analysis/advisories/fiki_icing.py
+++ b/src/weatherbrief/analysis/advisories/fiki_icing.py
@@ -67,6 +67,7 @@ class FIKIIcingEvaluator:
     def catalog_entry() -> AdvisoryCatalogEntry:
         return AdvisoryCatalogEntry(
             id="fiki_icing",
+            timing_class="scan",
             name="FIKI Icing",
             short_description="Icing manageable for FIKI-equipped",
             description=(

--- a/src/weatherbrief/analysis/advisories/flight_category.py
+++ b/src/weatherbrief/analysis/advisories/flight_category.py
@@ -106,6 +106,8 @@ class FlightCategoryEvaluator:
     def catalog_entry() -> AdvisoryCatalogEntry:
         return AdvisoryCatalogEntry(
             id="flight_category",
+            timing_class="cheap",  # scan? → cheap: IMC/fog burn-off is a timing case,
+                                   # but ceiling/vis fidelity is OM/TAF not GRIB
             name="Airport Weather",
             short_description="Flight category and convective risk at departure and arrival",
             description=(

--- a/src/weatherbrief/analysis/advisories/freezing_precip.py
+++ b/src/weatherbrief/analysis/advisories/freezing_precip.py
@@ -45,6 +45,7 @@ class FreezingPrecipEvaluator:
     def catalog_entry() -> AdvisoryCatalogEntry:
         return AdvisoryCatalogEntry(
             id="freezing_precip",
+            timing_class="scan",  # scan? → scan: severe & diurnal T-crossing (safety wins)
             name="Freezing Precipitation",
             short_description="Freezing rain / ice pellets along the route",
             description=(

--- a/src/weatherbrief/analysis/advisories/icing_escape.py
+++ b/src/weatherbrief/analysis/advisories/icing_escape.py
@@ -153,6 +153,7 @@ class IcingEscapeEvaluator:
     def catalog_entry() -> AdvisoryCatalogEntry:
         return AdvisoryCatalogEntry(
             id="icing_escape",
+            timing_class="scan",
             name="Icing Escape (non-FIKI)",
             short_description="Icing at cruise and warm-air escape viability",
             description=(

--- a/src/weatherbrief/analysis/advisories/ifr_feasibility.py
+++ b/src/weatherbrief/analysis/advisories/ifr_feasibility.py
@@ -165,6 +165,7 @@ class IFRFeasibilityEvaluator:
     def catalog_entry() -> AdvisoryCatalogEntry:
         return AdvisoryCatalogEntry(
             id="ifr_feasibility",
+            timing_class="scan",
             name="IFR Feasibility",
             short_description="Overall IFR flight viability",
             description=(

--- a/src/weatherbrief/analysis/advisories/llws.py
+++ b/src/weatherbrief/analysis/advisories/llws.py
@@ -70,6 +70,7 @@ class LLWSEvaluator:
     def catalog_entry() -> AdvisoryCatalogEntry:
         return AdvisoryCatalogEntry(
             id="llws",
+            timing_class="cheap",
             name="Low-Level Wind Shear",
             short_description="Wind shear in the lowest 1000m at departure and arrival",
             description=(

--- a/src/weatherbrief/analysis/advisories/registry.py
+++ b/src/weatherbrief/analysis/advisories/registry.py
@@ -34,6 +34,25 @@ def get_altitude_dependent_ids() -> set[str]:
     return {aid for aid, cls in _EVALUATORS.items() if cls.catalog_entry().altitude_dependent}
 
 
+def get_timing_class_ids(timing_class: str) -> set[str]:
+    """Return IDs of evaluators whose catalog ``timing_class`` matches.
+
+    Used by the timing-scenario scan: ``get_timing_class_ids("scan")`` is the
+    set whose RED/AMBER presence triggers (and is ranked by) the ECMWF day-scan.
+    Declarative — a new evaluator that sets ``timing_class="scan"`` auto-joins.
+    """
+    _ensure_loaded()
+    return {
+        aid for aid, cls in _EVALUATORS.items()
+        if cls.catalog_entry().timing_class == timing_class
+    }
+
+
+def get_scan_class_ids() -> set[str]:
+    """Convenience: the ``"scan"``-class advisory IDs (the timing-scan trigger set)."""
+    return get_timing_class_ids("scan")
+
+
 def resolve_enabled_ids(enabled_map: dict[str, bool] | None) -> set[str] | None:
     """Resolve a saved per-profile advisory enable map into the set to evaluate.
 

--- a/src/weatherbrief/analysis/advisories/sun.py
+++ b/src/weatherbrief/analysis/advisories/sun.py
@@ -72,6 +72,7 @@ class SunEvaluator:
             category="sun",
             default_enabled=True,
             altitude_dependent=False,
+            timing_class="cheap",  # pure astronomy — glare time is computable exactly
             parameters=[
                 AdvisoryParameterDef(
                     key="glare_azimuth_deg",

--- a/src/weatherbrief/analysis/advisories/vfr_feasibility.py
+++ b/src/weatherbrief/analysis/advisories/vfr_feasibility.py
@@ -518,6 +518,7 @@ class VFRFeasibilityEvaluator:
     def catalog_entry() -> AdvisoryCatalogEntry:
         return AdvisoryCatalogEntry(
             id="vfr_feasibility",
+            timing_class="scan",
             name="VFR Feasibility",
             short_description="Overall VFR flight viability",
             description=(

--- a/src/weatherbrief/analysis/advisories/vmc_cruise.py
+++ b/src/weatherbrief/analysis/advisories/vmc_cruise.py
@@ -24,6 +24,7 @@ class VMCCruiseEvaluator:
     def catalog_entry() -> AdvisoryCatalogEntry:
         return AdvisoryCatalogEntry(
             id="vmc_cruise",
+            timing_class="scan",
             name="VMC at Cruise",
             short_description="Can maintain VMC at cruise altitude",
             description=(

--- a/src/weatherbrief/api/agent.py
+++ b/src/weatherbrief/api/agent.py
@@ -303,7 +303,11 @@ def get_briefing(
 
     advisories = _read_json(pack_dir, "route_advisories.json")
     if advisories:
-        result["advisories"] = views.summarize_advisories(advisories)
+        adv_summary = views.summarize_advisories(advisories)
+        result["advisories"] = adv_summary
+        # Timing-scenario referral: web-only interactive confirm → point there.
+        if any(a.get("timing_referral") for a in adv_summary):
+            result["timing_note"] = views.TIMING_NOTE
 
     digest_json = _read_json(pack_dir, "digest.json")
     if digest_json:

--- a/src/weatherbrief/api/packs.py
+++ b/src/weatherbrief/api/packs.py
@@ -860,6 +860,7 @@ _STAGE_LABELS: dict[str, str] = {
     "generate_skewt": "Generating Skew-T",
     "briefing_ready": "Briefing ready",
     "llm_digest": "Generating AI digest",
+    "time_scan": "Scanning for a smoother departure window",
 }
 
 _STAGE_PROGRESS: dict[str, float] = {
@@ -881,6 +882,9 @@ _STAGE_PROGRESS: dict[str, float] = {
     # to surface the stage label between provisional persist and digest.
     "briefing_ready": 0.88,
     "llm_digest": 0.95,
+    # Runs after the digest; the briefing is already shown, so this only adds
+    # the "a smoother departure may exist" hook when it finishes.
+    "time_scan": 0.97,
 }
 
 
@@ -2591,6 +2595,101 @@ def compute_alt_advisories(
         db.flush()
 
     return advisory_result.manifest.model_dump()
+
+
+@router.get("/{timestamp}/time-options")
+def get_time_options(
+    flight_id: str,
+    timestamp: str,
+    user_id: str = Depends(current_user_id),
+    db: Session = Depends(get_db),
+):
+    """Return the timing-scenario scan (``time_options.json``) for a pack.
+
+    404 while the scan hasn't run (or was gated off) — the client shows
+    "looking…" / nothing rather than an empty verdict.
+    """
+    pack_dir = _get_pack_dir(db, flight_id, timestamp, viewer_id=user_id)
+    path = pack_dir / "time_options.json"
+    if not path.exists():
+        raise HTTPException(status_code=404, detail="Timing options not available")
+    return FileResponse(path, media_type="application/json")
+
+
+class TimeConfirmRequest(BaseModel):
+    """Body for the on-tap multi-model confirm — identifies the candidate."""
+
+    departure_time: str  # ISO-8601 of the candidate departure to confirm
+
+
+@router.post("/{timestamp}/time-options/confirm")
+def confirm_time_option(
+    flight_id: str,
+    timestamp: str,
+    body: TimeConfirmRequest,
+    request: Request,
+    user_id: str = Depends(current_user_id),
+    db: Session = Depends(get_db),
+):
+    """Multi-model confirm of one candidate departure (the deferred, gated cost).
+
+    Runs the full GFS+ICON+ECMWF enrichment at the candidate's flight window and
+    grades it multi-model, caching the :class:`TimeConfirmation` onto the
+    candidate in ``time_options.json``. Synchronous (FastAPI runs this in a
+    worker thread); the ICON/GFS decode is BACKGROUND-priority. A future
+    enhancement can make this SSE-streamed (plan Open question 4).
+    """
+    from weatherbrief.tasks.artifacts import load_time_options, save_time_options
+    from weatherbrief.tasks.time_scan import confirm_candidate
+
+    flight = _load_owned_flight(db, flight_id, user_id)
+    pack_dir = _get_pack_dir(db, flight_id, timestamp, viewer_id=user_id)
+
+    scan = load_time_options(pack_dir)
+    if scan is None:
+        raise HTTPException(status_code=404, detail="Timing options not available")
+
+    try:
+        cand_time = datetime.fromisoformat(body.departure_time)
+    except ValueError:
+        raise HTTPException(status_code=422, detail="departure_time must be ISO-8601")
+
+    candidate = scan.candidate_at(cand_time)
+    if candidate is None:
+        raise HTTPException(status_code=404, detail="No such candidate departure time")
+
+    db_path = getattr(request.app.state, "db_path", "")
+    route = _build_route_config(flight, db_path)
+    enabled_ids, enabled_map, user_params, aggregation, adv_models, icing_method, cloud_method, convective_method, recompute_conds, locale, _auto_front_detection = \
+        _load_advisory_profile(db, flight, user_id, request, pack_dir)
+
+    data_dir = Path(os.environ.get("DATA_DIR", "data"))
+    confirmation = confirm_candidate(
+        pack_dir,
+        route,
+        cand_time,
+        data_dir=data_dir,
+        advisory_models=adv_models,
+        enabled_ids=enabled_ids,
+        advisory_enabled=enabled_map,
+        user_params=user_params,
+        aggregation=aggregation,
+        airport_conditions_recompute=recompute_conds,
+        icing_method=icing_method,
+        cloud_method=cloud_method,
+        convective_method=convective_method,
+        locale=locale,
+        cruise_speed_ias_kt=_resolve_cruise_ias_kt(db, flight),
+    )
+    if confirmation is None:
+        raise HTTPException(status_code=500, detail="Multi-model confirm failed")
+
+    # Cache the confirmation onto the candidate and upgrade its confidence.
+    candidate.confirmed = confirmation
+    candidate.confidence = "confirmed"
+    save_time_options(pack_dir, scan)
+
+    return confirmation.model_dump()
 
 
 def _recompute_airport_conditions(

--- a/src/weatherbrief/connectors/views.py
+++ b/src/weatherbrief/connectors/views.py
@@ -29,6 +29,14 @@ MITIGATION_NOTE = (
     "downgrade."
 )
 
+TIMING_NOTE = (
+    "Timing options (candidate departure windows scanned against ECMWF) are a "
+    "web-app feature — the connector is stateless/synchronous and can't run the "
+    "interactive 'tap to check all models' confirm. When an advisory carries "
+    "timing_referral, tell the user a smoother departure window may exist and to "
+    "open the briefing in the app to explore it. Do NOT invent alternate times."
+)
+
 CONVECTIVE_NOTE = (
     "thermo.peak.el_top_ft is parcel-derived (the equilibrium level the digest "
     "narrates as 'convective tops'), NOT the model's convective cloud field. "
@@ -150,6 +158,14 @@ def summarize_advisories(advisories: dict) -> list[dict]:
         if cat:
             entry["name"] = cat.get("name")
             entry["category"] = cat.get("category")
+
+        # Timing referral (timing-scenario scan): a neutral pointer, set on a
+        # flagged scan-class advisory, telling the agent that candidate
+        # departure windows can be explored in the app. Stateless connectors
+        # can't run the interactive confirm, so we refer rather than expose half
+        # a workflow. Never a valenced flag, never changes the grade.
+        if cat and cat.get("timing_class") == "scan" and entry["status"] in ("amber", "red"):
+            entry["timing_referral"] = True
 
         # Layer A: expand the full per-model detail + thresholds, and point the
         # agent at the drill-down tool, only when there is something worth

--- a/src/weatherbrief/digest/prompt_builder.py
+++ b/src/weatherbrief/digest/prompt_builder.py
@@ -790,6 +790,38 @@ def _format_tactical_mitigations_context(
     return "\n".join(["Tactical (per-advisory, no altitude change):", *lines])
 
 
+def _format_timing_hint_context(
+    manifest: RouteAdvisoriesManifest,
+) -> str | None:
+    """Synchronous timing *pointer* for the digest — no numbers, no async scan.
+
+    The full timing-scenario scan is a low-priority background job that runs
+    *after* the digest is generated, so the digest can't cite its results. The
+    honest synchronous hint uses the same Relevance signal the scan gates on: a
+    ``scan``-class advisory (GRIB-dependent, genuinely diurnal — convection,
+    cloud, icing, feasibility) flagged RED/AMBER at the planned time. When one
+    is, a calmer departure window *may* exist; point the pilot at the app's
+    Timing options rather than inventing numbers here.
+    """
+    from weatherbrief.analysis.advisories import get_scan_class_ids
+
+    scan_ids = get_scan_class_ids()
+    name_map = {entry.id: entry.name for entry in manifest.catalog}
+    flagged = [
+        name_map.get(a.advisory_id, a.advisory_id)
+        for a in manifest.advisories
+        if a.advisory_id in scan_ids and a.aggregate_status in ("red", "amber")
+    ]
+    if not flagged:
+        return None
+    joined = ", ".join(flagged[:3])
+    return (
+        "Timing (see Timing options in the app — a scan runs there):\n"
+        f"  {joined} — these can vary through the day; a calmer departure window "
+        "may exist. Pointer only — the app checks candidate departure times against ECMWF."
+    )
+
+
 def _format_options_to_improve_context(
     altitude_table: AltitudeTableResult | None,
     route_advisories: RouteAdvisoriesManifest | None,
@@ -811,6 +843,9 @@ def _format_options_to_improve_context(
         tactical = _format_tactical_mitigations_context(route_advisories)
         if tactical:
             sub_blocks.append(tactical)
+        timing = _format_timing_hint_context(route_advisories)
+        if timing:
+            sub_blocks.append(timing)
     if not sub_blocks:
         return None
     header = "=== OPTIONS TO IMPROVE (advice only — do NOT change the assessment) ==="

--- a/src/weatherbrief/mcp/server.py
+++ b/src/weatherbrief/mcp/server.py
@@ -498,7 +498,14 @@ def get_briefing(
         # Fetch advisories
         advisories = client.get_advisories(flight_id, timestamp)
         if advisories:
-            result["advisories"] = _summarize_advisories(advisories)
+            adv_summary = _summarize_advisories(advisories)
+            result["advisories"] = adv_summary
+            # Timing-scenario referral: point to the app when a scan-class
+            # hazard is flagged (the interactive confirm is web-only).
+            if any(a.get("timing_referral") for a in adv_summary):
+                from weatherbrief.connectors.views import TIMING_NOTE
+
+                result["timing_note"] = TIMING_NOTE
 
         # Fetch digest
         digest_json = client.get_digest_json(flight_id, timestamp)

--- a/src/weatherbrief/models/__init__.py
+++ b/src/weatherbrief/models/__init__.py
@@ -97,6 +97,13 @@ from weatherbrief.models.advisories import (  # noqa: F401
     RouteAdvisoriesManifest,
     RouteAdvisoryResult,
 )
+from weatherbrief.models.time_scan import (  # noqa: F401
+    TimeCandidate,
+    TimeConfirmation,
+    TimeScanBaseline,
+    TimeScanWindow,
+    TimeWindowScan,
+)
 from weatherbrief.models.fronts import (  # noqa: F401
     FrontChainModel,
     FrontChainNodeModel,

--- a/src/weatherbrief/models/advisories.py
+++ b/src/weatherbrief/models/advisories.py
@@ -7,6 +7,7 @@ deterministic GREEN/AMBER/RED assessments per advisory per model.
 from __future__ import annotations
 
 from enum import Enum
+from typing import Literal
 
 from pydantic import BaseModel, Field
 
@@ -151,6 +152,14 @@ class AdvisoryCatalogEntry(BaseModel):
     category: str  # e.g. "icing", "cloud", "turbulence", "convective", "model"
     default_enabled: bool = True
     altitude_dependent: bool = False
+    # Timing-scan participation (timing-scenario-scan feature). Declarative
+    # sibling of ``altitude_dependent``: the scan job asks the registry which
+    # IDs are ``"scan"``-class so a new evaluator auto-participates. See the
+    # unifying principle — scan-worthy ⟺ GRIB-dependent ⟺ OM-insufficient.
+    #   "scan"  — worth the expensive ECMWF day-scan (RED/AMBER triggers it)
+    #   "cheap" — OM-sufficient; a free variance hint at most, never the scan
+    #   "none"  — timing is not the lever (default)
+    timing_class: Literal["scan", "cheap", "none"] = "none"
     parameters: list[AdvisoryParameterDef] = Field(default_factory=list)
 
 

--- a/src/weatherbrief/models/time_scan.py
+++ b/src/weatherbrief/models/time_scan.py
@@ -1,0 +1,117 @@
+"""Pydantic models for the timing-scenario scan (``time_options.json``).
+
+The scan answers *"a better departure time may exist"* for hazards that
+genuinely vary through the day. It is an **attention-director, never a
+verdict** — a neutral soft hook, provisional until the user asks for a
+multi-model confirm. See ``designs/plans/timing-scenario-plan.md``.
+
+Honesty ladder encoded in the fields:
+
+    SCANNING → CANDIDATES (ECMWF-only, provisional) → CONFIRMED (multi-model)
+
+``TimeCandidate.confidence`` is ``"ecmwf_only"`` until a
+:class:`TimeConfirmation` is attached on user tap. The confirm-downgrade
+(*"you tapped a suggestion, it turned out worse"*) is a first-class designed
+outcome — ``TimeConfirmation.better_than_baseline`` can be ``False``.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class TimeConfirmation(BaseModel):
+    """Multi-model check of one candidate, filled on user tap (deferred cost).
+
+    The candidate's ICON/GFS GRIB is off the flight window, so producing this
+    triggers a deferred fetch+decode — the heavy cost we gate on demonstrated
+    user intent. Cached on the candidate once computed.
+    """
+
+    models_checked: list[str] = Field(default_factory=list)
+    assessment: str = "GREEN"            # GREEN/AMBER/RED across the checked models
+    assessment_reason: str = ""
+    # Did the full multi-model check still agree the window is better than the
+    # planned time? ``False`` is the on-brand downgrade case, not an error.
+    better_than_baseline: bool = False
+    improves: list[str] = Field(default_factory=list)
+    worsens: list[str] = Field(default_factory=list)
+    detail: str = ""                     # human phrasing incl. the downgrade case
+    confirmed_at: datetime | None = None
+
+
+class TimeCandidate(BaseModel):
+    """One candidate departure time, graded ECMWF-only (provisional).
+
+    A candidate is a **departure shift**: moving departure moves *every* route
+    point's ETA (``valid_times``), which is why we store the shift, not a single
+    valid-time. ``improves``/``worsens`` are the FULL-picture diff vs the
+    baseline (so we never surface a window that fixed icing but quietly
+    introduced a crosswind); ``margin`` ranks on the trigger (scan-class) set.
+    """
+
+    departure_time: datetime
+    departure_shift_hours: float          # signed hours vs the planned departure
+    valid_times: list[datetime] = Field(default_factory=list)  # per-route-point ETAs
+    ecmwf_assessment: str = "GREEN"       # GREEN/AMBER/RED, ECMWF-only
+    ecmwf_assessment_reason: str = ""
+    improves: list[str] = Field(default_factory=list)  # advisory ids improved vs baseline
+    worsens: list[str] = Field(default_factory=list)   # advisory ids worsened vs baseline
+    margin: float = 0.0                   # trigger-weighted improvement (ranking key)
+    confidence: Literal["ecmwf_only", "confirmed"] = "ecmwf_only"
+    is_preferred: bool = False            # the pilot's pinned preferred departure time
+    is_baseline: bool = False             # the planned departure (shift 0)
+    confirmed: TimeConfirmation | None = None
+
+
+class TimeScanBaseline(BaseModel):
+    """The planned departure, graded ECMWF-only — the diff reference."""
+
+    departure_time: datetime
+    ecmwf_assessment: str = "GREEN"
+    ecmwf_assessment_reason: str = ""
+
+
+class TimeScanWindow(BaseModel):
+    """The searched departure window and why it stops where it does.
+
+    ``horizon_clipped`` marks the hard fidelity edge: beyond the ECMWF
+    0–90h (168h at 00/12z) horizon even the scan would drop to degraded OM, so
+    the window visibly stops there rather than silently degrading.
+    """
+
+    start: datetime                       # earliest candidate departure
+    end: datetime                         # latest candidate departure
+    cadence_hours: float = 1.0            # nominal native cadence (1h ≤90h)
+    daylight_clipped: bool = False        # bounded by daylight (RouteSunAnalysis)
+    horizon_clipped: bool = False         # bounded by ECMWF fidelity horizon
+    day_flex: str = "day"                 # "day" | "prev" | "next"
+
+
+class TimeWindowScan(BaseModel):
+    """Top-level ``time_options.json`` artifact.
+
+    Old packs (no scan) simply have no file — the endpoint 404s and the client
+    shows nothing, so there is no back-compat surface to defend.
+    """
+
+    baseline: TimeScanBaseline
+    window: TimeScanWindow
+    candidates: list[TimeCandidate] = Field(default_factory=list)
+    # scan-class advisories RED/AMBER at the planned time that triggered the scan
+    scan_flagged: list[str] = Field(default_factory=list)
+    models: list[str] = Field(default_factory=list)   # models available for a confirm pass
+    ecmwf_run_ts: int | None = None       # ECMWF init unix ts (staleness on refresh)
+    generated_at: datetime | None = None
+    # Whether the extended (daylight-enriched) cross-section artifact was written.
+    cross_section_ext: bool = False
+
+    def candidate_at(self, departure_time: datetime) -> TimeCandidate | None:
+        """Find a candidate by departure time (used by the confirm endpoint)."""
+        for c in self.candidates:
+            if c.departure_time == departure_time:
+                return c
+        return None

--- a/src/weatherbrief/pipeline.py
+++ b/src/weatherbrief/pipeline.py
@@ -160,6 +160,9 @@ class BriefingResult:
     models_skipped_region: list[str] = field(default_factory=list)
     diagnostics: list[Diagnostic] = field(default_factory=list)
     alt_advisory_result: AdvisoryResult | None = None
+    # Timing-scenario scan (timing-scenario-scan feature). None when gated off
+    # (no scan-class advisory flagged) or ECMWF unavailable.
+    time_scan: "TimeWindowScan | None" = None
     # DWD Surface Analysis & Forecast — references into the shared chart
     # cache (DATA_DIR/dwd_charts/<run_cycle>/). Bytes are not stored here.
     dwd_charts_run_cycle: str | None = None
@@ -782,6 +785,42 @@ def execute_briefing(
         if digest_result.diagnostic:
             result.diagnostics.append(digest_result.diagnostic)
         stage_timings["llm_digest"] = perf_counter() - _t0
+
+    # === 7.5 Timing-scenario scan (detached background, ECMWF-only) ===
+    # Fire-and-forget: the briefing finishes and `complete` fires as usual; the
+    # scan runs on a separate thread and writes `time_options.json` when done,
+    # which the client picks up the next time the briefing is viewed. We do NOT
+    # block the refresh on it (the daylight ECMWF re-decode can take a couple of
+    # minutes). The Relevance gate inside run_time_scan makes it a fast no-op on
+    # the common case (no scan-class advisory flagged → returns before any
+    # decode). The scan reads everything it needs from pack_dir on disk, so it
+    # is safe to run after execute_briefing returns.
+    if pack_dir and route_advisories_manifest is not None:
+        from weatherbrief.tasks.time_scan import submit_time_scan_background
+
+        submit_time_scan_background(
+            pack_dir,
+            route,
+            departure_time,
+            flight_duration_hours=route.flight_duration_hours,
+            advisory_models=options.advisory_models,
+            enabled_ids=adv_enabled_ids,
+            advisory_enabled=options.advisory_enabled,
+            user_params=options.advisory_params,
+            aggregation=adv_aggregation,
+            airports_db_path=options.airports_db_path,
+            icing_method=options.icing_method,
+            cloud_method=options.cloud_method,
+            convective_method=options.convective_method,
+            locale=options.locale,
+            cruise_speed_ias_kt=options.cruise_speed_ias_kt,
+            # alt_departure_time is reframed as the pinned "preferred departure
+            # time" — always graded as a candidate when set.
+            preferred_departure_time=options.alt_departure_time,
+            as_of_time=as_of_time,
+            # ECMWF GRIB dir comes from the ECMWF_GRIB_DIR env var (same as the
+            # main enrichment path), resolved inside run_time_scan.
+        )
 
     # === 8. Always: text digest ===
     from weatherbrief.digest.text import format_digest

--- a/src/weatherbrief/tasks/advise.py
+++ b/src/weatherbrief/tasks/advise.py
@@ -718,6 +718,9 @@ def run_alt_from_pack(
     convective_method: str | None = None,
     locale: str | None = None,
     cruise_speed_ias_kt: float | None = None,
+    cross_sections: list[RouteCrossSection] | None = None,
+    persist: bool = True,
+    detect_fronts: bool = True,
 ) -> AdvisoryResult:
     """Re-run analysis + advisories at an alt departure time using existing pack data.
 
@@ -725,6 +728,19 @@ def run_alt_from_pack(
     ``analyze_all_route_points`` with the alt departure time (which picks
     different hourly forecasts via ``at_time()``), then evaluates advisories.
     Saves the result as ``route_advisories_alt.json``.
+
+    The timing-scenario scan drives this in a per-candidate loop, so three
+    knobs let it reuse the machinery without side effects:
+
+    * ``cross_sections`` — when provided (e.g. the daylight-extended set from
+      :func:`extend_ecmwf_enrichment_daylight`), skip the disk load and grade
+      against these. This is what lets an off-window candidate be graded on
+      *decoded* ECMWF fields rather than a silent ``at_time()`` clamp.
+    * ``persist`` — ``False`` skips writing ``route_advisories_alt.json`` (the
+      scan grades many candidates and keeps them in ``time_options.json``).
+    * ``detect_fronts`` — ``False`` skips the alt front re-detection (fronts is
+      an experimental, timing-``none`` evaluator; re-detecting per candidate
+      would write files in a tight loop).
     """
     from weatherbrief.tasks.analyze import analyze_all_route_points
     from weatherbrief.tasks.artifacts import (
@@ -734,7 +750,8 @@ def run_alt_from_pack(
         save_alt_advisory_artifacts,
     )
 
-    cross_sections = load_cross_sections(pack_dir)
+    if cross_sections is None:
+        cross_sections = load_cross_sections(pack_dir)
     route_points = load_route_points(pack_dir)
     elevation = load_elevation_profile(pack_dir)
 
@@ -784,7 +801,7 @@ def run_alt_from_pack(
         # scenario against stale fronts. Re-sampling the same snapshot at the alt
         # hours costs ~nothing. Gated on the primary artifact's presence (= the
         # ``auto_front_detection`` master was on at briefing time).
-        if pack_dir is not None and (pack_dir / "route_fronts.json").exists():
+        if detect_fronts and pack_dir is not None and (pack_dir / "route_fronts.json").exists():
             try:
                 from weatherbrief.tasks.fronts import run_fronts
 
@@ -830,7 +847,8 @@ def run_alt_from_pack(
             airport_conditions=airport_conds,
         )
 
-        save_alt_advisory_artifacts(pack_dir, manifest)
+        if persist:
+            save_alt_advisory_artifacts(pack_dir, manifest)
         logger.info("Alt advisory evaluation complete: %d advisories", len(advisory_results))
 
         return AdvisoryResult(manifest=manifest, airport_conditions=airport_conds)

--- a/src/weatherbrief/tasks/artifacts.py
+++ b/src/weatherbrief/tasks/artifacts.py
@@ -262,6 +262,53 @@ def load_cross_sections(pack_dir: Path) -> list[RouteCrossSection]:
     ]
 
 
+def save_cross_sections_ext(
+    pack_dir: Path, cross_sections: list[RouteCrossSection],
+) -> None:
+    """Persist the daylight-extended cross-sections to ``cross_section_ext.json``.
+
+    Written by the timing-scenario scan after :func:`extend_ecmwf_enrichment_daylight`
+    re-decodes the daylight ECMWF fhours. Kept as a *separate* artifact so the
+    background job never clobbers the primary ``cross_section.json`` that the
+    live briefing, altitude table, and alt path read. The confirm endpoint
+    reloads it to grade a candidate at ICON/GFS's nearest native step.
+    """
+    pack_dir.mkdir(parents=True, exist_ok=True)
+    cs_data = [cs.model_dump(mode="json") for cs in cross_sections]
+    (pack_dir / "cross_section_ext.json").write_text(json.dumps({"cross_sections": cs_data}))
+
+
+def load_cross_sections_ext(pack_dir: Path) -> list[RouteCrossSection]:
+    """Load the daylight-extended cross-sections, or ``[]`` if not scanned yet."""
+    data = _read_json_or_gz(pack_dir / "cross_section_ext.json")
+    if not data:
+        return []
+    return [
+        RouteCrossSection.model_validate(item)
+        for item in data.get("cross_sections", [])
+    ]
+
+
+def save_time_options(pack_dir: Path, scan: "TimeWindowScan") -> None:
+    """Persist the timing-scenario scan to ``time_options.json``."""
+    pack_dir.mkdir(parents=True, exist_ok=True)
+    (pack_dir / "time_options.json").write_text(scan.model_dump_json(indent=2))
+
+
+def load_time_options(pack_dir: Path) -> "TimeWindowScan | None":
+    """Load the timing-scenario scan, returning *None* if not present."""
+    from weatherbrief.models import TimeWindowScan
+
+    to_path = pack_dir / "time_options.json"
+    if not to_path.exists():
+        return None
+    try:
+        return TimeWindowScan.model_validate_json(to_path.read_text())
+    except Exception:
+        logger.warning("Failed to load time_options.json from %s", pack_dir, exc_info=True)
+        return None
+
+
 def load_elevation_profile(pack_dir: Path) -> ElevationProfile | None:
     """Load elevation profile, returning *None* if missing."""
     ep_path = pack_dir / "elevation_profile.json"

--- a/src/weatherbrief/tasks/time_scan.py
+++ b/src/weatherbrief/tasks/time_scan.py
@@ -1,0 +1,769 @@
+"""Timing-scenario scan — better departure-window discovery.
+
+Implements ``designs/plans/timing-scenario-plan.md``. When a briefing flags a
+hazard that genuinely varies through the day, this surfaces *"a better
+departure time may exist"* — an **attention-director, never a verdict**.
+
+Two regimes, treated separately (see the plan's *enrichment-window reality*):
+
+* **±3h of the flight window** — free re-analysis of already-enriched data
+  (``run_alt_from_pack`` as-is; used by the pinned *preferred* departure time).
+* **Full daylight window** — the v1 primitive here:
+  :func:`extend_ecmwf_enrichment_daylight` **re-decodes the daylight ECMWF
+  fhours** (decode-only, local disk) into an extended cross-section set, so a
+  candidate hour is graded on *decoded* ECMWF fields — never a silent
+  ``at_time()`` clamp that would present OM-clamped values labelled ECMWF.
+
+Hard invariant: **never grade a candidate hour whose ECMWF fields aren't
+decoded.** Extend enrichment to cover it, or refuse the hour.
+
+Cost asymmetry exploited: ECMWF is both the best model and the locally-delivered
+one, so the cheap background search is ECMWF-only (full fidelity, decode-only).
+The expensive multi-model confirm (ICON/GFS download+decode) is gated on a user
+tap — see :func:`confirm_candidate`.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+
+from weatherbrief.models import (
+    AdvisoryAggregation,
+    RouteAdvisoriesManifest,
+    RouteConfig,
+    RouteCrossSection,
+    TimeCandidate,
+    TimeConfirmation,
+    TimeScanBaseline,
+    TimeScanWindow,
+    TimeWindowScan,
+)
+
+logger = logging.getLogger(__name__)
+
+# Enrichment filters GRIB steps to the window ± this margin (mirrors the
+# flight-window filter in ``fetch/grib/__init__.py``). The honest ECMWF
+# coverage is bounded by the decoded native anchors, so this only affects which
+# anchors get decoded, not the honesty edge (which is min/max decoded anchor).
+_ENRICH_MARGIN = timedelta(hours=3)
+
+# Cap on candidate departures graded per scan, so a fleet of flights can't
+# stampede the decode pool. Daylight rarely has more native anchors than this.
+_MAX_GRID = 24
+
+# Severity ranking for the improve/worsen diff.
+_SEV = {"green": 0, "amber": 1, "red": 2}
+
+# A candidate is surfaced only if it drops at least this much *net* severity on
+# the trigger (scan-class) advisory set — the "better margin" that suppresses
+# noise. 1 == at least one scan advisory drops a level with no offsetting
+# scan-class regression.
+_MIN_TRIGGER_MARGIN = 1
+
+# How many improving windows to keep in the artifact (the UI caps at ~3).
+_MAX_IMPROVING_KEPT = 5
+
+
+# ---------------------------------------------------------------------------
+# ECMWF daylight enrichment-window extension (the v1 primitive)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class EcmwfExtendResult:
+    """Outcome of extending ECMWF enrichment across the daylight window."""
+
+    cross_sections: list[RouteCrossSection]
+    run_ts: int | None = None                       # ECMWF init unix ts
+    decoded_valid_times: list[datetime] = field(default_factory=list)  # sorted native anchors
+    horizon: datetime | None = None                 # base_time + max step_hours
+
+    @property
+    def coverage(self) -> tuple[datetime, datetime] | None:
+        """Honest ECMWF coverage ``[earliest anchor, latest anchor]`` or None."""
+        if not self.decoded_valid_times:
+            return None
+        return (self.decoded_valid_times[0], self.decoded_valid_times[-1])
+
+    def covers(self, valid_times: list[datetime]) -> bool:
+        """True iff every valid-time falls inside the decoded coverage.
+
+        The honesty guardrail: propagation interpolates ECMWF fields *between*
+        decoded anchors, so any time in ``[first, last]`` is ECMWF-derived;
+        outside it, ``at_time()`` would clamp to OM — refuse those.
+        """
+        cov = self.coverage
+        if cov is None or not valid_times:
+            return False
+        lo, hi = cov
+        return all(lo <= _aware(t) <= hi for t in valid_times)
+
+
+def _aware(dt: datetime) -> datetime:
+    return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+
+
+def _ecmwf_run_coverage(
+    cover_until: datetime,
+    *,
+    as_of_time: datetime | None,
+    ecmwf_data_dir: Path | None,
+) -> tuple[int | None, list[datetime], datetime | None]:
+    """Select the ECMWF run and return ``(run_ts, decoded_anchors, horizon)``.
+
+    Mirrors the run selection ``_enrich_ecmwf_inner`` performs internally, so
+    the anchors we compute here match the fhours the enrichment actually
+    decodes. ``decoded_anchors`` are the pressure-level (a2) native valid-times
+    within the enrichment window (``cover-back margin`` … ``cover_until +
+    margin``), which is exactly the honest ECMWF coverage.
+    """
+    from weatherbrief.fetch.grib.ecmwf_fetch import (
+        ecmwf_grib_dir,
+        find_best_ecmwf_run,
+        scan_ecmwf_files,
+    )
+
+    grib_dir = ecmwf_data_dir or ecmwf_grib_dir()
+    all_files = scan_ecmwf_files(grib_dir)
+    if as_of_time is not None:
+        all_files = [f for f in all_files if f.base_time <= as_of_time]
+    if not all_files:
+        return None, [], None
+
+    run_files = find_best_ecmwf_run(all_files, cover_until=cover_until, data_dir=grib_dir)
+    if not run_files:
+        return None, [], None
+
+    base_time = run_files[0].base_time
+    max_step = max(f.step_hours for f in run_files)
+    horizon = base_time + timedelta(hours=max_step)
+
+    anchors = sorted(
+        base_time + timedelta(hours=f.step_hours)
+        for f in run_files
+        if f.is_pressure_level
+    )
+    return int(base_time.timestamp()), anchors, horizon
+
+
+def extend_ecmwf_enrichment_daylight(
+    pack_dir: Path,
+    *,
+    window_start: datetime,
+    window_end: datetime,
+    flight_duration_hours: float,
+    as_of_time: datetime | None = None,
+    ecmwf_data_dir: Path | None = None,
+    cross_sections: list[RouteCrossSection] | None = None,
+    persist: bool = True,
+) -> EcmwfExtendResult:
+    """Re-decode the daylight ECMWF fhours into an extended cross-section set.
+
+    ``window_start`` / ``window_end`` bound the candidate *departure* times; the
+    enrichment must cover departures through their arrivals, so it spans
+    ``[window_start, window_end + flight_duration]``. Decode-only (local ECPDS
+    disk, no download). Enriches the ECMWF cross-sections in place and
+    interpolates the gap hours, then optionally writes ``cross_section_ext.json``.
+
+    Reuses the production enrichment machinery: ``_enrich_ecmwf`` writes GRIB
+    pressure levels + surface diagnostics onto the matching hours, and
+    ``propagate_all`` fills the between-anchor hours. ``all_forecasts=[]`` is
+    passed deliberately — only the cross-sections (what the re-grade reads) need
+    enriching; the waypoint-only forecasts are irrelevant to the scan.
+    """
+    from weatherbrief.fetch.grib import (
+        DecodePriority,
+        _enrich_ecmwf,
+        set_decode_priority,
+    )
+    from weatherbrief.fetch.grib.fill import propagate_all
+    from weatherbrief.tasks.artifacts import (
+        load_cross_sections,
+        load_route_points,
+        save_cross_sections_ext,
+    )
+
+    cs = cross_sections if cross_sections is not None else load_cross_sections(pack_dir)
+    route_points = load_route_points(pack_dir)
+    if not cs or not route_points:
+        return EcmwfExtendResult(cross_sections=cs or [])
+
+    cover_until = window_end + timedelta(hours=max(flight_duration_hours, 1))
+    run_ts, anchors, horizon = _ecmwf_run_coverage(
+        cover_until, as_of_time=as_of_time, ecmwf_data_dir=ecmwf_data_dir,
+    )
+    if run_ts is None:
+        logger.info("time-scan: no ECMWF run available to extend enrichment")
+        return EcmwfExtendResult(cross_sections=cs)
+
+    # Restrict the reported coverage to the anchors within the enrichment
+    # window — outside it the enrichment won't decode, so grading there would
+    # clamp to OM.
+    lo = window_start - _ENRICH_MARGIN
+    hi = cover_until + _ENRICH_MARGIN
+    decoded = [a for a in anchors if lo <= a <= hi]
+
+    # Decode-only ECMWF enrichment across the daylight span, at BACKGROUND
+    # priority so it never starves a live briefing (issue #172 dispatcher).
+    span_h = (cover_until - window_start).total_seconds() / 3600.0
+    set_decode_priority(DecodePriority.BACKGROUND)
+    _enrich_ecmwf(
+        cs, [], route_points, window_start,
+        flight_duration_hours=span_h,
+        as_of_time=as_of_time,
+        ecmwf_data_dir=ecmwf_data_dir,
+    )
+    propagate_all(cs, [], gfs_init=None)
+
+    if persist:
+        save_cross_sections_ext(pack_dir, cs)
+
+    return EcmwfExtendResult(
+        cross_sections=cs, run_ts=run_ts, decoded_valid_times=decoded, horizon=horizon,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Daylight window
+# ---------------------------------------------------------------------------
+
+
+def _sun_events_for(lat: float, lon: float, on: date) -> tuple[datetime | None, datetime | None]:
+    """Return ``(morning, evening)`` sunrise/sunset on *on* for a point."""
+    try:
+        from euro_aip.utils.solar import sun_events
+
+        ev = sun_events(lat, lon, on, depression=0.0)
+        return ev.get("morning"), ev.get("evening")
+    except Exception:
+        logger.debug("time-scan: sun_events failed for (%s, %s)", lat, lon, exc_info=True)
+        return None, None
+
+
+def compute_daylight_window(
+    route: RouteConfig,
+    departure_time: datetime,
+    flight_duration_hours: float,
+) -> tuple[datetime, datetime, bool]:
+    """Daylight departure window ``(start, latest_departure, clipped)``.
+
+    Departure no earlier than sunrise at the origin, arrival no later than
+    sunset at the destination — a day-VFR-friendly window (GA pilots typically
+    flex within the day). Falls back to a generous ±6h around the planned time
+    if solar computation is unavailable. ``clipped`` marks that daylight (not
+    just the horizon) bounded the window.
+    """
+    dep = _aware(departure_time)
+    day = dep.date()
+    dur = timedelta(hours=max(flight_duration_hours, 0.0))
+
+    o_lat, o_lon = route.origin.lat, route.origin.lon
+    d_lat, d_lon = route.destination.lat, route.destination.lon
+    sunrise_o, _ = _sun_events_for(o_lat, o_lon, day)
+    _, sunset_d = _sun_events_for(d_lat, d_lon, day)
+
+    if sunrise_o is None or sunset_d is None:
+        # No reliable solar edges (polar day/night, or failure) → don't clip.
+        return dep - timedelta(hours=6), dep + timedelta(hours=6), False
+
+    start = _aware(sunrise_o)
+    latest_departure = _aware(sunset_d) - dur
+    if latest_departure <= start:
+        # Flight barely fits the daylight window — search collapses to the
+        # planned time; keep a hair of slack so the planned time is includable.
+        return min(start, dep), max(start, dep), True
+    return start, latest_departure, True
+
+
+# ---------------------------------------------------------------------------
+# Candidate grading + diff
+# ---------------------------------------------------------------------------
+
+
+def _candidate_valid_times(
+    route_points, departure: datetime, flight_duration_hours: float,
+) -> list[datetime]:
+    """Per-route-point ETAs for a departure — the honesty-check inputs.
+
+    Uses the same ``compute_interpolated_time`` the analysis stage uses, so the
+    coverage check matches exactly the hours the re-grade will read.
+    """
+    from weatherbrief.tasks.analyze import compute_interpolated_time
+
+    if not route_points:
+        return [departure]
+    total = route_points[-1].distance_from_origin_nm
+    return [
+        compute_interpolated_time(
+            departure, flight_duration_hours, rp.distance_from_origin_nm, total,
+        )
+        for rp in route_points
+    ]
+
+
+def _grade_candidate(
+    pack_dir: Path,
+    route: RouteConfig,
+    departure: datetime,
+    cross_sections: list[RouteCrossSection],
+    *,
+    advisory_models: list[str],
+    enabled_ids: set[str] | None,
+    advisory_enabled: dict[str, bool] | None,
+    user_params: dict | None,
+    aggregation: AdvisoryAggregation | None,
+    airports_db_path: str | None = None,
+    airport_conditions_recompute=None,
+    icing_method: str | None = None,
+    cloud_method: str | None = None,
+    convective_method: str | None = None,
+    locale: str | None = None,
+    cruise_speed_ias_kt: float | None = None,
+) -> RouteAdvisoriesManifest | None:
+    """Grade one departure against the (extended) cross-sections, no persistence."""
+    from weatherbrief.tasks.advise import run_alt_from_pack
+
+    res = run_alt_from_pack(
+        pack_dir, departure, route,
+        advisory_models=advisory_models,
+        enabled_ids=enabled_ids,
+        advisory_enabled=advisory_enabled,
+        user_params=user_params,
+        aggregation=aggregation,
+        airports_db_path=airports_db_path,
+        airport_conditions_recompute=airport_conditions_recompute,
+        icing_method=icing_method,
+        cloud_method=cloud_method,
+        convective_method=convective_method,
+        locale=locale,
+        cruise_speed_ias_kt=cruise_speed_ias_kt,
+        cross_sections=cross_sections,
+        persist=False,
+        detect_fronts=False,
+    )
+    return res.manifest
+
+
+def _diff_manifests(
+    baseline: RouteAdvisoriesManifest,
+    candidate: RouteAdvisoriesManifest,
+    scan_ids: set[str],
+) -> tuple[list[str], list[str], int]:
+    """Full-picture diff. Returns ``(improves, worsens, trigger_margin)``.
+
+    ``improves``/``worsens`` span the **full** advisory set (so we never surface
+    a window that fixed icing but quietly introduced a crosswind), while
+    ``trigger_margin`` sums the net severity drop over the scan-class set only —
+    the ranking objective. Scope (what triggers/ranks) stays separate from the
+    objective (grade the whole picture).
+    """
+    bmap = {a.advisory_id: a.aggregate_status for a in baseline.advisories}
+    improves: list[str] = []
+    worsens: list[str] = []
+    trigger_margin = 0
+    for a in candidate.advisories:
+        b = bmap.get(a.advisory_id)
+        if b is None:
+            continue
+        # aggregate_status is an ``AdvisoryStatus`` str-enum; take ``.value`` so
+        # the severity lookup keys on "red"/"amber"/"green" (str(enum) would be
+        # "AdvisoryStatus.RED").
+        bv = _SEV.get(getattr(b, "value", b))
+        cv = _SEV.get(getattr(a.aggregate_status, "value", a.aggregate_status))
+        if bv is None or cv is None:  # either side UNAVAILABLE → ignore
+            continue
+        d = bv - cv  # positive == improved (severity dropped)
+        if d > 0:
+            improves.append(a.advisory_id)
+        elif d < 0:
+            worsens.append(a.advisory_id)
+        if a.advisory_id in scan_ids:
+            trigger_margin += d
+    return improves, worsens, trigger_margin
+
+
+# ---------------------------------------------------------------------------
+# Scan orchestration
+# ---------------------------------------------------------------------------
+
+_ECMWF_MODEL = "ecmwf"
+
+
+def _load_baseline_manifest(pack_dir: Path) -> RouteAdvisoriesManifest | None:
+    p = pack_dir / "route_advisories.json"
+    if not p.exists():
+        return None
+    try:
+        return RouteAdvisoriesManifest.model_validate_json(p.read_text())
+    except Exception:
+        logger.warning("time-scan: failed to load route_advisories.json", exc_info=True)
+        return None
+
+
+def _relevance_flagged(baseline: RouteAdvisoriesManifest, scan_ids: set[str]) -> list[str]:
+    """Scan-class advisories that are RED/AMBER at the planned time (the firm gate)."""
+    return [
+        a.advisory_id
+        for a in baseline.advisories
+        if a.advisory_id in scan_ids and a.aggregate_status in ("red", "amber")
+    ]
+
+
+def run_time_scan(
+    pack_dir: Path,
+    route: RouteConfig,
+    departure_time: datetime,
+    *,
+    flight_duration_hours: float,
+    advisory_models: list[str] | None = None,
+    enabled_ids: set[str] | None = None,
+    advisory_enabled: dict[str, bool] | None = None,
+    user_params: dict | None = None,
+    aggregation: AdvisoryAggregation | None = None,
+    airports_db_path: str | None = None,
+    airport_conditions_recompute=None,
+    icing_method: str | None = None,
+    cloud_method: str | None = None,
+    convective_method: str | None = None,
+    locale: str | None = None,
+    cruise_speed_ias_kt: float | None = None,
+    preferred_departure_time: datetime | None = None,
+    as_of_time: datetime | None = None,
+    ecmwf_data_dir: Path | None = None,
+) -> TimeWindowScan | None:
+    """Run the ECMWF-only daylight timing scan, persisting ``time_options.json``.
+
+    Returns the scan (also written to disk) or ``None`` when the scan is gated
+    off (no scan-class advisory flagged, ECMWF absent, or no daylight/horizon
+    coverage). Designed to run *after* ``run_advisories`` at BACKGROUND decode
+    priority.
+    """
+    from weatherbrief.analysis.advisories import get_scan_class_ids
+    from weatherbrief.tasks.advise import derive_assessment_from_advisories
+    from weatherbrief.tasks.artifacts import load_route_points, save_time_options
+
+    dep = _aware(departure_time)
+    scan_ids = get_scan_class_ids()
+
+    # 1. Relevance gate (firm) — need a scan-class advisory RED/AMBER now.
+    baseline = _load_baseline_manifest(pack_dir)
+    if baseline is None:
+        return None
+    flagged = _relevance_flagged(baseline, scan_ids)
+    if not flagged:
+        logger.info("time-scan: no scan-class advisory flagged — skipping")
+        return None
+    if _ECMWF_MODEL not in [m.lower() for m in baseline.models]:
+        logger.info("time-scan: ECMWF not in fetched models — skipping")
+        return None
+
+    # 2. Daylight window (departure bounds).
+    day_start, day_end, daylight_clipped = compute_daylight_window(
+        route, dep, flight_duration_hours,
+    )
+
+    # 3. Extend ECMWF enrichment across the daylight window (the real cost).
+    ext = extend_ecmwf_enrichment_daylight(
+        pack_dir,
+        window_start=day_start,
+        window_end=day_end,
+        flight_duration_hours=flight_duration_hours,
+        as_of_time=as_of_time,
+        ecmwf_data_dir=ecmwf_data_dir,
+    )
+    cov = ext.coverage
+    if cov is None:
+        logger.info("time-scan: no decoded ECMWF coverage — skipping")
+        return None
+    cov_lo, cov_hi = cov
+    dur = timedelta(hours=max(flight_duration_hours, 0.0))
+
+    # 4. Native-cadence candidate grid, clipped to daylight ∩ ECMWF horizon.
+    #    A candidate is honest only if its whole flight fits the decoded window.
+    horizon_clipped = ext.horizon is not None and (day_end + dur) > ext.horizon
+    grid_lo = max(day_start, cov_lo)
+    grid_hi = min(day_end, cov_hi - dur)
+    route_points = load_route_points(pack_dir)
+
+    grid: list[datetime] = [
+        a for a in ext.decoded_valid_times if grid_lo <= a <= grid_hi
+    ]
+    # Always include the planned time (baseline) and, if in coverage, the pinned
+    # preferred time — even if they're between native anchors (interpolated,
+    # still honest inside coverage).
+    graded_times: dict[datetime, dict] = {}
+
+    def _consider(t: datetime, *, is_baseline=False, is_preferred=False) -> None:
+        t = _aware(t)
+        vts = _candidate_valid_times(route_points, t, flight_duration_hours)
+        if not ext.covers(vts):
+            return  # honesty guardrail: refuse hours we didn't decode
+        entry = graded_times.setdefault(t, {"is_baseline": False, "is_preferred": False, "vts": vts})
+        entry["is_baseline"] = entry["is_baseline"] or is_baseline
+        entry["is_preferred"] = entry["is_preferred"] or is_preferred
+
+    _consider(dep, is_baseline=True)
+    if preferred_departure_time is not None:
+        _consider(preferred_departure_time, is_preferred=True)
+    for t in grid[:_MAX_GRID]:
+        _consider(t)
+
+    if len(graded_times) <= 1:
+        logger.info("time-scan: no gradable candidates besides the planned time")
+        # Still emit a (candidate-less) scan so the UI can say "no better window".
+
+    # 5. Grade every considered time ECMWF-only against the extended sections.
+    grade_kwargs = dict(
+        advisory_models=[_ECMWF_MODEL],
+        enabled_ids=enabled_ids,
+        advisory_enabled=advisory_enabled,
+        user_params=user_params,
+        aggregation=aggregation,
+        airports_db_path=airports_db_path,
+        airport_conditions_recompute=airport_conditions_recompute,
+        icing_method=icing_method,
+        cloud_method=cloud_method,
+        convective_method=convective_method,
+        locale=locale,
+        cruise_speed_ias_kt=cruise_speed_ias_kt,
+    )
+
+    baseline_manifest = _grade_candidate(
+        pack_dir, route, dep, ext.cross_sections, **grade_kwargs,
+    )
+    if baseline_manifest is None:
+        logger.warning("time-scan: baseline ECMWF grade failed — skipping")
+        return None
+    base_assess, base_reason = derive_assessment_from_advisories(baseline_manifest)
+
+    candidates: list[TimeCandidate] = []
+    baseline_row: TimeCandidate | None = None
+    preferred_row: TimeCandidate | None = None
+    improving: list[TimeCandidate] = []
+
+    for t, meta in graded_times.items():
+        is_base = meta["is_baseline"]
+        if is_base:
+            manifest = baseline_manifest  # reuse — same time, same grade
+        else:
+            manifest = _grade_candidate(pack_dir, route, t, ext.cross_sections, **grade_kwargs)
+        if manifest is None:
+            continue
+        improves, worsens, margin = _diff_manifests(baseline_manifest, manifest, scan_ids)
+        assess, reason = derive_assessment_from_advisories(manifest)
+        shift_h = round((t - dep).total_seconds() / 3600.0, 2)
+        row = TimeCandidate(
+            departure_time=t,
+            departure_shift_hours=shift_h,
+            valid_times=meta["vts"],
+            ecmwf_assessment=assess,
+            ecmwf_assessment_reason=reason,
+            improves=improves,
+            worsens=worsens,
+            margin=float(margin),
+            confidence="ecmwf_only",
+            is_preferred=meta["is_preferred"],
+            is_baseline=is_base,
+        )
+        if is_base:
+            baseline_row = row
+        elif meta["is_preferred"]:
+            preferred_row = row
+        elif margin >= _MIN_TRIGGER_MARGIN:
+            improving.append(row)
+
+    # 6. Rank improving windows: best margin first, ties → nearest the
+    #    preferred time (else nearest the planned time). Cap for the artifact.
+    anchor = _aware(preferred_departure_time) if preferred_departure_time else dep
+
+    def _rank_key(r: TimeCandidate) -> tuple:
+        return (-r.margin, abs((r.departure_time - anchor).total_seconds()))
+
+    improving.sort(key=_rank_key)
+    improving = improving[:_MAX_IMPROVING_KEPT]
+
+    # Assemble candidate list: baseline first, then preferred (if distinct), then windows.
+    if baseline_row is not None:
+        candidates.append(baseline_row)
+    if preferred_row is not None:
+        candidates.append(preferred_row)
+    candidates.extend(improving)
+
+    scan = TimeWindowScan(
+        baseline=TimeScanBaseline(
+            departure_time=dep,
+            ecmwf_assessment=base_assess,
+            ecmwf_assessment_reason=base_reason,
+        ),
+        window=TimeScanWindow(
+            start=grid_lo,
+            end=grid_hi,
+            cadence_hours=1.0,
+            daylight_clipped=daylight_clipped,
+            horizon_clipped=horizon_clipped,
+            day_flex="day",
+        ),
+        candidates=candidates,
+        scan_flagged=flagged,
+        models=[m for m in baseline.models if m.lower() != "best_match"],
+        ecmwf_run_ts=ext.run_ts,
+        generated_at=datetime.now(timezone.utc),
+        cross_section_ext=True,
+    )
+    save_time_options(pack_dir, scan)
+    logger.info(
+        "time-scan: %d candidate(s) (%d improving) over daylight window %s–%s",
+        len(candidates), len(improving), grid_lo.isoformat(), grid_hi.isoformat(),
+    )
+    return scan
+
+
+_SCAN_EXECUTOR = None
+
+
+def _scan_executor():
+    """Lazily-created single-worker executor for detached background scans.
+
+    ``max_workers=1`` serialises scans across a fleet of flights so a burst of
+    refreshes can't stampede the decode pool. Threads are joined at interpreter
+    exit (so a scan in flight isn't silently dropped on shutdown).
+    """
+    global _SCAN_EXECUTOR
+    if _SCAN_EXECUTOR is None:
+        import concurrent.futures
+
+        _SCAN_EXECUTOR = concurrent.futures.ThreadPoolExecutor(
+            max_workers=1, thread_name_prefix="time-scan",
+        )
+    return _SCAN_EXECUTOR
+
+
+def submit_time_scan_background(pack_dir: Path, route: RouteConfig,
+                                departure_time: datetime, **kwargs) -> None:
+    """Fire-and-forget: run :func:`run_time_scan` on a detached background thread.
+
+    The briefing pipeline calls this *after* the visible artifacts are on disk
+    and returns immediately, so the refresh completes as usual. The scan reads
+    everything it needs from ``pack_dir`` on disk, writes ``time_options.json``
+    when done, and the client picks it up on its next ``GET .../time-options``
+    (i.e. next time the briefing is viewed). Never blocks or fails the caller.
+    """
+    def _run() -> None:
+        try:
+            run_time_scan(pack_dir, route, departure_time, **kwargs)
+        except Exception:
+            logger.warning("Background time-scan failed (non-fatal)", exc_info=True)
+
+    try:
+        _scan_executor().submit(_run)
+    except Exception:
+        logger.warning("Could not submit background time-scan", exc_info=True)
+
+
+def confirm_candidate(
+    pack_dir: Path,
+    route: RouteConfig,
+    candidate_time: datetime,
+    *,
+    data_dir: Path,
+    advisory_models: list[str] | None = None,
+    enabled_ids: set[str] | None = None,
+    advisory_enabled: dict[str, bool] | None = None,
+    user_params: dict | None = None,
+    aggregation: AdvisoryAggregation | None = None,
+    airports_db_path: str | None = None,
+    airport_conditions_recompute=None,
+    icing_method: str | None = None,
+    cloud_method: str | None = None,
+    convective_method: str | None = None,
+    locale: str | None = None,
+    cruise_speed_ias_kt: float | None = None,
+    as_of_time: datetime | None = None,
+) -> TimeConfirmation | None:
+    """Multi-model confirm of one candidate (the deferred, gated-on-tap cost).
+
+    That candidate's ICON/GFS GRIB is off the flight window, so this runs the
+    full GFS+ICON+ECMWF enrichment at the candidate's flight window (the
+    download+decode we gate on demonstrated intent), then grades the full
+    advisory model set and diffs against the planned time's multi-model grade
+    (the pack's ``route_advisories.json``).
+
+    ``better_than_baseline=False`` is the on-brand downgrade outcome — a tapped
+    suggestion that ICON/GFS reveal isn't actually better.
+    """
+    from weatherbrief.analysis.advisories import get_scan_class_ids
+    from weatherbrief.fetch.grib import DecodePriority, enrich_forecasts
+    from weatherbrief.tasks.advise import (
+        derive_assessment_from_advisories,
+        run_alt_from_pack,
+    )
+    from weatherbrief.tasks.artifacts import (
+        load_cross_sections,
+        load_cross_sections_ext,
+        load_route_points,
+    )
+
+    cand = _aware(candidate_time)
+    planned = _load_baseline_manifest(pack_dir)
+    if planned is None:
+        return None
+
+    # Start from the daylight-extended sections if present (ECMWF already there),
+    # else the primary sections. Enrich GFS+ICON at the candidate window.
+    cs = load_cross_sections_ext(pack_dir) or load_cross_sections(pack_dir)
+    route_points = load_route_points(pack_dir)
+    if not cs or not route_points:
+        return None
+
+    try:
+        enrich_forecasts(
+            cs, [], route_points, cand,
+            data_dir=data_dir,
+            flight_duration_hours=route.flight_duration_hours,
+            as_of_time=as_of_time,
+            priority=DecodePriority.BACKGROUND,
+        )
+    except Exception:
+        logger.warning("time-scan confirm: multi-model enrichment failed", exc_info=True)
+        # Fall through — we can still grade on whatever is enriched (degraded),
+        # but honesty says a failed confirm should surface as unavailable.
+        return None
+
+    res = run_alt_from_pack(
+        pack_dir, cand, route,
+        advisory_models=advisory_models,   # None → full default multi-model set
+        enabled_ids=enabled_ids,
+        advisory_enabled=advisory_enabled,
+        user_params=user_params,
+        aggregation=aggregation,
+        airports_db_path=airports_db_path,
+        airport_conditions_recompute=airport_conditions_recompute,
+        icing_method=icing_method,
+        cloud_method=cloud_method,
+        convective_method=convective_method,
+        locale=locale,
+        cruise_speed_ias_kt=cruise_speed_ias_kt,
+        cross_sections=cs,
+        persist=False,
+        detect_fronts=False,
+    )
+    if res.manifest is None:
+        return None
+
+    scan_ids = get_scan_class_ids()
+    improves, worsens, margin = _diff_manifests(planned, res.manifest, scan_ids)
+    assess, reason = derive_assessment_from_advisories(res.manifest)
+    better = margin >= _MIN_TRIGGER_MARGIN
+
+    return TimeConfirmation(
+        models_checked=res.manifest.models,
+        assessment=assess,
+        assessment_reason=reason,
+        better_than_baseline=better,
+        improves=improves,
+        worsens=worsens,
+        confirmed_at=datetime.now(timezone.utc),
+    )

--- a/tests/test_altitude_table_diff.py
+++ b/tests/test_altitude_table_diff.py
@@ -183,8 +183,18 @@ def test_options_to_improve_consolidates_altitude_and_tactical():
 
 
 def test_options_to_improve_none_when_both_empty():
-    # No table and no tactical mitigations → whole section omitted.
-    assert _format_options_to_improve_context(None, _manifest(_advisory("vfr_feasibility"))) is None
+    # No table, no tactical mitigations, and no flagged scan-class advisory
+    # (empty manifest → no timing hint either) → whole section omitted.
+    assert _format_options_to_improve_context(None, _manifest()) is None
+
+
+def test_options_to_improve_timing_hint_when_scan_class_flagged():
+    # A flagged scan-class advisory (vfr_feasibility RED) adds the timing
+    # pointer sub-block even with no altitude table / tactical mitigations.
+    block = _format_options_to_improve_context(None, _manifest(_advisory("vfr_feasibility")))
+    assert block is not None
+    assert "Timing" in block
+    assert "Timing options in the app" in block
 
 
 def test_options_to_improve_altitude_only_when_no_tactical():

--- a/tests/test_time_scan.py
+++ b/tests/test_time_scan.py
@@ -1,0 +1,221 @@
+"""Unit tests for the timing-scenario scan pure logic.
+
+Covers the parts that don't need ECMWF GRIB on disk: the timing_class registry
+mapping, the full-picture diff, the daylight window, the honesty coverage
+guardrail, and model round-trips. The full enrichment→grade integration is
+exercised against a real synced pack, not here.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from weatherbrief.analysis.advisories import (
+    get_scan_class_ids,
+    get_timing_class_ids,
+)
+from weatherbrief.models import (
+    RouteAdvisoriesManifest,
+    RouteAdvisoryResult,
+    TimeWindowScan,
+    TimeScanBaseline,
+    TimeScanWindow,
+)
+from weatherbrief.tasks.time_scan import (
+    EcmwfExtendResult,
+    _diff_manifests,
+)
+
+
+def _adv(advisory_id: str, status: str) -> RouteAdvisoryResult:
+    return RouteAdvisoryResult(advisory_id=advisory_id, aggregate_status=status)
+
+
+def _manifest(statuses: dict[str, str]) -> RouteAdvisoriesManifest:
+    return RouteAdvisoriesManifest(
+        advisories=[_adv(k, v) for k, v in statuses.items()],
+        models=["ecmwf"],
+    )
+
+
+# --- timing_class registry ---------------------------------------------------
+
+
+def test_timing_class_mapping_partitions_all_evaluators():
+    scan = get_timing_class_ids("scan")
+    cheap = get_timing_class_ids("cheap")
+    none = get_timing_class_ids("none")
+    # No overlaps, and every evaluator lands in exactly one bucket.
+    assert scan & cheap == set()
+    assert scan & none == set()
+    assert cheap & none == set()
+    assert len(scan) + len(cheap) + len(none) == 21
+
+
+def test_scan_class_matches_plan():
+    assert get_scan_class_ids() == {
+        "convective", "convective_character", "icing_escape", "fiki_icing",
+        "cloud_top", "vmc_cruise", "vfr_feasibility", "ifr_feasibility",
+        "freezing_precip",
+    }
+
+
+def test_fronts_is_none_experimental():
+    # fronts is experimental/default-off → must not trigger the scan.
+    assert "fronts" not in get_scan_class_ids()
+
+
+# --- full-picture diff -------------------------------------------------------
+
+
+def test_diff_improves_worsens_and_trigger_margin():
+    scan_ids = {"convective", "icing_escape"}
+    baseline = _manifest({
+        "convective": "red",       # scan-class, will improve
+        "icing_escape": "amber",   # scan-class, unchanged
+        "airport_wind": "green",   # non-scan, will worsen
+    })
+    candidate = _manifest({
+        "convective": "amber",     # red→amber : improved (scan)
+        "icing_escape": "amber",   # unchanged
+        "airport_wind": "amber",   # green→amber : worsened (non-scan)
+    })
+    improves, worsens, margin = _diff_manifests(baseline, candidate, scan_ids)
+    assert improves == ["convective"]
+    assert worsens == ["airport_wind"]
+    # Only the scan-class delta counts toward the ranking margin (+1).
+    assert margin == 1
+
+
+def test_diff_ignores_unavailable_either_side():
+    scan_ids = {"convective"}
+    baseline = _manifest({"convective": "unavailable"})
+    candidate = _manifest({"convective": "green"})
+    improves, worsens, margin = _diff_manifests(baseline, candidate, scan_ids)
+    assert improves == [] and worsens == [] and margin == 0
+
+
+def test_diff_non_scan_improvement_does_not_earn_margin():
+    scan_ids = {"convective"}
+    baseline = _manifest({"airport_wind": "red"})
+    candidate = _manifest({"airport_wind": "green"})
+    improves, worsens, margin = _diff_manifests(baseline, candidate, scan_ids)
+    # Surfaced in the full-picture improves list, but earns no trigger margin.
+    assert improves == ["airport_wind"]
+    assert margin == 0
+
+
+# --- honesty coverage guardrail ---------------------------------------------
+
+
+def _dt(h: int) -> datetime:
+    return datetime(2026, 7, 2, h, tzinfo=timezone.utc)
+
+
+def test_coverage_and_covers_guardrail():
+    ext = EcmwfExtendResult(
+        cross_sections=[],
+        decoded_valid_times=[_dt(6), _dt(9), _dt(12)],
+    )
+    assert ext.coverage == (_dt(6), _dt(12))
+    # Entirely inside decoded coverage → honest.
+    assert ext.covers([_dt(7), _dt(8), _dt(11)]) is True
+    # Straddles the late edge → refuse (would clamp to OM past 12z).
+    assert ext.covers([_dt(11), _dt(13)]) is False
+    # Before the early edge → refuse.
+    assert ext.covers([_dt(5), _dt(7)]) is False
+
+
+def test_coverage_none_when_no_anchors():
+    ext = EcmwfExtendResult(cross_sections=[])
+    assert ext.coverage is None
+    assert ext.covers([_dt(9)]) is False
+
+
+# --- model round-trip --------------------------------------------------------
+
+
+def _catalog():
+    from weatherbrief.models import AdvisoryCatalogEntry
+    return [
+        AdvisoryCatalogEntry(
+            id="convective", name="Convection", short_description="x",
+            description="y", category="convective", timing_class="scan",
+        ),
+        AdvisoryCatalogEntry(
+            id="headwind", name="Headwind", short_description="x",
+            description="y", category="wind",  # timing_class defaults to "none"
+        ),
+    ]
+
+
+# --- digest synchronous timing hint -----------------------------------------
+
+
+def test_digest_timing_hint_fires_on_flagged_scan_class():
+    from weatherbrief.digest.prompt_builder import _format_timing_hint_context
+
+    m = RouteAdvisoriesManifest(
+        advisories=[
+            RouteAdvisoryResult(advisory_id="convective", aggregate_status="red"),
+            RouteAdvisoryResult(advisory_id="headwind", aggregate_status="amber"),
+        ],
+        catalog=_catalog(),
+    )
+    hint = _format_timing_hint_context(m)
+    assert hint is not None
+    assert "Convection" in hint
+    assert "Headwind" not in hint  # non-scan-class must not appear
+    assert "Timing options" in hint
+
+
+def test_digest_timing_hint_silent_when_no_scan_class_flagged():
+    from weatherbrief.digest.prompt_builder import _format_timing_hint_context
+
+    m = RouteAdvisoriesManifest(
+        advisories=[RouteAdvisoryResult(advisory_id="headwind", aggregate_status="red")],
+        catalog=_catalog(),
+    )
+    assert _format_timing_hint_context(m) is None
+
+
+# --- MCP / connector referral ------------------------------------------------
+
+
+def test_connector_timing_referral_on_flagged_scan_class_only():
+    from weatherbrief.connectors.views import summarize_advisories
+
+    adv = {
+        "catalog": [c.model_dump() for c in _catalog()],
+        "advisories": [
+            {"advisory_id": "convective", "aggregate_status": "red", "per_model": []},
+            {"advisory_id": "headwind", "aggregate_status": "red", "per_model": []},
+        ],
+    }
+    out = {a["id"]: a for a in summarize_advisories(adv)}
+    assert out["convective"].get("timing_referral") is True
+    assert "timing_referral" not in out["headwind"]  # not scan-class
+
+
+def test_connector_no_referral_when_scan_class_green():
+    from weatherbrief.connectors.views import summarize_advisories
+
+    adv = {
+        "catalog": [c.model_dump() for c in _catalog()],
+        "advisories": [
+            {"advisory_id": "convective", "aggregate_status": "green", "per_model": []},
+        ],
+    }
+    out = {a["id"]: a for a in summarize_advisories(adv)}
+    assert "timing_referral" not in out["convective"]
+
+
+def test_time_window_scan_round_trip_and_candidate_at():
+    scan = TimeWindowScan(
+        baseline=TimeScanBaseline(departure_time=_dt(9), ecmwf_assessment="AMBER"),
+        window=TimeScanWindow(start=_dt(6), end=_dt(16)),
+    )
+    dumped = scan.model_dump_json()
+    loaded = TimeWindowScan.model_validate_json(dumped)
+    assert loaded.baseline.ecmwf_assessment == "AMBER"
+    assert loaded.candidate_at(_dt(9)) is None  # no candidates yet

--- a/web/briefing.html
+++ b/web/briefing.html
@@ -89,6 +89,11 @@
       </div>
     </div>
 
+    <!-- Timing-scenario scan (better departure windows) — self-contained neutral
+         panel; renderTimeOptions toggles its own display and suppresses it
+         entirely unless there is a genuinely better window to surface. -->
+    <div id="time-options-wrapper" style="display: none;"></div>
+
     <!-- Pilot Reports (PIREPs) -->
     <div id="pireps-wrapper" class="section collapsible" data-section="pireps" style="display: none;">
       <h3>Pilot Reports (PIREPs)</h3>

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -3887,6 +3887,128 @@ label {
   margin-top: 0.25rem;
 }
 
+/* Timing-scenario panel (#330 TIMING axis): a neutral soft hook surfacing
+   calmer departure windows. Attention-director, never a verdict — the panel
+   chrome reuses the mitigation "tip" blue-gray (never green/red on the hook).
+   The per-candidate ECMWF/confirm badges DO carry status colour (that's a real
+   grade for that window), but the panel itself stays neutral. */
+.time-options-panel {
+  margin: 1rem 0;
+  padding: 0.75rem 0.9rem;
+  border-radius: var(--radius);
+  border-left: 3px solid color-mix(in srgb, var(--primary) 45%, var(--border));
+  background: color-mix(in srgb, var(--primary) 7%, var(--surface));
+}
+.time-options-header {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--text);
+  margin-bottom: 0.6rem;
+}
+.time-options-rows {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+.time-option-row {
+  padding: 0.5rem 0.6rem;
+  border-radius: var(--radius);
+  background: var(--surface);
+  border: 1px solid var(--border);
+}
+.time-option-row--baseline {
+  background: transparent;
+  border-style: dashed;
+  opacity: 0.85;
+}
+.time-option-head {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+.time-option-time {
+  font-weight: 600;
+  font-size: 0.85rem;
+}
+.time-option-shift {
+  font-weight: 500;
+  color: var(--text-muted);
+}
+.time-option-tag {
+  font-size: 0.72rem;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+.time-option-tag--preferred {
+  color: var(--text);
+  text-transform: none;
+  letter-spacing: 0;
+}
+.time-option-diff {
+  margin-top: 0.3rem;
+  font-size: 0.78rem;
+  color: var(--text);
+  line-height: 1.4;
+}
+.time-option-worsens {
+  color: var(--text-muted);
+}
+.time-option-provisional {
+  margin-top: 0.35rem;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+}
+.time-option-provisional-label {
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-muted);
+}
+.time-option-confirm-btn {
+  border: none;
+  background: none;
+  padding: 0;
+  cursor: pointer;
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--primary);
+}
+.time-option-confirm-btn:hover:not(:disabled) {
+  text-decoration: underline;
+}
+.time-option-confirm-btn:disabled {
+  color: var(--text-muted);
+  cursor: default;
+}
+.time-option-confirmed {
+  margin-top: 0.35rem;
+  font-size: 0.78rem;
+  line-height: 1.4;
+}
+.time-option-confirmed-label {
+  font-weight: 600;
+}
+.time-option-confirmed-detail {
+  color: var(--text-muted);
+  margin-left: 0.35rem;
+}
+/* The downgrade ("actually not better") is a first-class outcome, shown plainly
+   in neutral text — not an error, not red. */
+.time-option-confirmed--downgrade .time-option-confirmed-label {
+  color: var(--text-muted);
+}
+.time-option-note,
+.time-option-footnote {
+  margin: 0.6rem 0 0;
+  font-size: 0.72rem;
+  color: var(--text-muted);
+  line-height: 1.4;
+}
+
 /* "All clear" block: unanimous-green + unavailable advisories as two-line
    compact cards (header + detail, no per-model row) in a denser grid, so a long
    consistent-green list doesn't dominate the section. */

--- a/web/ts/adapters/api-adapter.ts
+++ b/web/ts/adapters/api-adapter.ts
@@ -14,6 +14,7 @@ import type {
 } from '../store/types';
 import type { AltitudeTableResult, RouteAdvisoriesManifest } from '../types/advisories';
 import type { RouteFrontsManifest } from '../types/fronts';
+import type { TimeConfirmation, TimeWindowScan } from '../types/time-scan';
 import type { SoundingProfileData } from '../visualization/skewt/types';
 import { API_BASE, apiFetch, redirectToLogin } from '../utils';
 
@@ -598,6 +599,43 @@ export async function fetchAltitudeTableCached(
   return apiFetch<AltitudeTableResult>(
     `/flights/${encodeURIComponent(flightId)}/packs/${encodeURIComponent(timestamp)}/advisories/altitude-table`,
     { method: 'GET' },
+  );
+}
+
+// --- Timing-scenario scan (better departure windows) ---
+
+/** Fetch the timing-scenario scan (``time_options.json``) for a pack.
+ *  Returns null on 404 — the scan hasn't run or was gated off, which the client
+ *  treats as "nothing to show", not an error. Other errors propagate. */
+export async function fetchTimeOptions(
+  flightId: string,
+  timestamp: string,
+): Promise<TimeWindowScan | null> {
+  try {
+    return await apiFetch<TimeWindowScan>(
+      `/flights/${encodeURIComponent(flightId)}/packs/${encodeURIComponent(timestamp)}/time-options`,
+    );
+  } catch (err) {
+    // apiFetch surfaces the status in the message as `API 404: …`.
+    if (err instanceof Error && /^API 404:/.test(err.message)) return null;
+    throw err;
+  }
+}
+
+/** Multi-model confirm of one candidate departure ("check all models"). The
+ *  server runs the full GFS+ICON+ECMWF enrichment synchronously (several
+ *  seconds) and caches the confirmation onto the candidate. */
+export async function confirmTimeOption(
+  flightId: string,
+  timestamp: string,
+  departureTime: string,
+): Promise<TimeConfirmation> {
+  return apiFetch<TimeConfirmation>(
+    `/flights/${encodeURIComponent(flightId)}/packs/${encodeURIComponent(timestamp)}/time-options/confirm`,
+    {
+      method: 'POST',
+      body: JSON.stringify({ departure_time: departureTime }),
+    },
   );
 }
 

--- a/web/ts/briefing-main.ts
+++ b/web/ts/briefing-main.ts
@@ -6,7 +6,8 @@ import * as api from './adapters/api-adapter';
 import * as ui from './managers/briefing-ui';
 import { fetchPirepsByFlight } from './adapters/pirep-adapter';
 import { renderPirepList } from './managers/pirep-ui';
-import { renderAdvisories, renderAltitudeTablePopup, setLiveAdvisoryCatalog, type AltitudeOverrideConfig, type AltTimeToggleConfig, type ProfileSelectorConfig } from './managers/advisories-ui';
+import { renderAdvisories, renderAltitudeTablePopup, setLiveAdvisoryCatalog, advisoryName, type AltitudeOverrideConfig, type AltTimeToggleConfig, type ProfileSelectorConfig } from './managers/advisories-ui';
+import { renderTimeOptions } from './managers/time-options-ui';
 import { overlayAltitudeStatuses } from './helpers/altitude-diff';
 import { fetchProfiles, type ProfileResponse } from './adapters/profiles-adapter';
 import { fetchAdvisoryCatalog } from './adapters/preferences-adapter';
@@ -510,6 +511,20 @@ async function init(): Promise<void> {
       return overlayAltitudeStatuses(base, state.altitudeTable, state.advisoryAltitudeOverride);
     }
     return base;
+  }
+
+  /** Render the timing-scenario panel (better departure windows). Suppresses
+   *  itself when there's nothing better to show. Advisory ids are named via the
+   *  shared advisory catalog lookup so both surfaces agree. */
+  function renderTimeOptionsPanel(state: BriefingState): void {
+    renderTimeOptions(
+      document.getElementById('time-options-wrapper'),
+      state.timeOptions,
+      {
+        onConfirm: (dt) => store.getState().confirmTimeCandidate(dt),
+        resolveName: (id) => advisoryName(id, state.routeAdvisories),
+      },
+    );
   }
 
   // Apply initial display mode
@@ -1412,6 +1427,7 @@ async function init(): Promise<void> {
       state.routeAnalyses !== prev.routeAnalyses ||
       state.routeAdvisories !== prev.routeAdvisories ||
       state.altAdvisories !== prev.altAdvisories ||
+      state.timeOptions !== prev.timeOptions ||
       state.showingAlt !== prev.showingAlt ||
       state.elevationProfile !== prev.elevationProfile ||
       state.advisoryAltitudeOverride !== prev.advisoryAltitudeOverride ||
@@ -1419,6 +1435,7 @@ async function init(): Promise<void> {
     ) {
       ui.renderAssessment(state.currentPack, state.flight, state.routeAdvisories, state.altAdvisories, state.digestPending, () => store.getState().generateDigest());
       renderAdvisories(getEffectiveAdvisories(state), () => store.getState().recalculateAdvisories(), state.displayMode, getAltitudeOverrideConfig(state), handleAltitudeTable, getAltTimeToggleConfig(state), getProfileSelectorConfig(state), handleAdvisoryChip);
+      renderTimeOptionsPanel(state);
       ui.renderRefreshDelta(state.snapshot);
       ui.renderRouteSigmets(state.snapshot);
       ui.renderRouteObservations(state.snapshot, () => store.getState().refreshObservations());
@@ -1927,6 +1944,7 @@ async function init(): Promise<void> {
     }
     ui.renderAssessment(s.currentPack, s.flight, s.routeAdvisories, s.altAdvisories, s.digestPending, () => store.getState().generateDigest());
     renderAdvisories(getEffectiveAdvisories(s), () => store.getState().recalculateAdvisories(), s.displayMode, getAltitudeOverrideConfig(s), handleAltitudeTable, getAltTimeToggleConfig(s), getProfileSelectorConfig(s), handleAdvisoryChip);
+    renderTimeOptionsPanel(s);
     ui.renderRefreshDelta(s.snapshot);
     ui.renderRouteSigmets(s.snapshot);
     ui.renderRouteObservations(s.snapshot, () => store.getState().refreshObservations());

--- a/web/ts/managers/advisories-ui.ts
+++ b/web/ts/managers/advisories-ui.ts
@@ -22,6 +22,17 @@ export function setLiveAdvisoryCatalog(entries: AdvisoryCatalogEntry[]): void {
   liveCatalog = entries;
 }
 
+/** Resolve an advisory id to its display name, preferring the live catalog
+ *  (current code copy) then the pack-baked manifest catalog, falling back to the
+ *  raw id. Shared with the timing-options panel so both surfaces name advisories
+ *  the same way. */
+export function advisoryName(id: string, manifest?: RouteAdvisoriesManifest | null): string {
+  const live = liveCatalog?.find(e => e.id === id);
+  if (live) return live.name;
+  const packed = manifest?.catalog.find(e => e.id === id);
+  return packed?.name ?? id;
+}
+
 /** Visibility for an airport condition, region-aware.
  *  Prefers raw meters (visibility_m); falls back to legacy SM for old packs. */
 function formatCondVis(cond: AirportModelCondition): string | null {

--- a/web/ts/managers/time-options-ui.ts
+++ b/web/ts/managers/time-options-ui.ts
@@ -1,0 +1,209 @@
+/** Timing-scenario panel renderer — a neutral soft hook surfacing calmer
+ *  departure windows. Attention-director, never a verdict: no green/red framing
+ *  on the hook itself, never auto-switches the plan. See
+ *  `designs/plans/timing-scenario-plan.md`.
+ *
+ *  Suppression rule (against noise): the whole panel is hidden unless there is
+ *  at least one *improving* candidate (not baseline, not just the pinned
+ *  preferred time). Shown: the baseline reference row + the pinned preferred row
+ *  (if present) + the improving windows, ranked best-first, capped at ~3. */
+
+import type { TimeCandidate, TimeConfirmation, TimeWindowScan } from '../types/time-scan';
+import { escapeHtml, formatDepartureTime } from '../utils';
+
+/** Max improving windows to surface — decision D (cap ~3). */
+const MAX_IMPROVING = 3;
+
+export interface TimeOptionsCallbacks {
+  /** "Check all models" for one candidate. Resolves once the store has merged
+   *  the confirmation (which re-renders this panel). */
+  onConfirm: (departureTime: string) => Promise<void>;
+  /** Map an advisory id to its display name (reuses the advisory catalog). */
+  resolveName: (advisoryId: string) => string;
+}
+
+// The delegated click handler is bound once per container; it reads the current
+// callbacks from module scope so re-renders don't stack duplicate listeners.
+let _onConfirm: TimeOptionsCallbacks['onConfirm'] | null = null;
+
+/** True when a candidate is a genuinely better window (improves something and
+ *  isn't just the baseline or the pinned preferred time). Drives suppression. */
+function isImproving(c: TimeCandidate): boolean {
+  return !c.is_baseline && !c.is_preferred && (c.improves.length > 0 || c.margin > 0);
+}
+
+function assessmentClass(assessment: string): string {
+  switch (assessment.toUpperCase()) {
+    case 'GREEN': return 'badge-green';
+    case 'AMBER': return 'badge-amber';
+    case 'RED': return 'badge-red';
+    default: return 'badge-muted';
+  }
+}
+
+/** Signed departure shift, e.g. "+1h", "−2h", "+1.5h"; empty for baseline. */
+function shiftLabel(hours: number): string {
+  if (!hours) return '';
+  const abs = Math.abs(hours);
+  const val = Number.isInteger(abs) ? String(abs) : abs.toFixed(1);
+  return `${hours > 0 ? '+' : '−'}${val}h`;
+}
+
+/** "today" / "the day before" / "the day after" from the window's day_flex. */
+function dayFlexLabel(dayFlex: string): string {
+  if (dayFlex === 'prev') return 'the day before';
+  if (dayFlex === 'next') return 'the day after';
+  return 'today';
+}
+
+/** improves / worsens line, mapped to display names. Empty when neither side
+ *  has anything. */
+function diffLine(
+  improves: string[],
+  worsens: string[],
+  resolveName: (id: string) => string,
+): string {
+  const parts: string[] = [];
+  if (improves.length > 0) {
+    parts.push(`<span class="time-option-improves">improves: ${escapeHtml(improves.map(resolveName).join(', '))}</span>`);
+  }
+  if (worsens.length > 0) {
+    parts.push(`<span class="time-option-worsens">worsens: ${escapeHtml(worsens.map(resolveName).join(', '))}</span>`);
+  }
+  return parts.length ? `<div class="time-option-diff">${parts.join(' · ')}</div>` : '';
+}
+
+/** The confirmed multi-model outcome — including the on-brand downgrade case. */
+function confirmedLine(
+  confirmed: TimeConfirmation,
+  resolveName: (id: string) => string,
+): string {
+  const label = confirmed.better_than_baseline
+    ? 'All models checked: still better'
+    : 'All models checked: actually not better';
+  const cls = confirmed.better_than_baseline ? 'time-option-confirmed--better' : 'time-option-confirmed--downgrade';
+  // Prefer the server's human phrasing; fall back to the mapped worsens list.
+  const detail = confirmed.detail
+    || (confirmed.worsens.length ? confirmed.worsens.map(resolveName).join(', ') : '');
+  return `
+    <div class="time-option-confirmed ${cls}">
+      <span class="time-option-confirmed-label">${escapeHtml(label)}</span>
+      ${detail ? `<span class="time-option-confirmed-detail">${escapeHtml(detail)}</span>` : ''}
+    </div>`;
+}
+
+function renderRow(c: TimeCandidate, cb: TimeOptionsCallbacks): string {
+  const time = formatDepartureTime(c.departure_time);
+  const shift = shiftLabel(c.departure_shift_hours);
+
+  let tag = '';
+  if (c.is_baseline) tag = '<span class="time-option-tag">as planned</span>';
+  else if (c.is_preferred) tag = '<span class="time-option-tag time-option-tag--preferred">★ your preferred time</span>';
+
+  const assessment = c.confirmed?.assessment ?? c.ecmwf_assessment;
+  const badge = `<span class="badge ${assessmentClass(assessment)}">${escapeHtml(String(assessment).toUpperCase())}</span>`;
+
+  // improves/worsens: use the confirmed diff once available, else the ECMWF one.
+  const improves = c.confirmed?.improves ?? c.improves;
+  const worsens = c.confirmed?.worsens ?? c.worsens;
+  const diff = c.is_baseline ? '' : diffLine(improves, worsens, cb.resolveName);
+
+  // Honesty ladder: provisional (ECMWF-only) until confirmed. The baseline row
+  // is never a "check all models" target — it's the reference, not a candidate.
+  let ladder = '';
+  if (!c.is_baseline) {
+    if (c.confidence === 'confirmed' && c.confirmed) {
+      ladder = confirmedLine(c.confirmed, cb.resolveName);
+    } else {
+      ladder = `
+        <div class="time-option-provisional">
+          <span class="time-option-provisional-label">ECMWF only</span>
+          <button type="button" class="time-option-confirm-btn"
+                  data-departure-time="${escapeHtml(c.departure_time)}">tap to check all models →</button>
+        </div>`;
+    }
+  }
+
+  return `
+    <div class="time-option-row${c.is_baseline ? ' time-option-row--baseline' : ''}">
+      <div class="time-option-head">
+        <span class="time-option-time">${escapeHtml(time)}${shift ? ` <span class="time-option-shift">${escapeHtml(shift)}</span>` : ''}</span>
+        ${badge}
+        ${tag}
+      </div>
+      ${diff}
+      ${ladder}
+    </div>`;
+}
+
+/**
+ * Render the timing-scenario panel into `container`. Suppresses (hides) the
+ * container entirely when there is nothing better to show. Wires the per-row
+ * "check all models" buttons via event delegation.
+ */
+export function renderTimeOptions(
+  container: HTMLElement | null,
+  timeOptions: TimeWindowScan | null,
+  callbacks: TimeOptionsCallbacks,
+): void {
+  if (!container) return;
+  _onConfirm = callbacks.onConfirm;
+
+  const improving = (timeOptions?.candidates ?? []).filter(isImproving);
+  // Suppress entirely unless at least one improving candidate cleared the margin.
+  if (!timeOptions || improving.length === 0) {
+    container.style.display = 'none';
+    container.innerHTML = '';
+    return;
+  }
+  container.style.display = '';
+
+  const shown = improving.slice(0, MAX_IMPROVING);
+  const baseline = timeOptions.candidates.find(c => c.is_baseline) ?? null;
+  const preferred = timeOptions.candidates.find(c => c.is_preferred) ?? null;
+
+  // Rows: baseline reference (context) → pinned preferred (if any) → improving.
+  const rows: TimeCandidate[] = [];
+  if (baseline) rows.push(baseline);
+  if (preferred && preferred !== baseline) rows.push(preferred);
+  rows.push(...shown);
+
+  const n = improving.length;
+  const header = `\u{1F550} ECMWF found ${n} better window${n === 1 ? '' : 's'} ${dayFlexLabel(timeOptions.window.day_flex)}`;
+
+  const horizonNote = timeOptions.window.horizon_clipped
+    ? `<p class="time-option-note">The search stops at the ECMWF forecast horizon.</p>`
+    : '';
+
+  container.innerHTML = `
+    <div class="time-options-panel">
+      <div class="time-options-header">${escapeHtml(header)}</div>
+      <div class="time-options-rows">
+        ${rows.map(c => renderRow(c, callbacks)).join('')}
+      </div>
+      ${horizonNote}
+      <p class="time-option-footnote">A neutral heads-up, not a recommendation — your plan is unchanged.</p>
+    </div>`;
+
+  // Bind the delegated confirm handler once per container (re-renders replace
+  // the innerHTML but keep the container, so a fresh listener each render would
+  // stack). The handler reads the current onConfirm from module scope.
+  if (!container.dataset.timeOptionsBound) {
+    container.dataset.timeOptionsBound = '1';
+    container.addEventListener('click', async (e) => {
+      const btn = (e.target as HTMLElement).closest('.time-option-confirm-btn') as HTMLButtonElement | null;
+      if (!btn || !_onConfirm) return;
+      const dt = btn.dataset.departureTime;
+      if (!dt) return;
+      btn.disabled = true;
+      btn.textContent = 'checking all models…';
+      try {
+        await _onConfirm(dt);
+        // Success re-renders the panel (store change) — nothing to restore.
+      } catch {
+        btn.disabled = false;
+        btn.textContent = 'tap to check all models →';
+      }
+    });
+  }
+}

--- a/web/ts/store/briefing-store.ts
+++ b/web/ts/store/briefing-store.ts
@@ -4,6 +4,7 @@ import { createStore } from 'zustand/vanilla';
 import type { DataStatus, ElevationProfile, FlightResponse, ForecastSnapshot, PackMeta, RouteAnalysesManifest, WeatherDigest } from './types';
 import type { AltitudeTableResult, RouteAdvisoriesManifest } from '../types/advisories';
 import type { RouteFrontsManifest } from '../types/fronts';
+import type { TimeWindowScan } from '../types/time-scan';
 import type { RouteWindOverlay } from '../adapters/api-adapter';
 import type { DisplayMode, Tier } from '../types/metrics';
 import type { VizLayout, VizSettings } from '../visualization/types';
@@ -92,6 +93,10 @@ export interface BriefingState {
    *  + cross-section front overlays. */
   routeFronts: RouteFrontsManifest | null;
   altAdvisories: RouteAdvisoriesManifest | null;
+  /** Timing-scenario scan (better departure windows). null when the scan
+   *  hasn't run / was gated off (endpoint 404s) — the panel then shows nothing.
+   *  Reset to null on pack load, like `altAdvisories`. */
+  timeOptions: TimeWindowScan | null;
   /** Per-route-point wind components at the advisoryAltitudeOverride.
    * null when no override is active (manifest values are correct). */
   windOverlay: RouteWindOverlay | null;
@@ -160,6 +165,13 @@ export interface BriefingState {
   sendEmail: () => Promise<void>;
   loadAltAdvisories: () => Promise<void>;
   computeAltAdvisories: () => Promise<void>;
+  /** Load the timing-scenario scan for the current pack (best-effort; 404 →
+   *  null → panel hidden). Called after a pack loads, like `loadAltAdvisories`. */
+  loadTimeOptions: () => Promise<void>;
+  /** "Check all models" for one candidate: calls the confirm endpoint and
+   *  merges the returned confirmation into the matching candidate (setting its
+   *  `confirmed` + `confidence="confirmed"`). Never switches the displayed plan. */
+  confirmTimeCandidate: (departureTime: string) => Promise<void>;
   toggleAltView: () => void;
   updateFlightAutoRefresh: (autoRefresh: boolean, hour: number | null) => void;
   updateFlightPrivacy: (isPrivate: boolean) => void;
@@ -260,6 +272,7 @@ export const briefingStore = createStore<BriefingState>((set, get) => ({
   routeAdvisories: null,
   routeFronts: null,
   altAdvisories: null,
+  timeOptions: null,
   windOverlay: null,
   showingAlt: false,
   elevationProfile: null,
@@ -374,11 +387,13 @@ export const briefingStore = createStore<BriefingState>((set, get) => ({
                       : available.includes('ecmwf') ? 'ecmwf'
                       : available[0];
       }
-      set({ currentPack: pack, snapshot, digest, routeAnalyses, routeAdvisories, routeFronts, elevationProfile, altitudeTable, selectedModel, advisoryAltitudeOverride: null, altAdvisories: null, windOverlay: null, showingAlt: false, selectedPointIndex: null, loading: false });
+      set({ currentPack: pack, snapshot, digest, routeAnalyses, routeAdvisories, routeFronts, elevationProfile, altitudeTable, selectedModel, advisoryAltitudeOverride: null, altAdvisories: null, timeOptions: null, windOverlay: null, showingAlt: false, selectedPointIndex: null, loading: false });
       // Auto-load alt advisories if available
       if (pack.has_alt_advisories) {
         get().loadAltAdvisories();
       }
+      // Load the timing-scenario scan (best-effort; 404 → stays null → hidden).
+      get().loadTimeOptions();
     } catch (err) {
       set({ loading: false, error: `Failed to load pack: ${err}` });
     }
@@ -799,6 +814,74 @@ export const briefingStore = createStore<BriefingState>((set, get) => ({
 
   toggleAltView: () => {
     set({ showingAlt: !get().showingAlt });
+  },
+
+  loadTimeOptions: async () => {
+    const { flight, currentPack, routeAdvisories } = get();
+    if (!flight || !currentPack) return;
+    const packTimestamp = currentPack.fetch_timestamp;
+
+    // The scan runs as a *detached background job* after the briefing finishes
+    // (the daylight ECMWF re-decode takes a couple of minutes), so right after
+    // a refresh time_options.json won't exist yet. When a scan is plausibly
+    // pending — a scan-class advisory (timing_class === 'scan') is flagged
+    // RED/AMBER — poll a few times so the panel appears without a manual reload.
+    // Otherwise (no scan expected, or old pack) a single fetch is enough.
+    const scanPending = (() => {
+      if (!routeAdvisories) return false;
+      const scanIds = new Set(
+        routeAdvisories.catalog
+          .filter(c => c.timing_class === 'scan')
+          .map(c => c.id),
+      );
+      return routeAdvisories.advisories.some(
+        a => scanIds.has(a.advisory_id)
+          && (a.aggregate_status === 'red' || a.aggregate_status === 'amber'),
+      );
+    })();
+    const maxAttempts = scanPending ? 10 : 1;  // ~10 × 20s ≈ 3.3 min ceiling
+    const retryDelayMs = 20_000;
+
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+      try {
+        const scan = await api.fetchTimeOptions(flight.id, packTimestamp);
+        // Drop the response if the user switched packs while it was in flight.
+        if (get().currentPack?.fetch_timestamp !== packTimestamp) return;
+        if (scan) {
+          set({ timeOptions: scan });
+          return;
+        }
+      } catch {
+        // Non-critical — timing options may not exist for this pack.
+      }
+      if (attempt < maxAttempts - 1) {
+        await new Promise(r => setTimeout(r, retryDelayMs));
+        // Bail out of the poll loop if the user navigated to another pack.
+        if (get().currentPack?.fetch_timestamp !== packTimestamp) return;
+      }
+    }
+  },
+
+  confirmTimeCandidate: async (departureTime: string) => {
+    const { flight, currentPack, timeOptions } = get();
+    if (!flight || !currentPack || !timeOptions) return;
+    try {
+      const confirmation = await api.confirmTimeOption(
+        flight.id, currentPack.fetch_timestamp, departureTime,
+      );
+      // Merge the confirmation into the matching candidate and upgrade its
+      // confidence. Never touches the displayed briefing (no auto-switch).
+      const current = get().timeOptions;
+      if (!current) return;
+      const candidates = current.candidates.map(c =>
+        c.departure_time === departureTime
+          ? { ...c, confirmed: confirmation, confidence: 'confirmed' as const }
+          : c,
+      );
+      set({ timeOptions: { ...current, candidates } });
+    } catch (err) {
+      set({ error: `Timing confirm failed: ${err}` });
+    }
   },
 
   updateFlightAutoRefresh: (autoRefresh: boolean, hour: number | null) => {

--- a/web/ts/types/advisories.ts
+++ b/web/ts/types/advisories.ts
@@ -42,6 +42,8 @@ export interface AdvisoryCatalogEntry {
   category: string;
   default_enabled: boolean;
   altitude_dependent: boolean;
+  /** Timing-scan participation: "scan" | "cheap" | "none" (timing-scenario scan). */
+  timing_class?: string;
   parameters: AdvisoryParameterDef[];
 }
 

--- a/web/ts/types/time-scan.ts
+++ b/web/ts/types/time-scan.ts
@@ -1,0 +1,68 @@
+/** TypeScript types for the timing-scenario scan (``time_options.json``),
+ *  matching the Python Pydantic models in ``models/time_scan.py``.
+ *
+ *  The scan is an attention-director, never a verdict — a neutral soft hook
+ *  surfacing calmer departure windows. The honesty ladder is encoded in
+ *  ``TimeCandidate.confidence``: ``"ecmwf_only"`` (provisional) until a
+ *  multi-model confirm attaches a {@link TimeConfirmation} on user tap. The
+ *  confirm-downgrade (``better_than_baseline: false``) is a first-class outcome,
+ *  not an error. */
+
+/** ECMWF (or multi-model) assessment grade — server sends upper-case. */
+export type TimeAssessment = 'GREEN' | 'AMBER' | 'RED';
+
+export interface TimeConfirmation {
+  /** Models actually checked in the confirm pass (ecmwf/gfs/icon/…). */
+  models_checked: string[];
+  assessment: TimeAssessment | string;
+  assessment_reason: string;
+  /** Did the full multi-model check still agree the window beats the planned
+   *  time? ``false`` is the on-brand downgrade case, shown plainly. */
+  better_than_baseline: boolean;
+  improves: string[];
+  worsens: string[];
+  detail: string;
+  confirmed_at: string | null;
+}
+
+export interface TimeCandidate {
+  departure_time: string;               // ISO-8601
+  departure_shift_hours: number;        // signed hours vs planned departure
+  valid_times: string[];                // per-route-point ETAs (ISO-8601)
+  ecmwf_assessment: TimeAssessment | string;
+  ecmwf_assessment_reason: string;
+  improves: string[];                   // advisory ids improved vs baseline
+  worsens: string[];                    // advisory ids worsened vs baseline
+  margin: number;                       // trigger-weighted improvement (ranking)
+  confidence: 'ecmwf_only' | 'confirmed';
+  is_preferred: boolean;                // the pilot's pinned preferred time
+  is_baseline: boolean;                 // the planned departure (shift 0)
+  confirmed: TimeConfirmation | null;   // filled on tap (or free in-window)
+}
+
+export interface TimeScanBaseline {
+  departure_time: string;
+  ecmwf_assessment: TimeAssessment | string;
+  ecmwf_assessment_reason: string;
+}
+
+export interface TimeScanWindow {
+  start: string;
+  end: string;
+  cadence_hours: number;
+  daylight_clipped: boolean;
+  /** Window stopped at the ECMWF fidelity horizon (hard edge, not silent OM). */
+  horizon_clipped: boolean;
+  day_flex: string;                     // "day" | "prev" | "next"
+}
+
+export interface TimeWindowScan {
+  baseline: TimeScanBaseline;
+  window: TimeScanWindow;
+  candidates: TimeCandidate[];
+  scan_flagged: string[];
+  models: string[];
+  ecmwf_run_ts: number | null;
+  generated_at: string | null;
+  cross_section_ext: boolean;
+}


### PR DESCRIPTION
Implements the timing-scenario scan (`designs/plans/timing-scenario-plan.md`) — the reserved `MitigationKind.TIMING` axis. When a briefing flags a GRIB-dependent hazard that genuinely varies through the day, it surfaces **"a better departure time may exist"** — an attention-director, never a verdict.

## How it works

- **The v1 primitive** `extend_ecmwf_enrichment_daylight` re-decodes the daylight ECMWF fhours (decode-only, local ECPDS disk, BACKGROUND priority) into a separate `cross_section_ext.json`, reusing the production `_enrich_ecmwf` + `propagate_all`. **Honesty invariant**: a candidate hour is graded only if its whole ETA span falls inside the *decoded* coverage — never a silent `at_time()` clamp presenting OM-clamped values as ECMWF.
- **`run_time_scan`**: Relevance gate (scan-class advisory RED/AMBER) → daylight window (euro_aip solar) → ECMWF-horizon clip → extend enrichment → grade native-cadence candidates ECMWF-only via `run_alt_from_pack` → full-picture improve/worsen diff with trigger-weighted margin → `time_options.json`.
- **Detached background job**: runs *after* the briefing completes, so the refresh finishes as usual and the timing panel appears when the briefing is next viewed (+ a gated in-session client poll so it auto-appears). The expensive multi-model **confirm** is gated on a user tap (deferred ICON/GFS decode); the confirm-**downgrade** is a first-class designed outcome.

## Layers

- `timing_class` on `AdvisoryCatalogEntry` + `get_scan_class_ids()`; all 21 evaluators annotated per the plan (9 `scan` / 5 `cheap` / 7 `none`).
- `TimeWindowScan` / `TimeCandidate` / `TimeConfirmation` models + `time_options.json` / `cross_section_ext.json` artifacts.
- Endpoints: `GET .../time-options`, `POST .../time-options/confirm`.
- `alt_departure_time` reframed as the pinned **preferred departure time** (scan anchor + ranking tiebreak; **no DB migration**).
- Digest synchronous timing pointer (no numbers) + MCP/ChatGPT `timing_referral`.
- Web UI: neutral soft 🕐 hook → candidate list, provisional→confirmed ladder, downgrade shown plainly, capped ~3, **never auto-switches** the plan.

## Validation

- Full end-to-end on a live ECMWF run (`20260702_00z`): a RED midday flight (`vfr_feasibility`) surfaced 3 calmer AMBER windows (08/09/17Z) with the correct full-picture diff (early windows improve VFR but *worsen* airport_wind). Verified the scan runs detached — `execute_briefing` returns before `time_options.json` exists, which lands ~2 min later.
- New `tests/test_time_scan.py`; touched Python suites green; frontend `tsc --noEmit` + esbuild clean.

## Known v1 follow-ups (plan open questions)

- Detached execution uses a single background thread; subprocess isolation (#236) is a future option (Open q6).
- Confirm endpoint is synchronous, not SSE-streamed (Open q4).
- Variance pre-filter dropped per the plan's default (always-scan-when-flagged).
- `cross_section_ext.json` is ~7–13 MB per scanned pack (could gzip / drop after confirm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)