### PR TITLE
iOS: render advisory highlights (scrim + verdict ribbon) on the cross-section

### DIFF
--- a/app/flyfun-weather/flyfun-weather/Models/API/AdvisoriesResponse.swift
+++ b/app/flyfun-weather/flyfun-weather/Models/API/AdvisoriesResponse.swift
@@ -42,8 +42,41 @@ struct ModelAdvisoryResult: Codable, Identifiable, Sendable {
     /// Per-model advice-only mitigations. Never alters `status`. Optional so old
     /// packs decode cleanly.
     let mitigations: [Mitigation]?
+    /// Cross-section highlight geometry (scrim regions + verdict ribbon, #374).
+    /// Absent/null on old packs and for evaluators that don't emit it — the
+    /// feature is then silently absent (chip behaves as before highlights).
+    let highlights: AdvisoryHighlights?
 
     var id: String { model }
+}
+
+/// Cross-section highlight geometry for one advisory × one model (#374).
+/// The backend owns the geometry; the client only renders it — so any advisory
+/// that gains an emitter server-side lights up here with no app change.
+struct AdvisoryHighlights: Codable, Sendable {
+    /// 1-D route verdict. Segments tile `[0, total_nm]` exactly (gapless).
+    let ribbon: [RibbonSegment]
+    /// 2-D scrim cutouts — where the hazard physically is (flagged areas only).
+    let regions: [HighlightRegion]
+    /// Distance of the advisory's peak (worst point) along the route, if any.
+    let peakDistNm: Double?
+}
+
+/// One run of the 1-D route verdict strip.
+struct RibbonSegment: Codable, Sendable {
+    let distFromNm: Double
+    let distToNm: Double
+    let severity: String  // "green" | "amber" | "red" | "unavailable"
+}
+
+/// One scrim cutout. `baseFt`/`topFt` both nil = full column (terrain-to-top).
+struct HighlightRegion: Codable, Sendable {
+    let distFromNm: Double
+    let distToNm: Double
+    let baseFt: Double?
+    let topFt: Double?
+    let kind: String
+    let severity: String
 }
 
 /// A decision that could improve a flagged sub-issue — advice only.

