### PR TITLE
designs: iOS App Intents / Siri + briefing-refresh notifications

### DIFF
--- a/designs/INDEX.md
+++ b/designs/INDEX.md
@@ -146,6 +146,15 @@ Sync engine + forecast-driven prompting engine — largely Phase 3a/3b design in
 3-phase roadmap: Phase 1 (online viewer — DONE), Phase 2 (offline + push — resilience done, push pending), Phase 3 (3a manual + sync, 3b prompting, 3c live sharing). Cross-section renderer layer waves. Decisions made and open questions.
 → Full doc: ios-app-roadmap.md
 
+### ios-app-intents [proposed]
+App Intents / Siri / Apple Intelligence surface for the iOS app — the on-device sibling of the MCP tool catalog. Phase 1 (current iOS 26): `FlightEntity`/`AirportEntity`, open/refresh/check intents, `AppShortcutsProvider` phrases, `EntityStringQuery` resolver for "the flight tomorrow to Fairoaks", Spotlight indexing. Phase 2 (WWDC26/iOS 27): View Annotations ("explain this", "show the cross-section"), on-device Foundation Models narration of cached advisories. No SiriKit to migrate. MCP⇆intent parity table. Nothing built yet.
+Key exports (planned): `FlightEntity`, `AirportEntity`, `OpenFlightListIntent`, `OpenBriefingIntent`, `CheckBriefingIntent`, `RefreshBriefingIntent`, `AirportWeatherIntent`, `ExplainAdvisoryIntent`, `FlyFunShortcuts`
+→ Full doc: ios-app-intents.md
+
+### ios-app-briefing-notifications [proposed]
+APNs push when a briefing finishes refreshing — closes the loop for the Siri refresh intent. Builds on the existing `DeviceTokenRow` table and the scheduler's email-on-completion seam: adds client registration (`POST /api/devices`), a `notify/push.py` APNs sender mirroring `notify/email.py`, and emits at both refresh-complete seams (auto-refresh scheduler + manual `api/packs.py`). Change-gated via `compute_refresh_delta`; inherits the #192 model-update defer. Partially foundationed, sender + registration not built.
+→ Full doc: ios-app-briefing-notifications.md
+
 ### rzskewt
 Swift package for Skew-T log-P diagrams. Extracted to own repo: `github.com/roznet/rztskew`. Full atmospheric thermodynamics, Canvas rendering, 47 unit tests. Design docs live in that repo's `designs/` directory.
 Key exports: `SkewTView`, `SkewTRenderer`, `SoundingProfile`, `Thermodynamics`

--- a/designs/ios-app-briefing-notifications.md
+++ b/designs/ios-app-briefing-notifications.md
@@ -23,10 +23,10 @@ seams. Push notifications are the outstanding item in Phase 2 M2 of the
 
 | Piece | Where | Reuse |
 |---|---|---|
