### PR TITLE
Fix iOS flight-create submitting raw Field-15 route tokens

### DIFF
--- a/app/flyfun-weather/flyfun-weather/ViewModels/AddFlightViewModel.swift
+++ b/app/flyfun-weather/flyfun-weather/ViewModels/AddFlightViewModel.swift
@@ -158,6 +158,15 @@ final class AddFlightViewModel {
         return abs(departureDate.timeIntervalSince(originalDate)) > 1
     }
 
+    /// Whether the typed route differs from the flight being edited (case- and
+    /// spacing-insensitive). Gates submit-time interpretation on edit — an
+    /// untouched route is already clean, so it needs no round-trip. On create
+    /// there is no baseline, so this is always `true`.
+    var routeChangedFromOriginal: Bool {
+        guard let original = editingFlight else { return true }
+        return waypoints != original.waypoints.map { $0.uppercased() }
+    }
+
     /// Whether the edited alt-departure instant differs from the flight's stored
     /// one (or newly sets one). Used only in `.alternate` mode.
     private func altDepartureChanged(from original: FlightResponse) -> Bool {
@@ -202,6 +211,59 @@ final class AddFlightViewModel {
     func applyInterpretedRoute() {
         guard let interpreted = routeInterpretation?.interpreted, interpreted.count >= 2 else { return }
         waypointsText = interpreted.joined(separator: " ")
+    }
+
+    /// How a submit-time route interpretation resolved (mirrors the web's
+    /// `interpretAndConfirmRoute` save gate).
+    enum RouteSubmitInterpretation: Equatable {
+        /// Route resolved cleanly (nothing skipped / off-route). The interpreted
+        /// waypoints have already been written back to the field — safe to submit.
+        case ready
+        /// The resolver dropped tokens the pilot typed. The caller should present
+        /// the interpret sheet so the pilot can confirm before submitting.
+        case needsConfirmation
+        /// Interpretation failed, or resolved to fewer than two usable waypoints.
+        /// `errorMessage` is set; the caller must abort rather than submit raw tokens.
+        case failed
+    }
+
+    /// Interpret the typed route on the server *at submit time* and decide how the
+    /// create/save should proceed. Always awaited before the request goes out, so
+    /// raw ICAO Field-15 syntax — speed/level groups like `N0180VFR`, airway labels
+    /// (`Q230`), SIDs (`BEBEX7W`), `DCT` — is resolved to clean waypoints and never
+    /// sent verbatim (the server rejects those as "must be 2-5 alphanumeric").
+    ///
+    /// This mirrors the web save flow, which awaits `interpretAndConfirmRoute` and
+    /// aborts on failure rather than falling back to the raw input. Relying on the
+    /// debounced `resolveRoute()` alone is racy: a pilot who pastes a route and taps
+    /// Create before the debounce fires (or whose interpret call failed silently)
+    /// would otherwise submit the raw tokens.
+    func interpretRouteForSubmit() async -> RouteSubmitInterpretation {
+        let route = waypointsText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard waypoints.count >= 2 else {
+            errorMessage = "Enter at least two waypoints."
+            return .failed
+        }
+        isInterpreting = true
+        defer { isInterpreting = false }
+        do {
+            let result = try await repository.interpretRoute(rawRoute: route)
+            routeInterpretation = result
+            applyRouteTimeZones(from: result.waypoints)
+            guard result.interpreted.count >= 2 else {
+                errorMessage = "Couldn't resolve a route from \u{201C}\(route)\u{201D}. Check the waypoints and try again."
+                return .failed
+            }
+            if result.isClean {
+                applyInterpretedRoute()
+                return .ready
+            }
+            return .needsConfirmation
+        } catch {
+            errorMessage = "Couldn't interpret the route: \(error.localizedDescription)"
+            Self.logger.error("Route interpret failed at submit: \(error)")
+            return .failed
+        }
     }
 
     /// Resolve the typed route on the server: validates/normalises waypoints,

--- a/app/flyfun-weather/flyfun-weather/ViewModels/AddFlightViewModel.swift
+++ b/app/flyfun-weather/flyfun-weather/ViewModels/AddFlightViewModel.swift
@@ -83,6 +83,14 @@ final class AddFlightViewModel {
 
     // Submission
     var isSubmitting: Bool = false
+    /// True from the moment the pilot taps Create/Save until the whole submit
+    /// flow (interpret → optional confirm sheet → create/save) settles. Unlike
+    /// `isSubmitting`, this covers the new pre-submit interpret round trip, whose
+    /// `await` would otherwise leave the button tappable long enough for a
+    /// double-tap to launch a second, independent create. The view sets it
+    /// synchronously in `submit()` (before any suspension) and disables the
+    /// button on it, so the second tap is rejected before it can spawn work.
+    var isPreparingSubmit: Bool = false
     var errorMessage: String?
     /// Streamed progress message shown while regenerating the briefing (§4.4).
     var statusMessage: String?
@@ -143,10 +151,16 @@ final class AddFlightViewModel {
         waypoints.count >= 2 && !isSubmitting && (!isEditing || hasChanges)
     }
 
+    /// Whether the typed route differs from the flight being edited (case- and
+    /// spacing-insensitive). Single source for the three change gates below.
+    private func routeDiffers(from original: FlightResponse) -> Bool {
+        waypoints != original.waypoints.map { $0.uppercased() }
+    }
+
     /// Any edited field differs from the original (gates the Save button).
     var hasChanges: Bool {
         guard let original = editingFlight else { return true }
-        if waypoints != original.waypoints.map({ $0.uppercased() }) { return true }
+        if routeDiffers(from: original) { return true }
         if cruiseAltitudeFt != original.cruiseAltitudeFt { return true }
         if abs(flightDurationHours - original.flightDurationHours) > 0.01 { return true }
         if selectedAircraftId != original.aircraftId { return true }
@@ -164,7 +178,7 @@ final class AddFlightViewModel {
     /// there is no baseline, so this is always `true`.
     var routeChangedFromOriginal: Bool {
         guard let original = editingFlight else { return true }
-        return waypoints != original.waypoints.map { $0.uppercased() }
+        return routeDiffers(from: original)
     }
 
     /// Whether the edited alt-departure instant differs from the flight's stored
@@ -181,7 +195,7 @@ final class AddFlightViewModel {
     /// they save without the re-briefing confirm (§4.4).
     var hasForecastAffectingChange: Bool {
         guard let original = editingFlight else { return false }
-        if waypoints != original.waypoints.map({ $0.uppercased() }) { return true }
+        if routeDiffers(from: original) { return true }
         if cruiseAltitudeFt != original.cruiseAltitudeFt { return true }
         if abs(flightDurationHours - original.flightDurationHours) > 0.01 { return true }
         // A profile carries model/method choices, so changing it can change the
@@ -239,6 +253,11 @@ final class AddFlightViewModel {
     /// Create before the debounce fires (or whose interpret call failed silently)
     /// would otherwise submit the raw tokens.
     func interpretRouteForSubmit() async -> RouteSubmitInterpretation {
+        // Clear any banner from a prior failed attempt: only createFlight()/
+        // saveEditedFlight() reset it, and the `.needsConfirmation` path reaches
+        // neither, so a now-successful interpret would otherwise leave a stale
+        // "Couldn't interpret…" error showing behind the confirm sheet.
+        errorMessage = nil
         let route = waypointsText.trimmingCharacters(in: .whitespacesAndNewlines)
         guard waypoints.count >= 2 else {
             errorMessage = "Enter at least two waypoints."

--- a/app/flyfun-weather/flyfun-weather/Views/Flights/AddFlightView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Flights/AddFlightView.swift
@@ -65,7 +65,7 @@ struct AddFlightView: View {
                 }
                 ToolbarItem(placement: .confirmationAction) {
                     Button(viewModel.submitTitle) { submit() }
-                        .disabled(!viewModel.canSubmit)
+                        .disabled(!viewModel.canSubmit || viewModel.isPreparingSubmit)
                         .accessibilityIdentifier("submitFlightButton")
                 }
             }
@@ -129,7 +129,14 @@ struct AddFlightView: View {
                 // Run the submit only after the interpret sheet is fully gone, so
                 // the parent `dismiss()` on success isn't competing with the
                 // sheet's own dismissal (which would otherwise be dropped).
-                guard let context = runSubmitAfterInterpretDismiss else { return }
+                guard let context = runSubmitAfterInterpretDismiss else {
+                    // Dismissed without accepting (Cancel, or the read-only
+                    // preview). Release the submit guard if a confirmation flow
+                    // was holding it; harmless no-op for the preview path.
+                    interpretConfirmContext = nil
+                    viewModel.isPreparingSubmit = false
+                    return
+                }
                 runSubmitAfterInterpretDismiss = nil
                 interpretConfirmContext = nil
                 Task {
@@ -137,6 +144,7 @@ struct AddFlightView: View {
                     case .create: await performCreate()
                     case .edit: await continueEditAfterInterpret()
                     }
+                    viewModel.isPreparingSubmit = false
                 }
             }) {
                 RouteInterpretSheet(
@@ -162,6 +170,13 @@ struct AddFlightView: View {
     // MARK: - Submit
 
     private func submit() {
+        // Synchronous double-submit gate: `submit()` is the single entry from the
+        // toolbar button and runs on the main actor, so setting the flag here —
+        // before the first suspension in `prepare*` — atomically rejects a rapid
+        // second tap that would otherwise race through the new interpret phase and
+        // create a duplicate flight. Cleared at every terminal branch below.
+        guard !viewModel.isPreparingSubmit else { return }
+        viewModel.isPreparingSubmit = true
         Task { viewModel.isEditing ? await prepareEdit() : await prepareCreate() }
     }
 
@@ -173,11 +188,13 @@ struct AddFlightView: View {
         switch await viewModel.interpretRouteForSubmit() {
         case .ready:
             await performCreate()
+            viewModel.isPreparingSubmit = false
         case .needsConfirmation:
             interpretConfirmContext = .create
             showInterpretSheet = true
+            // Guard held through the confirm sheet; released in the sheet's onDismiss.
         case .failed:
-            break   // errorMessage is shown in the form
+            viewModel.isPreparingSubmit = false   // errorMessage is shown in the form
         }
     }
 
@@ -193,12 +210,14 @@ struct AddFlightView: View {
             case .needsConfirmation:
                 interpretConfirmContext = .edit
                 showInterpretSheet = true
-                return
+                return   // guard held; released in the sheet's onDismiss
             case .failed:
+                viewModel.isPreparingSubmit = false
                 return
             }
         }
         await continueEditAfterInterpret()
+        viewModel.isPreparingSubmit = false
     }
 
     /// Post-interpretation edit gate: only a forecast-affecting change triggers

--- a/app/flyfun-weather/flyfun-weather/Views/Flights/AddFlightView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Flights/AddFlightView.swift
@@ -12,16 +12,21 @@ struct AddFlightView: View {
     @State private var showRebriefConfirm = false
     @State private var showInterpretSheet = false
     @State private var showAutorouterSheet = false
-    /// True when the interpret sheet is shown as a pre-create confirmation
-    /// (because the route dropped tokens), so "Accept" proceeds to create.
-    @State private var confirmingInterpretBeforeCreate = false
-    /// Set when the pilot taps "Accept & Create" so the create runs from the
-    /// interpret sheet's `onDismiss` — i.e. only once that sheet is fully gone.
-    /// Dismissing the sheet and calling the parent `dismiss()` in the same turn
-    /// collides (SwiftUI drops the second transition), which left the form up
-    /// with the flight never appearing to be created. Sequencing via onDismiss
-    /// mirrors the web, which awaits the confirm modal's close before creating.
-    @State private var createAfterInterpretDismiss = false
+    /// Which submit a create/save flow is confirming through the interpret sheet.
+    /// `nil` means the sheet is the read-only preview opened by the "Interpret
+    /// route" button (no Accept button); `.create` / `.edit` add an Accept button
+    /// whose title matches the submit it will complete.
+    @State private var interpretConfirmContext: SubmitContext?
+    /// Set when the pilot taps Accept so the submit runs from the interpret
+    /// sheet's `onDismiss` — i.e. only once that sheet is fully gone. Dismissing
+    /// the sheet and calling the parent `dismiss()` in the same turn collides
+    /// (SwiftUI drops the second transition), which left the form up with the
+    /// flight never appearing to be created. Sequencing via onDismiss mirrors the
+    /// web, which awaits the confirm modal's close before submitting.
+    @State private var runSubmitAfterInterpretDismiss: SubmitContext?
+
+    /// Distinguishes the two submit paths that route through the interpret sheet.
+    private enum SubmitContext { case create, edit }
 
     /// Called with the created OR updated flight.
     let onCreated: (FlightResponse) -> Void
@@ -121,25 +126,31 @@ struct AddFlightView: View {
                 FlexibilityExplainer()
             }
             .sheet(isPresented: $showInterpretSheet, onDismiss: {
-                // Run the create only after the interpret sheet is fully gone, so
+                // Run the submit only after the interpret sheet is fully gone, so
                 // the parent `dismiss()` on success isn't competing with the
                 // sheet's own dismissal (which would otherwise be dropped).
-                guard createAfterInterpretDismiss else { return }
-                createAfterInterpretDismiss = false
-                Task { await performCreate() }
+                guard let context = runSubmitAfterInterpretDismiss else { return }
+                runSubmitAfterInterpretDismiss = nil
+                interpretConfirmContext = nil
+                Task {
+                    switch context {
+                    case .create: await performCreate()
+                    case .edit: await continueEditAfterInterpret()
+                    }
+                }
             }) {
                 RouteInterpretSheet(
                     interpretation: viewModel.routeInterpretation,
                     rawRoute: viewModel.waypointsText,
                     isResolving: viewModel.isInterpreting,
-                    acceptTitle: confirmingInterpretBeforeCreate ? "Accept & Create" : nil,
+                    acceptTitle: acceptTitle(for: interpretConfirmContext),
                     onAccept: {
                         // Adopt the server's understood route (airways/SIDs/speed
-                        // tokens dropped) before creating, matching the web — the
-                        // create request then carries the resolved waypoints the
-                        // pilot just confirmed, not the raw typed tokens.
+                        // tokens dropped) before submitting, matching the web — the
+                        // request then carries the resolved waypoints the pilot just
+                        // confirmed, not the raw typed tokens.
                         viewModel.applyInterpretedRoute()
-                        createAfterInterpretDismiss = true
+                        runSubmitAfterInterpretDismiss = interpretConfirmContext
                         showInterpretSheet = false
                     },
                     onResolve: { await viewModel.resolveRoute() }
@@ -151,21 +162,62 @@ struct AddFlightView: View {
     // MARK: - Submit
 
     private func submit() {
-        if viewModel.isEditing {
-            // Only a forecast-affecting change triggers the re-briefing cost
-            // confirm (§4.4); aircraft-only edits save silently.
-            if viewModel.hasForecastAffectingChange {
-                showRebriefConfirm = true
-            } else {
-                Task { await submitEdit(regenerate: false) }
-            }
-        } else if viewModel.routeHasDroppedTokens {
-            // The route dropped tokens — show the interpretation so the pilot can
-            // confirm what we understood before creating (mirrors the web).
-            confirmingInterpretBeforeCreate = true
+        Task { viewModel.isEditing ? await prepareEdit() : await prepareCreate() }
+    }
+
+    /// Interpret the route on the server before creating (mirrors the web save
+    /// gate), then create directly on a clean route or route through the confirm
+    /// sheet when the resolver dropped tokens. On interpret failure we abort with
+    /// the error shown in the form — never submit the raw Field-15 tokens.
+    private func prepareCreate() async {
+        switch await viewModel.interpretRouteForSubmit() {
+        case .ready:
+            await performCreate()
+        case .needsConfirmation:
+            interpretConfirmContext = .create
             showInterpretSheet = true
+        case .failed:
+            break   // errorMessage is shown in the form
+        }
+    }
+
+    /// The edit sibling of `prepareCreate`: interpret only when the route text
+    /// changed (an untouched route is already clean), then run the re-briefing
+    /// gate. A dropped-token route pauses on the confirm sheet, whose Accept
+    /// continues via `continueEditAfterInterpret`.
+    private func prepareEdit() async {
+        if viewModel.routeChangedFromOriginal {
+            switch await viewModel.interpretRouteForSubmit() {
+            case .ready:
+                break
+            case .needsConfirmation:
+                interpretConfirmContext = .edit
+                showInterpretSheet = true
+                return
+            case .failed:
+                return
+            }
+        }
+        await continueEditAfterInterpret()
+    }
+
+    /// Post-interpretation edit gate: only a forecast-affecting change triggers
+    /// the re-briefing cost confirm (§4.4); aircraft-only edits save silently.
+    private func continueEditAfterInterpret() async {
+        if viewModel.hasForecastAffectingChange {
+            showRebriefConfirm = true
         } else {
-            Task { await performCreate() }
+            await submitEdit(regenerate: false)
+        }
+    }
+
+    /// Accept-button title for the interpret sheet, matching the submit it will
+    /// complete. `nil` (the read-only preview) shows no Accept button.
+    private func acceptTitle(for context: SubmitContext?) -> String? {
+        switch context {
+        case .create: return "Accept & Create"
+        case .edit: return "Accept & Save"
+        case nil: return nil
         }
     }
 
@@ -346,7 +398,7 @@ struct AddFlightView: View {
 
             if viewModel.waypoints.count >= 2 {
                 Button {
-                    confirmingInterpretBeforeCreate = false
+                    interpretConfirmContext = nil
                     showInterpretSheet = true
                 } label: {
                     HStack {

--- a/app/flyfun-weather/flyfun-weatherTests/RouteCreateLogicTests.swift
+++ b/app/flyfun-weather/flyfun-weatherTests/RouteCreateLogicTests.swift
@@ -100,6 +100,99 @@ private func deviceDate(_ y: Int, _ m: Int, _ d: Int) -> Date {
 }
 
 @MainActor
+@Suite struct RouteSubmitInterpretationTests {
+    /// A Field-15 route with a speed/level token (`N0180VFR`) resolves cleanly
+    /// on the server (the token is silently dropped as syntax) → `.ready`, and
+    /// the field is rewritten to the interpreted waypoints so the raw token is
+    /// never submitted. This is the reported bug: without submit-time interpret,
+    /// `N0180VFR` reaches the server and is rejected as "must be 2-5 alphanumeric".
+    @Test func cleanRouteStripsFieldFifteenSyntaxAndIsReady() async {
+        let repo = MockBriefingRepository()
+        repo.interpretRouteResult = .success(makeInterpretResponse(interpreted: ["EGKA", "EGKB"]))
+        let vm = AddFlightViewModel(repository: repo)
+        vm.waypointsText = "EGKA N0180VFR EGKB"
+
+        let outcome = await vm.interpretRouteForSubmit()
+
+        #expect(outcome == .ready)
+        #expect(vm.waypoints == ["EGKA", "EGKB"])          // N0180VFR stripped
+        #expect(repo.lastInterpretRawRoute == "EGKA N0180VFR EGKB")
+    }
+
+    /// The created flight carries the interpreted waypoints, not the raw tokens —
+    /// end-to-end proof that the speed/level token never reaches `createFlight`.
+    @Test func createAfterInterpretSubmitsInterpretedWaypoints() async {
+        let repo = MockBriefingRepository()
+        repo.interpretRouteResult = .success(makeInterpretResponse(interpreted: ["EGKA", "EGKB"]))
+        repo.createFlightResult = .success(makeFlight(waypoints: ["EGKA", "EGKB"]))
+        let vm = AddFlightViewModel(repository: repo)
+        vm.waypointsText = "EGKA N0180VFR EGKB"
+
+        #expect(await vm.interpretRouteForSubmit() == .ready)
+        _ = await vm.createFlight()
+
+        #expect(repo.lastCreateRequest?.waypoints == ["EGKA", "EGKB"])
+    }
+
+    /// A route the resolver couldn't fully place (unknown token) defers to the
+    /// confirm sheet and leaves the raw field untouched so the sheet can show
+    /// exactly what the pilot typed vs. what was understood.
+    @Test func droppedTokenNeedsConfirmationAndKeepsRawField() async {
+        let repo = MockBriefingRepository()
+        repo.interpretRouteResult = .success(
+            makeInterpretResponse(interpreted: ["EGKA", "EGKB"], skipped: ["ZZZZ"])
+        )
+        let vm = AddFlightViewModel(repository: repo)
+        vm.waypointsText = "EGKA ZZZZ EGKB"
+
+        let outcome = await vm.interpretRouteForSubmit()
+
+        #expect(outcome == .needsConfirmation)
+        #expect(vm.waypointsText == "EGKA ZZZZ EGKB")      // raw kept for the sheet
+    }
+
+    /// A failed interpret (e.g. offline) aborts with an error rather than falling
+    /// back to submitting the raw tokens — matches the web, which aborts the save.
+    @Test func interpretFailureAbortsWithError() async {
+        let repo = MockBriefingRepository()
+        repo.interpretRouteResult = .failure(MockError.injected("offline"))
+        let vm = AddFlightViewModel(repository: repo)
+        vm.waypointsText = "EGKA EGKB"
+
+        let outcome = await vm.interpretRouteForSubmit()
+
+        #expect(outcome == .failed)
+        #expect(vm.errorMessage != nil)
+    }
+
+    /// A route resolving to fewer than two usable waypoints is a non-starter and
+    /// must abort — never send a one-point route to create.
+    @Test func fewerThanTwoResolvedWaypointsFails() async {
+        let repo = MockBriefingRepository()
+        repo.interpretRouteResult = .success(makeInterpretResponse(interpreted: ["EGKA"]))
+        let vm = AddFlightViewModel(repository: repo)
+        vm.waypointsText = "EGKA GARBAGE"
+
+        let outcome = await vm.interpretRouteForSubmit()
+
+        #expect(outcome == .failed)
+        #expect(vm.errorMessage != nil)
+    }
+
+    /// On edit, an untouched route needs no server round-trip (`routeChangedFromOriginal`
+    /// is false); a changed one does.
+    @Test func routeChangeDetectionGatesInterpretOnEdit() {
+        let repo = MockBriefingRepository()
+        let flight = makeFlight(waypoints: ["LFMD", "LFML"])
+        let vm = AddFlightViewModel(repository: repo, flight: flight)
+        #expect(vm.routeChangedFromOriginal == false)      // seeded verbatim
+
+        vm.waypointsText = "LFMD LFMT LFML"
+        #expect(vm.routeChangedFromOriginal == true)
+    }
+}
+
+@MainActor
 @Suite struct RouteAutocompleteTests {
     @Test func lastTokenIsTheTrailingIdentifier() {
         #expect(RouteAutocompleteController.lastToken(in: "EGTF LFQ") == "LFQ")

--- a/app/flyfun-weather/flyfun-weatherTests/RouteCreateLogicTests.swift
+++ b/app/flyfun-weather/flyfun-weatherTests/RouteCreateLogicTests.swift
@@ -151,6 +151,25 @@ private func deviceDate(_ y: Int, _ m: Int, _ d: Int) -> Date {
         #expect(vm.waypointsText == "EGKA ZZZZ EGKB")      // raw kept for the sheet
     }
 
+    /// A retry that now interprets successfully must clear a prior failure's
+    /// banner even on the `.needsConfirmation` path, which never reaches
+    /// `createFlight()` where `errorMessage` is otherwise reset — otherwise a
+    /// stale "Couldn't interpret…" error lingers behind the confirm sheet.
+    @Test func interpretClearsStaleErrorOnNeedsConfirmation() async {
+        let repo = MockBriefingRepository()
+        repo.interpretRouteResult = .success(
+            makeInterpretResponse(interpreted: ["EGKA", "EGKB"], skipped: ["ZZZZ"])
+        )
+        let vm = AddFlightViewModel(repository: repo)
+        vm.errorMessage = "Couldn't interpret the route: offline"
+        vm.waypointsText = "EGKA ZZZZ EGKB"
+
+        let outcome = await vm.interpretRouteForSubmit()
+
+        #expect(outcome == .needsConfirmation)
+        #expect(vm.errorMessage == nil)
+    }
+
     /// A failed interpret (e.g. offline) aborts with an error rather than falling
     /// back to submitting the raw tokens — matches the web, which aborts the save.
     @Test func interpretFailureAbortsWithError() async {

--- a/app/flyfun-weather/flyfun-weatherTests/TestSupport.swift
+++ b/app/flyfun-weather/flyfun-weatherTests/TestSupport.swift
@@ -39,12 +39,16 @@ final class MockBriefingRepository: BriefingRepository, @unchecked Sendable {
     var aircraftResult: Result<[AircraftResponse], Error> = .success([])
     var createFlightResult: Result<FlightResponse, Error> = .failure(MockError.notStubbed("createFlight"))
     var updateFlightResult: Result<UpdateFlightResponse, Error> = .failure(MockError.notStubbed("updateFlight"))
+    var interpretRouteResult: Result<InterpretRouteResponse, Error> = .failure(MockError.notStubbed("interpretRoute"))
     var submitPirepsBatchResult: Result<[PirepResponse], Error> = .success([PirepResponse.offline])
 
     // Call counters + captured args for behaviour assertions.
     private(set) var flightsCallCount = 0
     private(set) var submitPirepsBatchCallCount = 0
+    private(set) var interpretRouteCallCount = 0
     private(set) var lastUpdateRequest: UpdateFlightRequest?
+    private(set) var lastCreateRequest: CreateFlightRequest?
+    private(set) var lastInterpretRawRoute: String?
 
     /// Optional hook awaited *inside* `flights()` before it returns — lets a test
     /// gate the network so it can observe intermediate ViewModel state (e.g. the
@@ -56,7 +60,10 @@ final class MockBriefingRepository: BriefingRepository, @unchecked Sendable {
         if let hook = beforeFlightsReturn { await hook() }
         return try flightsResult.get()
     }
-    func createFlight(_ request: CreateFlightRequest) async throws -> FlightResponse { try createFlightResult.get() }
+    func createFlight(_ request: CreateFlightRequest) async throws -> FlightResponse {
+        lastCreateRequest = request
+        return try createFlightResult.get()
+    }
     func updateFlight(flightId: String, request: UpdateFlightRequest) async throws -> UpdateFlightResponse {
         lastUpdateRequest = request
         return try updateFlightResult.get()
@@ -66,7 +73,11 @@ final class MockBriefingRepository: BriefingRepository, @unchecked Sendable {
     func usageSummary() async throws -> UsageSummaryResponse {
         try JSONDecoder.weatherBrief.decode(UsageSummaryResponse.self, from: Data("{}".utf8))
     }
-    func interpretRoute(rawRoute: String) async throws -> InterpretRouteResponse { throw MockError.notStubbed("interpretRoute") }
+    func interpretRoute(rawRoute: String) async throws -> InterpretRouteResponse {
+        interpretRouteCallCount += 1
+        lastInterpretRawRoute = rawRoute
+        return try interpretRouteResult.get()
+    }
     func routeDistance(waypoints: [String]) async throws -> RouteDistanceResponse { throw MockError.notStubbed("routeDistance") }
     func autorouterRoutes(limit: Int) async throws -> [AutorouterRoute] { [] }
     func searchAircraftTypes(_ query: String) async throws -> [AircraftTypeResponse] { throw MockError.notStubbed("searchAircraftTypes") }
@@ -151,6 +162,34 @@ func makeUpdateResponse(
     obj["invalidation"] = invalidation.rawValue
     let data = try JSONSerialization.data(withJSONObject: obj)
     return try JSONDecoder.weatherBrief.decode(UpdateFlightResponse.self, from: data)
+}
+
+/// Build an `InterpretRouteResponse` fixture for stubbing
+/// `MockBriefingRepository.interpretRouteResult`. Defaults to a clean 2-point
+/// route (nothing skipped / off-route); pass `skipped` / `offRoute` to model a
+/// route the resolver dropped tokens from.
+func makeInterpretResponse(
+    interpreted: [String] = ["LFMD", "LFML"],
+    skipped: [String] = [],
+    offRoute: [String] = [],
+    originalTokens: [String]? = nil
+) -> InterpretRouteResponse {
+    let waypoints = interpreted.enumerated().map { idx, icao in
+        RouteWaypointInfo(
+            icao: icao,
+            name: icao,
+            lat: 43.0 + Double(idx),
+            lon: 6.0 + Double(idx),
+            timezone: "Europe/Paris"
+        )
+    }
+    return InterpretRouteResponse(
+        originalTokens: originalTokens ?? (interpreted + skipped + offRoute),
+        interpreted: interpreted,
+        skipped: skipped,
+        offRoute: offRoute,
+        waypoints: waypoints
+    )
 }
 
 func makePirepRequest(remarks: String = "test") -> SubmitPirepRequest {


### PR DESCRIPTION
## Problem

Creating a flight on iOS from an ICAO Field-15 route (e.g. one containing a speed/level+rules token like `N0180VFR`) could fail with **"Invalid waypoint 'N0180VFR': must be 2-5 alphanumeric characters"**.

Both clients already share the same server-side parser (`POST /api/flights/interpret-route` → `parse_field15` + `resolve_waypoints`) — there is **no** on-device Swift parser. The divergence was purely in the iOS **submit workflow**.

The server has a deliberate two-stage design:
1. **Smart, context-aware interpretation** (`/interpret-route`) — `parse_field15` drops flight-plan syntax (speed/level, `DCT`, airway labels, SIDs) by grammar; `resolve_waypoints` places the survivors using full route context (departure/destination anchoring + detour filtering, needs ≥2 points).
2. **Dumb per-token guardrail** (`WAYPOINT_RE = ^[A-Z0-9]{2,5}$` in `CreateFlightRequest.validate_waypoints`) — a context-free backstop meant only for already-cleaned codes.

The **web** always awaits stage 1 at submit (`interpretAndConfirmRoute`) and aborts on failure, so raw syntax never reaches stage 2. **iOS** only ran stage 1 best-effort via the debounced `resolveRoute()`. If the pilot pasted a route and tapped **Create** before the 500 ms debounce + network round-trip finished (or if `resolveRoute()` failed silently), `routeInterpretation` was `nil`, `routeHasDroppedTokens` was `false`, and the form submitted the **raw** `waypoints` straight to the strict validator.

So it wasn't the wrong function or a bad triage — it was a sequencing bug: the context-aware step wasn't guaranteed to run before submit.

## Fix

Mirror the web: always run interpretation at submit time.

- **`AddFlightViewModel.interpretRouteForSubmit()`** — interprets on the server at submit and returns `ready` / `needsConfirmation` / `failed`. Clean routes auto-apply the interpreted waypoints; dropped-token routes defer to the confirm sheet; failures set `errorMessage` and abort — raw tokens are never submitted.
- **`AddFlightView.submit()`** — restructured to interpret before both create and edit (edit only when the route text changed), routing confirmation through the existing `RouteInterpretSheet` via a shared create/edit continuation.
- **`AddFlightViewModel.routeChangedFromOriginal`** — gates the edit-path round-trip so an untouched route needs no interpret call.

## Tests

- `MockBriefingRepository` now stubs `interpretRoute` and captures the create request.
- `RouteSubmitInterpretationTests` covers: clean route strips Field-15 syntax and is `ready`; the created flight carries interpreted (not raw) waypoints; dropped tokens defer to confirmation and keep the raw field; interpret failure and `<2` resolved waypoints both abort with an error; edit-path route-change gating.

> Note: this is an iOS target, so the new Swift tests could not be compiled/run in the CI-less Linux environment they were written in — they follow the existing patterns in the file but should be built in Xcode to confirm green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UJRLqEEkRpDzQs9ZMkgeCX)_