### PR TITLE
feat(notify): auto-refresh defaults flight bell to "always"

### DIFF
--- a/designs/ios-app-briefing-notifications.md
+++ b/designs/ios-app-briefing-notifications.md
@@ -177,26 +177,27 @@ This generalizes into an explicit, channel-aware model with a per-flight overrid
 
 **Per-flight override** (flight settings — generalizes today's "email me when done"), on `FlightRow`:
 
-- `notify_override`: `default` (follow global) | `on` (notify for **any** completion of this
-  flight, even if global is `off`/`auto`) | `mute` (never for this flight). Channels always
-  follow the global channel selection.
+- `notify_override`: `default` (follow global scope + change filter) | `notify` (**always** —
+  notify for **any** completion of this flight, even if global is `off`/`auto` **and even when
+  the assessment is unchanged**; the change filter does not apply) | `mute` (never for this
+  flight). Channels always follow the global channel selection.
 
-**Effective decision** (evaluated in `notify/dispatch.py`, driven from `_notify_refresh_complete`):
+**Effective decision** (evaluated in `notify/dispatch.py::notify_qualifies` + presence, driven from `_notify_refresh_complete`). NOTE: as *shipped* (#371) the WHEN/HOW split is what the top-of-doc summary describes — the pseudocode below is the final form (an earlier draft gated email per-`triggered_by`; that was replaced by presence):
 
 ```
-# Shared gate (notify_qualifies) — drives the badge and both channels:
+# Single WHEN decision — presence AND the shared gate — drives badge + both channels:
+if present:  stop                          # user was watching this refresh finish
 if flight.notify_override == "mute":  stop
-elif flight.notify_override == "notify":  qualifies    # any completion
-else:                                                  # default → global scope
+elif flight.notify_override == "notify":  qualifies    # ALWAYS — bypasses scope AND the change filter
+else:                                                  # default → global scope + change filter
     scope == "off" → stop
     else (all / legacy auto) → qualifies
-if notify_change_only and not delta.changed:  stop
+    if notify_change_only and not delta.changed:  stop
 advance the badge
-# Per-channel trigger rule (#371):
-push  → deliver on every qualifying refresh
-email → deliver only if triggered_by is non-user-present (skip a bare "user")
-    # push additionally suppressed if the app is foregrounded on this flight —
-    # a DELIVERY RULE, not a user setting (resolves the earlier ★ question)
+# HOW (channels) — pure user preference, trigger-agnostic:
+push  → deliver if notify_push
+email → deliver if notify_email
+# (?source= / triggered_by is usage attribution only — it does NOT gate notifications)
 ```
 
 ### UX principles
@@ -213,10 +214,17 @@ email → deliver only if triggered_by is non-user-present (skip a bare "user")
 
 ### Other choices worth offering / deciding
 
-- **★ DECIDED — per-flight notify is independent of auto-refresh.** They are two separate
-  controls today and stay separate: the notify override never enables or schedules
-  auto-refresh. (A per-flight "notify" is most useful precisely for manual/Siri refreshes
-  on a flight whose auto-refresh is off — the Siri-loop case.)
+- **★ DECIDED — per-flight notify stays a separate control, but auto-refresh seeds a smart
+  default.** The data model stays independent: the notify override never enables or schedules
+  auto-refresh, and a per-flight `notify` is still useful for manual/Siri refreshes on a flight
+  whose auto-refresh is off — the Siri-loop case. What changed (post-#371): the old auto-refresh
+  meant "email me whenever a new report is ready" — every scheduled run, unconditionally. The
+  new default (`notify_change_only` on) is quieter, gating on assessment change; but a report's
+  *detail* often moves while the assessment holds, so auto-refresh users would perceive it as
+  going silent. Fix: **enabling auto-refresh defaults that flight's bell to `notify`** (see
+  `api/flights.py::update_auto_refresh`) — restoring the every-completion ping (which is why
+  `notify` bypasses the change filter). It's a default, not a hard link: the user can drop the
+  bell back to `default` or `mute` afterward, and disabling auto-refresh leaves the bell as-is.
 - **Batching/digest** — the scheduler can finish several flights close together; a future
   digest could replace N separate pushes.
 - **Per-channel scope** — deliberately NOT in v1 (one scope for all channels); revisit only

--- a/src/weatherbrief/api/flights.py
+++ b/src/weatherbrief/api/flights.py
@@ -1667,6 +1667,14 @@ def update_auto_refresh(
     row = _load_owned_row(db, flight_id, user_id)
     row.auto_refresh = req.auto_refresh
     row.auto_refresh_hour = req.auto_refresh_hour
+    if req.auto_refresh:
+        # Enabling auto-refresh restores the pre-#366 "tell me whenever a new
+        # report is ready" behavior: default this flight's bell to "always" so
+        # every scheduled refresh notifies, even when the assessment is
+        # unchanged but the detail moved. Still fully overridable — the user can
+        # mute or drop back to "default" afterward. Disabling auto-refresh
+        # leaves the bell untouched (we don't silently undo a notify choice).
+        row.notify_override = "notify"
     db.flush()
     updated = load_flight(db, flight_id)
     return _flight_to_response(updated, db, viewer_id=user_id)

--- a/src/weatherbrief/notify/dispatch.py
+++ b/src/weatherbrief/notify/dispatch.py
@@ -68,21 +68,29 @@ def notify_qualifies(
     Channel- and trigger-agnostic — scope + per-flight override + the change
     filter. The caller combines this with *presence* (was the user watching the
     refresh's UI stream) to form the single WHEN decision that gates the badge
-    and both channels. ``scope`` "off" silences default-resolution flights; any
-    other value — "all", or legacy "auto" — means notifications are on. The
-    manual-vs-automatic line is drawn by presence (in the caller), NOT here and
-    NOT per-channel.
+    and both channels.
+
+    Per-flight override precedence, evaluated first:
+
+    - ``mute`` → never, regardless of scope.
+    - ``notify`` → **always**: every completion for this flight, bypassing both
+      global ``scope`` and the ``change_only`` filter. This is the strong opt-in
+      and the default applied when auto-refresh is enabled — it restores the
+      pre-#366 "notify me whenever a new report is ready" behavior, which fires
+      even when the assessment is unchanged but the detail moved.
+    - ``default`` → follow global scope + the change filter. ``scope`` "off"
+      silences these flights; any other value — "all", or legacy "auto" — is on.
+
+    The manual-vs-automatic line is drawn by presence (in the caller), NOT here
+    and NOT per-channel — so a refresh the user watched finish is suppressed even
+    for a ``notify`` flight.
     """
     if notify_override == "mute":
         return False
     if notify_override == "notify":
-        qualifies = True
-    elif scope == "off":
-        qualifies = False
-    else:  # "all", or legacy "auto" — notifications on
-        qualifies = True
+        return True  # always — bypasses scope + change filter (see docstring)
 
-    if not qualifies:
+    if scope == "off":
         return False
     if change_only and not changed:
         return False

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -533,6 +533,22 @@ class TestFlightsAPI:
         )
         assert resp.status_code == 404
 
+    def test_enable_auto_refresh_defaults_bell_to_notify(self, client, sample_flight):
+        """Enabling auto-refresh promotes the flight's bell to "always" (notify),
+        restoring the pre-#366 "tell me when a new report is ready" behavior."""
+        fid = sample_flight.id
+        resp = client.patch(f"/api/flights/{fid}/auto-refresh", json={"auto_refresh": True})
+        assert resp.status_code == 200
+        assert resp.json()["notify_override"] == "notify"
+
+    def test_disable_auto_refresh_leaves_bell_untouched(self, client, sample_flight):
+        """Turning auto-refresh back off does not silently undo the notify choice."""
+        fid = sample_flight.id
+        client.patch(f"/api/flights/{fid}/auto-refresh", json={"auto_refresh": True})
+        resp = client.patch(f"/api/flights/{fid}/auto-refresh", json={"auto_refresh": False})
+        assert resp.status_code == 200
+        assert resp.json()["notify_override"] == "notify"
+
 
 # --- Flight subscriptions ---
 

--- a/tests/test_briefing_notifications.py
+++ b/tests/test_briefing_notifications.py
@@ -74,11 +74,13 @@ def test_gate_change_only_suppresses_unchanged():
              changed=True)
 
 
-def test_gate_change_only_applies_even_under_notify_override():
-    # The content filter is applied after the scope/override decision, so it
-    # gates the "notify" override too (design pseudocode order).
-    assert not Q(notify_override="notify", scope="off", change_only=True,
-                 changed=False)
+def test_gate_notify_override_bypasses_change_filter():
+    # "notify" means ALWAYS: it fires on every completion, so the change filter
+    # does NOT gate it. This restores the pre-#366 auto-refresh behavior — a
+    # "new report is ready" ping even when the assessment is unchanged but the
+    # detail moved. (Presence, applied by the caller, can still suppress it.)
+    assert Q(notify_override="notify", scope="off", change_only=True,
+             changed=False)
     assert Q(notify_override="notify", scope="off", change_only=True,
              changed=True)
 
@@ -496,6 +498,26 @@ def test_notify_override_notify_fires_even_when_scope_off(db_session, dev_user, 
     prefs.app_prefs_json = '{"notify_scope": "off"}'
     db_session.flush()
     meta = _seed(db_session)
+    dispatch_mod.notify_briefing_refresh(
+        db_session, _mkflight("notify"), meta, pack_dir=None, user_id=DEV_USER_ID, present=False,
+    )
+    db_session.flush()
+    assert calls["email"] == 1
+    assert badge_mod.compute_badge_count(db_session, DEV_USER_ID) == 1
+
+
+def test_notify_override_notify_fires_on_unchanged_refresh(db_session, dev_user, monkeypatch):
+    # Per-flight "Always" fires even when the assessment is UNCHANGED and the
+    # global change filter is on — this is the auto-refresh "new report ready"
+    # behavior (detail moved, assessment didn't). A default-override flight in
+    # the same state would be suppressed by change_only.
+    calls = _spy_channels(monkeypatch)
+    _add_flight(db_session)
+    t0 = datetime(2026, 7, 8, 8, 0, tzinfo=timezone.utc)
+    t1 = datetime(2026, 7, 8, 10, 0, tzinfo=timezone.utc)
+    _add_pack(db_session, "f1", t0, assessment="GREEN")
+    _add_pack(db_session, "f1", t1, assessment="GREEN")  # same assessment → unchanged
+    meta = BriefingPackMeta(flight_id="f1", fetch_timestamp=t1, days_out=2, assessment="GREEN")
     dispatch_mod.notify_briefing_refresh(
         db_session, _mkflight("notify"), meta, pack_dir=None, user_id=DEV_USER_ID, present=False,
     )

--- a/web/ts/briefing-main.ts
+++ b/web/ts/briefing-main.ts
@@ -2284,6 +2284,11 @@ async function init(): Promise<void> {
         });
         // Update the flight in store with new auto-refresh fields
         store.getState().updateFlightAutoRefresh(updated.auto_refresh, updated.auto_refresh_hour);
+        // Enabling auto-refresh promotes the bell to "always" server-side; mirror
+        // the returned override so the notification control reflects it live.
+        if (updated.notify_override) {
+          store.getState().updateFlightNotifyOverride(updated.notify_override);
+        }
         if (autoRefresh !== wasEnabled) {
           track(autoRefresh ? EVENTS.AUTO_REFRESH_ENABLED : EVENTS.AUTO_REFRESH_DISABLED);
         }


### PR DESCRIPTION
## Summary

When a user enables **auto-refresh** on a flight, that flight's notification bell now defaults to **"always"** — and "always" (`notify_override = "notify"`) now genuinely means *every completion*, bypassing both global scope and the change filter.

### Why

Before the notification rework (#366/#371), auto-refresh implicitly meant *"tell me whenever a new report is ready"* — a ping on every scheduled run. The new global default (`notify_change_only` on) is quieter: it gates on **assessment** change. But a report's **detail** frequently moves while the assessment holds steady, so users who'd opted into auto-refresh perceived it as having gone silent.

This restores that old behavior as a **smart default** — without re-coupling the two controls:

- Enabling auto-refresh seeds `notify_override = "notify"` (still fully overridable afterward).
- Disabling auto-refresh **leaves the bell untouched** — we don't silently undo a notify choice.
- The per-flight override still never schedules auto-refresh, so the data model stays independent (the ★ DECIDED decoupling holds).
- The **presence gate is unchanged**: a refresh the user is actively watching finish is still suppressed on every channel, even for an "always" flight.

Note: because `notify_change_only` defaults on and push defaults off, a plain-email user gets exactly the old daily-email cadence back; only a user who has turned push on would receive a daily *push* on every auto-refresh (which they opted into).

## Changes

- `notify/dispatch.py` — `notify_qualifies`: `"notify"` returns early, bypassing scope **and** the change filter (this aligns the gate with the intent already documented on `FlightRow.notify_override`, which the old code contradicted).
- `api/flights.py` — `update_auto_refresh` seeds `notify_override = "notify"` on enable.
- `web/ts/briefing-main.ts` — the auto-refresh toggle now mirrors the returned `notify_override` into the store, so the bell flips to "Always" live instead of staying stale until reload.
- Tests: flipped the pure-gate test to the new semantics; added an integration test that a `notify` flight fires on an **unchanged** refresh; added endpoint tests for enable→bell=notify and disable→bell unchanged.
- `designs/ios-app-briefing-notifications.md` — pseudocode + ★ DECIDED note updated.

## Testing

- `pytest tests/test_briefing_notifications.py tests/test_api.py::TestFlightsAPI` — 77 passed
- `pytest tests/test_scheduler.py` — 61 passed
- `tsc --noEmit` clean for touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)