### PR TITLE
iOS: auto-download briefings for offline + age-based cache eviction

### DIFF
--- a/app/flyfun-weather/flyfun-weather/App/AppState.swift
+++ b/app/flyfun-weather/flyfun-weather/App/AppState.swift
@@ -50,6 +50,11 @@ final class AppState {
     private(set) var repository: (any BriefingRepository)?
     let pirepOfflineStore = PirepOfflineStore()
     let userPreferences = UserPreferencesStore()
+    /// Local device settings (e.g. offline auto-download mode). Server-side flags
+    /// live in `userPreferences`; this is the on-device counterpart.
+    let settings = AppSettingsStore()
+    /// Live network reachability — gates Wi-Fi-only auto-download.
+    let networkMonitor = NetworkMonitor()
     /// (i)-popup help content (metrics + advisories). Seeded from disk cache or
     /// the bundled baseline at init; refreshed opportunistically when online.
     let helpCatalog = HelpCatalogStore()
@@ -256,6 +261,17 @@ final class AppState {
         guard let apiClient else { return }
         await userPreferences.refresh(using: apiClient)
     }
+
+    /// Evict cached packs for flights that departed more than a week ago, so the
+    /// offline cache doesn't grow unbounded as auto-download fills it. Safe to
+    /// call on launch and foreground — a no-op when nothing is stale.
+    func pruneStaleCache() async {
+        guard let caching = cachingRepository else { return }
+        await caching.pruneStalePacks(olderThanDays: Self.cacheRetentionDays)
+    }
+
+    /// Cached packs are kept until their flight is this many days in the past.
+    static let cacheRetentionDays = 7
 
     /// Pull the latest (i)-popup help content. Non-blocking; safe to call on
     /// launch, sign-in, and foreground — a `304` is a cheap no-op.

--- a/app/flyfun-weather/flyfun-weather/App/WeatherBriefApp.swift
+++ b/app/flyfun-weather/flyfun-weather/App/WeatherBriefApp.swift
@@ -34,6 +34,7 @@ struct WeatherBriefApp: App {
                     Task { await appState.syncPendingPireps() }
                     Task { await appState.refreshUserPreferences() }
                     Task { await appState.refreshHelpCatalog() }
+                    Task { await appState.pruneStaleCache() }
                 }
             }
         }

--- a/app/flyfun-weather/flyfun-weather/Services/AppSettingsStore.swift
+++ b/app/flyfun-weather/flyfun-weather/Services/AppSettingsStore.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+/// How the app auto-downloads briefing packs for offline use when a briefing is
+/// displayed. The pack data is the same bundle the explicit download button
+/// fetches, so an auto-downloaded pack renders fully (incl. Skew-Ts) offline.
+enum AutoDownloadMode: String, CaseIterable, Identifiable, Sendable {
+    /// Never auto-download; only explicit per-pack downloads are cached.
+    case off
+    /// Auto-download only on Wi-Fi / wired (the default).
+    case wifiOnly
+    /// Auto-download on any connection, including cellular.
+    case wifiAndCellular
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .off: "Off"
+        case .wifiOnly: "Wi-Fi Only"
+        case .wifiAndCellular: "Wi-Fi & Cellular"
+        }
+    }
+
+    /// Whether auto-download should proceed under the given connectivity.
+    func allows(isOnWiFi: Bool, isConnected: Bool) -> Bool {
+        switch self {
+        case .off: false
+        case .wifiOnly: isOnWiFi
+        case .wifiAndCellular: isConnected
+        }
+    }
+}
+
+/// Local, device-side app settings — distinct from the server-backed
+/// `UserPreferencesStore`. Persisted in `UserDefaults` so the chosen value is
+/// available immediately at launch and while offline.
+@Observable
+@MainActor
+final class AppSettingsStore {
+    private static let autoDownloadKey = "autoDownloadMode"
+
+    /// Whether/where to auto-download briefings for offline use. Defaults to
+    /// Wi-Fi only so the feature never silently spends a pilot's cellular data.
+    var autoDownloadMode: AutoDownloadMode {
+        didSet {
+            guard oldValue != autoDownloadMode else { return }
+            UserDefaults.standard.set(autoDownloadMode.rawValue, forKey: Self.autoDownloadKey)
+        }
+    }
+
+    init() {
+        if let raw = UserDefaults.standard.string(forKey: Self.autoDownloadKey),
+           let mode = AutoDownloadMode(rawValue: raw) {
+            self.autoDownloadMode = mode
+        } else {
+            self.autoDownloadMode = .wifiOnly
+        }
+    }
+}

--- a/app/flyfun-weather/flyfun-weather/Services/BriefingCacheStore.swift
+++ b/app/flyfun-weather/flyfun-weather/Services/BriefingCacheStore.swift
@@ -154,6 +154,25 @@ actor BriefingCacheStore {
         Self.logger.info("Deleted cached pack \(key)")
     }
 
