### PR TITLE
iOS: seamless sync to latest online pack + live refreshing indicator

### DIFF
--- a/app/flyfun-weather/flyfun-weather/App/AppState.swift
+++ b/app/flyfun-weather/flyfun-weather/App/AppState.swift
@@ -72,6 +72,28 @@ final class AppState {
     /// the bundled baseline at init; refreshed opportunistically when online.
     let helpCatalog = HelpCatalogStore()
 
+    /// External "server data changed" nudge (e.g. a refresh push). The flight list
+    /// and any open briefing observe this and re-sync to the newest online pack —
+    /// push is just one more sync trigger, not a special path. `token` makes every
+    /// signal distinct (so back-to-back nudges each fire); `flightId` carries the
+    /// affected flight when known. Bump via `signalExternalSync`.
+    private(set) var externalSync = ExternalSyncSignal(token: 0, flightId: nil)
+
+    /// A distinct, observable data-sync nudge. `Equatable` so SwiftUI `onChange`
+    /// fires once per signal.
+    struct ExternalSyncSignal: Equatable {
+        var token: Int
+        var flightId: String?
+    }
+
+    /// Request a seamless re-sync of the visible flight list / open briefing to
+    /// the latest online pack. Cheap by design — the observers no-op when nothing
+    /// changed. `flightId` is the affected flight when the trigger names one
+    /// (briefing push), else nil (e.g. a silent badge-sync).
+    func signalExternalSync(flightId: String?) {
+        externalSync = ExternalSyncSignal(token: externalSync.token &+ 1, flightId: flightId)
+    }
+
     /// Weak handle to the live instance so a foregrounding App Intent can trigger
     /// `consumePendingNavigation()` immediately when the app process is already
     /// alive (warm foreground / already-active). Nil on a cold launch — the scene

--- a/app/flyfun-weather/flyfun-weather/AppIntents/PendingNavigation.swift
+++ b/app/flyfun-weather/flyfun-weather/AppIntents/PendingNavigation.swift
@@ -9,6 +9,12 @@ enum PendingNavigation: Equatable, Sendable {
     case flightList
     /// Open a specific flight's briefing by id.
     case briefing(flightId: String)
+
+    /// The target flight id, when this navigation names one.
+    var flightId: String? {
+        if case .briefing(let id) = self { return id }
+        return nil
+    }
 }
 
 /// Cold-launch-safe hand-off for a `PendingNavigation`.

--- a/app/flyfun-weather/flyfun-weather/Models/API/ActiveRefreshResponse.swift
+++ b/app/flyfun-weather/flyfun-weather/Models/API/ActiveRefreshResponse.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+/// One entry from `GET /api/refresh/active` — a flight whose briefing is
+/// currently queued or refreshing on the server. Drives the live "Updating…"
+/// indicator on the flight-list row, mirroring the web's poll of the same
+/// endpoint. Property names rely on the shared decoder's `.convertFromSnakeCase`
+/// strategy; extra fields on the server payload are ignored.
+struct ActiveRefreshResponse: Codable, Sendable {
+    let flightId: String
+    /// "queued" | "refreshing".
+    let status: String?
+    let stage: String?
+    let detail: String?
+}

--- a/app/flyfun-weather/flyfun-weather/Models/API/PackMetaResponse.swift
+++ b/app/flyfun-weather/flyfun-weather/Models/API/PackMetaResponse.swift
@@ -11,6 +11,12 @@ struct PackMetaResponse: Codable, Sendable {
     let hasAdvisories: Bool
     let assessment: String?
     let assessmentReason: String?
+    /// Long-range early outlook (beyond the GRIB horizon), mutually exclusive
+    /// with `assessment` — a tendency ("what to expect"), not a verdict. Present
+    /// on far-out packs where no short-range assessment exists yet; the Advisory
+    /// hero falls back to it so a long-range briefing still shows a summary.
+    let outlook: String?
+    let outlookReason: String?
     let modelInitTimes: [String: Int]
     let gribInitTimes: [String: Int]
     let modelsSkippedRegion: [String]

--- a/app/flyfun-weather/flyfun-weather/Services/APIClient.swift
+++ b/app/flyfun-weather/flyfun-weather/Services/APIClient.swift
@@ -164,9 +164,11 @@ actor APIClient {
 
     // MARK: - Generic request methods
 
-    /// Fetch and decode a JSON response.
-    func request<T: Decodable>(_ path: String, method: String = "GET", body: Data? = nil) async throws -> T {
-        let data = try await requestData(path, method: method, body: body)
+    /// Fetch and decode a JSON response. `quietLog` suppresses the per-request log
+    /// line for high-frequency background polls (e.g. `/api/refresh/active` every
+    /// 5s) so they don't flood the console.
+    func request<T: Decodable>(_ path: String, method: String = "GET", body: Data? = nil, quietLog: Bool = false) async throws -> T {
+        let data = try await requestData(path, method: method, body: body, quietLog: quietLog)
         do {
             return try JSONDecoder.weatherBrief.decode(T.self, from: data)
         } catch {
@@ -251,9 +253,9 @@ actor APIClient {
     }
 
     /// Fetch raw data (for images, file downloads).
-    func requestData(_ path: String, method: String = "GET", body: Data? = nil) async throws -> Data {
+    func requestData(_ path: String, method: String = "GET", body: Data? = nil, quietLog: Bool = false) async throws -> Data {
         let url = baseURL.appendingPathComponent(path)
-        return try await _fetch(url: url, method: method, body: body, label: path)
+        return try await _fetch(url: url, method: method, body: body, label: path, quietLog: quietLog)
     }
 
     /// Fetch raw data while reporting transfer progress as bytes arrive.
@@ -293,7 +295,7 @@ actor APIClient {
         }
     }
 
-    private func _fetch(url: URL, method: String, body: Data?, label: String) async throws -> Data {
+    private func _fetch(url: URL, method: String, body: Data?, label: String, quietLog: Bool = false) async throws -> Data {
         var request = URLRequest(url: url)
         request.httpMethod = method
         if let body {
@@ -301,7 +303,7 @@ actor APIClient {
             request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         }
 
-        Self.logger.debug("\(method) \(label)")
+        if !quietLog { Self.logger.debug("\(method) \(label)") }
 
         let data: Data
         let http: HTTPURLResponse

--- a/app/flyfun-weather/flyfun-weather/Services/BriefingRepository.swift
+++ b/app/flyfun-weather/flyfun-weather/Services/BriefingRepository.swift
@@ -213,7 +213,9 @@ final class OnlineBriefingRepository: BriefingRepository {
     }
 
     func activeRefreshes() async throws -> [ActiveRefreshResponse] {
-        try await client.request("/api/refresh/active")
+        // Polled every 5s while the list is visible — suppress its request log
+        // so it doesn't flood the console.
+        try await client.request("/api/refresh/active", quietLog: true)
     }
 
     func submitPirep(_ request: SubmitPirepRequest) async throws -> PirepResponse {

--- a/app/flyfun-weather/flyfun-weather/Services/BriefingRepository.swift
+++ b/app/flyfun-weather/flyfun-weather/Services/BriefingRepository.swift
@@ -44,6 +44,9 @@ protocol BriefingRepository: Sendable {
     func soundingProfile(flightId: String, timestamp: String, pointIndex: Int, model: String) async throws -> SoundingProfileResponse
     func refreshStream(flightId: String) async -> AsyncThrowingStream<RefreshEvent, Error>
     func refreshStatus(flightId: String) async throws -> RefreshStatusResponse
+    /// Flights whose briefing is currently queued/refreshing server-side, for the
+    /// live flight-list "Updating…" indicator. Online-only.
+    func activeRefreshes() async throws -> [ActiveRefreshResponse]
 
     // PIREP
     func submitPirep(_ request: SubmitPirepRequest) async throws -> PirepResponse
@@ -207,6 +210,10 @@ final class OnlineBriefingRepository: BriefingRepository {
 
     func refreshStatus(flightId: String) async throws -> RefreshStatusResponse {
         try await client.request("/api/flights/\(flightId)/packs/refresh/status")
+    }
+
+    func activeRefreshes() async throws -> [ActiveRefreshResponse] {
+        try await client.request("/api/refresh/active")
     }
 
     func submitPirep(_ request: SubmitPirepRequest) async throws -> PirepResponse {

--- a/app/flyfun-weather/flyfun-weather/Services/CachingBriefingRepository.swift
+++ b/app/flyfun-weather/flyfun-weather/Services/CachingBriefingRepository.swift
@@ -211,6 +211,11 @@ final class CachingBriefingRepository: BriefingRepository, CacheStatusReporting 
         try await online.refreshStatus(flightId: flightId)
     }
 
+    func activeRefreshes() async throws -> [ActiveRefreshResponse] {
+        // Online-only — a live "which briefings are refreshing" query is never cached.
+        try await online.activeRefreshes()
+    }
+
     func submitPirep(_ request: SubmitPirepRequest) async throws -> PirepResponse {
         try await online.submitPirep(request)
     }

--- a/app/flyfun-weather/flyfun-weather/Services/FixtureBriefingRepository.swift
+++ b/app/flyfun-weather/flyfun-weather/Services/FixtureBriefingRepository.swift
@@ -167,6 +167,7 @@ final class FixtureBriefingRepository: BriefingRepository, CacheStatusReporting 
     func grametImage(flightId: String, timestamp: String) async throws -> Data { throw FixtureError.notProvided("grametImage") }
     func soundingProfile(flightId: String, timestamp: String, pointIndex: Int, model: String) async throws -> SoundingProfileResponse { throw FixtureError.notProvided("soundingProfile") }
     func refreshStatus(flightId: String) async throws -> RefreshStatusResponse { throw FixtureError.notProvided("refreshStatus") }
+    func activeRefreshes() async throws -> [ActiveRefreshResponse] { [] }
     func submitPirep(_ request: SubmitPirepRequest) async throws -> PirepResponse { throw FixtureError.notProvided("submitPirep") }
     func submitPirepsBatch(_ requests: [SubmitPirepRequest]) async throws -> [PirepResponse] { throw FixtureError.notProvided("submitPirepsBatch") }
 }

--- a/app/flyfun-weather/flyfun-weather/Services/PushNotifications.swift
+++ b/app/flyfun-weather/flyfun-weather/Services/PushNotifications.swift
@@ -83,6 +83,11 @@ final class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCent
     ) {
         Task { @MainActor in
             await AppState.current?.reconcileBadge()
+            // A refresh push means the server's data changed — nudge the visible
+            // list / open briefing to re-sync to the newest online pack (a silent
+            // badge-sync carries no flight_id, which is fine: the sync no-ops when
+            // nothing changed).
+            AppState.current?.signalExternalSync(flightId: PushSupport.pendingNavigation(from: userInfo)?.flightId)
             completionHandler(.newData)
         }
     }
@@ -96,7 +101,13 @@ final class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCent
         _ center: UNUserNotificationCenter,
         willPresent notification: UNNotification
     ) async -> UNNotificationPresentationOptions {
-        Task { @MainActor in await AppState.current?.reconcileBadge() }
+        let userInfo = notification.request.content.userInfo
+        Task { @MainActor in
+            await AppState.current?.reconcileBadge()
+            // Foregrounded when a refresh landed → re-sync the visible data so the
+            // suppressed banner still results in fresh content on screen.
+            AppState.current?.signalExternalSync(flightId: PushSupport.pendingNavigation(from: userInfo)?.flightId)
+        }
         return []
     }
 

--- a/app/flyfun-weather/flyfun-weather/ViewModels/BriefingViewModel.swift
+++ b/app/flyfun-weather/flyfun-weather/ViewModels/BriefingViewModel.swift
@@ -239,6 +239,14 @@ final class BriefingViewModel {
         // generation is in flight, its completion installs the newer pack itself.
         // `isSyncing` collapses overlapping triggers (e.g. foreground + push).
         guard flight.coverage == nil, !refreshState.isRefreshing, !isSyncing else { return }
+        // Don't yank the pilot off a pack they deliberately picked from the history
+        // menu: only auto-sync when the pack on screen is the latest one we know
+        // about. A brand-new server pack isn't in `packHistory` yet, so a viewer on
+        // the current latest still passes and the newer pack is allowed to adopt.
+        guard Self.isViewingLatestPack(current: pack?.fetchTimestamp, history: packHistory) else {
+            Self.logger.debug("syncLatestPack: viewing a historical pack — skipping auto-sync")
+            return
+        }
         isSyncing = true
         defer { isSyncing = false }
         let latest: PackMetaResponse
@@ -252,6 +260,21 @@ final class BriefingViewModel {
         guard latest.fetchTimestamp != pack?.fetchTimestamp else { return }
         Self.logger.info("syncLatestPack: newer pack \(latest.fetchTimestamp) available — adopting")
         await applyPack(latest, quiet: true)
+    }
+
+    /// Whether the pack on screen is the newest one the app knows about — the
+    /// gate for an automatic sync. False when the pilot has deliberately selected
+    /// an older pack from history (auto-sync must not replace it). Pure + static
+    /// so the timestamp comparison is unit-testable. A brand-new server pack isn't
+    /// in `history` yet, so a viewer on the current latest still counts as
+    /// "latest" and the newer pack is allowed to adopt. Parses to `Date` rather
+    /// than comparing ISO strings so fractional seconds can't misorder.
+    static func isViewingLatestPack(current: String?, history: [PackMetaResponse]) -> Bool {
+        guard let current, let currentDate = Date.parseISO8601(current) else { return true }
+        guard let newest = history.compactMap({ Date.parseISO8601($0.fetchTimestamp) }).max() else {
+            return true   // history not loaded yet — don't block the first sync
+        }
+        return currentDate >= newest
     }
 
     /// Adopt `newPack` as the active pack and (re)load its data + history. The
@@ -796,17 +819,25 @@ final class BriefingViewModel {
 
     // MARK: - Section loaders
 
-    // Section loaders share a `quiet` convention: a quiet reload (seamless sync)
-    // keeps the current data on screen — it only shows the spinner when there's
-    // nothing loaded yet, and keeps the old data (not an error wall) if the quiet
-    // fetch fails. A normal (non-quiet) load shows spinner/error as before.
+    // Section loaders share two conventions:
+    //  - `quiet` (seamless sync): keep current data on screen — only show the
+    //    spinner when nothing is loaded yet, and keep old data (not an error wall)
+    //    if a quiet fetch fails. A normal load shows spinner/error as before.
+    //  - stale-guard: after the await, only apply the result if `pack` still points
+    //    at `timestamp`. A concurrent sync / refresh / history-pick may have swapped
+    //    the active pack while this load was in flight; without the guard a late
+    //    result would paint one pack's data under another pack's hero/toolbar.
+    //    Mirrors `pollTimeOptions`' `pack?.fetchTimestamp == timestamp` check.
 
     private func loadAdvisories(timestamp: String, quiet: Bool = false) async {
         if !quiet || !advisoriesState.hasData { advisoriesState = .loading }
         do {
-            advisoriesState = .loaded(try await repository.advisories(flightId: flight.id, timestamp: timestamp))
+            let result = try await repository.advisories(flightId: flight.id, timestamp: timestamp)
+            guard pack?.fetchTimestamp == timestamp else { return }
+            advisoriesState = .loaded(result)
         } catch {
             Self.logger.error("Failed to load advisories: \(error)")
+            guard pack?.fetchTimestamp == timestamp else { return }
             if !quiet || !advisoriesState.hasData { advisoriesState = .error(error) }
         }
     }
@@ -814,9 +845,12 @@ final class BriefingViewModel {
     private func loadDigest(timestamp: String, quiet: Bool = false) async {
         if !quiet || !digestState.hasData { digestState = .loading }
         do {
-            digestState = .loaded(try await repository.digest(flightId: flight.id, timestamp: timestamp))
+            let result = try await repository.digest(flightId: flight.id, timestamp: timestamp)
+            guard pack?.fetchTimestamp == timestamp else { return }
+            digestState = .loaded(result)
         } catch {
             Self.logger.error("Failed to load digest: \(error)")
+            guard pack?.fetchTimestamp == timestamp else { return }
             if !quiet || !digestState.hasData { digestState = .error(error) }
         }
     }
@@ -824,9 +858,12 @@ final class BriefingViewModel {
     private func loadSnapshot(timestamp: String, quiet: Bool = false) async {
         if !quiet || !snapshotState.hasData { snapshotState = .loading }
         do {
-            snapshotState = .loaded(try await repository.snapshot(flightId: flight.id, timestamp: timestamp))
+            let result = try await repository.snapshot(flightId: flight.id, timestamp: timestamp)
+            guard pack?.fetchTimestamp == timestamp else { return }
+            snapshotState = .loaded(result)
         } catch {
             Self.logger.error("Failed to load snapshot: \(error)")
+            guard pack?.fetchTimestamp == timestamp else { return }
             if !quiet || !snapshotState.hasData { snapshotState = .error(error) }
         }
     }
@@ -835,6 +872,7 @@ final class BriefingViewModel {
         if !quiet || !routeAnalysesState.hasData { routeAnalysesState = .loading }
         do {
             let response = try await repository.routeAnalyses(flightId: flight.id, timestamp: timestamp)
+            guard pack?.fetchTimestamp == timestamp else { return }
             routeAnalysesState = .loaded(response)
             if !response.models.isEmpty {
                 let raModels = response.models.sorted()
@@ -846,6 +884,7 @@ final class BriefingViewModel {
             }
         } catch {
             Self.logger.error("Failed to load route analyses: \(error)")
+            guard pack?.fetchTimestamp == timestamp else { return }
             if !quiet || !routeAnalysesState.hasData { routeAnalysesState = .error(error) }
         }
     }
@@ -853,9 +892,12 @@ final class BriefingViewModel {
     private func loadElevation(timestamp: String, quiet: Bool = false) async {
         if !quiet || !elevationState.hasData { elevationState = .loading }
         do {
-            elevationState = .loaded(try await repository.elevation(flightId: flight.id, timestamp: timestamp))
+            let result = try await repository.elevation(flightId: flight.id, timestamp: timestamp)
+            guard pack?.fetchTimestamp == timestamp else { return }
+            elevationState = .loaded(result)
         } catch {
             Self.logger.error("Failed to load elevation: \(error)")
+            guard pack?.fetchTimestamp == timestamp else { return }
             if !quiet || !elevationState.hasData { elevationState = .error(error) }
         }
     }

--- a/app/flyfun-weather/flyfun-weather/ViewModels/BriefingViewModel.swift
+++ b/app/flyfun-weather/flyfun-weather/ViewModels/BriefingViewModel.swift
@@ -110,6 +110,9 @@ final class BriefingViewModel {
 
     // Refresh state
     private(set) var refreshState: RefreshState = .idle
+    /// Guards against overlapping `syncLatestPack()` runs when several triggers
+    /// fire close together (e.g. foreground + push). Non-observed — internal only.
+    @ObservationIgnored private var isSyncing = false
 
     // Download/cache state
     private(set) var downloadState: DownloadState = .notDownloaded
@@ -203,17 +206,8 @@ final class BriefingViewModel {
             return
         }
         do {
-            let pack = try await repository.latestPack(flightId: flight.id)
-            self.pack = pack
-            self.selectedPackTimestamp = pack.fetchTimestamp
-            updateModels(from: pack)
-
-            // Load pack history in parallel with data
-            async let historyTask: () = loadPackHistory()
-            async let dataTask: () = loadPackData(timestamp: pack.fetchTimestamp)
-            _ = await (historyTask, dataTask)
-            await checkCacheStatus()
-            await maybeAutoDownloadLatest()
+            let latest = try await repository.latestPack(flightId: flight.id)
+            await applyPack(latest)
         } catch APIError.notFound {
             // No briefing pack exists yet — this is the normal state right after a
             // flight is created (POST /api/flights only saves the flight; it does
@@ -227,6 +221,60 @@ final class BriefingViewModel {
             digestState = .error(error)
             snapshotState = .error(error)
         }
+    }
+
+    /// Seamlessly adopt the newest *already-generated* pack from the server
+    /// **without** starting a new briefing generation — the cheap "sync" that
+    /// mirrors what's live on the website. This is distinct from `refresh()`,
+    /// which runs the full pipeline to produce a *new* pack.
+    ///
+    /// A single `latestPack()` request that **no-ops when the timestamp is
+    /// unchanged** (the common case), so it's safe — and intended — to call from
+    /// many triggers: opening the briefing, pull-to-refresh, returning to the
+    /// foreground, and a refresh push. Best-effort: on any failure the current
+    /// pack stays on screen. The reload runs `quiet` so an update swaps in place
+    /// instead of flashing the sections back to spinners.
+    func syncLatestPack() async {
+        // Nothing to sync for a pending-coverage flight (no pack yet). While a
+        // generation is in flight, its completion installs the newer pack itself.
+        // `isSyncing` collapses overlapping triggers (e.g. foreground + push).
+        guard flight.coverage == nil, !refreshState.isRefreshing, !isSyncing else { return }
+        isSyncing = true
+        defer { isSyncing = false }
+        let latest: PackMetaResponse
+        do {
+            latest = try await repository.latestPack(flightId: flight.id)
+        } catch {
+            Self.logger.debug("syncLatestPack: latestPack fetch failed, keeping current pack: \(error)")
+            return
+        }
+        // Already showing the newest pack — seamless no-op (the frequent case).
+        guard latest.fetchTimestamp != pack?.fetchTimestamp else { return }
+        Self.logger.info("syncLatestPack: newer pack \(latest.fetchTimestamp) available — adopting")
+        await applyPack(latest, quiet: true)
+    }
+
+    /// Adopt `newPack` as the active pack and (re)load its data + history. The
+    /// single swap path shared by the initial load, refresh/poll completion, and
+    /// the seamless `syncLatestPack()`, so the logic can't drift across them.
+    ///
+    /// `quiet` keeps already-loaded sections on screen while the replacement
+    /// streams in (sync uses it, so picking up a newer online pack never flashes
+    /// the briefing back to spinners). A first load — with no data yet — still
+    /// shows spinners even when `quiet`, because the section loaders only suppress
+    /// the spinner when they already hold data.
+    private func applyPack(_ newPack: PackMetaResponse, quiet: Bool = false) async {
+        pack = newPack
+        // `packHistory` is still the previous pack's list here, so the
+        // `selectedPackTimestamp` didSet can't find `newPack` and won't kick a
+        // duplicate load — we load explicitly below, and refresh history alongside.
+        selectedPackTimestamp = newPack.fetchTimestamp
+        updateModels(from: newPack)
+        async let historyTask: () = loadPackHistory()
+        async let dataTask: () = loadPackData(timestamp: newPack.fetchTimestamp, quiet: quiet)
+        _ = await (historyTask, dataTask)
+        await checkCacheStatus()
+        await maybeAutoDownloadLatest()
     }
 
     /// Generate the briefing for a flight that has no pack yet (e.g. just created).
@@ -443,13 +491,7 @@ final class BriefingViewModel {
                         refreshState = .completed(elapsedSeconds: event.elapsedSeconds ?? 0)
                     }
                     if let newPack = event.pack {
-                        pack = newPack
-                        selectedPackTimestamp = newPack.fetchTimestamp
-                        updateModels(from: newPack)
-                        await loadPackHistory()
-                        await loadPackData(timestamp: newPack.fetchTimestamp)
-                        await checkCacheStatus()
-                        await maybeAutoDownloadLatest()
+                        await applyPack(newPack)
                     }
                     // Clear the transient banner after a delay.
                     try? await Task.sleep(for: .seconds(10))
@@ -514,19 +556,12 @@ final class BriefingViewModel {
                 let status = try await repository.refreshStatus(flightId: flight.id)
                 if !status.active {
                     refreshState = .completed(elapsedSeconds: 0)
-                    // Reload data
-                    let pack = try await repository.latestPack(flightId: flight.id)
-                    self.pack = pack
-                    selectedPackTimestamp = pack.fetchTimestamp
-                    updateModels(from: pack)
-                    await loadPackHistory()
-                    await loadPackData(timestamp: pack.fetchTimestamp)
-                    // A refresh started elsewhere (web/another device) still
-                    // produces a new pack here — mirror refresh()'s completion
-                    // path so an opted-in pilot gets it auto-downloaded for
-                    // offline use, instead of only on the next screen entry.
-                    await checkCacheStatus()
-                    await maybeAutoDownloadLatest()
+                    // Reload data. A refresh started elsewhere (web/another device)
+                    // still produces a new pack here — `applyPack` mirrors
+                    // refresh()'s completion path, so an opted-in pilot gets it
+                    // auto-downloaded for offline use, not only on the next entry.
+                    let latest = try await repository.latestPack(flightId: flight.id)
+                    await applyPack(latest)
                     try? await Task.sleep(for: .seconds(10))
                     if case .completed = refreshState {
                         refreshState = .idle
@@ -546,13 +581,13 @@ final class BriefingViewModel {
 
     // MARK: - Data loading
 
-    private func loadPackData(timestamp: String) async {
+    private func loadPackData(timestamp: String, quiet: Bool = false) async {
         await withTaskGroup(of: Void.self) { group in
-            group.addTask { await self.loadAdvisories(timestamp: timestamp) }
-            group.addTask { await self.loadDigest(timestamp: timestamp) }
-            group.addTask { await self.loadSnapshot(timestamp: timestamp) }
-            group.addTask { await self.loadRouteAnalyses(timestamp: timestamp) }
-            group.addTask { await self.loadElevation(timestamp: timestamp) }
+            group.addTask { await self.loadAdvisories(timestamp: timestamp, quiet: quiet) }
+            group.addTask { await self.loadDigest(timestamp: timestamp, quiet: quiet) }
+            group.addTask { await self.loadSnapshot(timestamp: timestamp, quiet: quiet) }
+            group.addTask { await self.loadRouteAnalyses(timestamp: timestamp, quiet: quiet) }
+            group.addTask { await self.loadElevation(timestamp: timestamp, quiet: quiet) }
         }
         // Kick the timing-scenario poll for this pack (no-op when Flexibility is
         // `none`). Runs after the briefing loads — the scan is a background job
@@ -761,38 +796,43 @@ final class BriefingViewModel {
 
     // MARK: - Section loaders
 
-    private func loadAdvisories(timestamp: String) async {
-        advisoriesState = .loading
+    // Section loaders share a `quiet` convention: a quiet reload (seamless sync)
+    // keeps the current data on screen — it only shows the spinner when there's
+    // nothing loaded yet, and keeps the old data (not an error wall) if the quiet
+    // fetch fails. A normal (non-quiet) load shows spinner/error as before.
+
+    private func loadAdvisories(timestamp: String, quiet: Bool = false) async {
+        if !quiet || !advisoriesState.hasData { advisoriesState = .loading }
         do {
             advisoriesState = .loaded(try await repository.advisories(flightId: flight.id, timestamp: timestamp))
         } catch {
-            advisoriesState = .error(error)
             Self.logger.error("Failed to load advisories: \(error)")
+            if !quiet || !advisoriesState.hasData { advisoriesState = .error(error) }
         }
     }
 
-    private func loadDigest(timestamp: String) async {
-        digestState = .loading
+    private func loadDigest(timestamp: String, quiet: Bool = false) async {
+        if !quiet || !digestState.hasData { digestState = .loading }
         do {
             digestState = .loaded(try await repository.digest(flightId: flight.id, timestamp: timestamp))
         } catch {
-            digestState = .error(error)
             Self.logger.error("Failed to load digest: \(error)")
+            if !quiet || !digestState.hasData { digestState = .error(error) }
         }
     }
 
-    private func loadSnapshot(timestamp: String) async {
-        snapshotState = .loading
+    private func loadSnapshot(timestamp: String, quiet: Bool = false) async {
+        if !quiet || !snapshotState.hasData { snapshotState = .loading }
         do {
             snapshotState = .loaded(try await repository.snapshot(flightId: flight.id, timestamp: timestamp))
         } catch {
-            snapshotState = .error(error)
             Self.logger.error("Failed to load snapshot: \(error)")
+            if !quiet || !snapshotState.hasData { snapshotState = .error(error) }
         }
     }
 
-    private func loadRouteAnalyses(timestamp: String) async {
-        routeAnalysesState = .loading
+    private func loadRouteAnalyses(timestamp: String, quiet: Bool = false) async {
+        if !quiet || !routeAnalysesState.hasData { routeAnalysesState = .loading }
         do {
             let response = try await repository.routeAnalyses(flightId: flight.id, timestamp: timestamp)
             routeAnalysesState = .loaded(response)
@@ -805,18 +845,18 @@ final class BriefingViewModel {
                 }
             }
         } catch {
-            routeAnalysesState = .error(error)
             Self.logger.error("Failed to load route analyses: \(error)")
+            if !quiet || !routeAnalysesState.hasData { routeAnalysesState = .error(error) }
         }
     }
 
-    private func loadElevation(timestamp: String) async {
-        elevationState = .loading
+    private func loadElevation(timestamp: String, quiet: Bool = false) async {
+        if !quiet || !elevationState.hasData { elevationState = .loading }
         do {
             elevationState = .loaded(try await repository.elevation(flightId: flight.id, timestamp: timestamp))
         } catch {
-            elevationState = .error(error)
             Self.logger.error("Failed to load elevation: \(error)")
+            if !quiet || !elevationState.hasData { elevationState = .error(error) }
         }
     }
 

--- a/app/flyfun-weather/flyfun-weather/ViewModels/FlightListViewModel.swift
+++ b/app/flyfun-weather/flyfun-weather/ViewModels/FlightListViewModel.swift
@@ -31,9 +31,15 @@ final class FlightListViewModel {
     private(set) var isOffline = false
     /// Flight IDs that have downloaded pack data available offline.
     private(set) var cachedFlightIds: Set<String> = []
+    /// Flight IDs whose briefing is currently queued/refreshing server-side —
+    /// drives the live "Updating…" row indicator. Fed by `pollActiveRefreshes`.
+    private(set) var refreshingFlightIds: Set<String> = []
 
     private let repository: any BriefingRepository
     private var isLoading = false
+    /// The active-refresh poll loop (one at a time). Detached from any `.task`, so
+    /// the view must start/stop it explicitly around visibility.
+    @ObservationIgnored private var refreshPollTask: Task<Void, Never>?
     private static let logger = Logger(subsystem: "aero.flyfun.weather", category: "FlightList")
 
     init(repository: any BriefingRepository) {
@@ -110,6 +116,54 @@ final class FlightListViewModel {
                 state = .error(error)
                 Self.logger.error("Failed to load flights: \(error)")
             }
+        }
+    }
+
+    // MARK: - Active-refresh polling (live "Updating…" row indicator)
+
+    /// Poll `GET /api/refresh/active` every 5s while the list is visible so a row
+    /// shows a live "Updating…" state whenever its briefing is refreshing —
+    /// including refreshes started elsewhere (web, auto-refresh, another device).
+    /// iOS has no server push for progress, so this mirrors the web's flat 5s poll
+    /// (a single user-scoped request per tick, independent of flight count).
+    ///
+    /// Bounded + idempotent: one loop at a time. When a flight *leaves* the active
+    /// set — its refresh just finished — the list is re-synced so that row's
+    /// summary/assessment updates immediately, making the same loop double as the
+    /// completion trigger. Call `stopActiveRefreshPolling()` when the list is
+    /// backgrounded or torn down.
+    func startActiveRefreshPolling() {
+        guard refreshPollTask == nil else { return }
+        refreshPollTask = Task { [weak self] in
+            await self?.pollActiveRefreshesLoop()
+        }
+    }
+
+    /// Stop the active-refresh poll loop (list backgrounded / disappeared).
+    func stopActiveRefreshPolling() {
+        refreshPollTask?.cancel()
+        refreshPollTask = nil
+    }
+
+    private func pollActiveRefreshesLoop() async {
+        while !Task.isCancelled {
+            do {
+                let entries = try await repository.activeRefreshes()
+                guard !Task.isCancelled else { return }
+                let newIds = Set(entries.map(\.flightId))
+                // A flight dropping out of the set means its refresh just
+                // completed — pull fresh summaries so the row updates at once.
+                let finished = refreshingFlightIds.subtracting(newIds)
+                refreshingFlightIds = newIds
+                if !finished.isEmpty {
+                    await loadFlights()
+                }
+            } catch {
+                // Transient (offline blip, 5xx) — keep the last known set and
+                // retry next tick rather than clearing the indicators.
+                Self.logger.debug("activeRefreshes poll failed: \(error)")
+            }
+            try? await Task.sleep(for: .seconds(5))
         }
     }
 

--- a/app/flyfun-weather/flyfun-weather/ViewModels/FlightListViewModel.swift
+++ b/app/flyfun-weather/flyfun-weather/ViewModels/FlightListViewModel.swift
@@ -36,14 +36,19 @@ final class FlightListViewModel {
     private(set) var refreshingFlightIds: Set<String> = []
 
     private let repository: any BriefingRepository
+    /// Live reachability — gates the active-refresh poll so it doesn't hammer the
+    /// radio while offline. Optional so tests/fixtures can omit it (poll then
+    /// always attempts, relying on error backoff).
+    private let networkMonitor: NetworkMonitor?
     private var isLoading = false
     /// The active-refresh poll loop (one at a time). Detached from any `.task`, so
     /// the view must start/stop it explicitly around visibility.
     @ObservationIgnored private var refreshPollTask: Task<Void, Never>?
     private static let logger = Logger(subsystem: "aero.flyfun.weather", category: "FlightList")
 
-    init(repository: any BriefingRepository) {
+    init(repository: any BriefingRepository, networkMonitor: NetworkMonitor? = nil) {
         self.repository = repository
+        self.networkMonitor = networkMonitor
     }
 
     func loadFlights() async {
@@ -145,25 +150,39 @@ final class FlightListViewModel {
         refreshPollTask = nil
     }
 
+    /// Healthy poll cadence (matches the web's flat 5s).
+    private static let refreshPollBaseDelay: Double = 5
+
     private func pollActiveRefreshesLoop() async {
+        var delay = Self.refreshPollBaseDelay
         while !Task.isCancelled {
-            do {
-                let entries = try await repository.activeRefreshes()
-                guard !Task.isCancelled else { return }
-                let newIds = Set(entries.map(\.flightId))
-                // A flight dropping out of the set means its refresh just
-                // completed — pull fresh summaries so the row updates at once.
-                let finished = refreshingFlightIds.subtracting(newIds)
-                refreshingFlightIds = newIds
-                if !finished.isEmpty {
-                    await loadFlights()
+            if networkMonitor?.isConnected == false {
+                // Offline: don't even attempt the round-trip — no point waking the
+                // radio every 5s. Clear stale indicators (we can't know a refresh is
+                // still running) and back off; the next online tick repopulates.
+                if !refreshingFlightIds.isEmpty { refreshingFlightIds = [] }
+                delay = min(delay * 2, 30)
+            } else {
+                do {
+                    let entries = try await repository.activeRefreshes()
+                    guard !Task.isCancelled else { return }
+                    let newIds = Set(entries.map(\.flightId))
+                    // A flight dropping out of the set means its refresh just
+                    // completed — pull fresh summaries so the row updates at once.
+                    let finished = refreshingFlightIds.subtracting(newIds)
+                    refreshingFlightIds = newIds
+                    if !finished.isEmpty {
+                        await loadFlights()
+                    }
+                    delay = Self.refreshPollBaseDelay   // healthy — reset cadence
+                } catch {
+                    // Offline blip / 5xx — back off (cap 60s) instead of hammering,
+                    // and keep the last known set for one cycle.
+                    delay = min(delay * 2, 60)
+                    Self.logger.debug("activeRefreshes poll failed (retry in \(Int(delay))s): \(error)")
                 }
-            } catch {
-                // Transient (offline blip, 5xx) — keep the last known set and
-                // retry next tick rather than clearing the indicators.
-                Self.logger.debug("activeRefreshes poll failed: \(error)")
             }
-            try? await Task.sleep(for: .seconds(5))
+            try? await Task.sleep(for: .seconds(delay))
         }
     }
 

--- a/app/flyfun-weather/flyfun-weather/ViewModels/FlightListViewModel.swift
+++ b/app/flyfun-weather/flyfun-weather/ViewModels/FlightListViewModel.swift
@@ -139,6 +139,11 @@ final class FlightListViewModel {
     /// backgrounded or torn down.
     func startActiveRefreshPolling() {
         guard refreshPollTask == nil else { return }
+        // `weak self` only guards the initial hop; once `pollActiveRefreshesLoop`
+        // is running it holds a strong `self` for the loop's lifetime. That's
+        // intentional — the loop is bounded by `stopActiveRefreshPolling()`
+        // (`.onDisappear` / backgrounding), so the view model is released promptly
+        // once polling stops; it just can't be freed mid-iteration.
         refreshPollTask = Task { [weak self] in
             await self?.pollActiveRefreshesLoop()
         }

--- a/app/flyfun-weather/flyfun-weather/ViewModels/FlightListViewModel.swift
+++ b/app/flyfun-weather/flyfun-weather/ViewModels/FlightListViewModel.swift
@@ -9,6 +9,16 @@ enum LoadingState<T> {
     case error(Error)
 }
 
+extension LoadingState {
+    /// Whether we currently hold loaded data. Used by a *quiet* reload to keep the
+    /// existing content on screen (and swap in place) instead of flashing back to a
+    /// spinner — the seamless-sync path.
+    var hasData: Bool {
+        if case .loaded = self { return true }
+        return false
+    }
+}
+
 /// View model for the flight list screen.
 @Observable
 @MainActor

--- a/app/flyfun-weather/flyfun-weather/Views/Briefing/AdvisoryTabView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Briefing/AdvisoryTabView.swift
@@ -67,28 +67,50 @@ struct AdvisoryTabView: View {
 
     @ViewBuilder
     private var heroSection: some View {
-        if let pack = viewModel.pack, let assessment = pack.assessment {
-            let severity = Assessment(rawValue: assessment.lowercased()) ?? .unavailable
-            HStack(spacing: 0) {
-                Rectangle()
-                    .fill(severity.color)
-                    .frame(width: 5)
-                VStack(alignment: .leading, spacing: Theme.spacingS) {
+        if let pack = viewModel.pack {
+            if let assessment = pack.assessment {
+                let severity = Assessment(rawValue: assessment.lowercased()) ?? .unavailable
+                heroCard(accent: severity.color, reason: pack.assessmentReason) {
                     AssessmentStringBadge(status: assessment)
-                    if let reason = pack.assessmentReason {
-                        Text(reason)
-                            .font(Theme.heroLabel)
-                            .foregroundStyle(Theme.text)
-                            .fixedSize(horizontal: false, vertical: true)
-                    }
                 }
-                .padding(Theme.cardPadding)
-                Spacer(minLength: 0)
+            } else if let outlook = pack.outlook {
+                // Long-range briefing (beyond the GRIB horizon): no traffic-light
+                // verdict yet, only a soft outlook tendency. Mirrors the flight-list
+                // card, which already falls back to the outlook badge — without this
+                // the hero was blank for far-out flights.
+                heroCard(accent: OutlookBadge.tint(for: outlook), reason: pack.outlookReason) {
+                    OutlookBadge(outlook: outlook)
+                }
             }
-            .background(severity.color.opacity(0.10))
-            .clipShape(RoundedRectangle(cornerRadius: Theme.cornerRadius))
-            .padding(.horizontal, Theme.cardPadding)
         }
+    }
+
+    /// Shared accented hero card: a colored side bar, a status badge, and the
+    /// reason line. Used by both the short-range assessment and the long-range
+    /// outlook so the two can't drift.
+    @ViewBuilder
+    private func heroCard<Badge: View>(
+        accent: Color, reason: String?, @ViewBuilder badge: () -> Badge
+    ) -> some View {
+        HStack(spacing: 0) {
+            Rectangle()
+                .fill(accent)
+                .frame(width: 5)
+            VStack(alignment: .leading, spacing: Theme.spacingS) {
+                badge()
+                if let reason {
+                    Text(reason)
+                        .font(Theme.heroLabel)
+                        .foregroundStyle(Theme.text)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+            .padding(Theme.cardPadding)
+            Spacer(minLength: 0)
+        }
+        .background(accent.opacity(0.10))
+        .clipShape(RoundedRectangle(cornerRadius: Theme.cornerRadius))
+        .padding(.horizontal, Theme.cardPadding)
     }
 
     // MARK: Watch chips

--- a/app/flyfun-weather/flyfun-weather/Views/Briefing/BriefingContainerView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Briefing/BriefingContainerView.swift
@@ -6,6 +6,7 @@ import TipKit
 struct BriefingContainerView: View {
     let flight: FlightResponse
     @Environment(AppState.self) private var appState
+    @Environment(\.scenePhase) private var scenePhase
     @State private var viewModel: BriefingViewModel?
     @State private var trackingService = FlightTrackingService()
     @State private var showingPirepSheet = false
@@ -116,6 +117,19 @@ struct BriefingContainerView: View {
             // Opening the briefing clears this flight from the badge (web + app),
             // and fires a silent badge-sync push to the user's other devices.
             await appState.markBriefingSeen(flightId: flight.id)
+        }
+        .onChange(of: scenePhase) {
+            // Returning to the foreground: seamlessly sync to the newest online
+            // pack (no-op if unchanged). Mirrors the flight list's foreground
+            // reload — the open briefing shouldn't stay frozen on a stale pack.
+            if scenePhase == .active {
+                Task { await viewModel?.syncLatestPack() }
+            }
+        }
+        .onChange(of: appState.externalSync) {
+            // A push (or any external "data changed" nudge) is just another sync
+            // trigger — adopt the newest online pack seamlessly.
+            Task { await viewModel?.syncLatestPack() }
         }
         .onDisappear {
             // Stop the timing-scenario poll when the briefing leaves the screen —
@@ -420,6 +434,16 @@ private struct BriefingContentView: View {
     }
 
     var body: some View {
+        content
+            // Pull-to-refresh = seamless *sync* to the newest online pack (NOT the
+            // ↻ button's full regeneration). The action propagates via the
+            // environment to whichever tab's vertical ScrollView is visible
+            // (Advisory / Discussion); the canvas tabs simply don't offer a pull.
+            .refreshable { await viewModel.syncLatestPack() }
+    }
+
+    @ViewBuilder
+    private var content: some View {
         if sizeClass == .regular {
             VStack(spacing: 0) {
                 BriefingTabBand(tabs: tabs, selection: $viewModel.selectedTab)

--- a/app/flyfun-weather/flyfun-weather/Views/Flights/FlightCardView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Flights/FlightCardView.swift
@@ -36,12 +36,12 @@ struct FlightCardView: View {
                 if isRefreshing {
                     HStack(spacing: 4) {
                         ProgressView().controlSize(.small)
-                        Text("Updating…")
+                        Text("Refreshing…")
                             .font(.caption2)
                             .foregroundStyle(.secondary)
                     }
                     .accessibilityElement(children: .ignore)
-                    .accessibilityLabel("Briefing updating")
+                    .accessibilityLabel("Briefing refreshing")
                 }
 
                 statusBadge
@@ -132,10 +132,12 @@ private struct PendingCoverageBadge: View {
 /// Soft tinted badge for a flight's long-range outlook (beyond the GRIB
 /// horizon). Deliberately softer than the assessment traffic light — an
 /// outlook is a tendency ("what to expect"), not a verdict.
-private struct OutlookBadge: View {
+struct OutlookBadge: View {
     let outlook: String
 
-    private var label: String {
+    /// Short human label for an outlook code. Static so the Advisory hero can
+    /// reuse the same mapping without duplicating it.
+    static func label(for outlook: String) -> String {
         switch outlook.uppercased() {
         case "TRENDING_SETTLED": "Settled"
         case "TRENDING_UNSETTLED": "Unsettled"
@@ -143,13 +145,17 @@ private struct OutlookBadge: View {
         }
     }
 
-    private var tint: Color {
+    /// Tint for an outlook code — reused by the Advisory hero's accent bar.
+    static func tint(for outlook: String) -> Color {
         switch outlook.uppercased() {
         case "TRENDING_SETTLED": Theme.green
         case "TRENDING_UNSETTLED": Theme.red
         default: Theme.amber
         }
     }
+
+    private var label: String { Self.label(for: outlook) }
+    private var tint: Color { Self.tint(for: outlook) }
 
     var body: some View {
         Text(label)

--- a/app/flyfun-weather/flyfun-weather/Views/Flights/FlightCardView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Flights/FlightCardView.swift
@@ -5,6 +5,9 @@ struct FlightCardView: View {
     let flight: FlightResponse
     var hasCachedData: Bool = false
     var isOffline: Bool = false
+    /// The flight's briefing is queued/refreshing server-side — show a live
+    /// "Updating…" tag alongside the (still-current) assessment badge.
+    var isRefreshing: Bool = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
@@ -28,6 +31,17 @@ struct FlightCardView: View {
                     Image(systemName: "arrow.down.circle.fill")
                         .foregroundStyle(.green)
                         .font(.caption)
+                }
+
+                if isRefreshing {
+                    HStack(spacing: 4) {
+                        ProgressView().controlSize(.small)
+                        Text("Updating…")
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                    }
+                    .accessibilityElement(children: .ignore)
+                    .accessibilityLabel("Briefing updating")
                 }
 
                 statusBadge

--- a/app/flyfun-weather/flyfun-weather/Views/Flights/FlightListView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Flights/FlightListView.swift
@@ -207,6 +207,12 @@ struct FlightListView: View {
         .onChange(of: appState.pendingNavigation) {
             applyPendingNavigation()
         }
+        .onChange(of: appState.externalSync) {
+            // A push (or other external "data changed" nudge) re-syncs the list so
+            // the per-flight summaries reflect the newest online packs. Warm
+            // refresh — the current list stays on screen (see loadFlights).
+            Task { await viewModel?.loadFlights() }
+        }
     }
 
     /// Consume an App Intent's navigation target (set on `AppState`) and route to

--- a/app/flyfun-weather/flyfun-weather/Views/Flights/FlightListView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Flights/FlightListView.swift
@@ -195,6 +195,8 @@ struct FlightListView: View {
             // A cold-launch intent may have set a target before the list existed;
             // resolve it now that flights are loaded.
             applyPendingNavigation()
+            // Begin the live "Updating…" row poll now the list is on screen.
+            vm.startActiveRefreshPolling()
         }
         .onChange(of: scenePhase) {
             if scenePhase == .active {
@@ -202,7 +204,14 @@ struct FlightListView: View {
                     await viewModel?.loadFlights()
                     applyPendingNavigation()
                 }
+                viewModel?.startActiveRefreshPolling()
+            } else {
+                // Don't poll in the background — resumes on the next `.active`.
+                viewModel?.stopActiveRefreshPolling()
             }
+        }
+        .onDisappear {
+            viewModel?.stopActiveRefreshPolling()
         }
         .onChange(of: appState.pendingNavigation) {
             applyPendingNavigation()
@@ -248,7 +257,8 @@ struct FlightListView: View {
         let hasCached = viewModel.cachedFlightIds.contains(flight.id)
         NavigationLink(value: flight) {
             FlightCardView(flight: flight, hasCachedData: hasCached,
-                           isOffline: viewModel.isOffline)
+                           isOffline: viewModel.isOffline,
+                           isRefreshing: viewModel.refreshingFlightIds.contains(flight.id))
         }
         .disabled(viewModel.isOffline && !hasCached)
         .swipeActions(edge: .trailing, allowsFullSwipe: false) {

--- a/app/flyfun-weather/flyfun-weather/Views/Flights/FlightListView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Flights/FlightListView.swift
@@ -189,7 +189,7 @@ struct FlightListView: View {
         }
         .task {
             guard let repo = appState.repository else { return }
-            let vm = FlightListViewModel(repository: repo)
+            let vm = FlightListViewModel(repository: repo, networkMonitor: appState.networkMonitor)
             viewModel = vm
             await vm.loadFlights()
             // A cold-launch intent may have set a target before the list existed;

--- a/app/flyfun-weather/flyfun-weatherTests/TestSupport.swift
+++ b/app/flyfun-weather/flyfun-weatherTests/TestSupport.swift
@@ -92,6 +92,7 @@ final class MockBriefingRepository: BriefingRepository, @unchecked Sendable {
         AsyncThrowingStream { $0.finish() }
     }
     func refreshStatus(flightId: String) async throws -> RefreshStatusResponse { throw MockError.notStubbed("refreshStatus") }
+    func activeRefreshes() async throws -> [ActiveRefreshResponse] { [] }
     func submitPirep(_ request: SubmitPirepRequest) async throws -> PirepResponse { throw MockError.notStubbed("submitPirep") }
     func submitPirepsBatch(_ requests: [SubmitPirepRequest]) async throws -> [PirepResponse] {
         submitPirepsBatchCallCount += 1

--- a/app/flyfun-weather/flyfun-weatherTests/ViewModelTests.swift
+++ b/app/flyfun-weather/flyfun-weatherTests/ViewModelTests.swift
@@ -351,4 +351,22 @@ import MapKit
         let label = m.packLabel(for: try pack(daysOut: 1, timestamp: "2026-06-24T09:00:00Z"))
         #expect(label == "D-1 · Jun 24 09:00 UTC")
     }
+
+    @Test func autoSyncOnlyWhenViewingLatestPack() throws {
+        let d0 = try pack(daysOut: 0, timestamp: "2026-06-24T12:00:00Z")   // newest
+        let d1 = try pack(daysOut: 1, timestamp: "2026-06-23T12:00:00Z")   // older
+        let history = [d0, d1]
+        // Viewing the newest pack → auto-sync allowed.
+        #expect(BriefingViewModel.isViewingLatestPack(current: d0.fetchTimestamp, history: history))
+        // Viewing an older pack picked from history → auto-sync suppressed.
+        #expect(!BriefingViewModel.isViewingLatestPack(current: d1.fetchTimestamp, history: history))
+        // History not loaded yet → don't block the first sync.
+        #expect(BriefingViewModel.isViewingLatestPack(current: d0.fetchTimestamp, history: []))
+        // No current pack → allowed.
+        #expect(BriefingViewModel.isViewingLatestPack(current: nil, history: history))
+        // Fractional seconds must not misorder vs a whole-second sibling: a viewer
+        // on the fractional (later) run still counts as latest.
+        let dFrac = try pack(daysOut: 0, timestamp: "2026-06-24T12:00:00.500Z")
+        #expect(BriefingViewModel.isViewingLatestPack(current: dFrac.fetchTimestamp, history: [dFrac, d0]))
+    }
 }


### PR DESCRIPTION
## Problem

An already-open iOS app never re-fetched while foregrounded, so a briefing refreshed on the website (or by auto-refresh) left the **flight-list summary** and the **open briefing** stale until a cold relaunch. The only briefing-level update affordance was the ↻ button — which triggers a *new full generation* (SSE stream), not a sync to what's already online. There was also **no pull-to-refresh on the briefing at all**.

## Approach — sync vs refresh

Two distinct operations, matching the web:

| | **Sync** (new) | **Refresh** (unchanged, ↻ button) |
|---|---|---|
| What | Adopt the newest *already-generated* pack | Generate a *new* briefing |
| Cost | 1 `latestPack()` request; no-op if unchanged | Full pipeline, minutes, SSE |
| Triggers | appear, pull-to-refresh, foreground, push | explicit button |
| UX | seamless (quiet swap, no spinner flash) | progress banner |

## What's in here

**1. Seamless sync (`4c255989`)**
- `BriefingViewModel.syncLatestPack()` — no-ops when the pack timestamp is unchanged, else adopts via a new shared `applyPack()` (consolidates 3 duplicated adopt-pack blocks). Reload is *quiet* — sections keep current data and swap in place (`LoadingState.hasData`).
- Wired to: briefing pull-to-refresh (was absent), return-to-foreground (`scenePhase`), and an `AppState.externalSync` nudge the APNs handlers now raise (push refreshes visible data, not just the badge). List already synced on appear/foreground/pull; now also on the push nudge.

**2. Live "Refreshing…" flight-list indicator (`5db0876c`)**
- iOS has no push for progress, so — like the web — the list polls `GET /api/refresh/active` (existing endpoint) every 5s while visible and marks each returned flight's row. One user-scoped request per tick regardless of flight count.
- When a flight leaves the active set (refresh finished), the loop re-syncs the list — the same loop doubles as the completion trigger.
- New `ActiveRefreshResponse` + `activeRefreshes()` on the repository protocol (online-only; caching passes through; fixture/mock return `[]`).

**3. Polish (`cdf22cd9`)**
- **Long-range hero fix:** the Advisory hero rendered only `pack.assessment`, so a far-out briefing (which carries `outlook` instead) showed a blank summary. The server already sends `outlook`/`outlook_reason` and the flight card already falls back to it — added the fields to iOS `PackMetaResponse` and the same assessment-else-outlook fallback to the hero (shared `heroCard`; reusable `OutlookBadge`).
- Row label "Refreshing…" (matches web).
- `quietLog` flag suppresses the 5s poll's request log.
- Offline-safe poll: skips the round-trip when `NetworkMonitor` is offline (clears stale indicators) + exponential backoff on failure (5s→cap 60s, reset on success).

The ↻ button is unchanged (explicit "generate a new briefing").

## Testing

- `xcodebuild build` (generic iOS Simulator) + full `flyfun-weatherTests` target green.
- ⚠️ Not yet verified on device — the seamless swap, pull-to-refresh gesture, and long-range hero need a real authenticated session (mock mode can't render the briefing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)