### PR TITLE
Cache-first cold start for flight list (#359)

### DIFF
--- a/app/flyfun-weather/flyfun-weather/Services/CachingBriefingRepository+Testing.swift
+++ b/app/flyfun-weather/flyfun-weather/Services/CachingBriefingRepository+Testing.swift
@@ -1,0 +1,28 @@
+#if DEBUG
+import Foundation
+import FlyFunCommon
+
+extension CachingBriefingRepository {
+    /// Build a repository around an injected `online` double and a temp-dir
+    /// cache, for unit tests of the offline/cache-first read paths (#359).
+    ///
+    /// The `client` is an inert stub `APIClient` (dummy base URL, in-memory
+    /// token store, never authenticated). The flight-list read path exercised by
+    /// these tests goes through `online` and `cache` only and never touches the
+    /// client, so it stays a placeholder. Lives in the app module (guarded by
+    /// `DEBUG`) because the test target doesn't link `FlyFunCommon`.
+    static func makeForTesting(
+        online: any BriefingRepository,
+        cache: BriefingCacheStore
+    ) -> CachingBriefingRepository {
+        let store = InMemoryBearerTokenStore()
+        let session = RollingBearerSession(store: store)
+        let client = APIClient(
+            baseURL: URL(string: "https://tests.invalid")!,
+            tokenStore: store,
+            rollingSession: session
+        )
+        return CachingBriefingRepository(client: client, online: online, cache: cache)
+    }
+}
+#endif

--- a/app/flyfun-weather/flyfun-weather/Services/CachingBriefingRepository.swift
+++ b/app/flyfun-weather/flyfun-weather/Services/CachingBriefingRepository.swift
@@ -14,7 +14,10 @@ enum DownloadState: Equatable {
 /// Caching is explicit — only packs downloaded via `downloadPack()` are cached.
 final class CachingBriefingRepository: BriefingRepository {
     private let client: APIClient
-    private let online: OnlineBriefingRepository
+    // Protocol type (not the concrete `OnlineBriefingRepository`) so the online
+    // layer can be faulted with a test double — the seam ServiceTests flagged as
+    // a follow-up. Production still injects `OnlineBriefingRepository`.
+    private let online: any BriefingRepository
     let cache: BriefingCacheStore
 
     private static let logger = Logger(subsystem: "aero.flyfun.weather", category: "CachingRepo")
@@ -31,7 +34,7 @@ final class CachingBriefingRepository: BriefingRepository {
     /// Whether the last `flights()` call was served from cache (offline).
     private(set) var isServingCachedFlights = false
 
-    init(client: APIClient, online: OnlineBriefingRepository, cache: BriefingCacheStore) {
+    init(client: APIClient, online: any BriefingRepository, cache: BriefingCacheStore) {
         self.client = client
         self.online = online
         self.cache = cache
@@ -108,6 +111,16 @@ final class CachingBriefingRepository: BriefingRepository {
             }
             throw error
         }
+    }
+
+    /// Cached flight list from `flights.json`, if present. No network — lets the
+    /// flight list paint instantly on cold start and revalidate in the
+    /// background (#359), instead of only serving as an offline fallback.
+    func cachedFlights() async -> [FlightResponse]? {
+        guard let data = await cache.readMetadata(name: "flights"),
+              let cached = try? JSONDecoder.weatherBrief.decode([FlightResponse].self, from: data)
+        else { return nil }
+        return cached
     }
 
     func packs(flightId: String) async throws -> [PackMetaResponse] {

--- a/app/flyfun-weather/flyfun-weather/ViewModels/FlightListViewModel.swift
+++ b/app/flyfun-weather/flyfun-weather/ViewModels/FlightListViewModel.swift
@@ -34,6 +34,18 @@ final class FlightListViewModel {
         guard !isLoading else { return }
         isLoading = true
         defer { isLoading = false }
+        // Cache-first cold start: if a cached list is on disk, paint it before
+        // touching the network so a fresh open never blocks on `/api/flights`
+        // behind a full-screen spinner (#359). Seeding from `.idle` turns the
+        // load below into the #1 warm-refresh path — the seeded list stays on
+        // screen behind the subtle indicator while fresh data swaps in. The
+        // server stays authoritative: the network result always replaces the
+        // seed (or the offline fallback keeps it, with `isOffline` set).
+        if case .idle = state,
+           let caching = repository as? CachingBriefingRepository,
+           let cached = await caching.cachedFlights(), !cached.isEmpty {
+            state = .loaded(cached)
+        }
         // Only show the full-screen spinner on the very first load. A refresh
         // (scene re-activation, pull-to-refresh, post-edit) keeps the current
         // list on screen and swaps in fresh data when it arrives, so reopening

--- a/app/flyfun-weather/flyfun-weatherTests/TestSupport.swift
+++ b/app/flyfun-weather/flyfun-weatherTests/TestSupport.swift
@@ -44,8 +44,14 @@ final class MockBriefingRepository: BriefingRepository, @unchecked Sendable {
     private(set) var flightsCallCount = 0
     private(set) var submitPirepsBatchCallCount = 0
 
+    /// Optional hook awaited *inside* `flights()` before it returns — lets a test
+    /// gate the network so it can observe intermediate ViewModel state (e.g. the
+    /// cache-seeded list painted before a slow fetch resolves, #359).
+    var beforeFlightsReturn: (@Sendable () async -> Void)?
+
     func flights() async throws -> [FlightResponse] {
         flightsCallCount += 1
+        if let hook = beforeFlightsReturn { await hook() }
         return try flightsResult.get()
     }
     func createFlight(_ request: CreateFlightRequest) async throws -> FlightResponse { try createFlightResult.get() }
@@ -125,6 +131,26 @@ func makePirepRequest(remarks: String = "test") -> SubmitPirepRequest {
     var request = try! JSONDecoder.weatherBrief.decode(SubmitPirepRequest.self, from: Data(json.utf8))
     request.remarks = remarks
     return request
+}
+
+/// A one-shot async gate: `wait()` suspends until another task calls `open()`.
+/// Lets a test hold a mocked network call suspended while it inspects the
+/// ViewModel state that was painted before the call resolved.
+actor TestGate {
+    private var continuations: [CheckedContinuation<Void, Never>] = []
+    private var isOpen = false
+
+    func wait() async {
+        if isOpen { return }
+        await withCheckedContinuation { continuations.append($0) }
+    }
+
+    func open() {
+        isOpen = true
+        let pending = continuations
+        continuations.removeAll()
+        for c in pending { c.resume() }
+    }
 }
 
 /// A unique temp directory for a test, auto-created. Caller removes it.

--- a/app/flyfun-weather/flyfun-weatherTests/ViewModelTests.swift
+++ b/app/flyfun-weather/flyfun-weatherTests/ViewModelTests.swift
@@ -141,6 +141,100 @@ import MapKit
             return
         }
     }
+
+    // MARK: Cache-first cold start (#359)
+
+    /// Seed `flights.json` into a temp-dir cache, then drive a real
+    /// `CachingBriefingRepository` whose online layer is a mock we can gate.
+    private func seededCache(_ flights: [FlightResponse]) async throws -> BriefingCacheStore {
+        let cache = BriefingCacheStore(cacheDir: makeTempDir())
+        try await cache.writeMetadata(JSONEncoder.weatherBrief.encode(flights), name: "flights")
+        return cache
+    }
+
+    /// Cold start with a cached list + a slow-but-successful fetch: paints the
+    /// cached list immediately (never a full-screen spinner) and swaps in the
+    /// fresh list once the network resolves.
+    @Test func coldStartSeedsCachedListThenSwapsFresh() async throws {
+        let cache = try await seededCache([makeFlight(id: "cached")])
+        let online = MockBriefingRepository()
+        online.flightsResult = .success([makeFlight(id: "fresh")])
+        let gate = TestGate()
+        online.beforeFlightsReturn = { await gate.wait() }
+        let vm = FlightListViewModel(repository: CachingBriefingRepository.makeForTesting(online: online, cache: cache))
+
+        let task = Task { await vm.loadFlights() }
+
+        // Spin the main actor until the seed has painted the cached list. The
+        // gated fetch keeps loadFlights suspended, so we observe the seed.
+        var seeded = false
+        for _ in 0..<200 where !seeded {
+            await Task.yield()
+            if case .loaded(let f) = vm.state, f.first?.id == "cached" { seeded = true }
+        }
+        #expect(seeded)                       // instant paint from cache…
+        #expect(vm.isRefreshing)              // …with the subtle indicator, not a wheel
+        if case .loading = vm.state { Issue.record("entered .loading despite cached list") }
+
+        gate.open()
+        await task.value
+
+        guard case .loaded(let fresh) = vm.state else {
+            Issue.record("expected .loaded(fresh), got \(vm.state)")
+            return
+        }
+        #expect(fresh.first?.id == "fresh")   // server stayed authoritative
+        #expect(vm.isRefreshing == false)
+        #expect(vm.isOffline == false)
+    }
+
+    /// True first run (no cached list): the full-screen spinner still shows.
+    @Test func coldStartWithoutCacheShowsSpinnerThenLoads() async throws {
+        let cache = BriefingCacheStore(cacheDir: makeTempDir())   // empty — no flights.json
+        let online = MockBriefingRepository()
+        online.flightsResult = .success([makeFlight(id: "fresh")])
+        let gate = TestGate()
+        online.beforeFlightsReturn = { await gate.wait() }
+        let vm = FlightListViewModel(repository: CachingBriefingRepository.makeForTesting(online: online, cache: cache))
+
+        let task = Task { await vm.loadFlights() }
+
+        var sawLoading = false
+        for _ in 0..<200 where !sawLoading {
+            await Task.yield()
+            if case .loading = vm.state { sawLoading = true }
+        }
+        #expect(sawLoading)                   // spinner on genuine first run
+        #expect(vm.isRefreshing == false)
+
+        gate.open()
+        await task.value
+
+        guard case .loaded(let fresh) = vm.state else {
+            Issue.record("expected .loaded(fresh), got \(vm.state)")
+            return
+        }
+        #expect(fresh.first?.id == "fresh")
+    }
+
+    /// Cached list present but the network throws: the cached list stays on
+    /// screen and the view model reports offline — never `.error`, never empty.
+    @Test func coldStartCachePresentNetworkThrowsStaysOffline() async throws {
+        let cache = try await seededCache([makeFlight(id: "cached")])
+        let online = MockBriefingRepository()
+        online.flightsResult = .failure(MockError.injected("offline"))
+        let vm = FlightListViewModel(repository: CachingBriefingRepository.makeForTesting(online: online, cache: cache))
+
+        await vm.loadFlights()
+
+        guard case .loaded(let flights) = vm.state else {
+            Issue.record("expected .loaded (cached), got \(vm.state)")
+            return
+        }
+        #expect(flights.first?.id == "cached")   // offline fallback served the cache
+        #expect(vm.isOffline == true)
+        #expect(vm.isRefreshing == false)
+    }
 }
 
 // MARK: - RouteMapViewModel (waypoint extraction + fit-region math)


### PR DESCRIPTION
## Summary
Implements cache-first loading for the flight list on cold start, eliminating the full-screen spinner when a cached list is available. The cached list paints instantly while a fresh fetch happens in the background, improving perceived performance on app reopen.

## Changes

- **FlightListViewModel**: Added cache-first logic in `loadFlights()` that seeds the UI with cached flights before fetching fresh data from the network. If a cached list exists and is non-empty, it's painted immediately in `.loaded` state, then the network fetch proceeds and replaces it (or the offline fallback keeps it if the network fails).

- **CachingBriefingRepository**: 
  - Changed `online` property type from concrete `OnlineBriefingRepository` to protocol type `any BriefingRepository` to enable test doubles
  - Added `cachedFlights()` method to read the cached flight list without network access, supporting the cache-first seed path

- **CachingBriefingRepository+Testing**: New testing helper that builds a `CachingBriefingRepository` with injected online and cache doubles, avoiding the need to construct a full `APIClient` in tests.

- **TestSupport**: 
  - Added `beforeFlightsReturn` hook to `MockBriefingRepository` to gate network calls, allowing tests to observe intermediate ViewModel state
  - Added `TestGate` actor to suspend async operations until explicitly released, enabling tests to inspect the UI after cache seed but before network resolution

- **ViewModelTests**: Added three comprehensive tests covering the cache-first cold start scenarios:
  - `coldStartSeedsCachedListThenSwapsFresh`: Cached list paints immediately with subtle refresh indicator, then swaps to fresh data
  - `coldStartWithoutCacheShowsSpinnerThenLoads`: True first run (no cache) still shows full-screen spinner
  - `coldStartCachePresentNetworkThrowsStaysOffline`: Network failure keeps cached list on screen with offline indicator

## Implementation Details

The cache-first logic is gated on `state == .idle` to only apply on the initial load, not on subsequent refreshes. The server remains authoritative — the network result always replaces the seed. If the network fails, the offline fallback keeps the cached list with `isOffline` set, never showing an error state or empty list.

https://claude.ai/code/session_018Wv195EpSrRm9goLKeEqES