### PR TITLE
Fix spurious VFR corridor tips from single-point terminal decks

### DIFF
--- a/designs/advisories.md
+++ b/designs/advisories.md
@@ -186,6 +186,16 @@ Two generators in `vfr_feasibility.py`:
   clear/blocked split AND flyable VFR room beneath the deck along the blocked stretch
   (`_under_deck_flyable`, `mitigation_min_base_agl_ft` default 3000 ft) — otherwise the
   clear air is unreachable and the grade is genuine.
+  - Since #335 both generators are unified in `_solver_mitigations` over one min-cost
+    vertical profile; the corridor tips carry two extra guards (#342): a terminal tip is
+    emitted only when the forcing deck is *real* — it covers ≥2 route points or ≥15 nm,
+    not just the departure/arrival field's own cloud that every climb-out transits
+    (`_terminal_deck_span`, **Bug A**) — and only when the break is within
+    `mitigation_max_reposition_nm`. The former `<= total/2` half-route split is gone:
+    `clean_terminal` already guards interior decks, so the split only produced a
+    knife-edge that dropped the correct arrival tip on a fractional-mile overshoot
+    (**Bug B**). The `cruise_imc` `altitude_marginal` copy reads "Marginal VMC around
+    {alt} ft" (a fly-lower target, parallel to the GREEN "VMC available at {alt} ft").
 
 **Surfacing** (each consumer treats mitigations as a soft hook, never a verdict):
 - **Web / iOS**: a neutral "lightbulb" hook on the advisory card → tip detail

--- a/src/weatherbrief/analysis/advisories/strings.py
+++ b/src/weatherbrief/analysis/advisories/strings.py
@@ -467,10 +467,13 @@ _STRINGS: dict[str, dict[str, str]] = {
         "es": "VMC disponible a {alt:,} ft",
     },
     "vfr.mitigation.altitude_marginal": {
-        "en": "Marginal VMC at {alt:,} ft",
-        "fr": "VMC marginale à {alt:,} ft",
-        "de": "Marginale VMC auf {alt:,} ft",
-        "es": "VMC marginal a {alt:,} ft",
+        # `cruise_imc` always scans downward from planned cruise, so this altitude is a
+        # fly-lower target — "around" reads as an option to act on, not a flat condition
+        # (#342 copy). Parallel to the GREEN `vfr.mitigation.altitude` ("VMC available at …").
+        "en": "Marginal VMC around {alt:,} ft",
+        "fr": "VMC marginale autour de {alt:,} ft",
+        "de": "Marginale VMC um {alt:,} ft",
+        "es": "VMC marginal en torno a {alt:,} ft",
     },
     "vfr.mitigation.climb_after": {
         "en": "VMC climb to cruise possible after ~{dist} nm from departure",

--- a/src/weatherbrief/analysis/advisories/vfr_feasibility.py
+++ b/src/weatherbrief/analysis/advisories/vfr_feasibility.py
@@ -300,6 +300,14 @@ _SEVERITY = {AdvisoryStatus.GREEN: 0, AdvisoryStatus.AMBER: 1, AdvisoryStatus.RE
 # solver prefer a truly-clear (0-cost) band over a marginal one on the hazard tier.
 _MARGINAL_COST = 1.0
 
+# A terminal (departure/arrival) deck earns a corridor tip only when it covers more than a
+# single route point: >= 2 route points OR a >= 15 nm along-track run. A lone terminal-field
+# cloud — which every normal climb-out transits — fails this and yields no "climb after /
+# descend before" tip. The profile-shape gate alone (``segments[0].alt_ft < cruise``) fires
+# for both a real deck and a single field cloud and cannot tell them apart (#342 Bug A).
+_TERMINAL_DECK_MIN_POINTS = 2
+_TERMINAL_DECK_MIN_RUN_NM = 15.0
+
 
 def _vfr_cell_cost(sounding, alt_ft: float, cloud_clearance_ft: float) -> float:
     """Occupancy cost of one altitude at one route point for the VFR cost field.
@@ -373,6 +381,56 @@ def _has_interior_below_cruise(profile: Profile, cruise: int) -> bool:
     return any(i not in lead and i not in trail for i in below)
 
 
+def _terminal_deck_span(
+    ctx: RouteContext,
+    model: str,
+    cruise: float,
+    lo_nm: float,
+    hi_nm: float,
+) -> tuple[int, float]:
+    """Count route points carrying a real climb/descent deck within ``[lo_nm, hi_nm]``.
+
+    A "deck" here is any BKN/OVC layer intruding the climb/descent band — ``top_ft`` above
+    the field and ``base_ft`` below cruise — i.e. a layer the flight must transit to reach
+    cruise (a sub-cruise deck, cruise itself clear) OR a cloud reaching cruise over the
+    field. Scanning only the terminal below-cruise run and requiring more than one such
+    point is what separates a genuine terminal deck from a lone departure-/arrival-field
+    cloud that every normal climb-out passes through (#342 Bug A). ``_check_enroute_vfr``
+    at cruise would count only the cruise-reaching clouds, silently dropping every
+    ordinary sub-cruise deck (the *primary* ``climb_deck`` case), so the band test is used
+    instead — it covers both while still keying on the same "not a single point" rule.
+
+    Returns ``(point_count, span_nm)`` over the qualifying points.
+    """
+    dists: list[float] = []
+    for rpa in ctx.analyses:
+        d = rpa.distance_from_origin_nm or 0.0
+        if not (lo_nm <= d <= hi_nm):
+            continue
+        sounding = rpa.sounding.get(model)
+        if sounding is None:
+            continue
+        floor = _field_elevation_ft(ctx, d)
+        for cl in sounding.cloud_layers:
+            if cl.coverage not in (CloudCoverage.BKN, CloudCoverage.OVC):
+                continue
+            if cl.top_ft > floor and cl.base_ft < cruise:
+                dists.append(d)
+                break
+    if not dists:
+        return 0, 0.0
+    return len(dists), max(dists) - min(dists)
+
+
+def _is_real_terminal_deck(count: int, span_nm: float) -> bool:
+    """A terminal deck earns a corridor tip only when it spans more than one point.
+
+    ``>= 2`` route points OR ``>= 15`` nm of along-track run (#342 Bug A). A single
+    terminal point — the departure/arrival field's own cloud — never qualifies.
+    """
+    return count >= _TERMINAL_DECK_MIN_POINTS or span_nm >= _TERMINAL_DECK_MIN_RUN_NM
+
+
 def _solver_mitigations(
     ctx: RouteContext,
     model: str,
@@ -405,10 +463,15 @@ def _solver_mitigations(
       exclusivity is emergent: when cruise is IMC the profile never reaches it, so no
       corridor transition exists — nothing to suppress.
 
-    The along-route break must fall before the route midpoint (a deck unbroken to
-    halfway can't be repositioned around) and within ``max_reposition_nm`` of the airport
-    (a break far out means flying under the deck for most of the leg). A :class:`Blockage`
-    (no continuous flyable band from the floor) yields no mitigation — the RED is genuine.
+    A terminal (climb/descent) tip is emitted only when the forcing deck is *real* — it
+    covers more than a single route point (>= 2 points / >= 15 nm), not just the departure/
+    arrival field's own cloud that every climb-out transits (#342 Bug A) — and the break is
+    within ``max_reposition_nm`` of the airport (a break far out means flying under the deck
+    for most of the leg). The former ``<= total / 2`` half-route split is gone: ``clean_terminal``
+    already guarantees the interior is clear, so the split only produced a knife-edge that
+    silently dropped the correct arrival tip on a fractional-mile miss (#342 Bug B). A
+    :class:`Blockage` (no continuous flyable band from the floor) yields no mitigation — the
+    RED is genuine.
     """
     model_cm = _build_vfr_cost_model(ctx, model, cloud_clearance_ft, floor_margin_ft)
     if model_cm is None:
@@ -464,13 +527,25 @@ def _solver_mitigations(
                 profile=prof_obj,
             ))
 
-    # climb_deck — departure forced low, climbs to cruise before the midpoint.
+    # climb_deck — departure forced low by a *real* terminal deck, climbing to cruise near
+    # departure. Two guards beyond profile shape:
+    #   - the deck must span more than a single point (>= 2 points / >= 15 nm), else it's the
+    #     departure field's own cloud that every climb-out transits — not a repositionable
+    #     deck (#342 Bug A);
+    #   - the break must be within `max_reposition_nm`. The old `<= total / 2` half-route
+    #     split is dropped: `clean_terminal` already guarantees the interior is clear, so a
+    #     terminal tip is meaningful whenever the break is close to the field — the half-route
+    #     knife-edge that silently dropped the correct tip on a 0.4 nm miss is gone (#342 Bug B).
     if reaches_cruise and clean_terminal and profile.segments[0].alt_ft < cruise:
         climb = next(
             (t for t in profile.transitions if t.to_alt_ft > t.from_alt_ft and t.to_alt_ft >= cruise),
             None,
         )
-        if climb is not None and climb.from_nm <= total / 2 and climb.from_nm <= max_reposition_nm:
+        if (
+            climb is not None
+            and climb.from_nm <= max_reposition_nm
+            and _is_real_terminal_deck(*_terminal_deck_span(ctx, model, cruise, 0.0, climb.to_nm))
+        ):
             dist = round(climb.from_nm)
             mitigations.append(Mitigation(
                 kind=MitigationKind.ROUTE_POSITION,
@@ -482,7 +557,9 @@ def _solver_mitigations(
                 profile=prof_obj,
             ))
 
-    # descent_deck — arrival forced low, descends from cruise after the midpoint.
+    # descent_deck — arrival forced low by a *real* terminal deck, descending from cruise
+    # near arrival. Same real-deck gate (#342 Bug A) and same drop of the `<= total / 2`
+    # split (#342 Bug B) as climb_deck above.
     if reaches_cruise and clean_terminal and profile.segments[-1].alt_ft < cruise:
         descent = next(
             (t for t in reversed(profile.transitions) if t.from_alt_ft > t.to_alt_ft and t.from_alt_ft >= cruise),
@@ -490,7 +567,9 @@ def _solver_mitigations(
         )
         if descent is not None:
             before = total - descent.to_nm
-            if before <= total / 2 and before <= max_reposition_nm:
+            if before <= max_reposition_nm and _is_real_terminal_deck(
+                *_terminal_deck_span(ctx, model, cruise, descent.from_nm, total)
+            ):
                 dist = round(before)
                 mitigations.append(Mitigation(
                     kind=MitigationKind.ROUTE_POSITION,

--- a/tests/test_vfr_mitigation.py
+++ b/tests/test_vfr_mitigation.py
@@ -9,8 +9,6 @@ from __future__ import annotations
 
 from datetime import datetime
 
-import pytest
-
 from weatherbrief.analysis.advisories import RouteContext
 from weatherbrief.analysis.advisories.vfr_feasibility import VFRFeasibilityEvaluator
 from weatherbrief.models import (
@@ -273,20 +271,53 @@ def test_along_route_descent_happy_path():
     assert m.mitigated_status == AdvisoryStatus.GREEN
 
 
-def test_along_route_uniformly_blocked():
-    """Deck unbroken from departure to the route midpoint → no along-route
-    mitigation (no VMC break before halfway to reposition around)."""
-    # High enough base to clear the AGL gate, so the no-mitigation result is due
-    # to the deck running unbroken to the midpoint (no clear point before
-    # total/2), not the gate. Route total = 200nm, midpoint = 100nm; blocking
-    # every point out to d=100 leaves no clear break in the departure half.
+def test_along_route_terminal_deck_past_midpoint_emits():
+    """A clean terminal deck extending PAST the route midpoint still earns its tip when the
+    break is within the reposition cap — the half-route knife-edge is gone (#342 Bug B).
+
+    Arrival deck from 100nm inward (past the 100nm midpoint) on a 200nm route; clear before.
+    The profile stays on top until it must descend under the deck ~80nm out, so the descent
+    completes 120nm before arrival — ``before`` (120) > ``total/2`` (100). The old
+    ``before <= total/2`` gate dropped this correct tip on exactly that kind of overshoot,
+    letting only a spurious departure tip survive. ``clean_terminal`` already guarantees the
+    interior is clear, so with the split removed the tip is offered whenever the break is
+    within ``max_reposition_nm`` (raised here to admit the 120nm break the deck's size
+    dictates; the default cap has its own test).
+    """
     deck = EnhancedCloudLayer(base_ft=4000, top_ft=5500, coverage=CloudCoverage.OVC)
-    analyses = [_rpa(i, i * 20.0, {"gfs": [deck] if i <= 5 else []}) for i in range(10)]
+    analyses = [_rpa(i, i * 20.0, {"gfs": [deck] if i >= 5 else []}) for i in range(10)]
+    result = VFRFeasibilityEvaluator.evaluate(
+        _ctx(analyses),
+        {**_VFR_DEFAULTS, "terminal_corridor_nm": 60, "mitigation_max_reposition_nm": 150},
+    )
+
+    assert result.aggregate_status == AdvisoryStatus.RED  # terminal OVC deck
+    descent = [m for m in _mitigations(result) if m.addresses == "descent_deck"]
+    assert len(descent) == 1
+    assert descent[0].distance_nm == 120.0  # before = 200 − 80, past the 100nm midpoint
+    assert descent[0].reference == "arrival"
+    assert descent[0].mitigated_status == AdvisoryStatus.GREEN
+
+
+def test_along_route_single_point_terminal_deck_suppressed():
+    """A lone terminal-field cloud at cruise → NO spurious corridor tip (#342 Bug A).
+
+    A thin cloud sitting at the planned cruise altitude over the departure field ONLY
+    makes the min-cost profile start below cruise (as every climb-out does) and climb
+    up once past it — which the profile-shape gate alone reads as a ``climb_deck``. But
+    nothing forced the flight low beyond the field's own cloud, so the tip is noise. The
+    real-deck gate (≥2 route points / ≥15nm of deck) suppresses it; a genuine multi-point
+    departure deck (the happy-path test) still emits.
+    """
+    # Thin OVC 7900–8100 straddles cruise (8000) at the departure field (nm 0) only.
+    field_cloud = EnhancedCloudLayer(base_ft=7900, top_ft=8100, coverage=CloudCoverage.OVC)
+    analyses = [_rpa(i, i * 20.0, {"gfs": [field_cloud] if i == 0 else []}) for i in range(10)]
     result = VFRFeasibilityEvaluator.evaluate(
         _ctx(analyses), {**_VFR_DEFAULTS, "terminal_corridor_nm": 60, **_NO_REPOSITION_CAP}
     )
 
-    assert result.aggregate_status == AdvisoryStatus.RED
+    # The profile is forced below cruise at nm 0 and climbs after — absent the real-deck
+    # gate this would emit a spurious "climb to cruise after ~20nm". It must not.
     assert not any(m.addresses == "climb_deck" for m in _mitigations(result))
 
 
@@ -402,28 +433,31 @@ def test_cruise_imc_suppresses_corridor_mitigation():
 def test_interior_deck_suppresses_corridor_mitigation():
     """An INTERIOR deck (away from both terminals) must NOT yield a corridor tip (#338).
 
-    Departure deck forces a low climb-out; the profile reaches cruise; but a mid-route
-    deck (spanning cruise to the ceiling) forces it back down and up again. The old
-    ``reaches_cruise`` check alone would emit a misleading "climb to cruise after ~20nm"
-    even though the flight has to descend again at the interior deck. The interior-dip
-    guard suppresses both corridor tips — the safe-but-silent behavior.
+    The profile reaches cruise, dips under a mid-route deck, climbs back to cruise, then
+    descends for the arrival deck — a genuine climb/dip/climb interior excursion. A thin
+    at-cruise interior deck (8000–8500) is what actually triggers the dip: a departure
+    deck instead traps the profile low for the whole route (one contiguous below-cruise
+    run, no interior dip), which is a distance-from-airport concern the reposition cap
+    handles, not the interior-dip guard. Here the guard fires (``clean_terminal`` False)
+    and suppresses the arrival ``descent_deck`` tip that would otherwise be misleading —
+    the flight has to descend at the interior deck too, not just at arrival.
     """
-    dep_deck = EnhancedCloudLayer(base_ft=4000, top_ft=6000, coverage=CloudCoverage.OVC)
-    # Interior deck spans cruise (8000) up to the ceiling → no on-top escape, must dip low.
-    interior = EnhancedCloudLayer(base_ft=7000, top_ft=18000, coverage=CloudCoverage.OVC)
-    layers = {}
+    # Thin at-cruise interior deck → the profile dips just under it, then climbs back.
+    interior = EnhancedCloudLayer(base_ft=8000, top_ft=8500, coverage=CloudCoverage.OVC)
+    # Arrival deck below cruise → a descent_deck candidate absent the interior dip.
+    arr_deck = EnhancedCloudLayer(base_ft=4000, top_ft=5500, coverage=CloudCoverage.OVC)
     analyses = [
-        _rpa(i, i * 20.0, {"gfs": [dep_deck] if i in (0, 1) else ([interior] if i in (4, 5) else [])})
+        _rpa(i, i * 20.0, {"gfs": [interior] if i in (3, 4) else ([arr_deck] if i in (8, 9) else [])})
         for i in range(10)
     ]
     result = VFRFeasibilityEvaluator.evaluate(
         _ctx(analyses), {**_VFR_DEFAULTS, "terminal_corridor_nm": 60, **_NO_REPOSITION_CAP}
     )
 
-    assert result.aggregate_status == AdvisoryStatus.RED  # interior OVC at cruise
+    assert result.aggregate_status == AdvisoryStatus.RED  # arrival OVC deck
     addresses = {m.addresses for m in _mitigations(result)}
-    assert "climb_deck" not in addresses      # would be misleading (must descend again)
-    assert "descent_deck" not in addresses
+    assert "climb_deck" not in addresses      # departure at cruise → no climb candidate
+    assert "descent_deck" not in addresses    # suppressed — interior dip, must descend twice
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes two bugs in VFR corridor mitigation logic (#342):
- **Bug A**: Single-point terminal-field clouds incorrectly trigger corridor tips (e.g., a thin cloud at cruise over the departure field alone makes the profile climb out, which the profile-shape gate misreads as a repositionable "climb_deck").
- **Bug B**: The half-route split (`<= total / 2`) creates a knife-edge that silently drops correct arrival tips when the break overshoots by a fraction of a mile.

## Key Changes

- **New constants** (`_TERMINAL_DECK_MIN_POINTS`, `_TERMINAL_DECK_MIN_RUN_NM`): Define a "real" terminal deck as one spanning ≥2 route points OR ≥15 nm of along-track run.

- **New function `_terminal_deck_span()`**: Scans the terminal climb/descent band (`[lo_nm, hi_nm]`) to count route points with BKN/OVC layers intruding between field elevation and cruise altitude. Returns `(point_count, span_nm)` to distinguish genuine multi-point decks from lone field clouds.

- **New function `_is_real_terminal_deck()`**: Gate that accepts only decks meeting the ≥2 points or ≥15 nm threshold.

- **Removed half-route split**: The `climb.from_nm <= total / 2` and `before <= total / 2` checks are gone. Since `clean_terminal` already guarantees the interior is clear, a terminal tip is meaningful whenever the break is within `max_reposition_nm`—the half-route knife-edge was unnecessary and dropped correct tips on fractional-mile misses.

- **Updated `climb_deck` and `descent_deck` logic**: Both now call `_is_real_terminal_deck(*_terminal_deck_span(...))` to gate the tip emission, ensuring only real multi-point decks earn corridor suggestions.

- **String copy update**: Changed `"vfr.mitigation.altitude_marginal"` from "Marginal VMC at {alt} ft" to "Marginal VMC around {alt} ft" to clarify it's a fly-lower target (parallel to the GREEN "VMC available at {alt} ft").

- **Test updates**: 
  - Replaced `test_along_route_uniformly_blocked()` with `test_along_route_terminal_deck_past_midpoint_emits()` to verify the half-route split removal allows correct tips past the midpoint.
  - Added `test_along_route_single_point_terminal_deck_suppressed()` to confirm lone field clouds no longer emit spurious tips.
  - Updated `test_interior_deck_suppresses_corridor_mitigation()` to reflect the new interior-dip guard behavior.

- **Design doc update**: Added context on the two new guards and the removal of the half-route split in `designs/advisories.md`.

## Implementation Details

The real-deck gate is applied *after* the profile-shape check (`profile.segments[0].alt_ft < cruise` for climb, `profile.segments[-1].alt_ft < cruise` for descent). The profile shape alone cannot distinguish a genuine multi-point deck from a single field cloud, so the new `_terminal_deck_span()` function explicitly scans the terminal band to count qualifying points and measure their span. This preserves the existing profile-based logic while adding the semantic check needed to suppress noise.

https://claude.ai/code/session_01EYPPTaufZyw7V9tvRU9MUD