### PR TITLE
Emit highlight regions from the remaining cross-section advisories (#375)

### DIFF
--- a/app/flyfun-weather/flyfun-weather/Views/CrossSection/Layers/CrossSectionPresets.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/CrossSection/Layers/CrossSectionPresets.swift
@@ -142,11 +142,14 @@ enum CrossSectionPresets {
 
     /// advisory_id → lens id (card chips). Mirrors web ADVISORY_TO_PRESET.
     static let advisoryToPreset: [String: String] = [
-        "icing_escape": "icing", "fiki_icing": "icing",
+        "icing_escape": "icing", "fiki_icing": "icing", "freezing_precip": "icing",
         "cloud_top": "clouds", "vmc_cruise": "clouds",
         "convective": "convective",
         "turbulence": "turbulence", "mountain_wind": "turbulence",
         "vfr_feasibility": "vfr", "ifr_feasibility": "ifr",
+        // enroute_precip is a visibility proxy → the VFR lens; the web
+        // override's routeGraph swap has no iOS equivalent (#375).
+        "enroute_precip": "vfr",
     ]
 
     /// Per-advisory extras unioned onto the base lens. Mirrors web
@@ -155,6 +158,7 @@ enum CrossSectionPresets {
     /// time by `applyAdvisoryPreset`'s `m[id] != nil` guard.
     static let advisoryOverrides: [String: (groups: [LayerGroup], lines: [String])] = [
         "fiki_icing": (groups: [], lines: ["minus-10c", "minus-20c", "sld-bands"]),
+        "freezing_precip": (groups: [], lines: ["sld-bands"]),
     ]
 
     /// The lens a given advisory's chip should apply, or nil if it has no chip.

--- a/designs/advisories.md
+++ b/designs/advisories.md
@@ -250,24 +250,35 @@ re-run `evaluate_all`. The ribbon (per-point verdict) and the card badge
 (route-level, extent-thresholded grade) deliberately use **different mappings** — a
 GREEN advisory with a short amber ribbon run is correct.
 
-**Emitting helpers** (`_helpers.py`, below): the two emitting evaluators build the
-geometry inside the per-point loops they already run:
+**Emitters** (#373 shipped `vmc_cruise` + `convective`; #375 added the rest).
+Every emitter builds the geometry inside the per-point loop it already runs and
+builds highlights only when the model has data (`total > 0`); shared
+conventions: no sounding → UNAVAILABLE ribbon segment; points skipped by an
+evaluator's relevance filters (altitude buffers, terrain thresholds) are
+ribbon-GREEN ("not relevant to your flight here" reads as clear); unless noted,
+`peak_dist_nm` = `ribbon_peak` (center of the longest red run, else amber).
 
-- `vmc_cruise` — ribbon: OVC→red, BKN→amber, else green, no sounding→unavailable.
-  Regions `kind="cruise_imc"`, band = envelope of the cloud layer(s) containing
-  cruise. `peak_dist_nm` via `ribbon_peak` (longest red run, else amber).
-- `convective` — ribbon: HIGH/EXTREME→red, LOW/MODERATE (≥ `min_risk`)→amber, else
-  (below floor / tops below cruise / no convection)→green, no sounding→unavailable.
-  Regions reuse the evaluator's own base/top resolution (`check_top_ft`, model
-  base/top with thermo-EL fallback): `kind="tower"` only when **both** base and
-  top resolve, else `kind="tower_unresolved"` full-column ghost (nwp_precip /
-  cover-only, or a resolved top with unknown base — never draw a bounded box that
-  implies a base the model lacks). `peak_dist_nm`
-  = the affected point with the worst graded risk, ties → highest CAPE (matches the
-  MCP deep-link peak). Both build highlights only when the model has data (`total > 0`).
+| Evaluator | Ribbon (per-point verdict) | Region kinds |
+|-----------|----------------------------|--------------|
+| `vmc_cruise` | OVC→red, BKN→amber, else green | `cruise_imc` — envelope of the layer(s) containing cruise |
+| `convective` | HIGH/EXTREME→red, ≥`min_risk`→amber, below floor / tops-below-cruise→green | `tower` only when **both** base and top resolve (evaluator's own `check_top_ft` resolution, thermo fallback), else `tower_unresolved` full-column ghost — never a bounded box implying a base the model lacks. Peak = worst graded risk, ties → highest CAPE (matches the MCP deep-link) |
+| `icing_escape` | green = no *relevant* icing (post `has_relevant_icing` — icing above cruise+buffer is deliberately green) · amber = icing with viable warm-air escape (incl. tight-margin) · red = no escape (fz below terrain+margin, or fz/terrain unknown at an affected point) | `icing_band` — envelope of the relevant zones |
+| `fiki_icing` | corridor points grade the transit column exactly as the route grade (SLD / SEVERE-when-`severe_is_red` / thickness ≥ red → red; thickness ≥ amber → amber); everywhere, icing within the cruise buffer → amber; thin transit-able icing away from cruise stays green | `icing_band` — envelope of zones overlapping `[0, cruise+buffer]` |
+| `turbulence` | red = SEVERE CAT **anywhere in the column** (the cutout showing where it sits is the ambiguity the highlight resolves — may exceed the badge, which keys on the cruise band) · amber = MODERATE CAT overlapping cruise or strong updraft near cruise · LIGHT stays green | `cat_layer` — envelope of the triggering layers. Strong-w resolves to a single level, not a band → no `strong_updraft` cutout (skip rather than invent geometry) |
+| `cloud_top` | binary: amber = can't get on top here, else green (the *amount* of amber tells the story) | `blocking_deck` — reachable layers whose `top + margin > ceiling` |
+| `vfr_feasibility` | worst firing sub-axis per x: cruise IMC→red / marginal clearance→amber (ribbon only), corridor deck OVC→red / BKN→amber, en-route precip per shared classifier **capped amber**; airport flight-category colours only the endpoint segments | `cruise_imc` + `climb_deck` / `descent_deck` (deck envelope over its corridor span) — the multi-kind case |
+| `ifr_feasibility` | worst per x of icing (amber) / convective (HIGH/EXTREME red, else amber); airport IFR-viability (LIFR amber, below-minimums red) colours the endpoints | `icing_band` (zones within the cruise buffer) + `tower`/`tower_unresolved` (same conventions as `convective`) |
+| `mountain_wind` | non-mountain points green; mountain points: no wind data→unavailable, wind ≥ red or (signature + ≥ corroborated red)→red, ≥ amber→amber. Peak = strongest-wind affected point. All-green ribbon on a flat route (GREEN-not-UNAVAILABLE choice), not `None` | `ridge_wind` (terrain → terrain+`altitude_margin_ft`) + `wave_signature` (the corroborating inversion band, red points only — visually explains the dropped RED bar). Envelope-merging absorbs bumpy-terrain noise into per-run rectangles; if a real rotor-day pack still reads noisy, dropping to ribbon-only is a one-line change |
+| `freezing_precip` | red = active FZRA/PL surface phase · amber = primed profile (warm nose, no active precip) · green otherwise | `freezing_precip_column` — `base=None` (surface) → warm-nose top from `detect_warm_nose`, falling back to a fixed shallow AGL band (terrain + 3000 ft) when the nose top doesn't resolve |
+| `enroute_precip` | mirrors `classify_precip_point` (shared with the VFR composite): moderate+ snow→red, any snow / moderate+ rain / FZRA-PL→amber, light/dry→green | `precip_column` — full column (`base/top = None`) |
 
-Remaining advisories (#375) and iOS rendering (#374) are follow-ups; only `vmc_cruise`
-and `convective` emit today.
+Not emitting (deliberate, #375): `headwind` (scalar — route graph is its home),
+airport advisories (`flight_category`, `airport_wind`, `density_altitude`,
+`llws` — point-in-space), `model_agreement`/`dd_nwp_agreement` (cross-model —
+Compare mode), `convective_character`, `fronts` and `sun` (dedicated layers).
+
+iOS rendering is #374; the geometry is data-driven so iOS picks all emitters up
+with no further backend work.
 
 ## Shared Helpers (`_helpers.py`)
 
@@ -275,6 +286,8 @@ and `convective` emit today.
 - **`build_ribbon(per_point, total_nm)`** → `list[RibbonSegment]` — merge consecutive same-severity route points into runs; boundaries fall midway between adjacent points; tiles `[0, total_nm]` exactly (sorted/non-overlapping/gapless invariants tested). No-sounding points → `UNAVAILABLE` (#373)
 - **`build_regions(per_point, total_nm)`** → `list[HighlightRegion]` — merge consecutive same-`kind`/`severity` flagged points (a `FlaggedCell` per flagged point, `None` otherwise) into one cutout using the **envelope** (min `base_ft` / max `top_ft`); all-`None` run stays a full column. Same cell-midpoint x-boundaries as the ribbon (#373)
 - **`ribbon_peak(segments)`** → center of the longest RED run, else longest AMBER run, else `None` — generic worst-point for evaluators whose peak is pure ribbon extent (`vmc_cruise`); richer peaks (convective's highest-CAPE) are computed in the evaluator (#373)
+- **`status_to_severity(status)`** / **`worst_severity(*sevs)`** → map a sub-axis `AdvisoryStatus` onto the ribbon scale and worst-of merge per-point severities — used by the composites for the multi-axis ribbon and the airport endpoint colouring (#375). `worst_severity` ranks UNAVAILABLE lowest so a flagged verdict overrides a data gap, never the reverse
+- **`classify_precip_point(precip)`** / **`precip_point_severity(cls, cap_amber=)`** (in `enroute_precip.py`) → single source of the per-point precip phase/intensity bucketing, shared by `classify_enroute_precip` (grade) and the ribbon builders (standalone + VFR composite with `cap_amber=True`) so geometry cannot drift from the grade (#375)
 - **`icing_zones_in_altitude_range(zones, floor_ft, ceiling_ft)`** → filter zones overlapping an altitude band
 - **`has_relevant_icing(zones, cruise_altitude_ft, buffer_ft=2000)`** → True if any zone overlaps `[0, cruise + buffer]`. Used by IFR feasibility, icing escape, and FIKI evaluators to ignore icing far above cruise altitude
 - **`min_icing_clearance(zones, cruise_altitude_ft)`** → minimum vertical distance (ft) from cruise to nearest icing zone. Used by FIKI evaluator
@@ -333,7 +346,7 @@ Recalculate loads route analyses + elevation + cross-sections from disk, applies
 - **Altitude table button**: opens a popup rendering the `/advisories/altitude-table` sweep — per-altitude advisory grid with best-below/best-above-cruise picks
 - **Profile selector** (`ProfileSelectorConfig`, owner-only): dropdown to switch the flight's advisory profile, re-running advisories with that profile's enabled/params/aggregation
 - **Alt-time toggle**: switches the displayed advisories between the planned departure and `alt_departure_time` (`routeAdvisories` vs `altAdvisories`)
-- **Advisory chips** (`handleAdvisoryChip`): clickable per-advisory chips that cross-link to the relevant map/cross-section context
+- **Advisory chips** (`handleAdvisoryChip`): clickable per-advisory chips that cross-link to the relevant map/cross-section context. Since #375 `freezing_precip` (→ `icing` preset + `sld-bands` override) and `enroute_precip` (→ `vfr` preset + precipitation route-graph override) also have chips; the mapping lives in `ADVISORY_TO_PRESET` (`web/ts/visualization/cross-section/advisory-presets.ts`), mirrored in iOS `CrossSectionPresets.swift`
 - Recalculate button triggers POST endpoint and re-renders. The top-level entry point is `renderAdvisories(...)` in `briefing-main.ts`, fed by `getEffectiveAdvisories(state)`
 
 **Info popup** (`components/info-popup.ts`):

--- a/src/weatherbrief/analysis/advisories/_helpers.py
+++ b/src/weatherbrief/analysis/advisories/_helpers.py
@@ -247,6 +247,38 @@ def build_regions(
     return regions
 
 
+# Rank for worst-of merging of per-point highlight severities. UNAVAILABLE ranks
+# lowest: it only enters a merge when a flagged verdict should override it (an
+# airport-axis endpoint colour over a data gap) — never the other way round.
+_SEVERITY_RANK = {
+    HighlightSeverity.UNAVAILABLE: -1,
+    HighlightSeverity.GREEN: 0,
+    HighlightSeverity.AMBER: 1,
+    HighlightSeverity.RED: 2,
+}
+
+_STATUS_TO_SEVERITY = {
+    AdvisoryStatus.GREEN: HighlightSeverity.GREEN,
+    AdvisoryStatus.AMBER: HighlightSeverity.AMBER,
+    AdvisoryStatus.RED: HighlightSeverity.RED,
+    AdvisoryStatus.UNAVAILABLE: HighlightSeverity.UNAVAILABLE,
+}
+
+
+def status_to_severity(status: AdvisoryStatus) -> HighlightSeverity:
+    """Map a sub-axis :class:`AdvisoryStatus` onto the ribbon severity scale.
+
+    Used by the composite evaluators (#375) to fold an airport-axis status into
+    the endpoint ribbon segments.
+    """
+    return _STATUS_TO_SEVERITY[status]
+
+
+def worst_severity(*severities: HighlightSeverity) -> HighlightSeverity:
+    """Worst-of merge for per-point ribbon severities (composites, #375)."""
+    return max(severities, key=lambda s: _SEVERITY_RANK[s])
+
+
 def ribbon_peak(segments: list[RibbonSegment]) -> float | None:
     """Center of the longest RED run, else the longest AMBER run, else ``None``.
 

--- a/src/weatherbrief/analysis/advisories/cloud_top.py
+++ b/src/weatherbrief/analysis/advisories/cloud_top.py
@@ -3,13 +3,22 @@
 from __future__ import annotations
 
 from weatherbrief.analysis.advisories import RouteContext
-from weatherbrief.analysis.advisories._helpers import format_extent, pct_above_threshold
+from weatherbrief.analysis.advisories._helpers import (
+    FlaggedCell,
+    build_regions,
+    build_ribbon,
+    format_extent,
+    pct_above_threshold,
+    ribbon_peak,
+)
 from weatherbrief.analysis.advisories.registry import register
 from weatherbrief.analysis.advisories.strings import adv_t
 from weatherbrief.models import (
     AdvisoryCatalogEntry,
+    AdvisoryHighlights,
     AdvisoryParameterDef,
     AdvisoryStatus,
+    HighlightSeverity,
     ModelAdvisoryResult,
     RouteAdvisoryResult,
 )
@@ -73,10 +82,18 @@ class CloudTopEvaluator:
             total = 0
             above_ceiling = 0
             max_top: float | None = None
+            # Per-point highlight geometry (#375). Binary per point: green =
+            # toppable or no cloud, amber = can't get on top here (the amount of
+            # amber tells the story); the cutout is the blocking deck.
+            ribbon_points: list[tuple[float, HighlightSeverity]] = []
+            region_cells: list[tuple[float, FlaggedCell | None]] = []
 
             for rpa in ctx.analyses:
+                dist = rpa.distance_from_origin_nm or 0.0
                 sounding = rpa.sounding.get(model)
                 if sounding is None:
+                    ribbon_points.append((dist, HighlightSeverity.UNAVAILABLE))
+                    region_cells.append((dist, None))
                     continue
                 total += 1
 
@@ -90,6 +107,8 @@ class CloudTopEvaluator:
                     if cl.base_ft <= cruise + margin_ft and cl.base_ft <= ceiling
                 ]
                 if not reachable:
+                    ribbon_points.append((dist, HighlightSeverity.GREEN))
+                    region_cells.append((dist, None))
                     continue
 
                 highest_top = max(cl.top_ft for cl in reachable)
@@ -98,6 +117,21 @@ class CloudTopEvaluator:
 
                 if highest_top + margin_ft > ceiling:
                     above_ceiling += 1
+                    # The blocking deck: the reachable layers whose tops violate
+                    # the ceiling margin.
+                    blocking = [
+                        cl for cl in reachable if cl.top_ft + margin_ft > ceiling
+                    ]
+                    ribbon_points.append((dist, HighlightSeverity.AMBER))
+                    region_cells.append((dist, FlaggedCell(
+                        kind="blocking_deck",
+                        severity=HighlightSeverity.AMBER,
+                        base_ft=int(min(cl.base_ft for cl in blocking)),
+                        top_ft=int(max(cl.top_ft for cl in blocking)),
+                    )))
+                else:
+                    ribbon_points.append((dist, HighlightSeverity.GREEN))
+                    region_cells.append((dist, None))
 
             loc = ctx.locale
             if total == 0:
@@ -114,10 +148,21 @@ class CloudTopEvaluator:
                 ext = format_extent(above_ceiling, total, ctx.total_distance_nm)
                 detail = adv_t("cloud_top.above_ceiling", loc, extent=ext, top=f"{max_top:.0f}")
 
+            # Highlights (#375) only when the model has data.
+            highlights = None
+            if total > 0:
+                ribbon = build_ribbon(ribbon_points, ctx.total_distance_nm)
+                highlights = AdvisoryHighlights(
+                    ribbon=ribbon,
+                    regions=build_regions(region_cells, ctx.total_distance_nm),
+                    peak_dist_nm=ribbon_peak(ribbon),
+                )
+
             per_model.append(ModelAdvisoryResult.build(
                 model=model, status=status, detail=detail,
                 affected=above_ceiling, total=total,
                 total_distance_nm=ctx.total_distance_nm,
+                highlights=highlights,
             ))
 
         return RouteAdvisoryResult.from_per_model("cloud_top", per_model, params)

--- a/src/weatherbrief/analysis/advisories/enroute_precip.py
+++ b/src/weatherbrief/analysis/advisories/enroute_precip.py
@@ -27,13 +27,21 @@ every divert/descent option, which is worth a composite caution).
 from __future__ import annotations
 
 from weatherbrief.analysis.advisories import RouteContext
-from weatherbrief.analysis.advisories._helpers import format_extent
+from weatherbrief.analysis.advisories._helpers import (
+    FlaggedCell,
+    build_regions,
+    build_ribbon,
+    format_extent,
+    ribbon_peak,
+)
 from weatherbrief.analysis.advisories.registry import register
 from weatherbrief.analysis.advisories.strings import adv_t
 from weatherbrief.models import (
     AdvisoryCatalogEntry,
+    AdvisoryHighlights,
     AdvisoryParameterDef,
     AdvisoryStatus,
+    HighlightSeverity,
     ModelAdvisoryResult,
     PrecipIntensity,
     PrecipPhase,
@@ -49,6 +57,46 @@ _DEFAULTS = {
     "snow_moderate_pct_red": 25.0,
     "rain_pct_amber": 30.0,
 }
+
+
+def classify_precip_point(precip) -> str | None:
+    """Classify one point's precipitation assessment into a hazard class.
+
+    Returns ``"snow_moderate"`` (moderate+ snow/mixed), ``"snow"`` (lighter
+    snow/mixed), ``"sig"`` (moderate+ rain, or FZRA/PL counted for visibility
+    extent only), ``"light"`` (light rain — comfort, not a hazard), or ``None``
+    (dry / no assessment). Single source of the per-point phase/intensity
+    bucketing, shared by :func:`classify_enroute_precip` and the highlight
+    ribbons (#375) so the geometry cannot drift from the grade.
+    """
+    if precip is None:
+        return None
+    phase = precip.surface_phase
+    intensity = precip.surface_intensity
+    if phase == PrecipPhase.DRY or intensity == PrecipIntensity.NONE:
+        return None
+    if phase in _SNOW_PHASES:
+        return "snow_moderate" if intensity in _SIGNIFICANT else "snow"
+    if phase in _FREEZING_PHASES:
+        # Visibility extent only — severity owned by freezing_precip.
+        return "sig"
+    if intensity in _SIGNIFICANT:
+        return "sig"
+    return "light"
+
+
+def precip_point_severity(cls: str | None, *, cap_amber: bool = False) -> HighlightSeverity:
+    """Ribbon severity for a :func:`classify_precip_point` class (#375).
+
+    Moderate+ snow → red (amber when ``cap_amber``, matching the VFR
+    composite's cap); any snow or significant rain/FZRA/PL → amber; light/dry
+    → green.
+    """
+    if cls == "snow_moderate":
+        return HighlightSeverity.AMBER if cap_amber else HighlightSeverity.RED
+    if cls in ("snow", "sig"):
+        return HighlightSeverity.AMBER
+    return HighlightSeverity.GREEN
 
 
 def classify_enroute_precip(
@@ -84,18 +132,14 @@ def classify_enroute_precip(
         if precip is None:
             continue
         has_signal = True
-        phase = precip.surface_phase
-        intensity = precip.surface_intensity
-        if phase == PrecipPhase.DRY or intensity == PrecipIntensity.NONE:
+        cls = classify_precip_point(precip)
+        if cls is None:
             continue
-        if phase in _SNOW_PHASES:
+        if cls in ("snow", "snow_moderate"):
             snow_pts += 1
-            if intensity in _SIGNIFICANT:
+            if cls == "snow_moderate":
                 snow_moderate_pts += 1
-        elif phase in _FREEZING_PHASES:
-            # Visibility extent only — severity owned by freezing_precip.
-            sig_rain_pts += 1
-        elif intensity in _SIGNIFICANT:
+        elif cls == "sig":
             sig_rain_pts += 1
         else:
             light_pts += 1
@@ -205,13 +249,50 @@ class EnroutePrecipEvaluator:
         per_model: list[ModelAdvisoryResult] = []
 
         for model in ctx.models:
-            status, detail, affected, total, _ = classify_enroute_precip(
+            status, detail, affected, total, has_signal = classify_enroute_precip(
                 ctx, model, params,
             )
+
+            # Per-point highlight geometry (#375): full-column precip cutouts
+            # (the hazard is the whole column below the melting layer) + a
+            # ribbon mirroring classify_precip_point. Skipped when the model
+            # has no precipitation signal (status UNAVAILABLE).
+            highlights = None
+            if has_signal and total > 0:
+                ribbon_points: list[tuple[float, HighlightSeverity]] = []
+                region_cells: list[tuple[float, FlaggedCell | None]] = []
+                for rpa in ctx.analyses:
+                    dist = rpa.distance_from_origin_nm or 0.0
+                    sounding = rpa.sounding.get(model)
+                    if sounding is None:
+                        ribbon_points.append((dist, HighlightSeverity.UNAVAILABLE))
+                        region_cells.append((dist, None))
+                        continue
+                    severity = precip_point_severity(
+                        classify_precip_point(sounding.precipitation)
+                    )
+                    ribbon_points.append((dist, severity))
+                    if severity in (HighlightSeverity.AMBER, HighlightSeverity.RED):
+                        region_cells.append((dist, FlaggedCell(
+                            kind="precip_column",
+                            severity=severity,
+                            base_ft=None,
+                            top_ft=None,
+                        )))
+                    else:
+                        region_cells.append((dist, None))
+                ribbon = build_ribbon(ribbon_points, ctx.total_distance_nm)
+                highlights = AdvisoryHighlights(
+                    ribbon=ribbon,
+                    regions=build_regions(region_cells, ctx.total_distance_nm),
+                    peak_dist_nm=ribbon_peak(ribbon),
+                )
+
             per_model.append(ModelAdvisoryResult.build(
                 model=model, status=status, detail=detail,
                 affected=affected, total=total,
                 total_distance_nm=ctx.total_distance_nm,
+                highlights=highlights,
             ))
 
         return RouteAdvisoryResult.from_per_model("enroute_precip", per_model, params)

--- a/src/weatherbrief/analysis/advisories/fiki_icing.py
+++ b/src/weatherbrief/analysis/advisories/fiki_icing.py
@@ -9,13 +9,22 @@ Evaluates three flight phases:
 from __future__ import annotations
 
 from weatherbrief.analysis.advisories import RouteContext
-from weatherbrief.analysis.advisories._helpers import min_icing_clearance
+from weatherbrief.analysis.advisories._helpers import (
+    FlaggedCell,
+    build_regions,
+    build_ribbon,
+    icing_zones_in_altitude_range,
+    min_icing_clearance,
+    ribbon_peak,
+)
 from weatherbrief.analysis.advisories.registry import register
 from weatherbrief.analysis.advisories.strings import adv_t
 from weatherbrief.models import (
     AdvisoryCatalogEntry,
+    AdvisoryHighlights,
     AdvisoryParameterDef,
     AdvisoryStatus,
+    HighlightSeverity,
     IcingRisk,
     IcingZone,
     ModelAdvisoryResult,
@@ -193,35 +202,77 @@ class FIKIIcingEvaluator:
             cruise_clear = 0
             cruise_total = 0
             total = 0
+            # Per-point highlight geometry (#375): the ribbon mirrors the loop's
+            # own per-point classification — transit thickness/severity/SLD in
+            # the departure/arrival corridors, cruise clear-air everywhere.
+            ribbon_points: list[tuple[float, HighlightSeverity]] = []
+            region_cells: list[tuple[float, FlaggedCell | None]] = []
 
             for rpa in ctx.analyses:
+                dist = rpa.distance_from_origin_nm or 0.0
                 sounding = rpa.sounding.get(model)
                 if sounding is None:
+                    ribbon_points.append((dist, HighlightSeverity.UNAVAILABLE))
+                    region_cells.append((dist, None))
                     continue
                 total += 1
 
-                dist = rpa.distance_from_origin_nm
                 zones = sounding.icing_zones
+                t, sev, sld = _transit_icing(zones, cruise_alt)
 
                 # --- departure / arrival transit icing ---
+                in_corridor = False
                 if dist <= proximity_nm:
-                    t, sev, sld = _transit_icing(zones, cruise_alt)
+                    in_corridor = True
                     dep_max_thickness = max(dep_max_thickness, t)
                     dep_worst = _worst_risk(dep_worst, sev)
                     dep_sld = dep_sld or sld
 
                 if dist >= total_dist - proximity_nm:
-                    t, sev, sld = _transit_icing(zones, cruise_alt)
+                    in_corridor = True
                     arr_max_thickness = max(arr_max_thickness, t)
                     arr_worst = _worst_risk(arr_worst, sev)
                     arr_sld = arr_sld or sld
 
                 # --- cruise clear-air check ---
                 cruise_total += 1
-                if not zones:
+                point_clear = (
+                    not zones
+                    or _min_icing_clearance(zones, cruise_alt) >= cruise_buffer_ft
+                )
+                if point_clear:
                     cruise_clear += 1
-                elif _min_icing_clearance(zones, cruise_alt) >= cruise_buffer_ft:
-                    cruise_clear += 1
+
+                # --- per-point ribbon verdict + icing-band cutout (#375) ---
+                # Corridor points grade the transit column exactly as the route
+                # grade does (SLD / SEVERE / thickness); everywhere the cruise
+                # clear-air check contributes amber when icing sits within the
+                # cruise buffer. Thin transit-able icing away from cruise stays
+                # green.
+                if in_corridor and (
+                    sld
+                    or (severe_is_red and sev == IcingRisk.SEVERE)
+                    or t >= transit_red
+                ):
+                    severity = HighlightSeverity.RED
+                elif (in_corridor and t >= transit_amber) or not point_clear:
+                    severity = HighlightSeverity.AMBER
+                else:
+                    severity = HighlightSeverity.GREEN
+
+                relevant_zones = icing_zones_in_altitude_range(
+                    zones, 0, cruise_alt + cruise_buffer_ft
+                )
+                if severity != HighlightSeverity.GREEN and relevant_zones:
+                    region_cells.append((dist, FlaggedCell(
+                        kind="icing_band",
+                        severity=severity,
+                        base_ft=int(min(z.base_ft for z in relevant_zones)),
+                        top_ft=int(max(z.top_ft for z in relevant_zones)),
+                    )))
+                else:
+                    region_cells.append((dist, None))
+                ribbon_points.append((dist, severity))
 
             # --- derive severity from the three metrics ---
             clear_pct = (
@@ -306,6 +357,14 @@ class FIKIIcingEvaluator:
             else:
                 detail = " | ".join(detail_parts)
 
+            # Highlights (#375) — the model has data here (total > 0).
+            ribbon = build_ribbon(ribbon_points, total_dist)
+            highlights = AdvisoryHighlights(
+                ribbon=ribbon,
+                regions=build_regions(region_cells, total_dist),
+                peak_dist_nm=ribbon_peak(ribbon),
+            )
+
             affected = cruise_total - cruise_clear
             per_model.append(
                 ModelAdvisoryResult.build(
@@ -315,6 +374,7 @@ class FIKIIcingEvaluator:
                     affected=affected,
                     total=cruise_total,
                     total_distance_nm=total_dist,
+                    highlights=highlights,
                 )
             )
 

--- a/src/weatherbrief/analysis/advisories/freezing_precip.py
+++ b/src/weatherbrief/analysis/advisories/freezing_precip.py
@@ -21,20 +21,35 @@ Two tiers per route point per model:
 from __future__ import annotations
 
 from weatherbrief.analysis.advisories import RouteContext
-from weatherbrief.analysis.advisories._helpers import format_extent
+from weatherbrief.analysis.advisories._helpers import (
+    FlaggedCell,
+    build_regions,
+    build_ribbon,
+    format_extent,
+    ribbon_peak,
+    terrain_at_distance,
+)
 from weatherbrief.analysis.advisories.registry import register
 from weatherbrief.analysis.advisories.strings import adv_t
 from weatherbrief.analysis.sounding.precipitation import detect_warm_nose
 from weatherbrief.models import (
     AdvisoryCatalogEntry,
+    AdvisoryHighlights,
     AdvisoryParameterDef,
     AdvisoryStatus,
+    HighlightSeverity,
     ModelAdvisoryResult,
     PrecipPhase,
     RouteAdvisoryResult,
 )
 
 _ACTIVE_PHASES = (PrecipPhase.FREEZING_RAIN, PrecipPhase.ICE_PELLETS)
+
+# Fallback depth of the freezing-precip column cutout when the warm-nose top
+# doesn't resolve at a flagged point: a fixed shallow AGL band (#375). The
+# hazard column is surface → warm-nose top; without the nose top we still show
+# where along the route it is, honestly shallow rather than full-column.
+_FALLBACK_COLUMN_AGL_FT = 3000
 
 
 @register
@@ -95,12 +110,22 @@ class FreezingPrecipEvaluator:
             has_signal_source = False
             loc = ctx.locale
 
+            # Per-point highlight geometry (#375): ribbon red = active FZRA/PL
+            # surface phase, amber = primed profile (warm nose, no active
+            # precip); the cutout is the hazard column, surface → warm-nose top.
+            ribbon_points: list[tuple[float, HighlightSeverity]] = []
+            region_cells: list[tuple[float, FlaggedCell | None]] = []
+
             for rpa in ctx.analyses:
+                dist = rpa.distance_from_origin_nm or 0.0
                 sounding = rpa.sounding.get(model)
                 if sounding is None:
+                    ribbon_points.append((dist, HighlightSeverity.UNAVAILABLE))
+                    region_cells.append((dist, None))
                     continue
                 total += 1
 
+                active = False
                 precip = sounding.precipitation
                 if precip is not None:
                     has_signal_source = True
@@ -109,16 +134,45 @@ class FreezingPrecipEvaluator:
                         or precip.freezing_rain_risk
                     ):
                         active_pts += 1
-                        continue
+                        active = True
 
-                # Primed: freezing-rain profile shape without active precip.
+                # Warm-nose profile shape (also the cutout's top at active
+                # points). Primed = the shape without active precip.
+                primed = False
+                nose_top: float | None = None
                 if sounding.derived_levels:
                     has_signal_source = True
-                    fz_risk, _, _, ice_pellets = detect_warm_nose(
+                    fz_risk, _, nose_top, ice_pellets = detect_warm_nose(
                         sounding.derived_levels
                     )
-                    if fz_risk or ice_pellets:
+                    if not active and (fz_risk or ice_pellets):
                         primed_pts += 1
+                        primed = True
+
+                if active:
+                    severity = HighlightSeverity.RED
+                elif primed:
+                    severity = HighlightSeverity.AMBER
+                else:
+                    # Includes sounding-without-precip-data points: the model-
+                    # level no-signal case is already UNAVAILABLE overall.
+                    severity = HighlightSeverity.GREEN
+
+                ribbon_points.append((dist, severity))
+                if severity in (HighlightSeverity.AMBER, HighlightSeverity.RED):
+                    if nose_top is None:
+                        terrain_ft = terrain_at_distance(ctx.elevation, dist) or 0.0
+                        nose_top = terrain_ft + _FALLBACK_COLUMN_AGL_FT
+                    # base_ft=None renders down to the surface — exactly the
+                    # below-cloud hazard column.
+                    region_cells.append((dist, FlaggedCell(
+                        kind="freezing_precip_column",
+                        severity=severity,
+                        base_ft=None,
+                        top_ft=int(nose_top),
+                    )))
+                else:
+                    region_cells.append((dist, None))
 
             if total == 0 or not has_signal_source:
                 per_model.append(ModelAdvisoryResult.build(
@@ -151,10 +205,20 @@ class FreezingPrecipEvaluator:
                 status = AdvisoryStatus.GREEN
                 detail = "No freezing precipitation signature"
 
+            # Highlights (#375) — the model has a precip signal here (the
+            # no-signal case returned UNAVAILABLE above).
+            ribbon = build_ribbon(ribbon_points, ctx.total_distance_nm)
+            highlights = AdvisoryHighlights(
+                ribbon=ribbon,
+                regions=build_regions(region_cells, ctx.total_distance_nm),
+                peak_dist_nm=ribbon_peak(ribbon),
+            )
+
             per_model.append(ModelAdvisoryResult.build(
                 model=model, status=status, detail=detail,
                 affected=active_pts + primed_pts, total=total,
                 total_distance_nm=ctx.total_distance_nm,
+                highlights=highlights,
             ))
 
         return RouteAdvisoryResult.from_per_model("freezing_precip", per_model, params)

--- a/src/weatherbrief/analysis/advisories/icing_escape.py
+++ b/src/weatherbrief/analysis/advisories/icing_escape.py
@@ -4,11 +4,15 @@ from __future__ import annotations
 
 from weatherbrief.analysis.advisories import RouteContext
 from weatherbrief.analysis.advisories._helpers import (
+    FlaggedCell,
     build_cost_model,
+    build_regions,
+    build_ribbon,
     format_extent,
-    has_relevant_icing,
+    icing_zones_in_altitude_range,
     max_terrain_near_point,
     pct_above_threshold,
+    ribbon_peak,
     to_mitigation_profile,
 )
 from weatherbrief.analysis.advisories.registry import register
@@ -22,8 +26,10 @@ from weatherbrief.analysis.advisories.vertical_profile import (
 )
 from weatherbrief.models import (
     AdvisoryCatalogEntry,
+    AdvisoryHighlights,
     AdvisoryParameterDef,
     AdvisoryStatus,
+    HighlightSeverity,
     IcingRisk,
     IcingType,
     Mitigation,
@@ -256,18 +262,32 @@ class IcingEscapeEvaluator:
             affected = 0
             no_escape_count = 0
             has_tight_margin = False
+            # Per-point highlight geometry (#375). Every route point contributes
+            # a ribbon severity; affected points also contribute an icing-band
+            # cutout (envelope of the relevant zones).
+            ribbon_points: list[tuple[float, HighlightSeverity]] = []
+            region_cells: list[tuple[float, FlaggedCell | None]] = []
 
             for rpa in ctx.analyses:
+                dist = rpa.distance_from_origin_nm or 0.0
                 sounding = rpa.sounding.get(model)
                 if sounding is None:
+                    ribbon_points.append((dist, HighlightSeverity.UNAVAILABLE))
+                    region_cells.append((dist, None))
                     continue
                 total += 1
 
-                if not has_relevant_icing(
+                # Same zones has_relevant_icing accepts — icing above
+                # cruise + buffer is deliberately GREEN on the ribbon too
+                # ("not relevant to your flight here" reads as clear).
+                relevant_zones = icing_zones_in_altitude_range(
                     sounding.icing_zones,
-                    ctx.cruise_altitude_ft,
-                    icing_altitude_buffer_ft,
-                ):
+                    0,
+                    ctx.cruise_altitude_ft + icing_altitude_buffer_ft,
+                )
+                if not relevant_zones:
+                    ribbon_points.append((dist, HighlightSeverity.GREEN))
+                    region_cells.append((dist, None))
                     continue
 
                 affected += 1
@@ -281,14 +301,27 @@ class IcingEscapeEvaluator:
                     ctx.elevation, rpa.distance_from_origin_nm
                 )
 
+                # No-escape: freezing level below terrain + margin, or fz/terrain
+                # unknown at an affected point — the same points the grade counts
+                # as no-escape. Escape viable (incl. tight-margin) → amber.
                 if fz_level_ft is None or terrain_ft is None:
                     no_escape_count += 1
-                    continue
-
-                if fz_level_ft < terrain_ft + terrain_margin:
+                    severity = HighlightSeverity.RED
+                elif fz_level_ft < terrain_ft + terrain_margin:
                     no_escape_count += 1
-                elif fz_level_ft < terrain_ft + tight_margin:
-                    has_tight_margin = True
+                    severity = HighlightSeverity.RED
+                else:
+                    if fz_level_ft < terrain_ft + tight_margin:
+                        has_tight_margin = True
+                    severity = HighlightSeverity.AMBER
+
+                ribbon_points.append((dist, severity))
+                region_cells.append((dist, FlaggedCell(
+                    kind="icing_band",
+                    severity=severity,
+                    base_ft=int(min(z.base_ft for z in relevant_zones)),
+                    top_ft=int(max(z.top_ft for z in relevant_zones)),
+                )))
 
             # Determine model status
             loc = ctx.locale
@@ -323,11 +356,23 @@ class IcingEscapeEvaluator:
             # never alters the grade above) — #335.
             mitigations = _icing_escape_mitigations(ctx, model, terrain_margin, status, loc)
 
+            # Highlights (#375) only when the model has data. Peak: the no-escape
+            # (red) run center first, else the longest amber run center.
+            highlights = None
+            if total > 0:
+                ribbon = build_ribbon(ribbon_points, ctx.total_distance_nm)
+                highlights = AdvisoryHighlights(
+                    ribbon=ribbon,
+                    regions=build_regions(region_cells, ctx.total_distance_nm),
+                    peak_dist_nm=ribbon_peak(ribbon),
+                )
+
             per_model.append(ModelAdvisoryResult.build(
                 model=model, status=status, detail=detail,
                 affected=affected, total=total,
                 total_distance_nm=ctx.total_distance_nm,
                 mitigations=mitigations,
+                highlights=highlights,
             ))
 
         return RouteAdvisoryResult.from_per_model("icing_escape", per_model, params)

--- a/src/weatherbrief/analysis/advisories/ifr_feasibility.py
+++ b/src/weatherbrief/analysis/advisories/ifr_feasibility.py
@@ -7,14 +7,25 @@ and convective activity into a single go/no-go style assessment for IFR flights.
 from __future__ import annotations
 
 from weatherbrief.analysis.advisories import RouteContext
-from weatherbrief.analysis.advisories._helpers import format_extent, min_icing_clearance
+from weatherbrief.analysis.advisories._helpers import (
+    FlaggedCell,
+    build_regions,
+    build_ribbon,
+    format_extent,
+    min_icing_clearance,
+    ribbon_peak,
+    status_to_severity,
+    worst_severity,
+)
 from weatherbrief.analysis.advisories.registry import register
 from weatherbrief.analysis.advisories.strings import adv_t
 from weatherbrief.models import (
     AdvisoryCatalogEntry,
+    AdvisoryHighlights,
     AdvisoryParameterDef,
     AdvisoryStatus,
     ConvectiveRisk,
+    HighlightSeverity,
     ModelAdvisoryResult,
     RouteAdvisoryResult,
 )
@@ -50,16 +61,17 @@ def _check_airport_ifr(
     model: str,
     min_dep_ceiling_ft: float,
     min_arr_ceiling_ft: float,
-) -> tuple[AdvisoryStatus, str]:
+) -> tuple[AdvisoryStatus, str, AdvisoryStatus, AdvisoryStatus]:
     """Check departure and arrival airport conditions for IFR feasibility.
 
     IFR flights accept IFR conditions, but LIFR triggers amber and
     ceilings below configurable minimums trigger red.
 
-    Returns (status, detail_fragment).
+    Returns (status, detail_fragment, dep_status, arr_status). The per-airport
+    statuses colour the endpoint ribbon segments of the highlight (#375).
     """
     if ctx.airport_conditions is None:
-        return AdvisoryStatus.GREEN, ""
+        return AdvisoryStatus.GREEN, "", AdvisoryStatus.GREEN, AdvisoryStatus.GREEN
 
     dep = ctx.airport_conditions.departure
     arr = ctx.airport_conditions.arrival
@@ -68,33 +80,32 @@ def _check_airport_ifr(
 
     loc = ctx.locale
     parts: list[str] = []
-    worst = AdvisoryStatus.GREEN
+    per_airport: list[AdvisoryStatus] = []
 
     for label_key, icao, cond, min_ceil in [
         ("airport.dep", dep.icao, dep_cond, min_dep_ceiling_ft),
         ("airport.arr", arr.icao, arr_cond, min_arr_ceiling_ft),
     ]:
-        if cond is None:
-            continue
-        label = adv_t(label_key, loc)
-        cat = cond.flight_category
-
+        status = AdvisoryStatus.GREEN
         # LIFR is concerning for IFR
-        if cat == FlightCategory.LIFR:
+        if cond is not None and cond.flight_category == FlightCategory.LIFR:
+            label = adv_t(label_key, loc)
             # Check against minimum ceiling
             if cond.ceiling_ft is not None and cond.ceiling_ft < min_ceil:
-                worst = _worst_status(worst, AdvisoryStatus.RED)
+                status = AdvisoryStatus.RED
                 parts.append(adv_t(
                     "ifr.lifr_below_min", loc,
                     label=label, icao=icao,
                     ceiling=cond.ceiling_ft, min=int(min_ceil),
                 ))
             else:
-                worst = _worst_status(worst, AdvisoryStatus.AMBER)
+                status = AdvisoryStatus.AMBER
                 parts.append(adv_t("ifr.lifr", loc, label=label, icao=icao))
+        per_airport.append(status)
 
     detail = " | ".join(parts) if parts else ""
-    return worst, detail
+    worst = _worst_status(*per_airport)
+    return worst, detail, per_airport[0], per_airport[1]
 
 
 def _check_enroute_hazards(
@@ -103,26 +114,44 @@ def _check_enroute_hazards(
     convective_min_risk_idx: int,
     cruise_altitude_ft: float,
     icing_altitude_buffer_ft: float,
-) -> tuple[int, int, int, int, ConvectiveRisk]:
+) -> tuple[
+    int, int, int, int, ConvectiveRisk,
+    list[tuple[float, HighlightSeverity]],
+    list[tuple[float, FlaggedCell | None]],
+    list[tuple[float, FlaggedCell | None]],
+]:
     """Check en-route icing and convective hazards in a single pass.
 
     Uses the same clearance-based icing check as the FIKI advisory:
     a point counts as "icing affected" only when an icing zone is within
     *icing_altitude_buffer_ft* of cruise altitude.
 
-    Returns (total, affected, icing_count, conv_count, worst_conv_risk).
+    Returns (total, affected, icing_count, conv_count, worst_conv_risk,
+    ribbon_points, icing_cells, conv_cells).
     - affected: number of unique points with icing OR convective risk
     - icing_count / conv_count: individual counts for detail messages
+    - ribbon_points / icing_cells / conv_cells: per-point highlight geometry
+      (#375) — the ribbon is the worst of the two axes at each x (icing amber,
+      convective amber or red for HIGH/EXTREME); the two cell lists carry the
+      ``icing_band`` and ``tower``/``tower_unresolved`` cutouts (multi-kind, so
+      one list each).
     """
     total = 0
     affected = 0
     icing_count = 0
     conv_count = 0
     worst_conv_risk = ConvectiveRisk.NONE
+    ribbon_points: list[tuple[float, HighlightSeverity]] = []
+    icing_cells: list[tuple[float, FlaggedCell | None]] = []
+    conv_cells: list[tuple[float, FlaggedCell | None]] = []
 
     for rpa in ctx.analyses:
+        dist = rpa.distance_from_origin_nm or 0.0
         sounding = rpa.sounding.get(model)
         if sounding is None:
+            ribbon_points.append((dist, HighlightSeverity.UNAVAILABLE))
+            icing_cells.append((dist, None))
+            conv_cells.append((dist, None))
             continue
         total += 1
 
@@ -132,6 +161,7 @@ def _check_enroute_hazards(
             < icing_altitude_buffer_ft
         )
         has_convective = False
+        conv_sev = HighlightSeverity.GREEN
 
         conv = sounding.convective
         if conv is not None:
@@ -140,15 +170,61 @@ def _check_enroute_hazards(
                 has_convective = True
                 if risk_idx > _CONVECTIVE_SEVERITY_INDEX.get(worst_conv_risk, 0):
                     worst_conv_risk = conv.risk_level
+                conv_sev = (
+                    HighlightSeverity.RED
+                    if conv.risk_level in (ConvectiveRisk.HIGH, ConvectiveRisk.EXTREME)
+                    else HighlightSeverity.AMBER
+                )
 
         if has_icing:
             icing_count += 1
+            # The triggering zones: those within the buffer of cruise.
+            band = [
+                z for z in sounding.icing_zones
+                if z.base_ft < cruise_altitude_ft + icing_altitude_buffer_ft
+                and z.top_ft > cruise_altitude_ft - icing_altitude_buffer_ft
+            ]
+            icing_cells.append((dist, FlaggedCell(
+                kind="icing_band",
+                severity=HighlightSeverity.AMBER,
+                base_ft=int(min(z.base_ft for z in band)) if band else None,
+                top_ft=int(max(z.top_ft for z in band)) if band else None,
+            )))
+        else:
+            icing_cells.append((dist, None))
+
         if has_convective:
             conv_count += 1
+            # Same geometry conventions as the convective emitter (#373): a
+            # bounded tower only when BOTH base and top resolve, else a
+            # full-column ghost.
+            if conv.base_ft is not None and conv.top_ft is not None:
+                conv_cells.append((dist, FlaggedCell(
+                    kind="tower",
+                    severity=conv_sev,
+                    base_ft=int(conv.base_ft),
+                    top_ft=int(conv.top_ft),
+                )))
+            else:
+                conv_cells.append((dist, FlaggedCell(
+                    kind="tower_unresolved",
+                    severity=conv_sev,
+                    base_ft=None,
+                    top_ft=None,
+                )))
+        else:
+            conv_cells.append((dist, None))
+
         if has_icing or has_convective:
             affected += 1
 
-    return total, affected, icing_count, conv_count, worst_conv_risk
+        icing_sev = HighlightSeverity.AMBER if has_icing else HighlightSeverity.GREEN
+        ribbon_points.append((dist, worst_severity(icing_sev, conv_sev)))
+
+    return (
+        total, affected, icing_count, conv_count, worst_conv_risk,
+        ribbon_points, icing_cells, conv_cells,
+    )
 
 
 @register
@@ -278,16 +354,20 @@ class IFRFeasibilityEvaluator:
 
         for model in ctx.models:
             # 1. Airport conditions
-            airport_status, airport_detail = _check_airport_ifr(
-                ctx, model, min_dep_ceiling_ft, min_arr_ceiling_ft
+            airport_status, airport_detail, dep_status, arr_status = (
+                _check_airport_ifr(
+                    ctx, model, min_dep_ceiling_ft, min_arr_ceiling_ft
+                )
             )
 
-            # 2. En-route hazards (single pass — no double-counting)
-            total, affected, icing_count, conv_count, worst_conv_risk = (
-                _check_enroute_hazards(
-                    ctx, model, convective_min_risk,
-                    ctx.cruise_altitude_ft, icing_altitude_buffer_ft,
-                )
+            # 2. En-route hazards (single pass — no double-counting), including
+            # the per-point highlight geometry (#375).
+            (
+                total, affected, icing_count, conv_count, worst_conv_risk,
+                ribbon_points, icing_cells, conv_cells,
+            ) = _check_enroute_hazards(
+                ctx, model, convective_min_risk,
+                ctx.cruise_altitude_ft, icing_altitude_buffer_ft,
             )
 
             loc = ctx.locale
@@ -352,10 +432,33 @@ class IFRFeasibilityEvaluator:
             else:
                 detail = " | ".join(detail_parts)
 
+            # 6. Highlights (#375) only when the model has en-route data. The
+            # airport IFR-viability axis colours the endpoint ribbon segments.
+            highlights = None
+            if total > 0:
+                if ribbon_points:
+                    first = min(range(len(ribbon_points)), key=lambda i: ribbon_points[i][0])
+                    last = max(range(len(ribbon_points)), key=lambda i: ribbon_points[i][0])
+                    for idx, ap_status in ((first, dep_status), (last, arr_status)):
+                        ap_sev = status_to_severity(ap_status)
+                        if ap_sev in (HighlightSeverity.AMBER, HighlightSeverity.RED):
+                            d, sev = ribbon_points[idx]
+                            ribbon_points[idx] = (d, worst_severity(sev, ap_sev))
+                ribbon = build_ribbon(ribbon_points, ctx.total_distance_nm)
+                highlights = AdvisoryHighlights(
+                    ribbon=ribbon,
+                    regions=(
+                        build_regions(icing_cells, ctx.total_distance_nm)
+                        + build_regions(conv_cells, ctx.total_distance_nm)
+                    ),
+                    peak_dist_nm=ribbon_peak(ribbon),
+                )
+
             per_model.append(ModelAdvisoryResult.build(
                 model=model, status=status, detail=detail,
                 affected=affected, total=total,
                 total_distance_nm=ctx.total_distance_nm,
+                highlights=highlights,
             ))
 
         return RouteAdvisoryResult.from_per_model("ifr_feasibility", per_model, params)

--- a/src/weatherbrief/analysis/advisories/mountain_wind.py
+++ b/src/weatherbrief/analysis/advisories/mountain_wind.py
@@ -25,6 +25,9 @@ from __future__ import annotations
 
 from weatherbrief.analysis.advisories import RouteContext
 from weatherbrief.analysis.advisories._helpers import (
+    FlaggedCell,
+    build_regions,
+    build_ribbon,
     format_extent,
     max_terrain_near_point,
     wind_at_altitude,
@@ -33,8 +36,11 @@ from weatherbrief.analysis.advisories.registry import register
 from weatherbrief.analysis.advisories.strings import adv_t
 from weatherbrief.models import (
     AdvisoryCatalogEntry,
+    AdvisoryHighlights,
     AdvisoryParameterDef,
     AdvisoryStatus,
+    HighlightSeverity,
+    InversionLayer,
     ModelAdvisoryResult,
     RouteAdvisoryResult,
     SoundingAnalysis,
@@ -55,11 +61,17 @@ _INV_ABOVE_FT = 2000.0
 def _wave_signatures(
     sounding: SoundingAnalysis | None,
     terrain_ft: float,
-) -> set[str]:
-    """Wave-supporting signatures at one point: 'inversion' and/or 'oscillating'."""
+) -> tuple[set[str], InversionLayer | None]:
+    """Wave-supporting signatures at one point: 'inversion' and/or 'oscillating'.
+
+    Also returns the corroborating ridge-top inversion layer (``None`` when the
+    signature is oscillation-only) — its band is the ``wave_signature`` cutout
+    geometry for the highlight (#375).
+    """
     sigs: set[str] = set()
+    inv_layer: InversionLayer | None = None
     if sounding is None:
-        return sigs
+        return sigs, inv_layer
     vm = sounding.vertical_motion
     if vm is not None and vm.classification == VerticalMotionClass.OSCILLATING:
         sigs.add("oscillating")
@@ -68,8 +80,9 @@ def _wave_signatures(
     for inv in sounding.inversion_layers:
         if inv.top_ft > lo and inv.base_ft < hi:
             sigs.add("inversion")
+            inv_layer = inv
             break
-    return sigs
+    return sigs, inv_layer
 
 
 @register
@@ -172,12 +185,26 @@ class MountainWindEvaluator:
             max_wind = 0.0
             wave_red = False          # corroborated point above the lower red bar
             wave_sigs: set[str] = set()  # signatures seen at strong-wind points
+            # Per-point highlight geometry (#375). Non-mountain points are GREEN
+            # ("not relevant to your flight here"), matching the grade's skip;
+            # mountain points with no wind data are UNAVAILABLE. Two cutout
+            # kinds: ridge_wind (the terrain-hugging affected band) and
+            # wave_signature (the corroborating inversion on rotor-day points).
+            ribbon_points: list[tuple[float, HighlightSeverity]] = []
+            ridge_cells: list[tuple[float, FlaggedCell | None]] = []
+            wave_cells: list[tuple[float, FlaggedCell | None]] = []
+            peak_dist: float | None = None
+            peak_speed = 0.0
 
             for rpa in ctx.analyses:
+                dist = rpa.distance_from_origin_nm or 0.0
                 terrain_ft = max_terrain_near_point(
                     ctx.elevation, rpa.distance_from_origin_nm
                 )
                 if terrain_ft is None or terrain_ft < terrain_threshold:
+                    ribbon_points.append((dist, HighlightSeverity.GREEN))
+                    ridge_cells.append((dist, None))
+                    wave_cells.append((dist, None))
                     continue
                 total += 1
 
@@ -186,19 +213,59 @@ class MountainWindEvaluator:
                     terrain_ft + altitude_margin, rpa.forecast_hour,
                 )
                 if wind is None:
+                    ribbon_points.append((dist, HighlightSeverity.UNAVAILABLE))
+                    ridge_cells.append((dist, None))
+                    wave_cells.append((dist, None))
                     continue
 
                 speed_kt, _ = wind
                 if speed_kt > max_wind:
                     max_wind = speed_kt
 
-                if speed_kt >= wind_amber:
-                    affected += 1
-                    sigs = _wave_signatures(rpa.sounding.get(model), terrain_ft)
-                    if sigs:
-                        wave_sigs |= sigs
-                        if speed_kt >= corroborated_red:
-                            wave_red = True
+                if speed_kt < wind_amber:
+                    ribbon_points.append((dist, HighlightSeverity.GREEN))
+                    ridge_cells.append((dist, None))
+                    wave_cells.append((dist, None))
+                    continue
+
+                affected += 1
+                sigs, inv_layer = _wave_signatures(rpa.sounding.get(model), terrain_ft)
+                if sigs:
+                    wave_sigs |= sigs
+                    if speed_kt >= corroborated_red:
+                        wave_red = True
+
+                # Red here = very strong wind regardless, or the rotor-day combo
+                # (wave signature + the lower corroborated bar) — the same two
+                # triggers as the route grade, located per point.
+                point_red = speed_kt >= wind_red or (
+                    bool(sigs) and speed_kt >= corroborated_red
+                )
+                severity = (
+                    HighlightSeverity.RED if point_red else HighlightSeverity.AMBER
+                )
+                ribbon_points.append((dist, severity))
+                ridge_cells.append((dist, FlaggedCell(
+                    kind="ridge_wind",
+                    severity=severity,
+                    base_ft=int(terrain_ft),
+                    top_ft=int(terrain_ft + altitude_margin),
+                )))
+                # The corroborating inversion band visually explains why the RED
+                # threshold dropped ("rotor day").
+                if point_red and inv_layer is not None:
+                    wave_cells.append((dist, FlaggedCell(
+                        kind="wave_signature",
+                        severity=HighlightSeverity.RED,
+                        base_ft=int(inv_layer.base_ft),
+                        top_ft=int(inv_layer.top_ft),
+                    )))
+                else:
+                    wave_cells.append((dist, None))
+
+                if speed_kt > peak_speed:
+                    peak_speed = speed_kt
+                    peak_dist = dist
 
             loc = ctx.locale
             ext = format_extent(affected, total, ctx.total_distance_nm)
@@ -229,10 +296,25 @@ class MountainWindEvaluator:
                 status = AdvisoryStatus.GREEN
                 detail = adv_t("mountain_wind.light", loc, speed=f"{max_wind:.0f}")
 
+            # Highlights (#375): built whenever the route has points at all —
+            # a no-mountain route gets the all-green ribbon its GREEN grade
+            # implies (not None). Peak = the strongest-wind affected point.
+            highlights = None
+            if ribbon_points:
+                highlights = AdvisoryHighlights(
+                    ribbon=build_ribbon(ribbon_points, ctx.total_distance_nm),
+                    regions=(
+                        build_regions(ridge_cells, ctx.total_distance_nm)
+                        + build_regions(wave_cells, ctx.total_distance_nm)
+                    ),
+                    peak_dist_nm=peak_dist,
+                )
+
             per_model.append(ModelAdvisoryResult.build(
                 model=model, status=status, detail=detail,
                 affected=affected, total=total,
                 total_distance_nm=ctx.total_distance_nm,
+                highlights=highlights,
             ))
 
         return RouteAdvisoryResult.from_per_model("mountain_wind", per_model, params)

--- a/src/weatherbrief/analysis/advisories/turbulence.py
+++ b/src/weatherbrief/analysis/advisories/turbulence.py
@@ -3,14 +3,23 @@
 from __future__ import annotations
 
 from weatherbrief.analysis.advisories import RouteContext
-from weatherbrief.analysis.advisories._helpers import format_extent, pct_above_threshold
+from weatherbrief.analysis.advisories._helpers import (
+    FlaggedCell,
+    build_regions,
+    build_ribbon,
+    format_extent,
+    pct_above_threshold,
+    ribbon_peak,
+)
 from weatherbrief.analysis.advisories.registry import register
 from weatherbrief.analysis.advisories.strings import adv_t
 from weatherbrief.models import (
     AdvisoryCatalogEntry,
+    AdvisoryHighlights,
     AdvisoryParameterDef,
     AdvisoryStatus,
     CATRiskLevel,
+    HighlightSeverity,
     ModelAdvisoryResult,
     RouteAdvisoryResult,
 )
@@ -72,31 +81,76 @@ class TurbulenceEvaluator:
             affected = 0
             has_severe = False
             worst_cat = CATRiskLevel.NONE
+            # Per-point highlight geometry (#375). Ribbon: SEVERE CAT anywhere in
+            # the column → red (the cutout showing where it sits is exactly the
+            # ambiguity the highlight resolves); MODERATE CAT overlapping the
+            # cruise band or a strong updraft near cruise → amber; else green.
+            ribbon_points: list[tuple[float, HighlightSeverity]] = []
+            region_cells: list[tuple[float, FlaggedCell | None]] = []
 
             for rpa in ctx.analyses:
+                dist = rpa.distance_from_origin_nm or 0.0
                 sounding = rpa.sounding.get(model)
                 if sounding is None:
+                    ribbon_points.append((dist, HighlightSeverity.UNAVAILABLE))
+                    region_cells.append((dist, None))
                     continue
                 total += 1
 
                 point_affected = False
+                strong_w_here = False
+                severe_layers: list = []
+                moderate_cruise_layers: list = []
                 vm = sounding.vertical_motion
 
                 if vm is not None:
                     for layer in vm.cat_risk_layers:
-                        if layer.base_ft <= cruise <= layer.top_ft and layer.risk != CATRiskLevel.NONE:
+                        at_cruise = layer.base_ft <= cruise <= layer.top_ft
+                        if at_cruise and layer.risk != CATRiskLevel.NONE:
                             point_affected = True
                             if _CAT_ORDER.index(layer.risk) > _CAT_ORDER.index(worst_cat):
                                 worst_cat = layer.risk
                             if layer.risk == CATRiskLevel.SEVERE:
                                 has_severe = True
+                        # Highlight geometry: severe counts anywhere in the
+                        # column, moderate only when it overlaps cruise.
+                        if layer.risk == CATRiskLevel.SEVERE:
+                            severe_layers.append(layer)
+                        elif layer.risk == CATRiskLevel.MODERATE and at_cruise:
+                            moderate_cruise_layers.append(layer)
 
                     if vm.max_w_fpm is not None and abs(vm.max_w_fpm) > strong_w_fpm:
                         if vm.max_w_level_ft is not None and abs(vm.max_w_level_ft - cruise) < 3000:
                             point_affected = True
+                            strong_w_here = True
 
                 if point_affected:
                     affected += 1
+
+                # Per-point ribbon verdict + CAT-layer cutout (#375). Strong-w is
+                # resolved to a single level (max_w_level_ft), not a band — it
+                # contributes amber to the ribbon but no strong_updraft cutout
+                # (skip the kind rather than invent geometry).
+                if severe_layers:
+                    severity = HighlightSeverity.RED
+                    band = severe_layers
+                elif moderate_cruise_layers or strong_w_here:
+                    severity = HighlightSeverity.AMBER
+                    band = moderate_cruise_layers
+                else:
+                    severity = HighlightSeverity.GREEN
+                    band = []
+
+                ribbon_points.append((dist, severity))
+                if band:
+                    region_cells.append((dist, FlaggedCell(
+                        kind="cat_layer",
+                        severity=severity,
+                        base_ft=int(min(la.base_ft for la in band)),
+                        top_ft=int(max(la.top_ft for la in band)),
+                    )))
+                else:
+                    region_cells.append((dist, None))
 
             ext = format_extent(affected, total, ctx.total_distance_nm)
             loc = ctx.locale
@@ -114,10 +168,21 @@ class TurbulenceEvaluator:
                 risk_label = worst_cat.value.upper() if worst_cat != CATRiskLevel.NONE else "Turbulence"
                 detail = adv_t("turbulence.risk_over", loc, risk=risk_label, extent=ext)
 
+            # Highlights (#375) only when the model has data.
+            highlights = None
+            if total > 0:
+                ribbon = build_ribbon(ribbon_points, ctx.total_distance_nm)
+                highlights = AdvisoryHighlights(
+                    ribbon=ribbon,
+                    regions=build_regions(region_cells, ctx.total_distance_nm),
+                    peak_dist_nm=ribbon_peak(ribbon),
+                )
+
             per_model.append(ModelAdvisoryResult.build(
                 model=model, status=status, detail=detail,
                 affected=affected, total=total,
                 total_distance_nm=ctx.total_distance_nm,
+                highlights=highlights,
             ))
 
         return RouteAdvisoryResult.from_per_model("turbulence", per_model, params)

--- a/src/weatherbrief/analysis/advisories/vfr_feasibility.py
+++ b/src/weatherbrief/analysis/advisories/vfr_feasibility.py
@@ -17,11 +17,21 @@ from collections.abc import Iterator
 
 from weatherbrief.analysis.advisories import RouteContext
 from weatherbrief.analysis.advisories._helpers import (
+    FlaggedCell,
     build_cost_model,
+    build_regions,
+    build_ribbon,
     format_extent,
+    ribbon_peak,
+    status_to_severity,
     to_mitigation_profile,
+    worst_severity,
 )
-from weatherbrief.analysis.advisories.enroute_precip import classify_enroute_precip
+from weatherbrief.analysis.advisories.enroute_precip import (
+    classify_enroute_precip,
+    classify_precip_point,
+    precip_point_severity,
+)
 from weatherbrief.analysis.advisories.registry import register
 from weatherbrief.analysis.advisories.strings import adv_t
 from weatherbrief.analysis.advisories.vertical_profile import (
@@ -34,9 +44,11 @@ from weatherbrief.analysis.advisories.vertical_profile import (
 )
 from weatherbrief.models import (
     AdvisoryCatalogEntry,
+    AdvisoryHighlights,
     AdvisoryParameterDef,
     AdvisoryStatus,
     CloudCoverage,
+    HighlightSeverity,
     Mitigation,
     MitigationKind,
     ModelAdvisoryResult,
@@ -53,16 +65,17 @@ def _worst_status(*statuses: AdvisoryStatus) -> AdvisoryStatus:
 def _check_airport_vfr(
     ctx: RouteContext,
     model: str,
-) -> tuple[AdvisoryStatus, str]:
+) -> tuple[AdvisoryStatus, str, AdvisoryStatus, AdvisoryStatus]:
     """Check departure and arrival airport conditions for VFR feasibility.
 
     Uses the flight category (VFR/MVFR/IFR/LIFR) which already encodes
     ceiling and visibility thresholds per aviation standards.
 
-    Returns (status, detail_fragment).
+    Returns (status, detail_fragment, dep_status, arr_status). The per-airport
+    statuses colour the endpoint ribbon segments of the highlight (#375).
     """
     if ctx.airport_conditions is None:
-        return AdvisoryStatus.GREEN, ""
+        return AdvisoryStatus.GREEN, "", AdvisoryStatus.GREEN, AdvisoryStatus.GREEN
 
     dep = ctx.airport_conditions.departure
     arr = ctx.airport_conditions.arrival
@@ -70,23 +83,63 @@ def _check_airport_vfr(
     arr_cond = arr.condition_for_model(model)
 
     parts: list[str] = []
-    worst = AdvisoryStatus.GREEN
+    per_airport: list[AdvisoryStatus] = []
 
     loc = ctx.locale
     for label_key, icao, cond in [("airport.dep", dep.icao, dep_cond), ("airport.arr", arr.icao, arr_cond)]:
-        if cond is None:
-            continue
-        label = adv_t(label_key, loc)
-        cat = cond.flight_category
-        if cat in (FlightCategory.IFR, FlightCategory.LIFR):
-            worst = _worst_status(worst, AdvisoryStatus.RED)
-            parts.append(f"{label} {icao} {cat.value}")
-        elif cat == FlightCategory.MVFR:
-            worst = _worst_status(worst, AdvisoryStatus.AMBER)
-            parts.append(f"{label} {icao} MVFR")
+        status = AdvisoryStatus.GREEN
+        if cond is not None:
+            label = adv_t(label_key, loc)
+            cat = cond.flight_category
+            if cat in (FlightCategory.IFR, FlightCategory.LIFR):
+                status = AdvisoryStatus.RED
+                parts.append(f"{label} {icao} {cat.value}")
+            elif cat == FlightCategory.MVFR:
+                status = AdvisoryStatus.AMBER
+                parts.append(f"{label} {icao} MVFR")
+        per_airport.append(status)
 
     detail = " | ".join(parts) if parts else ""
-    return worst, detail
+    worst = _worst_status(*per_airport)
+    return worst, detail, per_airport[0], per_airport[1]
+
+
+def _point_enroute_vfr(
+    sounding,
+    altitude_ft: float,
+    cloud_clearance_ft: float,
+) -> tuple[str, float | None, float | None]:
+    """Classify one point's en-route cloud clearance at ``altitude_ft``.
+
+    Returns ``(cls, env_base_ft, env_top_ft)`` where ``cls`` is ``"imc"``
+    (inside a BKN/OVC layer), ``"marginal"`` (clearance < threshold), or
+    ``"clear"``; the envelope covers the BKN/OVC layer(s) containing the
+    altitude (``None`` unless in cloud). Single source of the per-point
+    classification, shared by :func:`_check_enroute_vfr` (grade) and the
+    highlight geometry (#375) so the two cannot drift.
+    """
+    in_cloud = False
+    marginal = False
+    env_base: float | None = None
+    env_top: float | None = None
+
+    for cl in sounding.cloud_layers:
+        if cl.coverage not in (CloudCoverage.BKN, CloudCoverage.OVC):
+            continue
+        # Check if the altitude is inside the cloud layer
+        if cl.base_ft <= altitude_ft <= cl.top_ft:
+            in_cloud = True
+            env_base = cl.base_ft if env_base is None else min(env_base, cl.base_ft)
+            env_top = cl.top_ft if env_top is None else max(env_top, cl.top_ft)
+            continue
+        # Check vertical clearance from cloud base or top
+        min_dist = min(abs(altitude_ft - cl.base_ft), abs(altitude_ft - cl.top_ft))
+        if min_dist < cloud_clearance_ft:
+            marginal = True
+
+    if in_cloud:
+        return "imc", env_base, env_top
+    return ("marginal" if marginal else "clear"), None, None
 
 
 def _check_enroute_vfr(
@@ -109,7 +162,6 @@ def _check_enroute_vfr(
     imc_count = 0
     marginal_count = 0
     clear_count = 0
-    cruise = altitude_ft
 
     for rpa in ctx.analyses:
         sounding = rpa.sounding.get(model)
@@ -117,26 +169,10 @@ def _check_enroute_vfr(
             continue
         total += 1
 
-        in_cloud = False
-        marginal = False
-
-        for cl in sounding.cloud_layers:
-            if cl.coverage not in (CloudCoverage.BKN, CloudCoverage.OVC):
-                continue
-            # Check if cruise altitude is inside the cloud layer
-            if cl.base_ft <= cruise <= cl.top_ft:
-                in_cloud = True
-                break
-            # Check vertical clearance from cloud base or top
-            dist_to_base = abs(cruise - cl.base_ft)
-            dist_to_top = abs(cruise - cl.top_ft)
-            min_dist = min(dist_to_base, dist_to_top)
-            if min_dist < cloud_clearance_ft:
-                marginal = True
-
-        if in_cloud:
+        cls, _, _ = _point_enroute_vfr(sounding, altitude_ft, cloud_clearance_ft)
+        if cls == "imc":
             imc_count += 1
-        elif marginal:
+        elif cls == "marginal":
             marginal_count += 1
         else:
             clear_count += 1
@@ -186,8 +222,9 @@ def _corridor_points(
     model: str,
     corridor_nm: float,
     phase: str,
-) -> Iterator[tuple[float, bool, bool, float | None]]:
-    """Yield ``(distance_nm, has_ovc, has_bkn, base_agl_ft)`` for each corridor point.
+) -> Iterator[tuple[float, bool, bool, float | None, float | None, float | None]]:
+    """Yield ``(distance_nm, has_ovc, has_bkn, base_agl_ft, deck_base_ft, deck_top_ft)``
+    for each corridor point.
 
     Single source of truth for both corridor membership and the transitable-deck
     condition, shared by the corridor grade (``_check_corridor_vfr``) and the
@@ -205,7 +242,9 @@ def _corridor_points(
     ``base_agl_ft`` is the height **above terrain** of the lowest blocking deck's
     base (``None`` when the point carries no deck) — the VFR room available
     *beneath* the deck, used by the mitigation's reachability gate. The grade
-    ignores it.
+    ignores it. ``deck_base_ft``/``deck_top_ft`` are the MSL envelope of the
+    deck layers at this point (``None`` when no deck) — the corridor-deck
+    cutout geometry for the highlight (#375).
 
     Points are yielded in ``ctx.analyses`` order (callers that need distance order
     sort the result).
@@ -228,6 +267,7 @@ def _corridor_points(
         has_ovc = False
         has_bkn = False
         lowest_base_ft: float | None = None
+        deck_top_ft: float | None = None
         for cl in sounding.cloud_layers:
             if cl.coverage not in (CloudCoverage.BKN, CloudCoverage.OVC):
                 continue
@@ -238,8 +278,10 @@ def _corridor_points(
                     has_bkn = True
                 if lowest_base_ft is None or cl.base_ft < lowest_base_ft:
                     lowest_base_ft = cl.base_ft
+                if deck_top_ft is None or cl.top_ft > deck_top_ft:
+                    deck_top_ft = cl.top_ft
         base_agl_ft = (lowest_base_ft - floor) if lowest_base_ft is not None else None
-        yield d, has_ovc, has_bkn, base_agl_ft
+        yield d, has_ovc, has_bkn, base_agl_ft, lowest_base_ft, deck_top_ft
 
 
 def _check_corridor_vfr(
@@ -276,7 +318,7 @@ def _check_corridor_vfr(
     for phase, key, icao, fallback in phases:
         has_ovc = False
         has_bkn = False
-        for _d, p_ovc, p_bkn, _base in _corridor_points(ctx, model, corridor_nm, phase):
+        for _d, p_ovc, p_bkn, _base, _db, _dt in _corridor_points(ctx, model, corridor_nm, phase):
             has_ovc = has_ovc or p_ovc
             has_bkn = has_bkn or p_bkn
 
@@ -288,6 +330,119 @@ def _check_corridor_vfr(
             parts.append(adv_t(key, loc, cov="BKN", icao=icao or fallback))
 
     return worst, parts
+
+
+def _build_vfr_highlights(
+    ctx: RouteContext,
+    model: str,
+    cloud_clearance_ft: float,
+    corridor_nm: float,
+    dep_status: AdvisoryStatus,
+    arr_status: AdvisoryStatus,
+) -> AdvisoryHighlights:
+    """Highlight geometry for the VFR composite (#375).
+
+    Regions are the union of the firing sub-axes, each with its own kind:
+    ``cruise_imc`` (cloud segments intersecting the cruise line, same geometry
+    as ``vmc_cruise``), and ``climb_deck``/``descent_deck`` (the corridor deck
+    bands near departure/arrival). The ribbon is the worst firing sub-axis at
+    each x — with en-route precipitation contributing per the shared classifier
+    capped at AMBER (matching the composite's cap) — and the airport
+    flight-category axis colouring only the endpoint segments.
+    """
+    cruise = ctx.cruise_altitude_ft
+
+    # Corridor decks by distance: dist → (severity, deck_base, deck_top).
+    corridor: dict[str, dict[float, tuple[HighlightSeverity, float | None, float | None]]] = {}
+    for phase in ("climb", "descent"):
+        by_dist: dict[float, tuple[HighlightSeverity, float | None, float | None]] = {}
+        for d, p_ovc, p_bkn, _base, deck_base, deck_top in _corridor_points(
+            ctx, model, corridor_nm, phase
+        ):
+            if p_ovc:
+                by_dist[d] = (HighlightSeverity.RED, deck_base, deck_top)
+            elif p_bkn:
+                by_dist[d] = (HighlightSeverity.AMBER, deck_base, deck_top)
+        corridor[phase] = by_dist
+
+    ribbon_points: list[tuple[float, HighlightSeverity]] = []
+    cruise_cells: list[tuple[float, FlaggedCell | None]] = []
+    climb_cells: list[tuple[float, FlaggedCell | None]] = []
+    descent_cells: list[tuple[float, FlaggedCell | None]] = []
+
+    for rpa in ctx.analyses:
+        dist = rpa.distance_from_origin_nm or 0.0
+        sounding = rpa.sounding.get(model)
+        if sounding is None:
+            ribbon_points.append((dist, HighlightSeverity.UNAVAILABLE))
+            cruise_cells.append((dist, None))
+            climb_cells.append((dist, None))
+            descent_cells.append((dist, None))
+            continue
+
+        # Cruise-line cloud axis (same geometry as vmc_cruise): IMC → red,
+        # marginal clearance → amber (ribbon only, the near-miss layer is not
+        # a cutout).
+        cls, env_base, env_top = _point_enroute_vfr(sounding, cruise, cloud_clearance_ft)
+        if cls == "imc":
+            cruise_sev = HighlightSeverity.RED
+            cruise_cells.append((dist, FlaggedCell(
+                kind="cruise_imc",
+                severity=cruise_sev,
+                base_ft=int(env_base) if env_base is not None else None,
+                top_ft=int(env_top) if env_top is not None else None,
+            )))
+        else:
+            cruise_sev = (
+                HighlightSeverity.AMBER if cls == "marginal" else HighlightSeverity.GREEN
+            )
+            cruise_cells.append((dist, None))
+
+        # Corridor-deck axes.
+        deck_sev = HighlightSeverity.GREEN
+        for phase, cells in (("climb", climb_cells), ("descent", descent_cells)):
+            hit = corridor[phase].get(dist)
+            if hit is None:
+                cells.append((dist, None))
+                continue
+            sev, deck_base, deck_top = hit
+            deck_sev = worst_severity(deck_sev, sev)
+            cells.append((dist, FlaggedCell(
+                kind="climb_deck" if phase == "climb" else "descent_deck",
+                severity=sev,
+                base_ft=int(deck_base) if deck_base is not None else None,
+                top_ft=int(deck_top) if deck_top is not None else None,
+            )))
+
+        # En-route precipitation axis, capped at AMBER like the composite grade.
+        precip_sev = precip_point_severity(
+            classify_precip_point(sounding.precipitation), cap_amber=True
+        )
+
+        ribbon_points.append((dist, worst_severity(cruise_sev, deck_sev, precip_sev)))
+
+    # Airport flight-category axis colours only the endpoint segments: worst-
+    # merge dep/arr status into the first/last route point.
+    if ribbon_points:
+        first = min(range(len(ribbon_points)), key=lambda i: ribbon_points[i][0])
+        last = max(range(len(ribbon_points)), key=lambda i: ribbon_points[i][0])
+        for idx, ap_status in ((first, dep_status), (last, arr_status)):
+            ap_sev = status_to_severity(ap_status)
+            if ap_sev in (HighlightSeverity.AMBER, HighlightSeverity.RED):
+                d, sev = ribbon_points[idx]
+                ribbon_points[idx] = (d, worst_severity(sev, ap_sev))
+
+    ribbon = build_ribbon(ribbon_points, ctx.total_distance_nm)
+    regions = (
+        build_regions(cruise_cells, ctx.total_distance_nm)
+        + build_regions(climb_cells, ctx.total_distance_nm)
+        + build_regions(descent_cells, ctx.total_distance_nm)
+    )
+    return AdvisoryHighlights(
+        ribbon=ribbon,
+        regions=regions,
+        peak_dist_nm=ribbon_peak(ribbon),
+    )
 
 
 # Severity order for the strict-improvement check on the cruise_imc mitigation.
@@ -694,7 +849,9 @@ class VFRFeasibilityEvaluator:
 
         for model in ctx.models:
             # 1. Airport conditions
-            airport_status, airport_detail = _check_airport_vfr(ctx, model)
+            airport_status, airport_detail, dep_status, arr_status = (
+                _check_airport_vfr(ctx, model)
+            )
 
             # 2. En-route cloud clearance
             total, imc_count, marginal_count, _ = _check_enroute_vfr(
@@ -793,11 +950,22 @@ class VFRFeasibilityEvaluator:
                 enroute_status, loc,
             )
 
+            # 8. Highlights (#375) only when the model has en-route data. The
+            # multi-kind cutouts (cruise IMC + corridor decks) are the point of
+            # this composite's geometry.
+            highlights = None
+            if total > 0:
+                highlights = _build_vfr_highlights(
+                    ctx, model, cloud_clearance_ft, corridor_nm,
+                    dep_status, arr_status,
+                )
+
             per_model.append(ModelAdvisoryResult.build(
                 model=model, status=status, detail=detail,
                 affected=affected, total=total,
                 total_distance_nm=ctx.total_distance_nm,
                 mitigations=mitigations,
+                highlights=highlights,
             ))
 
         return RouteAdvisoryResult.from_per_model("vfr_feasibility", per_model, params)

--- a/tests/analysis/advisories/test_highlights_remaining.py
+++ b/tests/analysis/advisories/test_highlights_remaining.py
@@ -1,0 +1,739 @@
+"""Tests for the remaining advisory highlight emitters (#375).
+
+The mechanism (helpers + vmc_cruise/convective) is covered by
+``test_highlights.py``; this file proves the per-evaluator geometry added in
+issue #375: icing_escape, fiki_icing, turbulence, cloud_top, the two
+composites (multi-kind cutouts + airport endpoint colouring), mountain_wind,
+freezing_precip, and enroute_precip. Shared invariants per evaluator: the
+ribbon tiles ``[0, total_nm]``, regions appear only on flagged points, and the
+severity mapping honours relevance-filter greens and UNAVAILABLE gaps.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from weatherbrief.analysis.advisories import RouteContext
+from weatherbrief.analysis.advisories.cloud_top import CloudTopEvaluator
+from weatherbrief.analysis.advisories.enroute_precip import EnroutePrecipEvaluator
+from weatherbrief.analysis.advisories.fiki_icing import FIKIIcingEvaluator
+from weatherbrief.analysis.advisories.freezing_precip import FreezingPrecipEvaluator
+from weatherbrief.analysis.advisories.icing_escape import IcingEscapeEvaluator
+from weatherbrief.analysis.advisories.ifr_feasibility import IFRFeasibilityEvaluator
+from weatherbrief.analysis.advisories.mountain_wind import MountainWindEvaluator
+from weatherbrief.analysis.advisories.turbulence import TurbulenceEvaluator
+from weatherbrief.analysis.advisories.vfr_feasibility import VFRFeasibilityEvaluator
+from weatherbrief.models import (
+    AdvisoryStatus,
+    CATRiskLayer,
+    CATRiskLevel,
+    CloudCoverage,
+    ConvectiveAssessment,
+    ConvectiveRisk,
+    DerivedLevel,
+    ElevationPoint,
+    ElevationProfile,
+    EnhancedCloudLayer,
+    HighlightSeverity,
+    HourlyForecast,
+    IcingRisk,
+    IcingType,
+    IcingZone,
+    InversionLayer,
+    ModelSource,
+    PrecipIntensity,
+    PrecipPhase,
+    PrecipitationAssessment,
+    PressureLevelData,
+    RouteCrossSection,
+    RoutePoint,
+    RoutePointAnalysis,
+    SoundingAnalysis,
+    ThermodynamicIndices,
+    VerticalMotionAssessment,
+    VerticalMotionClass,
+    Waypoint,
+    WaypointForecast,
+)
+from weatherbrief.models.airport_conditions import (
+    AirportConditions,
+    AirportConditionsSummary,
+    AirportModelCondition,
+    FlightCategory,
+)
+
+S = HighlightSeverity
+_T0 = datetime(2026, 3, 1, 12, 0)
+
+
+def _params(evaluator) -> dict[str, float]:
+    return {p.key: p.default for p in evaluator.catalog_entry().parameters}
+
+
+def _rpa(i: int, dist: float, sounding: dict[str, SoundingAnalysis]) -> RoutePointAnalysis:
+    return RoutePointAnalysis(
+        point_index=i,
+        lat=48.0 + i * 0.5,
+        lon=2.0 + i * 0.5,
+        distance_from_origin_nm=dist,
+        interpolated_time=_T0,
+        forecast_hour=_T0,
+        track_deg=90.0,
+        sounding=sounding,
+    )
+
+
+def _ctx(
+    soundings: list[SoundingAnalysis | None],
+    *,
+    cruise_ft: int = 8000,
+    ceiling_ft: int = 18000,
+    elevation: ElevationProfile | None = None,
+    airport_conditions: AirportConditions | None = None,
+    total_nm: float | None = None,
+) -> RouteContext:
+    """One point every 20 nm; ``None`` in ``soundings`` = no sounding (gap)."""
+    analyses = [
+        _rpa(i, i * 20.0, {} if s is None else {"gfs": s})
+        for i, s in enumerate(soundings)
+    ]
+    return RouteContext(
+        analyses=analyses,
+        cross_sections=[],
+        elevation=elevation,
+        airport_conditions=airport_conditions,
+        models=["gfs"],
+        cruise_altitude_ft=cruise_ft,
+        flight_ceiling_ft=ceiling_ft,
+        total_distance_nm=total_nm if total_nm is not None else 20.0 * (len(soundings) - 1),
+    )
+
+
+def _flat_elevation(n: int, elev_ft: float = 500.0) -> ElevationProfile:
+    total = 20.0 * (n - 1)
+    return ElevationProfile(
+        route_name="test",
+        points=[
+            ElevationPoint(distance_nm=i * 20.0, elevation_ft=elev_ft, lat=48.0, lon=2.0 + i * 0.5)
+            for i in range(n)
+        ],
+        max_elevation_ft=elev_ft,
+        total_distance_nm=total,
+    )
+
+
+def _airports(
+    dep_cat: FlightCategory,
+    arr_cat: FlightCategory,
+    dep_ceiling_ft: int | None = None,
+    arr_ceiling_ft: int | None = None,
+) -> AirportConditions:
+    return AirportConditions(
+        departure=AirportConditionsSummary(
+            icao="LFPG", name="Dep", conditions=[AirportModelCondition(
+                model="gfs", flight_category=dep_cat, ceiling_ft=dep_ceiling_ft,
+            )],
+        ),
+        arrival=AirportConditionsSummary(
+            icao="EGTF", name="Arr", conditions=[AirportModelCondition(
+                model="gfs", flight_category=arr_cat, ceiling_ft=arr_ceiling_ft,
+            )],
+        ),
+    )
+
+
+def _assert_tiles(ribbon, total_nm: float) -> None:
+    assert ribbon, "ribbon must not be empty"
+    assert ribbon[0].dist_from_nm == 0.0
+    assert abs(ribbon[-1].dist_to_nm - total_nm) < 1e-9
+    for a, b in zip(ribbon, ribbon[1:]):
+        assert abs(a.dist_to_nm - b.dist_from_nm) < 1e-9
+        assert a.dist_from_nm < a.dist_to_nm
+        assert a.severity != b.severity
+
+
+# ---------------------------------------------------------------------------
+# icing_escape
+# ---------------------------------------------------------------------------
+
+def _icing_sounding(base: float, top: float, fz: float | None) -> SoundingAnalysis:
+    return SoundingAnalysis(
+        icing_zones=[IcingZone(
+            base_ft=base, top_ft=top,
+            risk=IcingRisk.LIGHT, icing_type=IcingType.RIME,
+        )],
+        indices=ThermodynamicIndices(freezing_level_ft=fz),
+    )
+
+
+class TestIcingEscapeHighlights:
+    def test_escapable_icing_amber_band(self):
+        n = 10
+        ctx = _ctx(
+            [_icing_sounding(4000, 6000, 3000)] * n,
+            elevation=_flat_elevation(n),
+        )
+        res = IcingEscapeEvaluator.evaluate(ctx, _params(IcingEscapeEvaluator))
+        h = res.per_model[0].highlights
+        assert h is not None
+        _assert_tiles(h.ribbon, ctx.total_distance_nm)
+        assert all(seg.severity == S.AMBER for seg in h.ribbon)
+        assert len(h.regions) == 1
+        assert h.regions[0].kind == "icing_band"
+        assert h.regions[0].severity == S.AMBER
+        assert h.regions[0].base_ft == 4000 and h.regions[0].top_ft == 6000
+        assert h.peak_dist_nm is not None
+
+    def test_no_escape_is_red(self):
+        # Freezing level 1200 < terrain 500 + margin 1000 → no escape.
+        n = 10
+        ctx = _ctx(
+            [_icing_sounding(2000, 6000, 1200)] * n,
+            elevation=_flat_elevation(n),
+        )
+        res = IcingEscapeEvaluator.evaluate(ctx, _params(IcingEscapeEvaluator))
+        h = res.per_model[0].highlights
+        assert all(seg.severity == S.RED for seg in h.ribbon)
+        assert all(r.severity == S.RED for r in h.regions)
+
+    def test_unknown_fz_or_terrain_is_red(self):
+        # elevation=None → terrain unknown at an affected point → no-escape red
+        # (matches the grade's no-escape count).
+        ctx = _ctx([_icing_sounding(4000, 6000, 3000)] * 5)
+        res = IcingEscapeEvaluator.evaluate(ctx, _params(IcingEscapeEvaluator))
+        h = res.per_model[0].highlights
+        assert all(seg.severity == S.RED for seg in h.ribbon)
+
+    def test_icing_above_buffer_is_green_no_region(self):
+        # Zone 11000-13000 with cruise 8000 + buffer 2000 → irrelevant → green.
+        n = 5
+        ctx = _ctx(
+            [_icing_sounding(11000, 13000, 3000)] * n,
+            elevation=_flat_elevation(n),
+        )
+        res = IcingEscapeEvaluator.evaluate(ctx, _params(IcingEscapeEvaluator))
+        h = res.per_model[0].highlights
+        assert all(seg.severity == S.GREEN for seg in h.ribbon)
+        assert h.regions == []
+        assert h.peak_dist_nm is None
+
+    def test_unavailable_gap(self):
+        n = 6
+        soundings: list[SoundingAnalysis | None] = [
+            _icing_sounding(4000, 6000, 3000)
+        ] * n
+        soundings[3] = None
+        ctx = _ctx(soundings, elevation=_flat_elevation(n))
+        res = IcingEscapeEvaluator.evaluate(ctx, _params(IcingEscapeEvaluator))
+        h = res.per_model[0].highlights
+        _assert_tiles(h.ribbon, ctx.total_distance_nm)
+        assert any(seg.severity == S.UNAVAILABLE for seg in h.ribbon)
+
+
+# ---------------------------------------------------------------------------
+# fiki_icing
+# ---------------------------------------------------------------------------
+
+class TestFIKIIcingHighlights:
+    def test_thick_transit_red_in_corridors_only(self):
+        # 6000 ft transit column (>= 5000 red) everywhere; cruise itself is
+        # clear (top 6000, cruise 8000, clearance 2000 >= buffer). Red in the
+        # dep/arr corridors (default proximity 50 nm), green mid-route.
+        n = 10  # total 180 nm; corridors cover d<=50 and d>=130
+        sounding = _icing_sounding(0, 6000, None)
+        ctx = _ctx([sounding] * n)
+        res = FIKIIcingEvaluator.evaluate(ctx, _params(FIKIIcingEvaluator))
+        h = res.per_model[0].highlights
+        assert h is not None
+        _assert_tiles(h.ribbon, ctx.total_distance_nm)
+        assert [seg.severity for seg in h.ribbon] == [S.RED, S.GREEN, S.RED]
+        assert all(r.kind == "icing_band" for r in h.regions)
+        assert {r.severity for r in h.regions} == {S.RED}
+
+    def test_cruise_icing_amber(self):
+        # Zone hugging cruise (7500-8500): thin (500 ft transit) but cruise is
+        # not clear → amber everywhere.
+        ctx = _ctx([_icing_sounding(7500, 8500, None)] * 6)
+        res = FIKIIcingEvaluator.evaluate(ctx, _params(FIKIIcingEvaluator))
+        h = res.per_model[0].highlights
+        assert all(seg.severity == S.AMBER for seg in h.ribbon)
+        assert all(r.severity == S.AMBER and r.kind == "icing_band" for r in h.regions)
+
+    def test_sld_in_corridor_red(self):
+        sld = SoundingAnalysis(icing_zones=[IcingZone(
+            base_ft=1000, top_ft=3000, risk=IcingRisk.LIGHT,
+            icing_type=IcingType.CLEAR, sld_risk=True,
+        )])
+        ctx = _ctx([sld] * 5)  # 80 nm — everything is in a corridor
+        res = FIKIIcingEvaluator.evaluate(ctx, _params(FIKIIcingEvaluator))
+        h = res.per_model[0].highlights
+        assert all(seg.severity == S.RED for seg in h.ribbon)
+
+    def test_no_icing_green(self):
+        ctx = _ctx([SoundingAnalysis()] * 5)
+        res = FIKIIcingEvaluator.evaluate(ctx, _params(FIKIIcingEvaluator))
+        h = res.per_model[0].highlights
+        assert len(h.ribbon) == 1 and h.ribbon[0].severity == S.GREEN
+        assert h.regions == []
+
+
+# ---------------------------------------------------------------------------
+# turbulence
+# ---------------------------------------------------------------------------
+
+def _cat_sounding(base: float, top: float, risk: CATRiskLevel) -> SoundingAnalysis:
+    return SoundingAnalysis(vertical_motion=VerticalMotionAssessment(
+        classification=VerticalMotionClass.QUIESCENT,
+        cat_risk_layers=[CATRiskLayer(base_ft=base, top_ft=top, risk=risk)],
+    ))
+
+
+class TestTurbulenceHighlights:
+    def test_moderate_at_cruise_amber_with_layer_band(self):
+        ctx = _ctx([_cat_sounding(7000, 9000, CATRiskLevel.MODERATE)] * 6)
+        res = TurbulenceEvaluator.evaluate(ctx, _params(TurbulenceEvaluator))
+        h = res.per_model[0].highlights
+        assert all(seg.severity == S.AMBER for seg in h.ribbon)
+        assert len(h.regions) == 1
+        assert h.regions[0].kind == "cat_layer"
+        assert h.regions[0].base_ft == 7000 and h.regions[0].top_ft == 9000
+
+    def test_severe_anywhere_in_column_is_red(self):
+        # SEVERE CAT at FL200-250, cruise 8000: the ribbon locates it (red +
+        # cutout where it sits) even though the layer is far above cruise —
+        # per the #375 spec, this is exactly the ambiguity the cutout resolves.
+        ctx = _ctx([_cat_sounding(20000, 25000, CATRiskLevel.SEVERE)] * 6)
+        res = TurbulenceEvaluator.evaluate(ctx, _params(TurbulenceEvaluator))
+        h = res.per_model[0].highlights
+        assert all(seg.severity == S.RED for seg in h.ribbon)
+        assert h.regions[0].kind == "cat_layer"
+        assert h.regions[0].severity == S.RED
+        assert h.regions[0].base_ft == 20000 and h.regions[0].top_ft == 25000
+
+    def test_light_at_cruise_is_green_ribbon(self):
+        # LIGHT counts toward the grade's extent but is not a per-point flag.
+        ctx = _ctx([_cat_sounding(7000, 9000, CATRiskLevel.LIGHT)] * 6)
+        res = TurbulenceEvaluator.evaluate(ctx, _params(TurbulenceEvaluator))
+        h = res.per_model[0].highlights
+        assert all(seg.severity == S.GREEN for seg in h.ribbon)
+        assert h.regions == []
+
+    def test_strong_updraft_amber_no_region(self):
+        # Strong w near cruise flags the point (amber ribbon) but is a single
+        # resolved level, not a band — no cutout is invented.
+        sounding = SoundingAnalysis(vertical_motion=VerticalMotionAssessment(
+            classification=VerticalMotionClass.CONVECTIVE,
+            max_w_fpm=400.0, max_w_level_ft=9000.0,
+        ))
+        ctx = _ctx([sounding] * 6)
+        res = TurbulenceEvaluator.evaluate(ctx, _params(TurbulenceEvaluator))
+        h = res.per_model[0].highlights
+        assert all(seg.severity == S.AMBER for seg in h.ribbon)
+        assert h.regions == []
+
+
+# ---------------------------------------------------------------------------
+# cloud_top
+# ---------------------------------------------------------------------------
+
+class TestCloudTopHighlights:
+    def test_blocking_deck_amber(self):
+        deck = EnhancedCloudLayer(base_ft=7000, top_ft=17500, coverage=CloudCoverage.OVC)
+        ctx = _ctx([SoundingAnalysis(cloud_layers=[deck])] * 6)
+        res = CloudTopEvaluator.evaluate(ctx, _params(CloudTopEvaluator))
+        h = res.per_model[0].highlights
+        assert all(seg.severity == S.AMBER for seg in h.ribbon)
+        assert len(h.regions) == 1
+        assert h.regions[0].kind == "blocking_deck"
+        assert h.regions[0].base_ft == 7000 and h.regions[0].top_ft == 17500
+
+    def test_toppable_green_no_region(self):
+        deck = EnhancedCloudLayer(base_ft=7000, top_ft=12000, coverage=CloudCoverage.OVC)
+        ctx = _ctx([SoundingAnalysis(cloud_layers=[deck])] * 6)
+        res = CloudTopEvaluator.evaluate(ctx, _params(CloudTopEvaluator))
+        h = res.per_model[0].highlights
+        assert all(seg.severity == S.GREEN for seg in h.ribbon)
+        assert h.regions == []
+        assert h.peak_dist_nm is None
+
+
+# ---------------------------------------------------------------------------
+# vfr_feasibility (composite: multi-kind cutouts + endpoint colouring)
+# ---------------------------------------------------------------------------
+
+class TestVFRFeasibilityHighlights:
+    def test_multi_kind_cutouts_at_overlapping_x(self):
+        # Point 0 carries BOTH a low deck (climb_deck) and cruise in cloud
+        # (cruise_imc): two different-kind cutouts at the same x that must NOT
+        # merge into one.
+        both = SoundingAnalysis(cloud_layers=[
+            EnhancedCloudLayer(base_ft=1000, top_ft=3000, coverage=CloudCoverage.OVC),
+            EnhancedCloudLayer(base_ft=7000, top_ft=9000, coverage=CloudCoverage.OVC),
+        ])
+        soundings: list[SoundingAnalysis | None] = [both] + [SoundingAnalysis()] * 9
+        ctx = _ctx(soundings)
+        res = VFRFeasibilityEvaluator.evaluate(ctx, _params(VFRFeasibilityEvaluator))
+        h = res.per_model[0].highlights
+        assert h is not None
+        _assert_tiles(h.ribbon, ctx.total_distance_nm)
+        kinds = {r.kind for r in h.regions}
+        assert kinds == {"cruise_imc", "climb_deck"}
+        imc = next(r for r in h.regions if r.kind == "cruise_imc")
+        deck = next(r for r in h.regions if r.kind == "climb_deck")
+        # Same x-extent (point 0's cell), different bands — not fused.
+        assert imc.dist_from_nm == deck.dist_from_nm == 0.0
+        assert imc.base_ft == 7000 and imc.top_ft == 9000
+        assert deck.base_ft == 1000 and deck.top_ft == 3000
+        # Worst axis at point 0 is red (OVC deck + IMC).
+        assert h.ribbon[0].severity == S.RED
+
+    def test_airport_endpoint_colouring(self):
+        # Clear en route; dep IFR → first ribbon segment red, rest green.
+        ctx = _ctx(
+            [SoundingAnalysis()] * 10,
+            airport_conditions=_airports(FlightCategory.IFR, FlightCategory.VFR),
+        )
+        res = VFRFeasibilityEvaluator.evaluate(ctx, _params(VFRFeasibilityEvaluator))
+        h = res.per_model[0].highlights
+        assert [seg.severity for seg in h.ribbon] == [S.RED, S.GREEN]
+        assert h.ribbon[0].dist_to_nm == 10.0  # first point's cell only
+
+    def test_precip_axis_capped_amber(self):
+        # Moderate snow everywhere: the standalone advisory ribbons it red,
+        # the composite caps it at amber.
+        snow = SoundingAnalysis(precipitation=PrecipitationAssessment(
+            surface_phase=PrecipPhase.SNOW,
+            surface_intensity=PrecipIntensity.MODERATE,
+        ))
+        ctx = _ctx([snow] * 6)
+        res = VFRFeasibilityEvaluator.evaluate(ctx, _params(VFRFeasibilityEvaluator))
+        h = res.per_model[0].highlights
+        assert all(seg.severity == S.AMBER for seg in h.ribbon)
+        # Precip contributes to the ribbon only — no vfr cutout kind for it.
+        assert h.regions == []
+
+    def test_marginal_clearance_amber_no_cutout(self):
+        near = SoundingAnalysis(cloud_layers=[
+            EnhancedCloudLayer(base_ft=8500, top_ft=10000, coverage=CloudCoverage.BKN),
+        ])
+        ctx = _ctx([near] * 6)
+        res = VFRFeasibilityEvaluator.evaluate(ctx, _params(VFRFeasibilityEvaluator))
+        h = res.per_model[0].highlights
+        assert all(seg.severity == S.AMBER for seg in h.ribbon)
+        assert h.regions == []
+
+
+# ---------------------------------------------------------------------------
+# ifr_feasibility (composite: icing + convective kinds, endpoint colouring)
+# ---------------------------------------------------------------------------
+
+class TestIFRFeasibilityHighlights:
+    def test_icing_and_tower_kinds_at_overlapping_x(self):
+        hazard = SoundingAnalysis(
+            icing_zones=[IcingZone(
+                base_ft=7000, top_ft=9000,
+                risk=IcingRisk.LIGHT, icing_type=IcingType.RIME,
+            )],
+            convective=ConvectiveAssessment(
+                risk_level=ConvectiveRisk.HIGH, cape_jkg=2000,
+                base_ft=4000, top_ft=35000,
+            ),
+        )
+        ctx = _ctx([hazard] * 8)
+        res = IFRFeasibilityEvaluator.evaluate(ctx, _params(IFRFeasibilityEvaluator))
+        h = res.per_model[0].highlights
+        assert h is not None
+        _assert_tiles(h.ribbon, ctx.total_distance_nm)
+        # Convective HIGH → red ribbon (worst of the two axes).
+        assert all(seg.severity == S.RED for seg in h.ribbon)
+        kinds = {r.kind for r in h.regions}
+        assert kinds == {"icing_band", "tower"}
+        icing = next(r for r in h.regions if r.kind == "icing_band")
+        tower = next(r for r in h.regions if r.kind == "tower")
+        assert icing.severity == S.AMBER
+        assert icing.base_ft == 7000 and icing.top_ft == 9000
+        assert tower.severity == S.RED
+        assert tower.base_ft == 4000 and tower.top_ft == 35000
+
+    def test_unresolved_tower_is_ghost(self):
+        hazard = SoundingAnalysis(convective=ConvectiveAssessment(
+            risk_level=ConvectiveRisk.MODERATE, base_ft=None, top_ft=None,
+            method="nwp_precip",
+        ))
+        ctx = _ctx([hazard] * 6)
+        res = IFRFeasibilityEvaluator.evaluate(ctx, _params(IFRFeasibilityEvaluator))
+        h = res.per_model[0].highlights
+        assert len(h.regions) == 1
+        assert h.regions[0].kind == "tower_unresolved"
+        assert h.regions[0].base_ft is None and h.regions[0].top_ft is None
+        assert all(seg.severity == S.AMBER for seg in h.ribbon)
+
+    def test_lifr_endpoint_amber(self):
+        ctx = _ctx(
+            [SoundingAnalysis()] * 8,
+            airport_conditions=_airports(
+                FlightCategory.LIFR, FlightCategory.VFR, dep_ceiling_ft=300,
+            ),
+        )
+        res = IFRFeasibilityEvaluator.evaluate(ctx, _params(IFRFeasibilityEvaluator))
+        h = res.per_model[0].highlights
+        assert [seg.severity for seg in h.ribbon] == [S.AMBER, S.GREEN]
+
+    def test_lifr_below_minimum_endpoint_red(self):
+        ctx = _ctx(
+            [SoundingAnalysis()] * 8,
+            airport_conditions=_airports(
+                FlightCategory.VFR, FlightCategory.LIFR, arr_ceiling_ft=100,
+            ),
+        )
+        res = IFRFeasibilityEvaluator.evaluate(ctx, _params(IFRFeasibilityEvaluator))
+        h = res.per_model[0].highlights
+        assert [seg.severity for seg in h.ribbon] == [S.GREEN, S.RED]
+
+
+# ---------------------------------------------------------------------------
+# mountain_wind (ridge_wind + wave_signature kinds)
+# ---------------------------------------------------------------------------
+
+_MW_N = 10
+_MW_TOTAL = 200.0
+
+
+def _mw_elevation(mountain: bool = True) -> ElevationProfile:
+    points = []
+    for i in range(_MW_N):
+        d = i * _MW_TOTAL / (_MW_N - 1)
+        elev = 5000.0 if (mountain and 4 <= i <= 6) else 500.0
+        points.append(ElevationPoint(distance_nm=d, elevation_ft=elev, lat=46.0, lon=6.0 + i * 0.2))
+    return ElevationProfile(
+        route_name="test", points=points,
+        max_elevation_ft=5000 if mountain else 500,
+        total_distance_nm=_MW_TOTAL,
+    )
+
+
+def _mw_cross_section(wind_speed_kt: float) -> RouteCrossSection:
+    route_points = [
+        RoutePoint(lat=46.0, lon=6.0 + i * 0.2, distance_from_origin_nm=i * _MW_TOTAL / (_MW_N - 1))
+        for i in range(_MW_N)
+    ]
+    forecasts = [
+        WaypointForecast(
+            waypoint=Waypoint(icao=f"P{i}", name=f"P{i}", lat=46.0, lon=6.0 + i * 0.2),
+            model=ModelSource.GFS,
+            fetched_at=_T0,
+            hourly=[HourlyForecast(
+                time=_T0,
+                pressure_levels=[PressureLevelData(
+                    pressure_hpa=800,
+                    wind_speed_kt=wind_speed_kt,
+                    wind_direction_deg=270.0,
+                )],
+            )],
+        )
+        for i in range(_MW_N)
+    ]
+    return RouteCrossSection(
+        model=ModelSource.GFS, route_points=route_points,
+        fetched_at=_T0, point_forecasts=forecasts,
+    )
+
+
+def _mw_ctx(wind_speed_kt: float, *, ridge_inversion: bool = False, mountain: bool = True) -> RouteContext:
+    sounding = SoundingAnalysis(
+        indices=ThermodynamicIndices(),
+        inversion_layers=(
+            [InversionLayer(base_ft=5500, top_ft=6500, strength_c=3.0)]
+            if ridge_inversion else []
+        ),
+        vertical_motion=VerticalMotionAssessment(
+            classification=VerticalMotionClass.QUIESCENT,
+        ),
+    )
+    analyses = [
+        RoutePointAnalysis(
+            point_index=i, lat=46.0, lon=6.0 + i * 0.2,
+            distance_from_origin_nm=i * _MW_TOTAL / (_MW_N - 1),
+            interpolated_time=_T0, forecast_hour=_T0, track_deg=90.0,
+            sounding={"gfs": sounding},
+        )
+        for i in range(_MW_N)
+    ]
+    return RouteContext(
+        analyses=analyses,
+        cross_sections=[_mw_cross_section(wind_speed_kt)],
+        elevation=_mw_elevation(mountain),
+        models=["gfs"],
+        cruise_altitude_ft=8000,
+        flight_ceiling_ft=18000,
+        total_distance_nm=_MW_TOTAL,
+    )
+
+
+class TestMountainWindHighlights:
+    def test_corroborated_red_with_wave_signature_band(self):
+        # 32 kt + ridge inversion → rotor-day red at the mountain points, with
+        # both the terrain-hugging ridge_wind band and the corroborating
+        # inversion band as separate kinds.
+        ctx = _mw_ctx(32.0, ridge_inversion=True)
+        res = MountainWindEvaluator.evaluate(ctx, _params(MountainWindEvaluator))
+        h = res.per_model[0].highlights
+        assert h is not None
+        _assert_tiles(h.ribbon, _MW_TOTAL)
+        assert [seg.severity for seg in h.ribbon] == [S.GREEN, S.RED, S.GREEN]
+        kinds = {r.kind for r in h.regions}
+        assert kinds == {"ridge_wind", "wave_signature"}
+        ridge = next(r for r in h.regions if r.kind == "ridge_wind")
+        wave = next(r for r in h.regions if r.kind == "wave_signature")
+        assert ridge.base_ft == 5000 and ridge.top_ft == 7000  # terrain → +margin
+        assert wave.base_ft == 5500 and wave.top_ft == 6500    # the inversion
+        assert h.peak_dist_nm is not None
+
+    def test_windy_ridge_amber_no_wave_band(self):
+        ctx = _mw_ctx(25.0)
+        res = MountainWindEvaluator.evaluate(ctx, _params(MountainWindEvaluator))
+        h = res.per_model[0].highlights
+        assert [seg.severity for seg in h.ribbon] == [S.GREEN, S.AMBER, S.GREEN]
+        assert {r.kind for r in h.regions} == {"ridge_wind"}
+        assert all(r.severity == S.AMBER for r in h.regions)
+
+    def test_no_mountains_solid_green_ribbon(self):
+        # GREEN-not-UNAVAILABLE choice: a flat route still gets an explicit
+        # all-green ribbon, not highlights=None.
+        ctx = _mw_ctx(45.0, mountain=False)
+        res = MountainWindEvaluator.evaluate(ctx, _params(MountainWindEvaluator))
+        h = res.per_model[0].highlights
+        assert h is not None
+        assert len(h.ribbon) == 1 and h.ribbon[0].severity == S.GREEN
+        assert h.regions == []
+
+    def test_mountain_points_without_wind_are_unavailable(self):
+        ctx = _mw_ctx(32.0)
+        from dataclasses import replace
+        res = MountainWindEvaluator.evaluate(
+            replace(ctx, cross_sections=[]), _params(MountainWindEvaluator),
+        )
+        h = res.per_model[0].highlights
+        assert [seg.severity for seg in h.ribbon] == [S.GREEN, S.UNAVAILABLE, S.GREEN]
+
+
+# ---------------------------------------------------------------------------
+# freezing_precip
+# ---------------------------------------------------------------------------
+
+def _fp_dry() -> SoundingAnalysis:
+    return SoundingAnalysis(
+        precipitation=PrecipitationAssessment(),
+        derived_levels=[
+            DerivedLevel(pressure_hpa=1000, altitude_ft=400, wet_bulb_c=4.0),
+            DerivedLevel(pressure_hpa=900, altitude_ft=3200, wet_bulb_c=0.5),
+            DerivedLevel(pressure_hpa=800, altitude_ft=6400, wet_bulb_c=-4.0),
+        ],
+    )
+
+
+def _fp_primed() -> SoundingAnalysis:
+    return SoundingAnalysis(
+        precipitation=PrecipitationAssessment(),
+        derived_levels=[
+            DerivedLevel(pressure_hpa=1000, altitude_ft=500, wet_bulb_c=-2.0),
+            DerivedLevel(pressure_hpa=925, altitude_ft=3000, wet_bulb_c=1.0),
+            DerivedLevel(pressure_hpa=900, altitude_ft=4000, wet_bulb_c=1.5),
+            DerivedLevel(pressure_hpa=800, altitude_ft=6500, wet_bulb_c=-5.0),
+        ],
+    )
+
+
+def _fp_active() -> SoundingAnalysis:
+    return SoundingAnalysis(precipitation=PrecipitationAssessment(
+        surface_phase=PrecipPhase.FREEZING_RAIN,
+        freezing_rain_risk=True, total_mm=1.2,
+    ))
+
+
+class TestFreezingPrecipHighlights:
+    def test_active_red_column_with_fallback_top(self):
+        # Active point has no derived levels → the cutout falls back to the
+        # fixed shallow AGL band (terrain unknown → 0 + 3000).
+        ctx = _ctx([_fp_dry()] * 4 + [_fp_active()])
+        res = FreezingPrecipEvaluator.evaluate(ctx, _params(FreezingPrecipEvaluator))
+        h = res.per_model[0].highlights
+        assert h is not None
+        _assert_tiles(h.ribbon, ctx.total_distance_nm)
+        assert h.ribbon[-1].severity == S.RED
+        assert len(h.regions) == 1
+        assert h.regions[0].kind == "freezing_precip_column"
+        assert h.regions[0].severity == S.RED
+        assert h.regions[0].base_ft is None      # down to the surface
+        assert h.regions[0].top_ft == 3000       # fallback AGL band
+
+    def test_primed_amber_column_topped_by_warm_nose(self):
+        ctx = _ctx([_fp_primed()] * 6)
+        res = FreezingPrecipEvaluator.evaluate(ctx, _params(FreezingPrecipEvaluator))
+        h = res.per_model[0].highlights
+        assert all(seg.severity == S.AMBER for seg in h.ribbon)
+        assert len(h.regions) == 1
+        assert h.regions[0].base_ft is None
+        assert h.regions[0].top_ft == 4000       # warm-nose top from the profile
+
+    def test_dry_green_no_regions(self):
+        ctx = _ctx([_fp_dry()] * 5)
+        res = FreezingPrecipEvaluator.evaluate(ctx, _params(FreezingPrecipEvaluator))
+        h = res.per_model[0].highlights
+        assert len(h.ribbon) == 1 and h.ribbon[0].severity == S.GREEN
+        assert h.regions == []
+
+    def test_no_signal_model_has_no_highlights(self):
+        # Soundings without precip data anywhere → UNAVAILABLE, no highlights.
+        ctx = _ctx([SoundingAnalysis()] * 5)
+        res = FreezingPrecipEvaluator.evaluate(ctx, _params(FreezingPrecipEvaluator))
+        assert res.per_model[0].status == AdvisoryStatus.UNAVAILABLE
+        assert res.per_model[0].highlights is None
+
+
+# ---------------------------------------------------------------------------
+# enroute_precip
+# ---------------------------------------------------------------------------
+
+def _precip(phase: PrecipPhase, intensity: PrecipIntensity) -> SoundingAnalysis:
+    return SoundingAnalysis(precipitation=PrecipitationAssessment(
+        surface_phase=phase, surface_intensity=intensity,
+    ))
+
+
+class TestEnroutePrecipHighlights:
+    def test_moderate_snow_red_full_column(self):
+        ctx = _ctx([_precip(PrecipPhase.SNOW, PrecipIntensity.MODERATE)] * 6)
+        res = EnroutePrecipEvaluator.evaluate(ctx, _params(EnroutePrecipEvaluator))
+        h = res.per_model[0].highlights
+        assert h is not None
+        _assert_tiles(h.ribbon, ctx.total_distance_nm)
+        assert all(seg.severity == S.RED for seg in h.ribbon)
+        assert len(h.regions) == 1
+        assert h.regions[0].kind == "precip_column"
+        assert h.regions[0].base_ft is None and h.regions[0].top_ft is None
+
+    def test_light_snow_amber(self):
+        ctx = _ctx([_precip(PrecipPhase.SNOW, PrecipIntensity.LIGHT)] * 6)
+        res = EnroutePrecipEvaluator.evaluate(ctx, _params(EnroutePrecipEvaluator))
+        h = res.per_model[0].highlights
+        assert all(seg.severity == S.AMBER for seg in h.ribbon)
+
+    def test_moderate_rain_amber(self):
+        ctx = _ctx([_precip(PrecipPhase.RAIN, PrecipIntensity.MODERATE)] * 6)
+        res = EnroutePrecipEvaluator.evaluate(ctx, _params(EnroutePrecipEvaluator))
+        h = res.per_model[0].highlights
+        assert all(seg.severity == S.AMBER for seg in h.ribbon)
+
+    def test_light_rain_green_no_region(self):
+        ctx = _ctx([_precip(PrecipPhase.RAIN, PrecipIntensity.LIGHT)] * 6)
+        res = EnroutePrecipEvaluator.evaluate(ctx, _params(EnroutePrecipEvaluator))
+        h = res.per_model[0].highlights
+        assert all(seg.severity == S.GREEN for seg in h.ribbon)
+        assert h.regions == []
+
+    def test_no_signal_no_highlights(self):
+        ctx = _ctx([SoundingAnalysis()] * 5)
+        res = EnroutePrecipEvaluator.evaluate(ctx, _params(EnroutePrecipEvaluator))
+        assert res.per_model[0].status == AdvisoryStatus.UNAVAILABLE
+        assert res.per_model[0].highlights is None

--- a/web/ts/visualization/cross-section/advisory-presets.ts
+++ b/web/ts/visualization/cross-section/advisory-presets.ts
@@ -95,6 +95,10 @@ const RESET_GROUPS: ReadonlySet<LayerGroup> = new Set<LayerGroup>([
 export const ADVISORY_OVERRIDES: Record<string, Partial<AdvisoryPreset>> = {
   // FIKI: add layer-thickness / warm-nose context (−10/−20 °C + SLD warm-nose).
   fiki_icing: { lines: ['minus-10c', 'minus-20c', 'sld-bands'] },
+  // Freezing precip: the SLD/warm-nose bands ARE the hazard signature (#375).
+  freezing_precip: { lines: ['sld-bands'] },
+  // En-route precip: swap the route graph to the precipitation trace (#375).
+  enroute_precip: { routeGraph: { left: 'precipitation', right: 'ceiling-nwp' } },
 };
 
 export const ADVISORY_PRESETS: Record<string, AdvisoryPreset> = {
@@ -226,11 +230,15 @@ export const ADVISORY_PRESETS: Record<string, AdvisoryPreset> = {
  * types — see the issue's "Out of scope").
  */
 export const ADVISORY_TO_PRESET: Record<string, string> = {
-  icing_escape: 'icing', fiki_icing: 'icing',
+  icing_escape: 'icing', fiki_icing: 'icing', freezing_precip: 'icing',
   cloud_top: 'clouds', vmc_cruise: 'clouds',
   convective: 'convective',
   turbulence: 'turbulence', mountain_wind: 'turbulence',
   vfr_feasibility: 'vfr', ifr_feasibility: 'ifr',
+  // enroute_precip is a visibility proxy → the VFR lens (clouds + obscuration
+  // + ceilings) reads better than bare Clouds; the override above swaps the
+  // route graph to precipitation (#375).
+  enroute_precip: 'vfr',
 };
 
 export function getAdvisoryPreset(id: string): AdvisoryPreset | undefined {


### PR DESCRIPTION
Implements #375 — every remaining cross-section-relevant evaluator now emits `AdvisoryHighlights` (scrim cutouts + verdict ribbon, mechanism from #373) inside its existing per-point loop. Zero client changes needed except the two new chips.

## Per-evaluator geometry

| Evaluator | Ribbon | Region kinds |
|---|---|---|
| `icing_escape` | green = no relevant icing (post altitude buffer) · amber = escape viable (incl. tight-margin) · red = no escape (incl. unknown fz/terrain) | `icing_band` (envelope of relevant zones) |
| `fiki_icing` | corridor points grade the transit column (SLD / SEVERE / thickness); cruise-buffer icing amber everywhere; thin transit-able icing away from cruise stays green | `icing_band` |
| `turbulence` | red = SEVERE CAT **anywhere in the column** (per issue spec — locates the layer the badge can't); amber = MODERATE at cruise or strong updraft; LIGHT green | `cat_layer`; no `strong_updraft` cutout — max-w is a single level, skip rather than invent geometry |
| `cloud_top` | binary amber = can't get on top here | `blocking_deck` (violating layers) |
| `vfr_feasibility` | worst firing sub-axis; precip via shared classifier capped amber; airport category colours endpoint segments | `cruise_imc` + `climb_deck`/`descent_deck` — the multi-kind case |
| `ifr_feasibility` | worst of icing (amber) / convective (HIGH+ red); airport IFR-viability endpoints | `icing_band` + `tower`/`tower_unresolved` (same conventions as `convective`) |
| `mountain_wind` | non-mountain green; no-wind-data unavailable; amber/red per the grade's own two red triggers | `ridge_wind` (terrain → +margin) + `wave_signature` (corroborating inversion, red points) |
| `freezing_precip` (new chip → `icing` + `sld-bands`) | red = active FZRA/PL · amber = primed profile | `freezing_precip_column`, surface → warm-nose top (fixed 3000 ft AGL fallback) |
| `enroute_precip` (new chip → `vfr` + precipitation route-graph) | mirrors `classify_precip_point`: moderate+ snow red, any snow / moderate+ rain amber | `precip_column` full column |

## Notes for review

- **Turbulence ribbon-vs-badge divergence**: the issue states the route-RED trigger is severity-anywhere, but the evaluator actually keys `has_severe` on the cruise band. I followed the issue's explicit ribbon spec (severe anywhere → red) without touching grading, so a severe layer far above cruise can ribbon red under a non-red badge. Deliberate, documented in the design doc + a test.
- **mountain_wind mock gate**: exercised the geometry on a real pack (KPAO→KGCN) with forced-low thresholds — envelope run-merging collapses bumpy terrain into per-run rectangles, so it reads acceptably; ribbon-only fallback remains a one-line change if a genuine rotor-day pack disagrees.
- Shared plumbing: `status_to_severity`/`worst_severity` in `_helpers`, per-airport statuses from the airport checks (endpoint colouring), `_corridor_points` now yields the deck envelope, per-point precip classifier extracted so the VFR composite and standalone advisory cannot drift.
- `enroute_precip` chip preset: chose `vfr` over `clouds` (visibility framing + obscuration bands), with a route-graph override to precipitation — flagged as implementer's call in the issue.

## Verification

- 36 new tests (`test_highlights_remaining.py`): tiling/severity invariants per evaluator, relevance-filter greens, UNAVAILABLE gaps, multi-kind overlapping-x cases for both composites, endpoint colouring, warm-nose fallback. Full suite: 3340 passed.
- Real-pack sweep (recalc from pack, invariant checks + geometry dump) over 4 diverse local packs (Greenland icing, Grand Canyon terrain, Alps VFR, Germany→Spain) — all invariants hold, geometry plausible.
- Web render spot-check on `bgsf_birk` (dev): new chips appear on the Freezing/En-route Precipitation cards.

Closes #375

🤖 Generated with [Claude Code](https://claude.com/claude-code)