### PR TITLE
feat(timing): Flexibility toggle + timing-scenario scan (slices 1–4)

### DIFF
--- a/alembic/versions/074_flight_flexibility.py
+++ b/alembic/versions/074_flight_flexibility.py
@@ -1,0 +1,49 @@
+"""Add flights.flexibility — the timing-scenario Flexibility toggle.
+
+Per-flight opt-in for the timing-scenario scan (timing-scenario-plan.md):
+none | alternate | same_day | prev_day | next_day. Default "none" — local
+yes/no flights do no scenario work. ``alt_departure_time`` is reused as the
+"alternate" mode's value (no rename).
+
+Batch mode per house rules: SQLite (dev) needs the copy-and-move, MySQL (prod)
+treats it as a plain ALTER. ``server_default`` backfills existing rows.
+
+Revision ID: 074
+Revises: 073
+Create Date: 2026-07-02
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "074"
+down_revision: Union[str, None] = "073"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("flights") as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "flexibility",
+                sa.String(16),
+                nullable=False,
+                server_default="none",
+            )
+        )
+    # Back-compat: flights that already use the alt-departure feature keep
+    # their alt grading — it now runs via the scenario job, gated on
+    # flexibility="alternate" (the synchronous in-pipeline alt stage retires).
+    op.execute(
+        "UPDATE flights SET flexibility = 'alternate' "
+        "WHERE alt_departure_time IS NOT NULL"
+    )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("flights") as batch_op:
+        batch_op.drop_column("flexibility")

--- a/designs/plans/timing-scenario-plan.md
+++ b/designs/plans/timing-scenario-plan.md
@@ -1,192 +1,341 @@
 # Timing scenario scan — better departure-window discovery
 
-> **Status (2026-06-30): brainstorm / exploration.** Not yet an issue, not
-> scheduled. This doc captures the thinking so far so we can keep iterating
-> before committing to a build. Implements the `MitigationKind.TIMING` axis that
-> was reserved (unimplemented) in the mitigation framework (#330). Several points
-> still open — see *Open questions*. Do NOT add to `designs/INDEX.md` (plans are
-> not MCP-discoverable by house rule).
+> **Status (2026-07-02): decisions locked — ready to implement (next:
+> `/worktree-init`).** History: brainstorm 2026-07-01 → code review of the reuse
+> premise (same day, reshaped around the enrichment window) → full code-verified
+> plan review + flow decisions 2026-07-02 (Flexibility toggle, background
+> scenario job, all open questions resolved — see *Decisions locked*).
+> Implements the `MitigationKind.TIMING` axis reserved in the mitigation
+> framework (#330). Do NOT add to `designs/INDEX.md` (plans are not
+> MCP-discoverable by house rule).
 
 ## Goal
 
-When a briefing flags a hazard that genuinely varies through the day, tell the
-pilot **"a better departure time may exist"** and let them explore it — without
-re-running a full multi-model briefing for every candidate hour. GA pilots
-commonly have ±a-day flexibility; surfacing a calmer window is high-value.
+When a pilot has schedule flexibility, let them ask **"is there a better
+departure time?"** — without re-running a full multi-model briefing for every
+candidate hour. GA pilots commonly have ±a-day flexibility; surfacing a calmer
+window is high-value.
 
 Posture (non-negotiable, inherits from the mitigation framework): an
 **attention-director, never a verdict**. Neutral soft hook (lightbulb, like the
 mitigations — never green/red), never auto-switches the plan, never overclaims.
 
+## The user flow — the Flexibility toggle
+
+Scanning is **user opt-in per flight**, not automatic. Flight create/edit gains
+a **Flexibility** setting:
+
+| Mode | Meaning | Cost class |
+|---|---|---|
+| **None** (default) | No scenario work — right for local yes/no flights | zero |
+| **Alternate time** | Grade one user-picked date/time (the old alt-departure feature, now a single-candidate scenario) | one candidate |
+| **Same day** | Scan the full daylight window of the target date | ECMWF day-scan |
+| **Previous day** / **Next day** | Scan the daylight window of the adjacent day as well | day-scan + extra OM fetch |
+
+- **Queued analysis, never blocking.** The main briefing pipeline is untouched —
+  the briefing renders exactly as today, then the scenario job starts as a
+  low-priority background job. The briefing page shows **"Scenarios running…"**
+  and fills in results when ready.
+- **Delivery is polling, not SSE.** The refresh SSE stream (`POST
+  /refresh/stream`) closes with `complete` when the pipeline finishes
+  (`api/packs.py:1990`) — before the scan does — so there is no live channel for
+  a `time_scan_ready` event. The client polls `GET .../time-options` (backed by
+  a scan-status field in pack meta) after `briefing_ready`. Same for confirm
+  results.
+- **User intent gates *whether*; a cheap early-exit may still gate *how much*.**
+  The earlier auto relevance gate is **dropped** — if the user set a scan mode,
+  the scenario job runs, even on an all-green flight (the honest result "no
+  better window found — your time is already the smoothest" is useful, not
+  waste). But a **quick "day pinned bad" check survives as step 0 of the scan
+  job** (benchmarked, not assumed — decision B): when the hazard is synoptic and
+  uniformly bad all day, exiting early with "no better window today — hazard is
+  pinned all day" both saves compute and is itself a fast, useful answer.
+  Two honest ways to build it, to compare when slice 2 gives real cost numbers:
+  - **OM variance sweep** (free data already on disk) — but OM has no icing
+    signal (CLW/ICMR are GRIB-only), so it can only ever gate
+    convective/cloud/wind days, never icing.
+  - **Coarse-ECMWF-first early-exit** — decode the daylight window at 3h cadence
+    first (~4–5 fhours), and only refine to 1h if any coarse hour beats the
+    baseline. Honest for *all* hazards including icing, and the coarse decode is
+    reusable work, not a throwaway check. (Check the accumulated-field
+    step-differencing behaves at 3h spacing before relying on precip at the
+    coarse pass.)
+
+  `timing_class` survives with a reduced role (below).
+- **Hint for `None` flights** (keeps the proactive attention-director goal):
+  when a hint-class advisory is RED/AMBER at the planned time, show the soft
+  lightbulb — "this hazard varies through the day — set Flexibility to scan for
+  a better window." Costs nothing, never auto-scans.
+- **±day realities.** Previous/Next day need an **extra OM fetch**: OM data on
+  disk covers only the target date — the pipeline windows the fetch with
+  `start_date = end_date = target day` (`tasks/fetch.py:275-313`,
+  `fetch_multi_point`); the next day is present only when the flight crosses
+  midnight. Previous day clamps away when already in the past; Next day can
+  cross the ECMWF horizon for far-out flights — the flexibility window must
+  **visibly stop where ECMWF fidelity stops**. The horizon is already derived
+  from the max step on disk per run (`ecmwf_fetch.py:381`), not hardcoded — use
+  that, not the nominal 90/168h order figures.
+- **DB:** one new column — a `flexibility` enum on flights (batch_alter
+  migration per house rules). `alt_departure_time` is reused as-is for the
+  Alternate-time value — no rename, no DTO break.
+
+## Decisions locked (2026-07-02)
+
+| # | Decision |
+|---|---|
+| A | Flexibility is opt-in, default None; soft hint on None flights when a hint-class advisory fires |
+| B | The toggle gates *whether* to run scenarios; a cheap "day pinned bad" early-exit inside the scan job may still gate *how much* — kept as a benchmarked optimization (OM variance vs coarse-ECMWF-first, see flow section), not a v1 blocker. `timing_class` only drives the hint + ranking emphasis |
+| C | Hint-class set = the 8 `scan` advisories + `freezing_precip` + `flight_category`; `fronts` excluded (experimental, default-off). Low-stakes and declarative (`timing_class` config) — since every candidate is graded on the full set, the lightbulb trigger can be re-tuned anytime without rework |
+| D | Margin/presentation confirmed: surface a candidate only if it improves ≥1 grade and doesn't materially worsen anything; ranked, cap ~3, alternate time pinned (exact thresholds tuned at build time) |
+| E | On-tap multi-model confirm is **in v1** |
+| F | Previous/Next day modes are **in v1** |
+| G | Extended enrichment stays **ephemeral** in the scan job; only `time_options.json` is persisted — no mutation of published pack artifacts |
+| H | Scan keyed by **(flight, ECMWF run)**: a refresh on the same run reuses the existing scan; a new run re-scans automatically |
+
 ## Why this is hard — the data-cost reality
 
 A timing search means evaluating advisories at valid-times other than the flight
 window. The cost is **not uniform across models** (verified against `fetch.md`,
-`icing-models-analysis.md`, `convective-analysis.md`):
+`icing-models-analysis.md`, `convective-analysis.md`, and code 2026-07-02):
 
 | Layer | Full-day cost | Fidelity off the flight window |
 |---|---|---|
-| Open-Meteo base | **free** — whole 24h target day already on disk (`fetch.md:103`) | **degraded** icing/convective |
-| **ECMWF** | **decode only, no download** — full GRIB run preloaded (0–90h, 168h at 00/12z) | **full** (CLW/ICMR from a2 GRIB) |
-| GFS | moderate (S3 byte-range) | full |
-| ICON | **heavy download** (DWD) | full |
+| Open-Meteo base | **free for the target day** — whole 24h already on disk (`tasks/fetch.py:275-313`); **adjacent days need a new fetch** | **degraded** icing/convective |
+| **ECMWF** | **decode only, no download** — full GRIB run on local ECPDS disk (`ECMWF_GRIB_DIR`, horizon from files on disk) | **full** (CLW/ICMR from a2 GRIB) — *but not decoded into the pack off-window; see below* |
+| GFS | moderate — per-fhour S3 byte-range (a handful of ranged GETs per fhour, `grib_fetch.py:33`, `gfs_idx.py`) | full |
+| ICON | **heavy download** — per fhour ≈ 40 model levels × N variables of bz2 files from DWD (`icon_eu_fetch.py:433-462`) | full |
 
-The trap: **Open-Meteo alone would mislead** exactly on the axes that matter most.
-`CLWMR`/`ICMR` (cloud-water/ice — 0.35 of the icing fuzzy-logic weight) are
-GRIB-only and absent for MétéoFr/UKMO/GEM (always synthesized). Convective DD is
-OM-computable (CAPE is an OM field) but the NWP-native firing signal + safety
-`cross_check` need GRIB. So a cheap OM-only sweep produces *confident-but-wrong*
-conclusions on icing and convection. Conversely, a faithful full-multi-model
-sweep across 10–12 daylight hours × (1–3 days) is ~10–36 briefing-equivalents —
-far too expensive to run eagerly.
+The trap: **Open-Meteo alone would mislead** exactly on the axes that matter
+most. `CLWMR`/`ICMR` (cloud-water/ice — 0.35 of the icing fuzzy-logic weight)
+are GRIB-only and absent for MétéoFr/UKMO/GEM (always synthesized). Convective
+DD is OM-computable (CAPE is an OM field) but the NWP-native firing signal +
+safety `cross_check` need GRIB. So a cheap OM-only sweep produces
+*confident-but-wrong* conclusions on icing and convection. Conversely, a
+faithful full-multi-model sweep across 10–12 daylight hours × (1–3 days) is
+~10–36 briefing-equivalents — far too expensive to run eagerly.
 
-## Core idea — ECMWF-anchored coarse-to-fine
+## The enrichment-window reality (decisive finding)
+
+The reuse premise — "just re-grade at another hour with `run_alt_from_pack`,
+it's free" — is only **half true**, and getting this wrong would silently
+violate the honesty posture. Verified in code:
+
+- `run_alt_from_pack` (`tasks/advise.py:704`) **does** take an arbitrary
+  `alt_departure_time: datetime` and an `advisory_models` subset, and re-runs
+  analysis + front detection at the shifted ETAs (it also re-writes
+  `route_fronts_alt.json` and airport conditions). So the *re-grading machinery*
+  generalises to any hour and any model set for free. ✓
+- **But it re-grades against the *saved pack* `cross_sections`, not against the
+  on-disk GRIB.** GRIB enrichment is windowed around the flight — **the ±3h
+  margin is ECMWF-specific** (`margin = timedelta(hours=3)`,
+  `fetch/grib/__init__.py:2071-2077`); GFS and ICON use forward flight-window
+  hours instead (`grib_fetch.py:176`, `icon_eu_fetch.py:361`), not a symmetric
+  bracket. OM base spans the whole target day, but CLW/ICMR/cloud-diagnostics —
+  the icing fuel and the GRIB cloud geometry — exist only in each model's
+  enriched window. **Coverage must therefore be checked per model, never
+  assumed.**
+- `at_time()` picks the **closest** stored hour and **silently clamps** past the
+  edge (`models/analysis.py:329-342`, ~18 call sites, one method definition). So
+  a naive off-window `run_alt_from_pack` returns OM-clamped values **labelled
+  ECMWF** — a confident-but-wrong provisional, the exact failure the posture
+  forbids.
+- **Accumulated-field constraint:** ECMWF tp/sf/cp are step-differenced across
+  consecutive processed steps (`grib/__init__.py:2067,2205`). The daylight
+  extension must decode a **contiguous run of fhours** — cherry-picking only
+  "promising" hours would corrupt precip/snow deltas.
+
+So there are **two regimes**, and the design treats them separately:
+
+| Regime | Cost | What it needs |
+|---|---|---|
+| **Inside the enriched window** (per model) | **free** — zero decode, pure re-analysis; **all models** are enriched here, so in-window candidates can be graded **multi-model immediately** | nothing new — `run_alt_from_pack` as-is |
+| **Full daylight window** | **decode-only, no download** (ECMWF row above) | **decode the daylight ECMWF fhours** into an extended (ephemeral, per decision G) cross-section set *first*, then re-grade |
+
+**The real v1 primitive is "extend the ECMWF enrichment window across daylight,"
+not "reuse `run_alt_from_pack` for free."** You reuse the analysis + advisory
+*machinery*; you build the full-day *data layer* fresh (bounded to ECMWF, decode
+from local disk). Hard invariant: **never grade a candidate hour whose fields
+aren't actually decoded for the model being claimed** — extend enrichment to
+cover it, or refuse the hour. No silent `at_time()` clamp. Implementation:
+record per-model enriched-hour **coverage as explicit metadata** and check it
+*before* grading (refuse up front), with an opt-in `strict` kwarg on `at_time`
+as a localized backstop — don't thread strictness through all ~18 call sites.
+
+## Core idea — ECMWF-anchored, native-cadence, coarse-to-fine
 
 Exploit the model-cost asymmetry: ECMWF is **both the best model and the
-preloaded one**.
+locally-delivered one**.
 
-1. **Cheap search (background, ECMWF-only).** After the main briefing, a
-   low-priority job sweeps ECMWF across the daylight window — full fidelity,
-   decode-only, no download. Ranks candidate windows.
-2. **Expensive confirm (on user tap, multi-model).** Only when the user taps a
-   candidate do we spend the ICON/GFS download+decode for that one hour. The
-   heavy cost is gated on demonstrated user intent.
+1. **Free tier (in-window).** Candidates inside the original enrichment window
+   have *all* models enriched already — they surface as **confirmed
+   immediately, for free**. ("Leave 2h earlier" is probably the most common
+   useful suggestion, and it costs nothing.)
+2. **Cheap search (background, ECMWF-only).** The scenario job decodes the
+   daylight ECMWF fhours (decode-only, no download, ephemeral) and sweeps
+   ECMWF-only advisories across them — full fidelity. Ranks candidate windows.
+3. **Expensive confirm (on user tap, multi-model).** Only when the user taps a
+   candidate do we spend the ICON/GFS download+decode. **Cost note:** a
+   candidate is a `departure_shift`, so the confirm needs ICON/GFS at *all*
+   native steps spanning the shifted flight window (typically 2–5 fhours), not
+   one step — roughly **one briefing-equivalent** of ICON+GFS fetch. Both
+   fetchers are already per-fhour (`icon_eu_fetch.py:433`, `grib_fetch.py:33`),
+   so no fetch-layer changes. Expect tens of seconds to a couple of minutes;
+   async with polling; result cached on the candidate (invalidated by new runs
+   per decision H).
 
 Bias is in the **safe direction**: ECMWF-only search can *miss* a good window,
 but the confirm pass kills any candidate ICON/GFS disagree with — we never
 surface a bad time, we only occasionally fail to find every good one.
 
+**Snap to native cadence, don't interpolate to clock hours.** The scan grid *is*
+the model's native valid-times: 1h where ECMWF publishes hourly, coarse (3h) in
+the later window (actual cadence read from files on disk). The confirm pass
+grades each candidate at ICON/GFS's nearest native steps.
+
 ### Flow — an honesty ladder
 
 ```
-SCANNING ──► CANDIDATES (ECMWF-only, provisional) ──► CONFIRMED (multi-model)
-  bg job          shown on reopen, soft hook            on user tap
+SCANNING ──► CANDIDATES ──────────────────────► CONFIRMED (multi-model)
+  bg job      in-window: confirmed for free        on user tap (off-window)
+              off-window: ECMWF-only, provisional
 ```
 
 - **Provisional** — "ECMWF suggests a calmer window at 09:00; other models not
   yet checked." Never claims more than the one model checked.
-- **Confirmed** — "all models checked: better" **or** "actually not better — ICON
-  sees convection at 09:30." The **downgrade case is a feature** — it shows the
-  cross-check working, on-brand for the attention-director stance.
+- **Confirmed** — "all models checked: better" **or** "actually not better —
+  ICON sees convection at 09:30." The **downgrade case is a feature** — it shows
+  the cross-check working, on-brand for the attention-director stance.
 
-## Gating — reserve the scan for when it makes sense
+## `timing_class` — hint trigger + ranking emphasis only
 
-The scan is expensive, so don't always run it. Enqueue only when **both** hold:
+With the Flexibility toggle as the compute gate, `timing_class` no longer
+decides *whether* to scan. Every candidate hour is graded on the **full**
+advisory set regardless (otherwise we'd surface a window that fixed icing and
+quietly introduced a crosswind), so e.g. fog burn-off shows up in results even
+though `flight_category` is not scan-driven. The classification now decides:
 
-1. **Relevance** — at least one `scan`-class advisory (table below) is RED/AMBER
-   at the planned time. All-green, or only `cheap`/`none`-class advisories
-   flagged (sun, density altitude, precip) → no scan.
-2. **Variance pre-filter** — use the **free local OM 24h data as an honest
-   *variance detector***: does the hazard field (CAPE, cloud, RH-icing proxy)
-   actually move across the day? OM is too degraded to *grade* icing, but it is
-   fair for "flat all day vs swinging." If convection is pinned RED dawn-to-dusk
-   (synoptic, not diurnal), skip the scan — timing won't help. (Honest use of
-   degraded data: variance, not absolute severity.)
+1. **The hint** on Flexibility=None flights (which advisories being RED/AMBER
+   triggers the lightbulb), and
+2. **Ranking emphasis** (what "improves" is worth surfacing first).
 
-**Config is declarative, not a hardcoded list.** Add a `timing_class` flag to
-`AdvisoryCatalogEntry` (sibling of `altitude_dependent`); the scan job asks the
-registry which IDs are `scan`-class, so a new evaluator auto-participates.
+Config stays declarative: add a `timing_class` flag to `AdvisoryCatalogEntry`
+(`models/advisories.py:144`, sibling of `altitude_dependent` at `:153`), with a
+registry helper mirroring `get_altitude_dependent_ids()`
+(`analysis/advisories/registry.py:31`), so a new evaluator auto-participates.
+Note two evaluators register their IDs via constants (`fronts`, `sun`) — don't
+grep for literal `id="..."`.
 
-**Scope vs objective stay separate** (keeps honesty): the trigger set decides
-*whether to scan* and *what to rank by*, but each candidate hour is graded on the
-**full** advisory set — otherwise we'd surface a window that fixed icing and
-quietly introduced a crosswind.
+### Mapping (all 21 evaluators — verified complete against the registry)
 
-### The unifying principle
+**Hint-class** (triggers the None-flight hint; decision C): the 8 `scan` rows +
+`freezing_precip` + `flight_category`.
 
-> **scan-worthy ⟺ GRIB-dependent ⟺ OM-insufficient.** The hazards that need the
-> good model are the same hazards worth scanning. The cheap-OM-sufficient
-> advisories (DA / wind / sun) don't need a scan — if timing helped, the free OM
-> data would already show it. So they get at most a cheap analytic hint, never
-> the ECMWF scan.
-
-## `timing_class` mapping (all 21 evaluators)
-
-Trigger threshold = RED or AMBER on a `scan`-class advisory.
-
-### `scan` — worth the expensive ECMWF day-scan
+#### `scan` — the timing-sensitive, GRIB-dependent core
 | Advisory | Cat | Why |
 |---|---|---|
 | `convective` | convective | Diurnal CAPE/firing, GRIB cross-check — canonical case |
 | `convective_character` | convective | Same diurnal convection, avoidability axis |
-| `icing_escape` | icing | In-cloud icing rides GRIB cloud-water + freezing level, both shift through the day; OM-synthesized misleads |
+| `icing_escape` | icing | In-cloud icing rides GRIB cloud-water + freezing level, both shift through the day |
 | `fiki_icing` | icing | Thickness/severity is GRIB-CLW-driven and evolves; OM under-reads |
 | `cloud_top` | cloud | Tops build/burn-off diurnally; GRIB cloud geometry |
 | `vmc_cruise` | cloud | BKN/OVC at cruise burns off/builds; GRIB cloud |
-| `vfr_feasibility` | feasibility | RED is usually enroute IMC / corridor decks (GRIB cloud) — the burn-off case |
+| `vfr_feasibility` | feasibility | RED is usually enroute IMC / corridor decks — the burn-off case |
 | `ifr_feasibility` | feasibility | Gated by icing + convective, both scan-class |
 
-### `scan?` — ambiguous, decide before committing
-| Advisory | Cat | Tension |
-|---|---|---|
-| `flight_category` | airport | Airport IMC/fog burn-off is a strong timing case, but ceiling/vis fidelity is OM/TAF not GRIB — earns the scan, or just a cheap ceiling hint? |
-| `freezing_precip` | icing | Severe (RED) and temp-crossing-zero is diurnal, but the T-profile is OM-complete — scan (safety) vs cheap (data sufficiency)? |
-| `fronts` | fronts | Front passage is diurnally-timed and GRIB-θe-derived → scan-worthy, but experimental/default-off — leave `none` until the advisory matures? |
+#### resolved `scan?` rows (decision C)
+| Advisory | Disposition |
+|---|---|
+| `flight_category` | **hint-class** (fog/ceiling burn-off is the classic timing case) but OM/TAF-driven — improvements surface via full-set grading, no GRIB work needed for it |
+| `freezing_precip` | **hint-class** — severe + the diurnal T-crossing-zero is the whole point |
+| `fronts` | **excluded** until the advisory matures (experimental, default-off) |
 
-### `cheap` — OM-sufficient, free hint at most, never the scan
-| Advisory | Cat | Why not scan |
-|---|---|---|
-| `density_altitude` | airport | Follows the temperature diurnal curve; obvious from local OM temp |
-| `sun` | sun | Pure astronomy — glare time computable exactly, no forecast scan at all |
-| `airport_wind` | airport | Surface wind is diurnal but OM-complete |
-| `llws` | airport | Nocturnal-jet shear is textbook-timing but low-level winds are OM-available |
+#### `cheap` — OM-sufficient, never drives the hint
+`density_altitude`, `sun`, `airport_wind`, `llws` — their timing sensitivity is
+already visible in free OM data; improvements still appear in candidate diffs.
 
-### `none` — timing not the lever
-| Advisory | Cat | Why |
-|---|---|---|
-| `headwind` | wind | Altitude-mitigated, weakly diurnal, informational |
-| `turbulence` | turbulence | Lever is altitude; its diurnal (thermal) part is already captured by the convective scan — separate scan double-counts |
-| `mountain_wind` | turbulence | Wind speed is OM; wave-erosion timing too subtle to scan reliably |
-| `enroute_precip` | precip | Surface precip is OM-complete and system-movement (spatial) driven, not a diurnal burn |
-| `model_agreement` | model | Intrinsic — no time changes model spread |
-| `dd_nwp_agreement` | model | Intrinsic dev/calibration signal |
+#### `none` — timing not the lever
+`headwind`, `turbulence` (altitude is the lever; its thermal part is captured by
+the convective scan), `mountain_wind`, `enroute_precip`, `model_agreement`,
+`dd_nwp_agreement`.
 
-v1 trigger set = the 8 `scan` rows; the 3 `scan?` rows are the first thing to settle.
+## Alternate time — the old alt-departure feature, unified
+
+The old `alt_departure_time` feature (single manually-set alternate time, graded
+synchronously in-pipeline with a planned↔alt toggle) is **subsumed as
+Flexibility=Alternate time — a single-candidate scenario job**:
+
+- **No column change.** `alt_departure_time` (DB `db/models.py:111`, DTOs)
+  keeps its name and stores the Alternate-time value.
+- **Grading moves out of the synchronous pipeline** into the scenario job
+  (`pipeline.py:437-444` alt stage retires). This resolves an ordering
+  contradiction: an off-window alternate time graded in-pipeline would hit
+  exactly the silent-clamp failure the invariant forbids, before any enrichment
+  extension exists. **Behavior change:** alt advisories now arrive a beat
+  *after* the briefing ("Scenarios running…") instead of with it — accepted.
+- **Artifact compatibility:** the job still writes `route_advisories_alt.json`
+  for the alternate time (web already consumes it — `briefing-store.ts:379`,
+  `briefing-main.ts:485`), now with an explicit **model-coverage/confidence
+  field**, since off-window grades are ECMWF-only until confirmed. The web
+  planned↔alt UI must render that label. (iOS has **zero** alt-departure code
+  today — nothing to migrate; the reframe is web-only.)
+- **Pinned in scan modes:** in Same-day/±day modes, the alternate time (if set)
+  is the pinned row in the candidate list and the ranking tiebreaker.
 
 ## Implementation sketch (reuse-heavy)
 
-**Artifact** — `time_options.json` on the pack, precompute-style like the
-altitude table (#259):
+**Artifact** — `time_options.json` on the pack, keyed by ECMWF run (decision H):
 ```
 TimeWindowScan {
-  baseline:   { time, ecmwf_assessment }              # planned time, ECMWF view
-  window:     { start, end, step, daylight_clipped, day_flex }
+  ecmwf_run: str                                       # staleness key (decision H)
+  baseline:   { time, ecmwf_assessment }               # planned time, ECMWF view
+  window:     { start, end, cadence, daylight_clipped, flexibility_mode }
   candidates: [ TimeCandidate {
-     valid_time, ecmwf_assessment,                     # GREEN/AMBER/RED
+     departure_shift, valid_times[],                   # a shift propagates per-point ETAs
+     ecmwf_assessment,                                 # GREEN/AMBER/RED
      improves: [advisory_ids], worsens: [...],         # FULL-picture diff vs baseline
-     confidence: "ecmwf_only",
-     confirmed: TimeConfirmation | null                # filled on tap
+     confidence: "confirmed_in_window" | "ecmwf_only" | "confirmed",
+     confirmed: TimeConfirmation | null                # filled on tap (or free in-window)
   } ]
 }
 ```
+(`departure_shift` not a single `valid_time`: shifting departure moves *every*
+route point's ETA — `analyze_all_route_points` re-derives per-point valid-times,
+`tasks/analyze.py:345-354`. The diff is vs the **ECMWF-only baseline**, stored —
+never apples-to-oranges vs the multi-model headline.)
 
-**Background job** — `run_time_scan`, enqueued after `run_advisories` in the
-refresh pipeline (subject to the two gates). Rides existing substrate: standalone
-subprocess isolation (#236), behind the decode priority dispatcher (#172) so it
-never starves a live briefing. Coarse-to-fine on time (3h scan → 1h refine).
-Daylight bounds free from `RouteSunAnalysis` / night intervals. Emits SSE
-`time_scan_ready`.
+**Background job** — `run_time_scan`. **Reality check: there is no task queue**
+(no Celery/arq; pipeline stages are sequential calls, background work is
+scheduler asyncio loops). This is the largest piece of new infrastructure: a
+post-refresh background task launched after the pipeline completes, on the
+standalone-subprocess substrate (#236 — note its supervisor is currently
+scheduler-cycle-specific, needs a per-briefing variant) with decodes at
+`DecodePriority.BACKGROUND` (#172) so it never starves a live briefing. Global
+scan concurrency = 1; skip when a scan for the same (flight, ECMWF run) exists.
+First step is **decode the daylight ECMWF fhours** (contiguous, ephemeral —
+decisions above), then re-grade ECMWF-only at each native-cadence step. Daylight
+bounds from `RouteSunAnalysis` / night intervals. (The altitude table is *not* a
+competing background job — it's computed inside `run_advisories` while
+cross-sections are in memory, `tasks/advise.py:375-390`.)
 
 **Endpoints**
-- `GET .../packs/{ts}/time-options` → the scan (404 while scanning → "looking…").
-- `POST .../packs/{ts}/time-options/{hh:mm}/confirm` → on-tap full check. This is
-  the existing `alt/compute` generalized to an arbitrary time. **Not instant** —
-  ICON/GFS GRIB at that hour is off-window, so confirm triggers the deferred
-  fetch+decode (the cost we gate on user intent). Make it **async (SSE)**; cache
-  the result on the candidate.
+- `GET .../packs/{ts}/time-options` → scan result or status ("Scenarios
+  running…" while pending; client polls).
+- `POST .../packs/{ts}/time-options/{step}/confirm` → on-tap full check
+  (ICON+GFS across the shifted window; async; polled; cached on the candidate).
 
-**Reuse, don't rebuild:** scan = `evaluate_all(advisory_models=["ecmwf"])` on
-local GRIB; confirm = the `alt_departure_time` path (`run_alt_from_pack` /
-`route_advisories_alt.json`) generalized to any hour, all models; scoring =
-`derive_assessment_from_advisories`; delivery = SSE refresh; comparison UI = the
-existing planned↔alt toggle.
+**Reuse, don't rebuild:** re-grading machinery = `run_alt_from_pack` (arbitrary
+time + `advisory_models` subset) — reused unchanged. What's *new* is the data
+layer (daylight ECMWF decode, bounded copy of the `fetch/grib` window logic),
+the coverage metadata + refusal check, and the background-job wiring. Scoring =
+`derive_assessment_from_advisories`; comparison UI = the existing planned↔alt
+toggle, generalised to candidate selection.
 
 ### UX hook (sketch)
 ```
 ┌────────────────────────────────────────────────┐
-│ 🕐  A smoother departure may exist               │
-│     ECMWF found 2 better windows today      [v] │
+│ 🕐  Scenarios: 2 better windows found       [v] │
 ├────────────────────────────────────────────────┤
+│  08:00 ★ your alternate time · AMBER            │
 │  09:00   ● improves: VFR, winds aloft           │
 │          ECMWF only · tap to check all models → │
 │  10:00   ● improves: VFR · worsens: density alt │
@@ -194,53 +343,93 @@ existing planned↔alt toggle.
 │                                  show full day ⌄ │
 └────────────────────────────────────────────────┘
 ```
-Three rules against noise: **suppress entirely** unless a candidate clears a
-margin; show only improving candidates, **ranked, capped ~3** ("2 windows found",
-not "12 hours scanned"); **never auto-switch** the plan.
+While pending: "🕐 Scenarios running…". Rules against noise (decision D):
+**suppress entirely** unless a candidate clears the margin; show only improving
+candidates (+ the pinned alternate time), **ranked, capped ~3**; **never
+auto-switch** the plan.
+
+## Digest & MCP surfacing
+
+**Digest — hint only, never the async numbers.** The scan finishes after the
+digest has been generated and shown. The digest gets at most the cheap
+synchronous hint ("this hazard swings through the day — see Timing options in
+the app") — note the OM diurnal-swing computation behind it is **new code**
+(nothing exists today; only observation-climatology diurnal profiles in
+`tasks/airport_summary.py`). The full scan block lives in the web UI — a
+deterministic table, no LLM needed. `MitigationKind.TIMING` LLM phrasing is a
+nice-to-have, not a dependency.
+
+**MCP / ChatGPT — provisional-only, refer to the app.** The connector path is
+stateless/synchronous, so no interactive confirm. The MCP surface points the
+user to the app rather than exposing half a workflow.
 
 ## Honesty guardrails
 
-- Never surface a time evaluated only on degraded data — provisional candidates
-  are explicitly ECMWF-only-labelled; the claim upgrades only on confirm.
+- **Never grade an hour whose fields aren't decoded for the model claimed.**
+  Coverage checked up front from explicit metadata; refuse otherwise. No silent
+  `at_time()` clamp (`strict` backstop).
+- Off-window candidates are explicitly ECMWF-only-labelled; the claim upgrades
+  only on confirm (in-window candidates are honestly labelled confirmed — all
+  models really are enriched there).
 - The confirm-downgrade ("you tapped a suggestion, it turned out worse") is a
   first-class designed outcome, not an error path.
-- Day-flexibility has a hard fidelity edge: beyond the ECMWF 0–90h (168h at
-  00/12z) horizon even the scan drops to degraded OM — the flexibility window
-  should visibly stop where ECMWF fidelity stops, not silently degrade.
-- Stale on refresh: a new model run invalidates the scan + confirmed candidates.
+- The flexibility window visibly stops where ECMWF fidelity stops (horizon from
+  max step on disk per run) — no silent degradation to OM.
+- Staleness: keyed by ECMWF run (decision H); a new run invalidates the scan and
+  all confirmations.
 
-## Open questions (to nail down before this becomes an issue)
+## Validation plan
 
-**Blocking prerequisite (verify first):** confirm `run_alt_from_pack` can re-grade
-at an **arbitrary same-day hour on local ECMWF GRIB with full icing/convective
-fidelity, no re-fetch**. The entire cheap-search premise rests on this; if it
-doesn't hold, the design changes shape.
+1. **Invariant test:** scan at `departure_shift = 0` must reproduce the baseline
+   ECMWF-only grades exactly.
+2. **Coverage-refusal test:** a candidate hour with missing enrichment is
+   refused, never clamp-graded.
+3. **Replay the eval-corpus convective cases** — Jun 21 LFMD→EGTF and Jun 27
+   EGTF→LFAT→LFQA are diurnal-timing cases with known ground truth: "would the
+   scan have found the morning window?" is the single best pre-build design
+   validation, runnable on the eval-workbench substrate.
+4. **Decode benchmark spike (gates the Same-day slice):** wall-time to decode
+   ~10–14 extra ECMWF fhours for a typical route at BACKGROUND priority on the
+   droplet. Decode is the known GIL/process-pool bottleneck; this number decides
+   whether scan-per-refresh is comfortable or the (flight, run) cache is doing
+   heavy lifting.
 
-1. **The 3 `scan?` rows** — `flight_category`, `freezing_precip`, `fronts`:
-   scan / cheap / none.
-2. **Search window** — daylight clip (reuse `RouteSunAnalysis`); cadence
-   (coarse-to-fine 3h→1h?); day-flexibility knob UX ("day only / ±prev / ±next")
-   and its ECMWF-horizon edge.
-3. **"Better" margin** — how much improvement surfaces a candidate; whole-picture
-   vs trigger-weighted ranking objective.
-4. **On-tap confirm** — async/SSE; result caching; promote a confirmed candidate
-   to a saved alt scenario?
-5. **Variance pre-filter** — build in v1 or defer as an optimization; what
-   "varies enough" threshold.
-6. **Execution + budget** — subprocess vs in-process task; caps on
-   candidate-hours/scan and scans/day so a fleet of flights can't stampede the
-   decode pool.
-7. **Cheap tier** — do we ever build the OM analytic hints for DA/sun/wind/LLWS,
-   or is the `cheap` class just "not the scan, no treatment"?
+## Implementation slices (all in v1, in order)
+
+1. **Toggle + unified Alternate time + in-window free tier.** Flexibility
+   column/UI; alt grading moves to the scenario job; candidates within the
+   existing enrichment window surface confirmed-for-free. No new data layer —
+   validates the job wiring, polling, UX, and ranking margin cheaply.
+2. **ECMWF daylight extension + Same-day scan.** The decode benchmark (above)
+   gates this slice. Ephemeral enrichment, coverage metadata, honesty ladder.
+3. **On-tap confirm** (ICON+GFS across the shifted window, async, cached).
+4. **Previous/Next day** (extra OM fetch, past-day clamp, horizon edge UX).
 
 ## Out of scope (v1)
 
-- Cheap analytic timing hints for the `cheap` tier (DA/sun/wind/LLWS).
+- Cheap analytic timing hints for the `cheap` tier (DA/sun/wind/LLWS) beyond the
+  shared hint.
 - Multi-day search beyond the ECMWF GRIB horizon.
 - Lateral route deviation (2-D) — the route is 1-D; only along-track timing.
+- iOS surfacing (alt-departure/scenarios are web-only client-side today).
+
+## Remaining build-time details (no user decision needed)
+
+- Exact margin thresholds for "improves / materially worsens" (shape decided —
+  decision D).
+- Hint copy + digest hint wording.
+- Whether the None-flight hint ships in slice 1 or with slice 2.
+- **Early-exit benchmark (decision B):** once slice 2 gives real scan-cost
+  numbers, compare OM-variance vs coarse-ECMWF-first on real packs —
+  `cost(check)` vs `cost(full scan) × skip_rate` — and keep whichever (if
+  either) pays for itself.
 
 ## References
 
 - Mitigation framework + `MitigationKind.TIMING` (reserved): [advisories.md](../advisories.md) *Mitigations* section, #328/#330
+- Reuse machinery: `run_alt_from_pack` (`tasks/advise.py:704`), `AdvisoryCatalogEntry` (`models/advisories.py:144`, `altitude_dependent` `:153`), registry helper pattern (`analysis/advisories/registry.py:31`)
+- Enrichment windows: ECMWF ±3h (`fetch/grib/__init__.py:2071-2077`); GFS forward window (`grib_fetch.py:176`); ICON forward window (`icon_eu_fetch.py:361`); silent clamp (`models/analysis.py:329-342`); accumulated-field step-differencing (`grib/__init__.py:2067,2205`)
+- OM fetch windowing: `tasks/fetch.py:275-313` (`fetch_multi_point`, target-day only)
+- Per-fhour fetch primitives: ICON (`icon_eu_fetch.py:433-462`), GFS byte-range (`grib_fetch.py:33`, `gfs_idx.py`)
 - Data-fidelity basis: [fetch.md](../fetch.md), [icing-models-analysis.md](../icing-models-analysis.md), [convective-analysis.md](../convective-analysis.md)
-- Reuse substrate: alt-departure path (advisories.md *Alt departure*), decode priority dispatcher (#172), standalone subprocess isolation (#236), altitude-table precompute (#259)
+- Substrate: decode priority dispatcher (#172, `DecodePriority`), standalone subprocess isolation (#236), altitude table inside `run_advisories` (#259, `tasks/advise.py:375-390`), alt artifacts (`tasks/artifacts.py:345-357`), web alt UI (`web/ts/store/briefing-store.ts:379`, `briefing-main.ts:485`)

--- a/designs/plans/timing-scenario-plan.md
+++ b/designs/plans/timing-scenario-plan.md
@@ -85,7 +85,7 @@ a **Flexibility** setting:
 |---|---|
 | A | Flexibility is opt-in, default None; soft hint on None flights when a hint-class advisory fires |
 | B | The toggle gates *whether* to run scenarios; a cheap "day pinned bad" early-exit inside the scan job may still gate *how much* — kept as a benchmarked optimization (OM variance vs coarse-ECMWF-first, see flow section), not a v1 blocker. `timing_class` only drives the hint + ranking emphasis |
-| C | Hint-class set = the 8 `scan` advisories + `freezing_precip` + `flight_category`; `fronts` excluded (experimental, default-off). Low-stakes and declarative (`timing_class` config) — since every candidate is graded on the full set, the lightbulb trigger can be re-tuned anytime without rework |
+| C | `freezing_precip` is a full `scan`-class member (9 scan rows total — severe, and the diurnal T-crossing IS the timing mechanism, so it counts toward the ranking margin, not just the hint; as-built, confirmed at review). Hint set = the 9 scan rows + `flight_category` (`timing_hint=True`); `fronts` excluded (experimental, default-off). Low-stakes and declarative (`timing_class` config) — since every candidate is graded on the full set, the lightbulb trigger can be re-tuned anytime without rework |
 | D | Margin/presentation confirmed: surface a candidate only if it improves ≥1 grade and doesn't materially worsen anything; ranked, cap ~3, alternate time pinned (exact thresholds tuned at build time) |
 | E | On-tap multi-model confirm is **in v1** |
 | F | Previous/Next day modes are **in v1** |
@@ -227,10 +227,11 @@ grep for literal `id="..."`.
 
 ### Mapping (all 21 evaluators — verified complete against the registry)
 
-**Hint-class** (triggers the None-flight hint; decision C): the 8 `scan` rows +
-`freezing_precip` + `flight_category`.
+**Hint-class** (triggers the None-flight hint; decision C): the 9 `scan` rows +
+`flight_category` (via `timing_hint=True` — the hint set is
+`get_scan_class_ids() | {timing_hint}` in the registry).
 
-#### `scan` — the timing-sensitive, GRIB-dependent core
+#### `scan` — the timing-sensitive core (9 rows, as-built)
 | Advisory | Cat | Why |
 |---|---|---|
 | `convective` | convective | Diurnal CAPE/firing, GRIB cross-check — canonical case |
@@ -241,12 +242,13 @@ grep for literal `id="..."`.
 | `vmc_cruise` | cloud | BKN/OVC at cruise burns off/builds; GRIB cloud |
 | `vfr_feasibility` | feasibility | RED is usually enroute IMC / corridor decks — the burn-off case |
 | `ifr_feasibility` | feasibility | Gated by icing + convective, both scan-class |
+| `freezing_precip` | icing | Severe, and the diurnal T-crossing-zero IS the timing mechanism — ranking-worthy, not hint-only |
 
 #### resolved `scan?` rows (decision C)
 | Advisory | Disposition |
 |---|---|
-| `flight_category` | **hint-class** (fog/ceiling burn-off is the classic timing case) but OM/TAF-driven — improvements surface via full-set grading, no GRIB work needed for it |
-| `freezing_precip` | **hint-class** — severe + the diurnal T-crossing-zero is the whole point |
+| `flight_category` | **hint-only** (`timing_class="cheap"`, `timing_hint=True`) — fog/ceiling burn-off is the classic timing case but OM/TAF-driven; improvements surface via full-set grading |
+| `freezing_precip` | **scan-class** (see table above) |
 | `fronts` | **excluded** until the advisory matures (experimental, default-off) |
 
 #### `cheap` — OM-sufficient, never drives the hint

--- a/designs/plans/timing-scenario-plan.md
+++ b/designs/plans/timing-scenario-plan.md
@@ -398,14 +398,22 @@ user to the app rather than exposing half a workflow.
 
 ## Implementation slices (all in v1, in order)
 
-1. **Toggle + unified Alternate time + in-window free tier.** Flexibility
+1. ✅ **Toggle + unified Alternate time + in-window free tier.** Flexibility
    column/UI; alt grading moves to the scenario job; candidates within the
    existing enrichment window surface confirmed-for-free. No new data layer —
    validates the job wiring, polling, UX, and ranking margin cheaply.
-2. **ECMWF daylight extension + Same-day scan.** The decode benchmark (above)
+2. ✅ **ECMWF daylight extension + Same-day scan.** The decode benchmark (above)
    gates this slice. Ephemeral enrichment, coverage metadata, honesty ladder.
-3. **On-tap confirm** (ICON+GFS across the shifted window, async, cached).
-4. **Previous/Next day** (extra OM fetch, past-day clamp, horizon edge UX).
+3. ✅ **On-tap confirm** (ICON+GFS across the shifted window, async, cached).
+4. ✅ **Previous/Next day** (extra OM fetch, past-day clamp, horizon edge UX).
+   As-built: prev/next-day already ride the slice-2 ECMWF-only tier where the
+   GRIB horizon reaches; slice 4 adds (a) `extend_openmeteo_adjacent_day` — an
+   ephemeral OM base re-fetch spliced in at **confirm** time so the multi-model
+   check isn't OM-clamped across the day boundary (`tasks/time_scan.py`); (b) a
+   forward-planning **past-day clamp** (`_clamp_past_grid`, gated on `dep >
+   now` so eval/replay packs are untouched) surfaced as
+   `TimeScanWindow.past_clipped`; (c) web copy for the past/horizon window
+   edges. The scan itself needs no OM (its provisional tier is ECMWF-only).
 
 ## Out of scope (v1)
 

--- a/src/weatherbrief/analysis/advisories/airport_wind.py
+++ b/src/weatherbrief/analysis/advisories/airport_wind.py
@@ -81,6 +81,7 @@ class AirportWindEvaluator:
                 "component. Thresholds are configurable for both crosswind and gusts."
             ),
             category="airport",
+            timing_class="cheap",
             parameters=[
                 AdvisoryParameterDef(
                     key="crosswind_green_kt",

--- a/src/weatherbrief/analysis/advisories/cloud_top.py
+++ b/src/weatherbrief/analysis/advisories/cloud_top.py
@@ -33,6 +33,7 @@ class CloudTopEvaluator:
                 "the pilot cannot get on top if needed."
             ),
             category="cloud",
+            timing_class="scan",
             altitude_dependent=True,
             parameters=[
                 AdvisoryParameterDef(

--- a/src/weatherbrief/analysis/advisories/convective.py
+++ b/src/weatherbrief/analysis/advisories/convective.py
@@ -63,6 +63,7 @@ class ConvectiveEvaluator:
                 "High/Extreme risk at any point triggers RED."
             ),
             category="convective",
+            timing_class="scan",
             altitude_dependent=True,
             parameters=[
                 AdvisoryParameterDef(

--- a/src/weatherbrief/analysis/advisories/convective_character.py
+++ b/src/weatherbrief/analysis/advisories/convective_character.py
@@ -240,6 +240,7 @@ class ConvectiveCharacterEvaluator:
                 "(severity) advisory — a big cell still grades RED there regardless."
             ),
             category="convective",
+            timing_class="scan",
             altitude_dependent=True,
             parameters=[
                 AdvisoryParameterDef(

--- a/src/weatherbrief/analysis/advisories/density_altitude.py
+++ b/src/weatherbrief/analysis/advisories/density_altitude.py
@@ -94,6 +94,7 @@ class DensityAltitudeEvaluator:
                 "terrain data."
             ),
             category="airport",
+            timing_class="cheap",
             parameters=[
                 AdvisoryParameterDef(
                     key="da_amber_ft",

--- a/src/weatherbrief/analysis/advisories/fiki_icing.py
+++ b/src/weatherbrief/analysis/advisories/fiki_icing.py
@@ -77,6 +77,7 @@ class FIKIIcingEvaluator:
                 "cruise in icing are concerning."
             ),
             category="icing",
+            timing_class="scan",
             default_enabled=False,  # opt-in for FIKI operators
             altitude_dependent=True,
             parameters=[

--- a/src/weatherbrief/analysis/advisories/flight_category.py
+++ b/src/weatherbrief/analysis/advisories/flight_category.py
@@ -120,6 +120,8 @@ class FlightCategoryEvaluator:
                 "fraction of the route it covers."
             ),
             category="airport",
+            timing_class="cheap",
+            timing_hint=True,
             parameters=[
                 AdvisoryParameterDef(
                     key="amber_ceiling_ft",

--- a/src/weatherbrief/analysis/advisories/freezing_precip.py
+++ b/src/weatherbrief/analysis/advisories/freezing_precip.py
@@ -63,6 +63,7 @@ class FreezingPrecipEvaluator:
                 "precipitation data."
             ),
             category="icing",
+            timing_class="scan",
             parameters=[
                 AdvisoryParameterDef(
                     key="primed_pct_amber",

--- a/src/weatherbrief/analysis/advisories/icing_escape.py
+++ b/src/weatherbrief/analysis/advisories/icing_escape.py
@@ -162,6 +162,7 @@ class IcingEscapeEvaluator:
                 "icing coverage along the route."
             ),
             category="icing",
+            timing_class="scan",
             altitude_dependent=True,
             parameters=[
                 AdvisoryParameterDef(

--- a/src/weatherbrief/analysis/advisories/ifr_feasibility.py
+++ b/src/weatherbrief/analysis/advisories/ifr_feasibility.py
@@ -176,6 +176,7 @@ class IFRFeasibilityEvaluator:
                 "triggers RED."
             ),
             category="flight_rules",
+            timing_class="scan",
             altitude_dependent=True,
             parameters=[
                 AdvisoryParameterDef(

--- a/src/weatherbrief/analysis/advisories/llws.py
+++ b/src/weatherbrief/analysis/advisories/llws.py
@@ -86,6 +86,7 @@ class LLWSEvaluator:
                 "or different timing (morning mixing erodes a nocturnal jet)."
             ),
             category="airport",
+            timing_class="cheap",
             parameters=[
                 AdvisoryParameterDef(
                     key="shear_amber_kt",

--- a/src/weatherbrief/analysis/advisories/registry.py
+++ b/src/weatherbrief/analysis/advisories/registry.py
@@ -34,6 +34,30 @@ def get_altitude_dependent_ids() -> set[str]:
     return {aid for aid, cls in _EVALUATORS.items() if cls.catalog_entry().altitude_dependent}
 
 
+def get_scan_class_ids() -> set[str]:
+    """IDs of ``timing_class="scan"`` evaluators — the timing-scan ranking set.
+
+    These are the timing-sensitive, GRIB-dependent hazards; the scan's
+    improvement margin is summed over this set (while every candidate is still
+    graded on the *full* advisory set).
+    """
+    _ensure_loaded()
+    return {aid for aid, cls in _EVALUATORS.items() if cls.catalog_entry().timing_class == "scan"}
+
+
+def get_timing_hint_ids() -> set[str]:
+    """IDs whose RED/AMBER triggers the Flexibility hint on unscanned flights.
+
+    The scan-class set plus explicitly ``timing_hint=True`` entries (e.g.
+    ``flight_category`` — OM/TAF-graded, so never scan-class, but airport
+    fog/ceiling burn-off is a classic timing case worth hinting on).
+    """
+    _ensure_loaded()
+    return get_scan_class_ids() | {
+        aid for aid, cls in _EVALUATORS.items() if cls.catalog_entry().timing_hint
+    }
+
+
 def resolve_enabled_ids(enabled_map: dict[str, bool] | None) -> set[str] | None:
     """Resolve a saved per-profile advisory enable map into the set to evaluate.
 

