### PR TITLE
Airport summary card as default panel view + click-to-open + dwell prefetch

### DIFF
--- a/web/maps.html
+++ b/web/maps.html
@@ -50,6 +50,8 @@
       border-radius: 8px; border: 1px solid var(--border); overflow: hidden;
     }
     .map-info { font-size: 0.75rem; color: var(--text-muted); margin-top: 0.4rem; }
+    /* Airport markers open the summary panel on click/tap — signal it. */
+    .wx-marker-clickable { cursor: pointer; }
 
     .map-legend {
       position: absolute; bottom: 30px; left: 10px; z-index: 1000;
@@ -168,12 +170,77 @@
     .ap-panel-status:empty { display: none; }
 
     .ap-panel-body { flex: 1 1 auto; display: flex; flex-direction: column; min-height: 0; }
-    .ap-panel.view-both .ap-cross,
-    .ap-panel.view-both .ap-skewt { flex: 1 1 50%; min-height: 0; position: relative; }
+    .ap-panel.view-card .ap-card-host { flex: 1 1 100%; min-height: 0; overflow-y: auto; }
     .ap-panel.view-cross .ap-cross { flex: 1 1 100%; min-height: 0; position: relative; }
     .ap-panel.view-skewt .ap-skewt { flex: 1 1 100%; min-height: 0; position: relative; }
     .ap-cross, .ap-skewt { background: var(--bg); position: relative; min-height: 0; }
     .ap-cross + .ap-skewt { border-top: 1px solid var(--border); }
+
+    /* --- Airport summary card (default panel view) ---
+     * Pure client-side render from the map's forecast data. Cells are
+     * colored inline by JS via the same scales as the markers; the CSS
+     * here owns layout + the diverging-row emphasis. */
+    .ap-card { padding: 0.6rem 0.7rem; display: flex; flex-direction: column; gap: 0.6rem; }
+    .ap-card-empty { padding: 1rem; color: var(--text-muted); font-size: 0.85rem; text-align: center; }
+
+    .ap-card-verdict { display: flex; align-items: center; gap: 0.6rem; }
+    .ap-card-cat {
+      font-size: 1.15rem; font-weight: 800; letter-spacing: 0.02em;
+      padding: 0.35rem 0.6rem; border-radius: 6px; min-width: 3.2rem; text-align: center;
+    }
+    .ap-card-verdict-meta { display: flex; flex-direction: column; line-height: 1.15; }
+    .ap-card-icao { font-weight: 700; font-size: 0.95rem; color: var(--text); }
+    .ap-card-validtime { font-size: 0.72rem; color: var(--text-muted); }
+    .ap-card-agr {
+      margin-left: auto; display: inline-flex; align-items: center; gap: 0.3rem;
+      font-size: 0.72rem; color: var(--text-muted); white-space: nowrap;
+    }
+    .ap-card-agr-dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; flex: none; }
+
+    .ap-card-alt {
+      display: flex; align-items: center; gap: 0.45rem; font-size: 0.78rem;
+      padding: 0.3rem 0.45rem; background: var(--bg);
+      border: 1px solid var(--border); border-radius: 5px;
+    }
+    .ap-card-alt-label { color: var(--text-muted); font-weight: 600; }
+    .ap-card-alt-val { font-weight: 700; }
+    .ap-card-alt-val.is-required { color: #ef4444; }
+    .ap-card-alt-val.is-none { color: #22c55e; }
+    .ap-card-alt-mode {
+      margin-left: auto; font-size: 0.66rem; color: var(--text-muted);
+      text-transform: uppercase; letter-spacing: 0.03em;
+    }
+
+    .ap-card-matrix-wrap { overflow-x: auto; }
+    .ap-card-matrix { width: 100%; border-collapse: collapse; font-size: 0.75rem; }
+    .ap-card-unit { color: var(--text-muted); font-weight: 500; font-size: 0.9em; }
+    .ap-card-matrix th {
+      font-weight: 700; color: var(--text-muted); text-align: center;
+      padding: 0.2rem 0.15rem; font-size: 0.66rem;
+      text-transform: uppercase; letter-spacing: 0.02em;
+      border-bottom: 1px solid var(--border);
+    }
+    .ap-card-matrix th.ap-card-metric-col { text-align: left; }
+    .ap-card-matrix td {
+      padding: 0.28rem 0.25rem; text-align: center; font-weight: 600;
+      border-bottom: 1px solid var(--border); white-space: nowrap;
+    }
+    .ap-card-matrix td.ap-card-metric-col {
+      text-align: left; color: var(--text); background: transparent;
+    }
+    .ap-card-matrix th.ap-card-consensus-col,
+    .ap-card-matrix td.ap-card-consensus-col { border-left: 2px solid var(--border); }
+    .ap-card-row { cursor: pointer; }
+    .ap-card-row:hover td.ap-card-metric-col { color: var(--primary); }
+    .ap-card-row:focus-visible { outline: 2px solid var(--primary); outline-offset: -2px; }
+    /* Diverging models → red rail on the metric label to draw the eye. */
+    .ap-card-row.is-diverging td.ap-card-metric-col {
+      box-shadow: inset 3px 0 0 #ef4444; padding-left: 0.45rem;
+    }
+    .ap-card-warn { color: #ef4444; margin-left: 0.2rem; }
+    .ap-card-row-plain { cursor: default; }
+    .ap-card-row-plain td { font-weight: 500; color: var(--text-muted); background: transparent; }
+    .ap-card-footnote { font-size: 0.66rem; color: var(--text-muted); }
 
     /* Loading state — kills the "blue sky = forecast is clear" trap by
      * desaturating the empty canvas and overlaying a "Loading…" badge

--- a/web/tests/unit/weather-map-format.test.ts
+++ b/web/tests/unit/weather-map-format.test.ts
@@ -1,0 +1,124 @@
+/** Tests for the shared forecast-map color/format helpers — the pilot-facing
+ *  color thresholds and model-agreement/alternate aggregation that drive both
+ *  the marker layer and the airport summary card. */
+
+import { describe, it, expect } from 'vitest';
+import {
+  getForecastColor, aggAltRequired, getAgreementForMetric, CAT_COLORS,
+} from '../../ts/visualization/weather-map-format';
+import type {
+  ForecastAirport, ModelForecast, ConsensusForecast,
+} from '../../ts/adapters/maps-adapter';
+
+function makeModelForecast(overrides: Partial<ModelForecast> = {}): ModelForecast {
+  return {
+    ceiling_ft: null,
+    visibility_m: null,
+    wind_speed_kt: null,
+    wind_dir_deg: null,
+    wind_gust_kt: null,
+    crosswind_kt: null,
+    headwind_kt: null,
+    best_runway_id: null,
+    gust_crosswind_kt: null,
+    gust_headwind_kt: null,
+    cloud_cover_pct: null,
+    cape_jkg: null,
+    convective_risk: 'none',
+    temperature_c: null,
+    flight_category: 'VFR',
+    ...overrides,
+  };
+}
+
+function makeAirport(models: Record<string, Partial<ModelForecast>>): ForecastAirport {
+  const built: Record<string, ModelForecast> = {};
+  for (const [k, v] of Object.entries(models)) built[k] = makeModelForecast(v);
+  return {
+    icao: 'EGLF', lat: 51.276, lon: -0.776,
+    models: built,
+    consensus: { flight_category: 'VFR', agreement: {} },
+  };
+}
+
+describe('getForecastColor', () => {
+  it('colors flight category from the shared CAT_COLORS scale (per model)', () => {
+    const apt = makeAirport({ gfs: { flight_category: 'IFR' } });
+    expect(getForecastColor(apt, 'flight_category', 'gfs')).toBe(CAT_COLORS.IFR);
+  });
+
+  it('applies ceiling thresholds (IFR band 500–1000 ft → red)', () => {
+    const apt = makeAirport({ gfs: { ceiling_ft: 800 } });
+    expect(getForecastColor(apt, 'ceiling_ft', 'gfs')).toBe('#ef4444');
+  });
+
+  it('applies wind-speed thresholds (25–35 kt → red)', () => {
+    const apt = makeAirport({ gfs: { wind_speed_kt: 30 } });
+    expect(getForecastColor(apt, 'wind_speed_kt', 'gfs')).toBe('#ef4444');
+  });
+
+  it('returns the muted color for a missing model', () => {
+    const apt = makeAirport({ gfs: {} });
+    expect(getForecastColor(apt, 'ceiling_ft', 'icon')).toBe('#888');
+  });
+
+  it('worst consensus picks the most restrictive category', () => {
+    const apt = makeAirport({
+      gfs: { flight_category: 'VFR' },
+      icon: { flight_category: 'MVFR' },
+      ecmwf: { flight_category: 'IFR' },
+    });
+    expect(getForecastColor(apt, 'flight_category', 'worst')).toBe(CAT_COLORS.IFR);
+  });
+});
+
+describe('aggAltRequired', () => {
+  it('worst mode flags a requirement if any model requires it', () => {
+    const apt = makeAirport({
+      gfs: { alt_required: { faa: false, easa: false } },
+      ecmwf: { alt_required: { faa: true, easa: false } },
+    });
+    expect(aggAltRequired(apt, 'worst')).toEqual({ faa: true, easa: false });
+  });
+
+  it('majority mode uses the modal value with worst tiebreak', () => {
+    const apt = makeAirport({
+      gfs: { alt_required: { faa: true, easa: false } },
+      icon: { alt_required: { faa: true, easa: false } },
+      ecmwf: { alt_required: { faa: false, easa: true } },
+    });
+    // FAA: two "yes" vs one "no" → yes. EASA: two "no" vs one "yes" → no.
+    expect(aggAltRequired(apt, 'majority')).toEqual({ faa: true, easa: false });
+  });
+
+  it('returns undefined when no model carries alternate flags', () => {
+    const apt = makeAirport({ gfs: {}, ecmwf: {} });
+    expect(aggAltRequired(apt, 'worst')).toBeUndefined();
+  });
+});
+
+describe('getAgreementForMetric', () => {
+  const consensus: ConsensusForecast = {
+    flight_category: 'IFR',
+    agreement: {
+      flight_category: 'divergent',
+      wind_speed_kt: 'mixed',
+      ceiling_ft: 'consistent',
+    },
+  };
+
+  it('reads the direct agreement key', () => {
+    expect(getAgreementForMetric(consensus, 'ceiling_ft')).toBe('consistent');
+    expect(getAgreementForMetric(consensus, 'flight_category')).toBe('divergent');
+  });
+
+  it('maps crosswind/headwind to the wind-speed agreement proxy', () => {
+    expect(getAgreementForMetric(consensus, 'crosswind_kt')).toBe('mixed');
+    expect(getAgreementForMetric(consensus, 'headwind_kt')).toBe('mixed');
+  });
+
+  it('returns null when the mapped key is absent', () => {
+    // convective_risk proxies to cape_jkg, which isn't in this consensus.
+    expect(getAgreementForMetric(consensus, 'convective_risk')).toBeNull();
+  });
+});

--- a/web/ts/maps-main.ts
+++ b/web/ts/maps-main.ts
@@ -3,15 +3,19 @@
 import { fetchCurrentUser } from './adapters/auth-adapter';
 import {
   fetchForecastMap, fetchAvailableDays,
-  type ForecastMapResponse, type DayAvailability,
+  type ForecastMapResponse, type DayAvailability, type ForecastAirport,
 } from './adapters/maps-adapter';
+import { isConsensusMode, type ConsensusMode } from './visualization/weather-map-consensus';
 import {
   fetchHewsonManifest, fetchHewsonSlice, fetchHewsonAllMetrics, fetchHewsonFronts,
   type HewsonManifest, type HewsonManifestSnapshot,
   type HewsonAllMetricsSlice,
 } from './adapters/hewson-map-adapter';
 import { WeatherMap, type ForecastMetric } from './visualization/weather-map';
-import { AirportProfilePanel } from './visualization/airport-profile-panel';
+import {
+  AirportProfilePanel,
+  type AirportSummaryInput, type ViewMode as ApViewMode,
+} from './visualization/airport-profile-panel';
 import { SynopticMap } from './visualization/synoptic-map';
 import {
   fetchSynopticChartsManifest, synopticChartUrl, projectionKeyFor,
@@ -87,9 +91,11 @@ let fcMetric: ForecastMetric = 'flight_category';
 // show fewer/more time ticks than the streamed payload contains.
 const AIRPORT_PROFILE_WINDOW_H = 3;
 
-// Airport profile panel state (right-click on a forecast marker)
+// Airport profile panel state (left-click / tap on a forecast marker)
 let airportPanel: AirportProfilePanel | null = null;
 let airportPanelIcao: string | null = null;
+// Panel's current view (Card / Cross-section / Skew-T), tracked for deep-linking.
+let airportPanelView: ApViewMode = 'card';
 
 // --- URL state ---
 //
@@ -115,6 +121,9 @@ const mapsUrlState = createUrlState({
   // consensus mode), so they're separate keys.
   'fc.apt':    { default: '' },
   'fc.apModel':{ default: 'ecmwf', values: ['gfs', 'icon', 'ecmwf'] as readonly string[] },
+  // Panel view: card (default) | cross | skewt. Lets a shared link land
+  // straight on the cross-section; bare links open the summary card.
+  'fc.apView': { default: 'card', values: ['card', 'cross', 'skewt'] as readonly string[] },
 });
 
 function syncUrl(): void {
@@ -126,6 +135,7 @@ function syncUrl(): void {
     'fc.metric': fcMetric,
     'fc.apt':    airportPanelIcao ?? '',
     'fc.apModel': airportPanel?.getModel() ?? 'ecmwf',
+    'fc.apView': airportPanelView,
   });
 }
 
@@ -332,16 +342,50 @@ function panelDefaultModel(): string {
   return ['gfs', 'icon', 'ecmwf'].includes(fcModel) ? fcModel : 'ecmwf';
 }
 
-function openAirportPanel(icao: string, opts: { initialModel?: string } = {}): void {
+/** Consensus column for the summary card: mirror the map's mode when it's a
+ *  consensus mode, else fall back to the conservative 'worst'. */
+function panelConsensusMode(): ConsensusMode {
+  return isConsensusMode(fcModel) ? fcModel : 'worst';
+}
+
+/** Build the card's summary input from data the map already holds — no
+ *  network. Returns undefined if the airport isn't in the current map set. */
+function summaryFor(icao: string): AirportSummaryInput | undefined {
+  const apt: ForecastAirport | undefined = forecastData?.airports.find((a) => a.icao === icao);
+  if (!apt || !forecastData) return undefined;
+  return {
+    airport: apt,
+    consensusMode: panelConsensusMode(),
+    validTime: new Date(forecastData.forecast_time),
+    modelInitTimes: forecastData.model_init_times,
+  };
+}
+
+/** Set the map's colored metric programmatically (e.g. from a card row
+ *  click) and keep the picker + URL + markers in sync. */
+function setMetric(metric: ForecastMetric): void {
+  if (fcMetric === metric) return;
+  fcMetric = metric;
+  const metricSel = $('metric-picker') as HTMLSelectElement | null;
+  if (metricSel) metricSel.value = metric;
+  syncUrl();
+  rerender();
+}
+
+function openAirportPanel(icao: string, opts: { initialModel?: string; initialView?: ApViewMode } = {}): void {
   const host = $('ap-panel-host') as HTMLElement | null;
   if (!host) return;
   host.style.display = 'flex';
+  if (opts.initialView) airportPanelView = opts.initialView;
   if (!airportPanel) {
     airportPanel = new AirportProfilePanel({
       container: host,
       initialModel: opts.initialModel ?? panelDefaultModel(),
+      initialView: opts.initialView,
       onClose: () => closeAirportPanel(),
       onModelChange: () => syncUrl(),
+      onMetricSelect: (metric) => setMetric(metric),
+      onViewChange: (v) => { airportPanelView = v; syncUrl(); },
     });
   } else if (opts.initialModel) {
     airportPanel.setModel(opts.initialModel);
@@ -350,6 +394,7 @@ function openAirportPanel(icao: string, opts: { initialModel?: string } = {}): v
   forecastMap?.setHighlightedIcao(icao);
   airportPanel.load({
     icao, startHour: forecastStartHour(), windowH: AIRPORT_PROFILE_WINDOW_H,
+    summary: summaryFor(icao),
   });
   syncUrl();
   // The map width changed — let Leaflet re-layout.
@@ -362,16 +407,19 @@ function closeAirportPanel(): void {
   airportPanel?.destroy();
   airportPanel = null;
   airportPanelIcao = null;
+  airportPanelView = 'card';
   forecastMap?.setHighlightedIcao(null);
   syncUrl();
   setTimeout(() => forecastMap?.invalidateSize(), 50);
 }
 
-function refreshAirportPanelOnHourChange(): void {
-  // Map's day/hour changed: reload the open panel; metric changes are ignored.
+/** Reload the open panel after a day/hour change refetches the map data,
+ *  so the card reflects the new valid time (and the cross-section rewindows). */
+function refreshOpenPanel(): void {
   if (!airportPanel || !airportPanelIcao) return;
   airportPanel.load({
     icao: airportPanelIcao, startHour: forecastStartHour(), windowH: AIRPORT_PROFILE_WINDOW_H,
+    summary: summaryFor(airportPanelIcao),
   });
 }
 
@@ -386,6 +434,9 @@ async function loadForecast(): Promise<void> {
         .map(([m, t]) => `${m.toUpperCase()}: ${new Date(t).toISOString().slice(0, 13)}Z`)
         .join(', ');
       showInfo(`${forecastData.airports.length} airports | Model runs: ${initTimes}`, 'map-info');
+      // Refresh the open panel now that fresh data has landed, so the card
+      // shows the new valid time's numbers (not the pre-change snapshot).
+      refreshOpenPanel();
     }
   } catch (err) {
     showInfo(`Failed to load forecast: ${err instanceof Error ? err.message : err}`, 'map-info');
@@ -436,15 +487,13 @@ function wireForecastControls(): void {
     syncPickersForDay();
     updateForecastDatetime();
     syncUrl();
-    loadForecast();
-    refreshAirportPanelOnHourChange();
+    loadForecast();  // refreshes the open panel once fresh data lands
   });
 
   wireButtonGroup('hour-picker', 'hour', (v) => {
     fcHour = parseInt(v);
     syncUrl();
-    loadForecast();
-    refreshAirportPanelOnHourChange();
+    loadForecast();  // refreshes the open panel once fresh data lands
   });
 
   // Custom handler rather than wireButtonGroup: now that unavailable models are
@@ -1081,6 +1130,9 @@ async function main(): Promise<void> {
   if (!container) return;
   forecastMap = new WeatherMap(container);
   forecastMap.init();
+  // Left-click / tap is the primary (touch-friendly) way to open the panel;
+  // right-click stays wired as a desktop alias.
+  forecastMap.setAirportClickHandler((icao) => openAirportPanel(icao));
   forecastMap.setAirportContextHandler((icao) => openAirportPanel(icao));
 
   // Set up the briefing-style info modal (used by the synoptic tab's (i)).
@@ -1178,7 +1230,10 @@ async function main(): Promise<void> {
   // has a marker to highlight.
   const urlIcao = init['fc.apt'];
   if (urlIcao && currentTab === 'forecast') {
-    openAirportPanel(urlIcao, { initialModel: init['fc.apModel'] });
+    openAirportPanel(urlIcao, {
+      initialModel: init['fc.apModel'],
+      initialView: init['fc.apView'] as ApViewMode,
+    });
   }
 }
 

--- a/web/ts/maps-main.ts
+++ b/web/ts/maps-main.ts
@@ -516,6 +516,13 @@ function wireForecastControls(): void {
     // All mode switches are client-side — per-model data is already in the response
     syncUrl();
     rerender();
+    // The open card's consensus column follows the map's mode
+    // (panelConsensusMode derives from fcModel) — keep it in lockstep with
+    // the markers instead of showing the previous mode's values.
+    if (airportPanel && airportPanelIcao) {
+      const s = summaryFor(airportPanelIcao);
+      if (s) airportPanel.updateSummary(s);
+    }
   });
 
   const metricSel = $('metric-picker') as HTMLSelectElement | null;

--- a/web/ts/visualization/airport-profile-panel.ts
+++ b/web/ts/visualization/airport-profile-panel.ts
@@ -25,6 +25,10 @@ import {
   type AirportProfileSnapshot, type AirportProfileStreamHandle,
   type AirportProfileEnriched,
 } from '../adapters/airport-profile-adapter';
+import { renderAirportSummaryCard } from './airport-summary-card';
+import type { ForecastAirport } from '../adapters/maps-adapter';
+import type { ConsensusMode } from './weather-map-consensus';
+import type { ForecastMetric } from './weather-map-format';
 
 /** Render a one-line summary of which GRIB sources contributed
  *  (or empty when none did, so the status row collapses). */
@@ -54,8 +58,11 @@ function statusLoading(label: string): string {
   return `${esc(label)}<span class="dots-spinner"></span>`;
 }
 
-type ViewMode = 'both' | 'cross' | 'skewt';
-const VIEW_MODE_KEY = 'wb_apProfileView';
+export type ViewMode = 'card' | 'cross' | 'skewt';
+// v2 key: the summary card is the new default. The old `wb_apProfileView`
+// defaulted to the heavy stacked 'both' view; migrating to a fresh key
+// lands every existing user on the card once, without a value-migration.
+const VIEW_MODE_KEY = 'wb_apProfileView2';
 /** Per-panel layer-enable map. Key is independent from the main
  *  briefing's `wb_visibleLayers` so toggles in this panel don't bleed
  *  into the main /briefing.html view. */
@@ -63,8 +70,8 @@ const LAYERS_KEY = 'wb_apProfileLayers';
 
 function loadViewMode(): ViewMode {
   const v = localStorage.getItem(VIEW_MODE_KEY);
-  if (v === 'cross' || v === 'skewt' || v === 'both') return v;
-  return 'both';
+  if (v === 'cross' || v === 'skewt' || v === 'card') return v;
+  return 'card';
 }
 function saveViewMode(m: ViewMode): void {
   localStorage.setItem(VIEW_MODE_KEY, m);
@@ -95,17 +102,38 @@ function saveEnabledLayers(m: Record<string, boolean>): void {
 export interface AirportProfilePanelOptions {
   container: HTMLElement;
   initialModel?: string;
+  /** Override the persisted default view (e.g. from a deep-link's
+   *  `fc.apView`). When omitted, the last-used view is restored. */
+  initialView?: ViewMode;
   onClose?: () => void;
   /** Fired when the user picks a different model from the panel's
    *  dropdown — lets the host round-trip the selection through URL
    *  state without polling. */
   onModelChange?: (model: string) => void;
+  /** Fired when the user clicks a metric row in the summary card — the
+   *  host switches the map's color dropdown to that metric. */
+  onMetricSelect?: (metric: ForecastMetric) => void;
+  /** Fired when the view mode changes (Card / Cross-section / Skew-T) so
+   *  the host can deep-link it. */
+  onViewChange?: (view: ViewMode) => void;
+}
+
+/** Snapshot summary the host already holds (from the forecast map response)
+ *  used to render the card synchronously, with no network round-trip. */
+export interface AirportSummaryInput {
+  airport: ForecastAirport;
+  consensusMode: ConsensusMode;
+  validTime: Date;
+  modelInitTimes?: Record<string, string>;
 }
 
 export interface AirportProfileRequest {
   icao: string;
   startHour: string;  // ISO 8601 UTC, e.g. "2026-05-07T12:00:00Z"
   windowH?: number;
+  /** Per-airport summary for the card. Optional so callers without it
+   *  (e.g. a deep-link before the map data lands) still open the panel. */
+  summary?: AirportSummaryInput;
 }
 
 const MODELS = ['gfs', 'icon', 'ecmwf'] as const;
@@ -116,7 +144,10 @@ export class AirportProfilePanel {
   private viewMode: ViewMode;
   private onClose?: () => void;
   private onModelChange?: (model: string) => void;
+  private onMetricSelect?: (metric: ForecastMetric) => void;
+  private onViewChange?: (view: ViewMode) => void;
 
+  private cardEl: HTMLDivElement;
   private crossEl: HTMLDivElement;
   private skewtEl: HTMLDivElement;
   private statusEl: HTMLDivElement;
@@ -126,6 +157,15 @@ export class AirportProfilePanel {
   private settingsBtn: HTMLButtonElement;
   private drawerEl: HTMLDivElement;
   private drawerOpen = false;
+
+  /** Per-airport summary for the card (from the forecast map response). */
+  private summary: AirportSummaryInput | null = null;
+  /** Dwell-prefetch timer + guard so the slow cross-section SSE fires on
+   *  intent (dwell / pointer-enter / switching to a heavy view), not on
+   *  every marker click. */
+  private prefetchTimer: number | null = null;
+  private streamStarted = false;
+  private static readonly PREFETCH_DWELL_MS = 400;
 
   private crossRenderer: CrossSectionRenderer | null = null;
   private skewtRenderer: SkewTRenderer | null = null;
@@ -155,9 +195,11 @@ export class AirportProfilePanel {
   constructor(opts: AirportProfilePanelOptions) {
     this.container = opts.container;
     this.model = opts.initialModel ?? 'ecmwf';
-    this.viewMode = loadViewMode();
+    this.viewMode = opts.initialView ?? loadViewMode();
     this.onClose = opts.onClose;
     this.onModelChange = opts.onModelChange;
+    this.onMetricSelect = opts.onMetricSelect;
+    this.onViewChange = opts.onViewChange;
 
     this.container.classList.add('ap-panel');
     this.container.innerHTML = `
@@ -174,7 +216,7 @@ export class AirportProfilePanel {
         </select>
         <label>View</label>
         <div class="ap-view-group btn-group" role="group">
-          <button class="btn-toggle" data-view="both">Both</button>
+          <button class="btn-toggle" data-view="card">Card</button>
           <button class="btn-toggle" data-view="cross">Cross-section</button>
           <button class="btn-toggle" data-view="skewt">Skew-T</button>
         </div>
@@ -182,6 +224,7 @@ export class AirportProfilePanel {
       </div>
       <div class="ap-panel-status" id="ap-status"></div>
       <div class="ap-panel-body">
+        <div class="ap-card-host" id="ap-card"></div>
         <div class="ap-cross" id="ap-cross"></div>
         <div class="ap-skewt" id="ap-skewt"></div>
       </div>
@@ -190,6 +233,7 @@ export class AirportProfilePanel {
 
     this.titleEl = this.container.querySelector('.ap-panel-title') as HTMLDivElement;
     this.statusEl = this.container.querySelector('.ap-panel-status') as HTMLDivElement;
+    this.cardEl = this.container.querySelector('.ap-card-host') as HTMLDivElement;
     this.crossEl = this.container.querySelector('.ap-cross') as HTMLDivElement;
     this.skewtEl = this.container.querySelector('.ap-skewt') as HTMLDivElement;
     this.modelSel = this.container.querySelector('.ap-model-sel') as HTMLSelectElement;
@@ -199,7 +243,7 @@ export class AirportProfilePanel {
 
     const viewGroup = this.container.querySelector('.ap-view-group') as HTMLElement;
     this.viewBtns = {
-      both: viewGroup.querySelector('[data-view="both"]') as HTMLButtonElement,
+      card: viewGroup.querySelector('[data-view="card"]') as HTMLButtonElement,
       cross: viewGroup.querySelector('[data-view="cross"]') as HTMLButtonElement,
       skewt: viewGroup.querySelector('[data-view="skewt"]') as HTMLButtonElement,
     };
@@ -219,12 +263,22 @@ export class AirportProfilePanel {
       if (!v) return;
       this.viewMode = v;
       saveViewMode(v);
+      this.onViewChange?.(v);
+      // Switching to a heavy view is explicit intent — start the SSE now
+      // if the dwell timer hasn't already fired.
+      if (v === 'cross' || v === 'skewt') this.ensureStream();
       this.applyViewMode();
       // Drawer contents depend on viewMode; re-render if open so a
       // section that just became visible shows its controls.
       if (this.drawerOpen) this.renderDrawer();
     });
     this.settingsBtn.addEventListener('click', () => this.toggleDrawer());
+
+    // Pointer entering the panel is an intent signal — warm the
+    // cross-section in the background so a switch to it feels instant.
+    this.container.addEventListener('pointerenter', () => {
+      if (this.currentRequest && !this.streamStarted) this.ensureStream();
+    });
   }
 
   /** Update the model from outside (e.g. for URL deep-linking). */
@@ -240,7 +294,10 @@ export class AirportProfilePanel {
     return this.model;
   }
 
-  /** Start (or restart) loading the profile for a new airport / hour. */
+  /** Open the panel for a new airport / hour. Renders the summary card
+   *  immediately from host-provided data; the slow cross-section SSE is
+   *  deferred (see `ensureStream` / dwell prefetch) unless a heavy view is
+   *  already selected. */
   load(req: AirportProfileRequest): void {
     // Drop the cache on icao or startHour change — the cached snapshots
     // are scoped to the previous request shape and no longer apply.
@@ -252,7 +309,39 @@ export class AirportProfilePanel {
       this.snapshotCache.clear();
     }
     this.currentRequest = req;
+    if (req.summary) this.summary = req.summary;
+
+    // Cancel any pending prefetch + in-flight stream from the prior request.
+    this.cancelPrefetch();
     if (this.stream) { this.stream.abort(); this.stream = null; }
+    this.streamStarted = false;
+
+    // Reset to an empty snapshot and render the card — instant, no network.
+    this.snapshot = {
+      meta: null, surface: [], levels: [], enriched: null, derived: [],
+    };
+    this.titleEl.textContent = req.icao;
+    this.statusEl.innerHTML = '';
+    this.clearRenderers();
+    this.renderCard();
+    this.applyViewMode();
+
+    // Heavy view already selected → fetch now; otherwise defer the slow
+    // cross-section SSE until the user shows intent.
+    if (this.viewMode === 'cross' || this.viewMode === 'skewt') {
+      this.ensureStream();
+    } else {
+      this.armPrefetch();
+    }
+  }
+
+  /** Kick off (or reuse) the cross-section SSE for the current request +
+   *  model. Idempotent per request+model via `streamStarted`; serves a
+   *  cached snapshot instantly when one exists. */
+  private ensureStream(): void {
+    if (this.streamStarted || !this.currentRequest) return;
+    this.cancelPrefetch();
+    const req = this.currentRequest;
 
     // Cache hit: skip the SSE round-trip entirely. Bump the entry to
     // the most-recently-used slot (Map preserves insertion order, so
@@ -263,6 +352,7 @@ export class AirportProfilePanel {
     if (cached) {
       this.snapshotCache.delete(cacheKey);
       this.snapshotCache.set(cacheKey, cached);
+      this.streamStarted = true;
       this.snapshot = cached;
       this.applyTitle(cached);
       this.statusEl.innerHTML = esc(formatEnrichmentBadge(cached.enriched));
@@ -273,6 +363,7 @@ export class AirportProfilePanel {
       return;
     }
 
+    this.streamStarted = true;
     this.snapshot = {
       meta: null, surface: [], levels: [], enriched: null, derived: [],
     };
@@ -288,6 +379,39 @@ export class AirportProfilePanel {
       { icao: req.icao, model: this.model, startHour: req.startHour, windowH: req.windowH },
       (phase, snapshot, raw) => this.onPhase(phase, snapshot, raw),
     );
+  }
+
+  /** Arm the dwell timer — if the user lingers on the card, warm the
+   *  cross-section so a later switch is instant. Cancelled on close,
+   *  reload, or an earlier intent signal (pointer-enter / view switch). */
+  private armPrefetch(): void {
+    this.cancelPrefetch();
+    this.prefetchTimer = window.setTimeout(() => {
+      this.prefetchTimer = null;
+      this.ensureStream();
+    }, AirportProfilePanel.PREFETCH_DWELL_MS);
+  }
+
+  private cancelPrefetch(): void {
+    if (this.prefetchTimer != null) {
+      clearTimeout(this.prefetchTimer);
+      this.prefetchTimer = null;
+    }
+  }
+
+  /** Render the summary card from the host-provided snapshot summary. */
+  private renderCard(): void {
+    if (!this.summary) {
+      this.cardEl.innerHTML = '<div class="ap-card-empty">Summary unavailable</div>';
+      return;
+    }
+    renderAirportSummaryCard(this.cardEl, {
+      airport: this.summary.airport,
+      consensusMode: this.summary.consensusMode,
+      validTime: this.summary.validTime,
+      modelInitTimes: this.summary.modelInitTimes,
+      onMetricSelect: this.onMetricSelect,
+    });
   }
 
   /** Toggle the dimmed/grayscale "loading" state on the canvas areas.
@@ -384,20 +508,25 @@ export class AirportProfilePanel {
   }
 
   private applyViewMode(): void {
-    for (const v of ['both', 'cross', 'skewt'] as const) {
+    for (const v of ['card', 'cross', 'skewt'] as const) {
       this.viewBtns[v].classList.toggle('active', v === this.viewMode);
     }
-    const showCross = this.viewMode === 'both' || this.viewMode === 'cross';
-    const showSkewT = this.viewMode === 'both' || this.viewMode === 'skewt';
+    const showCard = this.viewMode === 'card';
+    const showCross = this.viewMode === 'cross';
+    const showSkewT = this.viewMode === 'skewt';
+    this.cardEl.style.display = showCard ? 'block' : 'none';
     this.crossEl.style.display = showCross ? 'block' : 'none';
     this.skewtEl.style.display = showSkewT ? 'block' : 'none';
-    this.container.classList.toggle('view-both', this.viewMode === 'both');
-    this.container.classList.toggle('view-cross', this.viewMode === 'cross');
-    this.container.classList.toggle('view-skewt', this.viewMode === 'skewt');
+    // The gear (layers/overlays) only applies to the cross-section / Skew-T.
+    this.settingsBtn.style.display = showCard ? 'none' : '';
+    this.container.classList.toggle('view-card', showCard);
+    this.container.classList.toggle('view-cross', showCross);
+    this.container.classList.toggle('view-skewt', showSkewT);
 
-    // Force a re-render so canvases pick up the new container size.
+    // Build/refresh the active view's renderer from the current snapshot
+    // (also lets canvases pick up the new container size).
     setTimeout(() => {
-      this.crossRenderer?.render();
+      this.renderCross();
       this.renderSkewT();
     }, 0);
   }
@@ -418,7 +547,7 @@ export class AirportProfilePanel {
   }
 
   private renderCross(): void {
-    if (this.viewMode === 'skewt') return;
+    if (this.viewMode !== 'cross') return;
     const data = snapshotToVizData(this.snapshot);
     if (!data) return;
     const r = this.ensureCrossRenderer();
@@ -427,7 +556,7 @@ export class AirportProfilePanel {
   }
 
   private renderSkewT(): void {
-    if (this.viewMode === 'cross') return;
+    if (this.viewMode !== 'skewt') return;
     // TODO(#121-followup): Skew-T is locked to hour 0 of the window;
     // the cross-section above shows all 4 hours but there's no
     // affordance (click on a time tick, hour selector, etc.) to
@@ -549,11 +678,12 @@ export class AirportProfilePanel {
   /** Single teardown path: abort the SSE stream, dispose renderers,
    *  empty the container. Idempotent. */
   destroy(): void {
+    this.cancelPrefetch();
     if (this.stream) { this.stream.abort(); this.stream = null; }
     this.snapshotCache.clear();
     this.drawerOpen = false;
     this.clearRenderers();
     this.container.innerHTML = '';
-    this.container.classList.remove('ap-panel', 'view-both', 'view-cross', 'view-skewt', 'drawer-open');
+    this.container.classList.remove('ap-panel', 'view-card', 'view-cross', 'view-skewt', 'drawer-open');
   }
 }

--- a/web/ts/visualization/airport-profile-panel.ts
+++ b/web/ts/visualization/airport-profile-panel.ts
@@ -1,18 +1,16 @@
-/** Airport profile panel — right-click an airport on /maps.html to inspect
- *  its vertical conditions (cross-section + Skew-T) for a 4-hour window.
+/** Airport profile panel — click (or tap) an airport on /maps.html to
+ *  inspect it. Defaults to the summary Card (rendered synchronously from the
+ *  map's forecast data); the cross-section + Skew-T are behind the toggle and
+ *  fetched on intent (dwell / pointer-enter) via an SSE stream.
  *
  *  Renders into a host element that the maps page sizes via CSS. The panel
- *  owns its own SSE stream lifecycle; the only inputs from the host are
- *  airport coords + selected (day, hour, model).
+ *  owns its own SSE stream lifecycle; the inputs from the host are the
+ *  airport summary (for the card) + selected (day, hour, model).
  *
  *  View modes (segmented toggle, persisted to localStorage):
- *    'both'  — cross-section on top, Skew-T below (default)
+ *    'card'  — summary card, no network (default)
  *    'cross' — cross-section only
  *    'skewt' — Skew-T only
- *
- *  The issue calls out "stacked-views crowding (likely)" as something to
- *  revisit visually; the toggle is in place from day one so the follow-up
- *  is "change the default", not a refactor.
  */
 
 import { CrossSectionRenderer } from './cross-section/renderer';
@@ -268,9 +266,14 @@ export class AirportProfilePanel {
       // if the dwell timer hasn't already fired.
       if (v === 'cross' || v === 'skewt') this.ensureStream();
       this.applyViewMode();
-      // Drawer contents depend on viewMode; re-render if open so a
-      // section that just became visible shows its controls.
-      if (this.drawerOpen) this.renderDrawer();
+      // Card view has no layer/overlay controls (the gear is hidden), so
+      // close the drawer instead of leaving orphaned Cross/Skew-T sections.
+      // For cross/skewt, re-render so the just-shown section's controls appear.
+      if (v === 'card') {
+        if (this.drawerOpen) this.toggleDrawer();
+      } else if (this.drawerOpen) {
+        this.renderDrawer();
+      }
     });
     this.settingsBtn.addEventListener('click', () => this.toggleDrawer());
 
@@ -397,6 +400,14 @@ export class AirportProfilePanel {
       clearTimeout(this.prefetchTimer);
       this.prefetchTimer = null;
     }
+  }
+
+  /** Replace the card's summary and re-render just the card — used when the
+   *  map's model/consensus mode changes (the card's consensus column follows
+   *  it), without disturbing the cross-section stream. */
+  updateSummary(summary: AirportSummaryInput): void {
+    this.summary = summary;
+    this.renderCard();
   }
 
   /** Render the summary card from the host-provided snapshot summary. */
@@ -599,8 +610,10 @@ export class AirportProfilePanel {
   }
 
   private renderDrawer(): void {
-    const showCross = this.viewMode !== 'skewt';
-    const showSkewT = this.viewMode !== 'cross';
+    // Exact match — 'card' shows neither section (the drawer isn't reachable
+    // in card view; this is a guard against orphaned controls if it were).
+    const showCross = this.viewMode === 'cross';
+    const showSkewT = this.viewMode === 'skewt';
 
     // Build section shells; populate each with the appropriate
     // sub-control via the dedicated render helpers.

--- a/web/ts/visualization/airport-summary-card.ts
+++ b/web/ts/visualization/airport-summary-card.ts
@@ -1,0 +1,267 @@
+/** Airport summary card — the default view of the airport panel on the
+ *  forecast map (/maps.html).
+ *
+ *  Pure client-side render from the `ForecastAirport` that the map already
+ *  holds (`forecastData.airports`), so it appears instantly on click with
+ *  no network round-trip. It surfaces every metric the color dropdown can
+ *  show, for every model at once, plus the consensus — the one view the
+ *  map itself can't give you (the map colors a single metric at a time).
+ *
+ *  Structure, top-to-bottom by GA go/no-go priority:
+ *    1. Verdict: consensus flight-category badge + model-agreement chip
+ *    2. Alternate required (FAA/EASA)
+ *    3. Metric × model matrix (category, ceiling, vis, wind, xwind,
+ *       headwind, convective, CAPE, cloud, temp), cells colored via the
+ *       shared scales so they read identically to the markers. Rows where
+ *       the models diverge are flagged.
+ *
+ *  Colors/formatting come from `weather-map-format.ts` (shared with the
+ *  marker layer) — no duplicated thresholds.
+ */
+
+import type { ForecastAirport, ModelForecast } from '../adapters/maps-adapter';
+import { type ConsensusMode } from './weather-map-consensus';
+import {
+  type ForecastMetric, METRIC_LABEL, CAT_COLORS, AGREEMENT_COLORS,
+  getForecastColor, getConsensus, getAgreementForMetric, formatMetricValue,
+  altLabel, aggAltRequired,
+} from './weather-map-format';
+
+/** Model columns, fixed order. Only models present on the airport render. */
+const MODELS = ['gfs', 'icon', 'ecmwf'] as const;
+
+/** Matrix rows, top-to-bottom by decision priority. Flight category leads
+ *  (per-model category split is the single most useful comparison); the
+ *  rest follow what actually drives the category, then wind, then hazards.
+ *  `unit` is shown once in the row label so the cells stay narrow enough
+ *  for the side panel (units repeated per cell overflowed a 4-model row). */
+interface MatrixRow { metric: ForecastMetric; unit?: string; }
+const MATRIX_ROWS: MatrixRow[] = [
+  { metric: 'flight_category' },
+  { metric: 'ceiling_ft', unit: 'ft' },
+  { metric: 'visibility_m' },
+  { metric: 'wind_speed_kt', unit: 'kt' },
+  { metric: 'crosswind_kt', unit: 'kt' },
+  { metric: 'headwind_kt', unit: 'kt' },
+  { metric: 'convective_risk' },
+  { metric: 'cape_jkg', unit: 'J/kg' },
+  { metric: 'cloud_cover_pct' },
+];
+
+/** Compact per-cell value for the narrow matrix: units live in the row
+ *  label (see MATRIX_ROWS) and the best-runway id in the row label too, so
+ *  cells carry only the number (+ gust in parens). Falls back to the shared
+ *  formatter for region-aware fields (visibility). */
+function compactCell(data: { [k: string]: any }, metric: ForecastMetric): string {
+  switch (metric) {
+    case 'flight_category':
+      return data.flight_category ?? '—';
+    case 'ceiling_ft': {
+      const v = data.ceiling_ft;
+      if (v == null) return '—';
+      return v >= 10000 ? 'CAVOK' : String(Math.round(v));
+    }
+    case 'visibility_m':
+      return formatMetricValue(data, 'visibility_m');
+    case 'wind_speed_kt': {
+      const s = data.wind_speed_kt;
+      if (s == null) return '—';
+      const dir = data.wind_dir_deg != null ? `${Math.round(data.wind_dir_deg)}/` : '';
+      const g = data.wind_gust_kt ? `G${Math.round(data.wind_gust_kt)}` : '';
+      return `${dir}${Math.round(s)}${g}`;
+    }
+    case 'crosswind_kt':
+    case 'headwind_kt': {
+      const v = data[metric];
+      if (v == null) return '—';
+      const gust = metric === 'crosswind_kt' ? data.gust_crosswind_kt : data.gust_headwind_kt;
+      const g = gust != null ? ` (${Math.round(gust)})` : '';
+      return `${Math.round(v)}${g}`;
+    }
+    case 'cape_jkg':
+      return data.cape_jkg != null ? String(Math.round(data.cape_jkg)) : '—';
+    case 'convective_risk':
+      return data.convective_risk || 'none';
+    case 'cloud_cover_pct':
+      return data.cloud_cover_pct != null ? `${Math.round(data.cloud_cover_pct)}%` : '—';
+    default:
+      return formatMetricValue(data, metric);
+  }
+}
+
+export interface SummaryCardOptions {
+  airport: ForecastAirport;
+  /** Which consensus column to show. Mirrors the map's mode when it's a
+   *  consensus mode; falls back to 'worst' when an individual model is
+   *  selected on the map. */
+  consensusMode: ConsensusMode;
+  /** Valid time of the forecast sample (from the map's day/hour). */
+  validTime: Date;
+  /** Per-model init times, if known, for the freshness footnote. */
+  modelInitTimes?: Record<string, string>;
+  /** Fired when the user clicks a metric row — the host switches the map's
+   *  color dropdown to that metric so the card and map reinforce each
+   *  other. */
+  onMetricSelect?: (metric: ForecastMetric) => void;
+}
+
+function esc(s: string): string {
+  const d = document.createElement('div');
+  d.textContent = s;
+  return d.innerHTML;
+}
+
+/** Pick black or white text for readability over an arbitrary cell color.
+ *  Accepts #rgb / #rrggbb / rgb(r,g,b). Falls back to dark text. */
+function textOn(bg: string): string {
+  let r = 0, g = 0, b = 0;
+  const hex = bg.trim();
+  if (hex.startsWith('#')) {
+    const h = hex.slice(1);
+    if (h.length === 3) {
+      r = parseInt(h[0] + h[0], 16); g = parseInt(h[1] + h[1], 16); b = parseInt(h[2] + h[2], 16);
+    } else if (h.length === 6) {
+      r = parseInt(h.slice(0, 2), 16); g = parseInt(h.slice(2, 4), 16); b = parseInt(h.slice(4, 6), 16);
+    }
+  } else {
+    const m = hex.match(/rgb\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)/i);
+    if (m) { r = +m[1]; g = +m[2]; b = +m[3]; }
+  }
+  // Perceived luminance (sRGB weights). Bright cells → dark text.
+  const lum = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+  return lum > 0.6 ? '#111' : '#fff';
+}
+
+/** "Mon 14:00Z" from a UTC instant. */
+function formatValidTime(d: Date): string {
+  const day = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'][d.getUTCDay()];
+  const hh = String(d.getUTCHours()).padStart(2, '0');
+  const mm = String(d.getUTCMinutes()).padStart(2, '0');
+  return `${day} ${hh}:${mm}Z`;
+}
+
+/** "GFS 06Z · ICON 03Z · ECMWF 00Z" from init-time ISO strings. */
+function formatInitTimes(init: Record<string, string> | undefined, present: string[]): string {
+  if (!init) return '';
+  const parts: string[] = [];
+  for (const m of present) {
+    const iso = init[m];
+    if (!iso) continue;
+    const hh = String(new Date(iso).getUTCHours()).padStart(2, '0');
+    parts.push(`${m.toUpperCase()} ${hh}Z`);
+  }
+  return parts.length ? `Init: ${parts.join(' · ')}` : '';
+}
+
+/** Map a per-metric agreement bucket to a short label + dot color. */
+function agreementChip(bucket: string | null): { label: string; color: string } {
+  switch (bucket) {
+    case 'divergent': return { label: 'Models split', color: AGREEMENT_COLORS.divergent };
+    case 'mixed': return { label: 'Some disagreement', color: AGREEMENT_COLORS.mixed };
+    case 'consistent': return { label: 'Models agree', color: AGREEMENT_COLORS.consistent };
+    default: return { label: '', color: '#888' };
+  }
+}
+
+export function renderAirportSummaryCard(host: HTMLElement, opts: SummaryCardOptions): void {
+  const { airport, consensusMode, validTime, modelInitTimes, onMetricSelect } = opts;
+  const present = MODELS.filter((m) => airport.models[m]);
+  const consensus = getConsensus(airport, consensusMode);
+  const modeLabel = consensusMode === 'worst' ? 'Worst' : 'Majority';
+
+  // --- Verdict header ---
+  const catColor = CAT_COLORS[consensus.flight_category] || '#888';
+  const overallAgr = agreementChip(getAgreementForMetric(consensus, 'flight_category'));
+  const alt = aggAltRequired(airport, consensusMode);
+
+  let html = '<div class="ap-card">';
+
+  html += '<div class="ap-card-verdict">';
+  html += `<span class="ap-card-cat" style="background:${catColor};color:${textOn(catColor)}">`
+    + `${esc(consensus.flight_category)}</span>`;
+  html += '<div class="ap-card-verdict-meta">';
+  html += `<div class="ap-card-icao">${esc(airport.icao)}</div>`;
+  html += `<div class="ap-card-validtime">${esc(formatValidTime(validTime))}</div>`;
+  html += '</div>';
+  if (overallAgr.label) {
+    html += `<span class="ap-card-agr" title="Model agreement on flight category">`
+      + `<span class="ap-card-agr-dot" style="background:${overallAgr.color}"></span>`
+      + `${esc(overallAgr.label)}</span>`;
+  }
+  html += '</div>';
+
+  // --- Alternate required ---
+  html += '<div class="ap-card-alt">';
+  html += '<span class="ap-card-alt-label">Alternate required</span>';
+  const altText = alt ? altLabel(alt) : '—';
+  const altClass = alt && (alt.faa || alt.easa) ? 'is-required' : 'is-none';
+  html += `<span class="ap-card-alt-val ${altClass}">${esc(altText)}</span>`;
+  html += `<span class="ap-card-alt-mode">${esc(modeLabel)}</span>`;
+  html += '</div>';
+
+  // --- Metric × model matrix ---
+  // Best runway is a per-model field but is near-always the same across
+  // models; show it once on the crosswind/headwind row labels.
+  const bestRwy = present.map((m) => airport.models[m]?.best_runway_id).find((r) => r) ?? null;
+
+  html += '<div class="ap-card-matrix-wrap"><table class="ap-card-matrix"><thead><tr>';
+  html += '<th class="ap-card-metric-col"></th>';
+  for (const m of present) html += `<th>${esc(m.toUpperCase())}</th>`;
+  html += `<th class="ap-card-consensus-col" title="${esc(modeLabel)} consensus">${esc(modeLabel)}</th>`;
+  html += '</tr></thead><tbody>';
+
+  for (const row of MATRIX_ROWS) {
+    const metric = row.metric;
+    const diverges = getAgreementForMetric(consensus, metric) === 'divergent';
+    const rowCls = `ap-card-row${diverges ? ' is-diverging' : ''}`;
+    const unitBits: string[] = [];
+    if (row.unit) unitBits.push(esc(row.unit));
+    if ((metric === 'crosswind_kt' || metric === 'headwind_kt') && bestRwy) unitBits.push(`RWY ${esc(bestRwy)}`);
+    const unitLabel = unitBits.length ? ` <span class="ap-card-unit">${unitBits.join(' · ')}</span>` : '';
+    html += `<tr class="${rowCls}" data-metric="${esc(metric)}" tabindex="0" role="button" `
+      + `title="Color the map by ${esc(METRIC_LABEL[metric].toLowerCase())}">`;
+    html += `<td class="ap-card-metric-col">${esc(METRIC_LABEL[metric])}${unitLabel}`
+      + `${diverges ? '<span class="ap-card-warn" title="Models disagree">⚠</span>' : ''}</td>`;
+    for (const m of present) {
+      const bg = getForecastColor(airport, metric, m);
+      const val = compactCell(airport.models[m] as ModelForecast, metric);
+      html += `<td style="background:${bg};color:${textOn(bg)}">${esc(val)}</td>`;
+    }
+    // Consensus cell
+    const cbg = getForecastColor(airport, metric, consensusMode);
+    const cval = compactCell(consensus as unknown as Record<string, any>, metric);
+    html += `<td class="ap-card-consensus-col" style="background:${cbg};color:${textOn(cbg)}">${esc(cval)}</td>`;
+    html += '</tr>';
+  }
+
+  // Temperature row (not a colored map metric — plain per-model values).
+  const temps = present.map((m) => airport.models[m]?.temperature_c);
+  if (temps.some((t) => t != null)) {
+    html += '<tr class="ap-card-row ap-card-row-plain"><td class="ap-card-metric-col">Temp</td>';
+    for (let i = 0; i < present.length; i++) {
+      const t = temps[i];
+      html += `<td>${t != null ? esc(`${Math.round(t)}°C`) : '—'}</td>`;
+    }
+    html += '<td class="ap-card-consensus-col">—</td></tr>';
+  }
+
+  html += '</tbody></table></div>';
+
+  const initLine = formatInitTimes(modelInitTimes, present);
+  if (initLine) html += `<div class="ap-card-footnote">${esc(initLine)}</div>`;
+
+  html += '</div>';
+  host.innerHTML = html;
+
+  // Row click / keyboard → switch the map's colored metric.
+  if (onMetricSelect) {
+    host.querySelectorAll<HTMLElement>('.ap-card-row[data-metric]').forEach((row) => {
+      const metric = row.getAttribute('data-metric') as ForecastMetric | null;
+      if (!metric) return;
+      row.addEventListener('click', () => onMetricSelect(metric));
+      row.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onMetricSelect(metric); }
+      });
+    });
+  }
+}

--- a/web/ts/visualization/weather-map-format.ts
+++ b/web/ts/visualization/weather-map-format.ts
@@ -1,0 +1,243 @@
+/** Shared color scales + value formatting for the forecast overview map.
+ *
+ * Extracted from weather-map.ts so both the Leaflet marker layer and the
+ * airport summary card color/format identical values from the same source
+ * of truth (no duplicated thresholds). weather-map.ts re-exports
+ * `ForecastMetric` for existing importers.
+ */
+
+import type {
+  ForecastAirport, ConsensusForecast, AltRequired,
+} from '../adapters/maps-adapter';
+import { formatVisibility, formatHeading } from '../units';
+import {
+  isConsensusMode, computeConsensus, ordinalConsensus, type ConsensusMode,
+} from './weather-map-consensus';
+
+// --- Color scales ---
+
+export const CAT_COLORS: Record<string, string> = {
+  VFR: '#22c55e', MVFR: '#3b82f6', IFR: '#ef4444', LIFR: '#a855f7',
+};
+
+export const RISK_COLORS: Record<string, string> = {
+  none: '#22c55e', marginal: '#eab308', low: '#facc15', moderate: '#f97316', high: '#ef4444', extreme: '#991b1b',
+};
+
+/** Border color per agreement bucket (consensus modes). Keys match the
+ *  values the server bakes into `consensus.agreement[field]`. */
+export const AGREEMENT_COLORS: Record<string, string> = {
+  consistent: '#22c55e', mixed: '#f97316', divergent: '#ef4444',
+};
+
+function windSpeedColor(kt: number): string {
+  if (kt < 10) return '#22c55e';
+  if (kt < 15) return '#84cc16';
+  if (kt < 20) return '#eab308';
+  if (kt < 25) return '#f97316';
+  if (kt < 35) return '#ef4444';
+  return '#991b1b';
+}
+
+function crosswindColor(kt: number): string {
+  if (kt < 5) return '#22c55e';
+  if (kt < 10) return '#84cc16';
+  if (kt < 15) return '#eab308';
+  if (kt < 20) return '#f97316';
+  if (kt < 25) return '#ef4444';
+  return '#991b1b';
+}
+
+function headwindColor(kt: number): string {
+  if (kt < 10) return '#22c55e';
+  if (kt < 15) return '#84cc16';
+  if (kt < 20) return '#eab308';
+  if (kt < 25) return '#f97316';
+  if (kt < 30) return '#ef4444';
+  return '#991b1b';
+}
+
+function ceilingColor(ft: number | null): string {
+  if (ft === null) return '#888';
+  if (ft < 500) return '#a855f7';  // LIFR
+  if (ft < 1000) return '#ef4444'; // IFR
+  if (ft < 3000) return '#3b82f6'; // MVFR
+  return '#22c55e';                 // VFR
+}
+
+function capeColor(jkg: number): string {
+  if (jkg < 100) return '#22c55e';
+  if (jkg < 500) return '#eab308';
+  if (jkg < 1000) return '#f97316';
+  if (jkg < 2000) return '#ef4444';
+  return '#991b1b';
+}
+
+function visibilityColor(m: number): string {
+  const sm = m / 1609.34;
+  if (sm >= 5) return '#22c55e';   // VFR
+  if (sm >= 3) return '#3b82f6';   // MVFR
+  if (sm >= 1) return '#ef4444';   // IFR
+  return '#a855f7';                 // LIFR
+}
+
+export function cloudCoverColor(pct: number): string {
+  const g = Math.round(220 - (pct / 100) * 160);
+  return `rgb(${g},${g},${g + 10})`;
+}
+
+// --- Forecast metric extraction ---
+
+export type ForecastMetric = 'flight_category' | 'wind_speed_kt' | 'crosswind_kt' | 'headwind_kt' | 'ceiling_ft' | 'cape_jkg' | 'convective_risk' | 'cloud_cover_pct' | 'visibility_m' | 'alternate_needed';
+
+// --- Alternate-required (FAA/EASA) helpers (#249) ---
+
+// Alternate-required treated as an ordinal (no < yes=worse) so the Worst/Majority
+// toggle aggregates it the same way as flight category.
+const ALT_ORDER: Record<string, number> = { no: 0, yes: 1 };
+
+/** Per-model/aggregate label: None / EASA / FAA / FAA+EASA. */
+export function altLabel(f: AltRequired | undefined): string {
+  if (!f) return '—';
+  if (f.faa && f.easa) return 'FAA+EASA';
+  if (f.easa) return 'EASA';
+  if (f.faa) return 'FAA';
+  return 'None';
+}
+
+/** Aggregate per-model flags using the active consensus mode (worst = any model;
+ * majority = modal with worst tiebreak), matching the flight-category toggle. */
+export function aggAltRequired(airport: ForecastAirport, mode: ConsensusMode): AltRequired | undefined {
+  const flags = Object.values(airport.models)
+    .map((m) => m?.alt_required)
+    .filter((f): f is AltRequired => !!f);
+  if (!flags.length) return undefined;
+  const reg = (pick: (f: AltRequired) => boolean): boolean =>
+    ordinalConsensus(flags.map((f) => (pick(f) ? 'yes' : 'no')), ALT_ORDER, mode) === 'yes';
+  return { faa: reg((f) => f.faa), easa: reg((f) => f.easa) };
+}
+
+export function altNeededColor(airport: ForecastAirport, model: string): string {
+  const f = isConsensusMode(model) ? aggAltRequired(airport, model) : airport.models[model]?.alt_required;
+  if (!f) return '#888';
+  const n = (f.faa ? 1 : 0) + (f.easa ? 1 : 0);
+  return n === 0 ? '#22c55e' : n === 1 ? '#eab308' : '#ef4444'; // green / amber / red
+}
+
+export function getConsensus(airport: ForecastAirport, mode: ConsensusMode): ConsensusForecast {
+  return computeConsensus(airport, mode);
+}
+
+export function getForecastColor(airport: ForecastAirport, metric: ForecastMetric, model: string): string {
+  const data = isConsensusMode(model) ? getConsensus(airport, model) : airport.models[model];
+  if (!data) return '#888';
+
+  switch (metric) {
+    case 'flight_category':
+      return CAT_COLORS[data.flight_category] || '#888';
+    case 'wind_speed_kt':
+      return windSpeedColor(data.wind_speed_kt ?? 0);
+    case 'crosswind_kt':
+      return data.crosswind_kt != null ? crosswindColor(data.crosswind_kt) : '#888';
+    case 'headwind_kt':
+      return data.headwind_kt != null ? headwindColor(data.headwind_kt) : '#888';
+    case 'ceiling_ft':
+      return ceilingColor(data.ceiling_ft ?? null);
+    case 'cape_jkg':
+      return capeColor(data.cape_jkg ?? 0);
+    case 'convective_risk':
+      return RISK_COLORS[data.convective_risk || 'none'] || '#888';
+    case 'visibility_m':
+      return visibilityColor(data.visibility_m ?? 99999);
+    case 'cloud_cover_pct':
+      return cloudCoverColor(data.cloud_cover_pct ?? 0);
+    case 'alternate_needed':
+      return altNeededColor(airport, model);
+    default:
+      return '#888';
+  }
+}
+
+function fmtCeiling(ft: number | null | undefined): string {
+  if (ft == null) return '';
+  if (ft >= 10000) return 'CAVOK';
+  return `${Math.round(ft)} ft`;
+}
+
+function fmtVisibility(m: number | null | undefined): string {
+  return formatVisibility(m);
+}
+
+function fmtWind(speed: number | null | undefined, dir: number | null | undefined, gust: number | null | undefined): string {
+  if (speed == null) return '';
+  const dirStr = dir != null ? `${formatHeading(dir)}/` : '';
+  const gustStr = gust ? `G${Math.round(gust)}` : '';
+  return `${dirStr}${Math.round(speed)}${gustStr} kt`;
+}
+
+export const METRIC_LABEL: Record<ForecastMetric, string> = {
+  flight_category: 'Category',
+  wind_speed_kt: 'Wind',
+  crosswind_kt: 'Xwind',
+  headwind_kt: 'Headwind',
+  ceiling_ft: 'Ceiling',
+  cape_jkg: 'CAPE',
+  convective_risk: 'Convective',
+  visibility_m: 'Visibility',
+  cloud_cover_pct: 'Cloud cover',
+  alternate_needed: 'Alternate required?',
+};
+
+/** Format the value of a metric (no label) for tooltip / card display. */
+export function formatMetricValue(data: { [key: string]: any }, metric: ForecastMetric): string {
+  switch (metric) {
+    case 'flight_category':
+      return data.flight_category ?? '—';
+    case 'wind_speed_kt':
+      return data.wind_speed_kt != null ? fmtWind(data.wind_speed_kt, data.wind_dir_deg, data.wind_gust_kt) : '—';
+    case 'crosswind_kt':
+    case 'headwind_kt': {
+      const v = data[metric];
+      if (v == null) return '—';
+      const gust = metric === 'crosswind_kt' ? data.gust_crosswind_kt : data.gust_headwind_kt;
+      const gustStr = gust != null ? ` (G${Math.round(gust)})` : '';
+      const rwyStr = data.best_runway_id ? ` RWY ${data.best_runway_id}` : '';
+      return `${Math.round(v)}${gustStr} kt${rwyStr}`;
+    }
+    case 'ceiling_ft':
+      return data.ceiling_ft != null ? fmtCeiling(data.ceiling_ft) : '—';
+    case 'visibility_m':
+      return data.visibility_m != null ? fmtVisibility(data.visibility_m) : '—';
+    case 'cape_jkg':
+      return data.cape_jkg != null ? `${Math.round(data.cape_jkg)} J/kg` : '—';
+    case 'convective_risk':
+      return data.convective_risk || 'none';
+    case 'cloud_cover_pct':
+      return data.cloud_cover_pct != null ? `${Math.round(data.cloud_cover_pct)}%` : '—';
+    case 'alternate_needed':
+      return altLabel(data.alt_required);
+    default:
+      return '—';
+  }
+}
+
+/** Get the agreement key in the consensus dict for a given metric. */
+function metricAgreementKey(metric: ForecastMetric): string {
+  switch (metric) {
+    case 'flight_category': return 'flight_category';
+    case 'wind_speed_kt': return 'wind_speed_kt';
+    case 'crosswind_kt': return 'wind_speed_kt';  // closest proxy
+    case 'headwind_kt': return 'wind_speed_kt';   // closest proxy
+    case 'ceiling_ft': return 'ceiling_ft';
+    case 'cape_jkg': return 'cape_jkg';
+    case 'convective_risk': return 'cape_jkg';  // closest proxy
+    case 'visibility_m': return 'visibility_m';
+    case 'cloud_cover_pct': return 'cloud_cover_pct';
+    default: return 'flight_category';
+  }
+}
+
+export function getAgreementForMetric(consensus: ConsensusForecast, metric: ForecastMetric): string | null {
+  const key = metricAgreementKey(metric);
+  return consensus.agreement[key] ?? null;
+}

--- a/web/ts/visualization/weather-map.ts
+++ b/web/ts/visualization/weather-map.ts
@@ -2,9 +2,19 @@
 
 import * as L from 'leaflet';
 import type {
-  ForecastAirport, ForecastMapResponse, ModelForecast, ConsensusForecast, AltRequired,
+  ForecastAirport, ForecastMapResponse,
 } from '../adapters/maps-adapter';
-import { formatVisibility, getUnitsRegion, formatHeading } from '../units';
+import { getUnitsRegion } from '../units';
+import { isConsensusMode, type ConsensusMode } from './weather-map-consensus';
+import {
+  getForecastColor, getConsensus, getAgreementForMetric, formatMetricValue,
+  METRIC_LABEL, altLabel, aggAltRequired, AGREEMENT_COLORS,
+  CAT_COLORS, RISK_COLORS, cloudCoverColor,
+  type ForecastMetric,
+} from './weather-map-format';
+
+// Re-exported so existing importers (maps-main.ts) keep resolving the type here.
+export type { ForecastMetric };
 
 const LIGHT_TILES = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
 const DARK_TILES = 'https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png';
@@ -14,109 +24,7 @@ function isDark(): boolean {
   return document.documentElement.dataset.theme === 'dark';
 }
 
-// --- Color scales ---
-
-const CAT_COLORS: Record<string, string> = {
-  VFR: '#22c55e', MVFR: '#3b82f6', IFR: '#ef4444', LIFR: '#a855f7',
-};
-
-const RISK_COLORS: Record<string, string> = {
-  none: '#22c55e', marginal: '#eab308', low: '#facc15', moderate: '#f97316', high: '#ef4444', extreme: '#991b1b',
-};
-
-const AGREEMENT_COLORS: Record<string, string> = {
-  consistent: '#22c55e', mixed: '#f97316', divergent: '#ef4444',
-};
-
-function windSpeedColor(kt: number): string {
-  if (kt < 10) return '#22c55e';
-  if (kt < 15) return '#84cc16';
-  if (kt < 20) return '#eab308';
-  if (kt < 25) return '#f97316';
-  if (kt < 35) return '#ef4444';
-  return '#991b1b';
-}
-
-function crosswindColor(kt: number): string {
-  if (kt < 5) return '#22c55e';
-  if (kt < 10) return '#84cc16';
-  if (kt < 15) return '#eab308';
-  if (kt < 20) return '#f97316';
-  if (kt < 25) return '#ef4444';
-  return '#991b1b';
-}
-
-function headwindColor(kt: number): string {
-  if (kt < 10) return '#22c55e';
-  if (kt < 15) return '#84cc16';
-  if (kt < 20) return '#eab308';
-  if (kt < 25) return '#f97316';
-  if (kt < 30) return '#ef4444';
-  return '#991b1b';
-}
-
-function ceilingColor(ft: number | null): string {
-  if (ft === null) return '#888';
-  if (ft < 500) return '#a855f7';  // LIFR
-  if (ft < 1000) return '#ef4444'; // IFR
-  if (ft < 3000) return '#3b82f6'; // MVFR
-  return '#22c55e';                 // VFR
-}
-
-function capeColor(jkg: number): string {
-  if (jkg < 100) return '#22c55e';
-  if (jkg < 500) return '#eab308';
-  if (jkg < 1000) return '#f97316';
-  if (jkg < 2000) return '#ef4444';
-  return '#991b1b';
-}
-
-function visibilityColor(m: number): string {
-  const sm = m / 1609.34;
-  if (sm >= 5) return '#22c55e';   // VFR
-  if (sm >= 3) return '#3b82f6';   // MVFR
-  if (sm >= 1) return '#ef4444';   // IFR
-  return '#a855f7';                 // LIFR
-}
-
-function cloudCoverColor(pct: number): string {
-  const g = Math.round(220 - (pct / 100) * 160);
-  return `rgb(${g},${g},${g + 10})`;
-}
-
-// --- Forecast metric extraction ---
-
-export type ForecastMetric = 'flight_category' | 'wind_speed_kt' | 'crosswind_kt' | 'headwind_kt' | 'ceiling_ft' | 'cape_jkg' | 'convective_risk' | 'cloud_cover_pct' | 'visibility_m' | 'alternate_needed';
-
-// --- Alternate-required (FAA/EASA) helpers (#249) ---
-
-/** Per-model/aggregate label: None / EASA / FAA / FAA+EASA. */
-function altLabel(f: AltRequired | undefined): string {
-  if (!f) return '—';
-  if (f.faa && f.easa) return 'FAA+EASA';
-  if (f.easa) return 'EASA';
-  if (f.faa) return 'FAA';
-  return 'None';
-}
-
-/** Aggregate per-model flags using the active consensus mode (worst = any model;
- * majority = modal with worst tiebreak), matching the flight-category toggle. */
-function aggAltRequired(airport: ForecastAirport, mode: ConsensusMode): AltRequired | undefined {
-  const flags = Object.values(airport.models)
-    .map((m) => m?.alt_required)
-    .filter((f): f is AltRequired => !!f);
-  if (!flags.length) return undefined;
-  const reg = (pick: (f: AltRequired) => boolean): boolean =>
-    ordinalConsensus(flags.map((f) => (pick(f) ? 'yes' : 'no')), ALT_ORDER, mode) === 'yes';
-  return { faa: reg((f) => f.faa), easa: reg((f) => f.easa) };
-}
-
-function altNeededColor(airport: ForecastAirport, model: string): string {
-  const f = isConsensusMode(model) ? aggAltRequired(airport, model) : airport.models[model]?.alt_required;
-  if (!f) return '#888';
-  const n = (f.faa ? 1 : 0) + (f.easa ? 1 : 0);
-  return n === 0 ? '#22c55e' : n === 1 ? '#eab308' : '#ef4444'; // green / amber / red
-}
+// --- Alternate-required (FAA/EASA) tooltip ---
 
 function altNeededTooltip(airport: ForecastAirport, model: string): string {
   const lines: string[] = [`<b>${airport.icao}</b>`];
@@ -129,56 +37,6 @@ function altNeededTooltip(airport: ForecastAirport, model: string): string {
     lines.push(`Alternate required: <b>${altLabel(airport.models[model]?.alt_required)}</b>`);
   }
   return lines.join('<br>');
-}
-
-import { isConsensusMode, computeConsensus, ordinalConsensus, type ConsensusMode } from './weather-map-consensus';
-
-// Alternate-required treated as an ordinal (no < yes=worse) so the Worst/Majority
-// toggle aggregates it the same way as flight category.
-const ALT_ORDER: Record<string, number> = { no: 0, yes: 1 };
-
-function getConsensus(airport: ForecastAirport, mode: ConsensusMode): ConsensusForecast {
-  return computeConsensus(airport, mode);
-}
-
-function getForecastColor(airport: ForecastAirport, metric: ForecastMetric, model: string): string {
-  const data = isConsensusMode(model) ? getConsensus(airport, model) : airport.models[model];
-  if (!data) return '#888';
-
-  switch (metric) {
-    case 'flight_category':
-      return CAT_COLORS[data.flight_category] || '#888';
-    case 'wind_speed_kt':
-      return windSpeedColor(data.wind_speed_kt ?? 0);
-    case 'crosswind_kt':
-      return data.crosswind_kt != null ? crosswindColor(data.crosswind_kt) : '#888';
-    case 'headwind_kt':
-      return data.headwind_kt != null ? headwindColor(data.headwind_kt) : '#888';
-    case 'ceiling_ft':
-      return ceilingColor(data.ceiling_ft ?? null);
-    case 'cape_jkg':
-      return capeColor(data.cape_jkg ?? 0);
-    case 'convective_risk':
-      return RISK_COLORS[data.convective_risk || 'none'] || '#888';
-    case 'visibility_m':
-      return visibilityColor(data.visibility_m ?? 99999);
-    case 'cloud_cover_pct':
-      return cloudCoverColor(data.cloud_cover_pct ?? 0);
-    case 'alternate_needed':
-      return altNeededColor(airport, model);
-    default:
-      return '#888';
-  }
-}
-
-function fmtCeiling(ft: number | null | undefined): string {
-  if (ft == null) return '';
-  if (ft >= 10000) return 'CAVOK';
-  return `${Math.round(ft)} ft`;
-}
-
-function fmtVisibility(m: number | null | undefined): string {
-  return formatVisibility(m);
 }
 
 /** Region-aware legend rows for the visibility metric (flight-category bands). */
@@ -199,80 +57,6 @@ function visibilityLegendItems(): Array<{ color: string; label: string }> {
     { color: '#ef4444', label: '1.6-4.8 km (IFR)' },
     { color: '#a855f7', label: '< 1.6 km (LIFR)' },
   ];
-}
-
-function fmtWind(speed: number | null | undefined, dir: number | null | undefined, gust: number | null | undefined): string {
-  if (speed == null) return '';
-  const dirStr = dir != null ? `${formatHeading(dir)}/` : '';
-  const gustStr = gust ? `G${Math.round(gust)}` : '';
-  return `${dirStr}${Math.round(speed)}${gustStr} kt`;
-}
-
-const METRIC_LABEL: Record<ForecastMetric, string> = {
-  flight_category: 'Category',
-  wind_speed_kt: 'Wind',
-  crosswind_kt: 'Xwind',
-  headwind_kt: 'Headwind',
-  ceiling_ft: 'Ceiling',
-  cape_jkg: 'CAPE',
-  convective_risk: 'Convective',
-  visibility_m: 'Visibility',
-  cloud_cover_pct: 'Cloud cover',
-  alternate_needed: 'Alternate required?',
-};
-
-/** Format the value of a metric (no label) for tooltip display. */
-function formatMetricValue(data: { [key: string]: any }, metric: ForecastMetric): string {
-  switch (metric) {
-    case 'flight_category':
-      return data.flight_category ?? '—';
-    case 'wind_speed_kt':
-      return data.wind_speed_kt != null ? fmtWind(data.wind_speed_kt, data.wind_dir_deg, data.wind_gust_kt) : '—';
-    case 'crosswind_kt':
-    case 'headwind_kt': {
-      const v = data[metric];
-      if (v == null) return '—';
-      const gust = metric === 'crosswind_kt' ? data.gust_crosswind_kt : data.gust_headwind_kt;
-      const gustStr = gust != null ? ` (G${Math.round(gust)})` : '';
-      const rwyStr = data.best_runway_id ? ` RWY ${data.best_runway_id}` : '';
-      return `${Math.round(v)}${gustStr} kt${rwyStr}`;
-    }
-    case 'ceiling_ft':
-      return data.ceiling_ft != null ? fmtCeiling(data.ceiling_ft) : '—';
-    case 'visibility_m':
-      return data.visibility_m != null ? fmtVisibility(data.visibility_m) : '—';
-    case 'cape_jkg':
-      return data.cape_jkg != null ? `${Math.round(data.cape_jkg)} J/kg` : '—';
-    case 'convective_risk':
-      return data.convective_risk || 'none';
-    case 'cloud_cover_pct':
-      return data.cloud_cover_pct != null ? `${Math.round(data.cloud_cover_pct)}%` : '—';
-    case 'alternate_needed':
-      return altLabel(data.alt_required);
-    default:
-      return '—';
-  }
-}
-
-/** Get the agreement key in the consensus dict for a given metric. */
-function metricAgreementKey(metric: ForecastMetric): string {
-  switch (metric) {
-    case 'flight_category': return 'flight_category';
-    case 'wind_speed_kt': return 'wind_speed_kt';
-    case 'crosswind_kt': return 'wind_speed_kt';  // closest proxy
-    case 'headwind_kt': return 'wind_speed_kt';   // closest proxy
-    case 'ceiling_ft': return 'ceiling_ft';
-    case 'cape_jkg': return 'cape_jkg';
-    case 'convective_risk': return 'cape_jkg';  // closest proxy
-    case 'visibility_m': return 'visibility_m';
-    case 'cloud_cover_pct': return 'cloud_cover_pct';
-    default: return 'flight_category';
-  }
-}
-
-function getAgreementForMetric(consensus: ConsensusForecast, metric: ForecastMetric): string | null {
-  const key = metricAgreementKey(metric);
-  return consensus.agreement[key] ?? null;
 }
 
 function getForecastTooltip(airport: ForecastAirport, model: string, metric: ForecastMetric): string {
@@ -416,6 +200,7 @@ export class WeatherMap {
   private tileLayer: L.TileLayer | null = null;
   private zoomHandler: (() => void) | null = null;
   private contextHandler: AirportContextHandler | null = null;
+  private clickHandler: AirportContextHandler | null = null;
   private highlightedIcao: string | null = null;
   /** Marker registry. Stores the original style alongside the marker so
    *  `setHighlightedIcao(null)` can restore the exact pre-highlight
@@ -432,6 +217,13 @@ export class WeatherMap {
    *  The forecast tab uses this to open the airport-profile detail panel. */
   setAirportContextHandler(handler: AirportContextHandler | null): void {
     this.contextHandler = handler;
+  }
+
+  /** Register a callback fired when the user left-clicks (or taps) an
+   *  airport marker — the primary, touch-friendly way to open the
+   *  airport summary panel. Right-click stays wired as an alias. */
+  setAirportClickHandler(handler: AirportContextHandler | null): void {
+    this.clickHandler = handler;
   }
 
   /** Visually highlight one airport (typically the one currently shown
@@ -520,15 +312,25 @@ export class WeatherMap {
         color: border,
         weight: baseWeight,
         opacity: 1,
+        // Signal the marker is interactive (opens the summary panel).
+        className: 'wx-marker-clickable',
       });
 
       marker.bindTooltip(getForecastTooltip(apt, model, metric), { className: 'map-tooltip' });
-      // Right-click → open airport profile panel. Native contextmenu is
-      // suppressed so the browser menu doesn't fight Leaflet's event.
+      // Left-click / tap → open the airport summary panel. This is the
+      // primary, touch-friendly entry point (hover + right-click don't
+      // exist on touch devices).
+      marker.on('click', (e: L.LeafletMouseEvent) => {
+        L.DomEvent.stopPropagation(e.originalEvent);
+        this.clickHandler?.(apt.icao);
+      });
+      // Right-click → same panel, kept as a desktop alias. Native
+      // contextmenu is suppressed so the browser menu doesn't fight
+      // Leaflet's event.
       marker.on('contextmenu', (e: L.LeafletMouseEvent) => {
         L.DomEvent.preventDefault(e.originalEvent);
         L.DomEvent.stopPropagation(e.originalEvent);
-        this.contextHandler?.(apt.icao);
+        (this.clickHandler ?? this.contextHandler)?.(apt.icao);
       });
       marker.addTo(this.markersGroup);
       this.icaoToMarker.set(apt.icao, { marker, weight: baseWeight, color: border });


### PR DESCRIPTION
## What & why

On the forecast overview map, inspecting an airport required a **right-click** (unreachable on touch/iPad — no right-click, no hover tooltips) and immediately fired the slow per-request cross-section SSE. But a lot of the time the pilot just wants the numbers, which the client **already holds** in the map response (`ForecastAirport.models` carries every metric the color dropdown exposes, per model, plus a `consensus` with per-field agreement).

This surfaces that data instantly and defers the slow fetch:

- **Left-click / tap opens the panel** (right-click kept as a desktop alias) — touch-friendly.
- The panel defaults to a new **summary Card** rendered synchronously from data already in hand (zero network): a consensus flight-category verdict + model-agreement chip, the FAA/EASA alternate flags, and a **metric × model matrix** (all metrics × GFS/ICON/ECMWF + consensus). Cells are colored by the same scales as the markers; rows where the models diverge get a red rail + ⚠ so the eye lands on the uncertain forecasts. Clicking a metric row recolors the map by that metric.
- The cross-section / Skew-T SSE is **deferred and prefetched on intent** (~400 ms dwell or pointer-enter into the panel), or immediately when the user switches to a heavy view — so switching feels instant without spawning a compute on every glance.
- Shared color/format helpers were **extracted** from `weather-map.ts` into `weather-map-format.ts` so the card and markers stay in lockstep (no duplicated thresholds).
- View is deep-linked via `fc.apView` (`card|cross|skewt`); a one-time localStorage-key migration lands existing users on the card.

The toggle is now **Card | Cross-section | Skew-T** (the old stacked "Both" view is retired).

## Issue linkage

Closes #414

## Testing / verification

- `tsc --noEmit` clean on all touched files; `npm run build:maps` succeeds; full web unit suite green (500 tests).
- Verified the card in Chromium by bundling the component (its import subgraph is leaflet-free) with mock 3-model data and screenshotting at the panel's real 480 px width and 360 px minimum:
  - Correct worst-consensus verdict (IFR), "Models split" agreement chip, FAA+EASA alternate aggregation.
  - All metric rows in priority order; diverging rows (Category / Ceiling / Cloud) flagged.
  - Clicking a row fires `onMetricSelect` with the right metric.
  - No horizontal overflow of the panel at 480 px; the matrix scrolls internally at the 360 px minimum.
- Backend was not run (no venv/DB in this environment); change is front-end only (no server/API/iOS touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B4UemoyLJ8SpYy49oF7eKa

---
_Generated by [Claude Code](https://claude.ai/code/session_01B4UemoyLJ8SpYy49oF7eKa)_