--- a/app/flyfun-weather/flyfun-weather/Models/Domain/VizData.swift
+++ b/app/flyfun-weather/flyfun-weather/Models/Domain/VizData.swift
@@ -12,6 +12,55 @@ struct VizRouteData {
     let departureTime: String
     let flightDurationHours: Double
     let terrainProfile: [TerrainPoint]?
+    /// Advisory highlight geometry (scrim + verdict ribbon, #374) for the
+    /// tracked advisory × the rendered model. Unlike the fields above it is NOT
+    /// built by `extractVizData` (the geometry lives in the advisories manifest,
+    /// a separate artifact) — the cross-section scene attaches the derived value
+    /// just before rendering, mirroring web `briefing-main`. nil → the highlight
+    /// layer no-ops.
+    var advisoryHighlights: VizAdvisoryHighlights? = nil
+}
+
+/// Domain mirror of the API `AdvisoryHighlights` (#374). `Equatable` because the
+/// static cross-section scene's redraw gate compares it by value — the geometry
+/// is re-derived on every body evaluation, so identity can't be used.
+struct VizAdvisoryHighlights: Equatable {
+    struct Segment: Equatable {
+        let distFromNm: Double
+        let distToNm: Double
+        let severity: String
+    }
+
+    /// `baseFt`/`topFt` both nil = full column (terrain-to-top).
+    struct Region: Equatable {
+        let distFromNm: Double
+        let distToNm: Double
+        let baseFt: Double?
+        let topFt: Double?
+        let kind: String
+        let severity: String
+    }
+
+    let ribbon: [Segment]
+    let regions: [Region]
+    let peakDistNm: Double?
+
+    init(ribbon: [Segment], regions: [Region], peakDistNm: Double?) {
+        self.ribbon = ribbon
+        self.regions = regions
+        self.peakDistNm = peakDistNm
+    }
+
+    init(from api: AdvisoryHighlights) {
+        ribbon = api.ribbon.map {
+            Segment(distFromNm: $0.distFromNm, distToNm: $0.distToNm, severity: $0.severity)
+        }
+        regions = api.regions.map {
+            Region(distFromNm: $0.distFromNm, distToNm: $0.distToNm,
+                   baseFt: $0.baseFt, topFt: $0.topFt, kind: $0.kind, severity: $0.severity)
+        }
+        peakDistNm = api.peakDistNm
+    }
 }
 
 struct WaypointMarker {

--- a/app/flyfun-weather/flyfun-weather/ViewModels/BriefingViewModel.swift
+++ b/app/flyfun-weather/flyfun-weather/ViewModels/BriefingViewModel.swift
@@ -53,6 +53,11 @@ struct FocusIntent: Equatable {
     /// Advisory lens id to apply on the cross-section (e.g. "icing"); see
     /// `CrossSectionPresets`.
     var advisoryPresetId: String?
+    /// Concrete advisory instance behind the lens (e.g. "vmc_cruise"), set only
+    /// by advisory-card actions. Activates that advisory's cross-section
+    /// highlight (scrim + verdict ribbon, #374) when the pack carries highlight
+    /// geometry; a re-tap of the same advisory toggles the highlight off.
+    var advisoryId: String?
     var pointIndex: Int?
     var distanceNm: Double?
     var altitudeFt: Double?

--- a/app/flyfun-weather/flyfun-weather/ViewModels/CrossSectionViewModel.swift
+++ b/app/flyfun-weather/flyfun-weather/ViewModels/CrossSectionViewModel.swift
@@ -22,12 +22,31 @@ final class CrossSectionViewModel {
     /// Persisted across launches via `UserDefaults`.
     private(set) var themeId: CrossSectionThemeID
 
+    /// Advisory whose cross-section highlight (scrim + verdict ribbon, #374) is
+    /// tracked, or nil for none. Only the id is stored — the geometry is
+    /// re-derived from (advisories manifest × selected model) at render time, so
+    /// model switches and recalcs update the highlight with no stale-copy bugs,
+    /// and it no-ops gracefully when the advisory has no data (old pack).
+    /// Model/point changes do NOT clear it; lens application and manual layer
+    /// edits do (see `applyAdvisoryPreset` / `toggleLayer` / `setMethod` /
+    /// `applyPreset`).
+    private(set) var activeHighlightAdvisoryId: String?
+    /// Visibility of the active highlight. Deliberately NOT part of
+    /// `enabledLayers`: toggling it is a visibility control, not a lens edit —
+    /// it must neither flip the preset to Custom nor clear the highlight (and
+    /// keeping it out preserves the exact-map `currentPreset` comparison).
+    private(set) var highlightVisible = true
+
     /// `UserDefaults` key for the persisted theme choice.
     private static let themeDefaultsKey = "crossSectionThemeId"
     /// `UserDefaults` key for the persisted layer enablement map.
     private static let layersDefaultsKey = "crossSectionEnabledLayers"
     /// `UserDefaults` key for the persisted advisory-lens id (absent when none).
     private static let advisoryPresetDefaultsKey = "crossSectionAdvisoryPreset"
+    /// `UserDefaults` key for the persisted highlight advisory id (absent when
+    /// none). Mirrors the web, which persists `activeHighlightAdvisoryId` in its
+    /// viz settings; visibility intentionally resets to shown on relaunch.
+    private static let highlightAdvisoryDefaultsKey = "crossSectionHighlightAdvisory"
 
     init() {
         // Restore the last-chosen theme; fall back to GRAMET (the boot preset's
@@ -54,6 +73,7 @@ final class CrossSectionViewModel {
             enabledLayers = merged
         }
         activeAdvisoryPreset = UserDefaults.standard.string(forKey: Self.advisoryPresetDefaultsKey)
+        activeHighlightAdvisoryId = UserDefaults.standard.string(forKey: Self.highlightAdvisoryDefaultsKey)
         recomputeEffectiveLayers()
     }
 
@@ -74,6 +94,11 @@ final class CrossSectionViewModel {
             UserDefaults.standard.set(id, forKey: Self.advisoryPresetDefaultsKey)
         } else {
             UserDefaults.standard.removeObject(forKey: Self.advisoryPresetDefaultsKey)
+        }
+        if let id = activeHighlightAdvisoryId {
+            UserDefaults.standard.set(id, forKey: Self.highlightAdvisoryDefaultsKey)
+        } else {
+            UserDefaults.standard.removeObject(forKey: Self.highlightAdvisoryDefaultsKey)
         }
         // This is the single funnel for every `enabledLayers` mutation
         // (toggle/enable/preset/method/advisory-lens), so refresh the effective-
@@ -127,6 +152,7 @@ final class CrossSectionViewModel {
     func toggleLayer(_ id: String) {
         enabledLayers[id] = !(enabledLayers[id] ?? false)
         activeAdvisoryPreset = nil  // a manual edit is no longer a named lens
+        activeHighlightAdvisoryId = nil  // …and drops the advisory highlight (#374)
         persistLayerConfig()
     }
 
@@ -167,6 +193,7 @@ final class CrossSectionViewModel {
         if !map.isEmpty { enabledLayers = map }
         if let tid = preset.themeId { setTheme(tid) }
         activeAdvisoryPreset = nil
+        activeHighlightAdvisoryId = nil  // a layer preset drops the highlight (#374)
         persistLayerConfig()
     }
 
@@ -208,14 +235,68 @@ final class CrossSectionViewModel {
         }
         enabledLayers = m
         activeAdvisoryPreset = preset.id
+        // Applying a lens clears any prior highlight (web parity, #374): a bare
+        // lens from the picker therefore ends with no highlight, while the
+        // advisory-chip path re-sets it via `setHighlightAdvisory` AFTER this
+        // call — which is also what makes a same-chip re-tap toggle it off.
+        activeHighlightAdvisoryId = nil
         persistLayerConfig()
     }
 
     /// Clear the active lens (the picker's "None") without otherwise touching the
-    /// layer config.
+    /// layer config. Also drops the advisory highlight, like any lens change.
     func clearAdvisoryPreset() {
         activeAdvisoryPreset = nil
+        activeHighlightAdvisoryId = nil
         persistLayerConfig()
+    }
+
+    // MARK: - Advisory highlight (scrim + verdict ribbon, #374)
+
+    /// Track (or clear with nil) the advisory whose highlight the cross-section
+    /// renders. Setting a non-nil id force-shows the highlight (fresh intent — an
+    /// invisible highlight right after a chip tap looks broken); clearing leaves
+    /// the visibility flag alone.
+    func setHighlightAdvisory(_ advisoryId: String?) {
+        activeHighlightAdvisoryId = advisoryId
+        if advisoryId != nil { highlightVisible = true }
+        persistLayerConfig()
+    }
+
+    /// Show/hide the active highlight. A visibility control, NOT a lens edit —
+    /// it must not clear the highlight or the active lens (contrast
+    /// `toggleLayer`).
+    func setHighlightVisible(_ visible: Bool) {
+        highlightVisible = visible
+    }
+
+    /// The representative model for an advisory: the first `perModel` entry whose
+    /// status equals `aggregateStatus` (the same policy the server uses to choose
+    /// `aggregate_detail`), falling back to the first entry. The chip switches
+    /// the cross-section to this model so the highlight reflects the aggregate
+    /// verdict. Mirrors web `advisory-highlights.ts`.
+    static func representativeModel(for advisory: RouteAdvisoryResult) -> String? {
+        if let match = advisory.perModel.first(where: { $0.status == advisory.aggregateStatus }) {
+            return match.model
+        }
+        return advisory.perModel.first?.model
+    }
+
+    /// Derive the highlight geometry to render for (manifest × advisory × model),
+    /// or nil when the advisory is not highlighted / no longer exists / the model
+    /// has no entry / the pack carries no highlight data (old pack) — in every
+    /// case the highlight layer and its visibility toggle stay hidden. Mirrors
+    /// web `deriveHighlights`.
+    static func deriveHighlights(
+        manifest: AdvisoriesResponse?,
+        advisoryId: String?,
+        model: String
+    ) -> VizAdvisoryHighlights? {
+        guard let manifest, let advisoryId,
+              let advisory = manifest.advisories.first(where: { $0.advisoryId == advisoryId }),
+              let highlights = advisory.perModel.first(where: { $0.model == model })?.highlights
+        else { return nil }
+        return VizAdvisoryHighlights(from: highlights)
     }
 
     // MARK: - Methods (clouds/icing/turbulence/convection — one method per group)
@@ -235,6 +316,7 @@ final class CrossSectionViewModel {
             enabledLayers[id] = (id == layerId)
         }
         activeAdvisoryPreset = nil
+        activeHighlightAdvisoryId = nil  // a manual method edit drops the highlight (#374)
         persistLayerConfig()
     }
 

--- a/app/flyfun-weather/flyfun-weather/Views/Briefing/AdvisoryCardView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Briefing/AdvisoryCardView.swift
@@ -78,6 +78,7 @@ struct AdvisoryCardView: View {
                             target: .crossSection,
                             model: viewModel.selectedModel,
                             advisoryPresetId: preset.id,
+                            advisoryId: advisory.advisoryId,
                             pointIndex: viewModel.activePointIndex
                         ))
                     } label: {

--- a/app/flyfun-weather/flyfun-weather/Views/CrossSection/CrossSectionConfigSheet.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/CrossSection/CrossSectionConfigSheet.swift
@@ -8,6 +8,11 @@ import SwiftUI
 /// chrome (model-switching is more frequent than layer config).
 struct CrossSectionConfigSheet: View {
     @Bindable var csVM: CrossSectionViewModel
+    /// Whether an advisory highlight is active AND the selected model carries
+    /// geometry for it (#374) — gates the visibility toggle so it never shows a
+    /// dead control. Captured at presentation; it can't change while the sheet
+    /// is up (the model selector lives in the chart chrome, not here).
+    var highlightAvailable: Bool = false
     @Environment(\.dismiss) private var dismiss
     @State private var showMore = false
 
@@ -17,6 +22,7 @@ struct CrossSectionConfigSheet: View {
                 presetSection
                 themeSection
                 advisoryLensSection
+                highlightSection
                 methodSection
                 referenceSection
                 if showMore { moreSection }
@@ -105,6 +111,28 @@ struct CrossSectionConfigSheet: View {
                 Text(p.caption)
             } else {
                 Text("Focus the chart on one hazard (icing, clouds, convection…).")
+            }
+        }
+    }
+
+    // MARK: Advisory highlight — visibility only, never a lens edit (#374)
+
+    /// Show/hide toggle for the active advisory highlight (scrim + verdict
+    /// ribbon). Only rendered while a highlight is active with data for the
+    /// selected model. Deliberately NOT a layer toggle: flipping it neither
+    /// switches the preset to Custom nor clears the highlight.
+    @ViewBuilder
+    private var highlightSection: some View {
+        if highlightAvailable {
+            Section {
+                Toggle(isOn: Binding(
+                    get: { csVM.highlightVisible },
+                    set: { csVM.setHighlightVisible($0) }
+                )) {
+                    Text("Advisory highlight")
+                }
+            } footer: {
+                Text("Dims the chart outside the advisory's flagged areas; the strip under the chart grades the whole route for it.")
             }
         }
     }

--- a/app/flyfun-weather/flyfun-weather/Views/CrossSection/CrossSectionRenderer.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/CrossSection/CrossSectionRenderer.swift
@@ -70,6 +70,13 @@ struct CrossSectionRenderer {
 
         // Axes and grid (drawn outside clip)
         drawAxes(context: &context, transform: transform, data: data)
+
+        // Advisory highlight (scrim + verdict ribbon, #374) renders last — top of
+        // the stack, above the axes, matching the web layer order. It is invoked
+        // outside the plot-area clip (the ribbon draws in the bottom margin) and
+        // manages its own clipping; it no-ops when `data.advisoryHighlights` is
+        // nil (no tracked advisory / old pack / model without highlight data).
+        HighlightLayer().render(context: &context, transform: transform, data: data)
     }
 
     /// The dynamic overlay: the scrub cursor rule + the live aircraft marker.
@@ -156,9 +163,12 @@ struct CrossSectionRenderer {
             gridPath.addLine(to: CGPoint(x: x, y: plot.bottom))
             context.stroke(gridPath, with: .color(gridColor), lineWidth: 0.5)
 
-            // Label
+            // Label — offset below the verdict-ribbon strip, which hugs the plot
+            // bottom at [+2, +8] (#374). Keep in sync with `HighlightLayer`'s
+            // ribbonGap/ribbonHeight so the ribbon never paints over the labels
+            // (mirrors the web's DISTANCE_LABEL_DY fix).
             let text = context.resolve(Text("\(Int(dist)) nm").font(.system(size: 9)).foregroundColor(textColor))
-            context.draw(text, at: CGPoint(x: x, y: plot.bottom + 4), anchor: .top)
+            context.draw(text, at: CGPoint(x: x, y: plot.bottom + Self.distanceLabelDY), anchor: .top)
 
             dist += distInterval
         }
@@ -205,6 +215,10 @@ struct CrossSectionRenderer {
         context.stroke(hLine, with: .color(crossColor), lineWidth: 0.5)
         context.stroke(vLine, with: .color(crossColor), lineWidth: 0.5)
     }
+
+    /// Distance tick labels sit below the advisory verdict ribbon ([+2, +8],
+    /// #374) with a small gap. Fits the 30pt bottom margin (label ends ~+22).
+    private static let distanceLabelDY: CGFloat = 11
 
     private func altitudeTickInterval(_ maxAlt: Double) -> Double {
         if maxAlt <= 8000 { return 1000 }

--- a/app/flyfun-weather/flyfun-weather/Views/CrossSection/CrossSectionScene.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/CrossSection/CrossSectionScene.swift
@@ -33,16 +33,28 @@ struct StaticCrossSectionScene: View, Equatable {
     /// than relying on the undocumented behaviour of `Canvas` re-running its
     /// closure while `EquatableView` skips `body`.
     let renderSize: CGSize
+    /// Advisory highlight geometry (#374), derived by the call site from the
+    /// tracked advisory × selected model (never stored). Passed separately from
+    /// `data` — whose identity is `dataVersion` — because it changes on its own
+    /// triggers (chip tap / visibility toggle) without a data rebuild; being a
+    /// small `Equatable` value it participates in the redraw gate directly.
+    var highlights: VizAdvisoryHighlights? = nil
 
     static func == (lhs: Self, rhs: Self) -> Bool {
         lhs.dataVersion == rhs.dataVersion
             && lhs.themeId == rhs.themeId
             && lhs.renderSize == rhs.renderSize
             && lhs.enabledLayers == rhs.enabledLayers
+            && lhs.highlights == rhs.highlights
     }
 
     var body: some View {
         Canvas { context, size in
+            // Attach the derived highlight the way web briefing-main attaches
+            // `data.advisoryHighlights` before setData — the layer reads it from
+            // the data like every other layer.
+            var data = self.data
+            data.advisoryHighlights = highlights
             CrossSectionRenderer(data: data, enabledLayers: enabledLayers, themeId: themeId)
                 .renderStatic(context: &context, size: size)
         }

--- a/app/flyfun-weather/flyfun-weather/Views/CrossSection/CrossSectionTheme.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/CrossSection/CrossSectionTheme.swift
@@ -53,6 +53,12 @@ struct CrossSectionTheme: Sendable {
     var axisGrid: Color
     var axisWaypoint: Color
 
+    /// Dim-wash colour for the advisory-highlight scrim (#374). Web keeps the
+    /// light/dark variants in `highlight-layer.ts` keyed off the page theme; iOS
+    /// keys them off the chart theme instead (the wash covers the themed sky, and
+    /// only Light has a bright plot).
+    var scrimWash: Color
+
     // Terrain
     var terrainFill: RGB
     var terrainStroke: RGB
@@ -122,6 +128,7 @@ extension CrossSectionTheme {
         skyBackground: c(115, 149, 219),                 // #7395DB
         axisGrid: c(255, 255, 255, 0.35),
         axisWaypoint: c(255, 255, 255, 0.45),
+        scrimWash: c(0, 0, 0, 0.42),                     // web dark-theme wash
         terrainFill: RGB(r: 139, g: 115, b: 85),         // #8B7355
         terrainStroke: RGB(r: 107, g: 91, b: 69),        // #6B5B45
         freezingLevel: c(0, 188, 212),                   // #00bcd4
@@ -352,6 +359,7 @@ extension CrossSectionTheme {
         t.skyBackground = c(248, 249, 251)               // #F8F9FB
         t.axisGrid = c(20, 30, 50, 0.18)
         t.axisWaypoint = c(20, 30, 50, 0.32)
+        t.scrimWash = c(15, 23, 42, 0.34)                // web light-theme wash
         t.terrainFill = RGB(r: 164, g: 130, b: 86)       // #A48256
         t.terrainStroke = RGB(r: 122, g: 94, b: 61)      // #7A5E3D
         t.freezingLevel = c(2, 119, 189)                 // #0277BD

--- a/app/flyfun-weather/flyfun-weather/Views/CrossSection/CrossSectionView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/CrossSection/CrossSectionView.swift
@@ -53,7 +53,9 @@ struct CrossSectionView: View {
         .onChange(of: viewModel.focusIntent) { applyFocusIntent() }
         .task { updateVizData(); applyFocusIntent() }
         .sheet(isPresented: $showingConfig) {
-            CrossSectionConfigSheet(csVM: csVM)
+            // The Highlight visibility toggle shows only while a highlight is
+            // active AND the selected model has geometry for it (#374).
+            CrossSectionConfigSheet(csVM: csVM, highlightAvailable: derivedHighlights != nil)
         }
         // Gate the cross-section tips on this tab being on screen so they never
         // fire from the Advisory/Map tabs (#312).
@@ -208,9 +210,13 @@ struct CrossSectionView: View {
             // thin cursor rule + aircraft marker live in a cheap overlay Canvas
             // that redraws every tick instead (#303). `themeId` is part of the gate
             // so a theme switch repaints the static layers, not just the overlay (#320).
+            // The derived advisory highlight (#374) rides the same gate: it's a
+            // small Equatable value, so re-deriving it each body pass is cheap and
+            // only an actual geometry change repaints the scene.
             StaticCrossSectionScene(data: vizData, enabledLayers: layers,
                                     dataVersion: csVM.dataVersion, themeId: themeId,
-                                    renderSize: canvasSize)
+                                    renderSize: canvasSize,
+                                    highlights: csVM.highlightVisible ? derivedHighlights : nil)
                 // `.equatable()` is load-bearing: it forces SwiftUI to gate the
                 // redraw on the custom `==` (dataVersion + layers + themeId + size). Without
                 // it the reconciler falls back to reflecting the stored properties, can't
@@ -292,6 +298,11 @@ struct CrossSectionView: View {
     private func applyFocusIntent() {
         guard let intent = viewModel.focusIntent,
               intent.target == .crossSection || intent.target == .skewT else { return }
+        // Same-advisory re-tap toggles the highlight OFF while the lens stays
+        // (#374): capture "already on" BEFORE the lens application below clears
+        // the highlight, then skip re-activation.
+        let highlightAlreadyOn = intent.advisoryId != nil
+            && csVM.activeHighlightAdvisoryId == intent.advisoryId
         // An advisory lens configures the whole view; a single layerId just
         // force-enables one layer. Apply the lens first so a layerId can refine it.
         if let presetId = intent.advisoryPresetId,
@@ -299,7 +310,33 @@ struct CrossSectionView: View {
             csVM.applyAdvisoryPreset(preset)
         }
         if let layerId = intent.layerId { csVM.enableLayer(layerId) }
-        if let dist = intent.distanceNm {
+        // Highlight activation (#374). Old packs / non-emitting advisories carry
+        // no highlight geometry, so the guard falls through and the action
+        // behaves exactly as before highlights existed.
+        var peakDistNm: Double?
+        if let advisoryId = intent.advisoryId, !highlightAlreadyOn,
+           case .loaded(let manifest) = viewModel.advisoriesState,
+           let advisory = manifest.advisories.first(where: { $0.advisoryId == advisoryId }),
+           advisory.perModel.contains(where: { $0.highlights != nil }) {
+            // Switch to the advisory's representative model so the highlight
+            // reflects the aggregate verdict. Assigned directly (not via
+            // `selectModel`) — a programmatic switch must not overwrite the
+            // user's sticky model preference.
+            if let rep = CrossSectionViewModel.representativeModel(for: advisory),
+               viewModel.availableModels.contains(rep) {
+                viewModel.selectedModel = rep
+            }
+            csVM.setHighlightAdvisory(advisoryId)  // also force-shows the highlight
+            peakDistNm = advisory.perModel
+                .first(where: { $0.model == viewModel.selectedModel })?
+                .highlights?.peakDistNm
+        }
+        if let peak = peakDistNm {
+            // Land the cursor (and the shared active point → readout/Skew-T
+            // linkage) on the advisory's peak.
+            scrubDistanceNm = peak
+            selectNearestPoint(to: peak)
+        } else if let dist = intent.distanceNm {
             scrubDistanceNm = dist
         } else if let pointDist = activePointDistanceNm {
             scrubDistanceNm = pointDist
@@ -308,6 +345,28 @@ struct CrossSectionView: View {
         // A skewT-targeted intent (#310) means "scroll to the embedded Skew-T".
         if intent.target == .skewT { scrollTarget = "skewt" }
         viewModel.clearFocusIntent()
+    }
+
+    /// Snap the shared active route point to the nearest analysis point (same
+    /// rule as `updateScrub` — soundings are discrete).
+    private func selectNearestPoint(to dist: Double) {
+        guard case .loaded(let analyses) = viewModel.routeAnalysesState else { return }
+        let nearest = analyses.analyses.min {
+            abs($0.distanceFromOriginNm - dist) < abs($1.distanceFromOriginNm - dist)
+        }
+        viewModel.activePointIndex = nearest?.pointIndex
+    }
+
+    /// Advisory highlight geometry for the tracked advisory × the rendered model
+    /// (#374). Derived, never stored — model switches and pack recalcs update it
+    /// automatically, and it degrades to nil (highlight + toggle hidden) when the
+    /// advisory is gone or the pack/model has no data.
+    private var derivedHighlights: VizAdvisoryHighlights? {
+        guard case .loaded(let manifest) = viewModel.advisoriesState else { return nil }
+        return CrossSectionViewModel.deriveHighlights(
+            manifest: manifest,
+            advisoryId: csVM.activeHighlightAdvisoryId,
+            model: viewModel.selectedModel)
     }
 
     private func goToSounding() {

--- a/app/flyfun-weather/flyfun-weather/Views/CrossSection/Layers/CrossSectionLayer.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/CrossSection/Layers/CrossSectionLayer.swift
@@ -21,6 +21,10 @@ enum LayerGroup: String, CaseIterable {
     case turbulence
     case convection
     case reference
+    /// Advisory highlight (scrim + verdict ribbon, #374). Not a toggleable data
+    /// layer: its visibility is driven by the active advisory highlight, so it
+    /// never appears in the method/reference sections of the config sheet.
+    case highlight
 }
 
 extension LayerGroup {
@@ -45,6 +49,7 @@ extension LayerGroup {
         case .turbulence: "Turbulence"
         case .convection: "Convection"
         case .reference: "Reference"
+        case .highlight: "Highlight"
         }
     }
 }

--- a/app/flyfun-weather/flyfun-weather/Views/CrossSection/Layers/HighlightLayer.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/CrossSection/Layers/HighlightLayer.swift
@@ -1,0 +1,134 @@
+import SwiftUI
+
+// =============================================================================
+// SYNC — port of web/ts/visualization/cross-section/layers/highlight-layer.ts
+// (#373 web / #374 iOS). Keep geometry constants and composition rules aligned
+// so identical highlight data renders the same on both platforms.
+// =============================================================================
+
+/// Advisory highlight layer: scrim (focus) + verdict ribbon (judgement).
+///
+/// Two visual elements, each doing exactly one job:
+///  - **Scrim** — a translucent dim wash over the plot area with cutouts punched
+///    out where the hazard physically is, each cutout framed by a thin
+///    severity-colored outline. Dimming means "not the focus", never a verdict.
+///    Composed in a transparency layer (so `.destinationOut` punches the wash,
+///    not the sky/terrain beneath). No scrim at all when there are no flagged
+///    regions (the all-green case — never dim a clean chart).
+///  - **Verdict ribbon** — a ~6pt strip in the bottom margin (below the plot,
+///    above the distance labels) partitioning the whole route into
+///    green/amber/red/gray for this advisory. Renders even in the all-green case
+///    (an explicit "checked: clear the whole way").
+///
+/// Geometry is derived reactively from (advisories manifest × selected model)
+/// and attached as `data.advisoryHighlights`; this layer is pure rendering and
+/// no-ops when there is no highlight data. It is NOT registered in
+/// `CrossSectionLayer.allLayers`: the ribbon draws into the bottom margin, so it
+/// must bypass the plot-area clip the layer loop applies — the renderer invokes
+/// it explicitly last (top of the stack, above the axes), and it manages its own
+/// clipping.
+struct HighlightLayer: CrossSectionLayerProtocol {
+    let id = "advisory-highlight"
+    let name = "Highlight"
+    let group = LayerGroup.highlight
+
+    /// Ribbon strip geometry within the bottom margin: [plot.bottom + 2, + 8],
+    /// which sits ABOVE the distance-axis labels — the renderer pushes those to
+    /// `distanceLabelDY` (+11) to keep this strip clear. Keep in sync.
+    static let ribbonHeight: CGFloat = 6
+    static let ribbonGap: CGFloat = 2
+    private static let cutoutOutlineWidth: CGFloat = 1.5
+
+    @MainActor func render(context: inout GraphicsContext, transform: CoordTransform, data: VizRouteData) {
+        guard let highlights = data.advisoryHighlights else { return }
+        drawScrim(context: &context, transform: transform, regions: highlights.regions)
+        drawRibbon(context: &context, transform: transform, ribbon: highlights.ribbon)
+    }
+
+    /// Severity colour, aligned with the app's advisory status colours (the same
+    /// mapping the badges use). Unavailable = neutral gray. System colours adapt
+    /// to light/dark automatically.
+    private func severityColor(_ severity: String) -> Color {
+        (Assessment(rawValue: severity) ?? .unavailable).color
+    }
+
+    // MARK: - Scrim
+
+    @MainActor
+    private func drawScrim(context: inout GraphicsContext, transform: CoordTransform,
+                           regions: [VizAdvisoryHighlights.Region]) {
+        guard !regions.isEmpty else { return }  // all-green: never dim a clean chart
+        let plot = transform.plotArea
+        let plotRect = CGRect(x: plot.left, y: plot.top, width: plot.width, height: plot.height)
+        let merged = Self.mergedRegions(regions)
+
+        // Compose the dim wash + cutouts in a transparency layer so
+        // `.destinationOut` punches only the wash, not the sky/terrain/weather
+        // beneath, then composite the whole layer onto the main context.
+        context.drawLayer { layer in
+            layer.fill(Path(plotRect), with: .color(CrossSectionTheme.active.scrimWash))
+            layer.blendMode = .destinationOut
+            for region in merged {
+                layer.fill(Path(rect(for: region, transform: transform)), with: .color(.black))
+            }
+        }
+
+        // Stroke each cutout with a severity-coloured outline, clipped to the
+        // plot area so a full-column outline doesn't bleed into the margins.
+        var clipped = context
+        clipped.clip(to: Path(plotRect))
+        for region in merged {
+            clipped.stroke(Path(rect(for: region, transform: transform)),
+                           with: .color(severityColor(region.severity)),
+                           lineWidth: Self.cutoutOutlineWidth)
+        }
+    }
+
+    /// Pixel rect of a region. base/top nil → terrain-to-top (full column).
+    private func rect(for region: VizAdvisoryHighlights.Region, transform: CoordTransform) -> CGRect {
+        let plot = transform.plotArea
+        let x0 = transform.distanceToX(region.distFromNm)
+        let x1 = transform.distanceToX(region.distToNm)
+        let yTop = region.topFt.map { transform.altitudeToY($0) } ?? plot.top
+        let yBottom = region.baseFt.map { transform.altitudeToY($0) } ?? plot.bottom
+        return CGRect(x: x0, y: yTop, width: x1 - x0, height: yBottom - yTop)
+    }
+
+    /// Merge abutting same-kind/same-severity/same-span regions into one rect so
+    /// the outline pass doesn't stroke seams inside what reads as one visual
+    /// region. The server already envelope-merges contiguous runs; this is the
+    /// defensive client-side pass the issue asks for (visual parity with web).
+    static func mergedRegions(_ regions: [VizAdvisoryHighlights.Region]) -> [VizAdvisoryHighlights.Region] {
+        var out: [VizAdvisoryHighlights.Region] = []
+        for region in regions {
+            if let last = out.last,
+               last.kind == region.kind, last.severity == region.severity,
+               last.baseFt == region.baseFt, last.topFt == region.topFt,
+               abs(last.distToNm - region.distFromNm) < 0.01 {
+                out[out.count - 1] = VizAdvisoryHighlights.Region(
+                    distFromNm: last.distFromNm, distToNm: region.distToNm,
+                    baseFt: last.baseFt, topFt: last.topFt,
+                    kind: last.kind, severity: last.severity)
+            } else {
+                out.append(region)
+            }
+        }
+        return out
+    }
+
+    // MARK: - Verdict ribbon
+
+    @MainActor
+    private func drawRibbon(context: inout GraphicsContext, transform: CoordTransform,
+                            ribbon: [VizAdvisoryHighlights.Segment]) {
+        guard !ribbon.isEmpty else { return }
+        let y = transform.plotArea.bottom + Self.ribbonGap
+        for segment in ribbon {
+            let x0 = transform.distanceToX(segment.distFromNm)
+            let x1 = transform.distanceToX(segment.distToNm)
+            guard x1 > x0 else { continue }
+            context.fill(Path(CGRect(x: x0, y: y, width: x1 - x0, height: Self.ribbonHeight)),
+                         with: .color(severityColor(segment.severity)))
+        }
+    }
+}

--- a/app/flyfun-weather/flyfun-weatherTests/AdvisoryHighlightTests.swift
+++ b/app/flyfun-weather/flyfun-weatherTests/AdvisoryHighlightTests.swift
@@ -1,0 +1,260 @@
+//
+//  AdvisoryHighlightTests.swift
+//  flyfun-weatherTests
+//
+//  Advisory cross-section highlights (#374) — the iOS mirror of the web's
+//  advisory-highlights tests: decode contract (old packs → nil), the
+//  representative-model policy, the derive selector's nil paths, the store
+//  clearing rules, and the outline seam-merge.
+//
+
+import Testing
+import Foundation
+@testable import flyfun_weather
+
+// MARK: - Builders
+
+private func modelResult(
+    model: String,
+    status: String = "amber",
+    highlights: AdvisoryHighlights? = nil
+) -> ModelAdvisoryResult {
+    ModelAdvisoryResult(
+        model: model, status: status, detail: "d",
+        affectedPoints: 1, totalPoints: 10, affectedPct: 10,
+        affectedNm: 5, totalNm: 50, crossCheck: nil, mitigations: nil,
+        highlights: highlights)
+}
+
+private func advisory(
+    id: String = "vmc_cruise",
+    aggregateStatus: String = "amber",
+    perModel: [ModelAdvisoryResult]
+) -> RouteAdvisoryResult {
+    RouteAdvisoryResult(
+        advisoryId: id, aggregateStatus: aggregateStatus, aggregateDetail: "d",
+        perModel: perModel, parametersUsed: [:], aggregateMitigations: nil)
+}
+
+private func manifest(_ advisories: [RouteAdvisoryResult]) -> AdvisoriesResponse {
+    AdvisoriesResponse(
+        advisories: advisories, catalog: [], routeName: "r",
+        cruiseAltitudeFt: 6000, flightCeilingFt: 11000, totalDistanceNm: 50,
+        models: advisories.flatMap { $0.perModel.map(\.model) },
+        aggregation: "worst", airportConditions: nil)
+}
+
+private let sampleHighlights = AdvisoryHighlights(
+    ribbon: [RibbonSegment(distFromNm: 0, distToNm: 50, severity: "green")],
+    regions: [],
+    peakDistNm: nil)
+
+// MARK: - Decode contract
+
+@Suite struct HighlightDecodeTests {
+
+    @Test func decodesHighlightsFromSnakeCase() throws {
+        let json = """
+        {"model":"gfs","status":"amber","detail":"d","affected_points":1,
+         "total_points":10,"affected_pct":10.0,"affected_nm":5.0,"total_nm":50.0,
+         "highlights":{
+            "ribbon":[{"dist_from_nm":0,"dist_to_nm":50,"severity":"amber"}],
+            "regions":[{"dist_from_nm":10,"dist_to_nm":20,"base_ft":2000,
+                        "top_ft":5000,"kind":"cruise_imc","severity":"amber"},
+                       {"dist_from_nm":20,"dist_to_nm":30,"base_ft":null,
+                        "top_ft":null,"kind":"tower","severity":"red"}],
+            "peak_dist_nm":15.0}}
+        """
+        let result = try JSONDecoder.weatherBrief.decode(ModelAdvisoryResult.self, from: Data(json.utf8))
+        let highlights = try #require(result.highlights)
+        #expect(highlights.ribbon.count == 1)
+        #expect(highlights.ribbon[0].severity == "amber")
+        #expect(highlights.regions.count == 2)
+        #expect(highlights.regions[0].baseFt == 2000)
+        #expect(highlights.regions[1].baseFt == nil)   // full column
+        #expect(highlights.regions[1].topFt == nil)
+        #expect(highlights.peakDistNm == 15)
+    }
+
+    /// Old packs carry no `highlights` key at all — must decode to nil, so the
+    /// feature is silently absent and the chip behaves exactly as before.
+    @Test func oldPackDecodesToNil() throws {
+        let json = """
+        {"model":"gfs","status":"amber","detail":"d","affected_points":1,
+         "total_points":10,"affected_pct":10.0,"affected_nm":5.0,"total_nm":50.0}
+        """
+        let result = try JSONDecoder.weatherBrief.decode(ModelAdvisoryResult.self, from: Data(json.utf8))
+        #expect(result.highlights == nil)
+    }
+
+    /// The shared fixture (a real pre-#373 manifest) still decodes end to end.
+    @MainActor @Test func fixtureManifestStillDecodes() {
+        #expect(FixtureBriefingData.advisories.advisories
+            .allSatisfy { adv in adv.perModel.allSatisfy { $0.highlights == nil } })
+    }
+}
+
+// MARK: - Representative model + derive selector
+
+@MainActor @Suite struct HighlightDeriveTests {
+
+    @Test func representativeModelPrefersAggregateStatusMatch() {
+        let adv = advisory(aggregateStatus: "red", perModel: [
+            modelResult(model: "gfs", status: "amber"),
+            modelResult(model: "ecmwf", status: "red"),
+        ])
+        #expect(CrossSectionViewModel.representativeModel(for: adv) == "ecmwf")
+    }
+
+    @Test func representativeModelFallsBackToFirstEntry() {
+        let adv = advisory(aggregateStatus: "red", perModel: [
+            modelResult(model: "gfs", status: "amber"),
+            modelResult(model: "ecmwf", status: "green"),
+        ])
+        #expect(CrossSectionViewModel.representativeModel(for: adv) == "gfs")
+        #expect(CrossSectionViewModel.representativeModel(for: advisory(perModel: [])) == nil)
+    }
+
+    @Test func deriveReturnsSelectedModelsGeometry() {
+        let m = manifest([advisory(perModel: [
+            modelResult(model: "gfs"),
+            modelResult(model: "ecmwf", highlights: sampleHighlights),
+        ])])
+        let derived = CrossSectionViewModel.deriveHighlights(
+            manifest: m, advisoryId: "vmc_cruise", model: "ecmwf")
+        #expect(derived?.ribbon.count == 1)
+        #expect(derived?.ribbon.first?.severity == "green")
+    }
+
+    @Test func deriveNilPaths() {
+        let m = manifest([advisory(perModel: [
+            modelResult(model: "ecmwf", highlights: sampleHighlights),
+            modelResult(model: "gfs"),  // no highlights for this model
+        ])])
+        // No tracked advisory / no manifest.
+        #expect(CrossSectionViewModel.deriveHighlights(manifest: m, advisoryId: nil, model: "ecmwf") == nil)
+        #expect(CrossSectionViewModel.deriveHighlights(manifest: nil, advisoryId: "vmc_cruise", model: "ecmwf") == nil)
+        // Advisory vanished (recalc / other pack).
+        #expect(CrossSectionViewModel.deriveHighlights(manifest: m, advisoryId: "convective", model: "ecmwf") == nil)
+        // Model has no entry, or its entry carries no geometry (old pack).
+        #expect(CrossSectionViewModel.deriveHighlights(manifest: m, advisoryId: "vmc_cruise", model: "icon") == nil)
+        #expect(CrossSectionViewModel.deriveHighlights(manifest: m, advisoryId: "vmc_cruise", model: "gfs") == nil)
+    }
+}
+
+// MARK: - Store clearing rules
+
+@MainActor @Suite struct HighlightClearingTests {
+
+    /// The view model persists its layer config to shared `UserDefaults`, and
+    /// other suites (e.g. CrossSectionThemeTests' boot-default test) construct
+    /// fresh view models expecting clean defaults. Run each test body against
+    /// cleared keys and clear again in a `defer` — the body is synchronous
+    /// main-actor code, so no other main-actor test can observe the dirty state
+    /// mid-flight.
+    private static let persistedKeys = [
+        "crossSectionThemeId", "crossSectionEnabledLayers",
+        "crossSectionAdvisoryPreset", "crossSectionHighlightAdvisory",
+    ]
+
+    private func withCleanDefaults(_ body: (CrossSectionViewModel) -> Void) {
+        let clear = { for key in Self.persistedKeys { UserDefaults.standard.removeObject(forKey: key) } }
+        clear()
+        defer { clear() }
+        body(CrossSectionViewModel())
+    }
+
+    @Test func activationForcesVisibility() {
+        withCleanDefaults { vm in
+            vm.setHighlightVisible(false)
+            vm.setHighlightAdvisory("convective")
+            #expect(vm.activeHighlightAdvisoryId == "convective")
+            #expect(vm.highlightVisible)   // fresh intent — never an invisible highlight
+        }
+    }
+
+    @Test func visibilityToggleIsNotACustomEdit() {
+        withCleanDefaults { vm in
+            vm.applyAdvisoryPreset(CrossSectionPresets.advisory["convective"]!)
+            vm.setHighlightAdvisory("convective")
+            vm.setHighlightVisible(false)
+            // Hiding the highlight clears neither the highlight nor the lens.
+            #expect(vm.activeHighlightAdvisoryId == "convective")
+            #expect(vm.activeAdvisoryPreset == "convective")
+        }
+    }
+
+    @Test func manualLayerEditsClearTheHighlight() {
+        withCleanDefaults { vm in
+            vm.setHighlightAdvisory("convective")
+            vm.toggleLayer("freezing-level")
+            #expect(vm.activeHighlightAdvisoryId == nil)
+
+            vm.setHighlightAdvisory("convective")
+            vm.setMethod("icing-bands", for: .icing)
+            #expect(vm.activeHighlightAdvisoryId == nil)
+
+            vm.setHighlightAdvisory("convective")
+            vm.applyPreset(.gramet)
+            #expect(vm.activeHighlightAdvisoryId == nil)
+        }
+    }
+
+    @Test func lensChangesClearTheHighlight() {
+        withCleanDefaults { vm in
+            vm.setHighlightAdvisory("convective")
+            // A bare lens from the picker clears it (the chip path re-sets it after).
+            vm.applyAdvisoryPreset(CrossSectionPresets.advisory["icing"]!)
+            #expect(vm.activeHighlightAdvisoryId == nil)
+
+            vm.setHighlightAdvisory("convective")
+            vm.clearAdvisoryPreset()
+            #expect(vm.activeHighlightAdvisoryId == nil)
+        }
+    }
+
+    /// Model switches must NOT clear the highlight — there is deliberately no
+    /// model hook in the view model; geometry re-derives per model. Guard the
+    /// persistence contract instead: a relaunch restores the tracked advisory.
+    @Test func persistedHighlightRestores() {
+        withCleanDefaults { vm in
+            vm.setHighlightAdvisory("convective")
+            let restored = CrossSectionViewModel()
+            #expect(restored.activeHighlightAdvisoryId == "convective")
+        }
+    }
+}
+
+// MARK: - Outline seam-merge
+
+@Suite struct HighlightRegionMergeTests {
+
+    private func region(
+        _ from: Double, _ to: Double,
+        base: Double? = 2000, top: Double? = 5000,
+        kind: String = "cruise_imc", severity: String = "amber"
+    ) -> VizAdvisoryHighlights.Region {
+        .init(distFromNm: from, distToNm: to, baseFt: base, topFt: top,
+              kind: kind, severity: severity)
+    }
+
+    @Test func mergesAbuttingSameKindSameSeverityRects() {
+        let merged = HighlightLayer.mergedRegions([
+            region(0, 10), region(10, 20), region(20, 30),
+        ])
+        #expect(merged.count == 1)
+        #expect(merged[0].distFromNm == 0)
+        #expect(merged[0].distToNm == 30)
+    }
+
+    @Test func keepsDifferingOrGappedRectsApart() {
+        let merged = HighlightLayer.mergedRegions([
+            region(0, 10),
+            region(10, 20, severity: "red"),        // severity break
+            region(20, 30, base: 3000),             // span break
+            region(35, 40),                         // gap
+            region(40, 50, kind: "tower"),          // kind break
+        ])
+        #expect(merged.count == 5)
+    }
+}

--- a/web/ts/visualization/cross-section/layers/highlight-layer.ts
+++ b/web/ts/visualization/cross-section/layers/highlight-layer.ts
@@ -15,6 +15,10 @@
  *
  * Geometry is derived reactively (briefing-main attaches `data.advisoryHighlights`);
  * this layer is pure rendering. It no-ops when there is no highlight data.
+ *
+ * SYNC: the iOS app mirrors this renderer (geometry constants + composition
+ * rules) in app/flyfun-weather/flyfun-weather/Views/CrossSection/Layers/
+ * HighlightLayer.swift (#374) — keep the two in lockstep.
  */
 
 import type {


### PR DESCRIPTION
iOS mirror of the web advisory-highlight mechanism (#373). Closes #374.

## What it does

Tapping an advisory's **"On cross-section"** action now, in addition to applying the lens:

- switches to the advisory's **representative model** (first `per_model` entry matching the aggregate status — same policy the server uses for `aggregate_detail`),
- renders the **scrim** (dim wash with severity-outlined cutouts where the hazard physically is) and the **verdict ribbon** (~6pt strip under the plot grading the whole route green/amber/red/gray),
- force-shows the highlight and lands the cursor + shared active point on `peak_dist_nm` (drives the readout/Skew-T linkage),
- re-tapping the same advisory toggles the highlight off (lens stays).

The geometry is manifest data — only the advisory id is stored; scrim/ribbon re-derive from (advisories × selected model), so switching models shows that model's highlight, and any advisory that gains an emitter server-side lights up with no app change.

## Design requirements honored

- **All-green**: no scrim at all (never dim a clean chart), solid green ribbon = explicit "checked: clear".
- **Old packs / non-emitting advisories**: `highlights` decodes to nil → action behaves exactly as today.
- **Clearing**: bare lens from the picker, lens "None", manual layer/method/preset edits. Model/point changes do NOT clear.
- **Visibility toggle** (config sheet, shown only while the selected model has highlight data) is a visibility control, not a lens edit — clears nothing, doesn't flip the preset to Custom.
- Scrim composed in a transparency layer (`.destinationOut` punches the wash, not the sky/terrain); adjacent same-kind/severity rects seam-merged before stroking. Distance labels moved +4→+11 to clear the ribbon (mirrors the web `DISTANCE_LABEL_DY` fix). Severity colours = app advisory status colours; wash is theme-aware (`CrossSectionTheme.scrimWash`).

## SYNC

`/sync-ios-web` run (branch-diff scope): metrics-catalog IDENTICAL, preset tables untouched (highlights are data-driven by design), DTO structs match the Python models (optionality verified), and the one gap found — the web `highlight-layer.ts` lacked a reciprocal SYNC note for the new iOS mirror — is fixed in this PR.

## Testing

- Unit tests: decode contract (old pack → nil), representative-model policy, derive-selector nil paths, store clearing rules, outline seam-merge. Full `flyfun-weatherTests` suite passes on iPhone 17 Pro simulator.
- Build clean (`xcodebuild … Debug build`).
- Device verification against a real server still pending (mock mode can't render cross-section/advisories): tap action → model switch + scrim/ribbon; model switch re-derives; all-green → no scrim + green ribbon; old pack unchanged; toggle hides without clearing; dark mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)