--- a/src/weatherbrief/analysis/advisories/registry.py
+++ b/src/weatherbrief/analysis/advisories/registry.py
@@ -48,6 +48,10 @@ def get_scan_class_ids() -> set[str]:
 def get_timing_hint_ids() -> set[str]:
     """IDs whose RED/AMBER triggers the Flexibility hint on unscanned flights.
 
+    TODO(timing-scenario-plan.md, decision A): not yet consumed — the soft
+    "set Flexibility to scan for a better window" lightbulb on
+    Flexibility=None flights is a planned follow-up; this is its trigger set.
+
     The scan-class set plus explicitly ``timing_hint=True`` entries (e.g.
     ``flight_category`` — OM/TAF-graded, so never scan-class, but airport
     fog/ceiling burn-off is a classic timing case worth hinting on).

--- a/src/weatherbrief/analysis/advisories/sun.py
+++ b/src/weatherbrief/analysis/advisories/sun.py
@@ -70,6 +70,7 @@ class SunEvaluator:
                 "dusk AMBER via warn_near_sunset; glare AMBER always applies."
             ),
             category="sun",
+            timing_class="cheap",
             default_enabled=True,
             altitude_dependent=False,
             parameters=[

--- a/src/weatherbrief/analysis/advisories/vfr_feasibility.py
+++ b/src/weatherbrief/analysis/advisories/vfr_feasibility.py
@@ -530,6 +530,7 @@ class VFRFeasibilityEvaluator:
                 "AMBER flags marginal conditions or a BKN deck in a corridor."
             ),
             category="flight_rules",
+            timing_class="scan",
             altitude_dependent=True,
             parameters=[
                 AdvisoryParameterDef(

--- a/src/weatherbrief/analysis/advisories/vmc_cruise.py
+++ b/src/weatherbrief/analysis/advisories/vmc_cruise.py
@@ -31,6 +31,7 @@ class VMCCruiseEvaluator:
                 "BKN or OVC coverage at cruise means IMC conditions."
             ),
             category="cloud",
+            timing_class="scan",
             altitude_dependent=True,
             parameters=[
                 AdvisoryParameterDef(

--- a/src/weatherbrief/api/flights.py
+++ b/src/weatherbrief/api/flights.py
@@ -67,6 +67,10 @@ class CreateFlightRequest(BaseModel):
     flight_duration_hours: float | None = None
     profile_id: int | None = None  # flight profile to associate
     aircraft_id: int | None = None  # user aircraft to associate
+    # Timing-scenario Flexibility mode. "alternate" needs alt_departure_time,
+    # which is set via PATCH after creation (mirrors the existing alt flow), so
+    # it is rejected here; the web form creates then patches.
+    flexibility: Literal["none", "same_day", "prev_day", "next_day"] = "none"
 
     @field_validator("departure_time")
     @classmethod
@@ -143,6 +147,9 @@ class FlightResponse(BaseModel):
     waypoints: list[str] = []
     departure_time: str
     alt_departure_time: str | None = None
+    # Timing-scenario Flexibility mode (timing-scenario-plan.md): what the
+    # scenario job grades for this flight. "alternate" uses alt_departure_time.
+    flexibility: Literal["none", "alternate", "same_day", "prev_day", "next_day"] = "none"
     target_date: str  # backward compat (computed from departure_time)
     target_time_utc: int  # backward compat (computed from departure_time)
     cruise_altitude_ft: int
@@ -403,6 +410,7 @@ def _flight_to_response(
         waypoints=flight.waypoints,
         departure_time=flight.departure_time.isoformat(),
         alt_departure_time=flight.alt_departure_time.isoformat() if flight.alt_departure_time else None,
+        flexibility=flight.flexibility,
         target_date=flight.target_date,
         target_time_utc=flight.target_time_utc,
         cruise_altitude_ft=flight.cruise_altitude_ft,
@@ -720,6 +728,7 @@ def create_flight(
         flight_duration_hours=flight_duration_hours,
         raw_route=raw_route,
         parser_version=parser_version,
+        flexibility=req.flexibility,
         created_at=datetime.now(tz=timezone.utc),
     )
 
@@ -1615,6 +1624,9 @@ class UpdateFlightRequest(BaseModel):
     aircraft_id: int | None = None  # switch aircraft (applies speed/ceiling defaults)
     departure_time: str | None = None  # ISO 8601 (time-of-day change only; date must match)
     alt_departure_time: str | None = None  # ISO 8601 or "" to clear
+    # Timing-scenario Flexibility mode; None = no change. "alternate" grades
+    # alt_departure_time; day modes run the departure-window scan.
+    flexibility: Literal["none", "alternate", "same_day", "prev_day", "next_day"] | None = None
     cruise_altitude_ft: int | None = None
     flight_ceiling_ft: int | None = None
     flight_duration_hours: float | None = None
@@ -1818,6 +1830,16 @@ def update_flight(
                     detail="Alt departure time must differ from the primary departure time.",
                 )
             row.alt_departure_time = alt_dt
+
+    if req.flexibility is not None:
+        if req.flexibility == "alternate" and row.alt_departure_time is None and (
+            req.alt_departure_time in (None, "")
+        ):
+            raise HTTPException(
+                status_code=422,
+                detail="Flexibility 'alternate' requires an alt departure time.",
+            )
+        row.flexibility = req.flexibility
 
     db.flush()
     updated = load_flight(db, flight_id)

--- a/src/weatherbrief/api/flights.py
+++ b/src/weatherbrief/api/flights.py
@@ -1832,9 +1832,8 @@ def update_flight(
             row.alt_departure_time = alt_dt
 
     if req.flexibility is not None:
-        if req.flexibility == "alternate" and row.alt_departure_time is None and (
-            req.alt_departure_time in (None, "")
-        ):
+        # row.alt_departure_time already reflects this request (applied above).
+        if req.flexibility == "alternate" and row.alt_departure_time is None:
             raise HTTPException(
                 status_code=422,
                 detail="Flexibility 'alternate' requires an alt departure time.",

--- a/src/weatherbrief/api/packs.py
+++ b/src/weatherbrief/api/packs.py
@@ -1101,8 +1101,12 @@ def _prepare_refresh(flight, db_path, user_id, flight_id, db=None, *, is_privile
     )
     if as_of_time:
         options.as_of_time = as_of_time
-    if flight.alt_departure_time:
-        options.alt_departure_time = flight.alt_departure_time
+    # NOTE: options.alt_departure_time is deliberately NOT set anymore — the
+    # synchronous in-pipeline alt stage is retired. Alternate-time grading now
+    # runs in the timing-scenario background job (``tasks/time_scan_runner``,
+    # queued by ``_persist_pack_finalize``), gated on Flight.flexibility, and
+    # still writes route_advisories_alt.json + the pack-row alt fields. The
+    # BriefingOptions field stays for direct pipeline callers (tests/debug).
     if icing_method:
         options.icing_method = icing_method
     if cloud_method:
@@ -1504,6 +1508,17 @@ def _persist_pack_finalize(
             db, user_id, flight_id, result.usage, result_size_bytes=pack_size,
         )
         _charge_briefing_cost(db, user_id, result.usage, pack_size, usage_row_id)
+
+    # Timing-scenario scan (Flexibility): queued AFTER the briefing is fully
+    # persisted so it never delays or fails a refresh. All three refresh paths
+    # (streaming, sync, scheduler) converge here — one wire. The runner itself
+    # skips (with a terminal "skipped" status) when flexibility is "none".
+    try:
+        from weatherbrief.tasks.time_scan_runner import schedule_time_scan
+
+        schedule_time_scan(flight_id, Path(pack_path), fetch_ts)
+    except Exception:
+        logger.warning("time-scan: post-refresh scheduling failed", exc_info=True)
 
     logger.info("Briefing refreshed for %s: %s", flight_id, fetch_ts)
     return meta
@@ -2522,6 +2537,52 @@ def get_alt_advisories(
     return FileResponse(adv_path, media_type="application/json")
 
 
+@router.get("/{timestamp}/time-options")
+def get_time_options(
+    flight_id: str,
+    timestamp: str,
+    request: Request,
+    user_id: str = Depends(current_user_id),
+    db: Session = Depends(get_db),
+):
+    """Timing-scenario scan for a pack — status + result, poll-friendly.
+
+    Response shape: ``{"status": <TimeScanStatus fields>, "scan": <TimeWindowScan|null>}``.
+    The client polls after ``briefing_ready`` (the refresh SSE stream closes
+    before the background scan finishes, so there is no push channel) and stops
+    on a terminal status (``done`` / ``failed`` / ``skipped``).
+
+    Lazy-schedules the scan when the flight has Flexibility set but this pack
+    has no status yet — covers "pilot enabled Flexibility after the briefing
+    ran" without a re-refresh.
+    """
+    from weatherbrief.tasks.artifacts import load_time_options, load_time_scan_status
+    from weatherbrief.tasks.time_scan_runner import schedule_time_scan
+
+    flight = _load_flight_or_404(db, flight_id, viewer_id=user_id)
+    pack_dir = _get_pack_dir(db, flight_id, timestamp, viewer_id=user_id)
+
+    status = load_time_scan_status(pack_dir)
+    scan = load_time_options(pack_dir)
+
+    if status is None and scan is None:
+        if flight.flexibility != "none":
+            try:
+                fetch_ts = datetime.fromisoformat(timestamp)
+            except ValueError:
+                raise HTTPException(status_code=422, detail="Invalid pack timestamp")
+            db_path = getattr(request.app.state, "db_path", "")
+            schedule_time_scan(flight_id, pack_dir, fetch_ts, db_path=db_path)
+            status = load_time_scan_status(pack_dir)
+        else:
+            raise HTTPException(status_code=404, detail="Timing options not available")
+
+    return {
+        "status": status.model_dump(mode="json") if status else None,
+        "scan": scan.model_dump(mode="json") if scan else None,
+    }
+
+
 @router.post("/{timestamp}/advisories/alt/compute")
 def compute_alt_advisories(
     flight_id: str,
@@ -2664,7 +2725,7 @@ def _recompute_airport_conditions(
     return None
 
 
-def _load_advisory_profile(db, flight, user_id, request, pack_dir):
+def _load_advisory_profile(db, flight, user_id, request, pack_dir, *, db_path: str = ""):
     """Load advisory profile settings and build a recompute-conditions callback.
 
     Shared by recalculate_advisories and altitude_table endpoints.
@@ -2676,6 +2737,9 @@ def _load_advisory_profile(db, flight, user_id, request, pack_dir):
     no advisory customization). It is threaded through to the front advisory so
     an explicit ``fronts: false`` opt-out is honored independently of the
     ``auto_front_detection`` master (issue #196, model B).
+
+    ``request`` may be ``None`` for non-request callers (the timing-scan
+    background runner) — pass ``db_path`` explicitly then.
     """
     from weatherbrief.analysis.advisories import resolve_enabled_ids
     from weatherbrief.api.preferences import load_user_locale
@@ -2697,7 +2761,8 @@ def _load_advisory_profile(db, flight, user_id, request, pack_dir):
     cloud_method = profile_settings.get("cloud_method")
     convective_method = profile_settings.get("convective_method")
     auto_front_detection = bool(profile_settings.get("auto_front_detection", False))
-    db_path = getattr(request.app.state, "db_path", "")
+    if request is not None:
+        db_path = getattr(request.app.state, "db_path", "") or db_path
     locale = load_user_locale(db, user_id)
 
     def recompute_conds(rp_analyses, cross_sections, advisory_model_names):

--- a/src/weatherbrief/api/packs.py
+++ b/src/weatherbrief/api/packs.py
@@ -2564,20 +2564,28 @@ def get_time_options(
     from weatherbrief.tasks.artifacts import load_time_options, load_time_scan_status
     from weatherbrief.tasks.time_scan_runner import (
         reconcile_stale_confirms,
+        reconcile_stale_scan,
         schedule_time_scan,
     )
 
     flight = _load_flight_or_404(db, flight_id, viewer_id=user_id)
     pack_dir = _get_pack_dir(db, flight_id, timestamp, viewer_id=user_id)
 
-    # A restart mid-confirm orphans confirm_pending flags — clear them here
-    # so pollers don't see an eternal "checking all models…".
+    # A restart mid-scan / mid-confirm orphans "running" statuses and
+    # confirm_pending flags — clear them here so pollers don't see an eternal
+    # "Scenarios running…" / "checking all models…".
+    scan_was_stale = reconcile_stale_scan(pack_dir)
     reconcile_stale_confirms(pack_dir)
     status = load_time_scan_status(pack_dir)
     scan = load_time_options(pack_dir)
 
-    if status is None and scan is None:
-        if flight.flexibility != "none":
+    # Lazy/recovery scheduling is OWNER-only — scans are accounted against the
+    # owner's usage, and every other scan-triggering endpoint (rescan, confirm)
+    # is owner-gated; a shared-flight viewer must not spend the owner's quota.
+    is_owner = flight.user_id == user_id
+    never_scanned = status is None and scan is None
+    if never_scanned or scan_was_stale:
+        if is_owner and flight.flexibility != "none":
             try:
                 fetch_ts = datetime.fromisoformat(timestamp)
             except ValueError:
@@ -2585,7 +2593,7 @@ def get_time_options(
             db_path = getattr(request.app.state, "db_path", "")
             schedule_time_scan(flight_id, pack_dir, fetch_ts, db_path=db_path)
             status = load_time_scan_status(pack_dir)
-        else:
+        elif never_scanned:
             raise HTTPException(status_code=404, detail="Timing options not available")
 
     return {

--- a/src/weatherbrief/api/packs.py
+++ b/src/weatherbrief/api/packs.py
@@ -1513,6 +1513,11 @@ def _persist_pack_finalize(
     # persisted so it never delays or fails a refresh. All three refresh paths
     # (streaming, sync, scheduler) converge here — one wire. The runner itself
     # skips (with a terminal "skipped" status) when flexibility is "none".
+    # Known-benign race: the caller commits `db` just after we return, while
+    # the job (own session) needs the pack row only at its END — seconds of
+    # grading vs microseconds to commit. If the row were ever missed, the
+    # job's pack_row-is-None guard skips the alt-field update and the web
+    # poll's loadAltAdvisories path still surfaces the artifact.
     try:
         from weatherbrief.tasks.time_scan_runner import schedule_time_scan
 
@@ -2587,6 +2592,36 @@ def get_time_options(
         "status": status.model_dump(mode="json") if status else None,
         "scan": scan.model_dump(mode="json") if scan else None,
     }
+
+
+@router.post("/{timestamp}/time-options/rescan", status_code=202)
+def rescan_time_options(
+    flight_id: str,
+    timestamp: str,
+    request: Request,
+    user_id: str = Depends(current_user_id),
+    db: Session = Depends(get_db),
+):
+    """Re-queue the timing scan for a pack (owner only).
+
+    Used by the "Set as alternate time" flow after a flight PATCH: the changed
+    alternate must be re-graded and ``route_advisories_alt.json`` re-persisted.
+    Cheap when nothing changed — the runner's decision-H reuse check skips the
+    decode for a scan that is still valid.
+    """
+    from weatherbrief.tasks.time_scan_runner import schedule_time_scan
+
+    flight = _load_owned_flight(db, flight_id, user_id)
+    pack_dir = _get_pack_dir(db, flight_id, timestamp, viewer_id=user_id)
+    if flight.flexibility == "none":
+        raise HTTPException(status_code=409, detail="Flight has Flexibility 'none'")
+    try:
+        fetch_ts = datetime.fromisoformat(timestamp)
+    except ValueError:
+        raise HTTPException(status_code=422, detail="Invalid pack timestamp")
+    db_path = getattr(request.app.state, "db_path", "")
+    schedule_time_scan(flight_id, pack_dir, fetch_ts, db_path=db_path)
+    return {"status": "queued"}
 
 
 class TimeConfirmRequest(BaseModel):

--- a/src/weatherbrief/api/packs.py
+++ b/src/weatherbrief/api/packs.py
@@ -2557,11 +2557,17 @@ def get_time_options(
     ran" without a re-refresh.
     """
     from weatherbrief.tasks.artifacts import load_time_options, load_time_scan_status
-    from weatherbrief.tasks.time_scan_runner import schedule_time_scan
+    from weatherbrief.tasks.time_scan_runner import (
+        reconcile_stale_confirms,
+        schedule_time_scan,
+    )
 
     flight = _load_flight_or_404(db, flight_id, viewer_id=user_id)
     pack_dir = _get_pack_dir(db, flight_id, timestamp, viewer_id=user_id)
 
+    # A restart mid-confirm orphans confirm_pending flags — clear them here
+    # so pollers don't see an eternal "checking all models…".
+    reconcile_stale_confirms(pack_dir)
     status = load_time_scan_status(pack_dir)
     scan = load_time_options(pack_dir)
 
@@ -2581,6 +2587,56 @@ def get_time_options(
         "status": status.model_dump(mode="json") if status else None,
         "scan": scan.model_dump(mode="json") if scan else None,
     }
+
+
+class TimeConfirmRequest(BaseModel):
+    """Body for the on-tap multi-model confirm — identifies the candidate."""
+
+    departure_time: str  # ISO-8601 of the candidate departure to confirm
+
+
+@router.post("/{timestamp}/time-options/confirm", status_code=202)
+def confirm_time_option(
+    flight_id: str,
+    timestamp: str,
+    body: TimeConfirmRequest,
+    request: Request,
+    user_id: str = Depends(current_user_id),
+    db: Session = Depends(get_db),
+):
+    """Queue the multi-model check of one provisional candidate.
+
+    The deferred cost the plan gates on demonstrated user intent: fetches
+    GFS+ICON for the candidate's shifted flight window (roughly one
+    briefing-equivalent, tens of seconds to minutes), so it runs on the
+    background queue — 202 immediately, the client keeps polling
+    ``GET .../time-options`` until the candidate carries ``confirmed``.
+    """
+    from weatherbrief.tasks.time_scan_runner import schedule_time_confirm
+
+    flight = _load_owned_flight(db, flight_id, user_id)
+    pack_dir = _get_pack_dir(db, flight_id, timestamp, viewer_id=user_id)
+
+    try:
+        cand_time = datetime.fromisoformat(body.departure_time)
+    except ValueError:
+        raise HTTPException(status_code=422, detail="departure_time must be ISO-8601")
+
+    db_path = getattr(request.app.state, "db_path", "")
+    outcome = schedule_time_confirm(flight.id, pack_dir, cand_time, db_path=db_path)
+    if outcome == "busy":
+        # One confirm at a time per pack — each costs a briefing-equivalent
+        # of GFS+ICON fetch; don't let a tap-happy user stack them.
+        raise HTTPException(
+            status_code=429,
+            detail="A model check is already running for this briefing — wait for it to finish",
+        )
+    if outcome == "invalid":
+        raise HTTPException(
+            status_code=409,
+            detail="No such candidate, or it is already confirmed",
+        )
+    return {"status": "queued"}
 
 
 @router.post("/{timestamp}/advisories/alt/compute")

--- a/src/weatherbrief/db/models.py
+++ b/src/weatherbrief/db/models.py
@@ -111,6 +111,10 @@ class FlightRow(Base):
     alt_departure_time: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True), nullable=True, default=None
     )
