### PR TITLE
Add flexibility-explainer first-time modal and gate (#352)

### DIFF
--- a/src/weatherbrief/analytics/events.py
+++ b/src/weatherbrief/analytics/events.py
@@ -49,6 +49,9 @@ class Event(StrEnum):
     COMPARE_OPENED = "compare.opened"
     COMPARE_AIRPORT_ADDED = "compare.airport_added"
     ALTITUDE_TABLE_OPENED = "altitude_table.opened"
+    # Flexibility / timing-scenarios feature. Emitted once per briefing when
+    # scan results actually render (props: {mode}).
+    TIMING_SCENARIOS_USED = "timing_scenarios.used"
 
     # Onboarding -------------------------------------------------------------
     TOUR_STARTED = "tour.started"
@@ -79,6 +82,7 @@ FEATURE_OF: dict[str, str] = {
     Event.COMPARE_OPENED.value: "compare",
     Event.COMPARE_AIRPORT_ADDED.value: "compare",
     Event.ALTITUDE_TABLE_OPENED.value: "altitude_table",
+    Event.TIMING_SCENARIOS_USED.value: "timing_scenarios",
     Event.AUTO_REFRESH_ENABLED.value: "auto_refresh",
     Event.BRIEFING_REFRESH_REQUESTED.value: "manual_refresh",
 }
@@ -92,6 +96,7 @@ KNOWN_FEATURES: tuple[str, ...] = (
     "skewt",
     "compare",
     "altitude_table",
+    "timing_scenarios",
     "auto_refresh",
     "manual_refresh",
     "detailed_mode",

--- a/src/weatherbrief/api/usage.py
+++ b/src/weatherbrief/api/usage.py
@@ -53,6 +53,12 @@ class MonthUsage(BaseModel):
 class UsageSummary(BaseModel):
     today: TodayUsage
     month: MonthUsage
+    # Durable, all-time "has this user ever run a timing scan?" flag. Backs the
+    # web flexibility-explainer gate (show the first-time modal only until the
+    # user has genuinely run ≥1 scan). Count is surfaced too for future
+    # heavy-user / rate-limit triggers (not enforced here).
+    time_scan_used: bool = False
+    time_scan_count: int = 0
 
 
 # --- Core functions ---
@@ -92,6 +98,43 @@ def _query_today_usage(db: Session, user_id: str) -> dict:
         "gramet": int(row.gramet),
         "llm_digest": int(row.llm_digest),
     }
+
+
+def user_has_used_time_scan(db: Session, user_id: str) -> bool:
+    """Return True if the user has ever executed a timing scan.
+
+    Existence check, not a COUNT: one ``api_usage_log`` row is written per
+    executed ``time_scan`` (see ``tasks/time_scan_runner.py``). The
+    ``ix_api_usage_service`` index narrows to the small ``time_scan`` slice and
+    the ``LIMIT 1`` short-circuits, so this stays instant even for heavy users.
+    """
+    row = (
+        db.query(ApiUsageRow.id)
+        .filter(
+            ApiUsageRow.user_id == user_id,
+            ApiUsageRow.service == "time_scan",
+        )
+        .first()
+    )
+    return row is not None
+
+
+def count_user_time_scans(
+    db: Session, user_id: str, since: datetime | None = None
+) -> int:
+    """Count executed timing scans for a user (optionally since a timestamp).
+
+    Substrate for future triggers (heavy-user message, daily ``time_scan``
+    rate limit) — neither enforced yet. Cheap over the ``time_scan`` slice;
+    no dedicated ``user_id`` index needed at current volumes.
+    """
+    q = db.query(func.count()).filter(
+        ApiUsageRow.user_id == user_id,
+        ApiUsageRow.service == "time_scan",
+    )
+    if since is not None:
+        q = q.filter(ApiUsageRow.timestamp >= since)
+    return int(q.scalar() or 0)
 
 
 def check_rate_limits(db: Session, user_id: str, *, bypass: bool = False) -> None:
@@ -283,6 +326,8 @@ def get_usage_summary(db: Session, user_id: str) -> UsageSummary:
         .one()
     )
 