+    /// Whether any pack for this flight still has an index entry. The trailing
+    /// slash keeps `f1` from matching `f10` when testing the `flightId/timestamp` key.
+    func hasCachedPacks(flightId: String) -> Bool {
+        ensureLoaded()
+        let prefix = "\(flightId)/"
+        return index.keys.contains { $0.hasPrefix(prefix) }
+    }
+
+    /// Remove a flight's entire cache directory, including flight-level sidecar
+    /// metadata (flight.json, packs.json, latest-pack.json, pack-meta.json).
+    /// Only safe once every pack for the flight has been deleted from the index
+    /// — offline recovery walks index entries, so nothing reads these files once
+    /// no entry points at the flight. No-op on the index itself (already clear).
+    func removeFlightDirectory(flightId: String) {
+        let dir = cacheDir.appendingPathComponent(flightId, isDirectory: true)
+        try? FileManager.default.removeItem(at: dir)
+        Self.logger.info("Removed orphaned flight cache dir \(flightId)")
+    }
+
     func totalCacheSize() -> Int64 {
         ensureLoaded()
         return index.values.reduce(0) { $0 + $1.totalBytes }

--- a/app/flyfun-weather/flyfun-weather/Services/BriefingCacheStore.swift
+++ b/app/flyfun-weather/flyfun-weather/Services/BriefingCacheStore.swift
@@ -10,6 +10,11 @@ struct CachedPackEntry: Codable, Sendable, Identifiable {
     let downloadedAt: Date
     var endpoints: Set<String>
     var totalBytes: Int64
+    /// Flight departure (ISO-8601) captured at download time so cache eviction
+    /// can age packs out by flight date without a separate flight-metadata
+    /// lookup. Optional for backward compatibility with index entries written
+    /// before this field existed (they fall back to the cached flight record).
+    var departureTime: String? = nil
 
     var id: String { "\(flightId)/\(timestamp)" }
 
@@ -121,7 +126,8 @@ actor BriefingCacheStore {
         flightTitle: String,
         assessment: String?,
         endpoints: Set<String>,
-        totalBytes: Int64
+        totalBytes: Int64,
+        departureTime: String? = nil
     ) {
         ensureLoaded()
         let key = "\(flightId)/\(timestamp)"
@@ -132,7 +138,8 @@ actor BriefingCacheStore {
             assessment: assessment,
             downloadedAt: Date(),
             endpoints: endpoints,
-            totalBytes: totalBytes
+            totalBytes: totalBytes,
+            departureTime: departureTime
         )
         saveIndex()
     }

--- a/app/flyfun-weather/flyfun-weather/Services/CachingBriefingRepository.swift
+++ b/app/flyfun-weather/flyfun-weather/Services/CachingBriefingRepository.swift
@@ -319,12 +319,26 @@ final class CachingBriefingRepository: BriefingRepository {
     func pruneStalePacks(olderThanDays days: Int) async -> Int {
         let cutoff = Date().addingTimeInterval(-Double(days) * 86_400)
         var removed = 0
+        var touchedFlights: Set<String> = []
         for entry in await cache.cachedPacks() {
-            guard let departure = await departureDate(for: entry) else { continue }
-            if departure < cutoff {
-                await cache.deletePack(flightId: entry.flightId, timestamp: entry.timestamp)
-                removed += 1
-            }
+            let fallback = await cachedFlightDeparture(for: entry)
+            guard let stale = Self.isPackStale(
+                entryDepartureTime: entry.departureTime,
+                fallbackDeparture: fallback,
+                cutoff: cutoff
+            ), stale else { continue }
+            await cache.deletePack(flightId: entry.flightId, timestamp: entry.timestamp)
+            touchedFlights.insert(entry.flightId)
+            removed += 1
+        }
+        // A flight's departure is shared across all its packs, so evicting any
+        // one aged-out pack evicts them all in the same run. Once none remain,
+        // the flight-level sidecar metadata (flight.json, packs.json,
+        // latest-pack.json, pack-meta.json) is orphaned — offline recovery only
+        // walks index entries, so nothing references it — so drop the directory
+        // instead of leaking it forever.
+        for flightId in touchedFlights where await !cache.hasCachedPacks(flightId: flightId) {
+            await cache.removeFlightDirectory(flightId: flightId)
         }
         if removed > 0 {
             Self.logger.info("Pruned \(removed) stale cached pack(s) older than \(days)d")
@@ -332,23 +346,30 @@ final class CachingBriefingRepository: BriefingRepository {
         return removed
     }
 
-    /// Best-effort departure date for a cached pack: the value stored at download
-    /// time, else the cached flight metadata (for entries predating that field).
-    private func departureDate(for entry: CachedPackEntry) async -> Date? {
-        if let ts = entry.departureTime, let date = Self.parseISO(ts) { return date }
-        if let data = await cache.readFlightMetadata(flightId: entry.flightId, name: "flight"),
-           let flight = try? JSONDecoder.weatherBrief.decode(FlightResponse.self, from: data) {
-            return flight.departureDate
+    /// Resolve a cached pack's departure and decide whether it's older than the
+    /// cutoff. Pure (no I/O) so the cutoff comparison and the legacy fallback
+    /// from `entry.departureTime` to the cached flight record are unit-testable.
+    /// Returns nil when no departure can be determined — the caller keeps the
+    /// pack (conservative: never delete data we can't prove is stale).
+    static func isPackStale(entryDepartureTime: String?, fallbackDeparture: Date?, cutoff: Date) -> Bool? {
+        let departure: Date?
+        if let ts = entryDepartureTime, let parsed = Date.parseISO8601(ts) {
+            departure = parsed
+        } else {
+            departure = fallbackDeparture
         }
-        return nil
+        guard let departure else { return nil }
+        return departure < cutoff
     }
 
-    /// Parse an ISO-8601 timestamp, tolerating the optional fractional seconds
-    /// the server sometimes includes.
-    private static func parseISO(_ s: String) -> Date? {
-        let frac = ISO8601DateFormatter()
-        frac.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-        return frac.date(from: s) ?? ISO8601DateFormatter().date(from: s)
+    /// The cached flight record's departure, for legacy entries written before
+    /// `CachedPackEntry.departureTime` existed.
+    private func cachedFlightDeparture(for entry: CachedPackEntry) async -> Date? {
+        guard let data = await cache.readFlightMetadata(flightId: entry.flightId, name: "flight"),
+              let flight = try? JSONDecoder.weatherBrief.decode(FlightResponse.self, from: data) else {
+            return nil
+        }
+        return flight.departureDate
     }
 
     // MARK: - Private

--- a/app/flyfun-weather/flyfun-weather/Services/CachingBriefingRepository.swift
+++ b/app/flyfun-weather/flyfun-weather/Services/CachingBriefingRepository.swift
@@ -246,6 +246,7 @@ final class CachingBriefingRepository: BriefingRepository {
         flightTitle: String,
         assessment: String?,
         packMeta: PackMetaResponse? = nil,
+        departureTime: String? = nil,
         progress: @Sendable @escaping (_ fraction: Double, _ receivedBytes: Int64, _ totalBytes: Int64) -> Void
     ) async throws {
         progress(0, 0, 0)
@@ -284,7 +285,8 @@ final class CachingBriefingRepository: BriefingRepository {
             flightTitle: flightTitle,
             assessment: assessment,
             endpoints: downloaded,
-            totalBytes: diskBytes
+            totalBytes: diskBytes,
+            departureTime: departureTime
         )
         // Cache pack metadata for offline latestPack() recovery
         if let packMeta, let metaData = try? JSONEncoder.weatherBrief.encode(packMeta) {
@@ -303,6 +305,50 @@ final class CachingBriefingRepository: BriefingRepository {
 
     func cachedPacks() async -> [CachedPackEntry] {
         await cache.cachedPacks()
+    }
+
+    // MARK: - Cache eviction
+
+    /// Evict cached packs whose flight departed more than `days` ago.
+    ///
+    /// Departure date comes from the value captured at download time, falling
+    /// back to the cached flight record for legacy entries. Packs whose
+    /// departure can't be determined are kept (conservative — we never delete
+    /// data we can't prove is stale). Returns the number of packs removed.
+    @discardableResult
+    func pruneStalePacks(olderThanDays days: Int) async -> Int {
+        let cutoff = Date().addingTimeInterval(-Double(days) * 86_400)
+        var removed = 0
+        for entry in await cache.cachedPacks() {
+            guard let departure = await departureDate(for: entry) else { continue }
+            if departure < cutoff {
+                await cache.deletePack(flightId: entry.flightId, timestamp: entry.timestamp)
+                removed += 1
+            }
+        }
+        if removed > 0 {
+            Self.logger.info("Pruned \(removed) stale cached pack(s) older than \(days)d")
+        }
+        return removed
+    }
+
+    /// Best-effort departure date for a cached pack: the value stored at download
+    /// time, else the cached flight metadata (for entries predating that field).
+    private func departureDate(for entry: CachedPackEntry) async -> Date? {
+        if let ts = entry.departureTime, let date = Self.parseISO(ts) { return date }
+        if let data = await cache.readFlightMetadata(flightId: entry.flightId, name: "flight"),
+           let flight = try? JSONDecoder.weatherBrief.decode(FlightResponse.self, from: data) {
+            return flight.departureDate
+        }
+        return nil
+    }
+
+    /// Parse an ISO-8601 timestamp, tolerating the optional fractional seconds
+    /// the server sometimes includes.
+    private static func parseISO(_ s: String) -> Date? {
+        let frac = ISO8601DateFormatter()
+        frac.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return frac.date(from: s) ?? ISO8601DateFormatter().date(from: s)
     }
 
     // MARK: - Private

--- a/app/flyfun-weather/flyfun-weather/Services/NetworkMonitor.swift
+++ b/app/flyfun-weather/flyfun-weather/Services/NetworkMonitor.swift
@@ -1,0 +1,51 @@
+import Foundation
+import Network
+import OSLog
+
+/// Observes network reachability so callers can gate auto-download on Wi-Fi.
+///
+/// `NWPathMonitor` delivers updates on a background queue; we hop to the main
+/// actor to publish observable state so SwiftUI and the view models can read it
+/// without data races.
+@Observable
+@MainActor
+final class NetworkMonitor {
+    /// Whether any network path is currently usable.
+    private(set) var isConnected = false
+    /// Whether the active path is "expensive" (cellular / personal hotspot).
+    private(set) var isExpensive = false
+    /// Whether the active path is constrained (e.g. Low Data Mode).
+    private(set) var isConstrained = false
+
+    /// On Wi-Fi (or wired): connected, not cellular, not Low-Data. This is the
+    /// gate used for the default "Wi-Fi only" auto-download mode.
+    var isOnWiFi: Bool { isConnected && !isExpensive && !isConstrained }
+
+    @ObservationIgnored private let monitor = NWPathMonitor()
+    @ObservationIgnored private let queue = DispatchQueue(label: "aero.flyfun.weather.network-monitor")
+    private static let logger = Logger(subsystem: "aero.flyfun.weather", category: "Network")
+
+    init() {
+        monitor.pathUpdateHandler = { [weak self] path in
+            // Snapshot the Sendable scalars off the path before hopping actors.
+            let connected = path.status == .satisfied
+            let expensive = path.isExpensive
+            let constrained = path.isConstrained
+            Task { @MainActor in
+                self?.apply(connected: connected, expensive: expensive, constrained: constrained)
+            }
+        }
+        monitor.start(queue: queue)
+    }
+
+    deinit { monitor.cancel() }
+
+    private func apply(connected: Bool, expensive: Bool, constrained: Bool) {
+        isConnected = connected
+        isExpensive = expensive
+        isConstrained = constrained
+        Self.logger.debug(
+            "Path update: connected=\(connected) expensive=\(expensive) constrained=\(constrained)"
+        )
+    }
+}

--- a/app/flyfun-weather/flyfun-weather/Utilities/Extensions.swift
+++ b/app/flyfun-weather/flyfun-weather/Utilities/Extensions.swift
@@ -37,6 +37,25 @@ extension DateFormatter {
     }()
 }
 
+extension Date {
+    /// Parse an ISO-8601 timestamp, tolerating the optional fractional seconds
+    /// the server includes. The server sends `datetime.isoformat()`, which
+    /// carries microseconds (e.g. `2026-06-28T08:46:00.123456+00:00`), and the
+    /// default `ISO8601DateFormatter` rejects fractional seconds — so try the
+    /// fractional parser first, then plain. Shared so callers don't reimplement
+    /// the fractional-then-plain fallback (BriefingViewModel, CachingBriefingRepository).
+    static func parseISO8601(_ s: String) -> Date? {
+        isoParserFractional.date(from: s) ?? isoParserPlain.date(from: s)
+    }
+
+    private static let isoParserFractional: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return f
+    }()
+    private static let isoParserPlain = ISO8601DateFormatter()
+}
+
 extension String {
     /// Short display name for weather models — used in compact badges where space is tight.
     var shortModelName: String {

--- a/app/flyfun-weather/flyfun-weather/ViewModels/BriefingViewModel.swift
+++ b/app/flyfun-weather/flyfun-weather/ViewModels/BriefingViewModel.swift
@@ -277,21 +277,13 @@ final class BriefingViewModel {
         return dayKeyUTC.string(from: date)
     }
 
-    /// Parse an ISO-8601 timestamp. The server sends `datetime.isoformat()`,
-    /// which includes microseconds (e.g. `2026-06-28T08:46:00.123456+00:00`),
-    /// so try the fractional-seconds parser first, then plain. (Default
-    /// `ISO8601DateFormatter` rejects fractional seconds — that was why the time
-    /// never appeared.)
+    /// Parse an ISO-8601 timestamp, tolerating the server's fractional seconds.
+    /// Delegates to the shared `Date.parseISO8601` helper (was a bespoke
+    /// fractional-then-plain parser duplicated here and in the cache layer).
     private static func parseISO(_ s: String) -> Date? {
-        isoParserFrac.date(from: s) ?? isoParserPlain.date(from: s)
+        Date.parseISO8601(s)
     }
 
-    private static let isoParserFrac: ISO8601DateFormatter = {
-        let f = ISO8601DateFormatter()
-        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-        return f
-    }()
-    private static let isoParserPlain = ISO8601DateFormatter()
     private static let dayTimeUTC: DateFormatter = utcFormatter("MMM d HH:mm")
     private static let timeUTC: DateFormatter = utcFormatter("HH:mm")
     private static let dayKeyUTC: DateFormatter = utcFormatter("yyyy-MM-dd")
@@ -515,6 +507,12 @@ final class BriefingViewModel {
                     updateModels(from: pack)
                     await loadPackHistory()
                     await loadPackData(timestamp: pack.fetchTimestamp)
+                    // A refresh started elsewhere (web/another device) still
+                    // produces a new pack here — mirror refresh()'s completion
+                    // path so an opted-in pilot gets it auto-downloaded for
+                    // offline use, instead of only on the next screen entry.
+                    await checkCacheStatus()
+                    await maybeAutoDownloadLatest()
                     try? await Task.sleep(for: .seconds(10))
                     if case .completed = refreshState {
                         refreshState = .idle

--- a/app/flyfun-weather/flyfun-weather/ViewModels/BriefingViewModel.swift
+++ b/app/flyfun-weather/flyfun-weather/ViewModels/BriefingViewModel.swift
@@ -83,6 +83,11 @@ enum RefreshState: Equatable {
 final class BriefingViewModel {
     let flight: FlightResponse
     private let repository: any BriefingRepository
+    /// Local settings (offline auto-download mode) + connectivity. Optional so
+    /// fixtures/tests can construct a view model without the full app graph;
+    /// auto-download is simply skipped when either is absent.
+    private let settings: AppSettingsStore?
+    private let networkMonitor: NetworkMonitor?
 
     // Pack metadata
     private(set) var pack: PackMetaResponse?
@@ -131,9 +136,16 @@ final class BriefingViewModel {
 
     private static let logger = Logger(subsystem: "aero.flyfun.weather", category: "Briefing")
 
-    init(flight: FlightResponse, repository: any BriefingRepository) {
+    init(
+        flight: FlightResponse,
+        repository: any BriefingRepository,
+        settings: AppSettingsStore? = nil,
+        networkMonitor: NetworkMonitor? = nil
+    ) {
         self.flight = flight
         self.repository = repository
+        self.settings = settings
+        self.networkMonitor = networkMonitor
     }
 
     // MARK: - Deep-link focus (§4.6/§4.7/§4.9)
@@ -187,6 +199,7 @@ final class BriefingViewModel {
             async let dataTask: () = loadPackData(timestamp: pack.fetchTimestamp)
             _ = await (historyTask, dataTask)
             await checkCacheStatus()
+            await maybeAutoDownloadLatest()
         } catch APIError.notFound {
             // No briefing pack exists yet — this is the normal state right after a
             // flight is created (POST /api/flights only saves the flight; it does
@@ -332,6 +345,38 @@ final class BriefingViewModel {
         }
     }
 
+    /// Auto-download the latest pack for offline use when the pilot has opted in
+    /// (Settings → Offline Auto-Download, default Wi-Fi only) and the flight is
+    /// today or in the future. No-op if the pack is already cached, a download is
+    /// already running, or the current connectivity doesn't match the chosen
+    /// mode. Past flights are intentionally skipped — they age out via
+    /// `pruneStalePacks`. Reuses `downloadCurrentPack`, so the download banner
+    /// gives the same visible progress as a manual download.
+    private func maybeAutoDownloadLatest() async {
+        guard let settings, let networkMonitor,
+              repository is CachingBriefingRepository,
+              let pack else { return }
+
+        guard Self.isTodayOrFuture(flight.departureDate) else { return }
+        if packCacheStatus[pack.fetchTimestamp] == true { return }
+        if case .downloading = downloadState { return }
+
+        guard settings.autoDownloadMode.allows(
+            isOnWiFi: networkMonitor.isOnWiFi,
+            isConnected: networkMonitor.isConnected
+        ) else { return }
+
+        Self.logger.info("Auto-downloading pack \(pack.fetchTimestamp) for offline use")
+        await downloadCurrentPack()
+    }
+
+    /// Whether a departure is today or later (local calendar). A nil departure is
+    /// treated as eligible — better to cache than to silently skip.
+    private static func isTodayOrFuture(_ date: Date?) -> Bool {
+        guard let date else { return true }
+        return date >= Calendar.current.startOfDay(for: Date())
+    }
+
     /// Download the current pack for offline access.
     func downloadCurrentPack() async {
         guard let pack, let caching = repository as? CachingBriefingRepository else { return }
@@ -342,7 +387,8 @@ final class BriefingViewModel {
                 timestamp: pack.fetchTimestamp,
                 flightTitle: flight.shortTitle,
                 assessment: pack.assessment,
-                packMeta: pack
+                packMeta: pack,
+                departureTime: flight.departureTime
             ) { [weak self] fraction, received, total in
                 Task { @MainActor in
                     self?.downloadState = .downloading(progress: fraction, receivedBytes: received, totalBytes: total)
@@ -396,6 +442,8 @@ final class BriefingViewModel {
                         updateModels(from: newPack)
                         await loadPackHistory()
                         await loadPackData(timestamp: newPack.fetchTimestamp)
+                        await checkCacheStatus()
+                        await maybeAutoDownloadLatest()
                     }
                     // Clear the transient banner after a delay.
                     try? await Task.sleep(for: .seconds(10))

--- a/app/flyfun-weather/flyfun-weather/Views/Briefing/BriefingContainerView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Briefing/BriefingContainerView.swift
@@ -92,7 +92,12 @@ struct BriefingContainerView: View {
             if let caching = repo as? CachingBriefingRepository {
                 await caching.cacheFlightData(flight)
             }
-            let vm = BriefingViewModel(flight: flight, repository: repo)
+            let vm = BriefingViewModel(
+                flight: flight,
+                repository: repo,
+                settings: appState.settings,
+                networkMonitor: appState.networkMonitor
+            )
             viewModel = vm
             await vm.loadBriefing()
             await vm.checkActiveRefresh()

--- a/app/flyfun-weather/flyfun-weather/Views/SettingsView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/SettingsView.swift
@@ -36,6 +36,21 @@ struct SettingsView: View {
                 }
 
                 Section {
+                    Picker("Auto-Download", selection: Binding(
+                        get: { appState.settings.autoDownloadMode },
+                        set: { appState.settings.autoDownloadMode = $0 }
+                    )) {
+                        ForEach(AutoDownloadMode.allCases) { mode in
+                            Text(mode.label).tag(mode)
+                        }
+                    }
+                } header: {
+                    Text("Offline")
+                } footer: {
+                    Text("Automatically download upcoming briefings (today and later) for offline use, so Skew-Ts and the full briefing open instantly without a connection. Briefings for flights more than \(AppState.cacheRetentionDays) days past are cleared automatically.")
+                }
+
+                Section {
                     Label("Supplementary Tool", systemImage: "info.circle")
                         .foregroundStyle(.secondary)
                 } footer: {

--- a/app/flyfun-weather/flyfun-weatherTests/ServiceTests.swift
+++ b/app/flyfun-weather/flyfun-weatherTests/ServiceTests.swift
@@ -158,6 +158,92 @@ import Foundation
         await store.clearAll()
         #expect(await store.cachedPacks().isEmpty)
     }
+
+    /// `hasCachedPacks` tracks per-flight index membership (with the trailing-slash
+    /// guard so `f1` doesn't match `f10`), and `removeFlightDirectory` clears the
+    /// flight-level sidecar metadata that pack eviction would otherwise orphan.
+    @Test func flightDirectoryCleanupRemovesOrphanedSidecars() async throws {
+        let dir = makeTempDir(); defer { try? FileManager.default.removeItem(at: dir) }
+        let store = BriefingCacheStore(cacheDir: dir)
+
+        // A flight with one downloaded pack plus its offline-recovery sidecar.
+        await store.registerDownload(flightId: "f1", timestamp: "t1", flightTitle: "T",
+                                     assessment: nil, endpoints: all, totalBytes: 1)
+        try await store.writeFlightMetadata(Data("{}".utf8), flightId: "f1", name: "flight")
+        // A second flight whose id has "f1" as a prefix — must not be confused.
+        await store.registerDownload(flightId: "f10", timestamp: "t2", flightTitle: "T",
+                                     assessment: nil, endpoints: all, totalBytes: 1)
+
+        #expect(await store.hasCachedPacks(flightId: "f1"))
+        #expect(await store.hasCachedPacks(flightId: "f10"))
+        #expect(await store.hasCachedPacks(flightId: "f2") == false)
+
+        // Evict f1's only pack → no index entry references f1 any more.
+        await store.deletePack(flightId: "f1", timestamp: "t1")
+        #expect(await store.hasCachedPacks(flightId: "f1") == false)
+        #expect(await store.hasCachedPacks(flightId: "f10"))  // prefix flight untouched
+
+        // The sidecar survives pack deletion (deletePack only removes the pack
+        // subdir) — removeFlightDirectory is what clears the orphan.
+        #expect(await store.readFlightMetadata(flightId: "f1", name: "flight") != nil)
+        await store.removeFlightDirectory(flightId: "f1")
+        #expect(await store.readFlightMetadata(flightId: "f1", name: "flight") == nil)
+    }
+}
+
+// MARK: - Cache eviction staleness (pure cutoff + legacy fallback)
+
+@Suite struct PackStalenessTests {
+
+    private let cutoff = Date(timeIntervalSince1970: 1_000_000)          // reference "now - N days"
+    private func iso(_ t: TimeInterval) -> String {
+        ISO8601DateFormatter().string(from: Date(timeIntervalSince1970: t))
+    }
+
+    @Test func departureBeforeCutoffIsStale() {
+        let stale = CachingBriefingRepository.isPackStale(
+            entryDepartureTime: iso(500_000), fallbackDeparture: nil, cutoff: cutoff)
+        #expect(stale == true)
+    }
+
+    @Test func departureAfterCutoffSurvives() {
+        let stale = CachingBriefingRepository.isPackStale(
+            entryDepartureTime: iso(2_000_000), fallbackDeparture: nil, cutoff: cutoff)
+        #expect(stale == false)
+    }
+
+    /// Legacy entries lacking `departureTime` fall back to the cached flight record.
+    @Test func legacyEntryUsesFallbackDeparture() {
+        let stale = CachingBriefingRepository.isPackStale(
+            entryDepartureTime: nil,
+            fallbackDeparture: Date(timeIntervalSince1970: 500_000),
+            cutoff: cutoff)
+        #expect(stale == true)
+
+        let fresh = CachingBriefingRepository.isPackStale(
+            entryDepartureTime: nil,
+            fallbackDeparture: Date(timeIntervalSince1970: 2_000_000),
+            cutoff: cutoff)
+        #expect(fresh == false)
+    }
+
+    /// No departure anywhere → nil (caller keeps the pack; never delete blind).
+    @Test func unknownDepartureIsKept() {
+        #expect(CachingBriefingRepository.isPackStale(
+            entryDepartureTime: nil, fallbackDeparture: nil, cutoff: cutoff) == nil)
+        // An unparseable timestamp with no fallback is likewise indeterminate.
+        #expect(CachingBriefingRepository.isPackStale(
+            entryDepartureTime: "not-a-date", fallbackDeparture: nil, cutoff: cutoff) == nil)
+    }
+
+    /// A present-but-unparseable `departureTime` falls through to the fallback.
+    @Test func unparseableDepartureFallsBackToFlightRecord() {
+        let stale = CachingBriefingRepository.isPackStale(
+            entryDepartureTime: "garbage",
+            fallbackDeparture: Date(timeIntervalSince1970: 500_000),
+            cutoff: cutoff)
+        #expect(stale == true)
+    }
 }
 
 // MARK: - PirepOfflineStore (offline queue, temp file)

--- a/app/flyfun-weather/flyfun-weatherTests/ServiceTests.swift
+++ b/app/flyfun-weather/flyfun-weatherTests/ServiceTests.swift
@@ -45,6 +45,51 @@ import Foundation
     @Test func idIsFlightSlashTimestamp() {
         #expect(entry([]).id == "flt-1/2026-06-24T09:00:00Z")
     }
+
+    /// Index entries written before `departureTime` existed must still decode
+    /// (the field is optional → nil), so a cache upgrade doesn't wipe the index.
+    @Test func decodesLegacyEntryWithoutDepartureTime() throws {
+        let legacy = Data("""
+        {"flightId":"f1","timestamp":"t1","flightTitle":"T","assessment":"green",
+         "downloadedAt":0,"endpoints":["advisories"],"totalBytes":10}
+        """.utf8)
+        let decoded = try JSONDecoder().decode(CachedPackEntry.self, from: legacy)
+        #expect(decoded.departureTime == nil)
+        #expect(decoded.flightId == "f1")
+    }
+
+    @Test func departureTimeRoundTrips() throws {
+        let e = CachedPackEntry(
+            flightId: "f1", timestamp: "t1", flightTitle: "T", assessment: nil,
+            downloadedAt: Date(timeIntervalSince1970: 0), endpoints: [], totalBytes: 0,
+            departureTime: "2026-06-24T12:00:00Z"
+        )
+        let back = try JSONDecoder().decode(CachedPackEntry.self, from: JSONEncoder().encode(e))
+        #expect(back.departureTime == "2026-06-24T12:00:00Z")
+    }
+}
+
+// MARK: - AutoDownloadMode (pure connectivity gate)
+
+@Suite struct AutoDownloadModeTests {
+
+    @Test func offNeverDownloads() {
+        #expect(AutoDownloadMode.off.allows(isOnWiFi: true, isConnected: true) == false)
+    }
+
+    @Test func wifiOnlyRequiresWiFi() {
+        #expect(AutoDownloadMode.wifiOnly.allows(isOnWiFi: true, isConnected: true))
+        // Connected but on cellular (not Wi-Fi) → blocked.
+        #expect(AutoDownloadMode.wifiOnly.allows(isOnWiFi: false, isConnected: true) == false)
+        #expect(AutoDownloadMode.wifiOnly.allows(isOnWiFi: false, isConnected: false) == false)
+    }
+
+    @Test func wifiAndCellularNeedsOnlyConnectivity() {
+        #expect(AutoDownloadMode.wifiAndCellular.allows(isOnWiFi: false, isConnected: true))
+        #expect(AutoDownloadMode.wifiAndCellular.allows(isOnWiFi: true, isConnected: true))
+        // Fully offline → still nothing to download.
+        #expect(AutoDownloadMode.wifiAndCellular.allows(isOnWiFi: false, isConnected: false) == false)
+    }
 }
 
 // MARK: - BriefingCacheStore (on-disk index + pack data, temp dir)

--- a/designs/ios-app-data-models.md
+++ b/designs/ios-app-data-models.md
@@ -70,9 +70,11 @@ unavailable }` with SwiftUI `color` + `label`. This is the GREEN/AMBER/RED route
 - `BriefingCacheStore` (`BriefingCacheStore.swift`) — `actor`. On-disk cache of pack endpoints under
   Application Support (`BriefingCache/<flightId>/<timestamp>/<endpoint>.json`). Maintains an
   `index.json` of `CachedPackEntry` (`flightId`, `timestamp`, `flightTitle`, `assessment`,
-  `downloadedAt`, `endpoints: Set<String>`, `totalBytes`). `requiredEndpoints` = advisories, digest,
-  snapshot, route-analyses, elevation — a pack `isComplete` when all are present. Also stores
-  root/per-flight metadata files for offline list fallback.
+  `downloadedAt`, `endpoints: Set<String>`, `totalBytes`, `departureTime?`). `requiredEndpoints` =
+  advisories, digest, snapshot, route-analyses, elevation — a pack `isComplete` when all are present
+  (a downloaded pack also holds `sounding-{pt}-{model}` profiles from the bundle). `departureTime`
+  (optional, captured at download) lets `pruneStalePacks(olderThanDays:)` age packs out by flight
+  date. Also stores root/per-flight metadata files for offline list fallback.
 - `PirepOfflineStore` (`PirepOfflineStore.swift`) — `actor`. JSON-file queue of unsent
   `SubmitPirepRequest`s at `Documents/pending_pireps.json`. `enqueue` on failure, `sync(using:)`
   flushes via a batch submit. Server dedups on `clientUuid`.

--- a/designs/ios-app-overview.md
+++ b/designs/ios-app-overview.md
@@ -52,7 +52,9 @@ Phase 1 complete. Phase 2 complete (offline resilience hardening). Phase 3 M0 (a
 - Cached-flight indicators — `FlightListViewModel.cachedFlightIds: Set<String>` from `caching.cachedPacks()`; green dot per card, non-cached disabled offline
 - Resilient fallback — serves any matching cached timestamp, not just exact requested
 - Explicit per-pack download button with real byte-level progress (`requestDataStreaming` + `StreamingDownloadDelegate`; a single bundled, server-gzipped request fetches all endpoints, then writes each per-endpoint payload to disk)
-- Caches 5 endpoints (advisories, digest, snapshot, route-analyses, elevation) to `Application Support/BriefingCache/<flightId>/<timestamp>/<endpoint>.json` as plain JSON (decompressed on write); sounding-profile stays online-only
+- Caches the 5 required endpoints (advisories, digest, snapshot, route-analyses, elevation) **plus every `(point, model)` sounding profile** (keyed `sounding-{pt}-{model}`, straight from the bundle) to `Application Support/BriefingCache/<flightId>/<timestamp>/<endpoint>.json` as plain JSON (decompressed on write). Because the sounding keys match what `soundingProfile()` reads, a downloaded pack renders Skew-Ts instantly and fully offline — no per-tap round-trip
+- **Auto-download (opt-in, default Wi-Fi only)** — `AppSettingsStore.autoDownloadMode` (`off` / `wifiOnly` / `wifiAndCellular`, in Settings). When a briefing is displayed for a flight that is **today or later**, the latest pack auto-downloads in the background (gated by `NetworkMonitor` connectivity), reusing the same bundle + download banner. `BriefingViewModel.maybeAutoDownloadLatest()` fires from `loadBriefing` and after a refresh produces a new pack
+- **Cache eviction** — `CachingBriefingRepository.pruneStalePacks(olderThanDays:)` drops packs whose flight departed > `AppState.cacheRetentionDays` (7) days ago; departure date comes from `CachedPackEntry.departureTime` (captured at download), falling back to the cached flight record. Runs on launch/foreground (`scenePhase == .active`). Packs whose departure can't be determined are kept (conservative)
 - `BriefingCacheStore` actor with JSON index (`index.json`)
 - Sign-out protection when offline (would strand auth)
 
@@ -63,8 +65,7 @@ Phase 1 complete. Phase 2 complete (offline resilience hardening). Phase 3 M0 (a
 
 - Push notifications for briefing updates (Phase 2 M2)
 - SwiftData persistence (current cache is file-based)
-- Auto-sync / background refresh
-- Sounding profiles in offline download (online-only for now)
+- True background refresh (auto-download runs only while the briefing screen is open / on foreground, not via `BGTaskScheduler` or a background `URLSession`)
 - Phase 3 M2: route/airport watches, APNs notifications, spatial matching
 - Phase 3 M3: post-flight debrief, validation tooling
 - Phase 3a: voice PIREP (Siri shortcut), proactive prompting engine


### PR DESCRIPTION
Rebased onto current `main` (was 53 commits behind; clean, single commit, no conflicts) and opened for review — this branch had never been PR'd.

## What it does
Auto-caches the full briefing bundle when a briefing is displayed, so Skew-Ts and the whole pack open instantly and offline instead of paying a per-tap sounding-profile round-trip.

- **Offline Auto-Download setting** (`AppSettingsStore.autoDownloadMode`: off / Wi-Fi only / Wi-Fi & cellular; default Wi-Fi only, persisted in UserDefaults). Surfaced as a picker in Settings.
- **NetworkMonitor** — `NWPathMonitor` wrapper exposing `isConnected` / `isOnWiFi` to gate auto-download by connectivity.
- **`BriefingViewModel.maybeAutoDownloadLatest()`** — on briefing display and after a refresh produces a new pack, downloads the latest pack for offline use when opted in and the flight is today or later. Reuses `downloadCurrentPack` + its progress banner; no-op when already cached or a download is in flight.
- **Sounding profiles now cached** — every `(point, model)` sounding profile is written from the bundle under keys matching `soundingProfile()`, so a downloaded pack renders Skew-Ts fully offline.
- **Cache eviction** — `CachingBriefingRepository.pruneStalePacks(olderThanDays:)` drops packs whose flight departed > 7 days ago (`CachedPackEntry.departureTime`, backward-compatible, falls back to cached flight record). Runs on launch / foreground.

Design docs updated (`ios-app-overview`, `ios-app-data-models`).

## Tests
`AutoDownloadMode` connectivity gate; `CachedPackEntry` legacy decode + `departureTime` round-trip.

## Notes for review
- Not true background refresh — auto-download runs only while the briefing screen is open / on foreground, not via `BGTaskScheduler`.
- iOS-only; no backend changes, so independent of the pending web deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)