### PR TITLE
Advisory evidence contract + single-assessment loop (#393)

### DIFF
--- a/designs/advisories.md
+++ b/designs/advisories.md
@@ -240,6 +240,16 @@ no migration (pure JSON). There is **no** `aggregate_highlights` — the cross-s
 is per-model, and the web chip switches to the representative model (the same
 policy as `aggregate_detail`) to cover the aggregate view at the UI level.
 
+**Evidence contract (#393).** Three additive, legacy-safe provenance fields make
+the chips do more without new geometry: `RouteAdvisoryResult.representative_model`
+(the model whose per-model result sources the aggregate view — emitted from the
+backend so the web client reads it instead of reimplementing the rule; the old TS
+`representativeModel()` copy is deleted), `ModelAdvisoryResult.primary_method_id`
+(stable id of the method that controlled *this model's* grade — for a method
+badge, not the user's selected method), and `HighlightRegion.reason_code` /
+`metric_id` / `method_id` (stable non-localised tokens; `metric_id` lets a chip
+jump to the right cross-section layer). Old packs deserialize with all absent.
+
 Design decisions (don't relitigate): **backend owns the geometry** (which zones
 fired depends on evaluator thresholds/altitude buffers/user params — re-deriving
 client-side would drift and iOS would need a third copy); **distance-space (`nm`)**
@@ -279,6 +289,36 @@ Compare mode), `convective_character`, `fronts` and `sun` (dedicated layers).
 
 iOS rendering is #374; the geometry is data-driven so iOS picks all emitters up
 with no further backend work.
+
+## Single-assessment evidence helper (`_helpers.py`, #393)
+
+The nine single-axis evaluators (`vmc_cruise`, `cloud_top`, `turbulence`,
+`freezing_precip`, `mountain_wind`, `icing_escape`, `fiki_icing`,
+`enroute_precip`, `model_agreement`) emit **one `EvidenceSample` list per model**
+inside their per-point loop, and `summarize_evidence` derives *everything* from
+it — grade counts, geometry, coverage — so the verdict and the highlight can no
+longer come from two loops that drift (the class of bug #391 kept hitting).
+
+- **`EvidenceSample(distance_nm, assessed, severity, affected=None, in_domain=True, region=None)`** —
+  one route point's evidence. `severity` is the ribbon verdict; `affected`
+  (defaults to `severity in {AMBER,RED}`) is the grade count. They're passed
+  *separately* where an evaluator keys ribbon and grade on different predicates —
+  turbulence (SEVERE-anywhere ribbon vs cruise-band grade), FIKI (corridor cutout
+  vs cruise clear-air grade), enroute_precip (light rain: green ribbon, counts in
+  affected). `in_domain=False` drops a point from the coverage denominator
+  (mountain_wind measures coverage over mountain points only). `region` is the
+  `FlaggedCell` scrim cutout.
+- **`summarize_evidence(samples, total_nm, peak_dist_nm=None)`** → `EvidenceSummary(affected, assessed, domain, affected_nm, highlights, data_state)`.
+  `affected_nm` is the **midpoint-owned-cell** distance of the affected points (the
+  #391 geometry fix, landed here): each point owns the interval to its neighbours'
+  midpoints, and the affected cells are summed — so extent and ribbon share one
+  geometry and `affected_nm` can't contradict `affected_pct` (both count the same
+  samples). `ModelAdvisoryResult.build` takes an optional `affected_nm=` override
+  for exactly this. `data_state` is complete/partial/unavailable; `.below_coverage`
+  is the existing `below_coverage(assessed, domain)` predicate, applied **only to a
+  would-be-GREEN** verdict — never #389's binary `partial→UNAVAILABLE`, so a
+  flagged verdict on thin coverage always stands. Evaluators keep their own
+  extent-threshold sub-counts (e.g. vmc_cruise's OVC-only red bar) locally.
 
 ## Shared Helpers (`_helpers.py`)
 

--- a/src/weatherbrief/analysis/advisories/_helpers.py
+++ b/src/weatherbrief/analysis/advisories/_helpers.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, NamedTuple
 from collections.abc import Callable
 
 from weatherbrief.models import (
+    AdvisoryHighlights,
     AdvisoryStatus,
     ElevationProfile,
     HighlightRegion,
@@ -387,6 +388,148 @@ def below_coverage(assessed: int, domain: int) -> bool:
     "nothing to assess" branch, not here).
     """
     return domain > 0 and assessed < domain * _MIN_ASSESSED_FRACTION
+
+
+class EvidenceSample(NamedTuple):
+    """One route point's evidence for one evaluator × one model (#393).
+
+    The single per-point record that feeds **both** the grade (counts) and the
+    highlight geometry (ribbon + regions). Emitting one list per model — instead
+    of maintaining a ``total``/``affected`` counter loop *and* a separate
+    ``ribbon_points``/``region_cells`` loop — is what keeps the verdict and the
+    highlight from silently drifting: :func:`summarize_evidence` derives every
+    downstream number from this one list.
+
+    Fields:
+        ``distance_nm`` — along-route position from origin.
+        ``assessed`` — could this point actually be graded (does the model carry
+            the data here)? ``False`` renders the ribbon UNAVAILABLE at this
+            point and excludes it from the coverage numerator.
+        ``severity`` — the per-point ribbon verdict (what the highlight shows).
+            Unassessed points should carry ``UNAVAILABLE``; points an evaluator's
+            relevance filter skips (above cruise, non-mountain) carry ``GREEN``.
+        ``affected`` — whether this point counts toward the grade's ``affected``
+            total. ``None`` (the common case) derives it as
+            ``severity in {AMBER, RED}``. A few evaluators pass it explicitly
+            because their ribbon and grade key on *different* predicates — e.g.
+            turbulence colours the ribbon RED for SEVERE CAT anywhere in the
+            column while the grade keys on the cruise band, and FIKI flags a
+            corridor cutout while the grade keys on cruise clear-air. Passing it
+            here keeps ``affected_nm`` consistent with ``affected_pct`` (both
+            count the same points) without forcing the ribbon to match.
+        ``in_domain`` — is this point part of the coverage *domain* (the
+            denominator :func:`below_coverage` measures against)? Default True.
+            ``mountain_wind`` sets it ``False`` for non-mountain points so
+            coverage is measured over mountain points only — a genuinely flat
+            route still grades rather than going UNAVAILABLE.
+        ``region`` — the scrim cutout (:class:`FlaggedCell`) for a flagged point,
+            or ``None``. Carries the region kind/altitude band plus the #393
+            provenance tokens.
+    """
+
+    distance_nm: float
+    assessed: bool
+    severity: HighlightSeverity
+    affected: bool | None = None
+    in_domain: bool = True
+    region: FlaggedCell | None = None
+
+
+def _sample_affected(sample: EvidenceSample) -> bool:
+    """Whether a sample counts toward the grade's ``affected`` total."""
+    if sample.affected is not None:
+        return sample.affected
+    return sample.severity in (HighlightSeverity.AMBER, HighlightSeverity.RED)
+
+
+class EvidenceSummary(NamedTuple):
+    """Everything :func:`summarize_evidence` derives from one evidence list (#393).
+
+    ``assessed`` is the grade denominator (``ModelAdvisoryResult.build``'s
+    ``total``); ``affected`` its numerator. ``domain`` is the coverage universe.
+    ``affected_nm`` is the geometry-accurate extent (midpoint-owned cells of the
+    affected points) to pass to ``build``. ``highlights`` is the ribbon + scrim
+    geometry. ``data_state`` is complete / partial / unavailable.
+    """
+
+    affected: int
+    assessed: int
+    domain: int
+    affected_nm: float
+    highlights: AdvisoryHighlights
+    data_state: str  # "complete" | "partial" | "unavailable"
+
+    @property
+    def below_coverage(self) -> bool:
+        """True when a would-be-GREEN verdict rests on too small a share of the domain.
+
+        The same predicate the evaluators call directly today
+        (``below_coverage(total, domain)``) — apply it only to a GREEN status, so
+        a flagged verdict on thin coverage is never diluted.
+        """
+        return below_coverage(self.assessed, self.domain)
+
+
+def summarize_evidence(
+    samples: list[EvidenceSample],
+    total_nm: float,
+    *,
+    peak_dist_nm: float | None = None,
+) -> EvidenceSummary:
+    """Derive grade counts, geometry-accurate extent, highlights and coverage (#393).
+
+    One shared reduction over the evaluator's per-point :class:`EvidenceSample`
+    list. Because the counts and the highlight both come from this single list,
+    the grade and the ribbon cannot disagree, and ``affected_nm`` — the
+    midpoint-owned-cell distance of the *affected* points — stays consistent with
+    ``affected_pct`` (both count the same points). This is the #391 geometry fix,
+    landed here where it belongs rather than as a second pass over the route.
+
+    ``peak_dist_nm`` overrides the highlight's jump-to-worst point; when ``None``
+    it defaults to :func:`ribbon_peak` (longest red run, else amber). The caller
+    decides whether to attach ``.highlights`` to the result (evaluators gate on
+    "the model has data").
+    """
+    pts = sorted(samples, key=lambda s: s.distance_nm)
+    distances = [s.distance_nm for s in pts]
+
+    domain = sum(1 for s in pts if s.in_domain)
+    assessed = sum(1 for s in pts if s.assessed and s.in_domain)
+    affected = sum(1 for s in pts if _sample_affected(s))
+
+    # Geometry-accurate extent: each affected point owns the interval to the
+    # midpoints of its neighbours; union (here, sum — cells are disjoint by
+    # construction) the qualifying intervals. Falls out of the same cell edges
+    # the ribbon uses, so extent and ribbon share one geometry.
+    affected_nm = 0.0
+    if pts:
+        lefts, rights = _cell_edges(distances, total_nm)
+        affected_nm = sum(
+            rights[i] - lefts[i] for i, s in enumerate(pts) if _sample_affected(s)
+        )
+
+    ribbon = build_ribbon([(s.distance_nm, s.severity) for s in pts], total_nm)
+    highlights = AdvisoryHighlights(
+        ribbon=ribbon,
+        regions=build_regions([(s.distance_nm, s.region) for s in pts], total_nm),
+        peak_dist_nm=peak_dist_nm if peak_dist_nm is not None else ribbon_peak(ribbon),
+    )
+
+    if domain == 0 or assessed == 0:
+        data_state = "unavailable"
+    elif below_coverage(assessed, domain):
+        data_state = "partial"
+    else:
+        data_state = "complete"
+
+    return EvidenceSummary(
+        affected=affected,
+        assessed=assessed,
+        domain=domain,
+        affected_nm=round(affected_nm, 1),
+        highlights=highlights,
+        data_state=data_state,
+    )
 
 
 def pct_above_threshold(

--- a/src/weatherbrief/analysis/advisories/_helpers.py
+++ b/src/weatherbrief/analysis/advisories/_helpers.py
@@ -131,12 +131,21 @@ class FlaggedCell(NamedTuple):
     ``None`` base/top means a full column (the depth-unresolved convective
     ghost). Only flagged (AMBER/RED) points carry a ``FlaggedCell``; clean
     points pass ``None`` in :func:`build_regions`'s input.
+
+    ``reason_code`` / ``metric_id`` / ``method_id`` are optional stable,
+    non-localised provenance tokens (#393) carried onto the emitted
+    :class:`HighlightRegion` — see that model. They do not participate in
+    run-merging (only ``kind`` + ``severity`` do); the first cell of a run
+    supplies them for the merged region.
     """
 
     kind: str
     severity: HighlightSeverity
     base_ft: int | None
     top_ft: int | None
+    reason_code: str | None = None
+    metric_id: str | None = None
+    method_id: str | None = None
 
 
 def _cell_edges(distances: list[float], total_nm: float) -> tuple[list[float], list[float]]:
@@ -242,6 +251,12 @@ def build_regions(
             top_ft=max(tops) if tops else None,
             kind=cell.kind,
             severity=cell.severity,
+            # Provenance tokens (#393) come from the first cell of the run — all
+            # cells in a run share kind+severity and, by construction, the same
+            # reason/metric/method.
+            reason_code=cell.reason_code,
+            metric_id=cell.metric_id,
+            method_id=cell.method_id,
         ))
         i = j
     return regions

--- a/src/weatherbrief/analysis/advisories/cloud_top.py
+++ b/src/weatherbrief/analysis/advisories/cloud_top.py
@@ -4,19 +4,16 @@ from __future__ import annotations
 
 from weatherbrief.analysis.advisories import RouteContext
 from weatherbrief.analysis.advisories._helpers import (
+    EvidenceSample,
     FlaggedCell,
-    below_coverage,
-    build_regions,
-    build_ribbon,
     format_extent,
     pct_above_threshold,
-    ribbon_peak,
+    summarize_evidence,
 )
 from weatherbrief.analysis.advisories.registry import register
 from weatherbrief.analysis.advisories.strings import adv_t
 from weatherbrief.models import (
     AdvisoryCatalogEntry,
-    AdvisoryHighlights,
     AdvisoryParameterDef,
     AdvisoryStatus,
     HighlightSeverity,
@@ -81,23 +78,22 @@ class CloudTopEvaluator:
         per_model: list[ModelAdvisoryResult] = []
 
         for model in ctx.models:
-            total = 0
-            above_ceiling = 0
             max_top: float | None = None
-            # Per-point highlight geometry (#375). Binary per point: green =
-            # toppable or no cloud, amber = can't get on top here (the amount of
-            # amber tells the story); the cutout is the blocking deck.
-            ribbon_points: list[tuple[float, HighlightSeverity]] = []
-            region_cells: list[tuple[float, FlaggedCell | None]] = []
+            # One evidence sample per route point (#393): the grade count
+            # (above_ceiling) and the ribbon/scrim both derive from this list.
+            # Binary per point: green = toppable or no cloud, amber = can't get on
+            # top here; the cutout is the blocking deck.
+            samples: list[EvidenceSample] = []
 
             for rpa in ctx.analyses:
                 dist = rpa.distance_from_origin_nm or 0.0
                 sounding = rpa.sounding.get(model)
                 if sounding is None:
-                    ribbon_points.append((dist, HighlightSeverity.UNAVAILABLE))
-                    region_cells.append((dist, None))
+                    samples.append(EvidenceSample(
+                        distance_nm=dist, assessed=False,
+                        severity=HighlightSeverity.UNAVAILABLE,
+                    ))
                     continue
-                total += 1
 
                 # Only consider layers the pilot would actually encounter:
                 # base must be within margin of cruise altitude (close enough
@@ -109,8 +105,10 @@ class CloudTopEvaluator:
                     if cl.base_ft <= cruise + margin_ft and cl.base_ft <= ceiling
                 ]
                 if not reachable:
-                    ribbon_points.append((dist, HighlightSeverity.GREEN))
-                    region_cells.append((dist, None))
+                    samples.append(EvidenceSample(
+                        distance_nm=dist, assessed=True,
+                        severity=HighlightSeverity.GREEN,
+                    ))
                     continue
 
                 highest_top = max(cl.top_ft for cl in reachable)
@@ -118,23 +116,31 @@ class CloudTopEvaluator:
                     max_top = highest_top
 
                 if highest_top + margin_ft > ceiling:
-                    above_ceiling += 1
                     # The blocking deck: the reachable layers whose tops violate
                     # the ceiling margin.
                     blocking = [
                         cl for cl in reachable if cl.top_ft + margin_ft > ceiling
                     ]
-                    ribbon_points.append((dist, HighlightSeverity.AMBER))
-                    region_cells.append((dist, FlaggedCell(
-                        kind="blocking_deck",
+                    samples.append(EvidenceSample(
+                        distance_nm=dist, assessed=True,
                         severity=HighlightSeverity.AMBER,
-                        base_ft=int(min(cl.base_ft for cl in blocking)),
-                        top_ft=int(max(cl.top_ft for cl in blocking)),
-                    )))
+                        region=FlaggedCell(
+                            kind="blocking_deck",
+                            severity=HighlightSeverity.AMBER,
+                            base_ft=int(min(cl.base_ft for cl in blocking)),
+                            top_ft=int(max(cl.top_ft for cl in blocking)),
+                            metric_id="cloud_cover",
+                        ),
+                    ))
                 else:
-                    ribbon_points.append((dist, HighlightSeverity.GREEN))
-                    region_cells.append((dist, None))
+                    samples.append(EvidenceSample(
+                        distance_nm=dist, assessed=True,
+                        severity=HighlightSeverity.GREEN,
+                    ))
 
+            summary = summarize_evidence(samples, ctx.total_distance_nm)
+            total = summary.assessed
+            above_ceiling = summary.affected
             loc = ctx.locale
             if total == 0:
                 status = AdvisoryStatus.UNAVAILABLE
@@ -154,24 +160,18 @@ class CloudTopEvaluator:
             # is too small to represent the route becomes UNAVAILABLE — a clear
             # 2-of-20-points model has not established the other 18 are clear. A
             # flagged verdict is never downgraded (real hazard evidence stands).
-            if status == AdvisoryStatus.GREEN and below_coverage(total, len(ctx.analyses)):
+            if status == AdvisoryStatus.GREEN and summary.below_coverage:
                 status = AdvisoryStatus.UNAVAILABLE
                 detail = adv_t("no_data", loc)
 
             # Highlights (#375) only when the model has data.
-            highlights = None
-            if total > 0:
-                ribbon = build_ribbon(ribbon_points, ctx.total_distance_nm)
-                highlights = AdvisoryHighlights(
-                    ribbon=ribbon,
-                    regions=build_regions(region_cells, ctx.total_distance_nm),
-                    peak_dist_nm=ribbon_peak(ribbon),
-                )
+            highlights = summary.highlights if total > 0 else None
 
             per_model.append(ModelAdvisoryResult.build(
                 model=model, status=status, detail=detail,
                 affected=above_ceiling, total=total,
                 total_distance_nm=ctx.total_distance_nm,
+                affected_nm=summary.affected_nm,
                 highlights=highlights,
             ))
 

--- a/src/weatherbrief/analysis/advisories/enroute_precip.py
+++ b/src/weatherbrief/analysis/advisories/enroute_precip.py
@@ -28,18 +28,16 @@ from __future__ import annotations
 
 from weatherbrief.analysis.advisories import RouteContext
 from weatherbrief.analysis.advisories._helpers import (
+    EvidenceSample,
     FlaggedCell,
     below_coverage,
-    build_regions,
-    build_ribbon,
     format_extent,
-    ribbon_peak,
+    summarize_evidence,
 )
 from weatherbrief.analysis.advisories.registry import register
 from weatherbrief.analysis.advisories.strings import adv_t
 from weatherbrief.models import (
     AdvisoryCatalogEntry,
-    AdvisoryHighlights,
     AdvisoryParameterDef,
     AdvisoryStatus,
     HighlightSeverity,
@@ -261,52 +259,63 @@ class EnroutePrecipEvaluator:
         per_model: list[ModelAdvisoryResult] = []
 
         for model in ctx.models:
+            # The extent-thresholded grade (snow/rain sub-percentages) stays in
+            # the shared classifier; VFR feasibility reuses it too. The evidence
+            # list drives the geometry-accurate affected_nm and the highlight, and
+            # keys off the SAME per-point predicate (``classify_precip_point``), so
+            # the grade's ``affected`` and the ribbon cannot drift (#393).
             status, detail, affected, total, has_signal = classify_enroute_precip(
                 ctx, model, params,
             )
 
-            # Per-point highlight geometry (#375): full-column precip cutouts
-            # (the hazard is the whole column below the melting layer) + a
-            # ribbon mirroring classify_precip_point. Skipped when the model
-            # has no precipitation signal (status UNAVAILABLE).
-            highlights = None
-            if has_signal and total > 0:
-                ribbon_points: list[tuple[float, HighlightSeverity]] = []
-                region_cells: list[tuple[float, FlaggedCell | None]] = []
-                for rpa in ctx.analyses:
-                    dist = rpa.distance_from_origin_nm or 0.0
-                    sounding = rpa.sounding.get(model)
-                    # No sounding, or a sounding with no precipitation assessment,
-                    # is unassessable → UNAVAILABLE ribbon (matches the grade's
-                    # denominator, which now excludes these points).
-                    if sounding is None or sounding.precipitation is None:
-                        ribbon_points.append((dist, HighlightSeverity.UNAVAILABLE))
-                        region_cells.append((dist, None))
-                        continue
-                    severity = precip_point_severity(
-                        classify_precip_point(sounding.precipitation)
+            # One evidence sample per route point. ``severity`` (ribbon) maps
+            # light rain to GREEN; ``affected`` (grade) counts any precipitation
+            # incl. light rain — deliberately different, so each is passed
+            # explicitly. Full-column precip cutouts (hazard = whole column below
+            # the melting layer) on flagged points only.
+            samples: list[EvidenceSample] = []
+            for rpa in ctx.analyses:
+                dist = rpa.distance_from_origin_nm or 0.0
+                sounding = rpa.sounding.get(model)
+                # No sounding, or a sounding with no precipitation assessment, is
+                # unassessable → UNAVAILABLE ribbon (matches the grade's
+                # denominator, which excludes these points).
+                if sounding is None or sounding.precipitation is None:
+                    samples.append(EvidenceSample(
+                        distance_nm=dist, assessed=False,
+                        severity=HighlightSeverity.UNAVAILABLE,
+                    ))
+                    continue
+                cls = classify_precip_point(sounding.precipitation)
+                severity = precip_point_severity(cls)
+                region = None
+                if severity in (HighlightSeverity.AMBER, HighlightSeverity.RED):
+                    region = FlaggedCell(
+                        kind="precip_column",
+                        severity=severity,
+                        base_ft=None,
+                        top_ft=None,
+                        metric_id="precipitation",
                     )
-                    ribbon_points.append((dist, severity))
-                    if severity in (HighlightSeverity.AMBER, HighlightSeverity.RED):
-                        region_cells.append((dist, FlaggedCell(
-                            kind="precip_column",
-                            severity=severity,
-                            base_ft=None,
-                            top_ft=None,
-                        )))
-                    else:
-                        region_cells.append((dist, None))
-                ribbon = build_ribbon(ribbon_points, ctx.total_distance_nm)
-                highlights = AdvisoryHighlights(
-                    ribbon=ribbon,
-                    regions=build_regions(region_cells, ctx.total_distance_nm),
-                    peak_dist_nm=ribbon_peak(ribbon),
-                )
+                samples.append(EvidenceSample(
+                    distance_nm=dist, assessed=True, severity=severity,
+                    affected=cls is not None, region=region,
+                ))
+
+            summary = summarize_evidence(samples, ctx.total_distance_nm)
+
+            # Highlights only when the model has a precipitation signal (the
+            # no-signal case grades UNAVAILABLE). ``affected``/``total`` stay the
+            # classifier's authoritative counts (equal to the summary's, by the
+            # shared predicate); affected_nm is the summary's geometry-accurate
+            # extent of the same affected points.
+            highlights = summary.highlights if has_signal and total > 0 else None
 
             per_model.append(ModelAdvisoryResult.build(
                 model=model, status=status, detail=detail,
                 affected=affected, total=total,
                 total_distance_nm=ctx.total_distance_nm,
+                affected_nm=summary.affected_nm,
                 highlights=highlights,
             ))
 

--- a/src/weatherbrief/analysis/advisories/fiki_icing.py
+++ b/src/weatherbrief/analysis/advisories/fiki_icing.py
@@ -10,19 +10,16 @@ from __future__ import annotations
 
 from weatherbrief.analysis.advisories import RouteContext
 from weatherbrief.analysis.advisories._helpers import (
+    EvidenceSample,
     FlaggedCell,
-    below_coverage,
-    build_regions,
-    build_ribbon,
     icing_zones_in_altitude_range,
     min_icing_clearance,
-    ribbon_peak,
+    summarize_evidence,
 )
 from weatherbrief.analysis.advisories.registry import register
 from weatherbrief.analysis.advisories.strings import adv_t
 from weatherbrief.models import (
     AdvisoryCatalogEntry,
-    AdvisoryHighlights,
     AdvisoryParameterDef,
     AdvisoryStatus,
     HighlightSeverity,
@@ -203,11 +200,12 @@ class FIKIIcingEvaluator:
             cruise_clear = 0
             cruise_total = 0
             total = 0
-            # Per-point highlight geometry (#375): the ribbon mirrors the loop's
-            # own per-point classification — transit thickness/severity/SLD in
-            # the departure/arrival corridors, cruise clear-air everywhere.
-            ribbon_points: list[tuple[float, HighlightSeverity]] = []
-            region_cells: list[tuple[float, FlaggedCell | None]] = []
+            # One evidence sample per route point (#393). The ribbon severity
+            # (corridor transit thickness/severity/SLD + cruise clear-air) and
+            # the grade's ``affected`` (cruise NOT clear-air) key on different
+            # predicates, so each sample carries both — a corridor cutout can be
+            # flagged while the cruise-clear grade is not.
+            samples: list[EvidenceSample] = []
 
             for rpa in ctx.analyses:
                 dist = rpa.distance_from_origin_nm or 0.0
@@ -216,8 +214,10 @@ class FIKIIcingEvaluator:
                     # No sounding, or the active icing method could not run here
                     # (Ogimet-NWP with no native cloud envelope) — absent icing,
                     # not clear. UNAVAILABLE; excluded from both denominators.
-                    ribbon_points.append((dist, HighlightSeverity.UNAVAILABLE))
-                    region_cells.append((dist, None))
+                    samples.append(EvidenceSample(
+                        distance_nm=dist, assessed=False,
+                        severity=HighlightSeverity.UNAVAILABLE,
+                    ))
                     continue
                 total += 1
 
@@ -267,16 +267,23 @@ class FIKIIcingEvaluator:
                 relevant_zones = icing_zones_in_altitude_range(
                     zones, 0, cruise_alt + cruise_buffer_ft
                 )
+                region = None
                 if severity != HighlightSeverity.GREEN and relevant_zones:
-                    region_cells.append((dist, FlaggedCell(
+                    region = FlaggedCell(
                         kind="icing_band",
                         severity=severity,
                         base_ft=int(min(z.base_ft for z in relevant_zones)),
                         top_ft=int(max(z.top_ft for z in relevant_zones)),
-                    )))
-                else:
-                    region_cells.append((dist, None))
-                ribbon_points.append((dist, severity))
+                        metric_id="icing",
+                    )
+                # Grade ``affected`` = cruise NOT clear-air; ribbon ``severity``
+                # includes corridor transit — deliberately decoupled (#393).
+                samples.append(EvidenceSample(
+                    distance_nm=dist, assessed=True, severity=severity,
+                    affected=not point_clear, region=region,
+                ))
+
+            summary = summarize_evidence(samples, total_dist)
 
             # --- derive severity from the three metrics ---
             clear_pct = (
@@ -364,21 +371,13 @@ class FIKIIcingEvaluator:
             # Coverage tolerance (#391): a clear FIKI verdict from assessable
             # points at too small a share of the route cannot vouch for the rest
             # (safety-sensitive icing evaluator). Flagged verdicts always stand.
-            if status == AdvisoryStatus.GREEN and below_coverage(total, len(ctx.analyses)):
+            if status == AdvisoryStatus.GREEN and summary.below_coverage:
                 per_model.append(ModelAdvisoryResult.build(
                     model=model, status=AdvisoryStatus.UNAVAILABLE,
                     detail=adv_t("no_data", loc), affected=0, total=total,
                     total_distance_nm=total_dist,
                 ))
                 continue
-
-            # Highlights (#375) — the model has data here (total > 0).
-            ribbon = build_ribbon(ribbon_points, total_dist)
-            highlights = AdvisoryHighlights(
-                ribbon=ribbon,
-                regions=build_regions(region_cells, total_dist),
-                peak_dist_nm=ribbon_peak(ribbon),
-            )
 
             affected = cruise_total - cruise_clear
             per_model.append(
@@ -389,7 +388,8 @@ class FIKIIcingEvaluator:
                     affected=affected,
                     total=cruise_total,
                     total_distance_nm=total_dist,
-                    highlights=highlights,
+                    affected_nm=summary.affected_nm,
+                    highlights=summary.highlights,  # model has data here (total > 0)
                 )
             )
 

--- a/src/weatherbrief/analysis/advisories/freezing_precip.py
+++ b/src/weatherbrief/analysis/advisories/freezing_precip.py
@@ -22,12 +22,10 @@ from __future__ import annotations
 
 from weatherbrief.analysis.advisories import RouteContext
 from weatherbrief.analysis.advisories._helpers import (
+    EvidenceSample,
     FlaggedCell,
-    below_coverage,
-    build_regions,
-    build_ribbon,
     format_extent,
-    ribbon_peak,
+    summarize_evidence,
     terrain_at_distance,
 )
 from weatherbrief.analysis.advisories.registry import register
@@ -35,7 +33,6 @@ from weatherbrief.analysis.advisories.strings import adv_t
 from weatherbrief.analysis.sounding.precipitation import detect_warm_nose
 from weatherbrief.models import (
     AdvisoryCatalogEntry,
-    AdvisoryHighlights,
     AdvisoryParameterDef,
     AdvisoryStatus,
     HighlightSeverity,
@@ -105,17 +102,15 @@ class FreezingPrecipEvaluator:
         per_model: list[ModelAdvisoryResult] = []
 
         for model in ctx.models:
-            total = 0
             active_pts = 0
             primed_pts = 0
-            has_signal_source = False
             loc = ctx.locale
 
-            # Per-point highlight geometry (#375): ribbon red = active FZRA/PL
-            # surface phase, amber = primed profile (warm nose, no active
+            # One evidence sample per route point (#393): ribbon red = active
+            # FZRA/PL surface phase, amber = primed profile (warm nose, no active
             # precip); the cutout is the hazard column, surface → warm-nose top.
-            ribbon_points: list[tuple[float, HighlightSeverity]] = []
-            region_cells: list[tuple[float, FlaggedCell | None]] = []
+            # active/primed sub-counts are tracked alongside for the tiered grade.
+            samples: list[EvidenceSample] = []
 
             for rpa in ctx.analyses:
                 dist = rpa.distance_from_origin_nm or 0.0
@@ -131,11 +126,11 @@ class FreezingPrecipEvaluator:
                     sounding.derived_levels if sounding is not None else None
                 )
                 if sounding is None or not point_source:
-                    ribbon_points.append((dist, HighlightSeverity.UNAVAILABLE))
-                    region_cells.append((dist, None))
+                    samples.append(EvidenceSample(
+                        distance_nm=dist, assessed=False,
+                        severity=HighlightSeverity.UNAVAILABLE,
+                    ))
                     continue
-                total += 1
-                has_signal_source = True
 
                 active = False
                 if precip is not None:
@@ -167,26 +162,31 @@ class FreezingPrecipEvaluator:
                     # level no-signal case is already UNAVAILABLE overall.
                     severity = HighlightSeverity.GREEN
 
-                ribbon_points.append((dist, severity))
+                region = None
                 if severity in (HighlightSeverity.AMBER, HighlightSeverity.RED):
                     if nose_top is None:
                         terrain_ft = terrain_at_distance(ctx.elevation, dist) or 0.0
                         nose_top = terrain_ft + _FALLBACK_COLUMN_AGL_FT
                     # base_ft=None renders down to the surface — exactly the
                     # below-cloud hazard column.
-                    region_cells.append((dist, FlaggedCell(
+                    region = FlaggedCell(
                         kind="freezing_precip_column",
                         severity=severity,
                         base_ft=None,
                         top_ft=int(nose_top),
-                    )))
-                else:
-                    region_cells.append((dist, None))
+                        metric_id="precipitation",
+                    )
+                samples.append(EvidenceSample(
+                    distance_nm=dist, assessed=True, severity=severity, region=region,
+                ))
 
-            if total == 0 or not has_signal_source:
+            summary = summarize_evidence(samples, ctx.total_distance_nm)
+            total = summary.assessed
+
+            if total == 0:
                 per_model.append(ModelAdvisoryResult.build(
                     model=model, status=AdvisoryStatus.UNAVAILABLE,
-                    detail=adv_t("no_data", loc), affected=0, total=max(total, 0),
+                    detail=adv_t("no_data", loc), affected=0, total=0,
                     total_distance_nm=ctx.total_distance_nm,
                 ))
                 continue
@@ -218,7 +218,7 @@ class FreezingPrecipEvaluator:
             # points at too small a share of the route cannot vouch for the rest.
             # The active-FZRA RED and primed AMBER paths above are untouched — a
             # flagged verdict always stands on partial coverage.
-            if status == AdvisoryStatus.GREEN and below_coverage(total, len(ctx.analyses)):
+            if status == AdvisoryStatus.GREEN and summary.below_coverage:
                 per_model.append(ModelAdvisoryResult.build(
                     model=model, status=AdvisoryStatus.UNAVAILABLE,
                     detail=adv_t("no_data", loc), affected=0, total=total,
@@ -226,20 +226,12 @@ class FreezingPrecipEvaluator:
                 ))
                 continue
 
-            # Highlights (#375) — the model has a precip signal here (the
-            # no-signal case returned UNAVAILABLE above).
-            ribbon = build_ribbon(ribbon_points, ctx.total_distance_nm)
-            highlights = AdvisoryHighlights(
-                ribbon=ribbon,
-                regions=build_regions(region_cells, ctx.total_distance_nm),
-                peak_dist_nm=ribbon_peak(ribbon),
-            )
-
             per_model.append(ModelAdvisoryResult.build(
                 model=model, status=status, detail=detail,
                 affected=active_pts + primed_pts, total=total,
                 total_distance_nm=ctx.total_distance_nm,
-                highlights=highlights,
+                affected_nm=summary.affected_nm,
+                highlights=summary.highlights,
             ))
 
         return RouteAdvisoryResult.from_per_model("freezing_precip", per_model, params)

--- a/src/weatherbrief/analysis/advisories/icing_escape.py
+++ b/src/weatherbrief/analysis/advisories/icing_escape.py
@@ -4,16 +4,14 @@ from __future__ import annotations
 
 from weatherbrief.analysis.advisories import RouteContext
 from weatherbrief.analysis.advisories._helpers import (
+    EvidenceSample,
     FlaggedCell,
-    below_coverage,
     build_cost_model,
-    build_regions,
-    build_ribbon,
     format_extent,
     icing_zones_in_altitude_range,
     max_terrain_near_point,
     pct_above_threshold,
-    ribbon_peak,
+    summarize_evidence,
     to_mitigation_profile,
 )
 from weatherbrief.analysis.advisories.registry import register
@@ -27,7 +25,6 @@ from weatherbrief.analysis.advisories.vertical_profile import (
 )
 from weatherbrief.models import (
     AdvisoryCatalogEntry,
-    AdvisoryHighlights,
     AdvisoryParameterDef,
     AdvisoryStatus,
     HighlightSeverity,
@@ -266,15 +263,14 @@ class IcingEscapeEvaluator:
         per_model: list[ModelAdvisoryResult] = []
 
         for model in ctx.models:
-            total = 0
-            affected = 0
             no_escape_count = 0
             has_tight_margin = False
-            # Per-point highlight geometry (#375). Every route point contributes
-            # a ribbon severity; affected points also contribute an icing-band
-            # cutout (envelope of the relevant zones).
-            ribbon_points: list[tuple[float, HighlightSeverity]] = []
-            region_cells: list[tuple[float, FlaggedCell | None]] = []
+            # One evidence sample per route point (#393): the grade counts
+            # (affected / no-escape) and the ribbon/scrim geometry both come from
+            # this single list. Every assessed point gets a ribbon severity;
+            # flagged points also carry an icing-band cutout (envelope of the
+            # relevant zones) plus a reason_code for provenance.
+            samples: list[EvidenceSample] = []
 
             for rpa in ctx.analyses:
                 dist = rpa.distance_from_origin_nm or 0.0
@@ -283,10 +279,11 @@ class IcingEscapeEvaluator:
                     # No sounding, or the active icing method could not run here
                     # (e.g. Ogimet-NWP with no native cloud envelope) — its empty
                     # icing_zones is absent data, not a clear sky. UNAVAILABLE.
-                    ribbon_points.append((dist, HighlightSeverity.UNAVAILABLE))
-                    region_cells.append((dist, None))
+                    samples.append(EvidenceSample(
+                        distance_nm=dist, assessed=False,
+                        severity=HighlightSeverity.UNAVAILABLE,
+                    ))
                     continue
-                total += 1
 
                 # Icing above cruise + buffer is deliberately GREEN on the
                 # ribbon too ("not relevant to your flight here" reads as clear).
@@ -296,11 +293,11 @@ class IcingEscapeEvaluator:
                     ctx.cruise_altitude_ft + icing_altitude_buffer_ft,
                 )
                 if not relevant_zones:
-                    ribbon_points.append((dist, HighlightSeverity.GREEN))
-                    region_cells.append((dist, None))
+                    samples.append(EvidenceSample(
+                        distance_nm=dist, assessed=True,
+                        severity=HighlightSeverity.GREEN,
+                    ))
                     continue
-
-                affected += 1
 
                 # Get freezing level and terrain
                 fz_level_ft = None
@@ -317,21 +314,34 @@ class IcingEscapeEvaluator:
                 if fz_level_ft is None or terrain_ft is None:
                     no_escape_count += 1
                     severity = HighlightSeverity.RED
+                    reason = "no_escape_unknown"
                 elif fz_level_ft < terrain_ft + terrain_margin:
                     no_escape_count += 1
                     severity = HighlightSeverity.RED
+                    reason = "no_escape"
                 else:
                     if fz_level_ft < terrain_ft + tight_margin:
                         has_tight_margin = True
+                        reason = "tight_margin"
+                    else:
+                        reason = "warm_escape"
                     severity = HighlightSeverity.AMBER
 
-                ribbon_points.append((dist, severity))
-                region_cells.append((dist, FlaggedCell(
-                    kind="icing_band",
-                    severity=severity,
-                    base_ft=int(min(z.base_ft for z in relevant_zones)),
-                    top_ft=int(max(z.top_ft for z in relevant_zones)),
-                )))
+                samples.append(EvidenceSample(
+                    distance_nm=dist, assessed=True, severity=severity,
+                    region=FlaggedCell(
+                        kind="icing_band",
+                        severity=severity,
+                        base_ft=int(min(z.base_ft for z in relevant_zones)),
+                        top_ft=int(max(z.top_ft for z in relevant_zones)),
+                        reason_code=reason,
+                        metric_id="icing",
+                    ),
+                ))
+
+            summary = summarize_evidence(samples, ctx.total_distance_nm)
+            total = summary.assessed
+            affected = summary.affected
 
             # Determine model status
             loc = ctx.locale
@@ -366,7 +376,7 @@ class IcingEscapeEvaluator:
             # small a share of the route cannot vouch for the unassessed rest —
             # safety-sensitive for an icing evaluator. Flagged (no-escape/icing)
             # verdicts always stand.
-            if status == AdvisoryStatus.GREEN and below_coverage(total, len(ctx.analyses)):
+            if status == AdvisoryStatus.GREEN and summary.below_coverage:
                 status = AdvisoryStatus.UNAVAILABLE
                 detail = adv_t("no_data", loc)
 
@@ -376,19 +386,13 @@ class IcingEscapeEvaluator:
 
             # Highlights (#375) only when the model has data. Peak: the no-escape
             # (red) run center first, else the longest amber run center.
-            highlights = None
-            if total > 0:
-                ribbon = build_ribbon(ribbon_points, ctx.total_distance_nm)
-                highlights = AdvisoryHighlights(
-                    ribbon=ribbon,
-                    regions=build_regions(region_cells, ctx.total_distance_nm),
-                    peak_dist_nm=ribbon_peak(ribbon),
-                )
+            highlights = summary.highlights if total > 0 else None
 
             per_model.append(ModelAdvisoryResult.build(
                 model=model, status=status, detail=detail,
                 affected=affected, total=total,
                 total_distance_nm=ctx.total_distance_nm,
+                affected_nm=summary.affected_nm,
                 mitigations=mitigations,
                 highlights=highlights,
             ))

--- a/src/weatherbrief/analysis/advisories/model_agreement.py
+++ b/src/weatherbrief/analysis/advisories/model_agreement.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 from weatherbrief.analysis.advisories import RouteContext
 from weatherbrief.analysis.advisories._helpers import (
-    below_coverage,
+    EvidenceSample,
     format_extent,
     pct_above_threshold,
+    summarize_evidence,
 )
 from weatherbrief.analysis.advisories.registry import register
 from weatherbrief.analysis.advisories.strings import adv_t
@@ -15,6 +16,7 @@ from weatherbrief.models import (
     AdvisoryCatalogEntry,
     AdvisoryParameterDef,
     AdvisoryStatus,
+    HighlightSeverity,
     ModelAdvisoryResult,
     RouteAdvisoryResult,
 )
@@ -80,14 +82,17 @@ class ModelAgreementEvaluator:
         poor_pct_amber = params.get("poor_pct_amber", 25)
         poor_pct_red = params.get("poor_pct_red", 50)
 
-        # Model agreement is cross-model — evaluated once, not per-model
-        total = 0
-        poor_count = 0
+        # Model agreement is cross-model — evaluated once, not per-model. One
+        # evidence sample per route point (#393): ``affected`` = a POOR-agreement
+        # point, so affected_nm is the geometry-accurate extent of the disagreeing
+        # segment and coverage is derived from the same list. This advisory emits
+        # no highlights (cross-model — the Compare view is its home), so the
+        # ribbon severity is bookkeeping only.
         moderate_count = 0
+        samples: list[EvidenceSample] = []
 
         for rpa in ctx.analyses:
-            if not rpa.model_divergence:
-                continue
+            dist = rpa.distance_from_origin_nm or 0.0
             # A divergence with ``mean is None`` is "metric absent for every
             # model", which the scorer records as ``agreement=GOOD`` — "nothing
             # to disagree about", NOT "models agreed" (see models/analysis.py
@@ -95,20 +100,28 @@ class ModelAgreementEvaluator:
             # such a point as good agreement (#391); only real comparisons
             # (``mean is not None``) establish agreement, so a point with no real
             # comparison is unassessable and drops out of the denominator.
-            real = [d for d in rpa.model_divergence if d.mean is not None]
+            real = [d for d in rpa.model_divergence if d.mean is not None] if rpa.model_divergence else []
             if not real:
+                samples.append(EvidenceSample(
+                    distance_nm=dist, assessed=False,
+                    severity=HighlightSeverity.UNAVAILABLE,
+                ))
                 continue
-            total += 1
 
             n_poor = sum(1 for d in real if d.agreement == AgreementLevel.POOR)
             has_poor = n_poor >= min_poor_vars
             has_moderate = any(d.agreement == AgreementLevel.MODERATE for d in real)
 
-            if has_poor:
-                poor_count += 1
-            elif has_moderate:
+            if not has_poor and has_moderate:
                 moderate_count += 1
+            samples.append(EvidenceSample(
+                distance_nm=dist, assessed=True, affected=has_poor,
+                severity=HighlightSeverity.AMBER if has_poor else HighlightSeverity.GREEN,
+            ))
 
+        summary = summarize_evidence(samples, ctx.total_distance_nm)
+        total = summary.assessed
+        poor_count = summary.affected
         loc = ctx.locale
         if total == 0:
             status = AdvisoryStatus.UNAVAILABLE
@@ -125,7 +138,7 @@ class ModelAgreementEvaluator:
 
         # Coverage tolerance (#391): a "good agreement" verdict resting on real
         # comparisons at too few route points cannot vouch for the rest.
-        if status == AdvisoryStatus.GREEN and below_coverage(total, len(ctx.analyses)):
+        if status == AdvisoryStatus.GREEN and summary.below_coverage:
             status = AdvisoryStatus.UNAVAILABLE
             detail = adv_t("model_agreement.no_data", loc)
 
@@ -133,6 +146,7 @@ class ModelAgreementEvaluator:
             model="all", status=status, detail=detail,
             affected=poor_count, total=total,
             total_distance_nm=ctx.total_distance_nm,
+            affected_nm=summary.affected_nm,
         )]
 
         return RouteAdvisoryResult.from_per_model("model_agreement", per_model, params)

--- a/src/weatherbrief/analysis/advisories/mountain_wind.py
+++ b/src/weatherbrief/analysis/advisories/mountain_wind.py
@@ -25,12 +25,12 @@ from __future__ import annotations
 
 from weatherbrief.analysis.advisories import RouteContext
 from weatherbrief.analysis.advisories._helpers import (
+    EvidenceSample,
     FlaggedCell,
-    below_coverage,
     build_regions,
-    build_ribbon,
     format_extent,
     max_terrain_near_point,
+    summarize_evidence,
     wind_at_altitude,
 )
 from weatherbrief.analysis.advisories.registry import register
@@ -182,19 +182,16 @@ class MountainWindEvaluator:
 
         for model in ctx.models:
             terrain_known = 0  # points with a known terrain elevation
-            mountain_pts = 0   # points where terrain exceeds the threshold
-            total = 0          # mountain points with wind data (assessable)
-            affected = 0
             max_wind = 0.0
             wave_red = False          # corroborated point above the lower red bar
             wave_sigs: set[str] = set()  # signatures seen at strong-wind points
-            # Per-point highlight geometry (#375). Non-mountain points are GREEN
-            # ("not relevant to your flight here"), matching the grade's skip;
-            # mountain points with no wind data are UNAVAILABLE. Two cutout
-            # kinds: ridge_wind (the terrain-hugging affected band) and
-            # wave_signature (the corroborating inversion on rotor-day points).
-            ribbon_points: list[tuple[float, HighlightSeverity]] = []
-            ridge_cells: list[tuple[float, FlaggedCell | None]] = []
+            # One evidence sample per route point (#393). Non-mountain points are
+            # GREEN but out of the coverage domain (``in_domain=False``) so
+            # coverage is measured over mountain points only — a flat route grades
+            # GREEN, not UNAVAILABLE. Mountain points with no wind are in-domain
+            # but unassessed. The sample's region is the ridge_wind band; the
+            # wave_signature overlay (red points only) is built separately below.
+            samples: list[EvidenceSample] = []
             wave_cells: list[tuple[float, FlaggedCell | None]] = []
             peak_dist: float | None = None
             peak_speed = 0.0
@@ -207,19 +204,22 @@ class MountainWindEvaluator:
                 if terrain_ft is None:
                     # No elevation data here — we cannot say whether there is
                     # terrain, so this is UNAVAILABLE, not "no mountains" GREEN.
-                    ribbon_points.append((dist, HighlightSeverity.UNAVAILABLE))
-                    ridge_cells.append((dist, None))
+                    samples.append(EvidenceSample(
+                        distance_nm=dist, assessed=False, in_domain=False,
+                        severity=HighlightSeverity.UNAVAILABLE,
+                    ))
                     wave_cells.append((dist, None))
                     continue
                 terrain_known += 1
                 if terrain_ft < terrain_threshold:
                     # Terrain known and genuinely below the threshold — assessed
-                    # flat, no wave mechanism → GREEN.
-                    ribbon_points.append((dist, HighlightSeverity.GREEN))
-                    ridge_cells.append((dist, None))
+                    # flat, no wave mechanism → GREEN, out of the mountain domain.
+                    samples.append(EvidenceSample(
+                        distance_nm=dist, assessed=True, in_domain=False,
+                        severity=HighlightSeverity.GREEN,
+                    ))
                     wave_cells.append((dist, None))
                     continue
-                mountain_pts += 1
 
                 wind = wind_at_altitude(
                     ctx.cross_sections, model, rpa.point_index,
@@ -227,26 +227,28 @@ class MountainWindEvaluator:
                 )
                 if wind is None:
                     # Mountain point but no wind lookup — cannot assess the wave
-                    # risk here. UNAVAILABLE, and it does NOT enter the assessed
-                    # denominator (so an all-no-wind mountain route is UNAVAILABLE,
-                    # not a "light winds (0kt)" GREEN).
-                    ribbon_points.append((dist, HighlightSeverity.UNAVAILABLE))
-                    ridge_cells.append((dist, None))
+                    # risk here. UNAVAILABLE, in-domain but unassessed (so an
+                    # all-no-wind mountain route is UNAVAILABLE, not a "light
+                    # winds (0kt)" GREEN).
+                    samples.append(EvidenceSample(
+                        distance_nm=dist, assessed=False, in_domain=True,
+                        severity=HighlightSeverity.UNAVAILABLE,
+                    ))
                     wave_cells.append((dist, None))
                     continue
-                total += 1
 
                 speed_kt, _ = wind
                 if speed_kt > max_wind:
                     max_wind = speed_kt
 
                 if speed_kt < wind_amber:
-                    ribbon_points.append((dist, HighlightSeverity.GREEN))
-                    ridge_cells.append((dist, None))
+                    samples.append(EvidenceSample(
+                        distance_nm=dist, assessed=True, in_domain=True,
+                        severity=HighlightSeverity.GREEN,
+                    ))
                     wave_cells.append((dist, None))
                     continue
 
-                affected += 1
                 sigs, inv_layer = _wave_signatures(rpa.sounding.get(model), terrain_ft)
                 if sigs:
                     wave_sigs |= sigs
@@ -262,13 +264,17 @@ class MountainWindEvaluator:
                 severity = (
                     HighlightSeverity.RED if point_red else HighlightSeverity.AMBER
                 )
-                ribbon_points.append((dist, severity))
-                ridge_cells.append((dist, FlaggedCell(
-                    kind="ridge_wind",
+                samples.append(EvidenceSample(
+                    distance_nm=dist, assessed=True, in_domain=True,
                     severity=severity,
-                    base_ft=int(terrain_ft),
-                    top_ft=int(terrain_ft + altitude_margin),
-                )))
+                    region=FlaggedCell(
+                        kind="ridge_wind",
+                        severity=severity,
+                        base_ft=int(terrain_ft),
+                        top_ft=int(terrain_ft + altitude_margin),
+                        metric_id="wind_speed",
+                    ),
+                ))
                 # The corroborating inversion band visually explains why the RED
                 # threshold dropped ("rotor day").
                 if point_red and inv_layer is not None:
@@ -277,6 +283,7 @@ class MountainWindEvaluator:
                         severity=HighlightSeverity.RED,
                         base_ft=int(inv_layer.base_ft),
                         top_ft=int(inv_layer.top_ft),
+                        metric_id="wind_speed",
                     )))
                 else:
                     wave_cells.append((dist, None))
@@ -284,6 +291,13 @@ class MountainWindEvaluator:
                 if speed_kt > peak_speed:
                     peak_speed = speed_kt
                     peak_dist = dist
+
+            summary = summarize_evidence(
+                samples, ctx.total_distance_nm, peak_dist_nm=peak_dist,
+            )
+            mountain_pts = summary.domain   # points where terrain exceeds threshold
+            total = summary.assessed        # mountain points with wind data
+            affected = summary.affected
 
             loc = ctx.locale
             ext = format_extent(affected, total, ctx.total_distance_nm)
@@ -333,29 +347,32 @@ class MountainWindEvaluator:
             if (
                 status == AdvisoryStatus.GREEN
                 and mountain_pts > 0
-                and below_coverage(total, mountain_pts)
+                and summary.below_coverage
             ):
                 status = AdvisoryStatus.UNAVAILABLE
                 detail = adv_t("no_data", loc)
 
             # Highlights (#375): built whenever the route has points at all —
             # a no-mountain route gets the all-green ribbon its GREEN grade
-            # implies (not None). Peak = the strongest-wind affected point.
+            # implies (not None). The ridge_wind regions come from the evidence
+            # samples; the wave_signature overlay (red points only) is appended.
+            # Peak = the strongest-wind affected point.
             highlights = None
-            if ribbon_points:
+            if samples:
                 highlights = AdvisoryHighlights(
-                    ribbon=build_ribbon(ribbon_points, ctx.total_distance_nm),
+                    ribbon=summary.highlights.ribbon,
                     regions=(
-                        build_regions(ridge_cells, ctx.total_distance_nm)
+                        summary.highlights.regions
                         + build_regions(wave_cells, ctx.total_distance_nm)
                     ),
-                    peak_dist_nm=peak_dist,
+                    peak_dist_nm=summary.highlights.peak_dist_nm,
                 )
 
             per_model.append(ModelAdvisoryResult.build(
                 model=model, status=status, detail=detail,
                 affected=affected, total=total,
                 total_distance_nm=ctx.total_distance_nm,
+                affected_nm=summary.affected_nm,
                 highlights=highlights,
             ))
 

--- a/src/weatherbrief/analysis/advisories/turbulence.py
+++ b/src/weatherbrief/analysis/advisories/turbulence.py
@@ -4,19 +4,16 @@ from __future__ import annotations
 
 from weatherbrief.analysis.advisories import RouteContext
 from weatherbrief.analysis.advisories._helpers import (
+    EvidenceSample,
     FlaggedCell,
-    below_coverage,
-    build_regions,
-    build_ribbon,
     format_extent,
     pct_above_threshold,
-    ribbon_peak,
+    summarize_evidence,
 )
 from weatherbrief.analysis.advisories.registry import register
 from weatherbrief.analysis.advisories.strings import adv_t
 from weatherbrief.models import (
     AdvisoryCatalogEntry,
-    AdvisoryHighlights,
     AdvisoryParameterDef,
     AdvisoryStatus,
     CATRiskLevel,
@@ -78,16 +75,16 @@ class TurbulenceEvaluator:
         per_model: list[ModelAdvisoryResult] = []
 
         for model in ctx.models:
-            total = 0
-            affected = 0
             has_severe = False
             worst_cat = CATRiskLevel.NONE
-            # Per-point highlight geometry (#375). Ribbon: SEVERE CAT anywhere in
-            # the column → red (the cutout showing where it sits is exactly the
-            # ambiguity the highlight resolves); MODERATE CAT overlapping the
-            # cruise band or a strong updraft near cruise → amber; else green.
-            ribbon_points: list[tuple[float, HighlightSeverity]] = []
-            region_cells: list[tuple[float, FlaggedCell | None]] = []
+            # One evidence sample per route point (#393). The ribbon and the grade
+            # key on DIFFERENT predicates here, so each sample carries both: the
+            # ribbon ``severity`` (SEVERE CAT anywhere in the column → red — the
+            # cutout showing where it sits is the ambiguity the highlight
+            # resolves) and the grade ``affected`` flag (CAT/updraft in the cruise
+            # band). ``summarize_evidence`` counts ``affected`` for the grade while
+            # the ribbon renders ``severity``; they no longer live in two loops.
+            samples: list[EvidenceSample] = []
 
             for rpa in ctx.analyses:
                 dist = rpa.distance_from_origin_nm or 0.0
@@ -102,10 +99,11 @@ class TurbulenceEvaluator:
                 # gate on omega: an omega-less model still has a complete CAT
                 # assessment and must grade normally (#391 — the #389 mistake).
                 if sounding is None or vm is None:
-                    ribbon_points.append((dist, HighlightSeverity.UNAVAILABLE))
-                    region_cells.append((dist, None))
+                    samples.append(EvidenceSample(
+                        distance_nm=dist, assessed=False,
+                        severity=HighlightSeverity.UNAVAILABLE,
+                    ))
                     continue
-                total += 1
 
                 point_affected = False
                 strong_w_here = False
@@ -132,9 +130,6 @@ class TurbulenceEvaluator:
                         point_affected = True
                         strong_w_here = True
 
-                if point_affected:
-                    affected += 1
-
                 # Per-point ribbon verdict + CAT-layer cutout (#375). Strong-w is
                 # resolved to a single level (max_w_level_ft), not a band — it
                 # contributes amber to the ribbon but no strong_updraft cutout
@@ -149,17 +144,25 @@ class TurbulenceEvaluator:
                     severity = HighlightSeverity.GREEN
                     band = []
 
-                ribbon_points.append((dist, severity))
+                region = None
                 if band:
-                    region_cells.append((dist, FlaggedCell(
+                    region = FlaggedCell(
                         kind="cat_layer",
                         severity=severity,
                         base_ft=int(min(la.base_ft for la in band)),
                         top_ft=int(max(la.top_ft for la in band)),
-                    )))
-                else:
-                    region_cells.append((dist, None))
+                        metric_id="cat_risk",
+                    )
+                # ``affected`` (grade) keys on the cruise band; ``severity``
+                # (ribbon) on severe-anywhere — deliberately decoupled (#393).
+                samples.append(EvidenceSample(
+                    distance_nm=dist, assessed=True, severity=severity,
+                    affected=point_affected, region=region,
+                ))
 
+            summary = summarize_evidence(samples, ctx.total_distance_nm)
+            total = summary.assessed
+            affected = summary.affected
             ext = format_extent(affected, total, ctx.total_distance_nm)
             loc = ctx.locale
             if total == 0:
@@ -178,24 +181,18 @@ class TurbulenceEvaluator:
 
             # Coverage tolerance (#391): a smooth verdict from soundings-with-vm at
             # too small a share of the route cannot vouch for the unassessed rest.
-            if status == AdvisoryStatus.GREEN and below_coverage(total, len(ctx.analyses)):
+            if status == AdvisoryStatus.GREEN and summary.below_coverage:
                 status = AdvisoryStatus.UNAVAILABLE
                 detail = adv_t("no_data", loc)
 
             # Highlights (#375) only when the model has data.
-            highlights = None
-            if total > 0:
-                ribbon = build_ribbon(ribbon_points, ctx.total_distance_nm)
-                highlights = AdvisoryHighlights(
-                    ribbon=ribbon,
-                    regions=build_regions(region_cells, ctx.total_distance_nm),
-                    peak_dist_nm=ribbon_peak(ribbon),
-                )
+            highlights = summary.highlights if total > 0 else None
 
             per_model.append(ModelAdvisoryResult.build(
                 model=model, status=status, detail=detail,
                 affected=affected, total=total,
                 total_distance_nm=ctx.total_distance_nm,
+                affected_nm=summary.affected_nm,
                 highlights=highlights,
             ))
 

--- a/src/weatherbrief/analysis/advisories/vmc_cruise.py
+++ b/src/weatherbrief/analysis/advisories/vmc_cruise.py
@@ -4,18 +4,15 @@ from __future__ import annotations
 
 from weatherbrief.analysis.advisories import RouteContext
 from weatherbrief.analysis.advisories._helpers import (
+    EvidenceSample,
     FlaggedCell,
-    below_coverage,
-    build_regions,
-    build_ribbon,
     format_extent,
-    ribbon_peak,
+    summarize_evidence,
 )
 from weatherbrief.analysis.advisories.registry import register
 from weatherbrief.analysis.advisories.strings import adv_t
 from weatherbrief.models import (
     AdvisoryCatalogEntry,
-    AdvisoryHighlights,
     AdvisoryParameterDef,
     AdvisoryStatus,
     CloudCoverage,
@@ -77,23 +74,23 @@ class VMCCruiseEvaluator:
         per_model: list[ModelAdvisoryResult] = []
 
         for model in ctx.models:
-            total = 0
-            bkn_count = 0
             ovc_count = 0
-            # Per-point highlight geometry (#373). ribbon_points carries every
-            # route point (incl. no-sounding → UNAVAILABLE); region_cells carries
-            # a FlaggedCell only for BKN/OVC points, None otherwise.
-            ribbon_points: list[tuple[float, HighlightSeverity]] = []
-            region_cells: list[tuple[float, FlaggedCell | None]] = []
+            # One evidence sample per route point (#393) — grade counts and the
+            # highlight geometry both derive from this single list, so the BKN/OVC
+            # verdict and the ribbon cannot drift. ``ovc_count`` is the one
+            # sub-count the shared summary can't infer (the OVC-only red
+            # threshold), tracked alongside.
+            samples: list[EvidenceSample] = []
 
             for rpa in ctx.analyses:
                 dist = rpa.distance_from_origin_nm or 0.0
                 sounding = rpa.sounding.get(model)
                 if sounding is None:
-                    ribbon_points.append((dist, HighlightSeverity.UNAVAILABLE))
-                    region_cells.append((dist, None))
+                    samples.append(EvidenceSample(
+                        distance_nm=dist, assessed=False,
+                        severity=HighlightSeverity.UNAVAILABLE,
+                    ))
                     continue
-                total += 1
 
                 # Check cloud layers at cruise altitude, tracking the envelope
                 # (min base / max top) of layers that contain cruise for the
@@ -116,23 +113,26 @@ class VMCCruiseEvaluator:
                     ovc_count += 1
                     severity = HighlightSeverity.RED
                 elif worst_coverage == CloudCoverage.BKN:
-                    bkn_count += 1
                     severity = HighlightSeverity.AMBER
                 else:
                     severity = HighlightSeverity.GREEN
 
-                ribbon_points.append((dist, severity))
+                region = None
                 if severity in (HighlightSeverity.AMBER, HighlightSeverity.RED):
-                    region_cells.append((dist, FlaggedCell(
+                    region = FlaggedCell(
                         kind="cruise_imc",
                         severity=severity,
                         base_ft=int(env_base) if env_base is not None else None,
                         top_ft=int(env_top) if env_top is not None else None,
-                    )))
-                else:
-                    region_cells.append((dist, None))
+                        metric_id="cloud_cover",
+                    )
+                samples.append(EvidenceSample(
+                    distance_nm=dist, assessed=True, severity=severity, region=region,
+                ))
 
-            affected = bkn_count + ovc_count
+            summary = summarize_evidence(samples, ctx.total_distance_nm)
+            total = summary.assessed
+            affected = summary.affected  # bkn + ovc
             loc = ctx.locale
             if total == 0:
                 status = AdvisoryStatus.UNAVAILABLE
@@ -157,25 +157,19 @@ class VMCCruiseEvaluator:
             # small to represent the route becomes UNAVAILABLE — a clear subset
             # does not establish the unassessed remainder is clear. A flagged
             # (AMBER/RED) verdict is never downgraded.
-            if status == AdvisoryStatus.GREEN and below_coverage(total, len(ctx.analyses)):
+            if status == AdvisoryStatus.GREEN and summary.below_coverage:
                 status = AdvisoryStatus.UNAVAILABLE
                 detail = adv_t("no_data", loc)
 
-            # Build highlights only when the model has data (total > 0); an
-            # all-UNAVAILABLE model gets no scrim/ribbon (highlights=None).
-            highlights = None
-            if total > 0:
-                ribbon = build_ribbon(ribbon_points, ctx.total_distance_nm)
-                highlights = AdvisoryHighlights(
-                    ribbon=ribbon,
-                    regions=build_regions(region_cells, ctx.total_distance_nm),
-                    peak_dist_nm=ribbon_peak(ribbon),
-                )
+            # Attach highlights only when the model has data (total > 0); an
+            # all-UNAVAILABLE model gets no scrim/ribbon.
+            highlights = summary.highlights if total > 0 else None
 
             per_model.append(ModelAdvisoryResult.build(
                 model=model, status=status, detail=detail,
                 affected=affected, total=total,
                 total_distance_nm=ctx.total_distance_nm,
+                affected_nm=summary.affected_nm,
                 highlights=highlights,
             ))
 

--- a/src/weatherbrief/models/advisories.py
+++ b/src/weatherbrief/models/advisories.py
@@ -183,6 +183,18 @@ class HighlightRegion(BaseModel):
     top_ft: int | None = None
     kind: str                    # stable machine token, e.g. "cruise_imc", "tower"
     severity: HighlightSeverity  # amber | red (cutouts are only emitted for flagged areas)
+    # Stable, non-localised provenance tokens (#393). All additive and
+    # legacy-safe — old packs deserialize with them absent:
+    #   ``reason_code`` — the machine token for *why* this region fired (the
+    #     evaluator's per-point reason, e.g. "no_escape", "severe_cat"). Distinct
+    #     from ``kind`` (the geometry class) — several reasons can share a kind.
+    #   ``metric_id`` — the cross-section layer this region localises to, so a
+    #     chip can jump the user to the *right* layer rather than "the chart".
+    #   ``method_id`` — the analysis method that produced the region's evidence
+    #     (e.g. "ogimet_nwp", "sfip", "nwp_with_dd_floor"), when one controlled it.
+    reason_code: str | None = None
+    metric_id: str | None = None
+    method_id: str | None = None
 
 
 class AdvisoryHighlights(BaseModel):
@@ -325,6 +337,13 @@ class ModelAdvisoryResult(BaseModel):
     # issue #373). None on old packs and for evaluators that don't emit it. Never
     # affects the grade — it locates *where* the verdict comes from.
     highlights: AdvisoryHighlights | None = None
+    # Stable id of the analysis method that actually controlled this model's
+    # grade (#393) — ``sfip``, ``ogimet_nwp``, ``dewpoint_depression``, or a
+    # compound like ``nwp_with_dd_floor``. This is what a method badge on the
+    # chip must source from — NOT the user's selected method in settings, which
+    # may differ from the one that drove the result. None when the evaluator has
+    # no selectable method, and on old packs (legacy-safe).
+    primary_method_id: str | None = None
 
     @classmethod
     def build(
@@ -340,27 +359,33 @@ class ModelAdvisoryResult(BaseModel):
         cross_check: str | None = None,
         mitigations: list[Mitigation] | None = None,
         highlights: AdvisoryHighlights | None = None,
+        primary_method_id: str | None = None,
+        affected_nm: float | None = None,
     ) -> ModelAdvisoryResult:
         """Build a result, computing pct and nm from point counts.
 
         ``affected_mod`` is an optional higher-threshold count (e.g. convective
         MODERATE+); its pct/nm are derived the same way as the primary extent.
+
+        ``affected_nm`` is an optional geometry-accurate extent (#393): when the
+        evaluator derives grade and geometry from one ``EvidenceSample`` list, it
+        passes the midpoint-owned-cell distance of the *affected* points here. It
+        cannot then contradict ``affected_pct`` because both count the same
+        samples — the drift that reverted the earlier ribbon-derived attempt
+        (#391) is gone once one predicate feeds both. When omitted, ``affected_nm``
+        falls back to the proportional ``total_distance_nm * affected / total``.
         """
         # Explicit None check (not `or 0`) so a future caller can pass a genuine
         # 0 meaning "tracked this threshold, zero points qualified" (#302 review).
         mod = affected_mod if affected_mod is not None else 0
 
         # affected_nm is the nm form of affected_points and must stay consistent
-        # with affected_pct — all three key off the same ``affected`` count. A
-        # prior attempt to derive it from the highlights ribbon's flagged span was
-        # reverted (#391 review): the ribbon's amber/red membership does not match
-        # ``affected`` for every evaluator (enroute_precip counts light rain in
-        # ``affected`` but grades it ribbon-GREEN; the feasibility composites'
-        # ribbons carry corridor/precip/airport axes not in ``affected``), so a
-        # ribbon-derived affected_nm contradicted affected_pct on the same result.
-        # The genuinely geometry-accurate extent (midpoint-owned cells of the
-        # *affected* points) needs per-point distances threaded into build(); that
-        # belongs with the #393 single-assessment refactor, not here.
+        # with affected_pct — both key off the same ``affected`` count. Under the
+        # single-assessment refactor (#393) the evaluator may pass a
+        # geometry-accurate ``affected_nm`` (midpoint-owned cells of the affected
+        # points); it stays consistent because it counts the same samples that
+        # produced ``affected``. Absent it, we fall back to the proportion.
+        proportional_nm = round(total_distance_nm * affected / total, 1) if total > 0 else 0
         return cls(
             model=model,
             status=status,
@@ -368,7 +393,7 @@ class ModelAdvisoryResult(BaseModel):
             affected_points=affected,
             total_points=total,
             affected_pct=round(100 * affected / total, 1) if total > 0 else 0,
-            affected_nm=round(total_distance_nm * affected / total, 1) if total > 0 else 0,
+            affected_nm=round(affected_nm, 1) if affected_nm is not None else proportional_nm,
             total_nm=round(total_distance_nm, 1),
             affected_mod_points=mod,
             affected_mod_pct=round(100 * mod / total, 1) if total > 0 else 0,
@@ -376,6 +401,7 @@ class ModelAdvisoryResult(BaseModel):
             cross_check=cross_check,
             mitigations=mitigations if mitigations is not None else [],
             highlights=highlights,
+            primary_method_id=primary_method_id,
         )
 
 
@@ -409,6 +435,14 @@ class RouteAdvisoryResult(BaseModel):
     # model). Advice only — never alters ``aggregate_status``. Defaults empty so
     # old packs deserialize cleanly.
     aggregate_mitigations: list[Mitigation] = Field(default_factory=list)
+    # The model whose per-model result sources the aggregate view (#393): the
+    # first ``per_model`` entry whose status equals ``aggregate_status`` — the
+    # same representative that sets ``aggregate_detail`` / ``aggregate_mitigations``.
+    # Emitted so the client reads "which model's geometry do we highlight?" from
+    # the backend instead of reimplementing the rule (the deleted TS
+    # ``representativeModel()`` copy). None only when there are no per-model
+    # results, and on old packs (legacy-safe).
+    representative_model: str | None = None
 
     @classmethod
     def from_per_model(
@@ -440,6 +474,7 @@ class RouteAdvisoryResult(BaseModel):
             per_model=per_model,
             parameters_used=params,
             aggregate_mitigations=_aggregate_mitigations(per_model, agg),
+            representative_model=representative.model if representative else None,
         )
 
 

--- a/tests/analysis/advisories/test_aggregation.py
+++ b/tests/analysis/advisories/test_aggregation.py
@@ -163,6 +163,30 @@ class TestFromPerModelAggregation:
         result = RouteAdvisoryResult.from_per_model("test", per_model, {})
         assert result.aggregate_status == AdvisoryStatus.GREEN
 
+    def test_representative_model_matches_detail_source(self):
+        """representative_model (#393) is the model whose detail/mitigations win."""
+        per_model = self._make_per_model([AdvisoryStatus.GREEN, AdvisoryStatus.AMBER, AdvisoryStatus.RED])
+        result = RouteAdvisoryResult.from_per_model(
+            "test", per_model, {}, aggregation=AdvisoryAggregation.MAJORITY,
+        )
+        # No majority → tie among singletons broken to worst = RED; representative
+        # is the first RED-status model, the same one sourcing aggregate_detail.
+        assert result.aggregate_status == AdvisoryStatus.RED
+        assert result.representative_model == "model_2"
+        assert result.aggregate_detail == "detail_red"
+
+    def test_representative_model_first_matching_status(self):
+        per_model = self._make_per_model([AdvisoryStatus.GREEN, AdvisoryStatus.AMBER, AdvisoryStatus.AMBER])
+        result = RouteAdvisoryResult.from_per_model(
+            "test", per_model, {}, aggregation=AdvisoryAggregation.MAJORITY,
+        )
+        assert result.aggregate_status == AdvisoryStatus.AMBER
+        assert result.representative_model == "model_1"  # first AMBER
+
+    def test_representative_model_none_when_no_per_model(self):
+        result = RouteAdvisoryResult.from_per_model("test", [], {})
+        assert result.representative_model is None
+
 
 # ---------------------------------------------------------------------------
 # evaluate_all() with aggregation parameter

--- a/tests/analysis/advisories/test_evidence.py
+++ b/tests/analysis/advisories/test_evidence.py
@@ -1,0 +1,167 @@
+"""Tests for the single-assessment evidence helper (#393 Part 2).
+
+``summarize_evidence`` reduces one per-point :class:`EvidenceSample` list into
+the grade counts, the geometry-accurate ``affected_nm``, the highlight geometry,
+and the coverage ``data_state`` — the one place grade and highlight are derived
+from a single predicate so they cannot drift.
+"""
+
+from __future__ import annotations
+
+from weatherbrief.analysis.advisories._helpers import (
+    EvidenceSample,
+    FlaggedCell,
+    summarize_evidence,
+)
+from weatherbrief.models import HighlightSeverity as S
+
+
+def _sample(dist, sev, *, assessed=True, affected=None, in_domain=True, region=None):
+    return EvidenceSample(
+        distance_nm=dist, assessed=assessed, severity=sev,
+        affected=affected, in_domain=in_domain, region=region,
+    )
+
+
+class TestCounts:
+    def test_affected_derived_from_severity(self):
+        samples = [
+            _sample(0.0, S.GREEN),
+            _sample(50.0, S.AMBER),
+            _sample(100.0, S.RED),
+        ]
+        summ = summarize_evidence(samples, 100.0)
+        assert summ.assessed == 3
+        assert summ.domain == 3
+        assert summ.affected == 2  # amber + red
+
+    def test_unassessed_excluded_from_assessed_not_domain(self):
+        samples = [
+            _sample(0.0, S.GREEN),
+            _sample(50.0, S.UNAVAILABLE, assessed=False),
+            _sample(100.0, S.GREEN),
+        ]
+        summ = summarize_evidence(samples, 100.0)
+        assert summ.domain == 3          # all three points are in the domain
+        assert summ.assessed == 2        # only the two with data
+        assert summ.affected == 0
+
+    def test_explicit_affected_overrides_severity(self):
+        # Ribbon RED but the grade does not count it (turbulence severe-off-cruise).
+        samples = [
+            _sample(0.0, S.GREEN),
+            _sample(50.0, S.RED, affected=False),
+        ]
+        summ = summarize_evidence(samples, 100.0)
+        assert summ.affected == 0
+
+    def test_explicit_affected_true_with_green_ribbon(self):
+        # Grade counts a point the ribbon shows green (enroute_precip light rain).
+        samples = [_sample(0.0, S.GREEN, affected=True), _sample(50.0, S.GREEN)]
+        summ = summarize_evidence(samples, 100.0)
+        assert summ.affected == 1
+
+
+class TestAffectedNm:
+    def test_midpoint_owned_cells(self):
+        # Four evenly spaced points over 90nm → cell edges at 15/45/75. The
+        # single affected point at 30 owns [15, 45] = 30nm.
+        samples = [
+            _sample(0.0, S.GREEN),
+            _sample(30.0, S.AMBER),
+            _sample(60.0, S.GREEN),
+            _sample(90.0, S.GREEN),
+        ]
+        summ = summarize_evidence(samples, 90.0)
+        assert summ.affected_nm == 30.0
+
+    def test_endpoint_cell_reaches_route_bounds(self):
+        # Affected first point owns [0, midpoint] and last owns [midpoint, total].
+        samples = [_sample(0.0, S.RED), _sample(40.0, S.GREEN), _sample(100.0, S.RED)]
+        summ = summarize_evidence(samples, 100.0)
+        # first cell [0,20]=20, last cell [70,100]=30 → 50
+        assert summ.affected_nm == 50.0
+
+    def test_no_affected_is_zero(self):
+        summ = summarize_evidence([_sample(0.0, S.GREEN), _sample(50.0, S.GREEN)], 50.0)
+        assert summ.affected_nm == 0.0
+
+    def test_extent_consistent_with_full_route(self):
+        # All points affected → owns the whole route.
+        samples = [_sample(0.0, S.RED), _sample(50.0, S.RED), _sample(100.0, S.RED)]
+        summ = summarize_evidence(samples, 100.0)
+        assert summ.affected_nm == 100.0
+
+
+class TestHighlights:
+    def test_ribbon_tiles_and_regions_flagged_only(self):
+        cell = FlaggedCell(kind="k", severity=S.AMBER, base_ft=1000, top_ft=5000)
+        samples = [
+            _sample(0.0, S.GREEN),
+            _sample(50.0, S.AMBER, region=cell),
+            _sample(100.0, S.GREEN),
+        ]
+        summ = summarize_evidence(samples, 100.0)
+        assert summ.highlights.ribbon[0].dist_from_nm == 0.0
+        assert summ.highlights.ribbon[-1].dist_to_nm == 100.0
+        assert len(summ.highlights.regions) == 1
+        assert summ.highlights.regions[0].kind == "k"
+
+    def test_peak_defaults_to_ribbon_peak(self):
+        samples = [_sample(0.0, S.GREEN), _sample(40.0, S.RED), _sample(80.0, S.GREEN)]
+        summ = summarize_evidence(samples, 120.0)
+        assert summ.highlights.peak_dist_nm is not None
+
+    def test_peak_override(self):
+        samples = [_sample(0.0, S.RED), _sample(50.0, S.RED)]
+        summ = summarize_evidence(samples, 100.0, peak_dist_nm=42.0)
+        assert summ.highlights.peak_dist_nm == 42.0
+
+    def test_region_provenance_propagates(self):
+        cell = FlaggedCell(
+            kind="icing_band", severity=S.RED, base_ft=3000, top_ft=9000,
+            reason_code="no_escape", metric_id="icing", method_id="ogimet_nwp",
+        )
+        summ = summarize_evidence([_sample(0.0, S.RED, region=cell)], 100.0)
+        region = summ.highlights.regions[0]
+        assert region.reason_code == "no_escape"
+        assert region.metric_id == "icing"
+        assert region.method_id == "ogimet_nwp"
+
+
+class TestDataStateAndCoverage:
+    def test_complete_when_full_coverage(self):
+        samples = [_sample(float(i * 10), S.GREEN) for i in range(10)]
+        summ = summarize_evidence(samples, 90.0)
+        assert summ.data_state == "complete"
+        assert summ.below_coverage is False
+
+    def test_partial_below_half(self):
+        # 2 assessed of 10 domain → below the 0.5 coverage floor.
+        samples = [_sample(0.0, S.GREEN), _sample(10.0, S.GREEN)] + [
+            _sample(float(20 + i * 10), S.UNAVAILABLE, assessed=False) for i in range(8)
+        ]
+        summ = summarize_evidence(samples, 100.0)
+        assert summ.data_state == "partial"
+        assert summ.below_coverage is True
+
+    def test_unavailable_when_nothing_assessed(self):
+        samples = [_sample(float(i * 10), S.UNAVAILABLE, assessed=False) for i in range(4)]
+        summ = summarize_evidence(samples, 30.0)
+        assert summ.data_state == "unavailable"
+
+    def test_domain_override_excludes_out_of_domain(self):
+        # mountain_wind: non-mountain points out of domain; coverage over mountains.
+        samples = [
+            _sample(0.0, S.GREEN, in_domain=False),         # flat, not a mountain
+            _sample(25.0, S.GREEN, in_domain=False),        # flat, not a mountain
+            _sample(50.0, S.GREEN),                         # mountain, assessed
+            _sample(75.0, S.UNAVAILABLE, assessed=False),   # mountain, no wind
+            _sample(100.0, S.UNAVAILABLE, assessed=False),  # mountain, no wind
+        ]
+        summ = summarize_evidence(samples, 100.0)
+        assert summ.domain == 3      # three mountain points
+        assert summ.assessed == 1    # one with wind
+        # 1 assessed of 3 domain < 0.5*3=1.5 → below coverage. The two flat
+        # points do not dilute the mountain-only coverage denominator.
+        assert summ.below_coverage is True

--- a/web/tests/unit/advisory-highlights.test.ts
+++ b/web/tests/unit/advisory-highlights.test.ts
@@ -47,10 +47,12 @@ function advisory(
   id: string,
   aggStatus: RouteAdvisoryResult['aggregate_status'],
   perModel: ModelAdvisoryResult[],
+  representativeModel?: string | null,
 ): RouteAdvisoryResult {
   return {
     advisory_id: id, aggregate_status: aggStatus, aggregate_detail: '',
     per_model: perModel, parameters_used: {},
+    ...(representativeModel !== undefined ? { representative_model: representativeModel } : {}),
   };
 }
 
@@ -64,14 +66,20 @@ function manifest(advisories: RouteAdvisoryResult[]): RouteAdvisoriesManifest {
 // --- representative model ----------------------------------------------------
 
 describe('representativeModel', () => {
-  it('picks the first per-model entry whose status equals the aggregate', () => {
+  it('reads the backend representative_model field verbatim (#393)', () => {
     const adv = advisory('vmc_cruise', 'amber', [
       model('gfs', 'green'), model('ecmwf', 'amber'), model('icon', 'red'),
-    ]);
+    ], 'ecmwf');
     expect(representativeModel(adv)).toBe('ecmwf');
   });
 
-  it('falls back to the first per-model entry when none matches', () => {
+  it('trusts the backend field even when it differs from a naive status match', () => {
+    // The client no longer recomputes the rule — whatever the server picked wins.
+    const adv = advisory('vmc_cruise', 'amber', [model('gfs', 'green'), model('ecmwf', 'amber')], 'gfs');
+    expect(representativeModel(adv)).toBe('gfs');
+  });
+
+  it('falls back to the first per-model entry on old packs (no field)', () => {
     const adv = advisory('vmc_cruise', 'red', [model('gfs', 'green'), model('ecmwf', 'amber')]);
     expect(representativeModel(adv)).toBe('gfs');
   });

--- a/web/ts/types/advisories.ts
+++ b/web/ts/types/advisories.ts
@@ -108,6 +108,12 @@ export interface HighlightRegion {
   top_ft?: number | null;
   kind: string;
   severity: HighlightSeverity;
+  /** Stable, non-localised provenance tokens (#393). Absent on old packs.
+   *  `reason_code` — why this region fired; `metric_id` — the cross-section
+   *  layer a chip jumps to; `method_id` — the analysis method behind it. */
+  reason_code?: string | null;
+  metric_id?: string | null;
+  method_id?: string | null;
 }
 
 /** Cross-section highlight geometry for one advisory × one model (#373).
@@ -132,6 +138,11 @@ export interface ModelAdvisoryResult {
   /** Cross-section highlight geometry (#373). Absent/null on old packs and for
    *  models/evaluators that don't emit it → the derive selector returns null. */
   highlights?: AdvisoryHighlights | null;
+  /** Stable id of the analysis method that controlled this model's grade (#393),
+   *  e.g. `ogimet_nwp`, `sfip`, `nwp_with_dd_floor`. The source for a method
+   *  badge on the chip — NOT the user's selected method. Absent on old packs and
+   *  for evaluators with no selectable method. */
+  primary_method_id?: string | null;
 }
 
 export interface RouteAdvisoryResult {
@@ -141,6 +152,11 @@ export interface RouteAdvisoryResult {
   per_model: ModelAdvisoryResult[];
   parameters_used: Record<string, number>;
   aggregate_mitigations?: Mitigation[];
+  /** The model whose per-model result sources the aggregate view (#393): the
+   *  first `per_model` entry whose status equals `aggregate_status`. Emitted by
+   *  the backend so the client no longer reimplements the rule. Absent on old
+   *  packs → `representativeModel()` falls back to the first per-model entry. */
+  representative_model?: string | null;
 }
 
 export type FlightCategory = 'VFR' | 'MVFR' | 'IFR' | 'LIFR';

--- a/web/ts/visualization/cross-section/advisory-highlights.ts
+++ b/web/ts/visualization/cross-section/advisory-highlights.ts
@@ -8,10 +8,10 @@
  * stale-copy bugs, and a vanished advisory (old pack / recalc dropped it) simply
  * derives to `null`.
  *
- * Also home to the representative-model policy, mirroring the Python
- * `RouteAdvisoryResult.from_per_model` / `_aggregate_mitigations` semantics: the
- * first per-model entry whose status equals the aggregate status. The chip switches
- * the cross-section to this model so the highlight reflects the aggregate verdict.
+ * The representative-model choice (which model's geometry the chip switches the
+ * cross-section to) is decided by the backend and shipped as
+ * `RouteAdvisoryResult.representative_model` (#393). The client just reads it —
+ * the former line-for-line TypeScript reimplementation of the Python rule is gone.
  */
 
 import type {
@@ -25,15 +25,15 @@ import type {
 export const HIGHLIGHT_LAYER_ID = 'advisory-highlight';
 
 /**
- * The representative model for an advisory: the first `per_model` entry whose
- * status equals `aggregate_status` (the same policy Python uses to choose
- * `aggregate_detail` / `aggregate_mitigations`), falling back to the first
- * per-model entry. Returns `null` only when there are no per-model results.
+ * The representative model for an advisory — the model whose geometry the chip
+ * highlights. Read straight from the backend's `representative_model` field
+ * (#393), which the server derives with the same rule it uses for
+ * `aggregate_detail` / `aggregate_mitigations`. Falls back to the first
+ * per-model entry only for old packs that predate the field. Returns `null`
+ * only when there are no per-model results.
  */
 export function representativeModel(adv: RouteAdvisoryResult): string | null {
-  const match = adv.per_model.find((m) => m.status === adv.aggregate_status);
-  if (match) return match.model;
-  return adv.per_model[0]?.model ?? null;
+  return adv.representative_model ?? adv.per_model[0]?.model ?? null;
 }
 
 /** Find one advisory by id in a manifest (or null). */


### PR DESCRIPTION
## What & why

Implements both parts of #393. Neither part changes any meteorology — the grades are identical; the change is structural.

### Part 1 — Evidence contract (additive, legacy-safe)

Three provenance fields #389 carries that ours didn't. All optional; old packs deserialize with them absent.

- **`representative_model`** on `RouteAdvisoryResult` — the model whose per-model result sources the aggregate view. Emitted from the backend (same lookup that already drives `aggregate_detail` / `aggregate_mitigations`) so the client stops reimplementing the rule. The line-for-line TypeScript copy (`representativeModel()`) is **deleted**; it now reads the field with a first-model fallback for old packs.
- **`primary_method_id`** on `ModelAdvisoryResult` — stable id of the method that controlled *this model's* grade (the source for a future method badge, not the user's selected method).
- **`reason_code` / `metric_id` / `method_id`** on `HighlightRegion` (threaded through `FlaggedCell` + `build_regions`) — stable non-localised tokens; `metric_id` lets a chip jump to the right cross-section layer.

### Part 2 — Single-assessment loop

The verdict and the highlight used to come from two separate passes over the route, and they drifted — every bug in #391 was a variant of that. Now a **single `EvidenceSample` list per model** feeds one shared `summarize_evidence`, which derives grade counts, highlight geometry, `affected_nm`, and coverage `data_state` from one predicate — so grade and ribbon cannot disagree.

- New `EvidenceSample` / `EvidenceSummary` / `summarize_evidence` in `_helpers.py` (beside the existing helpers, per the issue).
- **`affected_nm` is now the midpoint-owned-cell distance** of the affected points (the #391 geometry fix), consistent with `affected_pct` because both count the same samples. `ModelAdvisoryResult.build` takes an optional `affected_nm=` override for this.
- Coverage still downgrades a would-be-GREEN via `below_coverage` (never #389's binary `partial → UNAVAILABLE`), with `mountain_wind`'s mountain-points-only domain preserved. SFIP no-omega left untouched.
- **All nine single-axis evaluators migrated**: `vmc_cruise`, `cloud_top`, `turbulence`, `freezing_precip`, `mountain_wind`, `icing_escape`, `fiki_icing`, `enroute_precip`, `model_agreement`. Where the ribbon and grade deliberately key on different predicates (turbulence severe-anywhere vs cruise-band; fiki corridor vs cruise clear-air; enroute_precip light-rain), each sample carries both facets so behaviour is preserved exactly.

### Deferred (out of this PR's scope)

- **`primary_method_id` population** — the field is wired end-to-end but left `None`; populating "the method that controlled the grade" (incl. compound ids like `nwp_with_dd_floor`) needs the method-resolution context threaded into `RouteContext`, which is tied to the #223 method-badge slice the issue excludes.
- **The composite evaluators** (`convective`, `ifr_feasibility`, `vfr_feasibility`) keep the old two-loop pattern and proportional `affected_nm` — the issue's "nine evaluators" list excludes them by design; natural candidates for a later slice.

## Issue linkage

Closes #393

## Testing / verification

- New `tests/analysis/advisories/test_evidence.py` (16 cases) covers the helper: counts, midpoint-cell `affected_nm`, region-provenance propagation, and the complete/partial/unavailable `data_state`.
- Added `representative_model` assertions to `test_aggregation.py`; updated the TS `advisory-highlights` tests to read the backend field.
- Full Python suite green (**3440 passed, 12 skipped**); the one unrelated failure (`test_auth::test_google_login_redirects`) fails identically on `main` — Google OAuth isn't configured in the sandbox.
- Web: `vitest` 479 passed; `tsc` clean on touched files (2 pre-existing errors in unrelated `eval/label-panel.ts`).
- Behaviour preservation validated by the 344-test advisory suite staying green after each evaluator migration.