+    time_scan_count = count_user_time_scans(db, user_id)
+
     return UsageSummary(
         today=TodayUsage(
             briefings=today_data["briefings"],
@@ -305,6 +350,8 @@ def get_usage_summary(db: Session, user_id: str) -> UsageSummary:
             llm_digest=int(month_row.llm_digest),
             total_tokens=int(month_row.input_tokens) + int(month_row.output_tokens),
         ),
+        time_scan_used=time_scan_count > 0,
+        time_scan_count=time_scan_count,
     )
 
 

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -14,12 +14,15 @@ from weatherbrief.api.usage import (
     _clip_flight_id,
     check_rate_limits,
     check_service_limits,
+    count_user_time_scans,
     get_usage_summary,
+    log_api_usage,
     log_briefing_usage,
+    user_has_used_time_scan,
 )
 from flyfun_common.db import current_user_id, get_db, DEV_USER_ID
 from flyfun_common.db.models import UserPreferencesRow, UserRow
-from weatherbrief.db.models import BriefingUsageRow
+from weatherbrief.db.models import ApiUsageRow, BriefingUsageRow
 from weatherbrief.pipeline import BriefingUsage
 
 
@@ -291,6 +294,69 @@ class TestUsageSummary:
         assert summary.today.briefings == 0
         assert summary.month.briefings == 1
         assert summary.month.total_tokens == 2500
+
+
+class TestTimeScanUsage:
+    """Durable per-user ``time_scan`` count helpers (flexibility gate substrate)."""
+
+    OTHER_USER = "other-user-123"
+
+    def _log_scan(self, db, user_id, *, pipeline="same_day"):
+        log_api_usage(
+            db, service="time_scan", pipeline=pipeline,
+            api_calls=1, user_id=user_id, flight_id="f-1",
+        )
+
+    def test_no_rows_returns_false(self, db_session):
+        assert user_has_used_time_scan(db_session, DEV_USER_ID) is False
+        assert count_user_time_scans(db_session, DEV_USER_ID) == 0
+
+    def test_other_service_does_not_count(self, db_session):
+        log_api_usage(
+            db_session, service="open_meteo", pipeline="briefing",
+            api_calls=5, user_id=DEV_USER_ID, flight_id="f-1",
+        )
+        db_session.commit()
+        assert user_has_used_time_scan(db_session, DEV_USER_ID) is False
+        assert count_user_time_scans(db_session, DEV_USER_ID) == 0
+
+    def test_other_user_does_not_count(self, db_session):
+        self._log_scan(db_session, self.OTHER_USER)
+        db_session.commit()
+        assert user_has_used_time_scan(db_session, DEV_USER_ID) is False
+        assert count_user_time_scans(db_session, DEV_USER_ID) == 0
+
+    def test_own_time_scan_row_counts(self, db_session):
+        self._log_scan(db_session, DEV_USER_ID)
+        self._log_scan(db_session, DEV_USER_ID, pipeline="next_day")
+        db_session.commit()
+        assert user_has_used_time_scan(db_session, DEV_USER_ID) is True
+        assert count_user_time_scans(db_session, DEV_USER_ID) == 2
+
+    def test_count_respects_since(self, db_session):
+        old = datetime.now(timezone.utc) - timedelta(days=3)
+        db_session.add(ApiUsageRow(
+            service="time_scan", pipeline="same_day", api_calls=1,
+            user_id=DEV_USER_ID, flight_id="f-old", timestamp=old,
+        ))
+        self._log_scan(db_session, DEV_USER_ID)  # now
+        db_session.commit()
+
+        one_day_ago = datetime.now(timezone.utc) - timedelta(days=1)
+        assert count_user_time_scans(db_session, DEV_USER_ID) == 2
+        assert count_user_time_scans(db_session, DEV_USER_ID, since=one_day_ago) == 1
+
+    def test_summary_surfaces_time_scan_flag(self, db_session):
+        summary = get_usage_summary(db_session, DEV_USER_ID)
+        assert summary.time_scan_used is False
+        assert summary.time_scan_count == 0
+
+        self._log_scan(db_session, DEV_USER_ID)
+        db_session.commit()
+
+        summary = get_usage_summary(db_session, DEV_USER_ID)
+        assert summary.time_scan_used is True
+        assert summary.time_scan_count == 1
 
 
 class TestUsageAPI:

--- a/web/briefing.html
+++ b/web/briefing.html
@@ -91,7 +91,7 @@
 
     <!-- Timing scenarios (Flexibility) — background scan results, polled after briefing_ready -->
     <div id="time-scenarios-wrapper" class="section collapsible" data-section="time-scenarios" style="display: none;">
-      <h3>&#128336; Timing Scenarios</h3>
+      <h3>&#128336; Timing Scenarios <button class="metric-info-btn flex-explainer-btn" title="About Flexibility scanning" aria-label="About Flexibility scanning">i</button></h3>
       <div class="section-body">
         <div id="time-scenarios-section">
           <p class="muted">Scenarios running<span class="dots-spinner"></span></p>

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -3059,6 +3059,18 @@ label {
   opacity: 0.8;
 }
 
+/* Flexibility / timing-scenario explainer (#352) — shared by the first-time
+   modal and the (i) popup on the Timing Scenarios header. */
+.flex-explainer h3 {
+  font-size: 1rem;
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+}
+.flex-explainer-actions {
+  margin-top: 0.9rem;
+  text-align: right;
+}
+
 .popup-learn-more {
   margin-top: 0.5rem;
   padding-top: 0.5rem;

--- a/web/tests/unit/flexibility-explainer.test.ts
+++ b/web/tests/unit/flexibility-explainer.test.ts
@@ -1,7 +1,27 @@
-/** Tests for the flexibility-explainer first-time gate predicate (#352). */
+/** Tests for the flexibility-explainer gate + first-time trigger (#352). */
 
-import { describe, it, expect } from 'vitest';
-import { shouldShowFlexibilityExplainer } from '../../ts/components/flexibility-explainer';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Mock the network + popup dependencies so the trigger can be exercised in the
+// node test env (no DOM / no real fetch).
+vi.mock('../../ts/adapters/preferences-adapter', () => ({
+  fetchUsageSummary: vi.fn(),
+}));
+vi.mock('../../ts/components/info-popup', () => ({
+  showPopupContent: vi.fn(),
+  hideMetricInfo: vi.fn(),
+}));
+
+import { fetchUsageSummary } from '../../ts/adapters/preferences-adapter';
+import { showPopupContent } from '../../ts/components/info-popup';
+import {
+  shouldShowFlexibilityExplainer,
+  maybeShowFlexibilityExplainer,
+  flexExplainerAcked,
+} from '../../ts/components/flexibility-explainer';
+
+const mockedFetch = vi.mocked(fetchUsageSummary);
+const mockedShow = vi.mocked(showPopupContent);
 
 describe('shouldShowFlexibilityExplainer', () => {
   it('shows when never used and not acked this session', () => {
@@ -15,5 +35,65 @@ describe('shouldShowFlexibilityExplainer', () => {
   it('hides once the user has genuinely run a scan (durable)', () => {
     expect(shouldShowFlexibilityExplainer({ timeScanUsed: true, sessionAcked: false })).toBe(false);
     expect(shouldShowFlexibilityExplainer({ timeScanUsed: true, sessionAcked: true })).toBe(false);
+  });
+});
+
+describe('maybeShowFlexibilityExplainer', () => {
+  beforeEach(() => {
+    const store = new Map<string, string>();
+    vi.stubGlobal('sessionStorage', {
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => { store.set(k, String(v)); },
+      removeItem: (k: string) => { store.delete(k); },
+    });
+    // openFlexibilityExplainer looks up the "Got it" button; null is fine here.
+    vi.stubGlobal('document', { querySelector: () => null });
+    mockedFetch.mockReset();
+    mockedShow.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('opens the modal once when the user has never run a scan', async () => {
+    mockedFetch.mockResolvedValue({ time_scan_used: false } as never);
+    await maybeShowFlexibilityExplainer();
+    expect(mockedShow).toHaveBeenCalledTimes(1);
+    expect(flexExplainerAcked()).toBe(true);
+  });
+
+  it('does not open the modal when the user has already used timing scan', async () => {
+    mockedFetch.mockResolvedValue({ time_scan_used: true } as never);
+    await maybeShowFlexibilityExplainer();
+    expect(mockedShow).not.toHaveBeenCalled();
+    // Still cached for the session so later dropdown toggles skip the fetch.
+    expect(flexExplainerAcked()).toBe(true);
+  });
+
+  it('short-circuits without fetching when already acked this session', async () => {
+    sessionStorage.setItem('wb_flex_explainer_ack', '1');
+    await maybeShowFlexibilityExplainer();
+    expect(mockedFetch).not.toHaveBeenCalled();
+    expect(mockedShow).not.toHaveBeenCalled();
+  });
+
+  it('sets the ack flag before awaiting, so a concurrent second call bails (no double-fire)', async () => {
+    let resolveFetch!: (v: { time_scan_used: boolean }) => void;
+    mockedFetch.mockReturnValue(
+      new Promise<{ time_scan_used: boolean }>((r) => { resolveFetch = r; }) as never,
+    );
+
+    const p1 = maybeShowFlexibilityExplainer();
+    // The flag is set synchronously (before the fetch resolves), so a second
+    // near-simultaneous trigger sees it and returns immediately.
+    expect(flexExplainerAcked()).toBe(true);
+    const p2 = maybeShowFlexibilityExplainer();
+
+    resolveFetch({ time_scan_used: false });
+    await Promise.all([p1, p2]);
+
+    expect(mockedFetch).toHaveBeenCalledTimes(1);
+    expect(mockedShow).toHaveBeenCalledTimes(1);
   });
 });

--- a/web/tests/unit/flexibility-explainer.test.ts
+++ b/web/tests/unit/flexibility-explainer.test.ts
@@ -1,0 +1,19 @@
+/** Tests for the flexibility-explainer first-time gate predicate (#352). */
+
+import { describe, it, expect } from 'vitest';
+import { shouldShowFlexibilityExplainer } from '../../ts/components/flexibility-explainer';
+
+describe('shouldShowFlexibilityExplainer', () => {
+  it('shows when never used and not acked this session', () => {
+    expect(shouldShowFlexibilityExplainer({ timeScanUsed: false, sessionAcked: false })).toBe(true);
+  });
+
+  it('hides when acked this session even if never used', () => {
+    expect(shouldShowFlexibilityExplainer({ timeScanUsed: false, sessionAcked: true })).toBe(false);
+  });
+
+  it('hides once the user has genuinely run a scan (durable)', () => {
+    expect(shouldShowFlexibilityExplainer({ timeScanUsed: true, sessionAcked: false })).toBe(false);
+    expect(shouldShowFlexibilityExplainer({ timeScanUsed: true, sessionAcked: true })).toBe(false);
+  });
+});

--- a/web/ts/adapters/preferences-adapter.ts
+++ b/web/ts/adapters/preferences-adapter.ts
@@ -124,6 +124,10 @@ export interface MonthUsage {
 export interface UsageSummary {
   today: TodayUsage;
   month: MonthUsage;
+  // Durable, all-time flag: has this user ever run a timing scan? Backs the
+  // flexibility-explainer first-time gate. Count is surfaced for future use.
+  time_scan_used: boolean;
+  time_scan_count: number;
 }
 
 export async function fetchUsageSummary(): Promise<UsageSummary> {

--- a/web/ts/analytics/events.ts
+++ b/web/ts/analytics/events.ts
@@ -26,6 +26,8 @@ export const EVENTS = {
   COMPARE_OPENED: 'compare.opened',
   COMPARE_AIRPORT_ADDED: 'compare.airport_added',
   ALTITUDE_TABLE_OPENED: 'altitude_table.opened',
+  // Flexibility / timing-scenarios feature (props: {mode}).
+  TIMING_SCENARIOS_USED: 'timing_scenarios.used',
 
   // Onboarding
   TOUR_STARTED: 'tour.started',

--- a/web/ts/briefing-main.ts
+++ b/web/ts/briefing-main.ts
@@ -17,6 +17,7 @@ import { SKEWT_OVERLAYS } from './visualization/skewt/overlay-bands';
 import { getVariableById } from './visualization/skewt/variable-panel';
 import { getMetric, renderCompactThresholdStrip } from './helpers/metrics-helper';
 import { initInfoPopup, showMetricInfo, showPopupContent } from './components/info-popup';
+import { openFlexibilityExplainer } from './components/flexibility-explainer';
 import { CrossSectionRenderer } from './visualization/cross-section/renderer';
 import { extractVizData, getUnavailableLayers } from './visualization/data-extract';
 import { getAllLayers, getCompactLayerOverrides } from './visualization/cross-section/layer-registry';
@@ -222,9 +223,17 @@ async function init(): Promise<void> {
   initSkewtViewTracking();
   document.addEventListener('click', (e) => {
     const btn = (e.target as HTMLElement).closest('.metric-info-btn') as HTMLElement | null;
+    if (!btn) return;
+    // The Timing Scenarios (i) button reuses .metric-info-btn styling but opens
+    // the shared flexibility explainer instead of a metric card (#352).
+    if (btn.classList.contains('flex-explainer-btn')) {
+      e.preventDefault();
+      openFlexibilityExplainer();
+      return;
+    }
     // advisory-info-btn and advisory-view-btn reuse .metric-info-btn styling but
     // have their own delegated handlers (in advisories-ui.ts) — skip them here.
-    if (btn && !btn.classList.contains('advisory-info-btn') && !btn.classList.contains('advisory-view-btn')) {
+    if (!btn.classList.contains('advisory-info-btn') && !btn.classList.contains('advisory-view-btn')) {
       e.preventDefault();
       showMetricInfo(btn.dataset.metric!, btn.dataset.value);
     }
@@ -712,6 +721,11 @@ async function init(): Promise<void> {
       : '';
 
     section.innerHTML = `<p>${escapeHtml(headline)}</p>${rows}${refusedNote}${pastNote}${horizonNote}`;
+
+    // Product-analytics signal (#352): flexibility used, counted once per
+    // briefing and only when actual scan results render (the pending / failed /
+    // skipped branches all return above). Mode is a low-cardinality prop.
+    trackOncePerBriefing(EVENTS.TIMING_SCENARIOS_USED, { mode: flex });
 
     // Wire the taps (fresh nodes on every render — no stale handlers).
     section.querySelectorAll<HTMLButtonElement>('.time-confirm-btn').forEach((btn) => {

--- a/web/ts/components/flexibility-explainer.ts
+++ b/web/ts/components/flexibility-explainer.ts
@@ -1,0 +1,118 @@
+/**
+ * Flexibility / timing-scenario explainer — single source of truth for the
+ * copy shown in two places (issue #352):
+ *
+ *  1. A first-time modal, shown the first time a user picks a scan mode on the
+ *     flight editor, gated so it stops once they have genuinely run a scan.
+ *  2. An always-reachable (i) popup on the briefing's Timing Scenarios header.
+ *
+ * Both render the *same* HTML via ``showPopupContent`` so the wording never
+ * drifts. Acknowledge-only: a single "Got it" button that closes the modal and
+ * sets the session flag; the user's dropdown selection stands (no revert).
+ */
+
+import { fetchUsageSummary } from '../adapters/preferences-adapter';
+import { hideMetricInfo, showPopupContent } from './info-popup';
+
+/** Session-scoped acknowledge flag — suppresses re-show for the rest of the
+ *  sitting. Deliberately ``sessionStorage`` (not ``localStorage``, not an
+ *  in-memory flag): survives cross-page navigation within a sitting but not a
+ *  browser restart, so the durable count gate stays the thing that decides
+ *  "shown enough". */
+const ACK_KEY = 'wb_flex_explainer_ack';
+
+/** Shared copy for both the first-time modal and the (i) popup. Keep the four
+ *  beats: what it does / two-step / background / use-deliberately. */
+export const flexibilityExplainerHtml = `
+  <div class="flex-explainer popup-section">
+    <h3>&#128336; About Flexibility scanning</h3>
+    <p>
+      Flexibility looks for a <strong>better departure window</strong> across the
+      period you pick — it grades the weather at other times and surfaces any
+      that come out calmer than your planned time.
+    </p>
+    <p>Because checking many times across many models is data-heavy, it runs in
+      <strong>two steps</strong>:</p>
+    <ol>
+      <li><strong>First pass — ECMWF only.</strong> A fast scan on the
+        locally-held ECMWF model finds candidate windows.</li>
+      <li><strong>Confirm — all models.</strong> Tap a promising candidate to
+        verify it against the other models before relying on it.</li>
+    </ol>
+    <p>
+      It runs <strong>in the background</strong> — you don't have to wait. Leave
+      the briefing and come back; the timing scenarios fill in automatically
+      when the scan finishes.
+    </p>
+    <p>
+      &#9888;&#65039; <strong>It's computationally and data-intensive.</strong>
+      Please use Flexibility only when you're genuinely weighing a different
+      time, not out of curiosity — a local yes/no flight doesn't need it.
+    </p>
+    <div class="flex-explainer-actions">
+      <button type="button" class="btn btn-primary flex-explainer-gotit">Got it</button>
+    </div>
+  </div>
+`;
+
+/** True once the user has acknowledged the explainer this session. */
+export function flexExplainerAcked(): boolean {
+  try {
+    return sessionStorage.getItem(ACK_KEY) === '1';
+  } catch {
+    return false;
+  }
+}
+
+/** Mark the explainer acknowledged for the rest of the session. */
+export function ackFlexExplainer(): void {
+  try {
+    sessionStorage.setItem(ACK_KEY, '1');
+  } catch {
+    /* sessionStorage may be blocked (private mode) — non-fatal */
+  }
+}
+
+/**
+ * Pure gate predicate (unit-tested). Show the first-time explainer only when
+ * the user has never run a scan (durable, per-account) AND hasn't already
+ * acknowledged it this session (ephemeral guard against re-fire while the
+ * count is still 0 between "picks a mode" and "scan ran").
+ */
+export function shouldShowFlexibilityExplainer(opts: {
+  timeScanUsed: boolean;
+  sessionAcked: boolean;
+}): boolean {
+  return !opts.timeScanUsed && !opts.sessionAcked;
+}
+
+/** Open the explainer popup and wire "Got it" to acknowledge + close. Used
+ *  directly by the always-reachable (i) button. */
+export function openFlexibilityExplainer(): void {
+  showPopupContent(flexibilityExplainerHtml);
+  const gotIt = document.querySelector('.flex-explainer-gotit') as HTMLElement | null;
+  gotIt?.addEventListener('click', () => {
+    ackFlexExplainer();
+    hideMetricInfo();
+  });
+}
+
+/**
+ * First-time trigger: evaluate the gate and, if it passes, open the explainer.
+ * Called on a non-``none`` flexibility selection. Session-acked short-circuits
+ * before the network call; the durable "used" flag comes from ``GET /usage``.
+ * On fetch failure we fall back to "not used" so we still gently inform.
+ */
+export async function maybeShowFlexibilityExplainer(): Promise<void> {
+  if (flexExplainerAcked()) return;
+  let timeScanUsed = false;
+  try {
+    timeScanUsed = (await fetchUsageSummary()).time_scan_used;
+  } catch {
+    timeScanUsed = false;
+  }
+  if (!shouldShowFlexibilityExplainer({ timeScanUsed, sessionAcked: flexExplainerAcked() })) {
+    return;
+  }
+  openFlexibilityExplainer();
+}

--- a/web/ts/components/flexibility-explainer.ts
+++ b/web/ts/components/flexibility-explainer.ts
@@ -102,6 +102,19 @@ export function openFlexibilityExplainer(): void {
  * Called on a non-``none`` flexibility selection. Session-acked short-circuits
  * before the network call; the durable "used" flag comes from ``GET /usage``.
  * On fetch failure we fall back to "not used" so we still gently inform.
+ *
+ * The gate is resolved exactly once per session: right after evaluating it we
+ * set the session-ack flag unconditionally, so subsequent dropdown toggles
+ * short-circuit at ``flexExplainerAcked()`` above. This gives two properties
+ * the "set only on Got it" approach lacked:
+ *   - closing the modal via ×/Esc/backdrop (not just "Got it") still suppresses
+ *     re-firing for the rest of the sitting;
+ *   - an established user (``time_scan_used`` true) never re-hits ``/usage`` on
+ *     every toggle — the gate becomes O(1) per session, not O(toggles).
+ * Setting it is safe in every post-fetch branch: we either just showed the
+ * modal (don't re-show this sitting) or the user has already used the feature
+ * (durable, won't change this session). A new session still re-evaluates,
+ * driven by the durable count.
  */
 export async function maybeShowFlexibilityExplainer(): Promise<void> {
   if (flexExplainerAcked()) return;
@@ -111,8 +124,10 @@ export async function maybeShowFlexibilityExplainer(): Promise<void> {
   } catch {
     timeScanUsed = false;
   }
-  if (!shouldShowFlexibilityExplainer({ timeScanUsed, sessionAcked: flexExplainerAcked() })) {
-    return;
-  }
-  openFlexibilityExplainer();
+  const show = shouldShowFlexibilityExplainer({
+    timeScanUsed,
+    sessionAcked: flexExplainerAcked(),
+  });
+  ackFlexExplainer();
+  if (show) openFlexibilityExplainer();
 }

--- a/web/ts/components/flexibility-explainer.ts
+++ b/web/ts/components/flexibility-explainer.ts
@@ -118,16 +118,23 @@ export function openFlexibilityExplainer(): void {
  */
 export async function maybeShowFlexibilityExplainer(): Promise<void> {
   if (flexExplainerAcked()) return;
+  // Set the ack flag BEFORE the await, not after. Beyond resolving the gate
+  // once per session, this guards re-entrancy: native `change` on a <select>
+  // fires synchronously per keyboard step, so the trigger can fire again
+  // before this call's fetch resolves. Writing the flag up front makes any
+  // concurrent second call bail at the sync check above instead of racing a
+  // duplicate /usage fetch and a modal teardown/reopen.
+  ackFlexExplainer();
   let timeScanUsed = false;
   try {
     timeScanUsed = (await fetchUsageSummary()).time_scan_used;
   } catch {
     timeScanUsed = false;
   }
-  const show = shouldShowFlexibilityExplainer({
-    timeScanUsed,
-    sessionAcked: flexExplainerAcked(),
-  });
-  ackFlexExplainer();
-  if (show) openFlexibilityExplainer();
+  // sessionAcked is definitionally false for the gate decision here: we
+  // returned early above if it was already set, and we are the call that just
+  // set it — so the gate reduces to "has the user already used the feature?".
+  if (shouldShowFlexibilityExplainer({ timeScanUsed, sessionAcked: false })) {
+    openFlexibilityExplainer();
+  }
 }

--- a/web/ts/flights-main.ts
+++ b/web/ts/flights-main.ts
@@ -25,6 +25,7 @@ import { showWelcomeWizard } from './components/welcome-wizard';
 import { initTheme } from './theme';
 import { initI18n, t } from './i18n/i18n';
 import { initInfoPopup } from './components/info-popup';
+import { maybeShowFlexibilityExplainer } from './components/flexibility-explainer';
 import { iasToTasISA, resolveCruiseSpeedIAS } from './utils/atmo';
 import {
   splitDurationCeil, combineDuration,
@@ -703,6 +704,13 @@ async function init(): Promise<void> {
       console.error('Welcome wizard error:', err);
     }
   }
+
+  // First-time flexibility explainer (#352): show the modal the first time a
+  // user picks a scan mode, gated by durable usage + a session ack flag.
+  const createFlex = document.getElementById('input-flexibility') as HTMLSelectElement | null;
+  createFlex?.addEventListener('change', () => {
+    if (createFlex.value !== 'none') void maybeShowFlexibilityExplainer();
+  });
 
   // --- Wire create flight form ---
   const form = document.getElementById('create-flight-form') as HTMLFormElement;

--- a/web/ts/managers/flight-detail-ui.ts
+++ b/web/ts/managers/flight-detail-ui.ts
@@ -8,6 +8,7 @@ import { $, escapeHtml, formatDate, formatDepartureTime, formatAlt, flightTitle,
 import { getDateLocale, t } from '../i18n/i18n';
 import { buildTimezoneOptions, utcToLocal } from '../utils/timezone';
 import { splitDurationCeil, combineDuration, buildDurationHourOptions, buildDurationMinuteOptions, formatDurationHM } from '../utils/duration';
+import { maybeShowFlexibilityExplainer } from '../components/flexibility-explainer';
 import { renderDebriefForm } from '../components/debrief-form';
 import { renderDebriefSummary } from '../components/debrief-summary';
 import { showRoutePopup } from '../components/route-interpret';
@@ -257,6 +258,9 @@ export function renderFlightInfo(
     const altTimeGroup = document.getElementById('edit-alt-time-group');
     flexSelect?.addEventListener('change', () => {
       if (altTimeGroup) altTimeGroup.style.display = flexSelect.value === 'alternate' ? '' : 'none';
+      // First-time flexibility explainer (#352): show the modal the first time
+      // a user picks a scan mode, gated by durable usage + session ack flag.
+      if (flexSelect.value !== 'none') void maybeShowFlexibilityExplainer();
     });
 
     // When profile changes, update altitude/ceiling to match the selected profile


### PR DESCRIPTION
## Summary
Implements a first-time explainer modal for the Flexibility (timing-scenario) feature, shown only when a user picks a scan mode for the first time. The explainer is gated by a durable per-account "has used timing scan" flag and a session-scoped acknowledgment to prevent re-firing. The same HTML is reused by an always-reachable (i) popup on the Timing Scenarios header.

## Key Changes

**Backend (usage tracking & API)**
- Added `user_has_used_time_scan()` and `count_user_time_scans()` helper functions to query `ApiUsageRow` for `time_scan` service entries
- Extended `UsageSummary` model with `time_scan_used` (boolean) and `time_scan_count` (integer) fields to surface the durable gate substrate
- Updated `get_usage_summary()` to populate these fields from the database
- Added comprehensive unit tests for the time-scan usage helpers and summary integration

**Frontend (explainer component & integration)**
- Created `flexibility-explainer.ts` with:
  - Shared HTML content (`flexibilityExplainerHtml`) used by both the first-time modal and (i) popup
  - `shouldShowFlexibilityExplainer()` pure gate predicate (unit-tested): shows only when `!timeScanUsed && !sessionAcked`
  - `flexExplainerAcked()` / `ackFlexExplainer()` for session-scoped acknowledgment via `sessionStorage`
  - `openFlexibilityExplainer()` to display the popup and wire the "Got it" button
  - `maybeShowFlexibilityExplainer()` async trigger that fetches usage summary and conditionally opens the modal
- Wired first-time trigger in `flights-main.ts`: listens to flexibility dropdown change and calls `maybeShowFlexibilityExplainer()` when a non-`none` mode is selected
- Wired always-reachable (i) button in `briefing-main.ts`: added `.flex-explainer-btn` class detection to open the explainer directly
- Updated `preferences-adapter.ts` to include the new `time_scan_used` and `time_scan_count` fields in the `UsageSummary` interface
- Added product-analytics event `TIMING_SCENARIOS_USED` (emitted once per briefing when scan results render, with `mode` prop)
- Updated `flight-detail-ui.ts` to call `maybeShowFlexibilityExplainer()` on flexibility selection in the flight editor

**Styling & HTML**
- Added CSS for `.flex-explainer` and `.flex-explainer-actions` in `style.css` (heading, spacing, button alignment)
- Updated `briefing.html` to add `.flex-explainer-btn` class to the Timing Scenarios (i) button

**Testing**
- Added `flexibility-explainer.test.ts` with unit tests for the gate predicate covering all four combinations of `timeScanUsed` and `sessionAcked`

## Implementation Details

- **Session vs. durable gating**: The session flag (`sessionStorage`) prevents re-fire while the count is still 0 between "picks a mode" and "scan ran"; the durable flag (`time_scan_used` from usage summary) is the long-term gate that survives browser restart
- **Graceful degradation**: `sessionStorage` access is wrapped in try-catch to handle private-mode browsers
- **Shared content**: Both the first-time modal and (i) popup render identical HTML via `showPopupContent()` to prevent copy drift
- **Non-destructive acknowledgment**: "Got it" closes the modal and sets the session flag; the user's dropdown selection stands (no revert)

https://claude.ai/code/session_01FCnL59YxvS7w8q86oPjvPi