### PR TITLE
Centralize heading/bearing formatting logic

### DIFF
--- a/app/flyfun-weather/flyfun-weather/Utilities/Extensions.swift
+++ b/app/flyfun-weather/flyfun-weather/Utilities/Extensions.swift
@@ -68,6 +68,15 @@ extension String {
     }
 }
 
+extension Int {
+    /// Zero-pad a compass heading/bearing to 3 digits (10° → "010"). Does NOT
+    /// append the ° symbol — call sites add °/@ as they do today. Single source
+    /// of truth for heading display (AirportConditionsView, PirepListView).
+    var paddedHeading: String {
+        String(format: "%03d", self)
+    }
+}
+
 extension URL {
     /// Extract a query parameter value by name.
     func queryParam(_ name: String) -> String? {

--- a/app/flyfun-weather/flyfun-weather/Views/Briefing/AirportConditionsView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Briefing/AirportConditionsView.swift
@@ -102,7 +102,7 @@ private struct AirportConditionCard: View {
             FlightCategoryBadge(category: condition.flightCategory)
 
             if let wind = condition.windSpeedKt, let dir = condition.windDirectionDeg {
-                Label("\(Int(dir))@\(Int(wind))kt", systemImage: "wind")
+                Label("\(Int(dir).paddedHeading)@\(Int(wind))kt", systemImage: "wind")
                     .font(.caption)
             }
 

--- a/app/flyfun-weather/flyfun-weather/Views/Briefing/PirepListView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Briefing/PirepListView.swift
@@ -121,7 +121,7 @@ struct PirepRowView: View {
                 detailRow("Temp", String(format: "%.0f°C", temp))
             }
             if let dir = pirep.windDir, let spd = pirep.windSpeedKt {
-                detailRow("Wind", String(format: "%03d° / %d kt", dir, spd))
+                detailRow("Wind", "\(dir.paddedHeading)° / \(spd) kt")
             }
             if let ac = pirep.aircraftType {
                 detailRow("Aircraft", ac)

--- a/web/ts/managers/advisories-ui.ts
+++ b/web/ts/managers/advisories-ui.ts
@@ -9,7 +9,7 @@ import { advisoryBand, isCompactBand, compareAdvisories } from '../helpers/advis
 import { formatAltitudeDeltaNote } from '../helpers/altitude-diff';
 import { $, escapeHtml, formatAlt, modelLabel } from '../utils';
 import { t } from '../i18n/i18n';
-import { formatVisibility } from '../units';
+import { formatVisibility, formatHeading } from '../units';
 import { ADVISORY_TO_PRESET } from '../visualization/cross-section/advisory-presets';
 import { computeSummaryCondition } from '../helpers/airport-summary';
 
@@ -76,7 +76,7 @@ function formatModelDetailPopup(advName: string, m: ModelAdvisoryResult): string
 function formatRunwayPopup(allRunways: RunwayWind[]): string {
   if (allRunways.length === 0) return '';
   const rows = allRunways.map(r =>
-    `<tr><td>${escapeHtml(r.runway_id)}</td><td>${r.heading_deg.toFixed(0)}&deg;</td>` +
+    `<tr><td>${escapeHtml(r.runway_id)}</td><td>${formatHeading(r.heading_deg)}&deg;</td>` +
     `<td>${r.crosswind_kt.toFixed(0)}kt</td><td>${r.headwind_kt > 0 ? '+' : ''}${r.headwind_kt.toFixed(0)}kt</td></tr>`
   ).join('');
   return `
@@ -88,14 +88,10 @@ function formatRunwayPopup(allRunways: RunwayWind[]): string {
   `;
 }
 
-function roundWind(deg: number): string {
-  return String(Math.round(deg / 10) * 10).padStart(3, '0');
-}
-
 function formatWind(cond: AirportModelCondition): string {
   if (cond.wind_speed_kt == null || cond.wind_direction_deg == null) return '\u2014';
 
-  const dir = roundWind(cond.wind_direction_deg);
+  const dir = formatHeading(cond.wind_direction_deg, 10);
   const spd = cond.wind_speed_kt.toFixed(0);
   const gust = cond.wind_gust_kt != null ? `G${cond.wind_gust_kt.toFixed(0)}` : '';
   return `${dir}@${spd}${gust}`;

--- a/web/ts/managers/briefing-ui.ts
+++ b/web/ts/managers/briefing-ui.ts
@@ -2815,7 +2815,10 @@ function renderComparisonTable(
 
     const valueCells = models.map((m) => {
       const val = d.model_values[m];
-      return `<td>${val !== undefined ? val.toFixed(1) : '\u2014'}</td>`;
+      if (val === undefined) return '<td>\u2014</td>';
+      // Compass headings zero-pad to 3 digits (10\u00b0 \u2192 010); everything else keeps 1 decimal.
+      const cell = metricId === 'wind_direction_deg' ? formatHeading(val) : val.toFixed(1);
+      return `<td>${cell}</td>`;
     }).join('');
     const agreeIcon = d.agreement === 'good' ? '&#10003;'
       : d.agreement === 'moderate' ? '&#9888;' : '&#10007;';
@@ -3051,10 +3054,6 @@ function formatMetricValue(metricId: string, value: number): string {
   // IDs that should show 1 decimal
   if (metricId === 'lifted_index' || metricId === 'showalter_index') {
     return value.toFixed(1);
-  }
-  // Compass headings: zero-pad to 3 digits (10° → 010)
-  if (metricId === 'wind_direction_deg') {
-    return formatHeading(value);
   }
   // IDs that show integer with comma formatting
   if (metricId === 'cape_surface_jkg' && Math.abs(value) >= 1000) {

--- a/web/ts/managers/briefing-ui.ts
+++ b/web/ts/managers/briefing-ui.ts
@@ -44,6 +44,7 @@ import {
   riskCssClass,
   variableToMetricId,
 } from '../helpers/metrics-helper';
+import { formatHeading } from '../units';
 import { showPopupContent } from '../components/info-popup';
 import * as api from '../adapters/api-adapter';
 import { $, escapeHtml, formatAlt, formatDate, formatDepartureTime, modelLabel, buildWindyUrl, flightTitle, flightRouteCompact } from '../utils';
@@ -1064,9 +1065,8 @@ function windTooltip(rwyId: string | null, crosswind: number | null): string {
 
 function formatWindStr(dir: number | null, speed: number | null, gust: number | null): string {
   if (dir == null || speed == null) return '';
-  const d = Math.round(dir / 10) * 10;
   const g = gust != null ? `G${Math.round(gust)}` : '';
-  return `${String(d).padStart(3, '0')}@${Math.round(speed)}${g}`;
+  return `${formatHeading(dir, 10)}@${Math.round(speed)}${g}`;
 }
 
 function renderObsPopup(apt: AirportObservation, comp: ObservationComparison | undefined): string {
@@ -3051,6 +3051,10 @@ function formatMetricValue(metricId: string, value: number): string {
   // IDs that should show 1 decimal
   if (metricId === 'lifted_index' || metricId === 'showalter_index') {
     return value.toFixed(1);
+  }
+  // Compass headings: zero-pad to 3 digits (10° → 010)
+  if (metricId === 'wind_direction_deg') {
+    return formatHeading(value);
   }
   // IDs that show integer with comma formatting
   if (metricId === 'cape_surface_jkg' && Math.abs(value) >= 1000) {

--- a/web/ts/managers/pirep-ui.ts
+++ b/web/ts/managers/pirep-ui.ts
@@ -3,6 +3,7 @@
 import type { PirepResponse, PirepFilters } from '../adapters/pirep-adapter';
 import { SEVERITY_COLORS, maxSeverity, hazardIconsRaw } from '../utils/pirep-helpers';
 import { escapeHtml } from '../utils';
+import { formatHeading } from '../units';
 
 const SEVERITY_LABELS: Record<string, string> = {
   none: 'None',
@@ -85,7 +86,7 @@ export function renderPirepDetailCard(pirep: PirepResponse): string {
   }
   if (pirep.temp_c != null) addRow('Temp', `${pirep.temp_c}°C`);
   if (pirep.wind_dir != null && pirep.wind_speed_kt != null) {
-    addRow('Wind', `${String(pirep.wind_dir).padStart(3, '0')}° / ${pirep.wind_speed_kt} kt`);
+    addRow('Wind', `${formatHeading(pirep.wind_dir)}° / ${pirep.wind_speed_kt} kt`);
   }
   if (pirep.aircraft_type) addRow('Aircraft', pirep.aircraft_type);
   addRow('Source', pirep.source);

--- a/web/ts/units.ts
+++ b/web/ts/units.ts
@@ -119,6 +119,14 @@ export function qnhDisplayValue(
   return region === 'us' ? hpa / HPA_PER_INHG : hpa;
 }
 
+/** Zero-pad a compass heading/bearing to 3 digits. Rounds to nearest `step`° first
+ *  (step=10 for wind chips/METAR/TAF, step=1 elsewhere). Does NOT append the ° symbol;
+ *  call sites append °/°T/@ themselves. */
+export function formatHeading(deg: number, step = 1): string {
+  const rounded = Math.round(deg / step) * step;
+  return String(rounded).padStart(3, '0');
+}
+
 /** Format a temperature in Celsius. (Not yet wired into surfaces.) */
 export function formatTemperature(
   celsius: number | null | undefined,

--- a/web/ts/visualization/cross-section/tooltip-formatters.ts
+++ b/web/ts/visualization/cross-section/tooltip-formatters.ts
@@ -9,7 +9,7 @@
 
 import type { VizPoint, VizCloudLayer, VizIcingZone, VizSfipZone, VizSldZone, VizCATLayer, VizInversionLayer, VizSurfaceObscuration } from '../types';
 import { fmtFL } from '../interaction-utils';
-import { formatVisibility } from '../../units';
+import { formatVisibility, formatHeading } from '../../units';
 import { getActiveTheme } from './theme';
 import { icingRiskColor, catRiskColor, cloudFillFromDD, nwpCloudFill, inversionOpacity } from '../scales';
 import { coverageToPct } from './layers/cloud-bands-factory';
@@ -314,7 +314,7 @@ const sunAtPoint: LayerTooltipDef = {
   getZones: (p): SunZone[] =>
     p.sun ? [{ baseFt: -1e6, topFt: 1e6, ...p.sun }] : [],
   formatLine: (z: SunZone) => {
-    const az = `az ${Math.round(z.azimuthDeg)}°T`;
+    const az = `az ${formatHeading(z.azimuthDeg)}°T`;
     if (z.elevationDeg <= 0) {
       return `${Math.abs(z.elevationDeg).toFixed(0)}° below horizon · ${az}`;
     }

--- a/web/ts/visualization/skewt/interaction.ts
+++ b/web/ts/visualization/skewt/interaction.ts
@@ -12,6 +12,7 @@ import type { SoundingProfileData, SoundingProfileLevel } from './types';
 import type { CompareModelDataset } from './compare-renderer';
 import { isDarkTheme } from '../interaction-utils';
 import { altitudeToPressure, pressureToAltitudeFt } from '../../utils/atmo';
+import { formatHeading } from '../../units';
 
 export interface SkewTInteractionCallbacks {
   /** Called with altitude in ft when hovering, undefined when leaving. */
@@ -166,7 +167,7 @@ export function attachSkewTInteraction(
     html += row('RH', level.relative_humidity_pct, '%');
     html += row('CC', level.cloud_area_fraction_pct, '%');
     if (level.wind_speed_kt != null && level.wind_direction_deg != null) {
-      html += `<div>${Math.round(level.wind_direction_deg)}°/${Math.round(level.wind_speed_kt)}kt</div>`;
+      html += `<div>${formatHeading(level.wind_direction_deg)}°/${Math.round(level.wind_speed_kt)}kt</div>`;
       if (data.track_deg != null) {
         const rel = (level.wind_direction_deg - data.track_deg) * Math.PI / 180;
         const hw = level.wind_speed_kt * Math.cos(rel);
@@ -391,7 +392,7 @@ export function attachSkewTCompareInteraction(
       html += `<td>${fmtV(level.temperature_c, '°C')}</td>`;
       html += `<td>${fmtV(level.dewpoint_c, '°C')}</td>`;
       if (level.wind_speed_kt != null && level.wind_direction_deg != null) {
-        html += `<td>${Math.round(level.wind_direction_deg)}°/${Math.round(level.wind_speed_kt)}kt</td>`;
+        html += `<td>${formatHeading(level.wind_direction_deg)}°/${Math.round(level.wind_speed_kt)}kt</td>`;
         if (ds.data.track_deg != null) {
           const rel = (level.wind_direction_deg - ds.data.track_deg) * Math.PI / 180;
           const hw = level.wind_speed_kt * Math.cos(rel);

--- a/web/ts/visualization/weather-map.ts
+++ b/web/ts/visualization/weather-map.ts
@@ -4,7 +4,7 @@ import * as L from 'leaflet';
 import type {
   ForecastAirport, ForecastMapResponse, ModelForecast, ConsensusForecast, AltRequired,
 } from '../adapters/maps-adapter';
-import { formatVisibility, getUnitsRegion } from '../units';
+import { formatVisibility, getUnitsRegion, formatHeading } from '../units';
 
 const LIGHT_TILES = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
 const DARK_TILES = 'https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png';
@@ -203,7 +203,7 @@ function visibilityLegendItems(): Array<{ color: string; label: string }> {
 
 function fmtWind(speed: number | null | undefined, dir: number | null | undefined, gust: number | null | undefined): string {
   if (speed == null) return '';
-  const dirStr = dir != null ? `${String(Math.round(dir)).padStart(3, '0')}/` : '';
+  const dirStr = dir != null ? `${formatHeading(dir)}/` : '';
   const gustStr = gust ? `G${Math.round(gust)}` : '';
   return `${dirStr}${Math.round(speed)}${gustStr} kt`;
 }


### PR DESCRIPTION
## Summary
Extracts repeated heading/bearing formatting logic into a single reusable function to ensure consistent zero-padded display across the codebase (web and iOS).

## Changes
- **New `formatHeading()` function** in `web/ts/units.ts`: Zero-pads compass headings to 3 digits with optional rounding step (10° for wind chips/METAR/TAF, 1° elsewhere). Does not append the ° symbol — call sites add it themselves.
- **New `paddedHeading` property** in Swift (`Extensions.swift`): Equivalent zero-padding for iOS, serving as the single source of truth for heading display in `AirportConditionsView` and `PirepListView`.
- **Replaced inline formatting** across web modules:
  - `advisories-ui.ts`: Runway heading and wind direction formatting
  - `briefing-ui.ts`: Wind direction in tooltips and metric value display
  - `skewt/interaction.ts`: Wind direction in sounding profile tooltips
  - `cross-section/tooltip-formatters.ts`: Sun azimuth display
  - `weather-map.ts`: Wind direction in map legend
  - `pirep-ui.ts`: PIREP wind direction display
- **Updated iOS views**:
  - `AirportConditionsView.swift`: Wind display using `paddedHeading`
  - `PirepListView.swift`: PIREP wind display using `paddedHeading`

## Implementation Details
- `formatHeading()` rounds to the nearest `step` degrees first, then zero-pads to 3 digits (e.g., 10° → "010", 350° → "350")
- Eliminates scattered `Math.round(deg / 10) * 10` and `padStart(3, '0')` patterns
- Maintains backward compatibility — all call sites already append ° or @ symbols as needed

https://claude.ai/code/session_0183gnUXnfYFXTgtwZfkWD2b