### PR TITLE
Cross-border flag: model prepared-vs-surprise, not just border-present (#344)

### DIFF
--- a/designs/alternates.md
+++ b/designs/alternates.md
@@ -287,19 +287,35 @@ A weather-better, close divert candidate can still carry **non-weather** frictio
 future signals (water crossing #345, military/joint-use, drive-time) reuse the
 same shape with no new rendering plumbing.
 
-The cross-border flag is built by the pure `analysis/operational_flags.py::cross_border_flag(origin_country, alt_country, alt_is_poe)`,
-called from `_build_alternate`. It **anchors on the origin (departure) country,
-not the destination** — the formalities you face on landing at an alternate are
-set by the country you departed from, since that is the border the flight
-actually crosses. Destination-anchoring is wrong whenever origin ≠ destination
-(e.g. an FR→CH flight diverting to an Italian field is FR→IT — both EU, no
-formalities — even though CH→IT would read customs-required). Severity comes
-**purely from the country-pair** via `euro_aip.borders.crossing_requirements`
-(membership rules live in the library, not re-encoded here): both formalities →
-`red`, exactly one → `amber`, neither / same country / unresolved country → no
-flag. `point_of_entry` modulates the detail **wording only** (reassurance vs
-"could not verify entry facilities"), **never** the severity. `OperationalFlag`
-carries `code` / `label` / `detail` / `severity` (`amber`|`red`, never green).
+The cross-border flag (`analysis/operational_flags.py::cross_border_flag(origin_country, destination_country, alt_country, alt_is_poe)`,
+called from `_build_alternate`) models **what the pilot is not prepared for**, not
+merely "is there a border." Preparedness is the flight you *filed*
+(`origin → destination`): if you filed an international arrival you already carry
+the documents and made the arrangements, so diverting across a border you planned
+for isn't the friction. Membership rules come from
+`euro_aip.borders.crossing_requirements` (origin→destination = "planned",
+origin→alternate = "alt"); the anchor is the **origin (departure) country** —
+strictly the last departure airport, `route.origin` for single-leg briefings.
+
+Three derived reasons, severity = worst that fires (none → no flag):
+
+| Reason | Fires when | Severity |
+|---|---|---|
+| **Unprepared formality** | alt needs an axis (customs/immigration) that the filed flight didn't | **red** if alt needs *both* axes, else **amber** (absolute grade) |
+| **Different country than filed** | alt is a different country than the destination **and** needs a formality, but adds no *new* axis (you're prepared, just wrong country) | **amber** |
+| **Facility gap** | alt needs a formality but is **not** a POE | **amber** ("could not verify") |
+
+Consequences worth knowing: a France-departed flight diverting to an EU field
+(FR→IT) is silent (no formality); the same flight diverting to the UK is red;
+UK→FR diverting to a German POE is **amber** (prepared, different country), not
+red. `point_of_entry` only ever *adds* the facility note, never changes severity.
+`OperationalFlag` carries `code` / `label` / `detail` / `severity`
+(`amber`|`red`, never green).
+
+**Known limitation:** `euro_aip.borders` models Schengen + EU-customs only, so the
+**IE↔GB Common Travel Area** is not represented — an Ireland↔UK pair reads as a
+full customs+immigration border (red) and over-flags (CTA removes immigration in
+practice). Accepted as a conservative over-warn.
 
 ## Output data model (`models/alternates.py`)
 `AlternateAirport` (geometry: `distance_from_dest_nm`, `enroute_distance_nm`,

--- a/designs/alternates.md
+++ b/designs/alternates.md
@@ -287,9 +287,13 @@ A weather-better, close divert candidate can still carry **non-weather** frictio
 future signals (water crossing #345, military/joint-use, drive-time) reuse the
 same shape with no new rendering plumbing.
 
-The cross-border flag is built by the pure `analysis/operational_flags.py::cross_border_flag(dest_country, alt_country, alt_is_poe)`,
-called from `_build_alternate`. It **anchors on the destination's country** (the
-surprise is "planned to land in FR, cleared instead into GB") and reads severity
+The cross-border flag is built by the pure `analysis/operational_flags.py::cross_border_flag(origin_country, alt_country, alt_is_poe)`,
+called from `_build_alternate`. It **anchors on the origin (departure) country,
+not the destination** — the formalities you face on landing at an alternate are
+set by the country you departed from, since that is the border the flight
+actually crosses. Destination-anchoring is wrong whenever origin ≠ destination
+(e.g. an FR→CH flight diverting to an Italian field is FR→IT — both EU, no
+formalities — even though CH→IT would read customs-required). Severity comes
 **purely from the country-pair** via `euro_aip.borders.crossing_requirements`
 (membership rules live in the library, not re-encoded here): both formalities →
 `red`, exactly one → `amber`, neither / same country / unresolved country → no

--- a/src/weatherbrief/analysis/operational_flags.py
+++ b/src/weatherbrief/analysis/operational_flags.py
@@ -12,9 +12,13 @@ re-encoded and drifted here.
 
 Design notes:
 
-- **Anchor on the destination's country.** The surprise the flag warns about is
-  "planned to land in FR, instead cleared into GB", so severity is read from the
-  destination→alternate pair.
+- **Anchor on the origin's country, not the destination's.** The formalities you
+  actually face on landing at the alternate are governed by the country you
+  *departed from* (the origin), because that is the border the flight crosses.
+  Anchoring on the destination is wrong whenever origin and destination differ:
+  e.g. a France→Switzerland flight diverting to an Italian field is FR→IT (both
+  EU — no formalities), even though the destination→alternate pair CH→IT would
+  wrongly read as customs-required.
 - **Severity is purely the country-pair**, never the point-of-entry status:
   both formalities → red, exactly one → amber, neither → no flag.
 - **Point-of-entry modulates the *message only*.** ``point_of_entry`` means the
@@ -27,10 +31,22 @@ Design notes:
 from __future__ import annotations
 
 from euro_aip.borders import crossing_requirements
+from euro_aip.utils.country_mapper import CountryMapper
 
 from weatherbrief.models.alternates import OperationalFlag
 
 CROSS_BORDER_CODE = "cross_border"
+
+# ISO-code → human country name, reusing the library's reference table so we
+# don't re-encode it here. Built once (it only assembles a couple of dicts).
+_COUNTRY_NAMES = CountryMapper()
+
+
+def _country_name(cc: str) -> str:
+    """Human country name for an ISO-3166-1 alpha-2 code (e.g. "IT" → "Italy"),
+    falling back to the upper-cased code when the library doesn't know it."""
+    name = _COUNTRY_NAMES.get_country_name(cc)
+    return name.title() if name else cc.strip().upper()
 
 
 def _formalities_phrase(immigration: bool, customs: bool) -> str:
@@ -61,22 +77,26 @@ def _poe_note(alt_is_poe: bool) -> str:
 
 
 def cross_border_flag(
-    dest_country: str | None,
+    origin_country: str | None,
     alt_country: str | None,
     alt_is_poe: bool,
 ) -> OperationalFlag | None:
-    """Cross-border operational flag for diverting from ``dest_country`` to an
-    alternate in ``alt_country``, or ``None`` when no border friction applies.
+    """Cross-border operational flag for diverting from a flight that departed
+    ``origin_country`` to an alternate in ``alt_country``, or ``None`` when no
+    border friction applies.
+
+    Anchored on the **origin** country because that is the border the flight
+    actually crosses on arrival at the alternate (see module docstring).
 
     Returns ``None`` when either country is unknown (nothing to compare), when
     the two are the same country, or when neither customs nor immigration is
     required. Otherwise a ``red`` flag (both formalities) or ``amber`` flag
     (exactly one). ``alt_is_poe`` only affects the ``detail`` wording.
     """
-    if not dest_country or not alt_country:
+    if not origin_country or not alt_country:
         return None
 
-    req = crossing_requirements(dest_country, alt_country)
+    req = crossing_requirements(origin_country, alt_country)
     if not req.immigration_required and not req.customs_required:
         # Same country, or both blocs shared → no border friction.
         return None
@@ -87,11 +107,12 @@ def cross_border_flag(
     severity = "red" if both else "amber"
     label = "Cross-border"
 
-    dest_cc = dest_country.strip().upper()
-    alt_cc = alt_country.strip().upper()
+    origin_name = _country_name(origin_country)
+    alt_name = _country_name(alt_country)
     detail = (
-        f"You planned to land in {dest_cc}; diverting to this {alt_cc} field is "
-        f"an unplanned international arrival — {_formalities_phrase(req.immigration_required, req.customs_required)}."
+        f"Diverting to this field in {alt_name} is an unplanned international "
+        f"arrival from {origin_name} — "
+        f"{_formalities_phrase(req.immigration_required, req.customs_required)}."
         f"{_poe_note(alt_is_poe)}"
     )
 

--- a/src/weatherbrief/analysis/operational_flags.py
+++ b/src/weatherbrief/analysis/operational_flags.py
@@ -1,31 +1,42 @@
 """Operational-friction flags for divert candidates (issue #344).
 
 Pure logic that turns *non-weather* friction into an :class:`OperationalFlag`.
-The first (and currently only) signal is **cross-border**: a divert field that
-is weather-better and close can still carry an unplanned international arrival
-(customs, immigration, GAR, PPR). "Different country" is too blunt — FR→BE is a
-different country with essentially none of that friction, while FR→GB is a hard
-customs + immigration border. Grading comes from the country-pair's membership
-of the Schengen area (immigration) and the EU customs union (customs), which is
-reference data owned by the library (``euro_aip.borders``) so it is not
-re-encoded and drifted here.
+The first (and currently only) signal is **cross-border**.
 
-Design notes:
+The flag models **what the pilot is not prepared for**, not merely "is there a
+border." Preparedness is set by the flight actually filed (origin → destination):
+if you filed an international arrival you already carry the documents and made the
+customs/immigration arrangements, so diverting across a border you had planned
+for is *not* the friction. The friction is one of three derived reasons:
 
-- **Anchor on the origin's country, not the destination's.** The formalities you
-  actually face on landing at the alternate are governed by the country you
-  *departed from* (the origin), because that is the border the flight crosses.
-  Anchoring on the destination is wrong whenever origin and destination differ:
-  e.g. a France→Switzerland flight diverting to an Italian field is FR→IT (both
-  EU — no formalities), even though the destination→alternate pair CH→IT would
-  wrongly read as customs-required.
-- **Severity is purely the country-pair**, never the point-of-entry status:
-  both formalities → red, exactly one → amber, neither → no flag.
-- **Point-of-entry modulates the *message only*.** ``point_of_entry`` means the
-  field handles both customs and immigration, but it is a *subset* of
-  customs-capable fields — many airports clear customs without being flagged
-  POE. So a non-POE field is an *uncertainty note* ("could not verify"), never a
-  severity downgrade.
+- **Unprepared formality** — the alternate needs customs or immigration that the
+  filed ``origin → destination`` did not. Graded by the alternate's **absolute**
+  formalities: both → ``red``, exactly one → ``amber``. (A domestic French flight
+  diverting to the UK; or a Switzerland-bound flight diverting to the UK, where
+  immigration is newly required and it is a full third-country border → red.)
+- **Different country than filed** — you *are* prepared for the border, but the
+  alternate is in a different country than your destination, so your flight plan
+  / customs notification points at the wrong authority. ``amber``. (A UK→France
+  flight diverting to a German point of entry: prepared for EU entry, just not
+  into Germany.)
+- **Facility gap** — the alternate needs a formality but is not a listed point of
+  entry, so entry facilities cannot be verified. ``amber``, phrased as
+  uncertainty (never an assertion that customs is unavailable).
+
+Severity is the worst reason that fires; the wording lists what applies. If none
+fire, there is no flag (same country you filed for with the facilities you
+planned; or a diversion that stays inside the same bloc as your departure).
+Membership rules live in :mod:`euro_aip.borders`, not re-encoded here;
+``point_of_entry`` only ever adds the facility note, never a downgrade.
+
+Anchoring is on the **origin (departure) country**, because that is the border a
+diversion actually crosses — strictly the *last departure airport*, which for
+these single-leg briefings is ``route.origin``.
+
+Known limitation: :mod:`euro_aip.borders` models Schengen + EU-customs only, so
+the **IE↔GB Common Travel Area** is not represented — an Ireland↔UK pair reads as
+a full customs+immigration border and will over-flag (CTA removes immigration in
+practice). Accepted as a conservative over-warn (issue #344).
 """
 
 from __future__ import annotations
@@ -50,7 +61,7 @@ def _country_name(cc: str) -> str:
 
 
 def _formalities_phrase(immigration: bool, customs: bool) -> str:
-    """Plain-language description of which formalities the country-pair triggers."""
+    """Plain-language description of which formalities a country-pair triggers."""
     if immigration and customs:
         return "customs and immigration both apply"
     if customs:
@@ -78,47 +89,69 @@ def _poe_note(alt_is_poe: bool) -> str:
 
 def cross_border_flag(
     origin_country: str | None,
+    destination_country: str | None,
     alt_country: str | None,
     alt_is_poe: bool,
 ) -> OperationalFlag | None:
-    """Cross-border operational flag for diverting from a flight that departed
-    ``origin_country`` to an alternate in ``alt_country``, or ``None`` when no
-    border friction applies.
+    """Cross-border operational flag for diverting a flight filed
+    ``origin_country → destination_country`` to an alternate in ``alt_country``,
+    or ``None`` when no border friction applies.
 
-    Anchored on the **origin** country because that is the border the flight
-    actually crosses on arrival at the alternate (see module docstring).
-
-    Returns ``None`` when either country is unknown (nothing to compare), when
-    the two are the same country, or when neither customs nor immigration is
-    required. Otherwise a ``red`` flag (both formalities) or ``amber`` flag
-    (exactly one). ``alt_is_poe`` only affects the ``detail`` wording.
+    See the module docstring for the model. Returns ``None`` when any country is
+    unknown (nothing to compare) or when none of the three reasons fires.
+    ``alt_is_poe`` never changes severity — it only adds the facility note.
     """
-    if not origin_country or not alt_country:
+    if not origin_country or not destination_country or not alt_country:
         return None
 
-    req = crossing_requirements(origin_country, alt_country)
-    if not req.immigration_required and not req.customs_required:
-        # Same country, or both blocs shared → no border friction.
-        return None
+    planned = crossing_requirements(origin_country, destination_country)
+    alt = crossing_requirements(origin_country, alt_country)
 
-    both = req.immigration_required and req.customs_required
-    # Severity is the single carrier of the amber/red distinction (web colours the
-    # chip by it; the digest prints it as a word), so the label stays constant.
-    severity = "red" if both else "amber"
-    label = "Cross-border"
+    has_formality = alt.customs_required or alt.immigration_required
+    # Unprepared: the alternate needs an axis the filed flight did not.
+    new_customs = alt.customs_required and not planned.customs_required
+    new_immigration = alt.immigration_required and not planned.immigration_required
+    unprepared = new_customs or new_immigration
+    diff_country = alt_country.strip().upper() != destination_country.strip().upper()
+    facility_gap = has_formality and not alt_is_poe
+
+    # Reasons, all derived. Severity is the worst that fires.
+    severities: list[str] = []
+    if unprepared:
+        # Absolute grade of the alternate's own formalities (decision: a full
+        # third-country border is red even if only one axis is newly required).
+        severities.append("red" if (alt.customs_required and alt.immigration_required) else "amber")
+    if diff_country and has_formality and not unprepared:
+        # Prepared for the border, but clearing into a different country than filed.
+        severities.append("amber")
+    if facility_gap:
+        severities.append("amber")
+    if not severities:
+        return None
+    severity = "red" if "red" in severities else "amber"
 
     origin_name = _country_name(origin_country)
+    dest_name = _country_name(destination_country)
     alt_name = _country_name(alt_country)
-    detail = (
-        f"Diverting to this field in {alt_name} is an unplanned international "
-        f"arrival from {origin_name} — "
-        f"{_formalities_phrase(req.immigration_required, req.customs_required)}."
-        f"{_poe_note(alt_is_poe)}"
-    )
+    formalities = _formalities_phrase(alt.immigration_required, alt.customs_required)
+
+    if unprepared:
+        lead = (
+            f"Diverting to this field in {alt_name} is an unplanned international "
+            f"arrival from {origin_name} — {formalities}."
+        )
+    elif diff_country:
+        lead = (
+            f"Diverting here clears you into {alt_name}, not {dest_name} as filed — "
+            f"{formalities}, but into a different country than your flight plan "
+            f"named (notify the authorities in {alt_name})."
+        )
+    else:  # facility gap only: same country you filed for, but not a listed POE
+        lead = f"Arriving here from {origin_name} requires border clearance — {formalities}."
 
     return OperationalFlag(
         code=CROSS_BORDER_CODE,
-        label=label,
-        detail=detail,
+        label="Cross-border",
+        detail=f"{lead}{_poe_note(alt_is_poe)}",
         severity=severity,
     )

--- a/src/weatherbrief/tasks/alternates.py
+++ b/src/weatherbrief/tasks/alternates.py
@@ -236,7 +236,7 @@ class _DestContext:
     cat_idx: int  # destination flight-category severity index
     wind_kt: float | None
     crosswind_kt: float | None
-    iso_country: str | None  # destination ISO-3166-1 alpha-2 (anchors cross-border flag)
+    origin_iso_country: str | None  # departure ISO-3166-1 alpha-2 (anchors cross-border flag)
 
 
 def _build_alternate(
@@ -319,7 +319,7 @@ def _build_alternate(
     operational_flags = []
     try:
         xborder = cross_border_flag(
-            dest_ctx.iso_country, ap.iso_country, bool(ap.point_of_entry)
+            dest_ctx.origin_iso_country, ap.iso_country, bool(ap.point_of_entry)
         )
         if xborder is not None:
             operational_flags.append(xborder)
@@ -437,17 +437,22 @@ def run_alternates(
     dest = route.destination
     origin = route.origin
 
-    # Destination country anchors the cross-border operational flag (#344): the
-    # friction is "planned to land in <dest country>, cleared instead into
-    # <alternate country>". Resolved once here from the euro_aip model. Wrapped
-    # like every other model access in this function — a lookup failure degrades
-    # to "no country" (→ no flag), it must never abort the whole stage.
-    dest_iso_country = None
+    # Origin (departure) country anchors the cross-border operational flag (#344):
+    # the formalities you face on landing at an alternate are set by the country
+    # you departed from, since that is the border the flight crosses — NOT the
+    # planned destination (which is wrong whenever origin ≠ destination). Resolved
+    # once here from the euro_aip model. Wrapped like every other model access in
+    # this function — a lookup failure degrades to "no country" (→ no flag), it
+    # must never abort the whole stage.
+    # NB: strictly this should be the country of the *last departure airport*; for
+    # these single-leg briefings that is route.origin. If multi-leg trips with
+    # intermediate landings ever enter scope, anchor on the last landing instead.
+    origin_iso_country = None
     try:
-        dest_ap = model.get_airport(dest.icao)
-        dest_iso_country = dest_ap.iso_country if dest_ap is not None else None
+        origin_ap = model.get_airport(origin.icao)
+        origin_iso_country = origin_ap.iso_country if origin_ap is not None else None
     except Exception:
-        logger.warning("Alternates: destination country lookup failed", exc_info=True)
+        logger.warning("Alternates: origin country lookup failed", exc_info=True)
 
     route_distances = compute_route_distances(route)
     dest_enroute_nm = route_distances[-1] if route_distances else 0.0
@@ -605,7 +610,7 @@ def run_alternates(
                 cat_idx=_cat_idx(dest_category),
                 wind_kt=dest_cons.get("wind_speed_kt"),
                 crosswind_kt=dest_crosswind,
-                iso_country=dest_iso_country,
+                origin_iso_country=origin_iso_country,
             )
             # Informational only: is the destination itself MVFR/IFR/LIFR (i.e.
             # you'd need an instrument approach to get into the *destination*).

--- a/src/weatherbrief/tasks/alternates.py
+++ b/src/weatherbrief/tasks/alternates.py
@@ -237,6 +237,7 @@ class _DestContext:
     wind_kt: float | None
     crosswind_kt: float | None
     origin_iso_country: str | None  # departure ISO-3166-1 alpha-2 (anchors cross-border flag)
+    dest_iso_country: str | None  # filed-destination ISO-3166-1 alpha-2 (the "prepared" baseline)
 
 
 def _build_alternate(
@@ -319,7 +320,10 @@ def _build_alternate(
     operational_flags = []
     try:
         xborder = cross_border_flag(
-            dest_ctx.origin_iso_country, ap.iso_country, bool(ap.point_of_entry)
+            dest_ctx.origin_iso_country,
+            dest_ctx.dest_iso_country,
+            ap.iso_country,
+            bool(ap.point_of_entry),
         )
         if xborder is not None:
             operational_flags.append(xborder)
@@ -437,22 +441,24 @@ def run_alternates(
     dest = route.destination
     origin = route.origin
 
-    # Origin (departure) country anchors the cross-border operational flag (#344):
-    # the formalities you face on landing at an alternate are set by the country
-    # you departed from, since that is the border the flight crosses — NOT the
-    # planned destination (which is wrong whenever origin ≠ destination). Resolved
+    # Cross-border operational flag (#344) needs both the departure country (the
+    # border a diversion actually crosses) and the filed-destination country (the
+    # "prepared" baseline — what formalities you already signed up for). Resolved
     # once here from the euro_aip model. Wrapped like every other model access in
     # this function — a lookup failure degrades to "no country" (→ no flag), it
     # must never abort the whole stage.
-    # NB: strictly this should be the country of the *last departure airport*; for
-    # these single-leg briefings that is route.origin. If multi-leg trips with
+    # NB: the departure anchor is strictly the *last departure airport*; for these
+    # single-leg briefings that is route.origin. If multi-leg trips with
     # intermediate landings ever enter scope, anchor on the last landing instead.
     origin_iso_country = None
+    dest_iso_country = None
     try:
         origin_ap = model.get_airport(origin.icao)
         origin_iso_country = origin_ap.iso_country if origin_ap is not None else None
+        dest_ap_meta = model.get_airport(dest.icao)
+        dest_iso_country = dest_ap_meta.iso_country if dest_ap_meta is not None else None
     except Exception:
-        logger.warning("Alternates: origin country lookup failed", exc_info=True)
+        logger.warning("Alternates: origin/destination country lookup failed", exc_info=True)
 
     route_distances = compute_route_distances(route)
     dest_enroute_nm = route_distances[-1] if route_distances else 0.0
@@ -611,6 +617,7 @@ def run_alternates(
                 wind_kt=dest_cons.get("wind_speed_kt"),
                 crosswind_kt=dest_crosswind,
                 origin_iso_country=origin_iso_country,
+                dest_iso_country=dest_iso_country,
             )
             # Informational only: is the destination itself MVFR/IFR/LIFR (i.e.
             # you'd need an instrument approach to get into the *destination*).

--- a/tests/test_alternates.py
+++ b/tests/test_alternates.py
@@ -657,26 +657,26 @@ def test_assess_threads_aggregation_mode():
 # ---------------------------------------------------------------------------
 
 
-def test_cross_border_flag_red_for_gb_alternate_from_fr_origin():
-    # A flight departing France (LFAT) toward the UK, offered EGMD (Lydd, GB) as
-    # an alternate: landing there from a French departure is a customs +
-    # immigration arrival → red. Anchored on the ORIGIN country. EGMD is a point
-    # of entry → reassurance wording.
+def test_cross_border_red_domestic_fr_diverting_to_uk():
+    # A domestic French flight LFAT→LFAC (both FR) offered EGMD (Lydd, GB) as an
+    # alternate: an unplanned customs + immigration arrival you didn't prepare
+    # for → red. EGMD is a POE → reassurance wording.
     route = RouteConfig(
-        name="LFAT-EGMH",
+        name="LFAT-LFAC",
         waypoints=[
             Waypoint(icao="LFAT", name="Le Touquet", lat=50.52, lon=1.62),  # origin FR
-            Waypoint(icao="EGMH", name="Manston", lat=51.34, lon=1.35),     # dest GB
+            Waypoint(icao="LFAC", name="Calais", lat=50.96, lon=1.95),      # dest FR
         ],
         flight_duration_hours=1.0,
     )
     lfat = _FakeAirport("LFAT", 50.52, 1.62, iso_country="FR")  # origin, for get_airport
+    lfac = _FakeAirport("LFAC", 50.96, 1.95, iso_country="FR")  # dest, for get_airport
     egmd = _FakeAirport("EGMD", 50.96, 0.94, iso_country="GB", point_of_entry=True)
     near = [
         {"airport": egmd, "enroute_distance_nm": None, "segment_distance_nm": 10.0},
     ]
-    snaps = {"EGMH": _all_models("EGMH"), "EGMD": _all_models("EGMD")}
-    result = _run(route, near, snaps, all_airports=[lfat, egmd])
+    snaps = {"LFAC": _all_models("LFAC"), "EGMD": _all_models("EGMD")}
+    result = _run(route, near, snaps, all_airports=[lfat, lfac, egmd])
 
     assert result is not None
     egmd_alt = next(a for a in result.alternates if a.icao == "EGMD")
@@ -689,11 +689,11 @@ def test_cross_border_flag_red_for_gb_alternate_from_fr_origin():
     assert "point of entry" in flags[0].detail  # POE reassurance, not "could not verify"
 
 
-def test_cross_border_anchors_on_origin_not_destination():
+def test_cross_border_no_flag_when_diversion_stays_intra_eu():
     # Regression (user-reported): a France-departed flight LFQA(FR) → LSGS(CH),
-    # diverting to LIMW(IT). Origin→alt is FR→IT — both in the EU, no
-    # formalities. The dest→alt pair CH→IT would WRONGLY read customs-required;
-    # assert we anchor on the origin and produce NO flag.
+    # diverting to LIMW(IT). Origin→alt is FR→IT — both in the EU, zero
+    # formalities — so NO flag, even though the alternate is a third country
+    # relative to the (CH) destination.
     route = RouteConfig(
         name="LFQA-LSGS",
         waypoints=[
@@ -703,36 +703,69 @@ def test_cross_border_anchors_on_origin_not_destination():
         flight_duration_hours=1.5,
     )
     lfqa = _FakeAirport("LFQA", 49.31, 4.05, iso_country="FR")
+    lsgs = _FakeAirport("LSGS", 46.22, 7.33, iso_country="CH")
     limw = _FakeAirport("LIMW", 45.72, 7.42, iso_country="IT")  # Aosta, IT alt near LSGS
     near = [
         {"airport": limw, "enroute_distance_nm": None, "segment_distance_nm": 15.0},
     ]
     snaps = {"LSGS": _all_models("LSGS"), "LIMW": _all_models("LIMW")}
-    result = _run(route, near, snaps, all_airports=[lfqa, limw])
+    result = _run(route, near, snaps, all_airports=[lfqa, lsgs, limw])
 
     assert result is not None
     limw_alt = next(a for a in result.alternates if a.icao == "LIMW")
     assert limw_alt.operational_flags == []
 
 
-def test_no_cross_border_flag_when_origin_country_unknown():
-    # If the origin (departure) country can't be resolved, we can't anchor the
-    # flag — no flag rather than a wrong one.
+def test_cross_border_amber_prepared_but_different_country_than_filed():
+    # UK→FR filed (prepared for the EU-entry border); divert to a German POE
+    # (EDDK). No NEW formality → amber "different country", NOT red. This also
+    # proves the DESTINATION country is threaded: origin-only logic would grade
+    # GB→DE as a full border → red.
     route = RouteConfig(
-        name="LFAT-EGMH",
+        name="EGKB-LFAT",
+        waypoints=[
+            Waypoint(icao="EGKB", name="Biggin Hill", lat=51.33, lon=0.03),  # origin GB
+            Waypoint(icao="LFAT", name="Le Touquet", lat=50.52, lon=1.62),   # dest FR
+        ],
+        flight_duration_hours=1.0,
+    )
+    egkb = _FakeAirport("EGKB", 51.33, 0.03, iso_country="GB")
+    lfat = _FakeAirport("LFAT", 50.52, 1.62, iso_country="FR")
+    eddk = _FakeAirport("EDDK", 50.87, 7.14, iso_country="DE", point_of_entry=True)
+    near = [
+        {"airport": eddk, "enroute_distance_nm": None, "segment_distance_nm": 15.0},
+    ]
+    snaps = {"LFAT": _all_models("LFAT"), "EDDK": _all_models("EDDK")}
+    result = _run(route, near, snaps, all_airports=[egkb, lfat, eddk])
+
+    assert result is not None
+    eddk_alt = next(a for a in result.alternates if a.icao == "EDDK")
+    flags = [f for f in eddk_alt.operational_flags if f.code == "cross_border"]
+    assert len(flags) == 1
+    assert flags[0].severity == "amber"  # softened — not red
+    assert "different country" in flags[0].detail
+    assert "Germany" in flags[0].detail
+
+
+def test_no_cross_border_flag_when_country_unknown():
+    # If origin or destination country can't be resolved, we can't build the
+    # "prepared" baseline — no flag rather than a wrong one.
+    route = RouteConfig(
+        name="LFAT-LFAC",
         waypoints=[
             Waypoint(icao="LFAT", name="Le Touquet", lat=50.52, lon=1.62),  # origin FR
-            Waypoint(icao="EGMH", name="Manston", lat=51.34, lon=1.35),     # dest GB
+            Waypoint(icao="LFAC", name="Calais", lat=50.96, lon=1.95),      # dest FR
         ],
         flight_duration_hours=1.0,
     )
     # LFAT (origin) deliberately absent from all_airports → get_airport → None.
+    lfac = _FakeAirport("LFAC", 50.96, 1.95, iso_country="FR")
     egmd = _FakeAirport("EGMD", 50.96, 0.94, iso_country="GB", point_of_entry=True)
     near = [
         {"airport": egmd, "enroute_distance_nm": None, "segment_distance_nm": 10.0},
     ]
-    snaps = {"EGMH": _all_models("EGMH"), "EGMD": _all_models("EGMD")}
-    result = _run(route, near, snaps, all_airports=[egmd])
+    snaps = {"LFAC": _all_models("LFAC"), "EGMD": _all_models("EGMD")}
+    result = _run(route, near, snaps, all_airports=[lfac, egmd])
 
     assert result is not None
     egmd_alt = next(a for a in result.alternates if a.icao == "EGMD")

--- a/tests/test_alternates.py
+++ b/tests/test_alternates.py
@@ -657,24 +657,25 @@ def test_assess_threads_aggregation_mode():
 # ---------------------------------------------------------------------------
 
 
-def test_cross_border_flag_red_for_gb_alternate_from_fr_dest():
-    # Canonical case: a flight to LFAT (FR) offered EGMD (GB) as an alternate —
-    # close + weather-better, but an unplanned international arrival (customs +
-    # immigration) → red. EGMD is a point of entry → reassurance wording.
+def test_cross_border_flag_red_for_gb_alternate_from_fr_origin():
+    # A flight departing France (LFAT) toward the UK, offered EGMD (Lydd, GB) as
+    # an alternate: landing there from a French departure is a customs +
+    # immigration arrival → red. Anchored on the ORIGIN country. EGMD is a point
+    # of entry → reassurance wording.
     route = RouteConfig(
-        name="EGKA-LFAT",
+        name="LFAT-EGMH",
         waypoints=[
-            Waypoint(icao="EGKA", name="Shoreham", lat=50.84, lon=-0.30),
-            Waypoint(icao="LFAT", name="Le Touquet", lat=50.52, lon=1.62),
+            Waypoint(icao="LFAT", name="Le Touquet", lat=50.52, lon=1.62),  # origin FR
+            Waypoint(icao="EGMH", name="Manston", lat=51.34, lon=1.35),     # dest GB
         ],
         flight_duration_hours=1.0,
     )
-    lfat = _FakeAirport("LFAT", 50.52, 1.62, iso_country="FR")
+    lfat = _FakeAirport("LFAT", 50.52, 1.62, iso_country="FR")  # origin, for get_airport
     egmd = _FakeAirport("EGMD", 50.96, 0.94, iso_country="GB", point_of_entry=True)
     near = [
         {"airport": egmd, "enroute_distance_nm": None, "segment_distance_nm": 10.0},
     ]
-    snaps = {"LFAT": _all_models("LFAT"), "EGMD": _all_models("EGMD")}
+    snaps = {"EGMH": _all_models("EGMH"), "EGMD": _all_models("EGMD")}
     result = _run(route, near, snaps, all_airports=[lfat, egmd])
 
     assert result is not None
@@ -684,26 +685,53 @@ def test_cross_border_flag_red_for_gb_alternate_from_fr_dest():
     assert len(flags) == 1
     assert flags[0].severity == "red"
     assert "customs and immigration" in flags[0].detail
+    assert "from France" in flags[0].detail
     assert "point of entry" in flags[0].detail  # POE reassurance, not "could not verify"
 
 
-def test_no_cross_border_flag_when_dest_country_unknown():
-    # If the destination country can't be resolved, we can't anchor the flag —
-    # no flag rather than a wrong one.
+def test_cross_border_anchors_on_origin_not_destination():
+    # Regression (user-reported): a France-departed flight LFQA(FR) → LSGS(CH),
+    # diverting to LIMW(IT). Origin→alt is FR→IT — both in the EU, no
+    # formalities. The dest→alt pair CH→IT would WRONGLY read customs-required;
+    # assert we anchor on the origin and produce NO flag.
     route = RouteConfig(
-        name="EGKA-LFAT",
+        name="LFQA-LSGS",
         waypoints=[
-            Waypoint(icao="EGKA", name="Shoreham", lat=50.84, lon=-0.30),
-            Waypoint(icao="LFAT", name="Le Touquet", lat=50.52, lon=1.62),
+            Waypoint(icao="LFQA", name="Reims", lat=49.31, lon=4.05),   # origin FR
+            Waypoint(icao="LSGS", name="Sion", lat=46.22, lon=7.33),    # dest CH
+        ],
+        flight_duration_hours=1.5,
+    )
+    lfqa = _FakeAirport("LFQA", 49.31, 4.05, iso_country="FR")
+    limw = _FakeAirport("LIMW", 45.72, 7.42, iso_country="IT")  # Aosta, IT alt near LSGS
+    near = [
+        {"airport": limw, "enroute_distance_nm": None, "segment_distance_nm": 15.0},
+    ]
+    snaps = {"LSGS": _all_models("LSGS"), "LIMW": _all_models("LIMW")}
+    result = _run(route, near, snaps, all_airports=[lfqa, limw])
+
+    assert result is not None
+    limw_alt = next(a for a in result.alternates if a.icao == "LIMW")
+    assert limw_alt.operational_flags == []
+
+
+def test_no_cross_border_flag_when_origin_country_unknown():
+    # If the origin (departure) country can't be resolved, we can't anchor the
+    # flag — no flag rather than a wrong one.
+    route = RouteConfig(
+        name="LFAT-EGMH",
+        waypoints=[
+            Waypoint(icao="LFAT", name="Le Touquet", lat=50.52, lon=1.62),  # origin FR
+            Waypoint(icao="EGMH", name="Manston", lat=51.34, lon=1.35),     # dest GB
         ],
         flight_duration_hours=1.0,
     )
-    # LFAT deliberately absent from all_airports → get_airport returns None.
+    # LFAT (origin) deliberately absent from all_airports → get_airport → None.
     egmd = _FakeAirport("EGMD", 50.96, 0.94, iso_country="GB", point_of_entry=True)
     near = [
         {"airport": egmd, "enroute_distance_nm": None, "segment_distance_nm": 10.0},
     ]
-    snaps = {"LFAT": _all_models("LFAT"), "EGMD": _all_models("EGMD")}
+    snaps = {"EGMH": _all_models("EGMH"), "EGMD": _all_models("EGMD")}
     result = _run(route, near, snaps, all_airports=[egmd])
 
     assert result is not None

--- a/tests/test_operational_flags.py
+++ b/tests/test_operational_flags.py
@@ -1,8 +1,10 @@
 """Tests for the cross-border operational-friction flag (#344).
 
-Severity comes purely from the country-pair (Schengen / EU-customs-union
-membership, owned by ``euro_aip.borders``); point-of-entry status modulates
-only the wording. These tests pin the acceptance criteria from the issue.
+The flag models what the pilot is *not prepared for*: a formality the filed
+``origin → destination`` didn't carry (graded by the alternate's absolute
+formalities), clearing into a different country than filed, or a field that
+can't process the arrival (not a POE). Membership rules live in
+``euro_aip.borders``; POE only ever adds the facility note, never a downgrade.
 """
 
 from weatherbrief.analysis.operational_flags import (
@@ -11,96 +13,135 @@ from weatherbrief.analysis.operational_flags import (
 )
 
 
-class TestSeverityFromCountryPair:
-    def test_fr_to_gb_is_red(self):
-        # LFAT (FR) dest + EGMD (GB) alt: customs + immigration → red.
-        flag = cross_border_flag("FR", "GB", alt_is_poe=True)
+class TestUnpreparedFormality:
+    """Reason 1: the alternate needs an axis the filed flight didn't. Absolute
+    grade — both axes red, one amber."""
+
+    def test_domestic_to_uk_is_red(self):
+        # FR→FR filed, divert to the UK: customs + immigration, unplanned → red.
+        flag = cross_border_flag("FR", "FR", "GB", alt_is_poe=True)
         assert flag is not None
         assert flag.code == CROSS_BORDER_CODE
         assert flag.severity == "red"
         assert "customs and immigration" in flag.detail
+        assert "from France" in flag.detail
 
-    def test_fr_to_ch_customs_only_is_amber(self):
-        # Switzerland: Schengen (no immigration) but outside EU customs → amber.
-        flag = cross_border_flag("FR", "CH", alt_is_poe=False)
-        assert flag is not None
+    def test_switzerland_bound_diverting_to_uk_is_red(self):
+        # CH→FR filed (customs-only prep); divert to UK adds immigration AND it's
+        # a full third-country border → red by absolute grade (decision: red even
+        # though only one axis is newly required).
+        flag = cross_border_flag("CH", "FR", "GB", alt_is_poe=True)
+        assert flag.severity == "red"
+        assert "from Switzerland" in flag.detail
+
+    def test_domestic_ch_to_france_customs_only_is_amber(self):
+        # CH→CH filed, divert to France: customs only (both Schengen) → amber.
+        flag = cross_border_flag("CH", "CH", "FR", alt_is_poe=False)
         assert flag.severity == "amber"
         assert "customs applies" in flag.detail
 
-    def test_fr_to_ie_immigration_only_is_amber(self):
-        # Ireland: EU customs (no customs) but outside Schengen → amber.
-        flag = cross_border_flag("FR", "IE", alt_is_poe=False)
-        assert flag is not None
+    def test_domestic_fr_to_ireland_immigration_only_is_amber(self):
+        # FR→FR filed, divert to Ireland: immigration only (both EU customs) → amber.
+        flag = cross_border_flag("FR", "FR", "IE", alt_is_poe=False)
         assert flag.severity == "amber"
         assert "immigration/passport control applies" in flag.detail
 
-    def test_fr_to_de_no_flag(self):
-        # Both blocs shared → no friction, no flag.
-        assert cross_border_flag("FR", "DE", alt_is_poe=False) is None
 
-    def test_same_country_no_flag(self):
-        assert cross_border_flag("FR", "FR", alt_is_poe=False) is None
+class TestPreparedButDifferentCountry:
+    """Reason 2: prepared for the border, but the alternate is a different
+    country than filed → amber (Q1 soften)."""
 
-    def test_channel_islands_is_red(self):
-        # Jersey is outside both blocs → full customs + immigration border.
-        flag = cross_border_flag("FR", "JE", alt_is_poe=False)
+    def test_prepared_intl_but_different_country_is_amber_not_red(self):
+        # UK→FR filed (prepared for the full EU-entry border); divert to a German
+        # POE. No NEW axis, so it softens to amber even though UK→DE is a full
+        # border — the friction is "wrong country", not "unprepared".
+        flag = cross_border_flag("GB", "FR", "DE", alt_is_poe=True)
+        assert flag.severity == "amber"  # NOT red
+        assert "Germany" in flag.detail
+        assert "France" in flag.detail
+        assert "different country" in flag.detail
+
+    def test_same_country_as_filed_poe_no_flag(self):
+        # UK→FR filed, divert to a French POE: prepared, same country, can clear → no flag.
+        assert cross_border_flag("GB", "FR", "FR", alt_is_poe=True) is None
+
+
+class TestFacilityGap:
+    """Reason 3: the alternate needs a formality but isn't a listed POE → amber
+    uncertainty (never an assertion that customs is unavailable)."""
+
+    def test_prepared_intl_but_alt_not_poe_is_amber(self):
+        # UK→FR filed, divert to a French field that is NOT a POE → amber "verify".
+        flag = cross_border_flag("GB", "FR", "FR", alt_is_poe=False)
+        assert flag.severity == "amber"
+        assert "not listed as a point of entry" in flag.detail
+        assert "could not be verified" in flag.detail
+
+
+class TestNoFlag:
+    def test_domestic_same_country_no_flag(self):
+        assert cross_border_flag("FR", "FR", "FR", alt_is_poe=True) is None
+
+    def test_intra_eu_different_country_no_formality_no_flag(self):
+        # Q2: FR→DE filed, divert to Belgium — all Schengen + EU customs, zero
+        # formalities. "Different country" alone (no obligation) must NOT flag.
+        assert cross_border_flag("FR", "DE", "BE", alt_is_poe=True) is None
+
+
+class TestKnownLimitations:
+    def test_cta_ie_gb_over_flags(self):
+        # euro_aip models Schengen + EU-customs only, not the IE↔GB Common Travel
+        # Area, so IE→GB reads as a full border → red. Accepted over-warn (#344).
+        flag = cross_border_flag("IE", "IE", "GB", alt_is_poe=True)
         assert flag is not None
         assert flag.severity == "red"
 
-    def test_case_insensitive(self):
-        assert cross_border_flag("fr", "gb", alt_is_poe=True).severity == "red"
 
-    def test_detail_expands_iso_codes_to_country_names(self):
-        # Wording uses full country names ("this field in Italy" / "from
-        # Switzerland"), not raw ISO codes. First arg is the ORIGIN country.
-        flag = cross_border_flag("CH", "IT", alt_is_poe=False)
+class TestMissingCountry:
+    def test_missing_origin_no_flag(self):
+        assert cross_border_flag(None, "FR", "GB", alt_is_poe=False) is None
+
+    def test_missing_destination_no_flag(self):
+        assert cross_border_flag("FR", None, "GB", alt_is_poe=False) is None
+
+    def test_missing_alt_no_flag(self):
+        assert cross_border_flag("FR", "FR", None, alt_is_poe=False) is None
+
+    def test_empty_string_no_flag(self):
+        assert cross_border_flag("FR", "FR", "", alt_is_poe=False) is None
+
+
+class TestWording:
+    def test_case_insensitive(self):
+        assert cross_border_flag("fr", "fr", "gb", alt_is_poe=True).severity == "red"
+
+    def test_expands_iso_codes_to_country_names(self):
+        flag = cross_border_flag("CH", "CH", "IT", alt_is_poe=False)
         assert "field in Italy" in flag.detail
         assert "from Switzerland" in flag.detail
         assert "this IT field" not in flag.detail
 
-    def test_detail_expands_multiword_country_name(self):
-        flag = cross_border_flag("FR", "GB", alt_is_poe=True)
+    def test_expands_multiword_country_name(self):
+        flag = cross_border_flag("FR", "FR", "GB", alt_is_poe=True)
         assert "field in United Kingdom" in flag.detail
-        assert "from France" in flag.detail
-
-    def test_fr_origin_to_it_alt_no_flag(self):
-        # Both in the EU (Schengen + customs union) → no border friction. This
-        # is the alt-country half of the origin-anchoring fix: a France-departed
-        # flight diverting to Italy has no formalities, regardless of where it
-        # was headed.
-        assert cross_border_flag("FR", "IT", alt_is_poe=False) is None
-
-
-class TestMissingCountry:
-    def test_missing_alt_country_no_flag(self):
-        assert cross_border_flag("FR", None, alt_is_poe=False) is None
-
-    def test_missing_origin_country_no_flag(self):
-        assert cross_border_flag(None, "GB", alt_is_poe=False) is None
-
-    def test_empty_string_no_flag(self):
-        assert cross_border_flag("FR", "", alt_is_poe=False) is None
 
 
 class TestPoeOverlayModulatesMessageNotSeverity:
     def test_poe_gives_reassurance_wording(self):
-        flag = cross_border_flag("FR", "GB", alt_is_poe=True)
+        flag = cross_border_flag("FR", "FR", "GB", alt_is_poe=True)
         assert flag.severity == "red"  # severity unchanged by POE
         assert "point of entry" in flag.detail
         assert "could not be verified" not in flag.detail
 
-    def test_non_poe_gives_uncertainty_note_not_downgrade(self):
-        # Requested behaviour: CH↔FR amber + non-POE → "could not verify
-        # customs requirement", NOT an assertion that it's unavailable.
-        flag = cross_border_flag("FR", "CH", alt_is_poe=False)
-        assert flag.severity == "amber"  # NOT downgraded
+    def test_non_poe_gives_uncertainty_note(self):
+        flag = cross_border_flag("FR", "FR", "GB", alt_is_poe=False)
+        assert flag.severity == "red"  # NOT downgraded / upgraded by POE
         assert "could not be verified" in flag.detail
-        assert "not listed as a point of entry" in flag.detail
 
     def test_poe_status_never_changes_severity(self):
         assert (
-            cross_border_flag("FR", "GB", alt_is_poe=True).severity
-            == cross_border_flag("FR", "GB", alt_is_poe=False).severity
+            cross_border_flag("FR", "FR", "GB", alt_is_poe=True).severity
+            == cross_border_flag("FR", "FR", "GB", alt_is_poe=False).severity
         )
 
 
@@ -109,11 +150,10 @@ class TestTextDigestRendering:
     (PR #349 review — the tag loop had no direct coverage)."""
 
     def test_cross_border_tag_rendered_with_severity(self):
-        from weatherbrief.analysis.operational_flags import cross_border_flag
         from weatherbrief.digest.text import _format_route_alternates
         from weatherbrief.models.alternates import AlternateAirport, RouteAlternates
 
-        flag = cross_border_flag("FR", "GB", alt_is_poe=True)  # red
+        flag = cross_border_flag("FR", "FR", "GB", alt_is_poe=True)  # red
         assert flag is not None
         alt = RouteAlternates(
             destination_icao="LFAT",

--- a/tests/test_operational_flags.py
+++ b/tests/test_operational_flags.py
@@ -50,12 +50,32 @@ class TestSeverityFromCountryPair:
     def test_case_insensitive(self):
         assert cross_border_flag("fr", "gb", alt_is_poe=True).severity == "red"
 
+    def test_detail_expands_iso_codes_to_country_names(self):
+        # Wording uses full country names ("this field in Italy" / "from
+        # Switzerland"), not raw ISO codes. First arg is the ORIGIN country.
+        flag = cross_border_flag("CH", "IT", alt_is_poe=False)
+        assert "field in Italy" in flag.detail
+        assert "from Switzerland" in flag.detail
+        assert "this IT field" not in flag.detail
+
+    def test_detail_expands_multiword_country_name(self):
+        flag = cross_border_flag("FR", "GB", alt_is_poe=True)
+        assert "field in United Kingdom" in flag.detail
+        assert "from France" in flag.detail
+
+    def test_fr_origin_to_it_alt_no_flag(self):
+        # Both in the EU (Schengen + customs union) → no border friction. This
+        # is the alt-country half of the origin-anchoring fix: a France-departed
+        # flight diverting to Italy has no formalities, regardless of where it
+        # was headed.
+        assert cross_border_flag("FR", "IT", alt_is_poe=False) is None
+
 
 class TestMissingCountry:
     def test_missing_alt_country_no_flag(self):
         assert cross_border_flag("FR", None, alt_is_poe=False) is None
 
-    def test_missing_dest_country_no_flag(self):
+    def test_missing_origin_country_no_flag(self):
         assert cross_border_flag(None, "GB", alt_is_poe=False) is None
 
     def test_empty_string_no_flag(self):


### PR DESCRIPTION
Follow-up to the merged #349, reworking **when** and **how hard** the cross-border operational-friction flag fires. The initial logic ("is origin→alternate a border?") over-flagged; this models **what the pilot is not prepared for**, using the flight actually *filed* (origin → destination) as the preparedness baseline.

## Model — three derived reasons

From `euro_aip.borders.crossing_requirements`: `planned = (origin→destination)`, `alt = (origin→alternate)`. Severity = worst reason that fires; none → no flag.

| Reason | Fires when | Severity |
|---|---|---|
| **Unprepared formality** | alt needs an axis (customs/immigration) the filed flight didn't | **red** if alt needs *both*, else **amber** (absolute grade) |
| **Different country than filed** | alt is a different country than the destination, needs a formality, but adds no *new* axis (prepared, wrong country) | **amber** |
| **Facility gap** | alt needs a formality but isn't a listed POE | **amber** ("could not verify") |

Anchored on the **origin** (departure) country — strictly the last departure airport, `route.origin` for single-leg. `point_of_entry` only ever adds the facility note, never changes severity.

## Behaviour

- FR-departed flight diverting to an EU field (`FR→IT`) → **silent** (this was the user-reported false amber).
- Same flight diverting to the UK → **red**.
- `UK→FR` diverting to a German POE → **amber** (prepared for the border, just a different country than filed), *not* red.
- `UK→FR` diverting to a French field that isn't a POE → **amber** (verify facilities).

Detail wording expands ISO codes to full country names via euro_aip's `CountryMapper`.

## Known limitation (documented, not coded around)

`euro_aip.borders` models Schengen + EU-customs only, so the **IE↔GB Common Travel Area** isn't represented — an Ireland↔UK pair reads as a full border and over-flags red. Accepted as a conservative over-warn.

## API / tests

`cross_border_flag(origin, destination, alt, alt_is_poe)`; `tasks/alternates.py` resolves the destination country alongside the origin (both wrapped, degrade to no-flag). Full suite **3157 passed**; the truth table above is pinned in `test_operational_flags.py`, plus `run_alternates` plumbing tests including one that proves the destination country is threaded (amber-not-red).

Refs #344.

🤖 Generated with [Claude Code](https://claude.com/claude-code)