-| Device token table | `db/models.py::DeviceTokenRow` (`token`, `environment`, `user_id`, CASCADE on user delete) | Store APNs tokens here; GDPR delete already handled |
-| Auto-refresh completion seam | `scheduler.py::_auto_refresh_one` → `_try_send_email` (~L452) | Emit the push at the same point, right beside the email |
-| Manual refresh completion | `api/packs.py` refresh path | Second emit seam — the one a Siri/app refresh hits |
-| Notification module pattern | `notify/email.py` (Resend/SMTP) | Mirror as `notify/push.py` |
+| Device token table + migration | `db/models.py::DeviceTokenRow` (`token`, `environment` `String(16)`, `user_id`); migration `032_pireps_and_device_tokens.py` | Table already created & migrated — just add the endpoint |
+| GDPR handling | `api/account_export.py` (token **excluded as a credential**, not exported) + `api/app.py` account-deletion purges rows | Delete/export already correct — nothing to add |
+| Single refresh-finalize sink | `api/packs.py::_persist_pack_finalize` — the shared function called by `_finalize_refresh` (scheduler + manual) **and** the streaming path | Emit the push **once** here → covers auto, in-app, and Siri/MCP refreshes in one place |
+| Email precedent | `scheduler.py::_try_send_email` (auto-refresh only, ~L452) | Mirror as `notify/push.py`; but hook the shared finalize, since push must ALSO cover manual/Siri (email doesn't) |
 | Change detection | `compute_refresh_delta` / worsened-conditions banner (`metar-taf-route-weather`) | Craft the body ("now AMBER — conditions worsened") + gate noisy sends |
 | Model-update-aware defer | `scheduler.py` issue #192 email-timing logic | Push inherits the same defer window — do not notify before/twice |
 
@@ -50,16 +50,22 @@ seams. Push notifications are the outstanding item in Phase 2 M2 of the
 - **`notify/push.py`** — token-based APNs (`.p8` key, HTTP/2, `apns-topic` = bundle id).
   One function `send_briefing_push(user_id, flight, meta, *, delta)` mirroring
   `send_briefing_email`. Route to the correct APNs host per stored `environment`.
-- **Emit at both seams**, guarded like `_try_send_email` (log-and-skip on any failure —
-  a push must never break a refresh):
-  - `scheduler.py::_auto_refresh_one` (auto-refresh) — beside the email send.
-  - `api/packs.py` manual refresh completion — so an app/Siri/MCP-triggered refresh
-    also notifies. **This is what closes the `RefreshBriefingIntent` loop.**
+- **Emit once from the shared finalize** `api/packs.py::_persist_pack_finalize`, guarded
+  like `_try_send_email` (log-and-skip on any failure — a push must never break a refresh).
+  Every refresh (auto, in-app, Siri/MCP) funnels through this one function, so a single
+  hook covers them all — including the `RefreshBriefingIntent` loop. Do **not** copy the
+  email's scheduler-only placement (email fires only for auto-refresh; push must be broader).
 - **Payload**: `alert` title/body from route + new assessment + `compute_refresh_delta`
   ("EGTF → LFAT: now AMBER, ceiling worsened"); custom data `{ flight_id, timestamp }`;
   optional badge.
 - **Send gating** — only on a *new* pack whose assessment changed or worsened (avoid
   "still green" spam). Configurable; default to meaningful-change-only.
+- **In-app suppression** — a user watching the SSE progress bar in-app shouldn't also get
+  a push. But an in-app manual refresh and a Siri/background refresh are **both**
+  `triggered_by="user"` today (`refresh_registry` only knows `user | scheduler`), so the
+  server can't yet tell them apart. See the decision in Open Questions — baseline is
+  client-side foreground suppression; optional server signal (`triggered_by="intent"` /
+  `notify_on_complete`) for precise targeting.
 - **Endpoint** `POST /api/devices` (register/upsert) + `DELETE /api/devices/{token}`.
 
 ### User preference
@@ -82,12 +88,19 @@ emit at both refresh-complete seams   ┘      ("…I'll let you know when it's 
 depend on this doc and can ship first. Only the refresh intent's satisfying
 close-the-loop UX needs the push.
 
-## Open Questions
+## Open Questions / Decisions needed
 
+- **★ Notify-when-done vs watching-live** — avoid a redundant push when the user triggered
+  the refresh from inside the app. `triggered_by` is only `user | scheduler` today, so a
+  Siri refresh is indistinguishable from an in-app one. **Recommend:** client-side
+  foreground suppression as the baseline (robust, no server change); optionally add a
+  `triggered_by="intent"` / `notify_on_complete` signal later for server-side precision.
+- **APNs provider library** — hand-rolled HTTP/2 + `.p8` JWT, or a small dep? Note the
+  server is Python/FastAPI; pick something that fits the async stack.
 - **APNs key management** — `.p8` key + key id + team id as deployment secrets
   (see [multi-user-deployment](./multi-user-deployment.md) secret handling).
-- **Environment routing** — sandbox vs production host per token; how to detect at
-  build/runtime and keep straight across TestFlight vs App Store.
+- **Environment routing** — sandbox vs production host per stored `environment`; how to
+  set it at build/runtime and keep straight across TestFlight vs App Store.
 - **Dedup with email** — users who get both email and push on the same refresh: fine,
   or offer "one or the other"?
 - **Manual-refresh scope** — notify only the triggering device, or all the user's

--- a/designs/ios-app-briefing-notifications.md
+++ b/designs/ios-app-briefing-notifications.md
@@ -57,15 +57,17 @@ seams. Push notifications are the outstanding item in Phase 2 M2 of the
   email's scheduler-only placement (email fires only for auto-refresh; push must be broader).
 - **Payload**: `alert` title/body from route + new assessment + `compute_refresh_delta`
   ("EGTF → LFAT: now AMBER, ceiling worsened"); custom data `{ flight_id, timestamp }`;
-  optional badge.
+  `aps.badge` = server-computed unseen count (see Badge section).
 - **Send gating** — only on a *new* pack whose assessment changed or worsened (avoid
   "still green" spam). Configurable; default to meaningful-change-only.
-- **In-app suppression** — a user watching the SSE progress bar in-app shouldn't also get
-  a push. But an in-app manual refresh and a Siri/background refresh are **both**
-  `triggered_by="user"` today (`refresh_registry` only knows `user | scheduler`), so the
-  server can't yet tell them apart. See the decision in Open Questions — baseline is
-  client-side foreground suppression; optional server signal (`triggered_by="intent"` /
-  `notify_on_complete`) for precise targeting.
+- **In-app suppression** — a user watching the SSE progress bar in-app shouldn't also get a
+  banner. This is largely **natural on iOS**: the app's `UNUserNotificationCenterDelegate.
+  willPresent` decides whether to show a banner while foregrounded (default: don't — just
+  update the badge / an in-app indicator). The remaining nuance is that an in-app manual
+  refresh and a Siri/background refresh are **both** `triggered_by="user"` today
+  (`refresh_registry` only knows `user | scheduler`), so the server can't distinguish "I'm
+  watching this" from "tell me when done". Baseline: client-side foreground suppression;
+  optional later server signal (`triggered_by="intent"` / `notify_on_complete`) for precision.
 - **Endpoint** `POST /api/devices` (register/upsert) + `DELETE /api/devices/{token}`.
 
 ### Notification preferences
@@ -147,11 +149,19 @@ is missed. There is already a precedent to mirror — system-message unseen coun
 (`api/messages.py`: `messages_last_seen_id` in prefs, server-computed `unseen_count`,
 `POST /messages/seen`). We do the same, per-flight.
 
-**State (per user × flight):**
-- `last_notified_pack_ts` — timestamp of the most recent notify-qualifying update.
-- `last_seen_pack_ts` — advanced when the user opens that flight's briefing on **web or app**.
+**State (per user × flight) — a flight counts at most once:**
+- `latest_pack_ts` — the flight's newest pack (already known server-side).
+- `last_notified_pack_ts` — pack ts of the most recent notify-qualifying update.
+- `last_seen_pack_ts` — set to the flight's **current `latest_pack_ts`** when the user opens
+  that flight's briefing (web or app).
 - Flight is **unseen** iff `last_notified_pack_ts > last_seen_pack_ts`.
-- **Badge = count of unseen flights**, computed server-side on demand (like `unseen_count`).
+- **Badge = count of unseen flights** (each flight 0 or 1), computed server-side on demand
+  (like `unseen_count`).
+
+This is exactly the intended semantics: if a flight refreshes **twice** and neither is
+opened it still counts **once** (we compare the *latest* notified pack, not each pack);
+opening the briefing marks the current latest pack seen and clears the flight no matter how
+many packs piled up; older unopened packs never add to the count.
 
 Storage: mirror messages (a `briefing_seen` map in `app_prefs_json`) or a small
 `flight_briefing_seen(user_id, flight_id, ts)` table. Flights per user are few; either
@@ -177,14 +187,17 @@ annoying-badge failure mode is the opposite — incrementing/decrementing on the
 trusting push delivery. The worry is well-founded; the ordering above is the fix.
 
 **Definitions to lock:**
-- **What clears "unseen"?** Opening the flight's **briefing detail** (web or app) — not
-  merely seeing it in the list. Per-flight watermark (any newer pack read clears it), not per-pack.
+- **Count once per flight** — the badge counts *flights with an unseen latest update*,
+  never packs. Two unopened refreshes on one flight = 1.
+- **What clears "unseen"?** Opening that flight's **briefing detail** (web or app) — not
+  merely seeing it in the list. Opening sets `last_seen_pack_ts = latest_pack_ts`, so the
+  flight clears even if several packs accumulated and only the newest was viewed.
 - **What counts toward the badge?** Only **notify-qualifying** updates (same gate as the
   notification: scope + change-filter + not muted) — mirroring "only highlighted messages
-  light the dot".
+  light the dot". A later non-qualifying refresh (e.g. unchanged) does **not** re-light a
+  flight you already cleared.
 - **Badge vs push-channel toggle** — reconcile keeps the badge correct even if *alert* push
-  is off; decide whether to show a badge when the push channel is disabled (recommend:
-  badge follows "a device is registered", independent of alert on/off).
+  is off; recommend the badge follows "a device is registered", independent of alert on/off.
 
 **New surface area:** `POST /api/flights/{id}/seen` (or fold into the existing briefing
 GET), `GET /api/flights/badge`, the silent-push path, and the app's foreground reconcile +
@@ -198,7 +211,7 @@ Notification work (this doc)                 App Intents (sibling doc)
 ──────────────────────────                   ─────────────────────────
 device_tokens endpoint + client reg   ┐
 notify/push.py + APNs key             ├─►    RefreshBriefingIntent
-emit at both refresh-complete seams   ┘      ("…I'll let you know when it's ready")
+emit from shared _persist_pack_finalize ┘    ("…I'll let you know when it's ready")
 ```
 
 `OpenBriefingIntent` / `OpenFlightListIntent` / `CheckBriefingIntent` do **not**
@@ -211,7 +224,6 @@ Resolved by the preferences model above: *notify-when-done vs watching-live* (a 
 **delivery rule** — foreground suppression — plus the `all`/`auto` scope), and *dedup with
 email* (channels are independent user choices). Remaining:
 
-- **Per-flight notify ⇒ auto-refresh coupling** — see "Other choices" above.
 - **APNs provider library** — hand-rolled HTTP/2 + `.p8` JWT, or a small dep that fits the
   async FastAPI stack?
 - **APNs key management** — `.p8` key + key id + team id as deployment secrets

--- a/designs/ios-app-briefing-notifications.md
+++ b/designs/ios-app-briefing-notifications.md
@@ -224,12 +224,26 @@ Resolved by the preferences model above: *notify-when-done vs watching-live* (a 
 **delivery rule** — foreground suppression — plus the `all`/`auto` scope), and *dedup with
 email* (channels are independent user choices). Remaining:
 
-- **APNs provider library** — hand-rolled HTTP/2 + `.p8` JWT, or a small dep that fits the
-  async FastAPI stack?
-- **APNs key management** — `.p8` key + key id + team id as deployment secrets
-  (see [multi-user-deployment](./multi-user-deployment.md) secret handling).
-- **Environment routing** — sandbox vs production host per stored `environment`; how to set
-  it at build/runtime and keep straight across TestFlight vs App Store.
+- **APNs provider library** — APNs is just HTTP/2 + a token (ES256 JWT from the `.p8`, header
+  `{kid}`, claims `{iss: team_id, iat}`, cached ~50 min). Options: **(a) roll it on `httpx`**
+  (already a dep; add `httpx[http2]` + `PyJWT` — ~120 lines, full control over retries and
+  response→token-cleanup, no bit-rot risk); **(b) `aioapns`** (async, maintained, token auth,
+  handles HTTP/2). **Avoid `PyAPNs2`/`apns2`** (built on the unmaintained `hyper`). Recommend
+  (a). Send: `POST /3/device/<token>` with `apns-topic: <bundle id>` and `apns-push-type:
+  alert` (or `background` for silent badge syncs); on `BadDeviceToken`/`Unregistered` delete
+  the row.
+- **APNs key management** — a **single `.p8` token-auth key works for BOTH environments**
+  (unlike the old cert auth). Store key + key id + team id as deployment secrets (same
+  handling as the existing Resend key).
+- **Sandbox vs production routing** — per-**token**, decided by the *app build on the device*,
+  **not** by which server runs: an Xcode **debug** build → `aps-environment: development` →
+  **sandbox** token → sandbox host; **TestFlight and App Store** → `production` → production
+  host (note: **TestFlight is production**, a common trap). The token value doesn't reveal its
+  environment, so the client reports it at register time (`#if DEBUG` → `sandbox` else
+  `production`; or read `aps-environment` from the embedded profile for full precision) and the
+  server routes on `device_tokens.environment`. Wrong host → misleading `BadDeviceToken`. Local
+  dev: a debug build on a real device → sandbox token → the local dev server (with the `.p8`
+  configured) sends to the **sandbox** host — no separate prod credential needed for dev.
 - **Manual-refresh device scope** — notify only the triggering device, or all the user's
   devices? (All is simpler and consistent with auto-refresh.)
 - **Quiet hours** — whether to suppress push overnight in v1 (badge sync is unaffected).

--- a/designs/ios-app-briefing-notifications.md
+++ b/designs/ios-app-briefing-notifications.md
@@ -68,11 +68,75 @@ seams. Push notifications are the outstanding item in Phase 2 M2 of the
   `notify_on_complete`) for precise targeting.
 - **Endpoint** `POST /api/devices` (register/upsert) + `DELETE /api/devices/{token}`.
 
-### User preference
+### Notification preferences
 
-Add a push on/off toggle, alongside the existing email preference
-(`defer_email_for_model_update` / `UserPreferencesStore`). Respect it at send time.
-Consider quiet-hours later.
+Today email-on-completion is **implicit** — it fires whenever a flight's `auto_refresh`
+runs (when SMTP is configured), with one timing refinement (`defer_email_for_model_update`).
+There is no separate per-flight email flag; "email me when done" ≈ `auto_refresh` on.
+This generalizes into an explicit, channel-aware model with a per-flight override.
+
+**Two orthogonal axes + a per-flight override.**
+
+**Global** (Settings → Notifications), stored in `app_prefs_json`:
+
+- **Channels** (*where* — independent, either/both/neither):
+  - Email → `notify_email` (default **on** if the account has an email).
+  - iOS push → `notify_push` (default **off**; conditional UI — show device state
+    ("2 devices") or an install hint; requires ≥1 `device_tokens` row).
+- **Scope** (*which refreshes* — single choice) → `notify_scope`:
+  - `auto` — only the scheduled near-departure auto-refresh (**default**; reproduces today).
+  - `all` — every completion, incl. manual / Siri / MCP.
+  - `off` — never, unless enabled per-flight.
+- **Content filter** → `notify_change_only` (default **on**): only when the assessment
+  changed/worsened (`compute_refresh_delta`), vs every completion.
+- **Timing** → migrate the existing `defer_email_for_model_update` into this group,
+  channel-agnostic ("wait for an imminent model run before notifying" — applies to push too).
+- *(Advanced, optional)* **Quiet hours** — suppress **push** overnight (local); email unaffected.
+
+**Per-flight override** (flight settings — generalizes today's "email me when done"), on `FlightRow`:
+
+- `notify_override`: `default` (follow global) | `on` (notify for **any** completion of this
+  flight, even if global is `off`/`auto`) | `mute` (never for this flight). Channels always
+  follow the global channel selection.
+
+**Effective decision** (evaluated at `_persist_pack_finalize`):
+
+```
+if flight.notify_override == "mute":  stop
+elif flight.notify_override == "on":  send            # any completion
+else:                                                  # default → global scope
+    scope == "all"  → send
+    scope == "auto" → send only if triggered_by == "scheduler"
+    scope == "off"  → stop
+if notify_change_only and not delta.changed:  stop
+for each ON channel (email, push):  deliver
+    # push additionally suppressed if the app is foregrounded on this flight —
+    # a DELIVERY RULE, not a user setting (resolves the earlier ★ question)
+```
+
+### UX principles
+
+- **Orthogonal controls, not a matrix.** Pick channels (multi-select) and one scope —
+  avoid a combinatorial email-auto / email-all / push-auto / push-all grid. One scope
+  applies to all selected channels.
+- **Per-flight is an override, not a second settings screen** — a 3-way segmented control
+  (Default / Notify / Mute) so the common case (follow global) is zero-thought.
+- **Push is conditional UI** — only actionable with a registered device; otherwise show a
+  gentle "install the app / enable notifications" hint.
+- **Migration preserves today's behavior** — existing users default to Email **on**,
+  scope `auto`, change-only **on**, push **off** until a device registers. No surprise.
+
+### Other choices worth offering / deciding
+
+- **Per-flight notify ⇒ auto-refresh?** A per-flight "notify me when done" is most useful
+  for manual/Siri refreshes on a flight whose `auto_refresh` is off (it's the Siri-loop
+  case). Decide whether that control also surfaces/toggles `auto_refresh`, or stays purely
+  a notification override.
+- **Batching/digest** — the scheduler can finish several flights close together; a future
+  digest could replace N separate pushes.
+- **Badge semantics** — define what the app-icon badge counts (flights with unseen updates?).
+- **Per-channel scope** — deliberately NOT in v1 (one scope for all channels); revisit only
+  if users ask for "email everything, push only auto".
 
 ## Sequencing vs App Intents
 
@@ -90,22 +154,20 @@ close-the-loop UX needs the push.
 
 ## Open Questions / Decisions needed
 
-- **★ Notify-when-done vs watching-live** — avoid a redundant push when the user triggered
-  the refresh from inside the app. `triggered_by` is only `user | scheduler` today, so a
-  Siri refresh is indistinguishable from an in-app one. **Recommend:** client-side
-  foreground suppression as the baseline (robust, no server change); optionally add a
-  `triggered_by="intent"` / `notify_on_complete` signal later for server-side precision.
-- **APNs provider library** — hand-rolled HTTP/2 + `.p8` JWT, or a small dep? Note the
-  server is Python/FastAPI; pick something that fits the async stack.
+Resolved by the preferences model above: *notify-when-done vs watching-live* (a push
+**delivery rule** — foreground suppression — plus the `all`/`auto` scope), and *dedup with
+email* (channels are independent user choices). Remaining:
+
+- **Per-flight notify ⇒ auto-refresh coupling** — see "Other choices" above.
+- **APNs provider library** — hand-rolled HTTP/2 + `.p8` JWT, or a small dep that fits the
+  async FastAPI stack?
 - **APNs key management** — `.p8` key + key id + team id as deployment secrets
   (see [multi-user-deployment](./multi-user-deployment.md) secret handling).
-- **Environment routing** — sandbox vs production host per stored `environment`; how to
-  set it at build/runtime and keep straight across TestFlight vs App Store.
-- **Dedup with email** — users who get both email and push on the same refresh: fine,
-  or offer "one or the other"?
-- **Manual-refresh scope** — notify only the triggering device, or all the user's
+- **Environment routing** — sandbox vs production host per stored `environment`; how to set
+  it at build/runtime and keep straight across TestFlight vs App Store.
+- **Manual-refresh device scope** — notify only the triggering device, or all the user's
   devices? (All is simpler and consistent with auto-refresh.)
-- **Throttling / quiet hours** — cap sends per flight per day; suppress overnight?
+- **Badge semantics & quiet hours** — define the badge count; whether quiet-hours ships v1.
 
 ## References
 

--- a/designs/ios-app-briefing-notifications.md
+++ b/designs/ios-app-briefing-notifications.md
@@ -1,0 +1,103 @@
+# iOS App — Briefing Refresh Notifications (APNs)
+
+> Push a notification to the app when a briefing finishes refreshing, so the pilot
+> knows to look — and so a Siri-triggered refresh can truthfully say "I'll let you
+> know when it's ready."
+
+**Status: PROPOSED — partially foundationed.** A `device_tokens` table already
+exists (`src/weatherbrief/db/models.py::DeviceTokenRow`), and the auto-refresh
+scheduler already sends an **email** on completion. What's missing: the client
+registration flow, the APNs sender, and wiring the send at the refresh-complete
+seams. Push notifications are the outstanding item in Phase 2 M2 of the
+[roadmap](./ios-app-roadmap.md).
+
+## Related Docs
+
+- [App Intents](./ios-app-intents.md) — the `RefreshBriefingIntent` whose loop this closes
+- [Overview](./ios-app-overview.md) — "push notifications for briefing updates" listed as not-built
+- [Architecture](./ios-app-architecture.md) — auth, deep links (`flyfunweather://`, universal links)
+- [Server API](./ios-app-server-api.md) — endpoints consumed/added
+- [Multi-user deployment](./multi-user-deployment.md) — secrets, Resend email precedent
+
+## What already exists (build on, don't duplicate)
+
+| Piece | Where | Reuse |
+|---|---|---|
+| Device token table | `db/models.py::DeviceTokenRow` (`token`, `environment`, `user_id`, CASCADE on user delete) | Store APNs tokens here; GDPR delete already handled |
+| Auto-refresh completion seam | `scheduler.py::_auto_refresh_one` → `_try_send_email` (~L452) | Emit the push at the same point, right beside the email |
+| Manual refresh completion | `api/packs.py` refresh path | Second emit seam — the one a Siri/app refresh hits |
+| Notification module pattern | `notify/email.py` (Resend/SMTP) | Mirror as `notify/push.py` |
+| Change detection | `compute_refresh_delta` / worsened-conditions banner (`metar-taf-route-weather`) | Craft the body ("now AMBER — conditions worsened") + gate noisy sends |
+| Model-update-aware defer | `scheduler.py` issue #192 email-timing logic | Push inherits the same defer window — do not notify before/twice |
+
+## Design
+
+### Client (iOS)
+
+1. Register for remote notifications; obtain the APNs device token.
+2. `POST /api/devices` with `{ token, environment }` (`environment` = `sandbox` |
+   `production`, since a TestFlight/dev build's token is APNs-sandbox and must not
+   be sent via the prod APNs host). Upsert on the existing `device_tokens` row.
+3. Re-register on token change; **unregister on sign-out** (`DELETE /api/devices/{token}`)
+   so a signed-out device stops receiving another user's briefings.
+4. On tap: read `flight_id` + `timestamp` from the payload and deep-link to the
+   updated briefing — reuse the [App Intents](./ios-app-intents.md) `PendingNavigation`
+   seam (or the existing `flyfunweather://` / universal-link handler), so tap and
+   "open my next FlyFun briefing" land on the same code path.
+
+### Server
+
+- **`notify/push.py`** — token-based APNs (`.p8` key, HTTP/2, `apns-topic` = bundle id).
+  One function `send_briefing_push(user_id, flight, meta, *, delta)` mirroring
+  `send_briefing_email`. Route to the correct APNs host per stored `environment`.
+- **Emit at both seams**, guarded like `_try_send_email` (log-and-skip on any failure —
+  a push must never break a refresh):
+  - `scheduler.py::_auto_refresh_one` (auto-refresh) — beside the email send.
+  - `api/packs.py` manual refresh completion — so an app/Siri/MCP-triggered refresh
+    also notifies. **This is what closes the `RefreshBriefingIntent` loop.**
+- **Payload**: `alert` title/body from route + new assessment + `compute_refresh_delta`
+  ("EGTF → LFAT: now AMBER, ceiling worsened"); custom data `{ flight_id, timestamp }`;
+  optional badge.
+- **Send gating** — only on a *new* pack whose assessment changed or worsened (avoid
+  "still green" spam). Configurable; default to meaningful-change-only.
+- **Endpoint** `POST /api/devices` (register/upsert) + `DELETE /api/devices/{token}`.
+
+### User preference
+
+Add a push on/off toggle, alongside the existing email preference
+(`defer_email_for_model_update` / `UserPreferencesStore`). Respect it at send time.
+Consider quiet-hours later.
+
+## Sequencing vs App Intents
+
+```
+Notification work (this doc)                 App Intents (sibling doc)
+──────────────────────────                   ─────────────────────────
+device_tokens endpoint + client reg   ┐
+notify/push.py + APNs key             ├─►    RefreshBriefingIntent
+emit at both refresh-complete seams   ┘      ("…I'll let you know when it's ready")
+```
+
+`OpenBriefingIntent` / `OpenFlightListIntent` / `CheckBriefingIntent` do **not**
+depend on this doc and can ship first. Only the refresh intent's satisfying
+close-the-loop UX needs the push.
+
+## Open Questions
+
+- **APNs key management** — `.p8` key + key id + team id as deployment secrets
+  (see [multi-user-deployment](./multi-user-deployment.md) secret handling).
+- **Environment routing** — sandbox vs production host per token; how to detect at
+  build/runtime and keep straight across TestFlight vs App Store.
+- **Dedup with email** — users who get both email and push on the same refresh: fine,
+  or offer "one or the other"?
+- **Manual-refresh scope** — notify only the triggering device, or all the user's
+  devices? (All is simpler and consistent with auto-refresh.)
+- **Throttling / quiet hours** — cap sends per flight per day; suppress overnight?
+
+## References
+
+- Device token model: `src/weatherbrief/db/models.py::DeviceTokenRow`
+- Refresh-complete seams: `src/weatherbrief/scheduler.py`, `src/weatherbrief/api/packs.py`
+- Email precedent to mirror: `src/weatherbrief/notify/email.py`
+- Change detection: `compute_refresh_delta` (see [metar-taf-route-weather](./metar-taf-route-weather.md))
+</content>

--- a/designs/ios-app-briefing-notifications.md
+++ b/designs/ios-app-briefing-notifications.md
@@ -128,15 +128,68 @@ for each ON channel (email, push):  deliver
 
 ### Other choices worth offering / deciding
 
-- **Per-flight notify ⇒ auto-refresh?** A per-flight "notify me when done" is most useful
-  for manual/Siri refreshes on a flight whose `auto_refresh` is off (it's the Siri-loop
-  case). Decide whether that control also surfaces/toggles `auto_refresh`, or stays purely
-  a notification override.
+- **★ DECIDED — per-flight notify is independent of auto-refresh.** They are two separate
+  controls today and stay separate: the notify override never enables or schedules
+  auto-refresh. (A per-flight "notify" is most useful precisely for manual/Siri refreshes
+  on a flight whose auto-refresh is off — the Siri-loop case.)
 - **Batching/digest** — the scheduler can finish several flights close together; a future
   digest could replace N separate pushes.
-- **Badge semantics** — define what the app-icon badge counts (flights with unseen updates?).
 - **Per-channel scope** — deliberately NOT in v1 (one scope for all channels); revisit only
   if users ask for "email everything, push only auto".
+
+*(Badge count / cross-surface sync has its own section below.)*
+
+## Badge count & cross-surface sync
+
+**Principle: the badge is a server-*derived* count, never a client-side increment.** Client
+counters drift the instant a second surface (web, another device) reads an update or a push
+is missed. There is already a precedent to mirror — system-message unseen count
+(`api/messages.py`: `messages_last_seen_id` in prefs, server-computed `unseen_count`,
+`POST /messages/seen`). We do the same, per-flight.
+
+**State (per user × flight):**
+- `last_notified_pack_ts` — timestamp of the most recent notify-qualifying update.
+- `last_seen_pack_ts` — advanced when the user opens that flight's briefing on **web or app**.
+- Flight is **unseen** iff `last_notified_pack_ts > last_seen_pack_ts`.
+- **Badge = count of unseen flights**, computed server-side on demand (like `unseen_count`).
+
+Storage: mirror messages (a `briefing_seen` map in `app_prefs_json`) or a small
+`flight_briefing_seen(user_id, flight_id, ts)` table. Flights per user are few; either
+works — lean to the table for cleanliness.
+
+**Three mechanisms keep web ↔ app ↔ multi-device in sync:**
+1. **Badge in every alert push** — when a notify-qualifying refresh completes, set
+   `aps.badge = <current server unseen count>` in the payload, so the visible notification
+   already carries the true number.
+2. **Silent badge-sync push on state change** — when unseen changes for a reason *other*
+   than a new alert (the user reads a flight on the **web**, or on another device), the
+   server sends a **silent** push (`content-available: 1`, no alert, `aps.badge: N`) to the
+   user's iOS devices so the badge drops to match. *This is what makes "read on web →
+   app badge 2 → 1" work.*
+3. **Authoritative reconcile on app foreground** — APNs (especially silent pushes) is
+   best-effort and coalesced by Apple, never guaranteed. So on `scenePhase == .active` the
+   app GETs the current count (`GET /api/flights/badge`, mirroring `/messages/status`) and
+   sets the badge directly. This is the correctness backstop.
+
+**Why this is accurate (and the naive version isn't):** the server count is the single
+source of truth, push is an optimization, foreground-reconcile is the guarantee. The
+annoying-badge failure mode is the opposite — incrementing/decrementing on the client and
+trusting push delivery. The worry is well-founded; the ordering above is the fix.
+
+**Definitions to lock:**
+- **What clears "unseen"?** Opening the flight's **briefing detail** (web or app) — not
+  merely seeing it in the list. Per-flight watermark (any newer pack read clears it), not per-pack.
+- **What counts toward the badge?** Only **notify-qualifying** updates (same gate as the
+  notification: scope + change-filter + not muted) — mirroring "only highlighted messages
+  light the dot".
+- **Badge vs push-channel toggle** — reconcile keeps the badge correct even if *alert* push
+  is off; decide whether to show a badge when the push channel is disabled (recommend:
+  badge follows "a device is registered", independent of alert on/off).
+
+**New surface area:** `POST /api/flights/{id}/seen` (or fold into the existing briefing
+GET), `GET /api/flights/badge`, the silent-push path, and the app's foreground reconcile +
+mark-seen on briefing open. The **web** calls the same `seen` endpoint on briefing view —
+that is what decrements the app badge.
 
 ## Sequencing vs App Intents
 
@@ -167,7 +220,9 @@ email* (channels are independent user choices). Remaining:
   it at build/runtime and keep straight across TestFlight vs App Store.
 - **Manual-refresh device scope** — notify only the triggering device, or all the user's
   devices? (All is simpler and consistent with auto-refresh.)
-- **Badge semantics & quiet hours** — define the badge count; whether quiet-hours ships v1.
+- **Quiet hours** — whether to suppress push overnight in v1 (badge sync is unaffected).
+- **Seen storage** — `briefing_seen` map in `app_prefs_json` (mirrors messages) vs a small
+  `flight_briefing_seen` table (see Badge section).
 
 ## References
 

--- a/designs/ios-app-intents.md
+++ b/designs/ios-app-intents.md
@@ -1,0 +1,233 @@
+# iOS App — App Intents, Siri & Apple Intelligence
+
+> Expose FlyFun briefings to Siri, Shortcuts, and Spotlight via App Intents.
+> The MCP tool catalog (`src/weatherbrief/mcp/server.py`) is the reference for
+> what capabilities to surface — this doc is its on-device sibling.
+
+**Status: PROPOSED — nothing built yet.** The app today has zero App Intents,
+zero App Shortcuts, no Widgets, and no Siri surface (grep for `AppIntent` /
+`AppShortcut` / `INIntent` returns nothing). It also has **no SiriKit**, so
+there is nothing to migrate — we start clean on the modern App Intents path
+(SiriKit was formally deprecated at WWDC 2026).
+
+## Related Docs
+
+- [Overview](./ios-app-overview.md) — current implementation status
+- [Architecture](./ios-app-architecture.md) — MVVM + Repository, auth, deep links
+- [Briefing Refresh Notifications](./ios-app-briefing-notifications.md) — APNs push on refresh-complete; **prerequisite** for the refresh intent to close its loop
+- [Roadmap](./ios-app-roadmap.md) — phase context (this is a Phase-1/2 cross-cut, adjacent to the Phase-3a voice-PIREP work)
+- Server sibling: `src/weatherbrief/mcp/server.py` — the MCP tools these intents mirror
+
+## Why App Intents (and the one hard constraint)
+
+App Intents is the single framework through which Siri and Apple Intelligence
+call into a third-party app. Our capabilities already exist as thin, offline-capable
+methods on `BriefingRepository`; the MCP server wraps them for Claude, and App
+Intents wraps the *same* methods for Siri. Intents should stay as thin as the MCP
+tools — no new networking, reuse `CachingBriefingRepository`.
+
+**The hard constraint:** there is **no weather/aviation App Schema** (WWDC26
+assistant schemas cover only messages, mail, photos, contacts, calendar, media).
+So every intent here is a *custom* App Intent. Consequences:
+
+- Custom intents are first-class in **Shortcuts, Spotlight, Widgets, Action Button,
+  Control Center**, and are Siri-reachable — but the trigger phrase must contain
+  the app name (e.g. "…my **FlyFun** briefing…"). A bare "refresh my weather
+  briefing" only routes to us if the user renames the shortcut in the Shortcuts app.
+- Siri does **not** parse "tomorrow to Fairoaks" into a flight for us. Natural-language
+  parameter resolution is *our* code, via an `EntityStringQuery` (see Resolver Design).
+  WWDC26's semantic index (`IndexedEntity`) improves match quality but the resolver is ours.
+
+Everything degrades gracefully across iOS 26 → 27: Phase 1 works today; Phase 2
+layers on WWDC26-only APIs where present.
+
+---
+
+## Phase 1 — App Intents + App Shortcuts (ships on current iOS 26)
+
+Target utterances (all require the "FlyFun" token in the phrase):
+
+- "Hey Siri, **show me my FlyFun briefings**" → opens the flight list
+- "Hey Siri, **open the FlyFun briefing for my next flight**" → opens that briefing
+- "Hey Siri, **refresh my FlyFun briefing for the flight tomorrow to Fairoaks**"
+- "Hey Siri, **what's my FlyFun assessment for Cannes?**" (spoken, no app open)
+
+### Entities
+
+| Entity | Backed by | Notes |
+|---|---|---|
+| `FlightEntity` | `FlightResponse` (`repository.flights()`) | `AppEntity` + **`IndexedEntity`** for Spotlight + Siri resolution. Display: `shortTitle` ("ORIGIN → DEST"), subtitle = departure date + assessment. `id` = flight id. |
+| `AirportEntity` | `AirportDatabase` (existing service) + `RZFlight` `KnownAirports` | ICAO + name; used by the airport-weather intent and to expand "Fairoaks" → `EGTF`. |
+
+### Intents
+
+| Intent | Foreground? | Maps to MCP tool | Behaviour |
+|---|---|---|---|
+| `OpenFlightListIntent` | opens app | `list_flights` | Navigate to the flight list page. No parameter. |
+| `OpenBriefingIntent` | opens app | `get_briefing` | `@Parameter var flight: FlightEntity?`. If nil → compute the **next** upcoming flight and open its briefing. |
+| `CheckBriefingIntent` | background (spoken) | `get_briefing` | `@Parameter var flight: FlightEntity`. Returns a spoken/snippet summary: assessment (GREEN/AMBER/RED) + the top one or two advisories. Reads from cache when offline. |
+| `FlightsOverviewIntent` | background (spoken) | `list_flights` | No parameter. Speaks a one-line-per-flight traffic-light summary of upcoming flights. |
+| `RefreshBriefingIntent` | background | `refresh_briefing` | `@Parameter var flight: FlightEntity`. Triggers refresh, returns **immediately** ("Refreshing your Fairoaks briefing — I'll let you know when it's ready"). See loop-closure note. |
+| `AirportWeatherIntent` | background (spoken) | `get_airport_weather` | `@Parameter var airport: AirportEntity`, `@Parameter var day: Int = 0`. Spoken consensus category + wind for the airport. |
+
+Notes:
+- **`OpenBriefingIntent` / `OpenFlightListIntent` ship first** — they need no parameter
+  resolution and no push, so they carry no resolver risk and prove the navigation plumbing.
+- **`RefreshBriefingIntent` depends on** [Briefing Refresh Notifications](./ios-app-briefing-notifications.md):
+  a refresh is ~2 min server-side and a background intent can't wait. Without the
+  "briefing ready" push, Siri can only say "started, open the app shortly." Sequence
+  the push work before (or alongside) this intent.
+
+### App Shortcuts (zero-setup Siri phrases)
+
+```swift
+struct FlyFunShortcuts: AppShortcutsProvider {
+    static var appShortcuts: [AppShortcut] {
+        AppShortcut(intent: OpenFlightListIntent(),
+            phrases: ["Show my \(.applicationName) briefings",
+                      "Open \(.applicationName)"],
+            shortTitle: "My Briefings", systemImageName: "list.bullet.rectangle")
+        AppShortcut(intent: OpenBriefingIntent(),
+            phrases: ["Open my next \(.applicationName) briefing",
+                      "Show my next flight in \(.applicationName)"],
+            shortTitle: "Next Briefing", systemImageName: "airplane")
+        AppShortcut(intent: RefreshBriefingIntent(),
+            phrases: ["Refresh my \(.applicationName) briefing",
+                      "Refresh my \(.applicationName) briefing for \(\.$flight)"],
+            shortTitle: "Refresh Briefing", systemImageName: "arrow.clockwise")
+        // + CheckBriefingIntent, AirportWeatherIntent
+    }
+}
+```
+
+### Resolver Design — "the flight tomorrow to Fairoaks"
+
+`FlightEntity` is resolved by an `EntityStringQuery`. Siri hands the extracted
+string to our code; we match it against upcoming flights and let Siri disambiguate
+when >1 matches:
+
+```swift
+struct FlightEntityQuery: EntityStringQuery {
+    func entities(matching string: String) async throws -> [FlightEntity] {
+        let flights = try await repository.flights()          // cache-first
+        return flights.filter { flight in
+            // destination match: expand "fairoaks" ↔ EGTF via AirportDatabase
+            matchesDestination(flight, string) ||
+            // relative-date match: "tomorrow", "today", weekday — parsed in-app
+            matchesRelativeDate(flight, string)
+        }.map(FlightEntity.init)
+    }
+    func suggestedEntities() async throws -> [FlightEntity] { /* upcoming flights */ }
+    func entities(for ids: [String]) async throws -> [FlightEntity] { /* by id */ }
+}
+```
+
+Reuse, per the CLAUDE.md "reuse the library" principle:
+- **`Services/AirportDatabase.swift`** (and `RZFlight` `KnownAirports`) to map spoken
+  place names ↔ ICAO — do not hand-roll name matching.
+- **`CachingBriefingRepository`** for `flights()` / `latestPack()` / `refreshBriefing`
+  so intents work from cache in the cockpit.
+
+### Navigation from an intent
+
+Foregrounding intents set a pending navigation target that the UI consumes, reusing
+the pattern already established for `onOpenURL`:
+
+- Add a `PendingNavigation` value on `AppState` (e.g. `.flightList`, `.briefing(flightId:)`).
+- `OpenBriefingIntent` / `OpenFlightListIntent` set it, return with `openAppWhenRun`.
+- `WeatherBriefApp` / `FlightListView` read it on `.active` and route — the same seam
+  `onOpenURL` already uses. Alternatively an intent can emit the existing
+  `flyfunweather://` deep link, but a typed `PendingNavigation` avoids URL parsing.
+
+### Auth & process model (Phase 1 has a low bar)
+
+- Intents run **in-process**, reusing the Keychain JWT via `APIClient` /
+  FlyFunCommon `RollingBearerSession` — no extra auth work.
+- **No App Group needed** for these intents (that's only for Widgets / Live Activities
+  / a separate extension process — out of scope here, tracked under Tier 2).
+
+### Spotlight
+
+`FlightEntity: IndexedEntity` (donated via `CSSearchableIndex`) makes flights
+searchable in Spotlight and improves Siri's resolution of "my flight to Cannes".
+Donate on flight-list load and on create; remove on delete.
+
+---
+
+## Phase 2 — View Annotations + Foundation Models (WWDC26 / iOS 27)
+
+Goal: act on **what's on screen** conversationally, and narrate cached data offline.
+
+### View Annotations ("explain this", "show me the cross-section")
+
+The View Annotations API tags on-screen SwiftUI views with App Entities so Siri
+knows the referent. Surface, smallest-first:
+
+| Utterance (while viewing a briefing) | Annotate | Intent | Maps to |
+|---|---|---|---|
+| "Explain this" (on an advisory row) | `AdvisoryEntity` on each advisory row | `ExplainAdvisoryIntent(advisory:)` | `get_advisory_detail` |
+| "Show me the cross-section" | `FlightEntity` on the briefing container | `ShowCrossSectionIntent` | in-app nav (Cross-Section tab) |
+| "Is this still green / what changed?" | `FlightEntity` on the container | `CheckBriefingIntent` (reused) | `get_briefing` |
+| "Explain the icing at waypoint 3" / "Skew-T here" | per-point annotations | (deferred — large surface, low marginal value) | — |
+
+`ExplainAdvisoryIntent` resolves the on-screen `AdvisoryEntity` → `repository.advisoryDetail(...)`
+→ speaks/shows the "why" (the same per-model, cross-check reasoning the MCP
+`get_advisory_detail` returns).
+
+### Foundation Models (on-device narration)
+
+The on-device model narrates our **cached** `AdvisoryDetailResponse` into a natural
+sentence for "explain this" — working **fully offline in the cockpit**. Split of
+authority:
+
+- **On-device / offline** — phrase cached advisory data ("convective is amber because
+  CAPE peaks near waypoint 4 while cloud cover stays low").
+- **Server / online** — the authoritative digest stays server-side (LangGraph); the
+  on-device narration never replaces it, only fills the offline gap.
+
+Optional: use the model to improve voice-PIREP parsing beyond the regex `PIREPParser`
+(cross-ref Phase 3a in the roadmap).
+
+### Testing
+
+Adopt the **App Intents Testing framework** (WWDC26) to validate Siri / Shortcuts /
+Spotlight through real system pathways without UI automation, alongside the existing
+XCTest suite.
+
+---
+
+## MCP ⇆ App Intents parity
+
+The MCP tools and the App Intents are two front doors over one repository. Keep them
+in sync the way `sync-ios-web` guards web↔iOS drift: when an MCP tool is added or its
+shape changes, check the mirroring intent. Current mapping:
+
+| MCP tool | Intent(s) |
+|---|---|
+| `list_flights` | `OpenFlightListIntent`, `FlightsOverviewIntent` |
+| `get_briefing` | `OpenBriefingIntent`, `CheckBriefingIntent` |
+| `refresh_briefing` | `RefreshBriefingIntent` |
+| `get_airport_weather` | `AirportWeatherIntent` |
+| `get_advisory_detail` | `ExplainAdvisoryIntent` (Phase 2) |
+| `create_flight` | *(kept in-app / Shortcuts-only — route+time too complex for voice)* |
+| `get_alternates`, `get_digest_context` | *(not surfaced initially — deep/niche)* |
+
+## Open Questions
+
+- **Phrase discoverability** — how much to lean on App Shortcuts phrases (need "FlyFun")
+  vs. teaching users to build their own Shortcuts (free phrasing). Onboarding tip?
+- **Refresh feedback without push** — interim UX if the notification work lands later:
+  local notification on next foreground? Poll `refreshStatus` in a short-lived background task?
+- **"Next flight" definition** — soonest by departure, or soonest that is today-or-later
+  and has a briefing? Align with `FlightListViewModel` ordering.
+- **iPhone vs iPad** — intents are universal; confirm navigation targets exist on both size classes.
+- **Spotlight donation lifecycle** — where to hook create/update/delete donations cleanly.
+
+## References
+
+- MCP server (parity source): `src/weatherbrief/mcp/server.py`
+- Repository surface: `app/flyfun-weather/flyfun-weather/Services/BriefingRepository.swift`
+- Airport name↔ICAO: `app/flyfun-weather/flyfun-weather/Services/AirportDatabase.swift`
+- Notifications prerequisite: [ios-app-briefing-notifications.md](./ios-app-briefing-notifications.md)
+</content>
+</invoke>

--- a/designs/ios-app-intents.md
+++ b/designs/ios-app-intents.md
@@ -102,31 +102,75 @@ struct FlyFunShortcuts: AppShortcutsProvider {
 
 ### Resolver Design — "the flight tomorrow to Fairoaks"
 
-`FlightEntity` is resolved by an `EntityStringQuery`. Siri hands the extracted
-string to our code; we match it against upcoming flights and let Siri disambiguate
-when >1 matches:
+`FlightEntity` is resolved by an `EntityStringQuery` over a **tiny, closed set** — the
+user's handful of upcoming flights. That makes a *deterministic* resolver the primary
+path and an on-device model a *fallback*, not the first resort. Two distinct "models"
+matter here:
+
+- **Siri's own resolution** (system-side, Gemini-backed at WWDC26): flattens/cleans the
+  phrase and, with `IndexedEntity`'s semantic index, does more matching before it even
+  calls our query. We benefit passively; it improves each OS release.
+- **Foundation Models framework** (a model *we* call): the on-device ~3B Apple
+  Intelligence LLM, available since iOS 26. With **guided generation** it turns a free
+  string into a typed `{place, when}` — ideal for messy phrasing.
+
+**Tiered resolution:**
+
+| Tier | Handles | Cost / availability |
+|---|---|---|
+| 1. Deterministic — `AirportDatabase`/`RZFlight` place↔ICAO + relative-date keywords | "Fairoaks", "EGTF", "Le Touquet", "tomorrow", weekday names | free, instant, offline, **every device** |
+| 2. Foundation Models guided generation → `{place, when}`, then re-run tier-1 match | loose phrasing: "my trip to the coast next weekend" | on-device, needs Apple-Intelligence-capable device + enabled |
+| 3. Siri disambiguation UI | still ≥2 matches after tiers 1–2 | system-provided |
+
+Tier 1 is the **floor** and must always exist: Foundation Models requires an
+Apple-Intelligence-capable device (iPhone 15 Pro / M-series+), the feature enabled, and
+the model present — so it can never be a hard dependency. Gate tier 2 on
+`SystemLanguageModel.default.availability`; if unavailable, fall straight to tier 3.
 
 ```swift
 struct FlightEntityQuery: EntityStringQuery {
     func entities(matching string: String) async throws -> [FlightEntity] {
-        let flights = try await repository.flights()          // cache-first
-        return flights.filter { flight in
-            // destination match: expand "fairoaks" ↔ EGTF via AirportDatabase
-            matchesDestination(flight, string) ||
-            // relative-date match: "tomorrow", "today", weekday — parsed in-app
-            matchesRelativeDate(flight, string)
-        }.map(FlightEntity.init)
+        let flights = try await repository.flights()             // cache-first
+        // Tier 1 — deterministic (authoritative)
+        var hits = flights.filter {
+            matchesDestination($0, string) ||                   // AirportDatabase place↔ICAO
+            matchesRelativeDate($0, string)                     // "tomorrow", weekday — parsed in-app
+        }
+        // Tier 2 — on-device LLM fallback, only when tier 1 is empty AND the model is available
+        if hits.isEmpty, case .available = SystemLanguageModel.default.availability {
+            let q = try await LanguageModelSession()
+                .respond(to: string, generating: FlightQuery.self)
+            hits = flights.filter { matches($0, place: q.place, when: q.when) }
+        }
+        return hits.map(FlightEntity.init)                      // Siri disambiguates if >1
     }
     func suggestedEntities() async throws -> [FlightEntity] { /* upcoming flights */ }
     func entities(for ids: [String]) async throws -> [FlightEntity] { /* by id */ }
 }
+
+@Generable struct FlightQuery {
+    @Guide(description: "airport or city name mentioned, e.g. Fairoaks")
+    var place: String?
+    @Guide(description: "when: tomorrow, Saturday, next week")
+    var when: String?
+}
 ```
 
-Reuse, per the CLAUDE.md "reuse the library" principle:
-- **`Services/AirportDatabase.swift`** (and `RZFlight` `KnownAirports`) to map spoken
-  place names ↔ ICAO — do not hand-roll name matching.
+**Division of authority:** the LLM only flattens *language* into `{place, when}`; the
+deterministic matcher against real flights stays the authority — so the model can never
+invent a flight that doesn't exist. This keeps correctness in well-tested code and uses
+the LLM only for input variety (per the CLAUDE.md "push complexity into well-tested
+code" principle).
+
+Reuse:
+- **`Services/AirportDatabase.swift`** + `RZFlight` `KnownAirports` for place↔ICAO — do
+  not hand-roll name matching.
 - **`CachingBriefingRepository`** for `flights()` / `latestPack()` / `refreshBriefing`
   so intents work from cache in the cockpit.
+
+**Scope:** all three tiers ship in v1 (decided). Tier 1 is the mandatory floor; tier 2 is
+gated on `SystemLanguageModel.default.availability`, so devices without Apple Intelligence
+degrade to tier 1 + Siri disambiguation with no loss of the core paths. *(see Decisions)*
 
 ### Navigation from an intent
 
@@ -211,6 +255,45 @@ shape changes, check the mirroring intent. Current mapping:
 | `get_advisory_detail` | `ExplainAdvisoryIntent` (Phase 2) |
 | `create_flight` | *(kept in-app / Shortcuts-only — route+time too complex for voice)* |
 | `get_alternates`, `get_digest_context` | *(not surfaced initially — deep/niche)* |
+
+## Decisions
+
+Locked (★) decisions first, then defaults still open to revision.
+
+1. **★ DECIDED — App Group provisioned now.** Even though Phase-1 intents run in-process
+   and don't consume it, we provision the shared App Group and place the Keychain
+   access-group + briefing cache in it from the start, so Widgets / Live Activities /
+   Control Center (broader-plan Tier 2) add no later Keychain/cache migration. *Task:
+   define the App Group id, move `KeychainBearerTokenStore` access-group + the
+   `BriefingCacheStore` / Application-Support path into the shared container in Phase 1.*
+2. **★ DECIDED — Refresh via Siri: freshness gate only, no confirmation.** A voice
+   "refresh" triggers a real, **billed** pipeline run (see
+   [cost-attribution](./cost-attribution-design.md)), but the server's `already_fresh`
+   gate prevents redundant spend and it is rate-limited (409/429). No extra Siri
+   confirmation step (friction in a hands-busy flow). *Task: define spoken responses for
+   `queued` / `already_fresh` / `already_in_progress` / `rate_limited`.*
+3. **★ DECIDED — Tier-2 on-device LLM fallback ships in v1.** Build the full tiered
+   resolver (deterministic → Foundation Models `{place, when}` → Siri disambiguation)
+   from the first release. Tier 1 remains the mandatory floor; tier 2 is gated on
+   `SystemLanguageModel.default.availability` so devices without Apple Intelligence fall
+   straight to tier 1/3. *Task: `@Generable FlightQuery` + availability gate + guided-generation call.*
+4. **Signed-out / expired-token behaviour.** Background intents can't run OAuth.
+   **Recommend:** attempt silent token refresh (`RollingBearerSession`) first; else
+   foreground intents throw `needsToContinueInForegroundError` ("Open FlyFun to sign in"),
+   background intents speak "Please open FlyFun to sign in first."
+5. **Empty-state / no-match dialog per intent.** "No upcoming flights", "I couldn't find a
+   flight to X", "You're offline and that briefing isn't downloaded." These spoken lines
+   *are* the voice UX — decide them explicitly.
+6. **Navigation seam.** Typed `PendingNavigation` on `AppState` (proposed) vs reuse
+   `flyfunweather://`. **Recommend: typed `PendingNavigation`**; must handle cold-launch
+   (set before window) and warm (`.active`).
+7. **AppShortcut phrase set.** ~10-shortcut soft limit, every phrase needs "FlyFun".
+   **Recommend: English phrases v1**, FR/DE localization as fast-follow (place resolution
+   is already language-agnostic via ICAO).
+8. **Spotlight donation lifecycle.** Donate `FlightEntity` on list-load + create, remove on
+   delete; avoid stale donations for server-deleted flights.
+9. **Privacy / prediction surfacing.** Routes are private. **Recommend: discoverable in
+   Shortcuts/Spotlight**, but review whether Siri may predict these on the Lock Screen.
 
 ## Open Questions
 

--- a/designs/ios-app-intents.md
+++ b/designs/ios-app-intents.md
@@ -168,9 +168,12 @@ Reuse:
 - **`CachingBriefingRepository`** for `flights()` / `latestPack()` / `refreshBriefing`
   so intents work from cache in the cockpit.
 
-**Scope:** all three tiers ship in v1 (decided). Tier 1 is the mandatory floor; tier 2 is
-gated on `SystemLanguageModel.default.availability`, so devices without Apple Intelligence
-degrade to tier 1 + Siri disambiguation with no loss of the core paths. *(see Decisions)*
+**Scope:** the whole resolver is part of the **Tier-1 / today** issue — the Foundation
+Models fallback is iOS 26, not a next-release feature. Resolver tier 1 is the mandatory
+floor; the LLM tier is gated on `SystemLanguageModel.default.availability`, so devices
+without Apple Intelligence degrade to deterministic + Siri disambiguation with no loss of
+core paths. (Naming note: *resolver* tiers 1–3 above are internal to this algorithm and
+distinct from the product **Tier 1 / Tier 2** issue split.) *(see Decisions)*
 
 ### Navigation from an intent
 
@@ -201,9 +204,12 @@ Donate on flight-list load and on create; remove on delete.
 
 ---
 
-## Phase 2 — View Annotations + Foundation Models (WWDC26 / iOS 27)
+## Phase 2 — On-screen context (iOS 27 / WWDC26)
 
-Goal: act on **what's on screen** conversationally, and narrate cached data offline.
+Goal: act on **what's on screen** conversationally. Phase 2 is scoped strictly to what
+genuinely needs the next iOS release — the **View Annotations API** and the **App Intents
+Testing framework**. (Foundation Models is *not* here: it ships in iOS 26 and lives in
+Phase 1 — the resolver fallback, and the optional on-device narration below.)
 
 ### View Annotations ("explain this", "show me the cross-section")
 
@@ -221,16 +227,24 @@ knows the referent. Surface, smallest-first:
 → speaks/shows the "why" (the same per-model, cross-check reasoning the MCP
 `get_advisory_detail` returns).
 
-### Foundation Models (on-device narration)
+### On-device narration (Foundation Models — iOS 26, so Tier-1-capable)
 
-The on-device model narrates our **cached** `AdvisoryDetailResponse` into a natural
-sentence for "explain this" — working **fully offline in the cockpit**. Split of
-authority:
+This capability is **iOS 26** and therefore not gated on the next release: the on-device
+model narrates our **cached** `AdvisoryDetailResponse` into a natural sentence for
+"explain this", **fully offline in the cockpit**. It can ship in the Tier-1 issue via a
+*parameterized* `ExplainAdvisoryIntent(advisory:)` (pick the flight+advisory in Shortcuts).
+What Phase 2 adds is only the **on-screen trigger** — View Annotations let the user say
+"explain **this**" while looking at the row, instead of naming it. Split of authority:
 
 - **On-device / offline** — phrase cached advisory data ("convective is amber because
   CAPE peaks near waypoint 4 while cloud cover stays low").
 - **Server / online** — the authoritative digest stays server-side (LangGraph); the
   on-device narration never replaces it, only fills the offline gap.
+
+Recommendation: build `ExplainAdvisoryIntent` + narration **alongside** the View
+Annotations in the Tier-2 issue, since the on-screen "explain this" is its natural UX —
+but note this is a *packaging choice*, not an OS constraint (the intent + narration are
+iOS-26-capable and could land in Tier 1 if wanted).
 
 Optional: use the model to improve voice-PIREP parsing beyond the regex `PIREPParser`
 (cross-ref Phase 3a in the roadmap).
@@ -263,16 +277,21 @@ shape changes, check the mirroring intent. Current mapping:
 
 This doc breaks into three **independently-shippable** GitHub issues:
 
-1. **Tier 1 — App Intents (iOS 26, ships today).** Entities (`FlightEntity` +
+Tiering is by **OS availability**: Tier 1 = everything implementable on **today's iOS 26**
+(including Foundation Models); Tier 2 = only what needs the **next release (iOS 27)**.
+
+1. **Tier 1 — App Intents, iOS 26 (everything doable today).** Entities (`FlightEntity` +
    `IndexedEntity`, `AirportEntity`), the open / check / overview / refresh / airport
-   intents, `FlyFunShortcuts`, the **deterministic** resolver + Siri disambiguation
-   (tiers 1 & 3), the `PendingNavigation` seam, Spotlight donation, App Group
-   provisioning (Decision 1), and the expired-token fallback (Decision 4). Functional on
-   every device.
-2. **Tier 2 — Apple Intelligence (WWDC26 / iOS 27).** The Foundation Models resolver
-   fallback (resolver tier 2), View Annotations ("explain this" / "show the
-   cross-section"), on-device narration of cached advisories, and the App Intents Testing
-   framework. Purely additive on top of Issue 1; gated on model availability.
+   intents, `FlyFunShortcuts`, the **full tiered resolver** — deterministic + **Foundation
+   Models `{place, when}` fallback** (iOS 26) + Siri disambiguation — the `PendingNavigation`
+   seam, Spotlight donation, App Group provisioning (Decision 1), and the expired-token
+   fallback (Decision 4). Core paths work on every device; the LLM tier lights up on
+   Apple-Intelligence-capable devices.
+2. **Tier 2 — iOS 27 / WWDC26 only.** The **View Annotations API** (on-screen "explain
+   this" / "show the cross-section") and the **App Intents Testing framework**. By
+   packaging choice, `ExplainAdvisoryIntent` + on-device advisory narration ride along
+   here (their natural UX is the on-screen trigger) — though both are iOS-26-capable and
+   could move to Tier 1 (see Phase 2 note).
 3. **Notification — briefing-refresh push.** See
    [ios-app-briefing-notifications.md](./ios-app-briefing-notifications.md).
 
@@ -297,12 +316,14 @@ Locked (★) decisions first, then defaults still open to revision.
    gate prevents redundant spend and it is rate-limited (409/429). No extra Siri
    confirmation step (friction in a hands-busy flow). *Task: define spoken responses for
    `queued` / `already_fresh` / `already_in_progress` / `rate_limited`.*
-3. **★ DECIDED — On-device LLM resolver fallback is committed, delivered in the Tier-2
-   Apple-Intelligence issue.** The full tiered resolver is the target: deterministic
-   (Tier-1 issue, mandatory floor) → Foundation Models `{place, when}` → Siri
-   disambiguation. The LLM fallback is gated on `SystemLanguageModel.default.availability`,
-   so the Tier-1 intent ships and works fully without it and tier 2 is purely additive.
-   *Task (Tier-2 issue): `@Generable FlightQuery` + availability gate + guided-generation call.*
+3. **★ DECIDED — Full tiered resolver ships in Tier 1 (today).** The Foundation Models
+   framework is available on **iOS 26**, so the on-device LLM fallback is implementable
+   now and belongs in the Tier-1 issue — Tier 2 is reserved for what genuinely needs the
+   next iOS release (View Annotations, App Intents Testing). Resolver = deterministic
+   (mandatory floor) → Foundation Models `{place, when}` fallback → Siri disambiguation,
+   with the LLM step gated on `SystemLanguageModel.default.availability` so non-AI devices
+   degrade to deterministic + disambiguation. *Task (Tier-1 issue): `@Generable FlightQuery`
+   + availability gate + guided-generation call.*
 4. **★ DECIDED — Signed-out / expired-token behaviour.** Attempt a silent token refresh
    (`RollingBearerSession`) first; if it fails, foreground intents throw
    `needsToContinueInForegroundError` ("Open FlyFun to sign in") and background intents

--- a/designs/ios-app-intents.md
+++ b/designs/ios-app-intents.md
@@ -183,12 +183,15 @@ the pattern already established for `onOpenURL`:
   `onOpenURL` already uses. Alternatively an intent can emit the existing
   `flyfunweather://` deep link, but a typed `PendingNavigation` avoids URL parsing.
 
-### Auth & process model (Phase 1 has a low bar)
+### Auth & process model
 
 - Intents run **in-process**, reusing the Keychain JWT via `APIClient` /
-  FlyFunCommon `RollingBearerSession` — no extra auth work.
-- **No App Group needed** for these intents (that's only for Widgets / Live Activities
-  / a separate extension process — out of scope here, tracked under Tier 2).
+  FlyFunCommon `RollingBearerSession` — no OAuth in the intent path (see Decision 4
+  for the expired-token fallback).
+- **App Group is provisioned in Phase 1** (Decision 1). The intents themselves don't
+  strictly require it, but we move the Keychain access-group + `BriefingCacheStore`
+  into the shared container now, so the later Widgets / Live Activities / Control Center
+  work needs no Keychain/cache migration.
 
 ### Spotlight
 
@@ -256,6 +259,28 @@ shape changes, check the mirroring intent. Current mapping:
 | `create_flight` | *(kept in-app / Shortcuts-only — route+time too complex for voice)* |
 | `get_alternates`, `get_digest_context` | *(not surfaced initially — deep/niche)* |
 
+## Implementation issues
+
+This doc breaks into three **independently-shippable** GitHub issues:
+
+1. **Tier 1 — App Intents (iOS 26, ships today).** Entities (`FlightEntity` +
+   `IndexedEntity`, `AirportEntity`), the open / check / overview / refresh / airport
+   intents, `FlyFunShortcuts`, the **deterministic** resolver + Siri disambiguation
+   (tiers 1 & 3), the `PendingNavigation` seam, Spotlight donation, App Group
+   provisioning (Decision 1), and the expired-token fallback (Decision 4). Functional on
+   every device.
+2. **Tier 2 — Apple Intelligence (WWDC26 / iOS 27).** The Foundation Models resolver
+   fallback (resolver tier 2), View Annotations ("explain this" / "show the
+   cross-section"), on-device narration of cached advisories, and the App Intents Testing
+   framework. Purely additive on top of Issue 1; gated on model availability.
+3. **Notification — briefing-refresh push.** See
+   [ios-app-briefing-notifications.md](./ios-app-briefing-notifications.md).
+
+Independence: all three can proceed in parallel. The only soft coupling is that
+`RefreshBriefingIntent` (Issue 1) gives its best "…I'll let you know when it's ready" UX
+once Issue 3 lands; until then it speaks the interim "started — open FlyFun shortly"
+(Open Questions → refresh feedback without push). Issue 1 does not *block* on Issue 3.
+
 ## Decisions
 
 Locked (★) decisions first, then defaults still open to revision.
@@ -272,15 +297,16 @@ Locked (★) decisions first, then defaults still open to revision.
    gate prevents redundant spend and it is rate-limited (409/429). No extra Siri
    confirmation step (friction in a hands-busy flow). *Task: define spoken responses for
    `queued` / `already_fresh` / `already_in_progress` / `rate_limited`.*
-3. **★ DECIDED — Tier-2 on-device LLM fallback ships in v1.** Build the full tiered
-   resolver (deterministic → Foundation Models `{place, when}` → Siri disambiguation)
-   from the first release. Tier 1 remains the mandatory floor; tier 2 is gated on
-   `SystemLanguageModel.default.availability` so devices without Apple Intelligence fall
-   straight to tier 1/3. *Task: `@Generable FlightQuery` + availability gate + guided-generation call.*
-4. **Signed-out / expired-token behaviour.** Background intents can't run OAuth.
-   **Recommend:** attempt silent token refresh (`RollingBearerSession`) first; else
-   foreground intents throw `needsToContinueInForegroundError` ("Open FlyFun to sign in"),
-   background intents speak "Please open FlyFun to sign in first."
+3. **★ DECIDED — On-device LLM resolver fallback is committed, delivered in the Tier-2
+   Apple-Intelligence issue.** The full tiered resolver is the target: deterministic
+   (Tier-1 issue, mandatory floor) → Foundation Models `{place, when}` → Siri
+   disambiguation. The LLM fallback is gated on `SystemLanguageModel.default.availability`,
+   so the Tier-1 intent ships and works fully without it and tier 2 is purely additive.
+   *Task (Tier-2 issue): `@Generable FlightQuery` + availability gate + guided-generation call.*
+4. **★ DECIDED — Signed-out / expired-token behaviour.** Attempt a silent token refresh
+   (`RollingBearerSession`) first; if it fails, foreground intents throw
+   `needsToContinueInForegroundError` ("Open FlyFun to sign in") and background intents
+   speak "Please open FlyFun to sign in first."
 5. **Empty-state / no-match dialog per intent.** "No upcoming flights", "I couldn't find a
    flight to X", "You're offline and that briefing isn't downloaded." These spoken lines
    *are* the voice UX — decide them explicitly.
@@ -292,8 +318,9 @@ Locked (★) decisions first, then defaults still open to revision.
    is already language-agnostic via ICAO).
 8. **Spotlight donation lifecycle.** Donate `FlightEntity` on list-load + create, remove on
    delete; avoid stale donations for server-deleted flights.
-9. **Privacy / prediction surfacing.** Routes are private. **Recommend: discoverable in
-   Shortcuts/Spotlight**, but review whether Siri may predict these on the Lock Screen.
+9. **★ DECIDED — Privacy / prediction surfacing: discoverable.** Flight routes are not
+   especially sensitive and surfacing requires the user's own unlocked device, so intents
+   and `FlightEntity` are discoverable in Shortcuts/Spotlight and Siri may predict them.
 
 ## Open Questions
 
@@ -304,7 +331,10 @@ Locked (★) decisions first, then defaults still open to revision.
 - **"Next flight" definition** — soonest by departure, or soonest that is today-or-later
   and has a briefing? Align with `FlightListViewModel` ordering.
 - **iPhone vs iPad** — intents are universal; confirm navigation targets exist on both size classes.
-- **Spotlight donation lifecycle** — where to hook create/update/delete donations cleanly.
+- **`AirportWeatherIntent` day parameter** — `Int` (0–3) is unfriendly for voice; make it
+  an `@AppEnum` ("today"/"tomorrow"/…) so Siri and Shortcuts read naturally.
+- **Siri output shape** — which intents use `ProvidesDialog` (spoken) vs `ShowsSnippetView`
+  (a small result card); e.g. `CheckBriefingIntent` likely wants both.
 
 ## References
 

--- a/designs/ios-app-overview.md
+++ b/designs/ios-app-overview.md
@@ -11,6 +11,8 @@
 - [UI](./ios-app-ui.md) — cockpit constraints, screen layouts, report cards
 - [Sync & Prompting](./ios-app-sync-prompting.md) — offline queue, WebSocket, forecast-driven prompts
 - [Roadmap](./ios-app-roadmap.md) — phases, decisions, open questions
+- [App Intents](./ios-app-intents.md) — Siri / Shortcuts / Apple Intelligence surface (proposed)
+- [Briefing Refresh Notifications](./ios-app-briefing-notifications.md) — APNs push on refresh-complete (proposed)
 
 ## Current Implementation Status (2026-05-30)
 


### PR DESCRIPTION
Two new design docs (docs-only — no code changes) that plan how to connect FlyFun to Siri / Apple Intelligence, mirroring the existing MCP + Claude integration. Researched against WWDC 2026 announcements and grounded in the current iOS app and server code.

## What's added

**`designs/ios-app-intents.md`** — App Intents / Siri / Shortcuts / Spotlight surface as the on-device sibling of the MCP tool catalog. Tiering is by OS availability:
- **Tier 1 (iOS 26, today):** `FlightEntity`/`AirportEntity`, open / check / overview / refresh / airport intents, `AppShortcutsProvider` phrases, the full tiered resolver (deterministic → Foundation Models `{place, when}` fallback → Siri disambiguation — Foundation Models ships in iOS 26), `PendingNavigation`, App Group provisioning, Spotlight, expired-token fallback.
- **Tier 2 (iOS 27 / WWDC26):** View Annotations ("explain this" / "show the cross-section") + App Intents Testing framework.
- No SiriKit to migrate; MCP⇆intent parity table; locked decisions captured.

**`designs/ios-app-briefing-notifications.md`** — APNs push when a briefing finishes refreshing (closes the Siri refresh loop). Builds on the existing `DeviceTokenRow` table + migration 032 and the scheduler's email seam:
- Emit once from the shared `_persist_pack_finalize` sink (covers auto / in-app / Siri / MCP).
- Channel-aware notification preferences (email and/or push; scope auto/all/off; per-flight override), migrating today's implicit auto-refresh email.
- Badge cross-surface sync — server-derived count-once-per-flight (mirrors the `messages.py` unseen pattern), with badge-in-push + silent sync push + foreground reconcile so a web read decrements the app badge.
- APNs library guidance and sandbox-vs-production routing clarified.

Both are wired into `designs/INDEX.md` and `designs/ios-app-overview.md`. Marked PROPOSED — nothing is implemented yet; follow-up issues track the three independently-shippable workstreams (Tier 1 App Intents, Tier 2 Apple Intelligence, Notifications).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0192qwHpbvpt1AP2LovCh3Rv

---
_Generated by [Claude Code](https://claude.ai/code/session_0192qwHpbvpt1AP2LovCh3Rv)_