+    # Timing-scenario flexibility mode (timing-scenario-plan.md):
+    # none | alternate | same_day | prev_day | next_day. "alternate" grades the
+    # single alt_departure_time; the day modes run the departure-window scan.
+    flexibility: Mapped[str] = mapped_column(String(16), default="none")
     last_auto_refresh_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True), nullable=True
     )

--- a/src/weatherbrief/fetch/grib/__init__.py
+++ b/src/weatherbrief/fetch/grib/__init__.py
@@ -751,6 +751,13 @@ def _decode_timeout_s() -> float:
         return _DECODE_TIMEOUT_DEFAULT_S
 
 
+# ECMWF enrichment decodes steps within the flight window ± this margin (see
+# the step filter in ``_enrich_ecmwf_inner``). Module-level so the timing-scan
+# coverage detector (``tasks/time_scan.py``) reads the SAME value instead of
+# mirroring a magic number that could drift.
+ECMWF_FLIGHT_WINDOW_MARGIN = timedelta(hours=3)
+
+
 # ---------------------------------------------------------------------------
 # Priority signal + dispatcher configuration (issue #171).
 # ---------------------------------------------------------------------------
@@ -2068,7 +2075,7 @@ def _enrich_ecmwf_inner(
 
     # Filter steps to the flight window (with margin) up-front so we can
     # fan out all decodes in parallel before merging.
-    margin = timedelta(hours=3)
+    margin = ECMWF_FLIGHT_WINDOW_MARGIN
     window_steps: list[tuple[int, dict[str, Path], datetime]] = []
     for step_hours, parts in sorted(files_by_step.items()):
         valid_time = latest_bt + timedelta(hours=step_hours)

--- a/src/weatherbrief/models/__init__.py
+++ b/src/weatherbrief/models/__init__.py
@@ -97,6 +97,16 @@ from weatherbrief.models.advisories import (  # noqa: F401
     RouteAdvisoriesManifest,
     RouteAdvisoryResult,
 )
+from weatherbrief.models.time_scan import (  # noqa: F401
+    FlexibilityMode,
+    ModelCoverage,
+    TimeCandidate,
+    TimeConfirmation,
+    TimeScanBaseline,
+    TimeScanStatus,
+    TimeScanWindow,
+    TimeWindowScan,
+)
 from weatherbrief.models.fronts import (  # noqa: F401
     FrontChainModel,
     FrontChainNodeModel,

--- a/src/weatherbrief/models/advisories.py
+++ b/src/weatherbrief/models/advisories.py
@@ -7,6 +7,7 @@ deterministic GREEN/AMBER/RED assessments per advisory per model.
 from __future__ import annotations
 
 from enum import Enum
+from typing import Literal
 
 from pydantic import BaseModel, Field
 
@@ -151,6 +152,19 @@ class AdvisoryCatalogEntry(BaseModel):
     category: str  # e.g. "icing", "cloud", "turbulence", "convective", "model"
     default_enabled: bool = True
     altitude_dependent: bool = False
+    # Timing-scenario participation (timing-scenario-plan.md). Declarative
+    # sibling of ``altitude_dependent`` — the scan asks the registry, so a new
+    # evaluator auto-participates. The unifying principle: scan-worthy ⟺
+    # GRIB-dependent ⟺ OM-insufficient.
+    #   "scan"  — timing-sensitive and GRIB-dependent; ranks the scan margin
+    #   "cheap" — timing-sensitive but OM-sufficient; never drives the scan
+    #   "none"  — timing is not the lever (default)
+    timing_class: Literal["scan", "cheap", "none"] = "none"
+    # Participates in the "set Flexibility to scan for a better window" hint on
+    # flights with Flexibility=None even when not scan-class (e.g. airport
+    # fog/ceiling burn-off is OM/TAF-graded but a classic timing case). The
+    # hint set is scan-class ∪ {timing_hint=True}.
+    timing_hint: bool = False
     parameters: list[AdvisoryParameterDef] = Field(default_factory=list)
 
 

--- a/src/weatherbrief/models/storage.py
+++ b/src/weatherbrief/models/storage.py
@@ -43,7 +43,14 @@ class Flight(BaseModel):
     flight_ceiling_ft: int = 18000
     flight_duration_hours: float = 0.0
     private: bool = False
-    alt_departure_time: datetime | None = None  # optional same-day alt departure
+    alt_departure_time: datetime | None = None  # the "Alternate time" flexibility value
+    # Timing-scenario flexibility (timing-scenario-plan.md): how much departure
+    # flexibility the pilot has, and therefore what the scenario job grades.
+    #   none      — no scenario work (local yes/no flights)
+    #   alternate — grade the one alt_departure_time as a pinned candidate
+    #   same_day  — scan the daylight window of the target date
+    #   prev_day / next_day — scan the adjacent day as well (needs extra OM fetch)
+    flexibility: Literal["none", "alternate", "same_day", "prev_day", "next_day"] = "none"
     auto_refresh: bool = False
     auto_refresh_hour: int | None = None
     last_auto_refresh_at: datetime | None = None

--- a/src/weatherbrief/models/time_scan.py
+++ b/src/weatherbrief/models/time_scan.py
@@ -79,12 +79,19 @@ class TimeCandidate(BaseModel):
 class TimeScanBaseline(BaseModel):
     """The planned departure graded through the same path as the candidates —
     the diff denominator (never compared against the multi-model headline of a
-    different model set)."""
+    different model set).
+
+    ``ecmwf_assessment`` is the ECMWF-only view of the planned time — the diff
+    denominator for ``ecmwf_only`` provisional candidates (slice 2), so their
+    improves/worsens compare like with like. None when no daylight extension
+    ran (pure in-window scan)."""
 
     departure_time: datetime
     assessment: str
     assessment_reason: str = ""
     models_used: list[str] = Field(default_factory=list)
+    ecmwf_assessment: str | None = None
+    ecmwf_assessment_reason: str | None = None
 
 
 class ModelCoverage(BaseModel):

--- a/src/weatherbrief/models/time_scan.py
+++ b/src/weatherbrief/models/time_scan.py
@@ -1,0 +1,157 @@
+"""Timing-scenario models — the Flexibility scan artifact (`time_options.json`).
+
+Implements the artifact side of ``designs/plans/timing-scenario-plan.md``: a
+per-pack record of candidate departure times graded against the planned time.
+Posture is inherited from the mitigation framework — an **attention-director,
+never a verdict**: candidates carry explicit model-coverage labels
+(``confidence``) and the scan never auto-switches the plan.
+
+Confidence ladder (the honesty ladder from the plan):
+
+* ``confirmed_in_window`` — the candidate's whole flight fits inside every
+  fetched model's enriched window, so the multi-model grade is as trustworthy
+  as the briefing itself. Free (pure re-analysis of pack data).
+* ``ecmwf_only`` — graded on daylight-extended ECMWF only (slice 2); other
+  models not yet checked. Provisional by construction.
+* ``confirmed`` — a user-tapped multi-model confirm (slice 3) upgraded (or
+  downgraded — a designed outcome, not an error) the provisional grade.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+#: Flexibility modes (mirrors ``Flight.flexibility``).
+FlexibilityMode = Literal["none", "alternate", "same_day", "prev_day", "next_day"]
+
+#: Candidate model-coverage labels — see module docstring.
+TimeConfidence = Literal["confirmed_in_window", "ecmwf_only", "confirmed"]
+
+
+class TimeConfirmation(BaseModel):
+    """Result of a multi-model check of one candidate (slice 3 on-tap confirm,
+    or filled at scan time when the candidate is in-window)."""
+
+    models_checked: list[str]
+    assessment: str  # GREEN / AMBER / RED
+    assessment_reason: str = ""
+    better_than_baseline: bool
+    improves: list[str] = Field(default_factory=list)
+    worsens: list[str] = Field(default_factory=list)
+    confirmed_at: datetime
+
+
+class TimeCandidate(BaseModel):
+    """One graded departure time.
+
+    ``departure_shift_hours`` is the essential coordinate — shifting departure
+    moves *every* route point's ETA (``analyze_all_route_points`` re-derives
+    per-point valid-times), so a candidate is a shifted flight, not a single
+    valid-time. ``valid_times`` records the per-point ETAs the grade actually
+    read — the honesty-audit trail for the coverage check.
+    """
+
+    departure_time: datetime
+    departure_shift_hours: float
+    valid_times: list[datetime] = Field(default_factory=list)
+
+    assessment: str  # GREEN / AMBER / RED (per ``models_used``)
+    assessment_reason: str = ""
+    models_used: list[str] = Field(default_factory=list)
+
+    # Full-picture diff vs the baseline grade over the SAME model set — never
+    # a window that fixed icing but quietly introduced a crosswind.
+    improves: list[str] = Field(default_factory=list)
+    worsens: list[str] = Field(default_factory=list)
+    # Net severity drop summed over the scan-class advisory set (the ranking
+    # objective; decision D). Positive == better on the timing-sensitive axes.
+    margin: float = 0.0
+
+    confidence: TimeConfidence
+    is_baseline: bool = False   # the planned departure, graded identically
+    is_alternate: bool = False  # the pinned Alternate-time row (Flexibility)
+    confirmed: TimeConfirmation | None = None  # slice-3 on-tap result
+
+
+class TimeScanBaseline(BaseModel):
+    """The planned departure graded through the same path as the candidates —
+    the diff denominator (never compared against the multi-model headline of a
+    different model set)."""
+
+    departure_time: datetime
+    assessment: str
+    assessment_reason: str = ""
+    models_used: list[str] = Field(default_factory=list)
+
+
+class ModelCoverage(BaseModel):
+    """Honest gradable span for one model, derived from the saved pack.
+
+    ``start``/``end`` bound the per-point valid-times a candidate may use for
+    this model. Rule-window ∩ data-marker: the fetch window rule bounds the
+    trailing forward-fill smear (GFS CLW / cloud diagnostics forward-fill past
+    the last native anchor), while the data marker catches enrichment that
+    failed inside the rule window. ``uniform`` marks OM-only models whose
+    fidelity doesn't change across the fetched day (their icing/cloud inputs
+    are synthesized at the flight window too)."""
+
+    model: str
+    start: datetime | None = None
+    end: datetime | None = None
+    uniform: bool = False
+
+
+class TimeScanWindow(BaseModel):
+    """The searched departure window and what clipped it."""
+
+    start: datetime
+    end: datetime
+    flexibility: FlexibilityMode
+    daylight_clipped: bool = False
+    horizon_clipped: bool = False
+
+
+class TimeWindowScan(BaseModel):
+    """The `time_options.json` artifact — everything the scenario UI renders."""
+
+    schema_version: int = 1
+    flexibility: FlexibilityMode
+    baseline: TimeScanBaseline
+    window: TimeScanWindow | None = None  # None for pure "alternate" mode
+    candidates: list[TimeCandidate] = Field(default_factory=list)
+
+    # Departure times considered but refused because some model's enriched
+    # coverage didn't span their flight — the honesty guardrail made visible
+    # (audit trail; the UI may render "N hours not checkable yet").
+    refused_times: list[datetime] = Field(default_factory=list)
+
+    coverage: list[ModelCoverage] = Field(default_factory=list)
+    models: list[str] = Field(default_factory=list)  # fetched model set
+    # Staleness key (decision H): a refresh landing on the same ECMWF run may
+    # reuse this scan; a new run invalidates it. None when ECMWF absent.
+    ecmwf_run_ts: int | None = None
+    generated_at: datetime
+
+    def candidate_at(self, departure: datetime) -> TimeCandidate | None:
+        """Find the candidate for a departure time (minute tolerance)."""
+        for c in self.candidates:
+            if abs((c.departure_time - departure).total_seconds()) < 60:
+                return c
+        return None
+
+
+class TimeScanStatus(BaseModel):
+    """Small `time_scan_status.json` sidecar — what the polling endpoint
+    returns while (or instead of) the artifact.
+
+    ``skipped`` carries a machine reason (e.g. ``"flexibility_none"``,
+    ``"no_coverage"``) so the client can distinguish "nothing to show" from
+    "still looking"."""
+
+    status: Literal["pending", "running", "done", "failed", "skipped"]
+    flexibility: FlexibilityMode = "none"
+    reason: str = ""
+    updated_at: datetime

--- a/src/weatherbrief/models/time_scan.py
+++ b/src/weatherbrief/models/time_scan.py
@@ -74,6 +74,9 @@ class TimeCandidate(BaseModel):
     is_baseline: bool = False   # the planned departure, graded identically
     is_alternate: bool = False  # the pinned Alternate-time row (Flexibility)
     confirmed: TimeConfirmation | None = None  # slice-3 on-tap result
+    # True while an on-tap confirm is queued/running for this candidate —
+    # the polling client renders "checking all models…" off this flag.
+    confirm_pending: bool = False
 
 
 class TimeScanBaseline(BaseModel):

--- a/src/weatherbrief/models/time_scan.py
+++ b/src/weatherbrief/models/time_scan.py
@@ -126,6 +126,10 @@ class TimeScanWindow(BaseModel):
     flexibility: FlexibilityMode
     daylight_clipped: bool = False
     horizon_clipped: bool = False
+    # Previous-day mode where part (or all) of the daylight window has already
+    # elapsed — those hours can't be forecast, so they're dropped up front
+    # rather than refused. True when at least one grid hour was clamped away.
+    past_clipped: bool = False
 
 
 class TimeWindowScan(BaseModel):

--- a/src/weatherbrief/models/time_scan.py
+++ b/src/weatherbrief/models/time_scan.py
@@ -38,6 +38,10 @@ class TimeConfirmation(BaseModel):
     models_checked: list[str]
     assessment: str  # GREEN / AMBER / RED
     assessment_reason: str = ""
+    # Per-model RED/AMBER breakdown, same "id=STATUS, ..." format as
+    # assessment_reason ({"gfs": "airport_weather=RED", ...}); a model with
+    # nothing flagged is simply absent. Feeds the detail-table dot tooltips.
+    per_model_reasons: dict[str, str] = Field(default_factory=dict)
     better_than_baseline: bool
     improves: list[str] = Field(default_factory=list)
     worsens: list[str] = Field(default_factory=list)

--- a/src/weatherbrief/storage/flights.py
+++ b/src/weatherbrief/storage/flights.py
@@ -90,6 +90,7 @@ def _flight_to_row(flight: Flight, user_id: str) -> FlightRow:
         flight_ceiling_ft=flight.flight_ceiling_ft,
         flight_duration_hours=flight.flight_duration_hours,
         alt_departure_time=flight.alt_departure_time,
+        flexibility=flight.flexibility,
         private=flight.private,
         auto_refresh=flight.auto_refresh,
         auto_refresh_hour=flight.auto_refresh_hour,
@@ -114,6 +115,7 @@ def _row_to_flight(row: FlightRow) -> Flight:
         flight_ceiling_ft=row.flight_ceiling_ft,
         flight_duration_hours=row.flight_duration_hours,
         alt_departure_time=_ensure_utc(row.alt_departure_time) if row.alt_departure_time else None,
+        flexibility=row.flexibility or "none",
         private=row.private,
         auto_refresh=row.auto_refresh,
         auto_refresh_hour=row.auto_refresh_hour,
@@ -408,6 +410,7 @@ def save_flight(session: Session, flight: Flight, user_id: str) -> None:
         existing.flight_ceiling_ft = flight.flight_ceiling_ft
         existing.flight_duration_hours = flight.flight_duration_hours
         existing.alt_departure_time = flight.alt_departure_time
+        existing.flexibility = flight.flexibility
         existing.private = flight.private
         existing.auto_refresh = flight.auto_refresh
         existing.auto_refresh_hour = flight.auto_refresh_hour

--- a/src/weatherbrief/tasks/advise.py
+++ b/src/weatherbrief/tasks/advise.py
@@ -660,6 +660,25 @@ def derive_assessment_from_advisories(
     return (assessment, reason)
 
 
+def per_model_reasons_from_manifest(
+    manifest: RouteAdvisoriesManifest,
+) -> dict[str, str]:
+    """Per-model RED/AMBER reason strings from an advisories manifest.
+
+    Same ``"id=STATUS, ..."`` format as :func:`derive_assessment_from_advisories`
+    builds for the aggregate, split by contributing model. A model with nothing
+    flagged is absent from the result — callers treat absence as all-clear.
+    """
+    per_model: dict[str, list[str]] = {}
+    for adv in manifest.advisories:
+        for m in adv.per_model:
+            if m.status.value in ("red", "amber"):
+                per_model.setdefault(m.model, []).append(
+                    f"{adv.advisory_id}={m.status.value.upper()}"
+                )
+    return {model: ", ".join(parts) for model, parts in per_model.items()}
+
+
 # Cap on the number of named category chips surfaced on the flights-list card.
 # Mirrors the briefing-page glance summary's intent: a few "what to look at"
 # cues, not an exhaustive list.

--- a/src/weatherbrief/tasks/advise.py
+++ b/src/weatherbrief/tasks/advise.py
@@ -718,6 +718,9 @@ def run_alt_from_pack(
     convective_method: str | None = None,
     locale: str | None = None,
     cruise_speed_ias_kt: float | None = None,
+    cross_sections: list[RouteCrossSection] | None = None,
+    persist: bool = True,
+    detect_fronts: bool = True,
 ) -> AdvisoryResult:
     """Re-run analysis + advisories at an alt departure time using existing pack data.
 
@@ -725,6 +728,15 @@ def run_alt_from_pack(
     ``analyze_all_route_points`` with the alt departure time (which picks
     different hourly forecasts via ``at_time()``), then evaluates advisories.
     Saves the result as ``route_advisories_alt.json``.
+
+    The timing-scenario scan (``tasks/time_scan.py``) drives this in a
+    per-candidate loop, so three knobs let it reuse the machinery without side
+    effects: ``cross_sections`` skips the disk load and grades against the
+    given (possibly enrichment-extended) sections; ``persist=False`` skips
+    writing ``route_advisories_alt.json`` (candidates live in
+    ``time_options.json``); ``detect_fronts=False`` skips the alt front re-run
+    (``fronts`` is timing-``none`` and re-detecting per candidate would write
+    files in a tight loop).
     """
     from weatherbrief.tasks.analyze import analyze_all_route_points
     from weatherbrief.tasks.artifacts import (
@@ -734,7 +746,8 @@ def run_alt_from_pack(
         save_alt_advisory_artifacts,
     )
 
-    cross_sections = load_cross_sections(pack_dir)
+    if cross_sections is None:
+        cross_sections = load_cross_sections(pack_dir)
     route_points = load_route_points(pack_dir)
     elevation = load_elevation_profile(pack_dir)
 
@@ -784,7 +797,7 @@ def run_alt_from_pack(
         # scenario against stale fronts. Re-sampling the same snapshot at the alt
         # hours costs ~nothing. Gated on the primary artifact's presence (= the
         # ``auto_front_detection`` master was on at briefing time).
-        if pack_dir is not None and (pack_dir / "route_fronts.json").exists():
+        if detect_fronts and pack_dir is not None and (pack_dir / "route_fronts.json").exists():
             try:
                 from weatherbrief.tasks.fronts import run_fronts
 
@@ -830,7 +843,8 @@ def run_alt_from_pack(
             airport_conditions=airport_conds,
         )
 
-        save_alt_advisory_artifacts(pack_dir, manifest)
+        if persist:
+            save_alt_advisory_artifacts(pack_dir, manifest)
         logger.info("Alt advisory evaluation complete: %d advisories", len(advisory_results))
 
         return AdvisoryResult(manifest=manifest, airport_conditions=airport_conds)

--- a/src/weatherbrief/tasks/artifacts.py
+++ b/src/weatherbrief/tasks/artifacts.py
@@ -262,6 +262,49 @@ def load_cross_sections(pack_dir: Path) -> list[RouteCrossSection]:
     ]
 
 
+def save_time_options(pack_dir: Path, scan: "TimeWindowScan") -> None:
+    """Persist the timing-scenario scan as ``time_options.json`` (decision G:
+    this is the only artifact the scan writes — extended enrichment stays
+    ephemeral, published pack artifacts are never mutated)."""
+    pack_dir.mkdir(parents=True, exist_ok=True)
+    (pack_dir / "time_options.json").write_text(scan.model_dump_json(indent=2))
+
+
+def load_time_options(pack_dir: Path) -> "TimeWindowScan | None":
+    """Load the timing-scenario scan, returning *None* if absent/corrupt."""
+    from weatherbrief.models import TimeWindowScan
+
+    path = pack_dir / "time_options.json"
+    if not path.exists():
+        return None
+    try:
+        return TimeWindowScan.model_validate_json(path.read_text())
+    except Exception:
+        logger.warning("Failed to load time_options.json from %s", pack_dir, exc_info=True)
+        return None
+
+
+def save_time_scan_status(pack_dir: Path, status: "TimeScanStatus") -> None:
+    """Persist the small ``time_scan_status.json`` sidecar the polling
+    endpoint reads while the scan is pending/running."""
+    pack_dir.mkdir(parents=True, exist_ok=True)
+    (pack_dir / "time_scan_status.json").write_text(status.model_dump_json())
+
+
+def load_time_scan_status(pack_dir: Path) -> "TimeScanStatus | None":
+    """Load the scan status sidecar, returning *None* if absent/corrupt."""
+    from weatherbrief.models import TimeScanStatus
+
+    path = pack_dir / "time_scan_status.json"
+    if not path.exists():
+        return None
+    try:
+        return TimeScanStatus.model_validate_json(path.read_text())
+    except Exception:
+        logger.warning("Failed to load time_scan_status.json from %s", pack_dir, exc_info=True)
+        return None
+
+
 def load_elevation_profile(pack_dir: Path) -> ElevationProfile | None:
     """Load elevation profile, returning *None* if missing."""
     ep_path = pack_dir / "elevation_profile.json"

--- a/src/weatherbrief/tasks/time_scan.py
+++ b/src/weatherbrief/tasks/time_scan.py
@@ -1,0 +1,570 @@
+"""Timing-scenario scan — grade candidate departure times (Flexibility).
+
+Implements ``designs/plans/timing-scenario-plan.md``. The pilot opts in per
+flight via ``Flight.flexibility``; the scan grades other departure times and
+surfaces "a smoother departure may exist" — an **attention-director, never a
+verdict**. User intent is the compute gate: when a scan mode is set we scan
+even an all-green flight ("no better window found" is a useful answer).
+
+Slice 1 (this module today) — the **in-window free tier**: candidates whose
+whole (shifted) flight fits inside every fetched model's enriched coverage are
+graded **multi-model, for free** (pure re-analysis of saved pack data via
+``run_alt_from_pack``) and labelled ``confirmed_in_window``. Hours outside
+coverage are **refused, never clamp-graded** (the honesty invariant: a naive
+``at_time()`` re-grade past the enrichment window would silently return
+OM-clamped values labelled as the GRIB model). Slice 2 adds the daylight ECMWF
+enrichment extension (decode-only, ephemeral) that turns refused hours into
+``ecmwf_only`` provisional candidates; slice 3 adds the on-tap multi-model
+confirm; slice 4 adds the ±day OM fetch.
+
+Coverage is **rule-window ∩ data-marker** per model per route point:
+
+* the fetch-window *rule* (ECMWF ±3h margin; GFS/ICON forward flight window)
+  bounds the trailing smear — GFS CLW/ICMR overlays and cloud diagnostics
+  forward-fill past the last native anchor (``fetch/grib/fill.py``), so data
+  presence alone would over-claim evening hours;
+* the data *marker* (pressure-level count above the OM baseline for
+  ECMWF/ICON — the same anchor detector ``_interp_levels_hourly`` uses —
+  CLW/diagnostics presence for GFS) catches enrichment that failed inside the
+  rule window.
+
+OM-only models (MétéoFrance/UKMO/GEM) are ``uniform``: their fidelity doesn't
+change across the fetched day (icing/cloud inputs are synthesized at the
+flight window too), so any hour of the fetched day is as honest as the
+planned one.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+from time import perf_counter
+from typing import Callable
+
+from weatherbrief.models import (
+    AdvisoryAggregation,
+    ModelCoverage,
+    ModelSource,
+    RouteAdvisoriesManifest,
+    RouteConfig,
+    RouteCrossSection,
+    TimeCandidate,
+    TimeScanBaseline,
+    TimeScanWindow,
+    TimeWindowScan,
+)
+
+logger = logging.getLogger(__name__)
+
+# ECMWF enrichment margin around the flight window — mirrors ``margin`` in
+# ``fetch/grib/__init__.py`` (``_enrich_ecmwf_inner`` step filter). If that
+# constant changes, coverage here goes conservative/stale rather than wrong
+# (the data marker still bounds what we actually grade).
+_ECMWF_ENRICH_MARGIN = timedelta(hours=3)
+
+# Candidate grid cap per scan — a fleet of flights can't stampede the
+# analysis stage. Daylight rarely exceeds this at hourly cadence.
+_MAX_GRID = 24
+
+# Severity ranking for the improve/worsen diff.
+_SEV = {"green": 0, "amber": 1, "red": 2}
+
+# A candidate surfaces only if the net severity drop over the scan-class set
+# reaches this margin with no offsetting scan-class regression (decision D).
+_MIN_MARGIN = 1
+
+# Improving windows kept in the artifact (the UI caps display at ~3).
+_MAX_IMPROVING_KEPT = 5
+
+#: GRIB-enriched models — coverage is windowed; everything else is uniform OM.
+_GRIB_MODELS = {ModelSource.ECMWF, ModelSource.GFS, ModelSource.ICON}
+
+
+def _aware(dt: datetime) -> datetime:
+    return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+
+
+# ---------------------------------------------------------------------------
+# Enrichment coverage (the honesty guardrail's data source)
+# ---------------------------------------------------------------------------
+
+
+def _hour_time(h) -> datetime:
+    return _aware(h.time)
+
+
+def _gfs_marker(h) -> bool:
+    """GFS enrichment overlays CLW/ICMR onto OM levels and attaches cloud
+    diagnostics — the level *count* doesn't change, so presence is the marker."""
+    if h.nwp_cloud_diagnostics is not None:
+        return True
+    return any(
+        pl.cloud_liquid_water_kg_kg is not None or pl.ice_mixing_ratio_kg_kg is not None
+        for pl in h.pressure_levels
+    )
+
+
+def _rule_window(
+    model: ModelSource, departure: datetime, duration_hours: float,
+) -> tuple[datetime, datetime]:
+    """The span the fetch stage *intended* to enrich for this model.
+
+    ECMWF filters steps to flight window ±3h; GFS/ICON fetch forward hours
+    from ``floor(departure)`` through ``departure + ceil(duration) (+1 when
+    departure has minutes)`` (``compute_flight_window_hours`` /
+    ``compute_icon_eu_flight_window_hours``).
+    """
+    dep = _aware(departure)
+    dep_end = dep + timedelta(hours=max(duration_hours, 1.0))
+    if model == ModelSource.ECMWF:
+        return dep - _ECMWF_ENRICH_MARGIN, dep_end + _ECMWF_ENRICH_MARGIN
+    floor = dep.replace(minute=0, second=0, microsecond=0)
+    import math
+
+    extra = 1 if dep.minute > 0 else 0
+    hi = dep + timedelta(hours=max(1, math.ceil(max(duration_hours, 0.0)) + extra))
+    return floor, hi
+
+
+def compute_model_coverage(
+    cross_sections: list[RouteCrossSection],
+    departure_time: datetime,
+    flight_duration_hours: float,
+) -> tuple[dict[str, list[tuple[datetime, datetime] | None]], list[ModelCoverage]]:
+    """Per-model, per-route-point gradable spans from the saved pack.
+
+    Returns ``(per_point, summary)``: ``per_point[model][i]`` is the honest
+    ``(lo, hi)`` valid-time span at route point ``i`` (None = no coverage at
+    that point), and ``summary`` is the per-model intersection across points
+    for the artifact.
+    """
+    per_point: dict[str, list[tuple[datetime, datetime] | None]] = {}
+    summary: list[ModelCoverage] = []
+
+    for cs in cross_sections:
+        model = cs.model
+        name = model.value
+        spans: list[tuple[datetime, datetime] | None] = []
+
+        if model not in _GRIB_MODELS:
+            # OM-only model: fidelity is uniform across the fetched day.
+            for wf in cs.point_forecasts:
+                if not wf.hourly:
+                    spans.append(None)
+                    continue
+                times = sorted(_hour_time(h) for h in wf.hourly)
+                spans.append((times[0], times[-1]))
+            per_point[name] = spans
+            agg = _intersect_spans(spans)
+            summary.append(
+                ModelCoverage(
+                    model=name,
+                    start=agg[0] if agg else None,
+                    end=agg[1] if agg else None,
+                    uniform=True,
+                )
+            )
+            continue
+
+        rule_lo, rule_hi = _rule_window(model, departure_time, flight_duration_hours)
+        n_uniform = 0
+        for wf in cs.point_forecasts:
+            hours = sorted(wf.hourly, key=_hour_time)
+            if not hours:
+                spans.append(None)
+                continue
+            if model == ModelSource.GFS:
+                marked = [_hour_time(h) for h in hours if _gfs_marker(h)]
+            else:
+                # ECMWF / ICON replace the level list — the codebase's own
+                # anchor detector: count above the day's OM baseline.
+                counts = [len(h.pressure_levels) for h in hours]
+                baseline = min(counts)
+                marked = [
+                    _hour_time(h)
+                    for h, c in zip(hours, counts)
+                    if c > baseline
+                ]
+            if not marked:
+                # Fidelity parity: this point was never GRIB-enriched (fetch
+                # gap), so the baseline graded it on OM data too — any hour of
+                # the fetched day is exactly as honest here as the planned one.
+                spans.append((_hour_time(hours[0]), _hour_time(hours[-1])))
+                n_uniform += 1
+                continue
+            lo = max(marked[0], rule_lo)
+            hi = min(marked[-1], rule_hi)
+            spans.append((lo, hi) if lo <= hi else None)
+
+        per_point[name] = spans
+        agg = _intersect_spans(spans)
+        summary.append(
+            ModelCoverage(
+                model=name,
+                start=agg[0] if agg else None,
+                end=agg[1] if agg else None,
+                uniform=n_uniform == len(cs.point_forecasts),
+            )
+        )
+
+    return per_point, summary
+
+
+def _intersect_spans(
+    spans: list[tuple[datetime, datetime] | None],
+) -> tuple[datetime, datetime] | None:
+    real = [s for s in spans if s is not None]
+    if not real or len(real) != len(spans):
+        return None
+    lo = max(s[0] for s in real)
+    hi = min(s[1] for s in real)
+    return (lo, hi) if lo <= hi else None
+
+
+def candidate_valid_times(
+    route_points, departure: datetime, flight_duration_hours: float,
+) -> list[datetime]:
+    """Per-route-point ETAs for a departure — the coverage-check inputs.
+
+    Uses the same ``compute_interpolated_time`` the analysis stage uses, so
+    the check matches exactly the hours the re-grade will read."""
+    from weatherbrief.tasks.analyze import compute_interpolated_time
+
+    dep = _aware(departure)
+    if not route_points:
+        return [dep]
+    total = route_points[-1].distance_from_origin_nm
+    return [
+        _aware(
+            compute_interpolated_time(
+                dep, flight_duration_hours, rp.distance_from_origin_nm, total,
+            )
+        )
+        for rp in route_points
+    ]
+
+
+def covers(
+    per_point: dict[str, list[tuple[datetime, datetime] | None]],
+    models: list[str],
+    valid_times: list[datetime],
+) -> bool:
+    """True iff every model grades every per-point ETA inside its honest span."""
+    for m in models:
+        spans = per_point.get(m)
+        if spans is None:
+            return False
+        for i, t in enumerate(valid_times):
+            span = spans[i] if i < len(spans) else None
+            if span is None or not (span[0] <= t <= span[1]):
+                return False
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Daylight window
+# ---------------------------------------------------------------------------
+
+
+def _sun_events_for(lat: float, lon: float, on: date):
+    try:
+        from euro_aip.utils.solar import sun_events
+
+        ev = sun_events(lat, lon, on)
+        return ev.get("morning"), ev.get("evening")
+    except Exception:
+        logger.debug("time-scan: sun_events failed for (%s, %s)", lat, lon, exc_info=True)
+        return None, None
+
+
+def compute_daylight_window(
+    route: RouteConfig,
+    departure_time: datetime,
+    flight_duration_hours: float,
+    *,
+    day_shift: int = 0,
+) -> tuple[datetime, datetime, bool]:
+    """Daylight departure window ``(earliest, latest, clipped)`` on the target
+    day shifted by ``day_shift`` (±1 for prev/next-day modes).
+
+    Departure no earlier than sunrise at the origin, arrival no later than
+    sunset at the destination — day-VFR-friendly. Falls back to ±6h around the
+    (shifted) planned time when solar edges are unavailable (polar day/night).
+    """
+    dep = _aware(departure_time) + timedelta(days=day_shift)
+    day = dep.date()
+    dur = timedelta(hours=max(flight_duration_hours, 0.0))
+
+    sunrise_o, _ = _sun_events_for(route.origin.lat, route.origin.lon, day)
+    _, sunset_d = _sun_events_for(route.destination.lat, route.destination.lon, day)
+
+    if sunrise_o is None or sunset_d is None:
+        return dep - timedelta(hours=6), dep + timedelta(hours=6), False
+
+    start = _aware(sunrise_o)
+    latest = _aware(sunset_d) - dur
+    if latest <= start:
+        # Flight barely fits daylight — window collapses toward the planned time.
+        return min(start, dep), max(start, dep), True
+    return start, latest, True
+
+
+# ---------------------------------------------------------------------------
+# Grading + diff
+# ---------------------------------------------------------------------------
+
+
+def _diff_manifests(
+    baseline: RouteAdvisoriesManifest,
+    candidate: RouteAdvisoriesManifest,
+    scan_ids: set[str],
+) -> tuple[list[str], list[str], int]:
+    """Full-picture diff. Returns ``(improves, worsens, margin)``.
+
+    ``improves``/``worsens`` span the **full** advisory set (never surface a
+    window that fixed icing but quietly introduced a crosswind); ``margin``
+    sums the net severity drop over the scan-class set only — the ranking
+    objective (scope vs objective stay separate).
+    """
+    bmap = {a.advisory_id: a.aggregate_status for a in baseline.advisories}
+    improves: list[str] = []
+    worsens: list[str] = []
+    margin = 0
+    for a in candidate.advisories:
+        b = bmap.get(a.advisory_id)
+        if b is None:
+            continue
+        # aggregate_status is a str-enum; ``getattr(x, "value", x)`` keys the
+        # severity table on "red"/"amber"/"green" for enum and plain-str alike.
+        bv = _SEV.get(getattr(b, "value", b))
+        cv = _SEV.get(getattr(a.aggregate_status, "value", a.aggregate_status))
+        if bv is None or cv is None:  # either side unavailable → not comparable
+            continue
+        d = bv - cv  # positive == improved (severity dropped)
+        if d > 0:
+            improves.append(a.advisory_id)
+        elif d < 0:
+            worsens.append(a.advisory_id)
+        if a.advisory_id in scan_ids:
+            margin += d
+    return improves, worsens, margin
+
+
+# ---------------------------------------------------------------------------
+# The scan
+# ---------------------------------------------------------------------------
+
+
+def run_time_scan(
+    pack_dir: Path,
+    route: RouteConfig,
+    departure_time: datetime,
+    *,
+    flexibility: str,
+    alt_departure_time: datetime | None = None,
+    advisory_models: list[str] | None = None,
+    enabled_ids: set[str] | None = None,
+    advisory_enabled: dict[str, bool] | None = None,
+    user_params: dict | None = None,
+    aggregation: AdvisoryAggregation | None = None,
+    airports_db_path: str | None = None,
+    airport_conditions_recompute: Callable | None = None,
+    icing_method: str | None = None,
+    cloud_method: str | None = None,
+    convective_method: str | None = None,
+    locale: str | None = None,
+    cruise_speed_ias_kt: float | None = None,
+) -> TimeWindowScan | None:
+    """Grade the flight's Flexibility scenarios against the saved pack.
+
+    Returns the scan (caller persists it as ``time_options.json``) or ``None``
+    when there is nothing to do (``flexibility="none"``, or missing pack
+    data). Never raises for data problems — refused candidates are recorded on
+    the scan, and hard failures return ``None`` after logging.
+
+    Slice-1 scope: every graded candidate is ``confirmed_in_window``
+    (multi-model, free). Hours outside coverage land in ``refused_times`` —
+    slice 2's ECMWF daylight extension will graduate them to ``ecmwf_only``.
+    ``ecmwf_run_ts`` stays ``None`` until slice 2 reads the run off disk (the
+    decision-H reuse key matters only once scans cost decode time).
+    """
+    from weatherbrief.analysis.advisories.registry import get_scan_class_ids
+    from weatherbrief.tasks.advise import (
+        _compute_advisory_model_names,
+        derive_assessment_from_advisories,
+        run_alt_from_pack,
+    )
+    from weatherbrief.tasks.artifacts import load_cross_sections, load_route_points
+
+    if flexibility == "none":
+        return None
+
+    t0 = perf_counter()
+    dep = _aware(departure_time)
+    duration = route.flight_duration_hours
+
+    cross_sections = load_cross_sections(pack_dir)
+    route_points = load_route_points(pack_dir)
+    if not cross_sections or not route_points:
+        logger.info("time-scan: missing cross-sections/route points — skipping")
+        return None
+
+    model_names = [cs.model.value for cs in cross_sections]
+    graded_models = _compute_advisory_model_names(model_names, advisory_models)
+    per_point, coverage_summary = compute_model_coverage(
+        cross_sections, dep, duration,
+    )
+
+    grade_kwargs = dict(
+        advisory_models=advisory_models,
+        enabled_ids=enabled_ids,
+        advisory_enabled=advisory_enabled,
+        user_params=user_params,
+        aggregation=aggregation,
+        airports_db_path=airports_db_path,
+        airport_conditions_recompute=airport_conditions_recompute,
+        icing_method=icing_method,
+        cloud_method=cloud_method,
+        convective_method=convective_method,
+        locale=locale,
+        cruise_speed_ias_kt=cruise_speed_ias_kt,
+        cross_sections=cross_sections,
+    )
+
+    def _grade(t: datetime, *, persist: bool, detect_fronts: bool):
+        res = run_alt_from_pack(
+            pack_dir, t, route,
+            persist=persist,
+            detect_fronts=detect_fronts,
+            **grade_kwargs,
+        )
+        return res.manifest
+
+    # --- Baseline: the planned departure through the SAME path, so diffs
+    # compare like with like (and shift=0 must reproduce the briefing grades).
+    baseline_manifest = _grade(dep, persist=False, detect_fronts=False)
+    if baseline_manifest is None:
+        logger.warning("time-scan: baseline grade failed — skipping")
+        return None
+    base_assess, base_reason = derive_assessment_from_advisories(baseline_manifest)
+    scan_ids = get_scan_class_ids()
+
+    # --- Candidate departure times by mode.
+    window_model: TimeScanWindow | None = None
+    grid: list[datetime] = []
+    if flexibility in ("same_day", "prev_day", "next_day"):
+        day_shift = {"same_day": 0, "prev_day": -1, "next_day": 1}[flexibility]
+        w_lo, w_hi, clipped = compute_daylight_window(
+            route, dep, duration, day_shift=day_shift,
+        )
+        window_model = TimeScanWindow(
+            start=w_lo, end=w_hi, flexibility=flexibility, daylight_clipped=clipped,
+        )
+        # Hourly grid across the window (pack data is hourly — its native
+        # cadence). Slice 2 snaps to decoded ECMWF anchors instead.
+        t = w_lo.replace(minute=0, second=0, microsecond=0)
+        if t < w_lo:
+            t += timedelta(hours=1)
+        while t <= w_hi and len(grid) < _MAX_GRID:
+            grid.append(t)
+            t += timedelta(hours=1)
+
+    # Consideration order: alternate first (pinned), then the grid.
+    considered: list[tuple[datetime, bool]] = []  # (time, is_alternate)
+    if alt_departure_time is not None:
+        considered.append((_aware(alt_departure_time), True))
+    for t in grid:
+        if not any(abs((t - c).total_seconds()) < 60 for c, _ in considered):
+            considered.append((t, False))
+
+    candidates: list[TimeCandidate] = []
+    refused: list[datetime] = []
+    baseline_vts = candidate_valid_times(route_points, dep, duration)
+    baseline_row = TimeCandidate(
+        departure_time=dep,
+        departure_shift_hours=0.0,
+        valid_times=baseline_vts,
+        assessment=base_assess,
+        assessment_reason=base_reason,
+        models_used=graded_models,
+        confidence="confirmed_in_window",
+        is_baseline=True,
+    )
+
+    improving: list[TimeCandidate] = []
+    alternate_row: TimeCandidate | None = None
+
+    for t, is_alt in considered:
+        if abs((t - dep).total_seconds()) < 60:
+            if is_alt:
+                alternate_row = baseline_row.model_copy(update={"is_alternate": True})
+            continue
+        vts = candidate_valid_times(route_points, t, duration)
+        if not covers(per_point, graded_models, vts):
+            # The honesty invariant: never grade an hour whose enriched fields
+            # aren't actually there — at_time() would silently clamp to the
+            # window edge and label OM values as the GRIB model.
+            refused.append(t)
+            continue
+        # The pinned alternate keeps feeding route_advisories_alt.json (the
+        # existing planned↔alt web UI) and re-runs alt front detection like the
+        # retired in-pipeline stage did.
+        manifest = _grade(t, persist=is_alt, detect_fronts=is_alt)
+        if manifest is None:
+            continue
+        improves, worsens, margin = _diff_manifests(baseline_manifest, manifest, scan_ids)
+        assess, reason = derive_assessment_from_advisories(manifest)
+        row = TimeCandidate(
+            departure_time=t,
+            departure_shift_hours=round((t - dep).total_seconds() / 3600.0, 2),
+            valid_times=vts,
+            assessment=assess,
+            assessment_reason=reason,
+            models_used=graded_models,
+            improves=improves,
+            worsens=worsens,
+            margin=float(margin),
+            confidence="confirmed_in_window",
+            is_alternate=is_alt,
+        )
+        if is_alt:
+            alternate_row = row
+        elif margin >= _MIN_MARGIN and not worsens:
+            improving.append(row)
+
+    # Rank: best margin first, ties broken by proximity to the alternate time
+    # (the pilot's stated preference) or else the planned time.
+    anchor = _aware(alt_departure_time) if alt_departure_time else dep
+    improving.sort(
+        key=lambda r: (-r.margin, abs((r.departure_time - anchor).total_seconds())),
+    )
+    improving = improving[:_MAX_IMPROVING_KEPT]
+
+    out_candidates = [baseline_row]
+    if alternate_row is not None:
+        out_candidates.append(alternate_row)
+    out_candidates.extend(improving)
+
+    scan = TimeWindowScan(
+        flexibility=flexibility,  # type: ignore[arg-type]
+        baseline=TimeScanBaseline(
+            departure_time=dep,
+            assessment=base_assess,
+            assessment_reason=base_reason,
+            models_used=graded_models,
+        ),
+        window=window_model,
+        candidates=out_candidates,
+        refused_times=refused,
+        coverage=coverage_summary,
+        models=model_names,
+        ecmwf_run_ts=None,
+        generated_at=datetime.now(timezone.utc),
+    )
+    logger.info(
+        "time-scan[%s]: %d graded (%d improving), %d refused in %.1fs",
+        flexibility, len(out_candidates), len(improving), len(refused),
+        perf_counter() - t0,
+    )
+    return scan

--- a/src/weatherbrief/tasks/time_scan.py
+++ b/src/weatherbrief/tasks/time_scan.py
@@ -388,6 +388,134 @@ def current_ecmwf_run_ts(
 
 
 # ---------------------------------------------------------------------------
+# On-tap multi-model confirm (slice 3 — the deferred, user-gated cost)
+# ---------------------------------------------------------------------------
+
+
+def confirm_candidate(
+    pack_dir: Path,
+    route: RouteConfig,
+    candidate_time: datetime,
+    *,
+    data_dir: Path,
+    advisory_models: list[str] | None = None,
+    enabled_ids: set[str] | None = None,
+    advisory_enabled: dict[str, bool] | None = None,
+    user_params: dict | None = None,
+    aggregation: AdvisoryAggregation | None = None,
+    airports_db_path: str | None = None,
+    airport_conditions_recompute: Callable | None = None,
+    icing_method: str | None = None,
+    cloud_method: str | None = None,
+    convective_method: str | None = None,
+    locale: str | None = None,
+    cruise_speed_ias_kt: float | None = None,
+):
+    """Multi-model check of one provisional candidate — the honesty-ladder top.
+
+    Fetches + decodes GFS (S3 byte-range) and ICON (DWD download) for the
+    candidate's *shifted* flight window — roughly one briefing-equivalent of
+    fetch, which is why it's gated on a user tap — then grades the full
+    advisory model set and diffs against the planned time graded through the
+    same path on the same data. ``better_than_baseline=False`` (a tapped
+    suggestion that ICON/GFS reveal isn't better) is a designed outcome, not
+    an error: it shows the cross-check working.
+
+    Uses the **latest available** model runs (``as_of_time=None``): DWD
+    opendata only retains current runs, and "do the other models agree right
+    now" is the honest question a confirm answers. ``models_checked`` on the
+    returned :class:`TimeConfirmation` records what actually contributed.
+
+    Ephemeral throughout (decision G): enrichment mutates a freshly loaded
+    copy; the caller persists only the updated ``time_options.json``.
+    Returns ``None`` when grading fails outright.
+    """
+    from weatherbrief.fetch.grib import DecodePriority, enrich_forecasts
+    from weatherbrief.models import TimeConfirmation
+    from weatherbrief.tasks.advise import (
+        derive_assessment_from_advisories,
+        run_alt_from_pack,
+    )
+    from weatherbrief.tasks.artifacts import load_cross_sections, load_route_points
+
+    from weatherbrief.analysis.advisories.registry import get_scan_class_ids
+
+    cand = _aware(candidate_time)
+    cross_sections = load_cross_sections(pack_dir)
+    route_points = load_route_points(pack_dir)
+    if not cross_sections or not route_points:
+        return None
+
+    try:
+        enrich_forecasts(
+            cross_sections, [], route_points, cand,
+            data_dir=data_dir,
+            flight_duration_hours=route.flight_duration_hours,
+            priority=DecodePriority.BACKGROUND,
+        )
+    except Exception:
+        # A failed multi-model enrichment must not degrade into a quiet
+        # OM-clamped grade presented as "all models checked".
+        logger.warning("time-scan confirm: enrichment failed", exc_info=True)
+        return None
+
+    def _grade(t: datetime):
+        res = run_alt_from_pack(
+            pack_dir, t, route,
+            advisory_models=advisory_models,
+            enabled_ids=enabled_ids,
+            advisory_enabled=advisory_enabled,
+            user_params=user_params,
+            aggregation=aggregation,
+            airports_db_path=airports_db_path,
+            airport_conditions_recompute=airport_conditions_recompute,
+            icing_method=icing_method,
+            cloud_method=cloud_method,
+            convective_method=convective_method,
+            locale=locale,
+            cruise_speed_ias_kt=cruise_speed_ias_kt,
+            cross_sections=cross_sections,
+            persist=False,
+            detect_fronts=False,
+        )
+        return res.manifest
+
+    # Baseline through the same path on the same (candidate-window-enriched)
+    # sections — like vs like. The planned window's own enrichment is intact
+    # (the candidate-window fetch only adds hours).
+    baseline_manifest = _grade(_aware_pack_departure(pack_dir) or cand)
+    candidate_manifest = _grade(cand)
+    if baseline_manifest is None or candidate_manifest is None:
+        return None
+
+    improves, worsens, margin = _diff_manifests(
+        baseline_manifest, candidate_manifest, get_scan_class_ids(),
+    )
+    assess, reason = derive_assessment_from_advisories(candidate_manifest)
+    return TimeConfirmation(
+        models_checked=candidate_manifest.models,
+        assessment=assess,
+        assessment_reason=reason,
+        better_than_baseline=margin >= _MIN_MARGIN and not worsens,
+        improves=improves,
+        worsens=worsens,
+        confirmed_at=datetime.now(timezone.utc),
+    )
+
+
+def _aware_pack_departure(pack_dir: Path) -> datetime | None:
+    """The pack's planned departure (from briefing.json), for the confirm diff."""
+    import json
+
+    try:
+        b = json.loads((pack_dir / "briefing.json").read_text())
+        raw = b.get("departure_time")
+        return _aware(datetime.fromisoformat(raw.replace("Z", "+00:00"))) if raw else None
+    except Exception:
+        return None
+
+
+# ---------------------------------------------------------------------------
 # Daylight window
 # ---------------------------------------------------------------------------
 

--- a/src/weatherbrief/tasks/time_scan.py
+++ b/src/weatherbrief/tasks/time_scan.py
@@ -80,6 +80,21 @@ _MAX_IMPROVING_KEPT = 5
 #: GRIB-enriched models — coverage is windowed; everything else is uniform OM.
 _GRIB_MODELS = {ModelSource.ECMWF, ModelSource.GFS, ModelSource.ICON}
 
+_ECMWF_MODEL = ModelSource.ECMWF.value
+
+
+def _pack_fetched_at(pack_dir: Path) -> datetime | None:
+    """The pack's fetch time — pins the extension to the run the briefing used."""
+    from weatherbrief.tasks.artifacts import load_fetch_meta
+
+    meta = load_fetch_meta(pack_dir)
+    if not meta or not meta.get("fetched_at"):
+        return None
+    try:
+        return datetime.fromisoformat(meta["fetched_at"])
+    except ValueError:
+        return None
+
 
 def _aware(dt: datetime) -> datetime:
     return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
@@ -263,6 +278,116 @@ def covers(
 
 
 # ---------------------------------------------------------------------------
+# ECMWF daylight enrichment extension (slice 2 — the plan's v1 primitive)
+# ---------------------------------------------------------------------------
+
+
+def extend_ecmwf_daylight(
+    cross_sections: list[RouteCrossSection],
+    route_points,
+    window_start: datetime,
+    window_end: datetime,
+    flight_duration_hours: float,
+    *,
+    as_of_time: datetime | None = None,
+) -> tuple[int | None, list[tuple[datetime, datetime] | None]]:
+    """Decode the daylight ECMWF fhours onto the loaded cross-sections.
+
+    Decode-only (local ECPDS disk, no download) at BACKGROUND priority so a
+    live briefing is never starved. Reuses the production enrichment machinery
+    by fabricating a wide "flight window": ``_enrich_ecmwf`` filters steps to
+    ``[departure − 3h, departure + duration + 3h]``, so passing the window
+    span as the duration decodes every step across daylight **contiguously**
+    (required — accumulated fields tp/sf/cp are step-differenced across
+    consecutive processed steps; cherry-picked hours would corrupt them).
+
+    Mutates only the ECMWF section of the **in-memory** list — decision G:
+    nothing here is ever persisted; ``time_options.json`` is the only artifact
+    the scan writes.
+
+    ``as_of_time`` should be the pack's ``fetched_at`` so the extension picks
+    the SAME run the briefing used — otherwise a run that landed between the
+    briefing and the scan would silently mix runs inside one grade.
+
+    Returns ``(run_ts, per_point_spans)`` — the ECMWF init unix timestamp (the
+    decision-H staleness key) and the recomputed honest per-point coverage.
+    ``(None, [])`` when ECMWF is absent or no run covers the window.
+    """
+    from weatherbrief.fetch.grib import (
+        DecodePriority,
+        _enrich_ecmwf,
+        set_decode_priority,
+    )
+    from weatherbrief.fetch.grib.fill import propagate_all
+
+    ecmwf_sections = [cs for cs in cross_sections if cs.model == ModelSource.ECMWF]
+    if not ecmwf_sections:
+        return None, []
+
+    w_lo = _aware(window_start)
+    dep_end = _aware(window_end) + timedelta(hours=max(flight_duration_hours, 1.0))
+    span_h = max((dep_end - w_lo).total_seconds() / 3600.0, 1.0)
+
+    set_decode_priority(DecodePriority.BACKGROUND)
+    run_ts = _enrich_ecmwf(
+        cross_sections, [], route_points, w_lo,
+        flight_duration_hours=span_h,
+        as_of_time=as_of_time,
+    )
+    if run_ts is None:
+        return None, []
+    # Interpolate any between-anchor gap hours (only matters past the 1h
+    # cadence horizon, where ECMWF steps at 3h/6h). ECMWF-only — the other
+    # models' sections were already propagated at pack time.
+    propagate_all(ecmwf_sections, [], gfs_init=None)
+
+    # Recompute the honest ECMWF coverage from the now-extended data, using
+    # the extended rule window (the fabricated flight window above).
+    rule_lo = w_lo - _ECMWF_ENRICH_MARGIN
+    rule_hi = dep_end + _ECMWF_ENRICH_MARGIN
+    spans: list[tuple[datetime, datetime] | None] = []
+    for wf in ecmwf_sections[0].point_forecasts:
+        hours = sorted(wf.hourly, key=_hour_time)
+        if not hours:
+            spans.append(None)
+            continue
+        counts = [len(h.pressure_levels) for h in hours]
+        baseline = min(counts)
+        marked = [_hour_time(h) for h, c in zip(hours, counts) if c > baseline]
+        if not marked:
+            spans.append((_hour_time(hours[0]), _hour_time(hours[-1])))
+            continue
+        lo = max(marked[0], rule_lo)
+        hi = min(marked[-1], rule_hi)
+        spans.append((lo, hi) if lo <= hi else None)
+    return run_ts, spans
+
+
+def current_ecmwf_run_ts(
+    cover_until: datetime, *, as_of_time: datetime | None = None,
+) -> int | None:
+    """The init timestamp of the run the extension would use — the decision-H
+    reuse key. Cheap (directory scan, no decode)."""
+    try:
+        from weatherbrief.fetch.grib.ecmwf_fetch import (
+            ecmwf_grib_dir,
+            find_best_ecmwf_run,
+            scan_ecmwf_files,
+        )
+
+        files = scan_ecmwf_files(ecmwf_grib_dir())
+        if as_of_time is not None:
+            files = [f for f in files if f.base_time <= as_of_time]
+        if not files:
+            return None
+        run = find_best_ecmwf_run(files, cover_until=cover_until, data_dir=ecmwf_grib_dir())
+        return int(run[0].base_time.timestamp()) if run else None
+    except Exception:
+        logger.debug("time-scan: current run lookup failed", exc_info=True)
+        return None
+
+
+# ---------------------------------------------------------------------------
 # Daylight window
 # ---------------------------------------------------------------------------
 
@@ -383,11 +508,18 @@ def run_time_scan(
     data). Never raises for data problems — refused candidates are recorded on
     the scan, and hard failures return ``None`` after logging.
 
-    Slice-1 scope: every graded candidate is ``confirmed_in_window``
-    (multi-model, free). Hours outside coverage land in ``refused_times`` —
-    slice 2's ECMWF daylight extension will graduate them to ``ecmwf_only``.
-    ``ecmwf_run_ts`` stays ``None`` until slice 2 reads the run off disk (the
-    decision-H reuse key matters only once scans cost decode time).
+    Two tiers (the honesty ladder):
+
+    1. **Free tier** — candidates whose whole shifted flight fits every
+       fetched model's enriched coverage grade multi-model
+       (``confirmed_in_window``), pure re-analysis.
+    2. **Provisional tier (slice 2)** — the rest get the daylight ECMWF
+       extension (decode-only, ephemeral) and grade ECMWF-only against an
+       ECMWF-only baseline (``ecmwf_only``). Hours even ECMWF can't cover
+       (horizon/daylight edges) land in ``refused_times``.
+
+    ``ecmwf_run_ts`` records the run the extension decoded — the decision-H
+    staleness key (a refresh on the same run may reuse this scan).
     """
     from weatherbrief.analysis.advisories.registry import get_scan_class_ids
     from weatherbrief.tasks.advise import (
@@ -432,12 +564,23 @@ def run_time_scan(
         cross_sections=cross_sections,
     )
 
-    def _grade(t: datetime, *, persist: bool, detect_fronts: bool):
+    def _grade(t: datetime, *, persist: bool, detect_fronts: bool,
+               models_override: list[str] | None = None):
+        kwargs = dict(grade_kwargs)
+        if models_override is not None:
+            kwargs["advisory_models"] = models_override
+            # Analyze only the graded models' cross-sections — the analysis
+            # stage is the per-candidate cost, and re-analyzing the other
+            # models just to discard them roughly 4x-es the provisional tier.
+            wanted = {m.lower() for m in models_override}
+            kwargs["cross_sections"] = [
+                cs for cs in cross_sections if cs.model.value in wanted
+            ]
         res = run_alt_from_pack(
             pack_dir, t, route,
             persist=persist,
             detect_fronts=detect_fronts,
-            **grade_kwargs,
+            **kwargs,
         )
         return res.manifest
 
@@ -494,6 +637,9 @@ def run_time_scan(
 
     improving: list[TimeCandidate] = []
     alternate_row: TimeCandidate | None = None
+    # (time, is_alternate) pairs the free tier couldn't grade — the daylight
+    # ECMWF extension (below) gives them a second, provisional chance.
+    deferred: list[tuple[datetime, bool, list[datetime]]] = []
 
     for t, is_alt in considered:
         if abs((t - dep).total_seconds()) < 60:
@@ -504,8 +650,9 @@ def run_time_scan(
         if not covers(per_point, graded_models, vts):
             # The honesty invariant: never grade an hour whose enriched fields
             # aren't actually there — at_time() would silently clamp to the
-            # window edge and label OM values as the GRIB model.
-            refused.append(t)
+            # window edge and label OM values as the GRIB model. Deferred to
+            # the ECMWF-only tier rather than refused outright.
+            deferred.append((t, is_alt, vts))
             continue
         # The pinned alternate keeps feeding route_advisories_alt.json (the
         # existing planned↔alt web UI) and re-runs alt front detection like the
@@ -533,11 +680,86 @@ def run_time_scan(
         elif margin >= _MIN_MARGIN and not worsens:
             improving.append(row)
 
-    # Rank: best margin first, ties broken by proximity to the alternate time
-    # (the pilot's stated preference) or else the planned time.
+    # --- Slice 2: ECMWF-only provisional tier for the deferred hours.
+    # Decode the daylight ECMWF fhours (local disk, BACKGROUND priority,
+    # ephemeral) and grade the deferred candidates ECMWF-only against an
+    # ECMWF-only baseline — like against like, labelled provisional.
+    ecmwf_run_ts: int | None = None
+    base_e_assess: str | None = None
+    base_e_reason: str | None = None
+    horizon_clipped = False
+    if deferred and _ECMWF_MODEL in [m.lower() for m in model_names]:
+        ext_lo = min(t for t, _, _ in deferred)
+        ext_hi = max(t for t, _, _ in deferred)
+        as_of = _pack_fetched_at(pack_dir)
+        ecmwf_run_ts, ecmwf_spans = extend_ecmwf_daylight(
+            cross_sections, route_points, ext_lo, ext_hi, duration,
+            as_of_time=as_of,
+        )
+        if ecmwf_run_ts is not None:
+            ecmwf_per_point = {_ECMWF_MODEL: ecmwf_spans}
+            base_e_manifest = _grade(
+                dep, persist=False, detect_fronts=False,
+                models_override=[_ECMWF_MODEL],
+            )
+            if base_e_manifest is not None:
+                base_e_assess, base_e_reason = derive_assessment_from_advisories(base_e_manifest)
+                span_his = [s[1] for s in ecmwf_spans if s]
+                horizon = min(span_his) if span_his else None
+                for t, is_alt, vts in deferred:
+                    if not covers(ecmwf_per_point, [_ECMWF_MODEL], vts):
+                        refused.append(t)
+                        if horizon and vts and vts[-1] > horizon:
+                            horizon_clipped = True
+                        continue
+                    manifest = _grade(
+                        t, persist=is_alt, detect_fronts=False,
+                        models_override=[_ECMWF_MODEL],
+                    )
+                    if manifest is None:
+                        continue
+                    improves, worsens, margin = _diff_manifests(
+                        base_e_manifest, manifest, scan_ids,
+                    )
+                    assess, reason = derive_assessment_from_advisories(manifest)
+                    row = TimeCandidate(
+                        departure_time=t,
+                        departure_shift_hours=round((t - dep).total_seconds() / 3600.0, 2),
+                        valid_times=vts,
+                        assessment=assess,
+                        assessment_reason=reason,
+                        models_used=[_ECMWF_MODEL],
+                        improves=improves,
+                        worsens=worsens,
+                        margin=float(margin),
+                        confidence="ecmwf_only",
+                        is_alternate=is_alt,
+                    )
+                    if is_alt:
+                        # Provisional alternate: route_advisories_alt.json was
+                        # persisted from the ECMWF-only manifest (its `models`
+                        # field carries the honest coverage).
+                        alternate_row = row
+                    elif margin >= _MIN_MARGIN and not worsens:
+                        improving.append(row)
+            else:
+                refused.extend(t for t, _, _ in deferred)
+        else:
+            logger.info("time-scan: no ECMWF run for the extension — deferred hours refused")
+            refused.extend(t for t, _, _ in deferred)
+    else:
+        refused.extend(t for t, _, _ in deferred)
+
+    # Rank: best margin first, then confirmed over provisional, ties broken by
+    # proximity to the alternate time (the pilot's stated preference) or else
+    # the planned time.
     anchor = _aware(alt_departure_time) if alt_departure_time else dep
     improving.sort(
-        key=lambda r: (-r.margin, abs((r.departure_time - anchor).total_seconds())),
+        key=lambda r: (
+            -r.margin,
+            0 if r.confidence == "confirmed_in_window" else 1,
+            abs((r.departure_time - anchor).total_seconds()),
+        ),
     )
     improving = improving[:_MAX_IMPROVING_KEPT]
 
@@ -546,6 +768,9 @@ def run_time_scan(
         out_candidates.append(alternate_row)
     out_candidates.extend(improving)
 
+    if window_model is not None:
+        window_model.horizon_clipped = horizon_clipped
+
     scan = TimeWindowScan(
         flexibility=flexibility,  # type: ignore[arg-type]
         baseline=TimeScanBaseline(
@@ -553,13 +778,15 @@ def run_time_scan(
             assessment=base_assess,
             assessment_reason=base_reason,
             models_used=graded_models,
+            ecmwf_assessment=base_e_assess,
+            ecmwf_assessment_reason=base_e_reason,
         ),
         window=window_model,
         candidates=out_candidates,
-        refused_times=refused,
+        refused_times=sorted(refused),
         coverage=coverage_summary,
         models=model_names,
-        ecmwf_run_ts=None,
+        ecmwf_run_ts=ecmwf_run_ts,
         generated_at=datetime.now(timezone.utc),
     )
     logger.info(

--- a/src/weatherbrief/tasks/time_scan.py
+++ b/src/weatherbrief/tasks/time_scan.py
@@ -42,6 +42,7 @@ from pathlib import Path
 from time import perf_counter
 from typing import Callable
 
+from weatherbrief.fetch.grib import ECMWF_FLIGHT_WINDOW_MARGIN
 from weatherbrief.models import (
     AdvisoryAggregation,
     ModelCoverage,
@@ -57,11 +58,10 @@ from weatherbrief.models import (
 
 logger = logging.getLogger(__name__)
 
-# ECMWF enrichment margin around the flight window — mirrors ``margin`` in
-# ``fetch/grib/__init__.py`` (``_enrich_ecmwf_inner`` step filter). If that
-# constant changes, coverage here goes conservative/stale rather than wrong
-# (the data marker still bounds what we actually grade).
-_ECMWF_ENRICH_MARGIN = timedelta(hours=3)
+# ECMWF enrichment margin around the flight window — the same constant the
+# enrichment step filter uses, so the coverage rule window can't drift from
+# what was actually decoded (imported at the top with the other deps).
+_ECMWF_ENRICH_MARGIN = ECMWF_FLIGHT_WINDOW_MARGIN
 
 # Candidate grid cap per scan — a fleet of flights can't stampede the
 # analysis stage. Daylight rarely exceeds this at hourly cadence.

--- a/src/weatherbrief/tasks/time_scan.py
+++ b/src/weatherbrief/tasks/time_scan.py
@@ -434,6 +434,7 @@ def confirm_candidate(
     from weatherbrief.models import TimeConfirmation
     from weatherbrief.tasks.advise import (
         derive_assessment_from_advisories,
+        per_model_reasons_from_manifest,
         run_alt_from_pack,
     )
     from weatherbrief.tasks.artifacts import load_cross_sections, load_route_points
@@ -496,6 +497,7 @@ def confirm_candidate(
         models_checked=candidate_manifest.models,
         assessment=assess,
         assessment_reason=reason,
+        per_model_reasons=per_model_reasons_from_manifest(candidate_manifest),
         better_than_baseline=margin >= _MIN_MARGIN and not worsens,
         improves=improves,
         worsens=worsens,

--- a/src/weatherbrief/tasks/time_scan.py
+++ b/src/weatherbrief/tasks/time_scan.py
@@ -388,6 +388,94 @@ def current_ecmwf_run_ts(
 
 
 # ---------------------------------------------------------------------------
+# Open-Meteo adjacent-day extension (slice 4 — the ±day base fetch)
+# ---------------------------------------------------------------------------
+
+
+def _pack_hourly_bounds(
+    cross_sections: list[RouteCrossSection],
+) -> tuple[datetime, datetime] | None:
+    """Overall ``(earliest, latest)`` OM hourly time present across the pack —
+    the fetched-day span. Used to decide whether a candidate window needs the
+    adjacent-day OM fetch (any ETA past this span would grade OM-clamped)."""
+    times: list[datetime] = []
+    for cs in cross_sections:
+        for wf in cs.point_forecasts:
+            if wf.hourly:
+                times.append(_hour_time(wf.hourly[0]))
+                times.append(_hour_time(wf.hourly[-1]))
+    return (min(times), max(times)) if times else None
+
+
+def extend_openmeteo_adjacent_day(
+    cross_sections: list[RouteCrossSection],
+    route_points,
+    start_date: date,
+    end_date: date,
+    *,
+    historical: bool = False,
+) -> int:
+    """Re-fetch the Open-Meteo base for ``[start_date, end_date]`` and splice it
+    onto the in-memory cross-sections (ephemeral — decision G).
+
+    The pack's OM base spans only the target day: the fetch stage windows the
+    request with ``start_date = end_date = target day``
+    (``tasks/fetch.py``). So a ±day candidate's per-point ETAs fall past the
+    last stored OM hour, and ``at_time()`` would silently clamp **every** model's
+    OM layer (and the OM-only models MétéoFr/UKMO/GEM outright) to the day edge
+    — the exact confident-but-wrong grade the honesty posture forbids. This
+    fills the OM layer for the candidate day(s) so the multi-model confirm
+    grades on real values; ``enrich_forecasts`` overlays GRIB fidelity
+    (ECMWF/GFS/ICON) afterwards, exactly as the target day was built.
+
+    Fetches each fetched model over the same date window; a model whose range
+    doesn't reach the day (raises / returns empty) is skipped, not faked.
+    Mutates ``cross_sections`` in place; returns the number of sections that
+    gained hours.
+    """
+    from weatherbrief.fetch.open_meteo import EmptyForecastError, OpenMeteoClient
+
+    client = OpenMeteoClient(historical=historical)
+    s = start_date.strftime("%Y-%m-%d")
+    e = end_date.strftime("%Y-%m-%d")
+    extended = 0
+    for cs in cross_sections:
+        try:
+            new_pfs = client.fetch_multi_point(
+                route_points, cs.model, start_date=s, end_date=e,
+            )
+        except EmptyForecastError:
+            logger.info(
+                "time-scan: %s has no OM data for %s–%s (out of range) — skipped",
+                cs.model.value, s, e,
+            )
+            continue
+        except Exception:
+            logger.debug(
+                "time-scan: OM adjacent-day fetch failed for %s",
+                cs.model.value, exc_info=True,
+            )
+            continue
+        if not new_pfs or len(new_pfs) != len(cs.point_forecasts):
+            continue
+        added = False
+        for existing_wf, new_wf in zip(cs.point_forecasts, new_pfs):
+            have = {_hour_time(h) for h in existing_wf.hourly}
+            for h in new_wf.hourly:
+                if _hour_time(h) not in have:
+                    existing_wf.hourly.append(h)
+                    added = True
+            existing_wf.hourly.sort(key=_hour_time)
+        if added:
+            extended += 1
+    logger.info(
+        "time-scan: OM adjacent-day extension %s–%s → %d/%d sections extended",
+        s, e, extended, len(cross_sections),
+    )
+    return extended
+
+
+# ---------------------------------------------------------------------------
 # On-tap multi-model confirm (slice 3 — the deferred, user-gated cost)
 # ---------------------------------------------------------------------------
 
@@ -446,6 +534,20 @@ def confirm_candidate(
     route_points = load_route_points(pack_dir)
     if not cross_sections or not route_points:
         return None
+
+    # ±day confirm: the pack's OM base covers only the target day, so a
+    # candidate on an adjacent day would grade every model's OM layer clamped to
+    # the day edge (and the OM-only models outright). Re-fetch the OM base for
+    # the candidate's day(s) FIRST, so enrich_forecasts overlays GRIB onto real
+    # OM values and the multi-model grade below is honest across the day
+    # boundary. Same-day candidates already have their OM base — the bounds
+    # check skips the fetch for them.
+    cand_end = cand + timedelta(hours=max(route.flight_duration_hours, 1.0))
+    bounds = _pack_hourly_bounds(cross_sections)
+    if bounds is None or cand < bounds[0] or cand_end > bounds[1]:
+        extend_openmeteo_adjacent_day(
+            cross_sections, route_points, cand.date(), cand_end.date(),
+        )
 
     try:
         enrich_forecasts(
@@ -563,6 +665,22 @@ def compute_daylight_window(
         # Flight barely fits daylight — window collapses toward the planned time.
         return min(start, dep), max(start, dep), True
     return start, latest, True
+
+
+def _clamp_past_grid(
+    grid: list[datetime], departure: datetime, now: datetime,
+) -> tuple[list[datetime], bool]:
+    """Drop already-elapsed candidate hours (slice 4's past-day clamp).
+
+    Only clamps when the planned ``departure`` is itself still in the future —
+    i.e. we're doing forward planning. An eval/replay of an already-flown pack
+    (``departure`` in the past) must grade its whole window unchanged, so those
+    packs are left alone. Returns ``(kept_grid, past_clipped)``.
+    """
+    if _aware(departure) <= now:
+        return grid, False
+    kept = [t for t in grid if t > now]
+    return kept, len(kept) != len(grid)
 
 
 # ---------------------------------------------------------------------------
@@ -742,6 +860,32 @@ def run_time_scan(
         while t <= w_hi and len(grid) < _MAX_GRID:
             grid.append(t)
             t += timedelta(hours=1)
+
+        # Past-day clamp (slice 4): drop already-elapsed hours up front —
+        # prev_day's window is largely behind "now", and a late-in-day scan
+        # trims same_day's morning too. Dropping beats a coverage refusal
+        # (which reads as "data gap", not "already flown"). An empty grid is
+        # the honest "the previous day is already behind you".
+        grid, window_model.past_clipped = _clamp_past_grid(
+            grid, dep, datetime.now(timezone.utc),
+        )
+
+        # ±day (slice 4): the pack's OM base only covers the target day, so the
+        # adjacent-day grid hours have NO hourly rows at all. That breaks the
+        # ECMWF daylight extension — `_enrich_ecmwf` *attaches* decoded GRIB to
+        # existing hourly rows (it never creates them), so with no adjacent-day
+        # rows it decodes the next-day steps, matches nothing, and bails with
+        # "no matching steps" → the whole day refuses. Lay down the adjacent-day
+        # OM skeleton first (all models), then recompute coverage so the ECMWF
+        # extension has rows to enrich and OM-only models span the new day.
+        if flexibility in ("prev_day", "next_day") and grid:
+            flight_end = w_hi + timedelta(hours=max(duration, 1.0))
+            extend_openmeteo_adjacent_day(
+                cross_sections, route_points, w_lo.date(), flight_end.date(),
+            )
+            per_point, coverage_summary = compute_model_coverage(
+                cross_sections, dep, duration,
+            )
 
     # Consideration order: alternate first (pinned), then the grid.
     considered: list[tuple[datetime, bool]] = []  # (time, is_alternate)

--- a/src/weatherbrief/tasks/time_scan.py
+++ b/src/weatherbrief/tasks/time_scan.py
@@ -840,8 +840,15 @@ def run_time_scan(
                         if horizon and vts and vts[-1] > horizon:
                             horizon_clipped = True
                         continue
+                    # detect_fronts=is_alt mirrors the free tier: the pinned
+                    # alternate keeps route_fronts_alt.json fresh (like the
+                    # retired in-pipeline stage), even when it grades
+                    # provisionally — an off-window alternate is the COMMON
+                    # case, and a stale planned-time fronts artifact under a
+                    # fresh alt manifest would lie. The tight-loop concern
+                    # only applies to the swept candidates.
                     manifest = _grade(
-                        t, persist=is_alt, detect_fronts=False,
+                        t, persist=is_alt, detect_fronts=is_alt,
                         models_override=[_ECMWF_MODEL],
                     )
                     if manifest is None:

--- a/src/weatherbrief/tasks/time_scan_runner.py
+++ b/src/weatherbrief/tasks/time_scan_runner.py
@@ -169,7 +169,19 @@ def _run_scan_job(flight_id: str, pack_dir: Path, fetch_ts: datetime, db_path: s
             alt_row = next((c for c in scan.candidates if c.is_alternate), None)
             if alt_row is not None:
                 _update_pack_alt_fields(db, flight_id, pack_dir, fetch_ts, alt_row)
-                db.commit()
+
+            # Usage accounting (abuse-limit substrate): one row per executed
+            # scan, keyed by mode. The decision-H reuse path above logs
+            # nothing — no compute was spent. A future per-user limit (e.g.
+            # N full-day scans/week) gates in schedule_time_scan by counting
+            # these rows; the data collection starts now.
+            from weatherbrief.api.usage import log_api_usage
+
+            log_api_usage(
+                db, service="time_scan", pipeline=flight.flexibility,
+                api_calls=1, user_id=flight.user_id, flight_id=flight_id,
+            )
+            db.commit()
 
             _write_status(pack_dir, "done", flight.flexibility)
         finally:
@@ -183,6 +195,175 @@ def _run_scan_job(flight_id: str, pack_dir: Path, fetch_ts: datetime, db_path: s
     finally:
         with _inflight_lock:
             _inflight.discard(str(pack_dir))
+
+
+def schedule_time_confirm(
+    flight_id: str, pack_dir: Path, candidate_time: datetime, *, db_path: str = "",
+) -> str:
+    """Queue an on-tap multi-model confirm for one candidate.
+
+    Marks the candidate ``confirm_pending`` in ``time_options.json`` (the
+    polling client renders "checking all models…" off that flag) and submits
+    the fetch+grade to the same single-worker queue as scans.
+
+    Returns ``"queued"``, ``"busy"`` (a confirm is already running for this
+    pack — one at a time, each costs a briefing-equivalent of GFS+ICON fetch,
+    so a tap-everything user can't stack five of them), or ``"invalid"`` (no
+    such candidate / already confirmed).
+    """
+    from weatherbrief.tasks.artifacts import load_time_options, save_time_options
+
+    try:
+        scan = load_time_options(pack_dir)
+        if scan is None:
+            return "invalid"
+        cand = scan.candidate_at(candidate_time)
+        if cand is None or cand.confirmed is not None:
+            return "invalid"
+
+        key = f"{pack_dir}#confirm@{candidate_time.isoformat()}"
+        pack_prefix = f"{pack_dir}#confirm@"
+        with _inflight_lock:
+            if key in _inflight:
+                return "queued"  # same candidate re-tapped — already on it
+            if any(k.startswith(pack_prefix) for k in _inflight):
+                return "busy"
+            _inflight.add(key)
+
+        if not cand.confirm_pending:
+            cand.confirm_pending = True
+            save_time_options(pack_dir, scan)
+        _executor.submit(
+            _run_confirm_job, flight_id, pack_dir, candidate_time,
+            db_path or _default_db_path(), key,
+        )
+        logger.info(
+            "time-scan: confirm queued for %s @ %s", flight_id, candidate_time,
+        )
+        return "queued"
+    except Exception:
+        logger.warning("time-scan: confirm scheduling failed for %s", flight_id, exc_info=True)
+        return "invalid"
+
+
+def _run_confirm_job(
+    flight_id: str, pack_dir: Path, candidate_time: datetime, db_path: str, key: str,
+) -> None:
+    """Worker: multi-model check of one candidate, cached onto the artifact."""
+    import os
+
+    from flyfun_common.db import SessionLocal
+
+    try:
+        db = SessionLocal()
+        try:
+            from weatherbrief.api.packs import _build_route_config, _load_advisory_profile
+            from weatherbrief.storage.flights import load_flight
+            from weatherbrief.tasks.artifacts import load_time_options, save_time_options
+            from weatherbrief.tasks.time_scan import confirm_candidate
+
+            flight = load_flight(db, flight_id)
+            route = _build_route_config(flight, db_path)
+            (
+                enabled_ids, enabled_map, user_params, aggregation, adv_models,
+                icing_method, cloud_method, convective_method, recompute_conds,
+                locale, _afd,
+            ) = _load_advisory_profile(
+                db, flight, flight.user_id, None, pack_dir, db_path=db_path,
+            )
+
+            confirmation = confirm_candidate(
+                pack_dir, route, candidate_time,
+                data_dir=Path(os.environ.get("DATA_DIR", "data")),
+                advisory_models=adv_models,
+                enabled_ids=enabled_ids,
+                advisory_enabled=enabled_map,
+                user_params=user_params,
+                aggregation=aggregation,
+                airports_db_path=db_path,
+                airport_conditions_recompute=recompute_conds,
+                icing_method=icing_method,
+                cloud_method=cloud_method,
+                convective_method=convective_method,
+                locale=locale,
+            )
+
+            # Re-load before mutating — the artifact may have moved while the
+            # fetch ran (another confirm finishing, never a concurrent write:
+            # the single-worker queue serializes all artifact writers).
+            scan = load_time_options(pack_dir)
+            cand = scan.candidate_at(candidate_time) if scan else None
+            if cand is None:
+                return
+            cand.confirm_pending = False
+            if confirmation is not None:
+                cand.confirmed = confirmation
+                cand.confidence = "confirmed"
+            save_time_options(pack_dir, scan)
+
+            # Usage accounting: one row per confirm attempt (the GFS+ICON
+            # fetch was spent whether or not grading succeeded). Future
+            # per-user limits gate in schedule_time_confirm on these rows.
+            from weatherbrief.api.usage import log_api_usage
+
+            log_api_usage(
+                db, service="time_scan", pipeline="confirm",
+                api_calls=1, user_id=flight.user_id, flight_id=flight_id,
+            )
+            db.commit()
+            logger.info(
+                "time-scan: confirm %s for %s @ %s",
+                "ok" if confirmation else "failed", flight_id, candidate_time,
+            )
+        finally:
+            db.close()
+    except Exception:
+        logger.warning("time-scan: confirm job failed for %s", flight_id, exc_info=True)
+        try:
+            from weatherbrief.tasks.artifacts import load_time_options, save_time_options
+
+            scan = load_time_options(pack_dir)
+            cand = scan.candidate_at(candidate_time) if scan else None
+            if cand is not None and cand.confirm_pending:
+                cand.confirm_pending = False
+                save_time_options(pack_dir, scan)
+        except Exception:
+            pass
+    finally:
+        with _inflight_lock:
+            _inflight.discard(key)
+
+
+def reconcile_stale_confirms(pack_dir: Path) -> bool:
+    """Clear ``confirm_pending`` flags with no live worker behind them.
+
+    A server restart (deploy, dev reload) mid-confirm kills the worker but
+    leaves the persisted flag — the UI would show "checking all models…"
+    forever and the one-at-a-time guard would block nothing (the in-memory
+    inflight set is empty after restart, so this is purely a display/honesty
+    fix). Called from the polling GET. Returns True when anything changed.
+    """
+    from weatherbrief.tasks.artifacts import load_time_options, save_time_options
+
+    scan = load_time_options(pack_dir)
+    if scan is None:
+        return False
+    pending = [c for c in scan.candidates if c.confirm_pending]
+    if not pending:
+        return False
+    prefix = f"{pack_dir}#confirm@"
+    with _inflight_lock:
+        live = {k for k in _inflight if k.startswith(prefix)}
+    changed = False
+    for c in pending:
+        key = f"{pack_dir}#confirm@{c.departure_time.isoformat()}"
+        if key not in live:
+            c.confirm_pending = False
+            changed = True
+    if changed:
+        save_time_options(pack_dir, scan)
+        logger.info("time-scan: cleared stale confirm_pending flag(s) in %s", pack_dir)
+    return changed
 
 
 def _reusable_scan(pack_dir: Path, flight):

--- a/src/weatherbrief/tasks/time_scan_runner.py
+++ b/src/weatherbrief/tasks/time_scan_runner.py
@@ -161,6 +161,11 @@ def _run_scan_job(flight_id: str, pack_dir: Path, fetch_ts: datetime, db_path: s
                 _write_status(pack_dir, "skipped", flight.flexibility, reason="no_data")
                 return
 
+            # Preserve paid confirm verdicts across a same-run rescan (e.g.
+            # the "Set as alternate" flow rebuilding the candidate list).
+            from weatherbrief.tasks.artifacts import load_time_options
+
+            merge_confirmed(load_time_options(pack_dir), scan)
             save_time_options(pack_dir, scan)
 
             # The pinned alternate row keeps the legacy pack-row alt fields
@@ -294,6 +299,14 @@ def _run_confirm_job(
             scan = load_time_options(pack_dir)
             cand = scan.candidate_at(candidate_time) if scan else None
             if cand is None:
+                # A rescan replaced the candidate list while we fetched — the
+                # paid result has nowhere to land. merge_confirmed prevents
+                # the reverse ordering; this direction we can only surface.
+                logger.warning(
+                    "time-scan: confirm result for %s @ %s dropped — candidate "
+                    "list changed while the check ran (rescan?)",
+                    flight_id, candidate_time,
+                )
                 return
             cand.confirm_pending = False
             if confirmation is not None:
@@ -332,6 +345,50 @@ def _run_confirm_job(
     finally:
         with _inflight_lock:
             _inflight.discard(key)
+
+
+def reconcile_stale_scan(pack_dir: Path) -> bool:
+    """Mark an orphaned ``pending``/``running`` scan status as failed.
+
+    A restart (deploy, dev reload) mid-scan leaves the sidecar at "running"
+    with no worker behind it — without this, the panel shows "Scenarios
+    running…" forever and the lazy-schedule never fires again (it only acts
+    on a missing status). Mirrors :func:`reconcile_stale_confirms`; the
+    caller (the polling GET) re-schedules for the owner after this flips the
+    status. Returns True when a stale status was cleared.
+    """
+    from weatherbrief.tasks.artifacts import load_time_scan_status
+
+    status = load_time_scan_status(pack_dir)
+    if status is None or status.status not in ("pending", "running"):
+        return False
+    with _inflight_lock:
+        if str(pack_dir) in _inflight:
+            return False  # a live worker really is on it
+    _write_status(pack_dir, "failed", status.flexibility, reason="interrupted")
+    logger.info("time-scan: cleared orphaned %s status in %s", status.status, pack_dir)
+    return True
+
+
+def merge_confirmed(old: "TimeWindowScan | None", new: "TimeWindowScan") -> None:
+    """Carry confirmed verdicts from a previous scan onto a fresh one.
+
+    A rescan (e.g. the "Set as alternate" flow) rebuilds the candidate list;
+    without this, a confirm that landed earlier — a paid briefing-equivalent
+    of GFS+ICON fetch — would silently vanish, and one queued *behind* the
+    rescan would find its candidate gone. Only merges when the new scan is
+    graded on the same ECMWF run and planned departure (a new run genuinely
+    invalidates old confirms — decision H).
+    """
+    if old is None or new.ecmwf_run_ts != old.ecmwf_run_ts:
+        return
+    if abs((new.baseline.departure_time - old.baseline.departure_time).total_seconds()) > 60:
+        return
+    for cand in new.candidates:
+        prev = old.candidate_at(cand.departure_time)
+        if prev is not None and prev.confirmed is not None and cand.confirmed is None:
+            cand.confirmed = prev.confirmed
+            cand.confidence = "confirmed"
 
 
 def reconcile_stale_confirms(pack_dir: Path) -> bool:

--- a/src/weatherbrief/tasks/time_scan_runner.py
+++ b/src/weatherbrief/tasks/time_scan_runner.py
@@ -119,6 +119,17 @@ def _run_scan_job(flight_id: str, pack_dir: Path, fetch_ts: datetime, db_path: s
                 )
                 return
 
+            # Decision-H reuse: a scan for the same flexibility mode, planned
+            # departure, and ECMWF run is still valid — skip the re-decode.
+            existing = _reusable_scan(pack_dir, flight)
+            if existing is not None:
+                logger.info(
+                    "time-scan: reusing existing scan for %s (same ECMWF run %s)",
+                    flight_id, existing.ecmwf_run_ts,
+                )
+                _write_status(pack_dir, "done", flight.flexibility)
+                return
+
             _write_status(pack_dir, "running", flight.flexibility)
 
             route = _build_route_config(flight, db_path)
@@ -172,6 +183,39 @@ def _run_scan_job(flight_id: str, pack_dir: Path, fetch_ts: datetime, db_path: s
     finally:
         with _inflight_lock:
             _inflight.discard(str(pack_dir))
+
+
+def _reusable_scan(pack_dir: Path, flight):
+    """Return the existing scan when it's still valid (decision H), else None.
+
+    Valid = same flexibility mode, same planned departure, and — when the scan
+    used the ECMWF extension — the run on disk hasn't moved. A scan with no
+    ``ecmwf_run_ts`` (pure free-tier) is cheap to redo, so it is NOT reused —
+    a fresher grade wins.
+    """
+    from weatherbrief.tasks.artifacts import load_time_options
+    from weatherbrief.tasks.time_scan import _pack_fetched_at, current_ecmwf_run_ts
+
+    scan = load_time_options(pack_dir)
+    if scan is None or scan.ecmwf_run_ts is None:
+        return None
+    if scan.flexibility != flight.flexibility:
+        return None
+    dep = flight.departure_time
+    if abs((scan.baseline.departure_time - dep).total_seconds()) > 60:
+        return None
+    cover_until = dep
+    if scan.window is not None:
+        cover_until = max(cover_until, scan.window.end)
+    # Compare against the run a re-scan would actually pick: the extension
+    # pins run selection to the pack's fetched_at, so use the same pin here —
+    # a newer run on disk doesn't invalidate this pack's scan.
+    would_use = current_ecmwf_run_ts(
+        cover_until, as_of_time=_pack_fetched_at(pack_dir),
+    )
+    if would_use != scan.ecmwf_run_ts:
+        return None
+    return scan
 
 
 def _update_pack_alt_fields(

--- a/src/weatherbrief/tasks/time_scan_runner.py
+++ b/src/weatherbrief/tasks/time_scan_runner.py
@@ -385,6 +385,16 @@ def _reusable_scan(pack_dir: Path, flight):
     dep = flight.departure_time
     if abs((scan.baseline.departure_time - dep).total_seconds()) > 60:
         return None
+    # A changed/new alternate time invalidates the scan — its pinned row (and
+    # route_advisories_alt.json) must be re-graded ("Set as alternate" flow).
+    if flight.alt_departure_time is not None:
+        alt = flight.alt_departure_time
+        has_alt_row = any(
+            c.is_alternate and abs((c.departure_time - alt).total_seconds()) < 60
+            for c in scan.candidates
+        )
+        if not has_alt_row:
+            return None
     cover_until = dep
     if scan.window is not None:
         cover_until = max(cover_until, scan.window.end)

--- a/src/weatherbrief/tasks/time_scan_runner.py
+++ b/src/weatherbrief/tasks/time_scan_runner.py
@@ -1,0 +1,197 @@
+"""Background runner for the timing-scenario scan (Flexibility).
+
+The scan is a **queued analysis that never blocks the briefing**: every
+refresh path (streaming user refresh, synchronous ``/refresh``, scheduler
+auto-refresh) finalizes the pack first, then calls :func:`schedule_time_scan`;
+the briefing UI shows "Scenarios running…" from the status sidecar and polls
+``GET .../time-options`` until it flips to ``done``. There is no task queue in
+this codebase — a dedicated single-worker executor IS the queue, and its
+``max_workers=1`` is the plan's global-concurrency-1 decision (a fleet of
+flights can't stampede the analysis stage; slice 2's decode work will ride the
+BACKGROUND priority of the decode dispatcher on top).
+
+``GET .../time-options`` also lazy-schedules: a pilot who sets Flexibility
+*after* the briefing ran gets a scan on first poll, without a re-refresh.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime, timezone
+from pathlib import Path
+from threading import Lock
+
+from weatherbrief.models import TimeScanStatus
+
+logger = logging.getLogger(__name__)
+
+# The queue (see module docstring). One scan at a time, process-wide.
+_executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="time-scan")
+
+# Packs currently pending/running — prevents double-submission when a poll
+# races the post-refresh hook. Keyed by str(pack_dir).
+_inflight: set[str] = set()
+_inflight_lock = Lock()
+
+
+def _write_status(pack_dir: Path, status: str, flexibility: str, reason: str = "") -> None:
+    from weatherbrief.tasks.artifacts import save_time_scan_status
+
+    save_time_scan_status(
+        pack_dir,
+        TimeScanStatus(
+            status=status,  # type: ignore[arg-type]
+            flexibility=flexibility,  # type: ignore[arg-type]
+            reason=reason,
+            updated_at=datetime.now(timezone.utc),
+        ),
+    )
+
+
+def schedule_time_scan(
+    flight_id: str, pack_dir: Path, fetch_ts: datetime, *, db_path: str = "",
+) -> bool:
+    """Queue a scan for a pack. Returns True when queued (or already queued).
+
+    Cheap to call unconditionally after any refresh: reads the flight's
+    ``flexibility`` and writes a ``skipped`` status for ``none`` so pollers get
+    a terminal answer instead of an eternal 404. Never raises — scenario work
+    must not fail a refresh.
+    """
+    try:
+        from flyfun_common.db import SessionLocal
+        from weatherbrief.storage.flights import load_flight
+
+        db = SessionLocal()
+        try:
+            flight = load_flight(db, flight_id)
+        finally:
+            db.close()
+
+        if flight.flexibility == "none":
+            _write_status(pack_dir, "skipped", "none", reason="flexibility_none")
+            return False
+
+        key = str(pack_dir)
+        with _inflight_lock:
+            if key in _inflight:
+                return True
+            _inflight.add(key)
+
+        _write_status(pack_dir, "pending", flight.flexibility)
+        _executor.submit(
+            _run_scan_job, flight_id, pack_dir, fetch_ts, db_path or _default_db_path(),
+        )
+        logger.info("time-scan: queued %s for flight %s", flight.flexibility, flight_id)
+        return True
+    except Exception:
+        logger.warning("time-scan: scheduling failed for %s", flight_id, exc_info=True)
+        return False
+
+
+def _default_db_path() -> str:
+    return os.environ.get("AIRPORTS_DB", "")
+
+
+def _run_scan_job(flight_id: str, pack_dir: Path, fetch_ts: datetime, db_path: str) -> None:
+    """Worker: grade the scenarios, persist artifacts, update the pack row."""
+    from flyfun_common.db import SessionLocal
+
+    try:
+        db = SessionLocal()
+        try:
+            from weatherbrief.api.packs import _build_route_config, _load_advisory_profile
+            from weatherbrief.storage.flights import load_flight
+            from weatherbrief.tasks.advise import derive_assessment_from_advisories
+            from weatherbrief.tasks.artifacts import save_time_options
+            from weatherbrief.tasks.time_scan import run_time_scan
+
+            flight = load_flight(db, flight_id)
+            # Re-read mode inside the worker — it may have changed while queued.
+            if flight.flexibility == "none":
+                _write_status(pack_dir, "skipped", "none", reason="flexibility_none")
+                return
+            if flight.flexibility == "alternate" and flight.alt_departure_time is None:
+                _write_status(
+                    pack_dir, "skipped", flight.flexibility, reason="no_alternate_time",
+                )
+                return
+
+            _write_status(pack_dir, "running", flight.flexibility)
+
+            route = _build_route_config(flight, db_path)
+            (
+                enabled_ids, enabled_map, user_params, aggregation, adv_models,
+                icing_method, cloud_method, convective_method, recompute_conds,
+                locale, _afd,
+            ) = _load_advisory_profile(
+                db, flight, flight.user_id, None, pack_dir, db_path=db_path,
+            )
+
+            scan = run_time_scan(
+                pack_dir, route, flight.departure_time,
+                flexibility=flight.flexibility,
+                alt_departure_time=flight.alt_departure_time,
+                advisory_models=adv_models,
+                enabled_ids=enabled_ids,
+                advisory_enabled=enabled_map,
+                user_params=user_params,
+                aggregation=aggregation,
+                airports_db_path=db_path,
+                airport_conditions_recompute=recompute_conds,
+                icing_method=icing_method,
+                cloud_method=cloud_method,
+                convective_method=convective_method,
+                locale=locale,
+            )
+            if scan is None:
+                _write_status(pack_dir, "skipped", flight.flexibility, reason="no_data")
+                return
+
+            save_time_options(pack_dir, scan)
+
+            # The pinned alternate row keeps the legacy pack-row alt fields
+            # (and the planned↔alt web UI) alive — mirror what the retired
+            # in-pipeline alt stage recorded.
+            alt_row = next((c for c in scan.candidates if c.is_alternate), None)
+            if alt_row is not None:
+                _update_pack_alt_fields(db, flight_id, pack_dir, fetch_ts, alt_row)
+                db.commit()
+
+            _write_status(pack_dir, "done", flight.flexibility)
+        finally:
+            db.close()
+    except Exception:
+        logger.warning("time-scan: job failed for %s", flight_id, exc_info=True)
+        try:
+            _write_status(pack_dir, "failed", "none", reason="internal_error")
+        except Exception:
+            pass
+    finally:
+        with _inflight_lock:
+            _inflight.discard(str(pack_dir))
+
+
+def _update_pack_alt_fields(
+    db, flight_id: str, pack_dir: Path, fetch_ts: datetime, alt_row,
+) -> None:
+    """Set has_alt_advisories / alt_assessment on the pack row (post-hoc, the
+    same update the on-demand ``/advisories/alt/compute`` endpoint performs)."""
+    from sqlalchemy import select
+
+    from weatherbrief.db.models import BriefingPackRow
+
+    naive_ts = fetch_ts.replace(tzinfo=None)
+    stmt = select(BriefingPackRow).where(
+        BriefingPackRow.flight_id == flight_id,
+        BriefingPackRow.fetch_timestamp == naive_ts,
+    )
+    pack_row = db.execute(stmt).scalar_one_or_none()
+    if pack_row is None:
+        return
+    pack_row.alt_assessment = alt_row.assessment
+    pack_row.alt_assessment_reason = alt_row.assessment_reason
+    pack_row.has_alt_advisories = (pack_dir / "route_advisories_alt.json").exists()
+    db.flush()

--- a/tests/test_time_scan.py
+++ b/tests/test_time_scan.py
@@ -280,6 +280,92 @@ class TestArtifacts:
 
 
 # ---------------------------------------------------------------------------
+# Provisional tier (slice 2): deferred hours graduate to ecmwf_only
+# ---------------------------------------------------------------------------
+
+
+class TestProvisionalTier:
+    def _write_pack(self, tmp_path: Path) -> None:
+        import json
+
+        # ECMWF enriched only 06-11 (flight window ±3h); GFS 07-10 forward.
+        cs_ecmwf = _cs(ModelSource.ECMWF, [_wf(ModelSource.ECMWF, enriched_hours=set(range(6, 12)))])
+        cs_gfs = _cs(ModelSource.GFS, [_wf(ModelSource.GFS, gfs_marked_hours=set(range(7, 11)))])
+        (tmp_path / "cross_section.json").write_text(json.dumps({
+            "cross_sections": [cs.model_dump(mode="json") for cs in (cs_ecmwf, cs_gfs)],
+        }, default=str))
+        (tmp_path / "route_points.json").write_text(json.dumps(
+            [rp.model_dump(mode="json") for rp in cs_ecmwf.route_points], default=str,
+        ))
+
+    def test_deferred_hours_grade_ecmwf_only_via_extension(self, tmp_path, monkeypatch):
+        """Hours the free tier can't grade go through the (patched) daylight
+        extension and come back as ``ecmwf_only`` provisional candidates —
+        never silently clamp-graded, never refused when ECMWF covers them."""
+        import weatherbrief.tasks.time_scan as ts
+        from weatherbrief.models import RouteConfig, Waypoint
+
+        self._write_pack(tmp_path)
+
+        def fake_extend(cross_sections, route_points, w_lo, w_hi, dur, *, as_of_time=None):
+            # Pretend the whole day was decoded: mark every hour enriched on
+            # the ECMWF section and report full-day coverage.
+            for cs in cross_sections:
+                if cs.model == ModelSource.ECMWF:
+                    for wf in cs.point_forecasts:
+                        for h in wf.hourly:
+                            h.pressure_levels = _levels(28)
+            return 1234567890, [(DAY, DAY + timedelta(hours=23))]
+
+        monkeypatch.setattr(ts, "extend_ecmwf_daylight", fake_extend)
+
+        route = RouteConfig(
+            name="t",
+            waypoints=[
+                Waypoint(icao="AAAA", name="A", lat=51.0, lon=0.0),
+                Waypoint(icao="BBBB", name="B", lat=51.0, lon=1.0),
+            ],
+            flight_duration_hours=1.0,
+        )
+        scan = ts.run_time_scan(tmp_path, route, DEP, flexibility="same_day")
+
+        assert scan is not None
+        assert scan.ecmwf_run_ts == 1234567890
+        confs = {c.confidence for c in scan.candidates if not c.is_baseline}
+        # At least some non-baseline candidates exist and every graded
+        # non-baseline one is honestly labelled (either tier, never unlabeled).
+        assert confs <= {"confirmed_in_window", "ecmwf_only"}
+        provisional = [c for c in scan.candidates if c.confidence == "ecmwf_only"]
+        # ecmwf-only view of the baseline was recorded as the diff denominator
+        if provisional:
+            assert scan.baseline.ecmwf_assessment is not None
+            for c in provisional:
+                assert c.models_used == ["ecmwf"]
+
+    def test_no_ecmwf_run_refuses_deferred(self, tmp_path, monkeypatch):
+        import weatherbrief.tasks.time_scan as ts
+        from weatherbrief.models import RouteConfig, Waypoint
+
+        self._write_pack(tmp_path)
+        monkeypatch.setattr(
+            ts, "extend_ecmwf_daylight", lambda *a, **k: (None, []),
+        )
+        route = RouteConfig(
+            name="t",
+            waypoints=[
+                Waypoint(icao="AAAA", name="A", lat=51.0, lon=0.0),
+                Waypoint(icao="BBBB", name="B", lat=51.0, lon=1.0),
+            ],
+            flight_duration_hours=1.0,
+        )
+        scan = ts.run_time_scan(tmp_path, route, DEP, flexibility="same_day")
+        assert scan is not None
+        assert scan.ecmwf_run_ts is None
+        assert scan.refused_times  # deferred hours fell back to refusal
+        assert all(c.confidence != "ecmwf_only" for c in scan.candidates)
+
+
+# ---------------------------------------------------------------------------
 # Declarative registry sets (locked mapping, decision C)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_time_scan.py
+++ b/tests/test_time_scan.py
@@ -1,0 +1,303 @@
+"""Tests for the timing-scenario scan (Flexibility) — tasks/time_scan.py.
+
+Covers the plan's validation invariants (timing-scenario-plan.md):
+- the diff/margin/ranking semantics (decision D),
+- the coverage detector: rule-window ∩ data-marker, forward-fill smear
+  bounding, per-point fidelity-parity fallback,
+- the honesty guardrail: off-coverage hours are refused, never clamp-graded,
+- artifact round-trips and the declarative timing_class registry sets.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from weatherbrief.models import (
+    AdvisoryStatus,
+    HourlyForecast,
+    ModelSource,
+    NWPCloudDiagnostics,
+    PressureLevelData,
+    RouteAdvisoriesManifest,
+    RouteAdvisoryResult,
+    RouteCrossSection,
+    RoutePoint,
+    TimeCandidate,
+    TimeScanBaseline,
+    TimeScanStatus,
+    TimeWindowScan,
+    Waypoint,
+    WaypointForecast,
+)
+from weatherbrief.tasks.time_scan import (
+    _diff_manifests,
+    _rule_window,
+    compute_model_coverage,
+    covers,
+)
+
+DEP = datetime(2026, 6, 27, 7, 30, tzinfo=timezone.utc)
+DAY = DEP.replace(hour=0, minute=0)
+
+
+# ---------------------------------------------------------------------------
+# Fixture builders
+# ---------------------------------------------------------------------------
+
+
+def _adv(advisory_id: str, status: AdvisoryStatus) -> RouteAdvisoryResult:
+    return RouteAdvisoryResult(advisory_id=advisory_id, aggregate_status=status)
+
+
+def _manifest(**statuses: AdvisoryStatus) -> RouteAdvisoriesManifest:
+    return RouteAdvisoriesManifest(
+        advisories=[_adv(k, v) for k, v in statuses.items()],
+        route_name="t", cruise_altitude_ft=8000, flight_ceiling_ft=18000,
+        total_distance_nm=100.0, models=["ecmwf"],
+    )
+
+
+def _levels(n: int, clw: bool = False) -> list[PressureLevelData]:
+    return [
+        PressureLevelData(
+            pressure_hpa=1000 - 25 * i,
+            temperature_c=10.0,
+            cloud_liquid_water_kg_kg=(0.0001 if clw else None),
+        )
+        for i in range(n)
+    ]
+
+
+def _wf(
+    model: ModelSource,
+    *,
+    enriched_hours: set[int] | None = None,
+    gfs_marked_hours: set[int] | None = None,
+) -> WaypointForecast:
+    """24 hourly rows on DEP's day. ``enriched_hours`` get 28 levels (the
+    ECMWF/ICON level-replacement marker); ``gfs_marked_hours`` get CLW +
+    diagnostics on OM-count levels (the GFS overlay marker)."""
+    hourly = []
+    for h in range(24):
+        t = DAY + timedelta(hours=h)
+        if enriched_hours and h in enriched_hours:
+            hourly.append(HourlyForecast(time=t, pressure_levels=_levels(28)))
+        elif gfs_marked_hours and h in gfs_marked_hours:
+            hourly.append(
+                HourlyForecast(
+                    time=t,
+                    pressure_levels=_levels(8, clw=True),
+                    nwp_cloud_diagnostics=NWPCloudDiagnostics(),
+                )
+            )
+        else:
+            hourly.append(HourlyForecast(time=t, pressure_levels=_levels(8)))
+    return WaypointForecast(
+        waypoint=Waypoint(icao="XXXX", name="X", lat=51.0, lon=0.0),
+        model=model,
+        fetched_at=DEP,
+        hourly=hourly,
+    )
+
+
+def _cs(model: ModelSource, forecasts: list[WaypointForecast]) -> RouteCrossSection:
+    rps = [
+        RoutePoint(lat=51.0, lon=float(i), distance_from_origin_nm=50.0 * i)
+        for i in range(len(forecasts))
+    ]
+    return RouteCrossSection(
+        model=model, route_points=rps, fetched_at=DEP, point_forecasts=forecasts,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Diff / margin (decision D semantics)
+# ---------------------------------------------------------------------------
+
+
+class TestDiffManifests:
+    def test_improvement_counts_margin_on_scan_class_only(self):
+        base = _manifest(
+            convective=AdvisoryStatus.RED,
+            headwind=AdvisoryStatus.AMBER,
+        )
+        cand = _manifest(
+            convective=AdvisoryStatus.AMBER,   # scan-class: margin +1
+            headwind=AdvisoryStatus.GREEN,     # timing-none: improves, no margin
+        )
+        improves, worsens, margin = _diff_manifests(base, cand, {"convective"})
+        assert set(improves) == {"convective", "headwind"}
+        assert worsens == []
+        assert margin == 1
+
+    def test_worsening_shows_in_full_picture(self):
+        base = _manifest(convective=AdvisoryStatus.RED, airport_wind=AdvisoryStatus.GREEN)
+        cand = _manifest(convective=AdvisoryStatus.GREEN, airport_wind=AdvisoryStatus.AMBER)
+        improves, worsens, margin = _diff_manifests(base, cand, {"convective"})
+        assert improves == ["convective"]
+        assert worsens == ["airport_wind"]  # never hide an introduced problem
+        assert margin == 2
+
+    def test_unavailable_is_not_comparable(self):
+        base = _manifest(convective=AdvisoryStatus.UNAVAILABLE)
+        cand = _manifest(convective=AdvisoryStatus.GREEN)
+        improves, worsens, margin = _diff_manifests(base, cand, {"convective"})
+        assert improves == [] and worsens == [] and margin == 0
+
+    def test_identical_manifests_zero_diff(self):
+        # The shift=0 invariant's core: same grades → empty diff, margin 0.
+        base = _manifest(convective=AdvisoryStatus.RED, vmc_cruise=AdvisoryStatus.AMBER)
+        improves, worsens, margin = _diff_manifests(base, base, {"convective", "vmc_cruise"})
+        assert improves == [] and worsens == [] and margin == 0
+
+
+# ---------------------------------------------------------------------------
+# Coverage: rule ∩ marker, smear bounding, fidelity parity
+# ---------------------------------------------------------------------------
+
+
+class TestModelCoverage:
+    def test_ecmwf_level_replacement_marker(self):
+        # Enriched 05..11 (flight window 07:30+1h ±3h) — span == marked hours.
+        cs = _cs(ModelSource.ECMWF, [_wf(ModelSource.ECMWF, enriched_hours=set(range(5, 12)))])
+        per_point, summary = compute_model_coverage([cs], DEP, 1.0)
+        lo, hi = per_point["ecmwf"][0]
+        assert lo == DAY + timedelta(hours=5)
+        assert hi == DAY + timedelta(hours=11)
+        assert summary[0].uniform is False
+
+    def test_gfs_forward_fill_smear_is_bounded_by_rule_window(self):
+        # GFS marked 07..23 — the trailing hours are the forward-fill smear
+        # (fill.py fills diagnostics/CLW past the last native anchor). The
+        # rule window (floor(dep)..dep+ceil(dur)+1h for :30 departures) must
+        # cut the claim back to 07:00..09:30.
+        cs = _cs(ModelSource.GFS, [_wf(ModelSource.GFS, gfs_marked_hours=set(range(7, 24)))])
+        per_point, _ = compute_model_coverage([cs], DEP, 1.0)
+        lo, hi = per_point["gfs"][0]
+        assert lo == DAY + timedelta(hours=7)
+        assert hi == DEP + timedelta(hours=2)  # 09:30, not 23:00
+
+    def test_unenriched_point_gets_fidelity_parity_uniform_span(self):
+        # Point 1 was never enriched (fetch gap) — the baseline graded it on
+        # OM data too, so any hour of the day is as honest there as the
+        # planned one. It must NOT veto the whole scan.
+        cs = _cs(
+            ModelSource.GFS,
+            [
+                _wf(ModelSource.GFS, gfs_marked_hours=set(range(7, 10))),
+                _wf(ModelSource.GFS),  # no markers at all
+            ],
+        )
+        per_point, summary = compute_model_coverage([cs], DEP, 1.0)
+        assert per_point["gfs"][1] == (DAY, DAY + timedelta(hours=23))
+        assert summary[0].uniform is False  # mixed, not fully uniform
+
+    def test_om_only_model_is_uniform_whole_day(self):
+        cs = _cs(ModelSource.UKMO, [_wf(ModelSource.UKMO)])
+        per_point, summary = compute_model_coverage([cs], DEP, 1.0)
+        assert per_point["ukmo"][0] == (DAY, DAY + timedelta(hours=23))
+        assert summary[0].uniform is True
+
+    def test_covers_refuses_eta_outside_span(self):
+        cs = _cs(ModelSource.ECMWF, [_wf(ModelSource.ECMWF, enriched_hours=set(range(5, 12)))])
+        per_point, _ = compute_model_coverage([cs], DEP, 1.0)
+        inside = [DAY + timedelta(hours=8)]
+        outside = [DAY + timedelta(hours=13)]
+        assert covers(per_point, ["ecmwf"], inside) is True
+        assert covers(per_point, ["ecmwf"], outside) is False
+
+    def test_covers_refuses_unknown_model(self):
+        assert covers({}, ["ecmwf"], [DEP]) is False
+
+
+class TestRuleWindow:
+    def test_ecmwf_margin(self):
+        lo, hi = _rule_window(ModelSource.ECMWF, DEP, 1.0)
+        assert lo == DEP - timedelta(hours=3)
+        assert hi == DEP + timedelta(hours=4)  # dep+1h flight +3h margin
+
+    def test_gfs_forward_window_with_minutes(self):
+        lo, hi = _rule_window(ModelSource.GFS, DEP, 1.0)
+        assert lo == DEP.replace(minute=0)  # floor hour
+        assert hi == DEP + timedelta(hours=2)  # ceil(1)+1 extra for :30
+
+
+# ---------------------------------------------------------------------------
+# Artifact round-trips
+# ---------------------------------------------------------------------------
+
+
+class TestArtifacts:
+    def _scan(self) -> TimeWindowScan:
+        return TimeWindowScan(
+            flexibility="same_day",
+            baseline=TimeScanBaseline(
+                departure_time=DEP, assessment="RED", models_used=["ecmwf"],
+            ),
+            candidates=[
+                TimeCandidate(
+                    departure_time=DEP + timedelta(hours=1),
+                    departure_shift_hours=1.0,
+                    assessment="AMBER",
+                    confidence="confirmed_in_window",
+                    margin=2.0,
+                )
+            ],
+            generated_at=DEP,
+        )
+
+    def test_time_options_round_trip(self, tmp_path: Path):
+        from weatherbrief.tasks.artifacts import load_time_options, save_time_options
+
+        save_time_options(tmp_path, self._scan())
+        loaded = load_time_options(tmp_path)
+        assert loaded is not None
+        assert loaded.candidates[0].confidence == "confirmed_in_window"
+        assert loaded.candidate_at(DEP + timedelta(hours=1)) is not None
+        assert loaded.candidate_at(DEP + timedelta(hours=5)) is None
+
+    def test_missing_artifact_is_none(self, tmp_path: Path):
+        from weatherbrief.tasks.artifacts import load_time_options
+
+        assert load_time_options(tmp_path) is None
+
+    def test_status_round_trip(self, tmp_path: Path):
+        from weatherbrief.tasks.artifacts import (
+            load_time_scan_status,
+            save_time_scan_status,
+        )
+
+        save_time_scan_status(
+            tmp_path,
+            TimeScanStatus(
+                status="running", flexibility="same_day",
+                updated_at=datetime.now(timezone.utc),
+            ),
+        )
+        loaded = load_time_scan_status(tmp_path)
+        assert loaded is not None and loaded.status == "running"
+
+
+# ---------------------------------------------------------------------------
+# Declarative registry sets (locked mapping, decision C)
+# ---------------------------------------------------------------------------
+
+
+class TestTimingClassRegistry:
+    def test_scan_class_set(self):
+        from weatherbrief.analysis.advisories.registry import get_scan_class_ids
+
+        assert get_scan_class_ids() == {
+            "convective", "convective_character", "icing_escape", "fiki_icing",
+            "cloud_top", "vmc_cruise", "vfr_feasibility", "ifr_feasibility",
+            "freezing_precip",
+        }
+
+    def test_hint_set_adds_flight_category(self):
+        from weatherbrief.analysis.advisories.registry import (
+            get_scan_class_ids,
+            get_timing_hint_ids,
+        )
+
+        assert get_timing_hint_ids() == get_scan_class_ids() | {"flight_category"}

--- a/tests/test_time_scan.py
+++ b/tests/test_time_scan.py
@@ -366,6 +366,79 @@ class TestProvisionalTier:
 
 
 # ---------------------------------------------------------------------------
+# Confirm scheduling: one-at-a-time guard + stale-flag recovery (slice 3)
+# ---------------------------------------------------------------------------
+
+
+class TestConfirmScheduling:
+    def _seed_scan(self, tmp_path: Path) -> None:
+        from weatherbrief.tasks.artifacts import save_time_options
+
+        scan = TimeWindowScan(
+            flexibility="same_day",
+            baseline=TimeScanBaseline(departure_time=DEP, assessment="RED"),
+            candidates=[
+                TimeCandidate(
+                    departure_time=DEP + timedelta(hours=h),
+                    departure_shift_hours=float(h),
+                    assessment="AMBER",
+                    confidence="ecmwf_only",
+                )
+                for h in (3, 4)
+            ],
+            generated_at=DEP,
+        )
+        save_time_options(tmp_path, scan)
+
+    def test_one_confirm_at_a_time_per_pack(self, tmp_path, monkeypatch):
+        import weatherbrief.tasks.time_scan_runner as runner
+
+        self._seed_scan(tmp_path)
+        # Queue but never run — the worker must not consume the inflight key.
+        monkeypatch.setattr(runner._executor, "submit", lambda *a, **k: None)
+
+        first = runner.schedule_time_confirm("f1", tmp_path, DEP + timedelta(hours=3))
+        assert first == "queued"
+        # Same candidate re-tapped: already on it.
+        again = runner.schedule_time_confirm("f1", tmp_path, DEP + timedelta(hours=3))
+        assert again == "queued"
+        # A DIFFERENT candidate while one runs: rejected (server-side mirror
+        # of the disabled buttons — each confirm costs a briefing-equivalent
+        # of GFS+ICON fetch).
+        other = runner.schedule_time_confirm("f1", tmp_path, DEP + timedelta(hours=4))
+        assert other == "busy"
+
+        # Cleanup the module-global inflight set for other tests.
+        with runner._inflight_lock:
+            runner._inflight.clear()
+
+    def test_unknown_candidate_is_invalid(self, tmp_path, monkeypatch):
+        import weatherbrief.tasks.time_scan_runner as runner
+
+        self._seed_scan(tmp_path)
+        monkeypatch.setattr(runner._executor, "submit", lambda *a, **k: None)
+        assert runner.schedule_time_confirm("f1", tmp_path, DEP + timedelta(hours=9)) == "invalid"
+
+    def test_reconcile_clears_orphaned_pending(self, tmp_path):
+        """A restart mid-confirm leaves confirm_pending with no live worker —
+        the polling GET reconciles it so the UI never shows an eternal
+        'checking all models…'."""
+        import weatherbrief.tasks.time_scan_runner as runner
+        from weatherbrief.tasks.artifacts import load_time_options, save_time_options
+
+        self._seed_scan(tmp_path)
+        scan = load_time_options(tmp_path)
+        scan.candidates[0].confirm_pending = True
+        save_time_options(tmp_path, scan)
+
+        assert runner.reconcile_stale_confirms(tmp_path) is True
+        reloaded = load_time_options(tmp_path)
+        assert not any(c.confirm_pending for c in reloaded.candidates)
+        # Idempotent: nothing left to clear.
+        assert runner.reconcile_stale_confirms(tmp_path) is False
+
+
+# ---------------------------------------------------------------------------
 # Declarative registry sets (locked mapping, decision C)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_time_scan.py
+++ b/tests/test_time_scan.py
@@ -453,6 +453,71 @@ class TestProvisionalTier:
         assert scan.refused_times  # deferred hours fell back to refusal
         assert all(c.confidence != "ecmwf_only" for c in scan.candidates)
 
+    def test_next_day_produces_ecmwf_only_candidates(self, tmp_path, monkeypatch):
+        """Slice 4 wiring: a next_day scan reaches the adjacent day — the
+        daylight ECMWF extension decodes next-day hours and the deferred
+        candidates come back ``ecmwf_only`` (not silently all-refused). DEP is
+        in the past, so the forward-planning past-clamp leaves the grid intact
+        (replay gate) and this stays deterministic."""
+        import weatherbrief.tasks.time_scan as ts
+        from weatherbrief.models import RouteConfig, Waypoint
+
+        self._write_pack(tmp_path)
+
+        def fake_extend(cross_sections, route_points, w_lo, w_hi, dur, *, as_of_time=None):
+            # Decode the *next* day: append enriched ECMWF hours across the
+            # extension window and report coverage that spans it.
+            hi = w_hi + timedelta(hours=dur + 3)
+            for cs in cross_sections:
+                if cs.model == ModelSource.ECMWF:
+                    for wf in cs.point_forecasts:
+                        have = {h.time for h in wf.hourly}
+                        t = w_lo.replace(minute=0, second=0, microsecond=0)
+                        while t <= hi:
+                            if t not in have:
+                                wf.hourly.append(
+                                    HourlyForecast(time=t, pressure_levels=_levels(28)),
+                                )
+                            t += timedelta(hours=1)
+                        wf.hourly.sort(key=lambda h: h.time)
+            return 1234567890, [(w_lo - timedelta(hours=3), hi)]
+
+        monkeypatch.setattr(ts, "extend_ecmwf_daylight", fake_extend)
+        # The real ±day path fetches the adjacent-day OM skeleton first (so the
+        # ECMWF extension has rows to enrich). Spy on it (no network) — the fake
+        # ECMWF extension above already supplies next-day rows for grading.
+        om_calls = []
+        monkeypatch.setattr(
+            ts, "extend_openmeteo_adjacent_day",
+            lambda cs, rps, s, e, **k: om_calls.append((s, e)) or 0,
+        )
+
+        route = RouteConfig(
+            name="t",
+            waypoints=[
+                Waypoint(icao="AAAA", name="A", lat=51.0, lon=0.0),
+                Waypoint(icao="BBBB", name="B", lat=51.0, lon=1.0),
+            ],
+            flight_duration_hours=1.0,
+        )
+        scan = ts.run_time_scan(tmp_path, route, DEP, flexibility="next_day")
+
+        assert scan is not None
+        assert scan.window is not None and scan.window.flexibility == "next_day"
+        assert not scan.window.past_clipped  # replay gate: past DEP untouched
+        # The wiring reached the adjacent day: the extension decoded it (run_ts
+        # set) and the next-day hours were graded against it, NOT refused. That
+        # they don't surface as "better" here is correct — the synthetic data
+        # grades identically everywhere, so there's honestly no better window
+        # (the ranking/suppression logic itself is covered mode-agnostically).
+        assert scan.ecmwf_run_ts == 1234567890
+        assert not scan.refused_times
+        # Any surfaced non-baseline candidate is honestly labelled + on the next day.
+        for c in scan.candidates:
+            if not c.is_baseline:
+                assert c.confidence == "ecmwf_only"
+                assert c.departure_time.date() > DEP.date()
+
 
 # ---------------------------------------------------------------------------
 # Confirm scheduling: one-at-a-time guard + stale-flag recovery (slice 3)
@@ -716,3 +781,107 @@ class TestTimingClassRegistry:
         )
 
         assert get_timing_hint_ids() == get_scan_class_ids() | {"flight_category"}
+
+
+# ---------------------------------------------------------------------------
+# Slice 4: ±day past-clamp + Open-Meteo adjacent-day extension
+# ---------------------------------------------------------------------------
+
+
+class TestClampPastGrid:
+    """Forward-planning drops elapsed hours; replay of a past pack is untouched."""
+
+    def test_future_flight_drops_elapsed_hours(self):
+        from weatherbrief.tasks.time_scan import _clamp_past_grid
+
+        now = datetime(2026, 6, 27, 10, 0, tzinfo=timezone.utc)
+        dep = datetime(2026, 6, 27, 14, 0, tzinfo=timezone.utc)  # still future
+        grid = [DAY + timedelta(hours=h) for h in range(6, 20)]
+        kept, clipped = _clamp_past_grid(grid, dep, now)
+        assert clipped is True
+        assert kept == [t for t in grid if t > now]
+        assert all(t > now for t in kept)
+
+    def test_all_past_yields_empty_grid(self):
+        from weatherbrief.tasks.time_scan import _clamp_past_grid
+
+        now = datetime(2026, 6, 27, 23, 0, tzinfo=timezone.utc)
+        dep = datetime(2026, 6, 28, 8, 0, tzinfo=timezone.utc)  # future flight
+        grid = [DAY + timedelta(hours=h) for h in range(6, 20)]  # all elapsed
+        kept, clipped = _clamp_past_grid(grid, dep, now)
+        assert kept == []
+        assert clipped is True
+
+    def test_replay_of_past_pack_not_clamped(self):
+        """An already-flown pack (dep in the past) grades its whole window —
+        eval/replay must be untouched by the forward-planning clamp."""
+        from weatherbrief.tasks.time_scan import _clamp_past_grid
+
+        now = datetime(2026, 7, 3, 12, 0, tzinfo=timezone.utc)
+        grid = [DAY + timedelta(hours=h) for h in range(6, 20)]
+        kept, clipped = _clamp_past_grid(grid, DEP, now)  # DEP = 2026-06-27 (past)
+        assert kept == grid
+        assert clipped is False
+
+
+class _FakeOMClient:
+    """Stand-in OpenMeteoClient: one 24h WaypointForecast per point on the
+    requested start_date, so the adjacent-day splice has data to merge."""
+
+    def __init__(self, *a, **k):
+        pass
+
+    def fetch_multi_point(self, points, model, *, start_date=None, end_date=None, **k):
+        base = datetime.fromisoformat(start_date).replace(tzinfo=timezone.utc)
+        out = []
+        for _ in points:
+            hourly = [
+                HourlyForecast(time=base + timedelta(hours=h), pressure_levels=_levels(8))
+                for h in range(24)
+            ]
+            out.append(WaypointForecast(
+                waypoint=Waypoint(icao="XXXX", name="X", lat=51.0, lon=0.0),
+                model=model, fetched_at=DEP, hourly=hourly,
+            ))
+        return out
+
+
+class TestExtendOpenMeteoAdjacentDay:
+    def test_splices_next_day_hours(self, monkeypatch):
+        import weatherbrief.fetch.open_meteo as om
+        from weatherbrief.tasks.time_scan import (
+            _pack_hourly_bounds,
+            extend_openmeteo_adjacent_day,
+        )
+
+        cs = _cs(
+            ModelSource.METEOFRANCE,
+            [_wf(ModelSource.METEOFRANCE), _wf(ModelSource.METEOFRANCE)],
+        )
+        before = _pack_hourly_bounds([cs])
+        monkeypatch.setattr(om, "OpenMeteoClient", _FakeOMClient)
+
+        next_day = (DAY + timedelta(days=1)).date()
+        extended = extend_openmeteo_adjacent_day([cs], cs.route_points, next_day, next_day)
+
+        assert extended == 1
+        after = _pack_hourly_bounds([cs])
+        assert after[1] > before[1]
+        assert after[1] >= DAY + timedelta(days=1, hours=23)
+        # OM-only model's honest coverage now spans into the next day.
+        per_point, _ = compute_model_coverage([cs], DEP, 1.0)
+        for span in per_point["meteofrance"]:
+            assert span is not None and span[1] >= DAY + timedelta(days=1)
+
+    def test_dedups_existing_day(self, monkeypatch):
+        """Re-fetching a day the pack already holds adds nothing (dedup by
+        time) — the hourly count is unchanged, no double rows."""
+        import weatherbrief.fetch.open_meteo as om
+        from weatherbrief.tasks.time_scan import extend_openmeteo_adjacent_day
+
+        cs = _cs(ModelSource.METEOFRANCE, [_wf(ModelSource.METEOFRANCE)])
+        n_before = len(cs.point_forecasts[0].hourly)
+        monkeypatch.setattr(om, "OpenMeteoClient", _FakeOMClient)
+
+        extend_openmeteo_adjacent_day([cs], cs.route_points, DAY.date(), DAY.date())
+        assert len(cs.point_forecasts[0].hourly) == n_before

--- a/tests/test_time_scan.py
+++ b/tests/test_time_scan.py
@@ -342,6 +342,39 @@ class TestProvisionalTier:
             for c in provisional:
                 assert c.models_used == ["ecmwf"]
 
+    def test_shift_zero_reproduces_independent_grade(self, tmp_path, monkeypatch):
+        """Plan Validation #1: the scan's baseline row must equal a grade of
+        the planned time computed independently through run_alt_from_pack —
+        not just a self-consistent zero diff."""
+        import weatherbrief.tasks.time_scan as ts
+        from weatherbrief.models import RouteConfig, Waypoint
+        from weatherbrief.tasks.advise import (
+            derive_assessment_from_advisories,
+            run_alt_from_pack,
+        )
+
+        self._write_pack(tmp_path)
+        monkeypatch.setattr(ts, "extend_ecmwf_daylight", lambda *a, **k: (None, []))
+        route = RouteConfig(
+            name="t",
+            waypoints=[
+                Waypoint(icao="AAAA", name="A", lat=51.0, lon=0.0),
+                Waypoint(icao="BBBB", name="B", lat=51.0, lon=1.0),
+            ],
+            flight_duration_hours=1.0,
+        )
+        scan = ts.run_time_scan(tmp_path, route, DEP, flexibility="same_day")
+        base_row = next(c for c in scan.candidates if c.is_baseline)
+
+        independent = run_alt_from_pack(
+            tmp_path, DEP, route, persist=False, detect_fronts=False,
+        )
+        ind_assess, _ = derive_assessment_from_advisories(independent.manifest)
+
+        assert base_row.assessment == ind_assess
+        assert base_row.margin == 0
+        assert not base_row.improves and not base_row.worsens
+
     def test_no_ecmwf_run_refuses_deferred(self, tmp_path, monkeypatch):
         import weatherbrief.tasks.time_scan as ts
         from weatherbrief.models import RouteConfig, Waypoint
@@ -436,6 +469,173 @@ class TestConfirmScheduling:
         assert not any(c.confirm_pending for c in reloaded.candidates)
         # Idempotent: nothing left to clear.
         assert runner.reconcile_stale_confirms(tmp_path) is False
+
+
+# ---------------------------------------------------------------------------
+# Runner: decision-H reuse, stale-status reconcile, confirm-merge (round 2)
+# ---------------------------------------------------------------------------
+
+
+def _flight_stub(**overrides):
+    from types import SimpleNamespace
+
+    base = dict(
+        flexibility="same_day",
+        departure_time=DEP,
+        alt_departure_time=None,
+        user_id="u1",
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def _scan_artifact(
+    tmp_path: Path,
+    *,
+    run_ts: int | None = 111,
+    candidates: list[TimeCandidate] | None = None,
+) -> TimeWindowScan:
+    from weatherbrief.tasks.artifacts import save_time_options
+
+    scan = TimeWindowScan(
+        flexibility="same_day",
+        baseline=TimeScanBaseline(departure_time=DEP, assessment="RED"),
+        candidates=candidates if candidates is not None else [],
+        ecmwf_run_ts=run_ts,
+        generated_at=DEP,
+    )
+    save_time_options(tmp_path, scan)
+    return scan
+
+
+class TestReusableScan:
+    """Decision-H: a scan for the same run/departure/mode skips the re-decode."""
+
+    def _patch_run(self, monkeypatch, ts):
+        import weatherbrief.tasks.time_scan as ts_mod
+
+        monkeypatch.setattr(ts_mod, "current_ecmwf_run_ts", lambda *a, **k: ts)
+        monkeypatch.setattr(ts_mod, "_pack_fetched_at", lambda p: DEP)
+
+    def test_reuses_same_run(self, tmp_path, monkeypatch):
+        import weatherbrief.tasks.time_scan_runner as runner
+
+        _scan_artifact(tmp_path, run_ts=111)
+        self._patch_run(monkeypatch, 111)
+        assert runner._reusable_scan(tmp_path, _flight_stub()) is not None
+
+    def test_new_run_invalidates(self, tmp_path, monkeypatch):
+        import weatherbrief.tasks.time_scan_runner as runner
+
+        _scan_artifact(tmp_path, run_ts=111)
+        self._patch_run(monkeypatch, 222)
+        assert runner._reusable_scan(tmp_path, _flight_stub()) is None
+
+    def test_changed_mode_or_departure_invalidates(self, tmp_path, monkeypatch):
+        import weatherbrief.tasks.time_scan_runner as runner
+
+        _scan_artifact(tmp_path, run_ts=111)
+        self._patch_run(monkeypatch, 111)
+        assert runner._reusable_scan(tmp_path, _flight_stub(flexibility="next_day")) is None
+        assert runner._reusable_scan(
+            tmp_path, _flight_stub(departure_time=DEP + timedelta(hours=2)),
+        ) is None
+
+    def test_new_alternate_invalidates(self, tmp_path, monkeypatch):
+        # "Set as alternate" must force a re-grade of the pinned row.
+        import weatherbrief.tasks.time_scan_runner as runner
+
+        _scan_artifact(tmp_path, run_ts=111)
+        self._patch_run(monkeypatch, 111)
+        assert runner._reusable_scan(
+            tmp_path, _flight_stub(alt_departure_time=DEP + timedelta(hours=3)),
+        ) is None
+
+    def test_free_tier_only_scan_not_reused(self, tmp_path, monkeypatch):
+        # No run_ts = no decode was spent; a fresh grade wins.
+        import weatherbrief.tasks.time_scan_runner as runner
+
+        _scan_artifact(tmp_path, run_ts=None)
+        self._patch_run(monkeypatch, 111)
+        assert runner._reusable_scan(tmp_path, _flight_stub()) is None
+
+
+class TestStaleScanReconcile:
+    def test_orphaned_running_status_flips_to_failed(self, tmp_path):
+        import weatherbrief.tasks.time_scan_runner as runner
+        from weatherbrief.tasks.artifacts import load_time_scan_status
+
+        runner._write_status(tmp_path, "running", "same_day")
+        assert runner.reconcile_stale_scan(tmp_path) is True
+        status = load_time_scan_status(tmp_path)
+        assert status.status == "failed" and status.reason == "interrupted"
+
+    def test_live_worker_is_left_alone(self, tmp_path):
+        import weatherbrief.tasks.time_scan_runner as runner
+
+        runner._write_status(tmp_path, "running", "same_day")
+        with runner._inflight_lock:
+            runner._inflight.add(str(tmp_path))
+        try:
+            assert runner.reconcile_stale_scan(tmp_path) is False
+        finally:
+            with runner._inflight_lock:
+                runner._inflight.discard(str(tmp_path))
+
+    def test_terminal_status_untouched(self, tmp_path):
+        import weatherbrief.tasks.time_scan_runner as runner
+        from weatherbrief.tasks.artifacts import load_time_scan_status
+
+        runner._write_status(tmp_path, "done", "same_day")
+        assert runner.reconcile_stale_scan(tmp_path) is False
+        assert load_time_scan_status(tmp_path).status == "done"
+
+
+class TestMergeConfirmed:
+    def _cand(self, hours: float, confirmed: bool = False) -> TimeCandidate:
+        from weatherbrief.models import TimeConfirmation
+
+        return TimeCandidate(
+            departure_time=DEP + timedelta(hours=hours),
+            departure_shift_hours=hours,
+            assessment="AMBER",
+            confidence="ecmwf_only",
+            confirmed=TimeConfirmation(
+                models_checked=["ecmwf", "gfs", "icon"],
+                assessment="RED",
+                better_than_baseline=False,
+                confirmed_at=DEP,
+            ) if confirmed else None,
+        )
+
+    def test_confirm_survives_same_run_rescan(self, tmp_path):
+        from weatherbrief.tasks.time_scan_runner import merge_confirmed
+
+        old = _scan_artifact(tmp_path, run_ts=111, candidates=[self._cand(3, confirmed=True)])
+        new = TimeWindowScan(
+            flexibility="same_day",
+            baseline=TimeScanBaseline(departure_time=DEP, assessment="RED"),
+            candidates=[self._cand(3)],
+            ecmwf_run_ts=111,
+            generated_at=DEP,
+        )
+        merge_confirmed(old, new)
+        assert new.candidates[0].confirmed is not None
+        assert new.candidates[0].confidence == "confirmed"
+
+    def test_new_run_drops_stale_confirms(self, tmp_path):
+        from weatherbrief.tasks.time_scan_runner import merge_confirmed
+
+        old = _scan_artifact(tmp_path, run_ts=111, candidates=[self._cand(3, confirmed=True)])
+        new = TimeWindowScan(
+            flexibility="same_day",
+            baseline=TimeScanBaseline(departure_time=DEP, assessment="RED"),
+            candidates=[self._cand(3)],
+            ecmwf_run_ts=222,
+            generated_at=DEP,
+        )
+        merge_confirmed(old, new)
+        assert new.candidates[0].confirmed is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_time_scan.py
+++ b/tests/test_time_scan.py
@@ -152,6 +152,62 @@ class TestDiffManifests:
         assert improves == [] and worsens == [] and margin == 0
 
 
+class TestPerModelReasons:
+    """per_model_reasons_from_manifest — the confirm's dot-table breakdown."""
+
+    def test_split_by_model_red_amber_only(self):
+        from weatherbrief.models import ModelAdvisoryResult
+        from weatherbrief.tasks.advise import per_model_reasons_from_manifest
+
+        manifest = RouteAdvisoriesManifest(advisories=[
+            RouteAdvisoryResult(
+                advisory_id="turbulence",
+                aggregate_status=AdvisoryStatus.RED,
+                per_model=[
+                    ModelAdvisoryResult(model="ecmwf", status=AdvisoryStatus.AMBER),
+                    ModelAdvisoryResult(model="gfs", status=AdvisoryStatus.RED),
+                    ModelAdvisoryResult(model="icon", status=AdvisoryStatus.GREEN),
+                ],
+            ),
+            RouteAdvisoryResult(
+                advisory_id="icing",
+                aggregate_status=AdvisoryStatus.AMBER,
+                per_model=[
+                    ModelAdvisoryResult(model="gfs", status=AdvisoryStatus.AMBER),
+                ],
+            ),
+        ])
+        out = per_model_reasons_from_manifest(manifest)
+        assert out == {
+            "ecmwf": "turbulence=AMBER",
+            "gfs": "turbulence=RED, icing=AMBER",
+        }
+        # All-green model is absent — the client treats absence as clear.
+        assert "icon" not in out
+
+    def test_empty_manifest(self):
+        from weatherbrief.tasks.advise import per_model_reasons_from_manifest
+
+        assert per_model_reasons_from_manifest(RouteAdvisoriesManifest()) == {}
+
+    def test_confirmation_round_trips_field(self):
+        from weatherbrief.models import TimeConfirmation
+
+        conf = TimeConfirmation(
+            models_checked=["ecmwf", "gfs"],
+            assessment="RED",
+            per_model_reasons={"gfs": "turbulence=RED"},
+            better_than_baseline=False,
+            confirmed_at=DEP,
+        )
+        again = TimeConfirmation.model_validate(conf.model_dump(mode="json"))
+        assert again.per_model_reasons == {"gfs": "turbulence=RED"}
+        # Old artifacts (pre-field) still validate.
+        legacy = conf.model_dump(mode="json")
+        legacy.pop("per_model_reasons")
+        assert TimeConfirmation.model_validate(legacy).per_model_reasons == {}
+
+
 # ---------------------------------------------------------------------------
 # Coverage: rule ∩ marker, smear bounding, fidelity parity
 # ---------------------------------------------------------------------------

--- a/web/briefing.html
+++ b/web/briefing.html
@@ -76,6 +76,16 @@
       Loading...
     </div>
 
+    <!-- Route Advisories -->
+    <div id="advisories-wrapper" class="section collapsible" data-section="advisories" style="display: none;">
+      <h3>Route Advisories</h3>
+      <div class="section-body">
+        <div id="advisories-section">
+          <p class="muted">Loading...</p>
+        </div>
+      </div>
+    </div>
+
     <!-- Alternate departure time assessment (rendered separately, outside the AI digest banner) -->
     <div id="alt-assessment-banner" class="alt-assessment-banner" style="display: none;"></div>
 
@@ -85,16 +95,6 @@
       <div class="section-body">
         <div id="time-scenarios-section">
           <p class="muted">Scenarios running&hellip;</p>
-        </div>
-      </div>
-    </div>
-
-    <!-- Route Advisories -->
-    <div id="advisories-wrapper" class="section collapsible" data-section="advisories" style="display: none;">
-      <h3>Route Advisories</h3>
-      <div class="section-body">
-        <div id="advisories-section">
-          <p class="muted">Loading...</p>
         </div>
       </div>
     </div>

--- a/web/briefing.html
+++ b/web/briefing.html
@@ -79,6 +79,16 @@
     <!-- Alternate departure time assessment (rendered separately, outside the AI digest banner) -->
     <div id="alt-assessment-banner" class="alt-assessment-banner" style="display: none;"></div>
 
+    <!-- Timing scenarios (Flexibility) — background scan results, polled after briefing_ready -->
+    <div id="time-scenarios-wrapper" class="section collapsible" data-section="time-scenarios" style="display: none;">
+      <h3>&#128336; Timing Scenarios</h3>
+      <div class="section-body">
+        <div id="time-scenarios-section">
+          <p class="muted">Scenarios running&hellip;</p>
+        </div>
+      </div>
+    </div>
+
     <!-- Route Advisories -->
     <div id="advisories-wrapper" class="section collapsible" data-section="advisories" style="display: none;">
       <h3>Route Advisories</h3>

--- a/web/briefing.html
+++ b/web/briefing.html
@@ -94,7 +94,7 @@
       <h3>&#128336; Timing Scenarios</h3>
       <div class="section-body">
         <div id="time-scenarios-section">
-          <p class="muted">Scenarios running&hellip;</p>
+          <p class="muted">Scenarios running<span class="dots-spinner"></span></p>
         </div>
       </div>
     </div>

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -2206,9 +2206,67 @@ label {
   transition: background 0.15s, border-color 0.15s;
 }
 
-.btn-outline:hover {
+.btn-outline:hover:not(:disabled) {
   background: var(--border);
   border-color: var(--text-muted);
+}
+
+.btn-outline:disabled {
+  color: var(--text-muted);
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+/* --- Timing scenarios --- */
+/* Keep the time label pinned to the candidate's first line even when the
+   details expander grows the row. */
+.time-scenario-row {
+  align-items: flex-start;
+}
+.time-scenario-row .info-label {
+  padding-top: 0.15rem;
+}
+/* Collapsed: one wrapping line per scenario (chip · shift · diff · status ·
+   details link). Opened: the expander drops to a full-width row below. */
+.time-scenario-row .info-value {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  column-gap: 0.45rem;
+  row-gap: 0.15rem;
+}
+.time-scenario-row details[open] {
+  flex-basis: 100%;
+}
+
+/* Expanded details: boxed so it visually belongs to its candidate row. */
+.time-detail-box {
+  display: inline-block;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg);
+  padding: 0.5rem 0.75rem;
+  margin: 0.3rem 0 0.5rem;
+}
+
+.time-detail-table {
+  border-collapse: collapse;
+}
+.time-detail-table th {
+  font-weight: 500;
+  color: var(--text-muted);
+  font-size: 0.9em;
+  text-align: center;
+  padding: 0.1rem 0.7rem;
+}
+.time-detail-table td {
+  text-align: center;
+  padding: 0.1rem 0.7rem;
+}
+.time-detail-table th:first-child,
+.time-detail-table td:first-child {
+  text-align: left;
+  padding-left: 0;
 }
 
 /* --- Image lightbox --- */

--- a/web/index.html
+++ b/web/index.html
@@ -95,6 +95,15 @@
             </div>
           </div>
           <div class="form-group">
+            <label for="input-flexibility" title="How much departure flexibility you have — scans other times in the background after each briefing">Flexibility</label>
+            <select id="input-flexibility">
+              <option value="none" selected>None</option>
+              <option value="same_day">Same day</option>
+              <option value="prev_day">Previous day</option>
+              <option value="next_day">Next day</option>
+            </select>
+          </div>
+          <div class="form-group">
             <label>&nbsp;</label>
             <button type="submit" class="btn btn-primary">Create Flight</button>
           </div>

--- a/web/ts/adapters/api-adapter.ts
+++ b/web/ts/adapters/api-adapter.ts
@@ -568,6 +568,7 @@ export interface TimeConfirmationDTO {
 export interface TimeCandidateDTO {
   departure_time: string;
   departure_shift_hours: number;
+  valid_times: string[];  // per-route-point ETAs the grade actually read
   assessment: string;            // GREEN / AMBER / RED
   assessment_reason: string;
   models_used: string[];
@@ -605,6 +606,18 @@ export async function fetchTimeOptions(
 ): Promise<TimeOptionsResponse> {
   return apiFetch<TimeOptionsResponse>(
     `/flights/${encodeURIComponent(flightId)}/packs/${encodeURIComponent(timestamp)}/time-options`
+  );
+}
+
+/** Re-queue the timing scan for a pack — used after "Set as alternate time"
+ *  so the changed alternate gets graded and the alt artifacts re-persist. */
+export async function rescanTimeOptions(
+  flightId: string,
+  timestamp: string,
+): Promise<{ status: string }> {
+  return apiFetch<{ status: string }>(
+    `/flights/${encodeURIComponent(flightId)}/packs/${encodeURIComponent(timestamp)}/time-options/rescan`,
+    { method: 'POST' },
   );
 }
 

--- a/web/ts/adapters/api-adapter.ts
+++ b/web/ts/adapters/api-adapter.ts
@@ -587,7 +587,7 @@ export interface TimeCandidateDTO {
 export interface TimeWindowScanDTO {
   flexibility: FlexibilityMode;
   baseline: { departure_time: string; assessment: string; assessment_reason: string };
-  window: { start: string; end: string; daylight_clipped: boolean; horizon_clipped: boolean } | null;
+  window: { start: string; end: string; daylight_clipped: boolean; horizon_clipped: boolean; past_clipped?: boolean } | null;
   candidates: TimeCandidateDTO[];
   refused_times: string[];
   generated_at: string;

--- a/web/ts/adapters/api-adapter.ts
+++ b/web/ts/adapters/api-adapter.ts
@@ -555,6 +555,16 @@ export interface TimeScanStatusDTO {
   updated_at: string;
 }
 
+export interface TimeConfirmationDTO {
+  models_checked: string[];
+  assessment: string;
+  assessment_reason: string;
+  better_than_baseline: boolean;
+  improves: string[];
+  worsens: string[];
+  confirmed_at: string;
+}
+
 export interface TimeCandidateDTO {
   departure_time: string;
   departure_shift_hours: number;
@@ -567,6 +577,8 @@ export interface TimeCandidateDTO {
   confidence: 'confirmed_in_window' | 'ecmwf_only' | 'confirmed';
   is_baseline: boolean;
   is_alternate: boolean;
+  confirmed: TimeConfirmationDTO | null;
+  confirm_pending: boolean;
 }
 
 export interface TimeWindowScanDTO {
@@ -593,6 +605,19 @@ export async function fetchTimeOptions(
 ): Promise<TimeOptionsResponse> {
   return apiFetch<TimeOptionsResponse>(
     `/flights/${encodeURIComponent(flightId)}/packs/${encodeURIComponent(timestamp)}/time-options`
+  );
+}
+
+/** Queue the on-tap multi-model check of one provisional candidate (202);
+ *  the result lands on the candidate via the regular time-options poll. */
+export async function confirmTimeOption(
+  flightId: string,
+  timestamp: string,
+  departureTime: string,
+): Promise<{ status: string }> {
+  return apiFetch<{ status: string }>(
+    `/flights/${encodeURIComponent(flightId)}/packs/${encodeURIComponent(timestamp)}/time-options/confirm`,
+    { method: 'POST', body: JSON.stringify({ departure_time: departureTime }) },
   );
 }
 

--- a/web/ts/adapters/api-adapter.ts
+++ b/web/ts/adapters/api-adapter.ts
@@ -123,6 +123,9 @@ export interface UpdateFlightRequest {
   aircraft_id?: number;
   departure_time?: string;
   alt_departure_time?: string | null;
+  // Timing-scenario Flexibility mode; omit for no change. 'alternate'
+  // requires an alt_departure_time (server 422s otherwise).
+  flexibility?: 'none' | 'alternate' | 'same_day' | 'prev_day' | 'next_day';
   cruise_altitude_ft?: number;
   flight_ceiling_ft?: number;
   flight_duration_hours?: number;
@@ -540,6 +543,56 @@ export async function computeAltAdvisories(
   return apiFetch<RouteAdvisoriesManifest>(
     `/flights/${encodeURIComponent(flightId)}/packs/${encodeURIComponent(timestamp)}/advisories/alt/compute`,
     { method: 'POST' },
+  );
+}
+
+export type FlexibilityMode = 'none' | 'alternate' | 'same_day' | 'prev_day' | 'next_day';
+
+export interface TimeScanStatusDTO {
+  status: 'pending' | 'running' | 'done' | 'failed' | 'skipped';
+  flexibility: FlexibilityMode;
+  reason: string;
+  updated_at: string;
+}
+
+export interface TimeCandidateDTO {
+  departure_time: string;
+  departure_shift_hours: number;
+  assessment: string;            // GREEN / AMBER / RED
+  assessment_reason: string;
+  models_used: string[];
+  improves: string[];
+  worsens: string[];
+  margin: number;
+  confidence: 'confirmed_in_window' | 'ecmwf_only' | 'confirmed';
+  is_baseline: boolean;
+  is_alternate: boolean;
+}
+
+export interface TimeWindowScanDTO {
+  flexibility: FlexibilityMode;
+  baseline: { departure_time: string; assessment: string; assessment_reason: string };
+  window: { start: string; end: string; daylight_clipped: boolean; horizon_clipped: boolean } | null;
+  candidates: TimeCandidateDTO[];
+  refused_times: string[];
+  generated_at: string;
+}
+
+export interface TimeOptionsResponse {
+  status: TimeScanStatusDTO | null;
+  scan: TimeWindowScanDTO | null;
+}
+
+/** Timing-scenario scan (Flexibility) — status + result, poll-friendly.
+ *  The scan runs as a background job after the briefing, so the client polls
+ *  this after briefing_ready until status is terminal (done/failed/skipped).
+ *  404s when the flight has Flexibility "none" and no scan was ever run. */
+export async function fetchTimeOptions(
+  flightId: string,
+  timestamp: string,
+): Promise<TimeOptionsResponse> {
+  return apiFetch<TimeOptionsResponse>(
+    `/flights/${encodeURIComponent(flightId)}/packs/${encodeURIComponent(timestamp)}/time-options`
   );
 }
 

--- a/web/ts/adapters/api-adapter.ts
+++ b/web/ts/adapters/api-adapter.ts
@@ -559,6 +559,8 @@ export interface TimeConfirmationDTO {
   models_checked: string[];
   assessment: string;
   assessment_reason: string;
+  /** Per-model "id=STATUS, ..." breakdown; a model with nothing flagged is absent. */
+  per_model_reasons?: Record<string, string>;
   better_than_baseline: boolean;
   improves: string[];
   worsens: string[];

--- a/web/ts/briefing-main.ts
+++ b/web/ts/briefing-main.ts
@@ -565,29 +565,59 @@ async function init(): Promise<void> {
         confLine = 'all models checked';
       }
 
-      // Progressive depth: an expander with everything already saved for
-      // this hour — the full red/amber breakdown, models, graded ETA span.
-      const reasonList = (reason: string) => {
-        const parts = reason.split(',').map((p) => p.trim()).filter((p) => p.includes('='));
-        if (!parts.length) return `<div class="muted">${escapeHtml(reason || 'All clear')}</div>`;
-        return parts.map((p) => {
-          const [id, status] = p.split('=');
-          const cls = status === 'RED' ? 'assessment-red-text'
-            : status === 'AMBER' ? 'assessment-amber-text' : '';
-          return `<div><span class="${cls}">●</span> ${escapeHtml(nameOf(id))}: ${escapeHtml(status)}</div>`;
-        }).join('');
+      // Progressive depth: an expander with a per-advisory dot table —
+      // Current (planned time) vs this hour's ECMWF view vs the all-model
+      // check when one has been run. Absent from a reason string = clear
+      // (every candidate is graded on the full advisory set).
+      const parseReason = (reason: string): Map<string, string> => {
+        const map = new Map<string, string>();
+        for (const part of reason.split(',')) {
+          const [id, st] = part.trim().split('=');
+          if (id && st) map.set(id.trim(), st.trim());
+        }
+        return map;
       };
+      const dot = (status: string, col: string, advisory: string) => {
+        const cls = status === 'RED' ? 'assessment-red-text'
+          : status === 'AMBER' ? 'assessment-amber-text' : 'assessment-green-text';
+        return `<span class="${cls}" title="${escapeHtml(`${advisory} — ${col}: ${status}`)}">●</span>`;
+      };
+      const baselineReason = scan.candidates.find((b) => b.is_baseline)?.assessment_reason ?? '';
+      const cols: { label: string; map: Map<string, string> }[] = [
+        { label: 'Current', map: parseReason(baselineReason) },
+      ];
+      if (!c.is_baseline) {
+        // The provisional grade is the ECMWF-extension view unless the free
+        // tier already covered this hour with every model in-window.
+        cols.push({
+          label: c.confirmed || c.confidence === 'ecmwf_only' ? 'ECMWF only' : 'All models',
+          map: parseReason(c.assessment_reason),
+        });
+        if (c.confirmed) {
+          cols.push({ label: 'All models', map: parseReason(c.confirmed.assessment_reason) });
+        }
+      }
+      const rank = (s: string | undefined) => (s === 'RED' ? 2 : s === 'AMBER' ? 1 : 0);
+      const worstOf = (id: string) => Math.max(...cols.map((col) => rank(col.map.get(id))));
+      const rowIds = [...new Set(cols.flatMap((col) => [...col.map.keys()]))]
+        .sort((a, b) => worstOf(b) - worstOf(a) || nameOf(a).localeCompare(nameOf(b)));
+      const tableHtml = rowIds.length
+        ? `<table class="time-detail-table">
+            <thead><tr><th></th>${cols.map((col) => `<th>${escapeHtml(col.label)}</th>`).join('')}</tr></thead>
+            <tbody>${rowIds.map((id) => `<tr>
+              <td>${escapeHtml(nameOf(id))}</td>
+              ${cols.map((col) => `<td>${dot(col.map.get(id) ?? 'GREEN', col.label, nameOf(id))}</td>`).join('')}
+            </tr>`).join('')}</tbody>
+          </table>`
+        : '<div class="muted">All advisories clear at every checked view.</div>';
       const etaSpan = c.valid_times.length
         ? `${formatDepartureTime(c.valid_times[0])} → ${formatDepartureTime(c.valid_times[c.valid_times.length - 1])}`
         : '';
-      let detailHtml = `
-        <div style="margin:0.25rem 0;"><strong>${c.confirmed ? 'ECMWF view' : 'At this hour'}</strong>${reasonList(c.assessment_reason)}</div>`;
-      if (c.confirmed) {
-        detailHtml += `
-        <div style="margin:0.25rem 0;"><strong>All-model check (${escapeHtml(c.confirmed.models_checked.map((m) => m.toUpperCase()).join(', '))})</strong>${reasonList(c.confirmed.assessment_reason)}</div>`;
-      }
-      detailHtml += `
-        <div class="muted" style="font-size:0.85em;">Graded with ${escapeHtml(c.models_used.map((m) => m.toUpperCase()).join(', '))}${etaSpan ? ` · route ETAs ${escapeHtml(etaSpan)}` : ''}</div>`;
+      const detailHtml = `
+        <div class="time-detail-box">
+          ${tableHtml}
+          <div class="muted" style="font-size:0.85em; margin-top:0.35rem;">Graded with ${escapeHtml(c.models_used.map((m) => m.toUpperCase()).join(', '))}${etaSpan ? ` · route ETAs ${escapeHtml(etaSpan)}` : ''}</div>
+        </div>`;
 
       // "Set as alternate time" — pins this scenario so the full per-advisory
       // detail flows through the existing planned↔alt view. Same-day only
@@ -598,14 +628,14 @@ async function init(): Promise<void> {
         : '';
 
       return `
-        <div class="info-row">
+        <div class="info-row time-scenario-row">
           <span class="info-label">${escapeHtml(time)}</span>
           <span class="info-value">
             ${effectiveChip}
             <span class="muted">${escapeHtml(shift)}${escapeHtml(tag)}</span>
-            ${diffs.length ? `<div>${escapeHtml(diffs.join(' · '))}</div>` : ''}
-            <div class="muted" style="font-size:0.8em;">${confLine}${setAltBtn}</div>
-            <details style="font-size:0.85em; margin-top:0.2rem;">
+            ${diffs.length ? `<span>${escapeHtml(diffs.join(' · '))}</span>` : ''}
+            <span class="muted" style="font-size:0.8em;">${confLine}${setAltBtn}</span>
+            <details style="font-size:0.85em;">
               <summary class="muted" style="cursor:pointer;">details</summary>
               ${detailHtml}
             </details>

--- a/web/ts/briefing-main.ts
+++ b/web/ts/briefing-main.ts
@@ -525,26 +525,54 @@ async function init(): Promise<void> {
       return `<span class="assessment-chip ${cls}">${escapeHtml(assessment)}</span>`;
     };
 
+    // One confirm at a time (server enforces with 429; mirror it in the UI):
+    // while any candidate is checking, the other check buttons are disabled.
+    const anyConfirmPending = scan.candidates.some((c) => c.confirm_pending);
+
     const rows = scan.candidates.map((c) => {
       const time = formatDepartureTime(c.departure_time);
       const shift = c.is_baseline
         ? 'as planned'
         : `${c.departure_shift_hours >= 0 ? '+' : ''}${c.departure_shift_hours}h`;
       const tag = c.is_baseline ? '' : c.is_alternate ? ' ★ your alternate' : '';
+      // Once confirmed, the multi-model diff replaces the provisional one —
+      // showing ECMWF-only "improves" next to a "not better after all"
+      // verdict would contradict itself.
+      const improves = c.confirmed ? c.confirmed.improves : c.improves;
+      const worsens = c.confirmed ? c.confirmed.worsens : c.worsens;
       const diffs: string[] = [];
-      if (c.improves.length) diffs.push(`improves: ${c.improves.map(nameOf).join(', ')}`);
-      if (c.worsens.length) diffs.push(`worsens: ${c.worsens.map(nameOf).join(', ')}`);
-      const conf = c.confidence === 'confirmed_in_window' || c.confidence === 'confirmed'
-        ? 'all models checked'
-        : 'ECMWF only — not yet confirmed by other models';
+      if (improves.length) diffs.push(`improves: ${improves.map(nameOf).join(', ')}`);
+      if (worsens.length) diffs.push(`worsens: ${worsens.map(nameOf).join(', ')}`);
+
+      // Confidence line + the slice-3 confirm affordance for provisional rows.
+      let confLine: string;
+      let effectiveChip = chip(c.assessment);
+      if (c.confirmed) {
+        // Multi-model verdict replaces the provisional one. A downgrade
+        // ("actually not better") is a designed outcome — say it plainly.
+        effectiveChip = chip(c.confirmed.assessment);
+        const models = c.confirmed.models_checked.map((m) => m.toUpperCase()).join(', ');
+        confLine = c.confirmed.better_than_baseline
+          ? `checked with ${escapeHtml(models)} — still looks smoother`
+          : `checked with ${escapeHtml(models)} — not clearly better after all`;
+      } else if (c.confirm_pending) {
+        confLine = 'checking all models…';
+      } else if (c.confidence === 'ecmwf_only') {
+        confLine = anyConfirmPending
+          ? `ECMWF only · <button type="button" class="btn btn-outline btn-sm time-confirm-btn" disabled title="One model check at a time — another is running">Check all models</button>`
+          : `ECMWF only · <button type="button" class="btn btn-outline btn-sm time-confirm-btn" data-departure="${escapeHtml(c.departure_time)}">Check all models</button>`;
+      } else {
+        confLine = 'all models checked';
+      }
+
       return `
         <div class="info-row">
           <span class="info-label">${escapeHtml(time)}</span>
           <span class="info-value">
-            ${chip(c.assessment)}
+            ${effectiveChip}
             <span class="muted">${escapeHtml(shift)}${escapeHtml(tag)}</span>
             ${diffs.length ? `<div>${escapeHtml(diffs.join(' · '))}</div>` : ''}
-            <div class="muted" style="font-size:0.8em;">${escapeHtml(conf)}</div>
+            <div class="muted" style="font-size:0.8em;">${confLine}</div>
           </span>
         </div>`;
     }).join('');
@@ -558,6 +586,14 @@ async function init(): Promise<void> {
       : '';
 
     section.innerHTML = `<p>${escapeHtml(headline)}</p>${rows}${refusedNote}`;
+
+    // Wire the confirm taps (fresh nodes on every render — no stale handlers).
+    section.querySelectorAll<HTMLButtonElement>('.time-confirm-btn').forEach((btn) => {
+      btn.addEventListener('click', () => {
+        const dep = btn.dataset.departure;
+        if (dep) void store.getState().confirmTimeOption(dep);
+      });
+    });
   }
 
   /** Build alt time toggle config if alt advisories are available. */

--- a/web/ts/briefing-main.ts
+++ b/web/ts/briefing-main.ts
@@ -480,6 +480,86 @@ async function init(): Promise<void> {
     }
   }
 
+  /** Timing-scenario section (Flexibility) — attention-director framing:
+   *  candidates are "what changes if you leave at X", never a go/no-go.
+   *  Data arrives from the background scan via the polled store state. */
+  function renderTimeScenarios(state: BriefingState): void {
+    const wrapper = document.getElementById('time-scenarios-wrapper');
+    const section = document.getElementById('time-scenarios-section');
+    if (!wrapper || !section) return;
+
+    const flex = state.flight?.flexibility ?? 'none';
+    const to = state.timeOptions;
+    if (flex === 'none' || !to) {
+      wrapper.style.display = 'none';
+      return;
+    }
+    wrapper.style.display = '';
+
+    const status = to.status?.status;
+    if (status === 'pending' || status === 'running' || (!status && !to.scan)) {
+      section.innerHTML = '<p class="muted">Scenarios running… checking other departure times against this briefing.</p>';
+      return;
+    }
+    if (status === 'failed') {
+      section.innerHTML = '<p class="muted">Scenario check failed — it will run again on the next refresh.</p>';
+      return;
+    }
+    if (status === 'skipped' || !to.scan) {
+      const reason = to.status?.reason === 'no_alternate_time'
+        ? 'Set an alternate departure time to grade it here.'
+        : 'No scenario data for this briefing.';
+      section.innerHTML = `<p class="muted">${escapeHtml(reason)}</p>`;
+      return;
+    }
+
+    const scan = to.scan;
+    const names = new Map<string, string>(
+      (state.routeAdvisories?.catalog ?? []).map((c) => [c.id, c.name]),
+    );
+    const nameOf = (id: string) => names.get(id) ?? id;
+    const chip = (assessment: string) => {
+      const cls = assessment === 'GREEN' ? 'assessment-green'
+        : assessment === 'AMBER' ? 'assessment-amber'
+        : assessment === 'RED' ? 'assessment-red' : 'assessment-none';
+      return `<span class="assessment-chip ${cls}">${escapeHtml(assessment)}</span>`;
+    };
+
+    const rows = scan.candidates.map((c) => {
+      const time = formatDepartureTime(c.departure_time);
+      const shift = c.is_baseline
+        ? 'as planned'
+        : `${c.departure_shift_hours >= 0 ? '+' : ''}${c.departure_shift_hours}h`;
+      const tag = c.is_baseline ? '' : c.is_alternate ? ' ★ your alternate' : '';
+      const diffs: string[] = [];
+      if (c.improves.length) diffs.push(`improves: ${c.improves.map(nameOf).join(', ')}`);
+      if (c.worsens.length) diffs.push(`worsens: ${c.worsens.map(nameOf).join(', ')}`);
+      const conf = c.confidence === 'confirmed_in_window' || c.confidence === 'confirmed'
+        ? 'all models checked'
+        : 'ECMWF only — not yet confirmed by other models';
+      return `
+        <div class="info-row">
+          <span class="info-label">${escapeHtml(time)}</span>
+          <span class="info-value">
+            ${chip(c.assessment)}
+            <span class="muted">${escapeHtml(shift)}${escapeHtml(tag)}</span>
+            ${diffs.length ? `<div>${escapeHtml(diffs.join(' · '))}</div>` : ''}
+            <div class="muted" style="font-size:0.8em;">${escapeHtml(conf)}</div>
+          </span>
+        </div>`;
+    }).join('');
+
+    const better = scan.candidates.filter((c) => !c.is_baseline && !c.is_alternate).length;
+    const headline = better > 0
+      ? `${better} departure window${better > 1 ? 's' : ''} look${better === 1 ? 's' : ''} smoother than the planned time — worth a look, not a verdict.`
+      : 'No clearly better window found in the hours checkable from this briefing.';
+    const refusedNote = scan.refused_times.length
+      ? `<p class="muted" style="font-size:0.85em;">${scan.refused_times.length} daylight hour${scan.refused_times.length > 1 ? 's' : ''} couldn’t be checked from this briefing’s data (outside the fetched forecast window).</p>`
+      : '';
+
+    section.innerHTML = `<p>${escapeHtml(headline)}</p>${rows}${refusedNote}`;
+  }
+
   /** Build alt time toggle config if alt advisories are available. */
   function getAltTimeToggleConfig(state: BriefingState): AltTimeToggleConfig | undefined {
     if (!state.flight?.alt_departure_time || !state.altAdvisories) return undefined;
@@ -1430,6 +1510,13 @@ async function init(): Promise<void> {
       renderPointSections(state);
       renderVisualization(state);
       ui.updateWindyLink(state.routeAnalyses, state.selectedPointIndex, state.selectedModel);
+    }
+    if (
+      state.timeOptions !== prev.timeOptions ||
+      state.currentPack !== prev.currentPack ||
+      state.flight !== prev.flight
+    ) {
+      renderTimeScenarios(state);
     }
     if (
       state.freshness !== prev.freshness ||

--- a/web/ts/briefing-main.ts
+++ b/web/ts/briefing-main.ts
@@ -565,6 +565,38 @@ async function init(): Promise<void> {
         confLine = 'all models checked';
       }
 
+      // Progressive depth: an expander with everything already saved for
+      // this hour — the full red/amber breakdown, models, graded ETA span.
+      const reasonList = (reason: string) => {
+        const parts = reason.split(',').map((p) => p.trim()).filter((p) => p.includes('='));
+        if (!parts.length) return `<div class="muted">${escapeHtml(reason || 'All clear')}</div>`;
+        return parts.map((p) => {
+          const [id, status] = p.split('=');
+          const cls = status === 'RED' ? 'assessment-red-text'
+            : status === 'AMBER' ? 'assessment-amber-text' : '';
+          return `<div><span class="${cls}">●</span> ${escapeHtml(nameOf(id))}: ${escapeHtml(status)}</div>`;
+        }).join('');
+      };
+      const etaSpan = c.valid_times.length
+        ? `${formatDepartureTime(c.valid_times[0])} → ${formatDepartureTime(c.valid_times[c.valid_times.length - 1])}`
+        : '';
+      let detailHtml = `
+        <div style="margin:0.25rem 0;"><strong>${c.confirmed ? 'ECMWF view' : 'At this hour'}</strong>${reasonList(c.assessment_reason)}</div>`;
+      if (c.confirmed) {
+        detailHtml += `
+        <div style="margin:0.25rem 0;"><strong>All-model check (${escapeHtml(c.confirmed.models_checked.map((m) => m.toUpperCase()).join(', '))})</strong>${reasonList(c.confirmed.assessment_reason)}</div>`;
+      }
+      detailHtml += `
+        <div class="muted" style="font-size:0.85em;">Graded with ${escapeHtml(c.models_used.map((m) => m.toUpperCase()).join(', '))}${etaSpan ? ` · route ETAs ${escapeHtml(etaSpan)}` : ''}</div>`;
+
+      // "Set as alternate time" — pins this scenario so the full per-advisory
+      // detail flows through the existing planned↔alt view. Same-day only
+      // (the alternate-time validation) and not for the plan/alternate rows.
+      const sameDay = c.departure_time.slice(0, 10) === scan.baseline.departure_time.slice(0, 10);
+      const setAltBtn = (!c.is_baseline && !c.is_alternate && sameDay)
+        ? ` <button type="button" class="btn btn-outline btn-sm time-setalt-btn" data-departure="${escapeHtml(c.departure_time)}" title="Pin this time as your alternate — full advisory detail appears in the planned/alt view">Set as alternate</button>`
+        : '';
+
       return `
         <div class="info-row">
           <span class="info-label">${escapeHtml(time)}</span>
@@ -572,7 +604,11 @@ async function init(): Promise<void> {
             ${effectiveChip}
             <span class="muted">${escapeHtml(shift)}${escapeHtml(tag)}</span>
             ${diffs.length ? `<div>${escapeHtml(diffs.join(' · '))}</div>` : ''}
-            <div class="muted" style="font-size:0.8em;">${confLine}</div>
+            <div class="muted" style="font-size:0.8em;">${confLine}${setAltBtn}</div>
+            <details style="font-size:0.85em; margin-top:0.2rem;">
+              <summary class="muted" style="cursor:pointer;">details</summary>
+              ${detailHtml}
+            </details>
           </span>
         </div>`;
     }).join('');
@@ -587,11 +623,17 @@ async function init(): Promise<void> {
 
     section.innerHTML = `<p>${escapeHtml(headline)}</p>${rows}${refusedNote}`;
 
-    // Wire the confirm taps (fresh nodes on every render — no stale handlers).
+    // Wire the taps (fresh nodes on every render — no stale handlers).
     section.querySelectorAll<HTMLButtonElement>('.time-confirm-btn').forEach((btn) => {
       btn.addEventListener('click', () => {
         const dep = btn.dataset.departure;
         if (dep) void store.getState().confirmTimeOption(dep);
+      });
+    });
+    section.querySelectorAll<HTMLButtonElement>('.time-setalt-btn').forEach((btn) => {
+      btn.addEventListener('click', () => {
+        const dep = btn.dataset.departure;
+        if (dep) void store.getState().setScenarioAsAlternate(dep);
       });
     });
   }

--- a/web/ts/briefing-main.ts
+++ b/web/ts/briefing-main.ts
@@ -498,7 +498,7 @@ async function init(): Promise<void> {
 
     const status = to.status?.status;
     if (status === 'pending' || status === 'running' || (!status && !to.scan)) {
-      section.innerHTML = '<p class="muted">Scenarios running… checking other departure times against this briefing.</p>';
+      section.innerHTML = '<p class="muted">Scenarios running — checking other departure times against this briefing<span class="dots-spinner"></span></p>';
       return;
     }
     if (status === 'failed') {
@@ -556,7 +556,7 @@ async function init(): Promise<void> {
           ? `checked with ${escapeHtml(models)} — still looks smoother`
           : `checked with ${escapeHtml(models)} — not clearly better after all`;
       } else if (c.confirm_pending) {
-        confLine = 'checking all models…';
+        confLine = 'checking all models<span class="dots-spinner"></span>';
       } else if (c.confidence === 'ecmwf_only') {
         confLine = anyConfirmPending
           ? `ECMWF only · <button type="button" class="btn btn-outline btn-sm time-confirm-btn" disabled title="One model check at a time — another is running">Check all models</button>`
@@ -623,8 +623,12 @@ async function init(): Promise<void> {
       // detail flows through the existing planned↔alt view. Same-day only
       // (the alternate-time validation) and not for the plan/alternate rows.
       const sameDay = c.departure_time.slice(0, 10) === scan.baseline.departure_time.slice(0, 10);
+      // Disabled while any model check runs — pinning an alternate queues a
+      // rescan, which isn't a natural thing to do mid-check.
       const setAltBtn = (!c.is_baseline && !c.is_alternate && sameDay)
-        ? ` <button type="button" class="btn btn-outline btn-sm time-setalt-btn" data-departure="${escapeHtml(c.departure_time)}" title="Pin this time as your alternate — full advisory detail appears in the planned/alt view">Set as alternate</button>`
+        ? (anyConfirmPending
+          ? ` <button type="button" class="btn btn-outline btn-sm time-setalt-btn" disabled title="Wait for the model check to finish">Set as alternate</button>`
+          : ` <button type="button" class="btn btn-outline btn-sm time-setalt-btn" data-departure="${escapeHtml(c.departure_time)}" title="Pin this time as your alternate — full advisory detail appears in the planned/alt view">Set as alternate</button>`)
         : '';
 
       return `

--- a/web/ts/briefing-main.ts
+++ b/web/ts/briefing-main.ts
@@ -577,14 +577,37 @@ async function init(): Promise<void> {
         }
         return map;
       };
-      const dot = (status: string, col: string, advisory: string) => {
+      // A column may carry a per-model breakdown (model → advisory-status
+      // map) — rendered as extra tooltip lines on its dots.
+      type DetailCol = {
+        label: string;
+        map: Map<string, string>;
+        perModel?: { model: string; map: Map<string, string> }[];
+      };
+      const dot = (status: string, col: DetailCol, id: string) => {
         const cls = status === 'RED' ? 'assessment-red-text'
           : status === 'AMBER' ? 'assessment-amber-text' : 'assessment-green-text';
-        return `<span class="${cls}" title="${escapeHtml(`${advisory} — ${col}: ${status}`)}">●</span>`;
+        const lines = [`${nameOf(id)} — ${col.label}: ${status}`];
+        for (const pm of col.perModel ?? []) {
+          lines.push(`${pm.model.toUpperCase()}: ${pm.map.get(id) ?? 'GREEN'}`);
+        }
+        return `<span class="${cls}" title="${escapeHtml(lines.join('\n'))}">●</span>`;
       };
+      // Current column: per-model split straight from the briefing's own
+      // advisories manifest (red/amber per model; absent = clear).
+      const currentPerModel = (state.routeAdvisories?.models ?? []).map((model) => {
+        const map = new Map<string, string>();
+        for (const adv of state.routeAdvisories?.advisories ?? []) {
+          const pm = adv.per_model.find((m) => m.model === model);
+          if (pm && (pm.status === 'red' || pm.status === 'amber')) {
+            map.set(adv.advisory_id, pm.status.toUpperCase());
+          }
+        }
+        return { model, map };
+      });
       const baselineReason = scan.candidates.find((b) => b.is_baseline)?.assessment_reason ?? '';
-      const cols: { label: string; map: Map<string, string> }[] = [
-        { label: 'Current', map: parseReason(baselineReason) },
+      const cols: DetailCol[] = [
+        { label: 'Current', map: parseReason(baselineReason), perModel: currentPerModel },
       ];
       if (!c.is_baseline) {
         // The provisional grade is the ECMWF-extension view unless the free
@@ -594,7 +617,14 @@ async function init(): Promise<void> {
           map: parseReason(c.assessment_reason),
         });
         if (c.confirmed) {
-          cols.push({ label: 'All models', map: parseReason(c.confirmed.assessment_reason) });
+          cols.push({
+            label: 'All models',
+            map: parseReason(c.confirmed.assessment_reason),
+            perModel: c.confirmed.models_checked.map((model) => ({
+              model,
+              map: parseReason(c.confirmed?.per_model_reasons?.[model] ?? ''),
+            })),
+          });
         }
       }
       const rank = (s: string | undefined) => (s === 'RED' ? 2 : s === 'AMBER' ? 1 : 0);
@@ -606,7 +636,7 @@ async function init(): Promise<void> {
             <thead><tr><th></th>${cols.map((col) => `<th>${escapeHtml(col.label)}</th>`).join('')}</tr></thead>
             <tbody>${rowIds.map((id) => `<tr>
               <td>${escapeHtml(nameOf(id))}</td>
-              ${cols.map((col) => `<td>${dot(col.map.get(id) ?? 'GREEN', col.label, nameOf(id))}</td>`).join('')}
+              ${cols.map((col) => `<td>${dot(col.map.get(id) ?? 'GREEN', col, id)}</td>`).join('')}
             </tr>`).join('')}</tbody>
           </table>`
         : '<div class="muted">All advisories clear at every checked view.</div>';

--- a/web/ts/briefing-main.ts
+++ b/web/ts/briefing-main.ts
@@ -518,19 +518,36 @@ async function init(): Promise<void> {
       (state.routeAdvisories?.catalog ?? []).map((c) => [c.id, c.name]),
     );
     const nameOf = (id: string) => names.get(id) ?? id;
+    // Reuse the advisory pill style (`.badge`) so the scenario assessment
+    // reads as the same soft filled RED/AMBER/GREEN pill as the advisory
+    // dashboard, not a hard-bordered box.
     const chip = (assessment: string) => {
-      const cls = assessment === 'GREEN' ? 'assessment-green'
-        : assessment === 'AMBER' ? 'assessment-amber'
-        : assessment === 'RED' ? 'assessment-red' : 'assessment-none';
-      return `<span class="assessment-chip ${cls}">${escapeHtml(assessment)}</span>`;
+      const cls = assessment === 'GREEN' ? 'badge-green'
+        : assessment === 'AMBER' ? 'badge-amber'
+        : assessment === 'RED' ? 'badge-red' : 'badge-none';
+      return `<span class="badge ${cls}">${escapeHtml(assessment)}</span>`;
     };
 
     // One confirm at a time (server enforces with 429; mirror it in the UI):
     // while any candidate is checking, the other check buttons are disabled.
     const anyConfirmPending = scan.candidates.some((c) => c.confirm_pending);
 
+    // Planned (baseline) UTC day — candidates on a different day (prev/next-day
+    // scans, or an off-day alternate) must say so, or "09:00" reads as today.
+    const baselineC = scan.candidates.find((c) => c.is_baseline);
+    const plannedDay = baselineC
+      ? new Date(baselineC.departure_time).toISOString().slice(0, 10) : '';
+    const dayLabelFor = (iso: string): string => {
+      const candDay = new Date(iso).toISOString().slice(0, 10);
+      if (!plannedDay || candDay === plannedDay) return '';
+      const diff = Math.round((Date.parse(candDay) - Date.parse(plannedDay)) / 86400000);
+      if (diff === 1) return ' · next day';
+      if (diff === -1) return ' · previous day';
+      return ` · ${diff > 0 ? '+' : ''}${diff} days`;
+    };
+
     const rows = scan.candidates.map((c) => {
-      const time = formatDepartureTime(c.departure_time);
+      const time = formatDepartureTime(c.departure_time) + dayLabelFor(c.departure_time);
       const shift = c.is_baseline
         ? 'as planned'
         : `${c.departure_shift_hours >= 0 ? '+' : ''}${c.departure_shift_hours}h`;
@@ -684,8 +701,17 @@ async function init(): Promise<void> {
     const refusedNote = scan.refused_times.length
       ? `<p class="muted" style="font-size:0.85em;">${scan.refused_times.length} daylight hour${scan.refused_times.length > 1 ? 's' : ''} couldn’t be checked from this briefing’s data (outside the fetched forecast window).</p>`
       : '';
+    // ±day edges (slice 4): explain why the window stops where it does, so a
+    // clipped prev/next-day scan doesn't read as a data gap.
+    const win = scan.window;
+    const pastNote = win?.past_clipped
+      ? `<p class="muted" style="font-size:0.85em;">Hours that have already passed were left out — only upcoming departure times are shown.</p>`
+      : '';
+    const horizonNote = win?.horizon_clipped
+      ? `<p class="muted" style="font-size:0.85em;">The window stops where ECMWF forecast fidelity ends — later hours aren’t checkable yet.</p>`
+      : '';
 
-    section.innerHTML = `<p>${escapeHtml(headline)}</p>${rows}${refusedNote}`;
+    section.innerHTML = `<p>${escapeHtml(headline)}</p>${rows}${refusedNote}${pastNote}${horizonNote}`;
 
     // Wire the taps (fresh nodes on every render — no stale handlers).
     section.querySelectorAll<HTMLButtonElement>('.time-confirm-btn').forEach((btn) => {

--- a/web/ts/flight-main.ts
+++ b/web/ts/flight-main.ts
@@ -296,7 +296,7 @@ async function init(): Promise<void> {
       const ceilEl = document.getElementById('edit-ceiling') as HTMLInputElement;
       const durHoursEl = document.getElementById('edit-duration-hours') as HTMLSelectElement;
       const durMinutesEl = document.getElementById('edit-duration-minutes') as HTMLSelectElement;
-      const altEnabledEl = document.getElementById('edit-alt-enabled') as HTMLInputElement;
+      const flexEl = document.getElementById('edit-flexibility') as HTMLSelectElement;
 
       syncUtcFromLocal();
 
@@ -311,8 +311,11 @@ async function init(): Promise<void> {
 
       // Save handles non-structural changes only — date/origin/dest stay the same.
       const departureTime = `${flight.target_date}T${editUtcHour.toString().padStart(2, '0')}:${editUtcMinute.toString().padStart(2, '0')}:00Z`;
-      const altEnabled = altEnabledEl?.checked ?? false;
-      const altDepartureTime = altEnabled
+      // Flexibility: the alternate time selects only apply in 'alternate'
+      // mode; other modes clear the stored alt time ("" clears server-side).
+      const flexibility = (flexEl?.value || 'none') as
+        'none' | 'alternate' | 'same_day' | 'prev_day' | 'next_day';
+      const altDepartureTime = flexibility === 'alternate'
         ? `${flight.target_date}T${editAltUtcHour.toString().padStart(2, '0')}:${editAltUtcMinute.toString().padStart(2, '0')}:00Z`
         : '';
 
@@ -333,6 +336,7 @@ async function init(): Promise<void> {
         aircraft_id: aircraftId,
         departure_time: departureTime,
         alt_departure_time: altDepartureTime,
+        flexibility,
         cruise_altitude_ft: altitude,
         flight_ceiling_ft: ceiling,
         flight_duration_hours: duration,

--- a/web/ts/flights-main.ts
+++ b/web/ts/flights-main.ts
@@ -720,6 +720,8 @@ async function init(): Promise<void> {
       const profileId = profileSelect?.value ? parseInt(profileSelect.value, 10) : undefined;
       const aircraftSelect = document.getElementById('input-aircraft') as HTMLSelectElement;
       const aircraftId = aircraftSelect?.value ? parseInt(aircraftSelect.value, 10) : undefined;
+      const flexSelect = document.getElementById('input-flexibility') as HTMLSelectElement;
+      const flexibility = (flexSelect?.value || 'none') as 'none' | 'same_day' | 'prev_day' | 'next_day';
 
       if (!targetDate) {
         ui.renderError(t('flights.form.errorDate'));
@@ -762,6 +764,7 @@ async function init(): Promise<void> {
           profileId: !isNaN(profileId!) ? profileId : undefined,
           aircraftId: !isNaN(aircraftId!) ? aircraftId : undefined,
           rawRoute: wpRaw,
+          flexibility,
         });
         // Pass flight_id via context (top-level field) so server-side
         // enrichment (upsert_flight_dim) picks it up.

--- a/web/ts/managers/flight-detail-ui.ts
+++ b/web/ts/managers/flight-detail-ui.ts
@@ -88,6 +88,9 @@ export function renderFlightInfo(
   const altUtcHour = altDt ? altDt.getUTCHours() : -1;
   const altUtcMinute = altDt ? altDt.getUTCMinutes() : 0;
   const hasAlt = altUtcHour >= 0;
+  // Timing-scenario Flexibility mode; legacy flights with an alt time but no
+  // stored mode render as 'alternate' (matches the migration-074 backfill).
+  const flexibility = flight.flexibility || (hasAlt ? 'alternate' : 'none');
 
   if (editing) {
     // Reference date for TZ calculations
@@ -195,13 +198,16 @@ export function renderFlightInfo(
           </span>
         </div>
         <div class="info-row">
-          <span class="info-label">Alt Time</span>
+          <span class="info-label">Flexibility</span>
           <span class="info-value">
-            <label class="alt-time-toggle">
-              <input type="checkbox" id="edit-alt-enabled" ${hasAlt ? 'checked' : ''}>
-              <span>Alternate departure</span>
-            </label>
-            <div class="time-input-group" id="edit-alt-time-group" style="${hasAlt ? '' : 'display:none'}">
+            <select id="edit-flexibility" class="edit-input">
+              <option value="none"${flexibility === 'none' ? ' selected' : ''}>None — just this flight</option>
+              <option value="alternate"${flexibility === 'alternate' ? ' selected' : ''}>Alternate time — grade one other departure</option>
+              <option value="same_day"${flexibility === 'same_day' ? ' selected' : ''}>Same day — scan for better windows</option>
+              <option value="prev_day"${flexibility === 'prev_day' ? ' selected' : ''}>Previous day</option>
+              <option value="next_day"${flexibility === 'next_day' ? ' selected' : ''}>Next day</option>
+            </select>
+            <div class="time-input-group" id="edit-alt-time-group" style="${flexibility === 'alternate' ? '' : 'display:none'}">
               <select id="edit-alt-hour" class="edit-input">${altHourOptions}</select>
               <span class="time-separator">:</span>
               <select id="edit-alt-minute" class="edit-input">${altMinuteOptions}</select>
@@ -246,11 +252,11 @@ export function renderFlightInfo(
       tzSelect.value = defaultTz;
     }
 
-    // Toggle alt time group visibility
-    const altCheckbox = document.getElementById('edit-alt-enabled') as HTMLInputElement;
+    // The alt time selects only apply to the 'alternate' Flexibility mode
+    const flexSelect = document.getElementById('edit-flexibility') as HTMLSelectElement;
     const altTimeGroup = document.getElementById('edit-alt-time-group');
-    altCheckbox?.addEventListener('change', () => {
-      if (altTimeGroup) altTimeGroup.style.display = altCheckbox.checked ? '' : 'none';
+    flexSelect?.addEventListener('change', () => {
+      if (altTimeGroup) altTimeGroup.style.display = flexSelect.value === 'alternate' ? '' : 'none';
     });
 
     // When profile changes, update altitude/ceiling to match the selected profile
@@ -270,17 +276,29 @@ export function renderFlightInfo(
       }
     });
   } else {
-    // Alt time display with delta
+    // Flexibility display: the mode, plus the alternate time (with delta)
+    // when that's the mode.
     let altTimeHtml = '';
-    if (altDt) {
+    if (flexibility === 'alternate' && altDt) {
       const deltaMs = altDt.getTime() - dt.getTime();
       const deltaH = deltaMs / 3600_000;
       const sign = deltaH >= 0 ? '+' : '';
       const deltaStr = Number.isInteger(deltaH) ? `${sign}${deltaH}h` : `${sign}${deltaH.toFixed(1)}h`;
       altTimeHtml = `
         <div class="info-row">
-          <span class="info-label">Alt Time</span>
-          <span class="info-value">${formatDepartureTime(flight.alt_departure_time!)} <span class="muted">(${deltaStr})</span></span>
+          <span class="info-label">Flexibility</span>
+          <span class="info-value">Alternate time — ${formatDepartureTime(flight.alt_departure_time!)} <span class="muted">(${deltaStr})</span></span>
+        </div>`;
+    } else if (flexibility !== 'none') {
+      const flexLabels: Record<string, string> = {
+        same_day: 'Same day — scan for better windows',
+        prev_day: 'Previous day',
+        next_day: 'Next day',
+      };
+      altTimeHtml = `
+        <div class="info-row">
+          <span class="info-label">Flexibility</span>
+          <span class="info-value">${escapeHtml(flexLabels[flexibility] || flexibility)}</span>
         </div>`;
     }
 

--- a/web/ts/managers/flight-detail-ui.ts
+++ b/web/ts/managers/flight-detail-ui.ts
@@ -295,10 +295,20 @@ export function renderFlightInfo(
         prev_day: 'Previous day',
         next_day: 'Next day',
       };
+      // A day-scan mode can also carry a pinned alternate ("Set as alternate"
+      // from the scenarios panel) — show it, or the card would hide a time
+      // that the planned↔alt view is actively grading.
+      let pinned = '';
+      if (altDt) {
+        const deltaH = (altDt.getTime() - dt.getTime()) / 3600_000;
+        const sign = deltaH >= 0 ? '+' : '';
+        const deltaStr = Number.isInteger(deltaH) ? `${sign}${deltaH}h` : `${sign}${deltaH.toFixed(1)}h`;
+        pinned = ` · alternate ${formatDepartureTime(flight.alt_departure_time!)} <span class="muted">(${deltaStr})</span>`;
+      }
       altTimeHtml = `
         <div class="info-row">
           <span class="info-label">Flexibility</span>
-          <span class="info-value">${escapeHtml(flexLabels[flexibility] || flexibility)}</span>
+          <span class="info-value">${escapeHtml(flexLabels[flexibility] || flexibility)}${pinned}</span>
         </div>`;
     }
 

--- a/web/ts/store/briefing-store.ts
+++ b/web/ts/store/briefing-store.ts
@@ -171,6 +171,10 @@ export interface BriefingState {
   /** Queue the multi-model check of one provisional candidate (slice 3);
    * the result arrives via the loadTimeOptions poll. */
   confirmTimeOption: (departureTime: string) => Promise<void>;
+  /** "Set as alternate time": pin a discovered scenario as the flight's
+   * alternate — full advisory detail then flows through the existing
+   * planned↔alt view once the re-queued scan persists the alt artifacts. */
+  setScenarioAsAlternate: (departureTime: string) => Promise<void>;
   updateFlightAutoRefresh: (autoRefresh: boolean, hour: number | null) => void;
   updateFlightPrivacy: (isPrivate: boolean) => void;
   subscribe: () => Promise<void>;
@@ -261,6 +265,9 @@ let _windOverlayTimer: number | null = null;
 let _windOverlaySeq = 0;
 // Timing-scenario poll backoff (3s → ×1.5 → cap 15s); reset on pack change.
 let timeOptionsPollDelay = 3_000;
+// Consecutive transient poll failures; only give up after a few (404 is the
+// sole immediate-terminal answer). Reset on any successful poll / pack change.
+let timeOptionsErrorStreak = 0;
 
 export const briefingStore = createStore<BriefingState>((set, get) => ({
   flight: null,
@@ -396,6 +403,7 @@ export const briefingStore = createStore<BriefingState>((set, get) => ({
       // endpoint lazy-schedules the scan if Flexibility was enabled after
       // this pack was generated.
       timeOptionsPollDelay = 3_000;
+      timeOptionsErrorStreak = 0;
       if (get().flight?.flexibility && get().flight!.flexibility !== 'none') {
         void get().loadTimeOptions();
       }
@@ -826,6 +834,7 @@ export const briefingStore = createStore<BriefingState>((set, get) => ({
       // Stale-guard: the user may have switched packs while we were fetching.
       if (get().currentPack?.fetch_timestamp !== packTs) return;
       set({ timeOptions: resp });
+      timeOptionsErrorStreak = 0;
 
       const status = resp.status?.status;
       const confirmPending = (resp.scan?.candidates ?? []).some((c) => c.confirm_pending);
@@ -847,11 +856,49 @@ export const briefingStore = createStore<BriefingState>((set, get) => ({
       if (status === 'done' && !get().altAdvisories) {
         void get().loadAltAdvisories();
       }
-    } catch {
-      // 404 (flexibility none / legacy pack) or transient error — hide section.
-      if (get().currentPack?.fetch_timestamp === packTs) {
+    } catch (err) {
+      if (get().currentPack?.fetch_timestamp !== packTs) return;
+      // 404 is a real answer (flexibility none / legacy pack) — hide the
+      // section. Anything else (network blip, 5xx) is transient: keep the
+      // poll cadence alive for a few retries so a single failed request
+      // can't make a mid-scan "Scenarios running…" silently vanish.
+      const msg = err instanceof Error ? err.message : String(err);
+      if (msg.includes('API 404')) {
+        set({ timeOptions: null });
+        return;
+      }
+      timeOptionsErrorStreak += 1;
+      if (timeOptionsErrorStreak <= 3) {
+        timeOptionsPollDelay = Math.min(timeOptionsPollDelay * 1.5, 15_000);
+        window.setTimeout(() => {
+          if (get().currentPack?.fetch_timestamp === packTs) {
+            void get().loadTimeOptions();
+          }
+        }, timeOptionsPollDelay);
+      } else {
         set({ timeOptions: null });
       }
+    }
+  },
+
+  setScenarioAsAlternate: async (departureTime: string) => {
+    const { flight, currentPack } = get();
+    if (!flight || !currentPack) return;
+    try {
+      const updated = await api.updateFlight(flight.id, {
+        alt_departure_time: departureTime,
+      });
+      set({ flight: updated });
+      // Re-queue the scan: the changed alternate invalidates the reuse check,
+      // so the pinned row re-grades and route_advisories_alt.json persists —
+      // full per-advisory detail then appears in the planned↔alt view.
+      await api.rescanTimeOptions(flight.id, currentPack.fetch_timestamp);
+      timeOptionsPollDelay = 3_000;
+      timeOptionsErrorStreak = 0;
+      window.setTimeout(() => void get().loadTimeOptions(), 2_000);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      set({ error: msg.replace(/^API \d+:\s*/, '') });
     }
   },
 

--- a/web/ts/store/briefing-store.ts
+++ b/web/ts/store/briefing-store.ts
@@ -168,6 +168,9 @@ export interface BriefingState {
   /** Poll the timing-scenario scan for the current pack (backoff, stops on
    * terminal status or pack change). Safe to call unconditionally. */
   loadTimeOptions: () => Promise<void>;
+  /** Queue the multi-model check of one provisional candidate (slice 3);
+   * the result arrives via the loadTimeOptions poll. */
+  confirmTimeOption: (departureTime: string) => Promise<void>;
   updateFlightAutoRefresh: (autoRefresh: boolean, hour: number | null) => void;
   updateFlightPrivacy: (isPrivate: boolean) => void;
   subscribe: () => Promise<void>;
@@ -825,7 +828,8 @@ export const briefingStore = createStore<BriefingState>((set, get) => ({
       set({ timeOptions: resp });
 
       const status = resp.status?.status;
-      if (status === 'pending' || status === 'running' || (!status && !resp.scan)) {
+      const confirmPending = (resp.scan?.candidates ?? []).some((c) => c.confirm_pending);
+      if (status === 'pending' || status === 'running' || confirmPending || (!status && !resp.scan)) {
         // Background job still working — poll with a gentle backoff. The
         // refresh SSE stream is already closed by the time the scan runs, so
         // polling is the delivery channel (see timing-scenario-plan.md).
@@ -848,6 +852,32 @@ export const briefingStore = createStore<BriefingState>((set, get) => ({
       if (get().currentPack?.fetch_timestamp === packTs) {
         set({ timeOptions: null });
       }
+    }
+  },
+
+  confirmTimeOption: async (departureTime: string) => {
+    const { flight, currentPack, timeOptions } = get();
+    if (!flight || !currentPack) return;
+    // One confirm at a time per pack (mirrors the server's 429 guard).
+    if (timeOptions?.scan?.candidates.some((c) => c.confirm_pending)) return;
+    try {
+      await api.confirmTimeOption(flight.id, currentPack.fetch_timestamp, departureTime);
+      // Optimistically flag the candidate so the UI shows "checking…"
+      // immediately; the poll takes over from the server's copy.
+      const to = get().timeOptions;
+      if (to?.scan) {
+        const scan = {
+          ...to.scan,
+          candidates: to.scan.candidates.map((c) =>
+            c.departure_time === departureTime ? { ...c, confirm_pending: true } : c,
+          ),
+        };
+        set({ timeOptions: { ...to, scan } });
+      }
+      timeOptionsPollDelay = 3_000;
+      window.setTimeout(() => void get().loadTimeOptions(), 3_000);
+    } catch (err) {
+      set({ error: `Confirm failed: ${err}` });
     }
   },
 

--- a/web/ts/store/briefing-store.ts
+++ b/web/ts/store/briefing-store.ts
@@ -4,7 +4,7 @@ import { createStore } from 'zustand/vanilla';
 import type { DataStatus, ElevationProfile, FlightResponse, ForecastSnapshot, PackMeta, RouteAnalysesManifest, WeatherDigest } from './types';
 import type { AltitudeTableResult, RouteAdvisoriesManifest } from '../types/advisories';
 import type { RouteFrontsManifest } from '../types/fronts';
-import type { RouteWindOverlay } from '../adapters/api-adapter';
+import type { RouteWindOverlay, TimeOptionsResponse } from '../adapters/api-adapter';
 import type { DisplayMode, Tier } from '../types/metrics';
 import type { VizLayout, VizSettings } from '../visualization/types';
 import { getTierDefaults } from '../helpers/metrics-helper';
@@ -125,6 +125,10 @@ export interface BriefingState {
   altitudeTableLoading: boolean;
   emailing: boolean;
   error: string | null;
+  /** Timing-scenario scan (Flexibility): status + result from the background
+   * job, polled after pack load until the status is terminal. null when the
+   * flight has Flexibility "none" (section hidden). */
+  timeOptions: TimeOptionsResponse | null;
 
   // Actions
   loadFlight: (id: string) => Promise<void>;
@@ -161,6 +165,9 @@ export interface BriefingState {
   loadAltAdvisories: () => Promise<void>;
   computeAltAdvisories: () => Promise<void>;
   toggleAltView: () => void;
+  /** Poll the timing-scenario scan for the current pack (backoff, stops on
+   * terminal status or pack change). Safe to call unconditionally. */
+  loadTimeOptions: () => Promise<void>;
   updateFlightAutoRefresh: (autoRefresh: boolean, hour: number | null) => void;
   updateFlightPrivacy: (isPrivate: boolean) => void;
   subscribe: () => Promise<void>;
@@ -249,6 +256,8 @@ function isStreamDrop(err: unknown): boolean {
 // scope (not store state) — purely transient request bookkeeping.
 let _windOverlayTimer: number | null = null;
 let _windOverlaySeq = 0;
+// Timing-scenario poll backoff (3s → ×1.5 → cap 15s); reset on pack change.
+let timeOptionsPollDelay = 3_000;
 
 export const briefingStore = createStore<BriefingState>((set, get) => ({
   flight: null,
@@ -260,6 +269,7 @@ export const briefingStore = createStore<BriefingState>((set, get) => ({
   routeAdvisories: null,
   routeFronts: null,
   altAdvisories: null,
+  timeOptions: null,
   windOverlay: null,
   showingAlt: false,
   elevationProfile: null,
@@ -374,10 +384,17 @@ export const briefingStore = createStore<BriefingState>((set, get) => ({
                       : available.includes('ecmwf') ? 'ecmwf'
                       : available[0];
       }
-      set({ currentPack: pack, snapshot, digest, routeAnalyses, routeAdvisories, routeFronts, elevationProfile, altitudeTable, selectedModel, advisoryAltitudeOverride: null, altAdvisories: null, windOverlay: null, showingAlt: false, selectedPointIndex: null, loading: false });
+      set({ currentPack: pack, snapshot, digest, routeAnalyses, routeAdvisories, routeFronts, elevationProfile, altitudeTable, selectedModel, advisoryAltitudeOverride: null, altAdvisories: null, windOverlay: null, showingAlt: false, selectedPointIndex: null, timeOptions: null, loading: false });
       // Auto-load alt advisories if available
       if (pack.has_alt_advisories) {
         get().loadAltAdvisories();
+      }
+      // Timing scenarios (Flexibility): kick off the status poll. The
+      // endpoint lazy-schedules the scan if Flexibility was enabled after
+      // this pack was generated.
+      timeOptionsPollDelay = 3_000;
+      if (get().flight?.flexibility && get().flight!.flexibility !== 'none') {
+        void get().loadTimeOptions();
       }
     } catch (err) {
       set({ loading: false, error: `Failed to load pack: ${err}` });
@@ -794,6 +811,43 @@ export const briefingStore = createStore<BriefingState>((set, get) => ({
       set({ altAdvisories: altAdv, currentPack: updatedPack });
     } catch (err) {
       set({ error: `Alt advisories computation failed: ${err}` });
+    }
+  },
+
+  loadTimeOptions: async () => {
+    const { flight, currentPack } = get();
+    if (!flight || !currentPack || flight.flexibility === 'none') return;
+    const packTs = currentPack.fetch_timestamp;
+    try {
+      const resp = await api.fetchTimeOptions(flight.id, packTs);
+      // Stale-guard: the user may have switched packs while we were fetching.
+      if (get().currentPack?.fetch_timestamp !== packTs) return;
+      set({ timeOptions: resp });
+
+      const status = resp.status?.status;
+      if (status === 'pending' || status === 'running' || (!status && !resp.scan)) {
+        // Background job still working — poll with a gentle backoff. The
+        // refresh SSE stream is already closed by the time the scan runs, so
+        // polling is the delivery channel (see timing-scenario-plan.md).
+        timeOptionsPollDelay = Math.min(timeOptionsPollDelay * 1.5, 15_000);
+        window.setTimeout(() => {
+          if (get().currentPack?.fetch_timestamp === packTs) {
+            void get().loadTimeOptions();
+          }
+        }, timeOptionsPollDelay);
+        return;
+      }
+      timeOptionsPollDelay = 3_000;
+      // The scan's pinned alternate row also (re)writes the legacy alt
+      // artifact + pack fields — pick them up when we don't have them yet.
+      if (status === 'done' && !get().altAdvisories) {
+        void get().loadAltAdvisories();
+      }
+    } catch {
+      // 404 (flexibility none / legacy pack) or transient error — hide section.
+      if (get().currentPack?.fetch_timestamp === packTs) {
+        set({ timeOptions: null });
+      }
     }
   },
 

--- a/web/ts/store/flights-store.ts
+++ b/web/ts/store/flights-store.ts
@@ -39,6 +39,7 @@ export interface FlightsState {
     profileId?: number;
     aircraftId?: number;
     rawRoute?: string;  // original Field-15 input from the popup flow
+    flexibility?: 'none' | 'same_day' | 'prev_day' | 'next_day';
   }) => Promise<FlightResponse>;
   deleteFlight: (id: string) => Promise<void>;
   unsubscribeFlight: (id: string) => Promise<void>;
@@ -147,6 +148,7 @@ export const flightsStore = createStore<FlightsState>((set, get) => ({
         profile_id: opts?.profileId,
         aircraft_id: opts?.aircraftId,
         raw_route: opts?.rawRoute,
+        flexibility: opts?.flexibility,
       });
       // Refresh the list
       await get().loadFlights();

--- a/web/ts/store/types.ts
+++ b/web/ts/store/types.ts
@@ -51,6 +51,9 @@ export interface FlightResponse {
   waypoints: string[];
   departure_time: string;
   alt_departure_time: string | null;
+  // Timing-scenario Flexibility mode (what the scenario job grades).
+  // 'alternate' uses alt_departure_time; day modes scan a daylight window.
+  flexibility: 'none' | 'alternate' | 'same_day' | 'prev_day' | 'next_day';
   target_date: string;        // backward compat (computed from departure_time)
   target_time_utc: number;    // backward compat (computed from departure_time)
   cruise_altitude_ft: number;
@@ -118,6 +121,9 @@ export interface CreateFlightRequest {
   flight_duration_hours?: number;
   profile_id?: number;
   aircraft_id?: number;
+  // Timing-scenario Flexibility. 'alternate' is set post-create via PATCH
+  // (needs an alt time), so create only offers the scan modes.
+  flexibility?: 'none' | 'same_day' | 'prev_day' | 'next_day';
   // Original Field-15 input. Present from web Save flows where the
   // pilot typed something like "EGTK DCT LFPB DCT LSGS" and the
   // interpret popup confirmed the resolved waypoints. Omitted from


### PR DESCRIPTION
Implements the **timing-scenario scan** (`designs/plans/timing-scenario-plan.md`, decisions locked 2026-07-02) — all four slices. Related to #330 (`MitigationKind.TIMING` axis); does not close it.

## What this does

A pilot opts into departure-time exploration per flight via a **Flexibility** setting (`none / alternate / same_day / prev_day / next_day`). After every briefing, a queued background job grades other departure times against the saved pack, and the briefing page shows a **Timing Scenarios** section — an attention-director ("2 windows look smoother — worth a look"), never a verdict.

## The honesty ladder

- **`confirmed_in_window`** — the candidate's whole flight fits every fetched model's enriched window → multi-model, free (pure re-analysis via `run_alt_from_pack`).
- **`ecmwf_only`** — off-window candidates graded on a daylight-extended ECMWF decode (local GRIB, no download, ephemeral) against an ECMWF-only baseline. Provisional by construction.
- **`confirmed`** — on user tap, a multi-model check (GFS + ICON fetch across the shifted window) upgrades **or honestly downgrades** the provisional grade. The downgrade is a designed outcome, not an error.

Hard invariant: **never grade an hour whose fields aren't actually decoded for the model claimed** — coverage is checked up front (rule-window ∩ data-marker, per model per route point) and out-of-coverage hours are refused, never silently `at_time()`-clamped.

## Slices

1. **Toggle + unified Alternate time + in-window free tier** — Flexibility column/UI; the old synchronous alt-departure stage retires into a single-candidate scenario job; in-window candidates surface confirmed-for-free.
2. **ECMWF daylight extension + Same-day scan** — ephemeral daylight decode, coverage metadata, the provisional tier.
3. **On-tap confirm** — ICON + GFS across the shifted window, async, one-at-a-time (429-guarded), cached, invalidated by a new ECMWF run (decision H).
4. **Previous/Next day** — see below.

## Slice 4 + the ±day enrichment fix

`_enrich_ecmwf` only **attaches** decoded GRIB to pre-existing hourly rows — it never creates them. A pack's Open-Meteo base covers only the target day, so an adjacent-day scan decoded the next-day ECMWF steps, matched no rows, and refused the whole day (`no matching steps`). This meant **±day never actually produced candidates**. Fix:

- **`extend_openmeteo_adjacent_day`** re-fetches the adjacent-day OM base and splices it onto the in-memory cross-sections (ephemeral, decision G) so the ECMWF daylight extension has rows to enrich. Called in the **scan** (before the ECMWF extension) and in the **confirm** path (before `enrich_forecasts`, so a cross-day multi-model confirm isn't OM-clamped).
- **Past-day clamp** (`_clamp_past_grid`): drop already-elapsed grid hours, gated on `dep > now` so eval/replay of a flown pack grades its whole window unchanged. Surfaced as `TimeScanWindow.past_clipped`.
- **Horizon/past window-edge UX** + a **"· next day" / "· previous day"** date label on off-day candidates (a bare "09:00" otherwise reads as the planned day).

## UI polish (independent)

- Timing-scenario assessment now uses the advisory `.badge` pill instead of the hard-bordered box — matches the advisory dashboard and the planned↔alt chips.

## Validation

- `tests/test_time_scan.py` — **42 passing**: diff/margin semantics, coverage detector (smear bounding, fidelity parity, uniform OM), refusal, rule windows, artifact round-trips, registry sets, the OM adjacent-day splice, the past-clamp gate, and next_day wiring.
- **End-to-end on dev** against a freshly-synced ECMWF run:
  - **next_day** (EGNS→EGHQ): RED planned day → **5 candidates on the next day, 3 GREEN / 2 AMBER, 0 refused**, ranked by improvement.
  - **prev_day** (EHRD→LKKV): AMBER planned day (convective) → **2 GREEN previous-day candidates** improving `convective`, `past_clipped` correctly False.
  - **same_day** confirm exercised (multi-model verdict cached on the candidate).

## Ranking / suppression

Baseline pinned first, then the pinned alternate, then improving candidates sorted by margin (net severity drop over the 9 scan-class advisories) → confirmed-over-provisional → proximity to the anchor; capped at 5. Only genuine improvements (`margin ≥ 1`, nothing materially worse) are shown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
