### PR TITLE
Serve map-metrics catalog to iOS; bake consensus server-side (#419)

### DIFF
--- a/designs/forecast-page.md
+++ b/designs/forecast-page.md
@@ -16,21 +16,23 @@ Backend                                    Frontend
 api/maps.py                                maps.html (template)
 ├── GET /maps/forecast (day,hour only)     maps-main.ts (controller)
 │   → cache or map_queries.get_forecast_   ├── state mgmt (day/hour/model/metric)
-│     map_data() — per-model + worst       ├── 4 tabs: forecast/synoptic/
-│     consensus baked in                   │           climatology/stats
+│     map_data() — per-model + BOTH        ├── 4 tabs: forecast/synoptic/
+│     consensus blocks baked in            │           climatology/stats
 ├── GET /maps/forecast/days                └── data loading + client rerender
 │   → per day: which hours + which         adapters/maps-adapter.ts (API client)
 │     models have data (D+0..D+6)          ├── fetchForecastMap(day,hour)
-└── GET /maps/airport-weather              └── fetchAvailableDays()
-    → forecast+obs for specific ICAOs      visualization/weather-map.ts (Leaflet map)
-api/airport_profile.py                     ├── setForecastData()
-└── GET /maps/airport-profile (SSE)        └── weather-map-consensus.ts
-    → on-demand single-airport                  (client-side computeConsensus)
-      cross-section (panel)                visualization/airport-profile-panel.ts
+├── GET /maps/airport-weather             └── fetchAvailableDays()
+│   → forecast+obs for specific ICAOs      visualization/weather-map.ts (Leaflet map)
+├── GET /flights/frequent-airports        ├── setForecastData()
+│   → top-5 dep/dest from history (#419)   └── weather-map-format.ts
+api/help.py  GET /help/catalog                  (reads baked consensus + served
+└── serves map-metrics-catalog.json              map-metrics-catalog.json colours)
+    (colours/thresholds) for iOS          visualization/airport-profile-panel.ts
                                            visualization/synoptic-map.ts (Hewson)
 Cache layer:                               visualization/climatology-tab.ts
-  verification_cache table (JSON blobs)
-  ├── forecast_map:{day}:{hour}  (no mode — one entry per day/hour)
+  verification_cache table (JSON blobs)    (airport-profile SSE panel:
+  ├── forecast_map:{ver}:{day}:{hour}       api/airport_profile.py, see below)
+  │     (versioned; one entry per day/hour)
   └── staleness: source_max_time vs live MAX
 
 Data source:
@@ -48,7 +50,7 @@ The page hosts four tabs (`forecast`, `synoptic`, `climatology`, `stats`). Only 
 - **Controls**: Day (D-0 to D-6), hour (sample hours — five on the near days, three on D-6), model selector. Day and hour buttons are rendered from `/maps/forecast/days`, not hardcoded.
 - **Model modes**: Worst consensus, Majority consensus, or individual model (GFS/ICON/ECMWF)
 - **Agreement indicator**: Border color shows model divergence (good/moderate/poor) in consensus modes
-- **All mode/metric switches are client-side rerenders.** `/maps/forecast` returns per-model data for every airport plus a server pre-computed worst consensus; the frontend (`weather-map-consensus.ts::computeConsensus`) recomputes worst/majority itself, so changing model OR metric is a pure rerender. Only day/hour changes trigger an API call (different snapshot set)
+- **All mode/metric switches are client-side rerenders.** `/maps/forecast` returns per-model data for every airport plus **both** server pre-computed consensus blocks (`consensus` = worst, `consensus_majority`); the frontend just re-reads the payload and recolours (`weather-map-format.getConsensus`), so changing model OR metric is a pure rerender with no consensus math. Only day/hour changes trigger an API call (different snapshot set)
 
 ### Airport Profile Panel
 - Right-clicking a forecast marker opens a side panel (`airport-profile-panel.ts`) with a single-airport time-axis cross-section.
@@ -77,11 +79,11 @@ Pattern: any new control on the forecast tab that affects the rendered view shou
 
 ## Consensus Algorithm
 
-Consensus now lives in **two** places that must stay behaviourally aligned:
-- **Server**: `analysis/airport_consensus.py::consensus()` (re-exported into `map_queries.py` as `_consensus`/`_shared_consensus`). Used to bake a `consensus` field into every airport in the API response (worst mode).
-- **Client**: `web/ts/visualization/weather-map-consensus.ts::computeConsensus()`. Recomputes worst OR majority from per-model data on every rerender — this is what actually colors the markers, so the client rules are authoritative for the UI.
+Consensus is computed **only on the server** (`analysis/airport_consensus.py::consensus()`, re-exported into `map_queries.py` as `_consensus`/`_shared_consensus`). Both modes are baked into every airport in the API response — `consensus` (worst) **and** `consensus_majority` (majority) — so the clients carry zero consensus math and cannot drift (#419). The web reads whichever block matches the selected mode (`weather-map-format.getConsensus`); the retired `computeConsensus` client recompute is gone. iOS reads the same baked blocks.
 
-Rules (both implementations):
+The server output covers every field the markers/card read: `flight_category`, `convective_risk` (ordinal over all models), the numeric fields (`wind_speed_kt`, `ceiling_ft`, `cape_jkg`, `visibility_m`, `crosswind_kt`, `headwind_kt`, `cloud_cover_pct`), `wind_dir_deg` (circular mean), and per-field `agreement`. `tests/test_consensus_parity.py` (+ `tests/fixtures/consensus_vectors.json`) pins the server to the reference values the client used to compute, field by field.
+
+Rules:
 - **Worst mode**: Pick most restrictive flight category across models (VFR=0 < MVFR < IFR < LIFR=3)
 - **Majority mode**: Most common category; ties broken by worst severity
 - **Agreement scoring**: Uses `compare_models()` divergence on wind/ceiling/CAPE/visibility/cloud → good/moderate/poor
@@ -93,7 +95,7 @@ Rules (both implementations):
 
 Both map endpoints use a `verification_cache` table (see [metar-taf-accuracy.md](./metar-taf-accuracy.md)) to serve pre-computed JSON responses. Cache is rebuilt after each standalone verification cycle via `cache_builder.rebuild_all()`.
 
-**Forecast map**: One cache entry per `forecast_map:{day}:{hour}` (no mode dimension — the cached payload holds per-model data + baked worst consensus, and the client derives every model/majority view from it). Staleness checked against `MAX(AirportForecastSnapshotRow.fetched_at)`.
+**Forecast map**: One cache entry per `forecast_map:{version}:{day}:{hour}` (no mode dimension — the cached payload holds per-model data + both baked consensus blocks). The key is **version-segmented** (`FORECAST_MAP_CACHE_VERSION` / `forecast_map_cache_key`, currently `v2`): bump it whenever the baked payload shape changes so entries written by the old code never match (`is_stale()` only checks `fetched_at` + the UTC-date rule, not the shape) and the endpoint falls through to the live path instead of serving a stale shape. Staleness checked against `MAX(AirportForecastSnapshotRow.fetched_at)`.
 
 **Fallback**: If cache is stale or missing, the endpoint falls back to a live `get_forecast_map_data()` query transparently.
 
@@ -107,6 +109,8 @@ Both map endpoints use a `verification_cache` table (see [metar-taf-accuracy.md]
 5. Group by airport → per-model data + computed consensus
 
 ## Color Scales
+
+The colour ramps, thresholds, metric labels and legends are **served data**, not hardcoded in the client: `web/ts/data/map-metrics-catalog.json` is the single source of truth, imported directly by `weather-map-format.ts` (the web bundle keeps one copy) and served ETag-cacheable to iOS via `/api/help` (`maps` section, `api/help.py`). A threshold or colour change is a one-line JSON edit both clients pick up — the same weather can't show in two colours on two devices (#419, B2). The table below is the current content of that catalog.
 
 | Metric | Scale |
 |--------|-------|
@@ -126,7 +130,7 @@ Both map endpoints use a `verification_cache` table (see [metar-taf-accuracy.md]
 ## Gotchas
 
 - **The grid is not rectangular, and the UI is drawn from the data**: the horizon runs D+0..D+6 and is set by ECMWF (168h wall), not by the model that reaches furthest — a day only GFS can reach has nothing to cross-check it. ICON-EU's cloud-diag GRIB stops at 120h, which falls exactly on the D+4/D+5 boundary, so **D+5 and D+6 carry two models**; and ECMWF delivers only 6-hourly steps past 144h, where 09Z/15Z never land, so **D+6 carries three sample hours, not five**. `tasks/forecast_grid.py` is the single source of truth (`MAX_FORECAST_DAY`, `MAP_FORECAST_DAYS`, `sample_hours_for_day`) — the cycle, cache builder and API all read it. `fetchAvailableDays()` reports what each day actually holds, and the day/hour pickers are **rendered from that response**, not from markup; a model that can't reach the selected day is disabled with an explanation, so its absence never reads as agreement. Don't restate the horizon rules in the client. (#415)
-- **Consensus is client-side**: Switching worst/majority/individual-model is all a pure client rerender (`computeConsensus`); only day/hour hits the API. Don't reintroduce a per-mode server query or per-mode cache key
+- **Consensus is baked, switching is a pure client rerender**: both `consensus` (worst) and `consensus_majority` are baked into the one payload; switching worst/majority/individual-model just re-reads the payload and recolours — only day/hour hits the API. Don't reintroduce a client-side recompute, a per-mode server query, or a per-mode cache key
 - **Per-model-only metrics (client `computeConsensus`)**: `convective_risk` uses worst-across-models (ordinal max) in consensus mode; `cloud_cover_pct` worst = max; `crosswind_kt` worst = max; `headwind_kt` worst = min (weakest headwind is least favourable; matches the server's `airport_consensus.py` — see Consensus Algorithm)
 - **Runway wind data**: Crosswind/headwind require runway headings from the airports database; airports without runway data show no crosswind/headwind values. Best runway is selected by minimizing crosswind then maximizing headwind
 - **Marker sizing**: Radius scales with zoom level (5px at z<=4 up to 11px at z>7) for readability at all zoom levels
@@ -137,9 +141,11 @@ Both map endpoints use a `verification_cache` table (see [metar-taf-accuracy.md]
 - Data source pipeline: [metar-taf-accuracy.md](./metar-taf-accuracy.md)
 - Flight category logic: `src/weatherbrief/analysis/airport_conditions.py`
 - Model comparison: `src/weatherbrief/analysis/comparison.py`
-- Consensus (server): `src/weatherbrief/analysis/airport_consensus.py` (`consensus`, `enrich_wind`; re-exported into `map_queries.py` as `_consensus`/`_enrich_wind`)
-- Consensus (client): `web/ts/visualization/weather-map-consensus.ts` (`computeConsensus`)
+- Consensus (server, single source): `src/weatherbrief/analysis/airport_consensus.py` (`consensus`, `enrich_wind`; re-exported into `map_queries.py` as `_consensus`/`_enrich_wind`). Both modes baked in `get_forecast_map_data`. Client reads the baked blocks via `weather-map-format.getConsensus` — the old `computeConsensus` recompute was retired in #419.
+- Consensus parity guardrail: `tests/test_consensus_parity.py` + `tests/fixtures/consensus_vectors.json`.
+- Map-metrics catalog (colours/thresholds/labels/legends): `web/ts/data/map-metrics-catalog.json`, served via `src/weatherbrief/api/help.py` (`maps` section).
+- Frequent airports (#419): `src/weatherbrief/api/flights.py` (`compute_frequent_airports`, `GET /flights/frequent-airports`).
 - API: `src/weatherbrief/api/maps.py`, `src/weatherbrief/api/airport_profile.py` (airport-profile SSE)
-- Queries: `src/weatherbrief/tasks/map_queries.py`
-- Frontend: `web/ts/maps-main.ts`, `web/ts/visualization/weather-map.ts`, `web/ts/visualization/airport-profile-panel.ts`, `web/ts/visualization/synoptic-map.ts`, `web/ts/visualization/climatology-tab.ts`
+- Queries: `src/weatherbrief/tasks/map_queries.py`; cache key: `src/weatherbrief/tasks/cache_builder.py` (`forecast_map_cache_key`, `FORECAST_MAP_CACHE_VERSION`)
+- Frontend: `web/ts/maps-main.ts`, `web/ts/visualization/weather-map.ts`, `web/ts/visualization/weather-map-format.ts` (catalog interpreter + `getConsensus`), `web/ts/visualization/airport-profile-panel.ts`, `web/ts/visualization/synoptic-map.ts`, `web/ts/visualization/climatology-tab.ts`
 - Synoptic / frontal overlay: [frontal-detection.md](./frontal-detection.md)

--- a/src/weatherbrief/analysis/airport_consensus.py
+++ b/src/weatherbrief/analysis/airport_consensus.py
@@ -131,8 +131,32 @@ def agreement_label(level: str) -> str:
 #   * higher is worse → ``max`` in worst mode (wind speed, crosswind, CAPE).
 _WORST_IS_MIN = frozenset({"ceiling_ft", "visibility_m", "headwind_kt"})
 _NUMERIC_FIELDS = (
-    "wind_speed_kt", "ceiling_ft", "cape_jkg", "visibility_m", "crosswind_kt", "headwind_kt",
+    "wind_speed_kt", "ceiling_ft", "cape_jkg", "visibility_m", "crosswind_kt",
+    "headwind_kt", "cloud_cover_pct",
 )
+
+# Convective-risk severity, low→high. Mirrors the client's ``RISK_ORDER`` in
+# ``web/ts/visualization/weather-map-consensus.ts`` so worst/majority pick the
+# same category on both sides.
+_RISK_ORDER = ("none", "marginal", "low", "moderate", "high", "extreme")
+
+
+def _ordinal_consensus(values: list[str], order: tuple[str, ...], mode: str) -> str:
+    """Reduce categorical values by ordinal severity.
+
+    ``worst`` → highest-ranked value; ``majority`` → modal value with the worst
+    tied candidate breaking ties. Unknown values rank 0 (matches the client's
+    ``?? 0`` fallback in ``ordinalConsensus``).
+    """
+    def rank(v: str) -> int:
+        return order.index(v) if v in order else 0
+
+    if mode == "worst":
+        return max(values, key=rank)
+    counts = Counter(values)
+    max_count = max(counts.values())
+    tied = [v for v, n in counts.items() if n == max_count]
+    return max(tied, key=rank)
 
 
 def _reduce_numeric(field: str, vals: list[float], mode: str) -> float:
@@ -160,8 +184,10 @@ def consensus(per_model: dict[str, dict], mode: str = "majority") -> dict[str, A
         majority's intent. Wind direction is a circular mean of the pool.
 
     The same rule applies uniformly to every numeric field (ceiling, visibility,
-    wind speed, crosswind, headwind, CAPE); only wind direction is special-cased.
-    Returns per-variable agreement labels alongside consensus values.
+    wind speed, crosswind, headwind, CAPE, cloud cover). Convective risk is an
+    ordinal reduced over all models (worst rank / modal-with-worst-tiebreak),
+    and wind direction is a circular mean — both special-cased. Returns
+    per-variable agreement labels alongside consensus values.
     """
     models_with_data = list(per_model.keys())
     if not models_with_data:
@@ -207,6 +233,13 @@ def consensus(per_model: dict[str, dict], mode: str = "majority") -> dict[str, A
         "flight_category": consensus_cat,
         "agreement": agreement,
     }
+
+    # Convective risk is ordinal like flight category, but reduced over ALL
+    # models (not the winning-category pool) — matching the client, which maps
+    # every model's risk before the ordinal reduction.
+    risks = [(per_model[m].get("convective_risk") or "none") for m in models_with_data]
+    result["convective_risk"] = _ordinal_consensus(risks, _RISK_ORDER, mode)
+
     for field in _NUMERIC_FIELDS:
         vals = [per_model[m].get(field) for m in pool]
         vals = [v for v in vals if v is not None]

--- a/src/weatherbrief/api/flights.py
+++ b/src/weatherbrief/api/flights.py
@@ -6,6 +6,7 @@ import hashlib
 import json
 import logging
 import re
+from collections import Counter
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Literal
 
@@ -18,7 +19,7 @@ from flyfun_common.auth import is_dev_mode
 from flyfun_common.db import current_user_id, get_db
 from flyfun_common.db.models import UserRow
 from weatherbrief.airports import RejectedWaypoint
-from weatherbrief.db.models import BriefingPackRow
+from weatherbrief.db.models import BriefingPackRow, FlightRow
 from weatherbrief.fetch.variables import (
     MAX_BOOKING_LEAD_DAYS,
     coverage_start_date,
@@ -1540,6 +1541,92 @@ def move_flight(
     save_flight(db, new_flight, user_id)
 
     return _flight_to_response(new_flight, db, viewer_id=user_id)
+
+
+# ---------------------------------------------------------------------------
+# Frequent airports — the user's most-used departures/destinations (#419, B3)
+# ---------------------------------------------------------------------------
+
+# Airport waypoints are 4-letter ICAO location indicators; a route may also
+# carry navaids/fixes (which are not airports), so frequency counting keeps
+# only ICAO-shaped tokens at the route ends.
+_ICAO_RE = re.compile(r"^[A-Z]{4}$")
+
+
+class FrequentAirport(BaseModel):
+    """One airport in a frequency ranking."""
+
+    icao: str
+    count: int
+
+
+class FrequentAirportsResponse(BaseModel):
+    """The user's most-used departure and destination airports."""
+
+    departures: list[FrequentAirport]
+    destinations: list[FrequentAirport]
+
+
+def compute_frequent_airports(
+    db: Session, user_id: str, *, top_n: int = 5
+) -> FrequentAirportsResponse:
+    """Rank the user's most-used departure and destination airports.
+
+    Derived from flight history — there is no ``home_base`` concept in the
+    schema, and the departure/destination are not stored as columns: the route
+    lives in ``FlightRow.waypoints_json`` (a JSON array), so departure is the
+    first waypoint and destination the last. Only the user's OWN flights are
+    counted (not flights they merely subscribe to), and only ICAO-shaped route
+    ends (navaids/fixes are skipped). Ties keep ``Counter.most_common`` order.
+
+    Pure logic (no ``Depends`` defaults) so it is unit-testable and reusable —
+    iOS centres the forecast map on cold open from this; the web can prefill
+    Add-Flight from it.
+    """
+    rows = db.execute(
+        select(FlightRow.waypoints_json).where(FlightRow.user_id == user_id)
+    ).scalars().all()
+
+    departures: Counter[str] = Counter()
+    destinations: Counter[str] = Counter()
+    for raw in rows:
+        try:
+            waypoints = json.loads(raw) if raw else []
+        except (TypeError, ValueError):
+            continue
+        codes = [w.upper() for w in waypoints if isinstance(w, str)]
+        if not codes:
+            continue
+        if _ICAO_RE.match(codes[0]):
+            departures[codes[0]] += 1
+        # Destination only when the route has a distinct end.
+        if len(codes) >= 2 and _ICAO_RE.match(codes[-1]):
+            destinations[codes[-1]] += 1
+
+    def _rank(counter: Counter[str]) -> list[FrequentAirport]:
+        return [
+            FrequentAirport(icao=icao, count=n)
+            for icao, n in counter.most_common(top_n)
+        ]
+
+    return FrequentAirportsResponse(
+        departures=_rank(departures), destinations=_rank(destinations)
+    )
+
+
+@router.get("/frequent-airports", response_model=FrequentAirportsResponse)
+def get_frequent_airports(
+    user_id: str = Depends(current_user_id),
+    db: Session = Depends(get_db),
+):
+    """Return the current user's top-5 departure and destination airports.
+
+    Discovery ("where can I fly this weekend") needs an origin; this derives one
+    from flight history instead of adding a preference + onboarding step. Used
+    by the iOS forecast map to centre on cold open, and reusable by the web
+    Add-Flight prefill. See ``compute_frequent_airports``.
+    """
+    return compute_frequent_airports(db, user_id)
 
 
 @router.get("/{flight_id}", response_model=FlightResponse)

--- a/src/weatherbrief/api/help.py
+++ b/src/weatherbrief/api/help.py
@@ -6,6 +6,12 @@ text. Two sections in one versioned, ETag-cacheable payload:
 
 - ``metrics``  — parsed verbatim from ``web/ts/data/metrics-catalog.json`` (the
   web bundle's only copy). English-only; see the ``lang`` note below.
+- ``maps``     — parsed verbatim from ``web/ts/data/map-metrics-catalog.json``
+  (the forecast-map colour scales, thresholds, labels and legends). Same
+  single-source pattern: the web bundle imports the JSON directly, iOS fetches
+  it here and caches it, so a threshold change is one JSON edit both clients
+  pick up (issue #419, B2). Language-independent (colours/numbers), but still
+  folded into the version hash so any edit re-validates the ETag.
 - ``advisories`` — the existing advisory catalog (``get_catalog()``), the same
   data already served at ``/user/preferences/advisories/catalog``.
 
@@ -47,10 +53,14 @@ SUPPORTED_LANGS = ("en", "fr", "de", "es")
 _METRICS_CATALOG_PATH = (
     Path(__file__).resolve().parents[3] / "web" / "ts" / "data" / "metrics-catalog.json"
 )
+_MAP_METRICS_CATALOG_PATH = (
+    Path(__file__).resolve().parents[3] / "web" / "ts" / "data" / "map-metrics-catalog.json"
+)
 
 # Per-language memoized (body bytes, version) — the catalog is static per process.
 _payload_cache: dict[str, tuple[bytes, str]] = {}
 _metrics_cache: dict[str, Any] | None = None
+_map_metrics_cache: dict[str, Any] | None = None
 
 
 def _load_metrics_catalog() -> dict[str, Any]:
@@ -65,6 +75,20 @@ def _load_metrics_catalog() -> dict[str, Any]:
         with _METRICS_CATALOG_PATH.open("r", encoding="utf-8") as fh:
             _metrics_cache = json.load(fh)
     return _metrics_cache
+
+
+def _load_map_metrics_catalog() -> dict[str, Any]:
+    """Load and memoize the forecast-map metrics catalog JSON (served as-is)."""
+    global _map_metrics_cache
+    if _map_metrics_cache is None:
+        if not _MAP_METRICS_CATALOG_PATH.exists():
+            raise RuntimeError(
+                f"map metrics catalog not found at {_MAP_METRICS_CATALOG_PATH} — "
+                "expected web/ts/data/map-metrics-catalog.json to be present"
+            )
+        with _MAP_METRICS_CATALOG_PATH.open("r", encoding="utf-8") as fh:
+            _map_metrics_cache = json.load(fh)
+    return _map_metrics_cache
 
 
 def _localize_advisories(
@@ -93,6 +117,7 @@ def _build_payload(lang: str) -> tuple[bytes, str]:
     core = {
         "lang": lang,
         "metrics": _load_metrics_catalog(),
+        "maps": _load_map_metrics_catalog(),
         "advisories": _localize_advisories(get_catalog(), lang),
     }
     canonical = json.dumps(core, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
@@ -101,6 +126,7 @@ def _build_payload(lang: str) -> tuple[bytes, str]:
     payload = {
         "version": version,
         "metrics": core["metrics"],
+        "maps": core["maps"],
         "advisories": core["advisories"],
     }
     body = json.dumps(payload, ensure_ascii=False).encode("utf-8")

--- a/src/weatherbrief/api/maps.py
+++ b/src/weatherbrief/api/maps.py
@@ -68,14 +68,18 @@ def get_forecast_map(
         hour: UTC sample hour. Which hours exist depends on the day — see
             ``/forecast/days``. Out-of-grid values snap to the nearest offered.
     """
-    from weatherbrief.tasks.cache_builder import get_cached, is_stale
+    from weatherbrief.tasks.cache_builder import (
+        forecast_map_cache_key,
+        get_cached,
+        is_stale,
+    )
     from weatherbrief.tasks.map_queries import get_forecast_map_data
 
     offered = sample_hours_for_day(day)
     if hour not in offered:
         hour = min(offered, key=lambda h: abs(h - hour))
 
-    cache_key = f"forecast_map:{day}:{hour}"
+    cache_key = forecast_map_cache_key(day, hour)
     if not is_stale(db, cache_key, "snapshot"):
         cached = get_cached(db, cache_key)
         if cached is not None:
@@ -289,7 +293,11 @@ def get_airport_weather(
     # no longer maps to today's date (post-midnight, before the next model
     # run); in that case compute live for the correct absolute date so the
     # response date stays consistent with the requested day/hour.
-    from weatherbrief.tasks.cache_builder import get_cached, is_stale
+    from weatherbrief.tasks.cache_builder import (
+        forecast_map_cache_key,
+        get_cached,
+        is_stale,
+    )
     from weatherbrief.tasks.map_queries import (
         enrich_with_observations,
         get_forecast_map_data,
@@ -299,7 +307,7 @@ def get_airport_weather(
     if hour not in offered:
         hour = min(offered, key=lambda h: abs(h - hour))
 
-    cache_key = f"forecast_map:{day}:{hour}"
+    cache_key = forecast_map_cache_key(day, hour)
     data = None
     if not is_stale(db, cache_key, "snapshot"):
         data = get_cached(db, cache_key)

--- a/src/weatherbrief/tasks/cache_builder.py
+++ b/src/weatherbrief/tasks/cache_builder.py
@@ -12,7 +12,9 @@ Cache key catalogue:
 - ``stats:{source}:{period}`` — dashboard digest payload
 - ``bias_leaderboard:{model}:{days_out}:{period}`` — top airports model
   over-promises for (#154)
-- ``forecast_map:{day}:{hour}`` — pan-European weather overview map
+- ``forecast_map:{version}:{day}:{hour}`` — pan-European weather overview map
+  (version-segmented; see ``FORECAST_MAP_CACHE_VERSION`` /
+  ``forecast_map_cache_key``)
 
 The legacy ``verif_map:*`` keys (verification-bias map view) were removed
 in #154; the view that consumed them is also gone.
@@ -51,6 +53,21 @@ _LEADERBOARD_PERIODS = {"7d": 168, "30d": 720, "90d": 2160}
 # far day carries fewer hours because ECMWF only delivers 6-hourly steps out
 # there — so it comes from the horizon policy rather than a literal here.
 from weatherbrief.tasks.forecast_grid import forecast_days, sample_hours_for_day
+
+# Cache-key version for the forecast-map payload. Bump whenever the baked
+# payload shape changes: old entries (written by the prior code) then never
+# match, so the endpoint falls through to the live ``get_forecast_map_data()``
+# path and serves the new shape immediately — instead of handing back a stale
+# payload that ``is_stale()`` considers fresh (it only checks fetched_at + the
+# UTC-date rule, not the shape). Without this, a deploy that drops the client's
+# fallback would show a ~12-hour half-outage until the next standalone cycle
+# rebuilt the cache. v2 (#419): added the baked ``consensus_majority`` block.
+FORECAST_MAP_CACHE_VERSION = "v2"
+
+
+def forecast_map_cache_key(day: int, hour: int) -> str:
+    """Deterministic cache key for one ``(day, hour)`` forecast-map slot."""
+    return f"forecast_map:{FORECAST_MAP_CACHE_VERSION}:{day}:{hour}"
 
 
 # ---------------------------------------------------------------------------
@@ -102,7 +119,7 @@ def is_stale(db: Session, cache_key: str, source: str) -> bool:
     verification scores.
 
     Forecast-map keys (``source == "snapshot"``) are *relative-day* indexed
-    (``forecast_map:{day}:{hour}``) but the cached payload holds an *absolute*
+    (``forecast_map:{version}:{day}:{hour}``) but the cached payload holds an *absolute*
     forecast date. Snapshots only refresh on the twice-daily fetch cycles, so
     after a UTC-midnight rollover the snapshot max-time is unchanged yet the
     relative day now maps to a new calendar date. Without a date check the
@@ -255,7 +272,7 @@ def rebuild_forecast_map_cache(db: Session, airports_db_path: str) -> int:
             # D-0: enrich with latest METAR/TAF observations from verification
             if day == 0:
                 data = enrich_with_observations(db, forecast_hour, data)
-            cache_key = f"forecast_map:{day}:{hour}"
+            cache_key = forecast_map_cache_key(day, hour)
             _upsert(db, cache_key, data, snapshot_max)
             count += 1
 

--- a/src/weatherbrief/tasks/map_queries.py
+++ b/src/weatherbrief/tasks/map_queries.py
@@ -211,8 +211,9 @@ def get_forecast_map_data(
     """Return forecast data for all watchlist airports at a given hour.
 
     Finds the latest model_init_time per model that has data for forecast_hour,
-    then returns per-airport, per-model forecasts with worst-consensus.
-    Majority consensus is computed client-side from per-model data.
+    then returns per-airport, per-model forecasts with both the worst
+    (``consensus``) and majority (``consensus_majority``) consensus baked in, so
+    the clients render without recomputing either.
     """
     coords = _get_coords(airports_db_path)
 
@@ -284,7 +285,11 @@ def get_forecast_map_data(
             "lon": lon,
             "approach_type": atype,
             "models": models_data,
-            "consensus": _consensus(models_data),
+            # Both consensus modes are baked so the clients (web + iOS) carry
+            # zero consensus logic — they read whichever block matches the
+            # selected Worst/Majority mode. See designs/forecast-page.md and #419.
+            "consensus": _consensus(models_data, "worst"),
+            "consensus_majority": _consensus(models_data, "majority"),
         })
 
     return {

--- a/tests/fixtures/consensus_vectors.json
+++ b/tests/fixtures/consensus_vectors.json
@@ -1,39 +1,51 @@
 {
-  "_comment": "Shared consensus test vectors: one source of truth pinning the Python airport_consensus.consensus and the TypeScript weather-map-consensus.computeConsensus to identical output. Consumed by tests/test_consensus_parity.py and web/tests/unit/consensus-parity.test.ts. Each case's `models` maps model name -> {flight_category, ceiling_ft, visibility_m, wind_speed_kt, crosswind_kt, headwind_kt}; `expected` gives the reduced values per mode. crosswind: worst=max (higher is worse). headwind: worst=min (a positive headwind is favourable, so the weakest headwind / strongest tailwind is the conservative pick). majority=median within the winning-category pool for every numeric. Keep the two consumers in lockstep with this file.",
+  "_comment": "Shared consensus test vectors: one source of truth pinning the Python airport_consensus.consensus to the reference behaviour the web forecast map used to compute client-side (weather-map-consensus.computeConsensus, retired in #419 — the client now reads the server-baked consensus/consensus_majority blocks straight off the payload). Consumed by tests/test_consensus_parity.py (server) and web/tests/unit/consensus-parity.test.ts (the briefing arrival card's computeSummaryCondition, which still recomputes). Each case's `models` maps model name -> {flight_category, ceiling_ft, visibility_m, wind_speed_kt, crosswind_kt, headwind_kt, convective_risk, cloud_cover_pct}; `expected` gives the reduced values per mode. Numerics: worst = least-favourable across ALL models (crosswind/cloud_cover max, headwind/ceiling/visibility min); majority = median within the winning-category pool. convective_risk is ordinal over ALL models (worst = highest severity none<marginal<low<moderate<high<extreme; majority = modal with worst-severity tiebreak). Keep this file, the server, and the retired-client's documented rules in lockstep.",
   "cases": [
     {
       "name": "all agree VFR",
       "models": {
-        "gfs":   {"flight_category": "VFR", "ceiling_ft": 5000, "visibility_m": 9999, "wind_speed_kt": 10, "crosswind_kt": 5, "headwind_kt": 12},
-        "icon":  {"flight_category": "VFR", "ceiling_ft": 4000, "visibility_m": 9000, "wind_speed_kt": 14, "crosswind_kt": 9, "headwind_kt": 8},
-        "ecmwf": {"flight_category": "VFR", "ceiling_ft": 4500, "visibility_m": 9500, "wind_speed_kt": 12, "crosswind_kt": 7, "headwind_kt": 10}
+        "gfs":   {"flight_category": "VFR", "ceiling_ft": 5000, "visibility_m": 9999, "wind_speed_kt": 10, "crosswind_kt": 5, "headwind_kt": 12, "convective_risk": "low",  "cloud_cover_pct": 30},
+        "icon":  {"flight_category": "VFR", "ceiling_ft": 4000, "visibility_m": 9000, "wind_speed_kt": 14, "crosswind_kt": 9, "headwind_kt": 8,  "convective_risk": "none", "cloud_cover_pct": 50},
+        "ecmwf": {"flight_category": "VFR", "ceiling_ft": 4500, "visibility_m": 9500, "wind_speed_kt": 12, "crosswind_kt": 7, "headwind_kt": 10, "convective_risk": "low",  "cloud_cover_pct": 40}
       },
       "expected": {
-        "worst":    {"flight_category": "VFR", "ceiling_ft": 4000, "visibility_m": 9000, "wind_speed_kt": 14, "crosswind_kt": 9, "headwind_kt": 8},
-        "majority": {"flight_category": "VFR", "ceiling_ft": 4500, "visibility_m": 9500, "wind_speed_kt": 12, "crosswind_kt": 7, "headwind_kt": 10}
+        "worst":    {"flight_category": "VFR", "ceiling_ft": 4000, "visibility_m": 9000, "wind_speed_kt": 14, "crosswind_kt": 9, "headwind_kt": 8,  "convective_risk": "low", "cloud_cover_pct": 50},
+        "majority": {"flight_category": "VFR", "ceiling_ft": 4500, "visibility_m": 9500, "wind_speed_kt": 12, "crosswind_kt": 7, "headwind_kt": 10, "convective_risk": "low", "cloud_cover_pct": 40}
       }
     },
     {
       "name": "2 VFR + 1 IFR -> majority VFR from the pool",
       "models": {
-        "gfs":   {"flight_category": "VFR", "ceiling_ft": 5000, "visibility_m": 9999, "wind_speed_kt": 10, "crosswind_kt": 5, "headwind_kt": 12},
-        "icon":  {"flight_category": "VFR", "ceiling_ft": 4000, "visibility_m": 9000, "wind_speed_kt": 14, "crosswind_kt": 9, "headwind_kt": 8},
-        "ecmwf": {"flight_category": "IFR", "ceiling_ft": 800,  "visibility_m": 3000, "wind_speed_kt": 30, "crosswind_kt": 20, "headwind_kt": -5}
+        "gfs":   {"flight_category": "VFR", "ceiling_ft": 5000, "visibility_m": 9999, "wind_speed_kt": 10, "crosswind_kt": 5,  "headwind_kt": 12, "convective_risk": "none", "cloud_cover_pct": 20},
+        "icon":  {"flight_category": "VFR", "ceiling_ft": 4000, "visibility_m": 9000, "wind_speed_kt": 14, "crosswind_kt": 9,  "headwind_kt": 8,  "convective_risk": "low",  "cloud_cover_pct": 60},
+        "ecmwf": {"flight_category": "IFR", "ceiling_ft": 800,  "visibility_m": 3000, "wind_speed_kt": 30, "crosswind_kt": 20, "headwind_kt": -5, "convective_risk": "high", "cloud_cover_pct": 90}
       },
       "expected": {
-        "worst":    {"flight_category": "IFR", "ceiling_ft": 800,  "visibility_m": 3000,   "wind_speed_kt": 30, "crosswind_kt": 20, "headwind_kt": -5},
-        "majority": {"flight_category": "VFR", "ceiling_ft": 4500, "visibility_m": 9499.5, "wind_speed_kt": 12, "crosswind_kt": 7,  "headwind_kt": 10}
+        "worst":    {"flight_category": "IFR", "ceiling_ft": 800,  "visibility_m": 3000,   "wind_speed_kt": 30, "crosswind_kt": 20, "headwind_kt": -5, "convective_risk": "high", "cloud_cover_pct": 90},
+        "majority": {"flight_category": "VFR", "ceiling_ft": 4500, "visibility_m": 9499.5, "wind_speed_kt": 12, "crosswind_kt": 7,  "headwind_kt": 10, "convective_risk": "high", "cloud_cover_pct": 40}
       }
     },
     {
       "name": "1 VFR + 1 IFR tie -> majority breaks to worse (IFR)",
       "models": {
-        "gfs":  {"flight_category": "VFR", "ceiling_ft": 5000, "visibility_m": 9999, "wind_speed_kt": 10, "crosswind_kt": 5,  "headwind_kt": 12},
-        "icon": {"flight_category": "IFR", "ceiling_ft": 900,  "visibility_m": 3000, "wind_speed_kt": 20, "crosswind_kt": 15, "headwind_kt": -3}
+        "gfs":  {"flight_category": "VFR", "ceiling_ft": 5000, "visibility_m": 9999, "wind_speed_kt": 10, "crosswind_kt": 5,  "headwind_kt": 12, "convective_risk": "low",      "cloud_cover_pct": 25},
+        "icon": {"flight_category": "IFR", "ceiling_ft": 900,  "visibility_m": 3000, "wind_speed_kt": 20, "crosswind_kt": 15, "headwind_kt": -3, "convective_risk": "moderate", "cloud_cover_pct": 85}
       },
       "expected": {
-        "worst":    {"flight_category": "IFR", "ceiling_ft": 900, "visibility_m": 3000, "wind_speed_kt": 20, "crosswind_kt": 15, "headwind_kt": -3},
-        "majority": {"flight_category": "IFR", "ceiling_ft": 900, "visibility_m": 3000, "wind_speed_kt": 20, "crosswind_kt": 15, "headwind_kt": -3}
+        "worst":    {"flight_category": "IFR", "ceiling_ft": 900, "visibility_m": 3000, "wind_speed_kt": 20, "crosswind_kt": 15, "headwind_kt": -3, "convective_risk": "moderate", "cloud_cover_pct": 85},
+        "majority": {"flight_category": "IFR", "ceiling_ft": 900, "visibility_m": 3000, "wind_speed_kt": 20, "crosswind_kt": 15, "headwind_kt": -3, "convective_risk": "moderate", "cloud_cover_pct": 85}
+      }
+    },
+    {
+      "name": "convective modal (majority) differs from worst; cloud median over pool",
+      "models": {
+        "gfs":   {"flight_category": "VFR", "ceiling_ft": 4000, "visibility_m": 9000, "wind_speed_kt": 10, "crosswind_kt": 4, "headwind_kt": 10, "convective_risk": "moderate", "cloud_cover_pct": 10},
+        "icon":  {"flight_category": "VFR", "ceiling_ft": 4200, "visibility_m": 9200, "wind_speed_kt": 12, "crosswind_kt": 6, "headwind_kt": 12, "convective_risk": "moderate", "cloud_cover_pct": 20},
+        "ecmwf": {"flight_category": "VFR", "ceiling_ft": 4400, "visibility_m": 9400, "wind_speed_kt": 14, "crosswind_kt": 8, "headwind_kt": 14, "convective_risk": "extreme",  "cloud_cover_pct": 30}
+      },
+      "expected": {
+        "worst":    {"flight_category": "VFR", "ceiling_ft": 4000, "visibility_m": 9000, "wind_speed_kt": 14, "crosswind_kt": 8, "headwind_kt": 10, "convective_risk": "extreme",  "cloud_cover_pct": 30},
+        "majority": {"flight_category": "VFR", "ceiling_ft": 4200, "visibility_m": 9200, "wind_speed_kt": 12, "crosswind_kt": 6, "headwind_kt": 12, "convective_risk": "moderate", "cloud_cover_pct": 20}
       }
     }
   ]

--- a/tests/test_consensus_parity.py
+++ b/tests/test_consensus_parity.py
@@ -1,10 +1,12 @@
 """Shared-vector parity test for the Python consensus.
 
-Pins ``analysis.airport_consensus.consensus`` to the same expected output as the
-TypeScript ``weather-map-consensus.computeConsensus`` (see
-``web/tests/unit/consensus-parity.test.ts``), both driven off
-``tests/fixtures/consensus_vectors.json``. If the two implementations drift, one
-of the two parity tests fails.
+Pins ``analysis.airport_consensus.consensus`` to the reference behaviour the web
+forecast map used to compute client-side. That client consensus was retired in
+#419 — the web now reads the server-baked ``consensus`` / ``consensus_majority``
+blocks straight off the payload — so this file is the guardrail that the server
+still produces exactly what the client used to, field-by-field, including the
+newly-baked ``convective_risk`` and ``cloud_cover_pct``. Driven off
+``tests/fixtures/consensus_vectors.json``.
 """
 
 from __future__ import annotations
@@ -33,3 +35,5 @@ def test_consensus_matches_shared_vector(case, mode):
     assert result["wind_speed_kt"] == pytest.approx(expected["wind_speed_kt"])
     assert result["crosswind_kt"] == pytest.approx(expected["crosswind_kt"])
     assert result["headwind_kt"] == pytest.approx(expected["headwind_kt"])
+    assert result["convective_risk"] == expected["convective_risk"]
+    assert result["cloud_cover_pct"] == pytest.approx(expected["cloud_cover_pct"])

--- a/tests/test_frequent_airports.py
+++ b/tests/test_frequent_airports.py
@@ -1,0 +1,90 @@
+"""Tests for the frequent-airports ranking (#419, B3).
+
+``compute_frequent_airports`` derives the user's most-used departure and
+destination airports from flight history (``FlightRow.waypoints_json`` first /
+last waypoint), since there is no ``home_base`` column in the schema.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from flyfun_common.db import DEV_USER_ID
+from weatherbrief.api.flights import compute_frequent_airports
+from weatherbrief.models import Flight
+from weatherbrief.storage.flights import save_flight
+
+
+def _flight(fid: str, waypoints: list[str], user_id: str = DEV_USER_ID) -> Flight:
+    return Flight(
+        id=fid,
+        user_id=user_id,
+        route_name=fid,
+        departure_time=datetime(2026, 2, 21, 9, tzinfo=timezone.utc),
+        waypoints=waypoints,
+        created_at=datetime(2026, 2, 14, 10, tzinfo=timezone.utc),
+    )
+
+
+class TestComputeFrequentAirports:
+    def test_empty_when_no_flights(self, db_session, dev_user):
+        result = compute_frequent_airports(db_session, dev_user)
+        assert result.departures == []
+        assert result.destinations == []
+
+    def test_counts_and_ranks_ends(self, db_session, dev_user):
+        # LFAT departs 3×, EGKA departs 1×; EGKA arrives 2×, LFAT arrives 1×.
+        save_flight(db_session, _flight("f1", ["LFAT", "LFRK", "EGKA"]), dev_user)
+        save_flight(db_session, _flight("f2", ["LFAT", "EGKA"]), dev_user)
+        save_flight(db_session, _flight("f3", ["LFAT", "EGLL"]), dev_user)
+        save_flight(db_session, _flight("f4", ["EGKA", "LFAT"]), dev_user)
+
+        result = compute_frequent_airports(db_session, dev_user)
+
+        assert result.departures[0].icao == "LFAT"
+        assert result.departures[0].count == 3
+        dep = {a.icao: a.count for a in result.departures}
+        assert dep == {"LFAT": 3, "EGKA": 1}
+        dest = {a.icao: a.count for a in result.destinations}
+        assert dest == {"EGKA": 2, "EGLL": 1, "LFAT": 1}
+
+    def test_skips_non_icao_waypoints_at_the_ends(self, db_session, dev_user):
+        # A route that starts/ends on a navaid/fix (not a 4-letter ICAO) is not
+        # counted as an airport departure/destination.
+        save_flight(db_session, _flight("f1", ["KONAN", "EGKA"]), dev_user)  # dep = navaid
+        save_flight(db_session, _flight("f2", ["LFAT", "REVTU"]), dev_user)  # dest = fix
+
+        result = compute_frequent_airports(db_session, dev_user)
+        assert {a.icao for a in result.departures} == {"LFAT"}
+        assert {a.icao for a in result.destinations} == {"EGKA"}
+
+    def test_single_waypoint_counts_departure_only(self, db_session, dev_user):
+        save_flight(db_session, _flight("f1", ["LFAT"]), dev_user)
+        result = compute_frequent_airports(db_session, dev_user)
+        assert {a.icao for a in result.departures} == {"LFAT"}
+        assert result.destinations == []
+
+    def test_top_n_limit(self, db_session, dev_user):
+        for i in range(7):
+            save_flight(db_session, _flight(f"f{i}", [f"LFA{chr(65 + i)}", "EGKA"]), dev_user)
+        result = compute_frequent_airports(db_session, dev_user, top_n=5)
+        assert len(result.departures) == 5
+
+    def test_scoped_to_the_user(self, db_session, dev_user):
+        from flyfun_common.db.models import UserRow
+
+        other = "other-user"
+        db_session.add(UserRow(
+            id=other, provider="local", provider_sub="other",
+            email="other@localhost", display_name="Other", approved=True,
+        ))
+        db_session.flush()
+
+        save_flight(db_session, _flight("mine", ["LFAT", "EGKA"]), dev_user)
+        save_flight(db_session, _flight("theirs", ["EGLL", "EGKB"], user_id=other), other)
+
+        result = compute_frequent_airports(db_session, dev_user)
+        assert {a.icao for a in result.departures} == {"LFAT"}
+        assert {a.icao for a in result.destinations} == {"EGKA"}

--- a/tests/test_help_catalog.py
+++ b/tests/test_help_catalog.py
@@ -21,9 +21,11 @@ def _clear_caches():
     """Reset the module-level memoization between tests."""
     help_module._payload_cache.clear()
     help_module._metrics_cache = None
+    help_module._map_metrics_cache = None
     yield
     help_module._payload_cache.clear()
     help_module._metrics_cache = None
+    help_module._map_metrics_cache = None
 
 
 @pytest.fixture
@@ -59,6 +61,15 @@ class TestPayloadBuilding:
         # Advisory entry shape mirrors AdvisoryCatalogEntry.
         entry = payload["advisories"][0]
         assert {"id", "name", "short_description", "description", "category"} <= set(entry)
+
+    def test_payload_carries_the_forecast_map_catalog(self):
+        # The forecast-map colour/threshold catalog is served here (B2, #419) so
+        # iOS reads the same scales the web bundle imports.
+        payload = json.loads(help_module._build_payload("en")[0])
+        maps = payload["maps"]
+        assert maps["scales"]["categorical"]["flight_category"]["VFR"] == "#22c55e"
+        assert "wind_speed_kt" in maps["scales"]["bands"]
+        assert maps["metrics"]["flight_category"]["label"] == "Category"
 
     def test_version_is_stable(self):
         _, v1 = help_module._build_payload("en")

--- a/tests/test_map_queries.py
+++ b/tests/test_map_queries.py
@@ -159,6 +159,12 @@ class TestGetForecastMapData:
         assert "icon" in apt["models"]
         assert "consensus" in apt
         assert apt["consensus"]["flight_category"] in ("VFR", "MVFR", "IFR", "LIFR")
+        # Both consensus modes are baked so the clients carry no consensus math (#419).
+        assert "consensus_majority" in apt
+        assert apt["consensus_majority"]["flight_category"] in ("VFR", "MVFR", "IFR", "LIFR")
+        # Newly-baked fields the web reads for the convective/cloud metrics.
+        assert "convective_risk" in apt["consensus"]
+        assert "cloud_cover_pct" in apt["consensus"]
 
     @patch("weatherbrief.tasks.map_queries._get_coords", return_value=FAKE_COORDS)
     def test_empty_when_no_data(self, _mock_coords, _mock_rwy, db_session):

--- a/web/tests/forecast-maps.spec.ts
+++ b/web/tests/forecast-maps.spec.ts
@@ -30,7 +30,8 @@ const MOCK_FORECAST: Record<string, unknown> = {
         icon: { ceiling_ft: 4500, visibility_m: 9999, wind_speed_kt: 14, wind_dir_deg: 220, wind_gust_kt: 20, cloud_cover_pct: 40, cape_jkg: 60, convective_risk: 'none', temperature_c: 13, flight_category: 'VFR' },
         ecmwf: { ceiling_ft: 800, visibility_m: 5000, wind_speed_kt: 10, wind_dir_deg: 240, wind_gust_kt: 15, cloud_cover_pct: 80, cape_jkg: 30, convective_risk: 'none', temperature_c: 12, flight_category: 'IFR' },
       },
-      consensus: { flight_category: 'IFR', agreement: { flight_category: 'mixed', wind_speed_kt: 'consistent', ceiling_ft: 'divergent', cape_jkg: 'consistent' }, wind_speed_kt: 12, wind_dir_deg: 230, ceiling_ft: 3433, cape_jkg: 47 },
+      consensus: { flight_category: 'IFR', agreement: { flight_category: 'mixed', wind_speed_kt: 'consistent', ceiling_ft: 'divergent', cape_jkg: 'consistent' }, wind_speed_kt: 14, wind_dir_deg: 230, ceiling_ft: 800, cape_jkg: 60, crosswind_kt: 9, headwind_kt: 8, visibility_m: 5000, convective_risk: 'none', cloud_cover_pct: 80 },
+      consensus_majority: { flight_category: 'VFR', agreement: { flight_category: 'mixed', wind_speed_kt: 'consistent', ceiling_ft: 'divergent', cape_jkg: 'consistent' }, wind_speed_kt: 13, wind_dir_deg: 225, ceiling_ft: 4750, cape_jkg: 55, crosswind_kt: 7, headwind_kt: 10, visibility_m: 9999, convective_risk: 'none', cloud_cover_pct: 35 },
     },
     {
       icao: 'EDDF', lat: 50.03, lon: 8.57,
@@ -39,7 +40,8 @@ const MOCK_FORECAST: Record<string, unknown> = {
         icon: { ceiling_ft: 5500, visibility_m: 9999, wind_speed_kt: 9, wind_dir_deg: 190, wind_gust_kt: null, cloud_cover_pct: 15, cape_jkg: 0, convective_risk: 'none', temperature_c: 15, flight_category: 'VFR' },
         ecmwf: { ceiling_ft: 5800, visibility_m: 9999, wind_speed_kt: 7, wind_dir_deg: 185, wind_gust_kt: null, cloud_cover_pct: 12, cape_jkg: 10, convective_risk: 'none', temperature_c: 15, flight_category: 'VFR' },
       },
-      consensus: { flight_category: 'VFR', agreement: { flight_category: 'consistent', wind_speed_kt: 'consistent', ceiling_ft: 'consistent', cape_jkg: 'consistent' }, wind_speed_kt: 8, wind_dir_deg: 185, ceiling_ft: 5767, cape_jkg: 3 },
+      consensus: { flight_category: 'VFR', agreement: { flight_category: 'consistent', wind_speed_kt: 'consistent', ceiling_ft: 'consistent', cape_jkg: 'consistent' }, wind_speed_kt: 9, wind_dir_deg: 185, ceiling_ft: 5500, cape_jkg: 10, visibility_m: 9999, convective_risk: 'none', cloud_cover_pct: 15 },
+      consensus_majority: { flight_category: 'VFR', agreement: { flight_category: 'consistent', wind_speed_kt: 'consistent', ceiling_ft: 'consistent', cape_jkg: 'consistent' }, wind_speed_kt: 8, wind_dir_deg: 185, ceiling_ft: 5800, cape_jkg: 0, visibility_m: 9999, convective_risk: 'none', cloud_cover_pct: 12 },
     },
   ],
 };
@@ -163,9 +165,13 @@ test.describe('Forecast page', () => {
 
   test('day picker is rendered from the grid, out to the far day', async ({ page }) => {
     await page.goto('/maps.html');
-    // Buttons come from /forecast/days, not from markup — D-0..D-6.
+    // Buttons come from /forecast/days, not from markup — seven days out.
     await expect(page.locator('#day-picker .btn-toggle')).toHaveCount(7);
     await expect(page.locator('#day-picker .btn-toggle[data-day="6"]')).toBeVisible();
+    // Labels are weekday + date, not D-N (#419, W1): D-0 reads "Today", and a
+    // later day reads a weekday + day-of-month, never "D-4".
+    await expect(page.locator('#day-picker .btn-toggle[data-day="0"]')).toHaveText('Today');
+    await expect(page.locator('#day-picker .btn-toggle[data-day="4"]')).not.toHaveText(/^D-/);
   });
 
   test('far day offers three hours, not five', async ({ page }) => {

--- a/web/tests/unit/consensus-parity.test.ts
+++ b/web/tests/unit/consensus-parity.test.ts
@@ -1,15 +1,17 @@
-/** Shared-vector parity test for the TypeScript forecast-map consensus.
+/** Shared-vector parity test for the TypeScript arrival-card consensus.
  *
- * Pins `weather-map-consensus.computeConsensus` to the same expected output as
- * the Python `airport_consensus.consensus` (see `tests/test_consensus_parity.py`),
- * both driven off `tests/fixtures/consensus_vectors.json`. If the two
- * implementations drift, one of the two parity tests fails.
+ * The forecast map's own consensus was retired from the client in #419 (it now
+ * reads the server-baked `consensus` / `consensus_majority` blocks straight off
+ * the payload — the server is pinned to these same vectors by
+ * `tests/test_consensus_parity.py`). What still recomputes client-side is the
+ * briefing arrival card's `computeSummaryCondition`, so its parity with the
+ * Python `airport_consensus.consensus` is what this file now guards. Both are
+ * driven off `tests/fixtures/consensus_vectors.json`.
  */
 
 import { describe, it, expect } from 'vitest';
-import { computeConsensus, type ConsensusMode } from '../../ts/visualization/weather-map-consensus';
+import { type ConsensusMode } from '../../ts/visualization/weather-map-consensus';
 import { computeSummaryCondition } from '../../ts/helpers/airport-summary';
-import type { ForecastAirport, ModelForecast } from '../../ts/adapters/maps-adapter';
 import type { AirportModelCondition, FlightCategory } from '../../ts/types/advisories';
 import vectors from '../../../tests/fixtures/consensus_vectors.json';
 
@@ -21,51 +23,6 @@ interface VectorFields {
   crosswind_kt: number;
   headwind_kt: number;
 }
-
-function makeModel(f: VectorFields): ModelForecast {
-  return {
-    ceiling_ft: f.ceiling_ft,
-    visibility_m: f.visibility_m,
-    wind_speed_kt: f.wind_speed_kt,
-    wind_dir_deg: null,
-    wind_gust_kt: null,
-    crosswind_kt: f.crosswind_kt,
-    headwind_kt: f.headwind_kt,
-    best_runway_id: null,
-    gust_crosswind_kt: null,
-    gust_headwind_kt: null,
-    cloud_cover_pct: null,
-    cape_jkg: null,
-    convective_risk: 'none',
-    temperature_c: null,
-    flight_category: f.flight_category,
-  };
-}
-
-describe('computeConsensus — shared-vector parity with Python', () => {
-  for (const mode of ['worst', 'majority'] as ConsensusMode[]) {
-    for (const c of vectors.cases) {
-      it(`${mode}: ${c.name}`, () => {
-        const models: Record<string, ModelForecast> = {};
-        for (const [name, fields] of Object.entries(c.models)) {
-          models[name] = makeModel(fields as VectorFields);
-        }
-        const airport: ForecastAirport = {
-          icao: 'TEST', lat: 0, lon: 0, models,
-          consensus: { flight_category: 'VFR', agreement: {} },
-        };
-        const result = computeConsensus(airport, mode);
-        const expected = (c.expected as Record<string, VectorFields>)[mode];
-        expect(result.flight_category).toBe(expected.flight_category);
-        expect(result.ceiling_ft).toBeCloseTo(expected.ceiling_ft, 4);
-        expect(result.visibility_m).toBeCloseTo(expected.visibility_m, 4);
-        expect(result.wind_speed_kt).toBeCloseTo(expected.wind_speed_kt, 4);
-        expect(result.crosswind_kt).toBeCloseTo(expected.crosswind_kt, 4);
-        expect(result.headwind_kt).toBeCloseTo(expected.headwind_kt, 4);
-      });
-    }
-  }
-});
 
 function makeCondition(model: string, f: VectorFields): AirportModelCondition {
   return {

--- a/web/tests/unit/weather-map-consensus.test.ts
+++ b/web/tests/unit/weather-map-consensus.test.ts
@@ -1,46 +1,16 @@
-/** Tests for forecast-map consensus aggregation (worst / majority modes). */
+/** Tests for the shared consensus reducers still used off the forecast map.
+ *
+ * The forecast map's worst/majority consensus is now baked server-side and
+ * read straight off the payload (#419), so `computeConsensus` was retired.
+ * What remains are the small pure reducers other surfaces share: the mode
+ * type-guard, `median`/`circularMean`, and `ordinalConsensus` (which powers
+ * the client-side FAA/EASA alternate-required aggregation). */
 
 import { describe, it, expect } from 'vitest';
 import {
-  isConsensusMode, median, circularMean, ordinalConsensus, computeConsensus,
+  isConsensusMode, median, circularMean, ordinalConsensus,
   CAT_ORDER, RISK_ORDER,
 } from '../../ts/visualization/weather-map-consensus';
-import type {
-  ForecastAirport, ModelForecast,
-} from '../../ts/adapters/maps-adapter';
-
-function makeModelForecast(overrides: Partial<ModelForecast> = {}): ModelForecast {
-  return {
-    ceiling_ft: null,
-    visibility_m: null,
-    wind_speed_kt: null,
-    wind_dir_deg: null,
-    wind_gust_kt: null,
-    crosswind_kt: null,
-    headwind_kt: null,
-    best_runway_id: null,
-    gust_crosswind_kt: null,
-    gust_headwind_kt: null,
-    cloud_cover_pct: null,
-    cape_jkg: null,
-    convective_risk: 'none',
-    temperature_c: null,
-    flight_category: 'VFR',
-    ...overrides,
-  };
-}
-
-function makeAirport(models: Record<string, Partial<ModelForecast>>): ForecastAirport {
-  const built: Record<string, ModelForecast> = {};
-  for (const [k, v] of Object.entries(models)) built[k] = makeModelForecast(v);
-  return {
-    icao: 'EGLF',
-    lat: 51.276,
-    lon: -0.776,
-    models: built,
-    consensus: { flight_category: 'VFR', agreement: {} },
-  };
-}
 
 describe('isConsensusMode', () => {
   it('detects "worst" and "majority"', () => {
@@ -131,119 +101,5 @@ describe('ordinalConsensus', () => {
   it('throws on empty input rather than reduce-of-empty TypeError', () => {
     expect(() => ordinalConsensus([], CAT_ORDER, 'worst')).toThrow(/empty/);
     expect(() => ordinalConsensus([], CAT_ORDER, 'majority')).toThrow(/empty/);
-  });
-});
-
-describe('computeConsensus', () => {
-  it('returns VFR / empty agreement when no models', () => {
-    const airport = makeAirport({});
-    const c = computeConsensus(airport, 'worst');
-    expect(c.flight_category).toBe('VFR');
-    expect(c.agreement).toEqual({});
-  });
-
-  it('worst flight_category picks highest-ranked', () => {
-    const a = makeAirport({
-      gfs: { flight_category: 'VFR' },
-      icon: { flight_category: 'IFR' },
-      ecmwf: { flight_category: 'MVFR' },
-    });
-    const c = computeConsensus(a, 'worst');
-    expect(c.flight_category).toBe('IFR');
-  });
-
-  it('worst takes max wind speed and min ceiling (most adverse)', () => {
-    const a = makeAirport({
-      gfs:   { wind_speed_kt: 10, ceiling_ft: 4000 },
-      icon:  { wind_speed_kt: 25, ceiling_ft: 1500 },
-      ecmwf: { wind_speed_kt: 18, ceiling_ft: 800 },
-    });
-    const c = computeConsensus(a, 'worst');
-    expect(c.wind_speed_kt).toBe(25);
-    expect(c.ceiling_ft).toBe(800);
-  });
-
-  it('majority uses median of numeric values', () => {
-    const a = makeAirport({
-      gfs:   { wind_speed_kt: 10 },
-      icon:  { wind_speed_kt: 20 },
-      ecmwf: { wind_speed_kt: 30 },
-    });
-    const c = computeConsensus(a, 'majority');
-    expect(c.wind_speed_kt).toBe(20);
-  });
-
-  it('majority takes the median of ONLY the winning-category pool', () => {
-    // 2 VFR + 1 IFR → category VFR; numbers come only from the two VFR models,
-    // so the IFR model's low ceiling / high wind never leak into the badge.
-    const a = makeAirport({
-      gfs:   { flight_category: 'VFR', wind_speed_kt: 10, ceiling_ft: 5000 },
-      icon:  { flight_category: 'VFR', wind_speed_kt: 14, ceiling_ft: 4000 },
-      ecmwf: { flight_category: 'IFR', wind_speed_kt: 30, ceiling_ft: 800 },
-    });
-    const c = computeConsensus(a, 'majority');
-    expect(c.flight_category).toBe('VFR');
-    expect(c.ceiling_ft).toBe(4500);   // median(5000, 4000)
-    expect(c.wind_speed_kt).toBe(12);  // median(10, 14)
-  });
-
-  it('skips numeric fields when no model has data', () => {
-    const a = makeAirport({
-      gfs:  { wind_speed_kt: 10 },
-      icon: { wind_speed_kt: 20 },
-    });
-    const c = computeConsensus(a, 'worst');
-    expect(c.wind_speed_kt).toBe(20);
-    expect(c.ceiling_ft).toBeUndefined();
-    expect(c.cape_jkg).toBeUndefined();
-  });
-
-  it('handles partial nulls (drops them, aggregates remainder)', () => {
-    const a = makeAirport({
-      gfs:   { wind_speed_kt: 10 },
-      icon:  { wind_speed_kt: null },
-      ecmwf: { wind_speed_kt: 20 },
-    });
-    const c = computeConsensus(a, 'worst');
-    expect(c.wind_speed_kt).toBe(20);
-  });
-
-  it('rounds aggregated numerics to 1 decimal', () => {
-    const a = makeAirport({
-      gfs:   { wind_speed_kt: 10.123 },
-      icon:  { wind_speed_kt: 20.456 },
-      ecmwf: { wind_speed_kt: 30.789 },
-    });
-    const c = computeConsensus(a, 'majority');
-    expect(c.wind_speed_kt).toBe(20.5);
-  });
-
-  it('treats blank convective_risk as "none"', () => {
-    const a = makeAirport({
-      gfs: { convective_risk: '' as never },
-      icon: { convective_risk: 'low' },
-    });
-    const c = computeConsensus(a, 'worst');
-    expect(c.convective_risk).toBe('low');
-  });
-
-  it('aggregates wind direction with circular mean, rounded to whole degrees', () => {
-    const a = makeAirport({
-      gfs:  { wind_dir_deg: 350 },
-      icon: { wind_dir_deg: 10 },
-    });
-    const c = computeConsensus(a, 'worst');
-    expect(c.wind_dir_deg).toBeDefined();
-    // Whole-degree result, no float artifacts like 359.9999999996
-    expect(Number.isInteger(c.wind_dir_deg!)).toBe(true);
-    // Mean of 350+10 should be 0 (or 360 — circular wrap)
-    expect(c.wind_dir_deg === 0 || c.wind_dir_deg === 360).toBe(true);
-  });
-
-  it('preserves the airport.consensus.agreement map', () => {
-    const a = makeAirport({ gfs: { flight_category: 'VFR' } });
-    a.consensus.agreement = { wind_speed_kt: 'consistent' };
-    const c = computeConsensus(a, 'worst');
-    expect(c.agreement).toEqual({ wind_speed_kt: 'consistent' });
   });
 });

--- a/web/tests/unit/weather-map-format.test.ts
+++ b/web/tests/unit/weather-map-format.test.ts
@@ -62,13 +62,26 @@ describe('getForecastColor', () => {
     expect(getForecastColor(apt, 'ceiling_ft', 'icon')).toBe('#888');
   });
 
-  it('worst consensus picks the most restrictive category', () => {
+  it('consensus modes read the server-baked block, not a client recompute (#419)', () => {
+    // Both blocks are baked server-side; the client just picks by mode. The
+    // per-model categories are deliberately inconsistent with the baked blocks
+    // to prove the colour comes from the baked value, not a recomputation.
     const apt = makeAirport({
       gfs: { flight_category: 'VFR' },
-      icon: { flight_category: 'MVFR' },
-      ecmwf: { flight_category: 'IFR' },
+      icon: { flight_category: 'VFR' },
+      ecmwf: { flight_category: 'VFR' },
     });
+    apt.consensus = { flight_category: 'IFR', agreement: {} };
+    apt.consensus_majority = { flight_category: 'MVFR', agreement: {} };
     expect(getForecastColor(apt, 'flight_category', 'worst')).toBe(CAT_COLORS.IFR);
+    expect(getForecastColor(apt, 'flight_category', 'majority')).toBe(CAT_COLORS.MVFR);
+  });
+
+  it('majority falls back to the worst block when no majority block is baked', () => {
+    const apt = makeAirport({ gfs: { flight_category: 'VFR' } });
+    apt.consensus = { flight_category: 'IFR', agreement: {} };
+    // No consensus_majority (older cached payload) → falls back to consensus.
+    expect(getForecastColor(apt, 'flight_category', 'majority')).toBe(CAT_COLORS.IFR);
   });
 });
 

--- a/web/ts/adapters/maps-adapter.ts
+++ b/web/ts/adapters/maps-adapter.ts
@@ -18,7 +18,12 @@ export interface ForecastAirport {
   lon: number;
   approach_type?: string | null;
   models: Record<string, ModelForecast>;
+  /** Worst-mode consensus, baked server-side. */
   consensus: ConsensusForecast;
+  /** Majority-mode consensus, baked server-side (#419). Optional so an older
+   *  cached payload without it still decodes; `getConsensus` falls back to
+   *  `consensus` when absent. */
+  consensus_majority?: ConsensusForecast;
 }
 
 export interface ModelForecast {

--- a/web/ts/data/map-metrics-catalog.json
+++ b/web/ts/data/map-metrics-catalog.json
@@ -1,0 +1,219 @@
+{
+  "_comment": "Forecast-map metric catalog: colour scales, thresholds, labels and legends for the pan-European overview map. Single source of truth imported by the web bundle (web/ts/visualization/weather-map-format.ts) and served ETag-cacheable to iOS via /api/help (api/help.py, `maps` section). A threshold or colour change is a one-line edit here that both clients pick up — see issue #419 (B2). `scales.categorical` maps a discrete value to a hex; `scales.bands` is a value→colour function: kind `threshold_asc` returns the first stop whose value is `< lt` else `default` (with `convert:\"m_to_sm\"` applied first for visibility, and `null_color` for a missing value); kind `gray_ramp` is the continuous cloud ramp rgb(g,g,g+blue_boost) with g=round(base-(pct/100)*span). `metrics` gives each map metric its label, how it is coloured, and its legend rows.",
+  "version": 1,
+  "scales": {
+    "categorical": {
+      "flight_category": { "VFR": "#22c55e", "MVFR": "#3b82f6", "IFR": "#ef4444", "LIFR": "#a855f7" },
+      "convective_risk": { "none": "#22c55e", "marginal": "#eab308", "low": "#facc15", "moderate": "#f97316", "high": "#ef4444", "extreme": "#991b1b" },
+      "agreement": { "consistent": "#22c55e", "mixed": "#f97316", "divergent": "#ef4444" }
+    },
+    "bands": {
+      "wind_speed_kt": {
+        "kind": "threshold_asc",
+        "stops": [
+          { "lt": 10, "color": "#22c55e" },
+          { "lt": 15, "color": "#84cc16" },
+          { "lt": 20, "color": "#eab308" },
+          { "lt": 25, "color": "#f97316" },
+          { "lt": 35, "color": "#ef4444" }
+        ],
+        "default": "#991b1b"
+      },
+      "crosswind_kt": {
+        "kind": "threshold_asc",
+        "stops": [
+          { "lt": 5, "color": "#22c55e" },
+          { "lt": 10, "color": "#84cc16" },
+          { "lt": 15, "color": "#eab308" },
+          { "lt": 20, "color": "#f97316" },
+          { "lt": 25, "color": "#ef4444" }
+        ],
+        "default": "#991b1b"
+      },
+      "headwind_kt": {
+        "kind": "threshold_asc",
+        "stops": [
+          { "lt": 10, "color": "#22c55e" },
+          { "lt": 15, "color": "#84cc16" },
+          { "lt": 20, "color": "#eab308" },
+          { "lt": 25, "color": "#f97316" },
+          { "lt": 30, "color": "#ef4444" }
+        ],
+        "default": "#991b1b"
+      },
+      "ceiling_ft": {
+        "kind": "threshold_asc",
+        "null_color": "#888",
+        "stops": [
+          { "lt": 500, "color": "#a855f7" },
+          { "lt": 1000, "color": "#ef4444" },
+          { "lt": 3000, "color": "#3b82f6" }
+        ],
+        "default": "#22c55e"
+      },
+      "cape_jkg": {
+        "kind": "threshold_asc",
+        "stops": [
+          { "lt": 100, "color": "#22c55e" },
+          { "lt": 500, "color": "#eab308" },
+          { "lt": 1000, "color": "#f97316" },
+          { "lt": 2000, "color": "#ef4444" }
+        ],
+        "default": "#991b1b"
+      },
+      "visibility_m": {
+        "kind": "threshold_desc",
+        "convert": "m_to_sm",
+        "stops": [
+          { "gte": 5, "color": "#22c55e" },
+          { "gte": 3, "color": "#3b82f6" },
+          { "gte": 1, "color": "#ef4444" }
+        ],
+        "default": "#a855f7"
+      },
+      "cloud_cover_pct": { "kind": "gray_ramp", "base": 220, "span": 160, "blue_boost": 10 }
+    }
+  },
+  "metrics": {
+    "flight_category": {
+      "label": "Category",
+      "color": { "kind": "categorical", "scale": "flight_category", "fallback": "#888" },
+      "legend": {
+        "title": "Flight Category",
+        "items": [
+          { "color": "#22c55e", "label": "VFR" },
+          { "color": "#3b82f6", "label": "MVFR" },
+          { "color": "#ef4444", "label": "IFR" },
+          { "color": "#a855f7", "label": "LIFR" }
+        ]
+      }
+    },
+    "wind_speed_kt": {
+      "label": "Wind",
+      "color": { "kind": "band", "scale": "wind_speed_kt", "field": "wind_speed_kt", "fallback": 0 },
+      "legend": {
+        "title": "Wind Speed (kt)",
+        "items": [
+          { "color": "#22c55e", "label": "< 10" },
+          { "color": "#84cc16", "label": "10-15" },
+          { "color": "#eab308", "label": "15-20" },
+          { "color": "#f97316", "label": "20-25" },
+          { "color": "#ef4444", "label": "25-35" },
+          { "color": "#991b1b", "label": "35+" }
+        ]
+      }
+    },
+    "crosswind_kt": {
+      "label": "Xwind",
+      "color": { "kind": "band", "scale": "crosswind_kt", "field": "crosswind_kt", "fallback": null },
+      "legend": {
+        "title": "Best Rwy Crosswind (kt)",
+        "items": [
+          { "color": "#22c55e", "label": "< 5" },
+          { "color": "#84cc16", "label": "5-10" },
+          { "color": "#eab308", "label": "10-15" },
+          { "color": "#f97316", "label": "15-20" },
+          { "color": "#ef4444", "label": "20-25" },
+          { "color": "#991b1b", "label": "25+" }
+        ]
+      }
+    },
+    "headwind_kt": {
+      "label": "Headwind",
+      "color": { "kind": "band", "scale": "headwind_kt", "field": "headwind_kt", "fallback": null },
+      "legend": {
+        "title": "Best Rwy Headwind (kt)",
+        "items": [
+          { "color": "#22c55e", "label": "< 10" },
+          { "color": "#84cc16", "label": "10-15" },
+          { "color": "#eab308", "label": "15-20" },
+          { "color": "#f97316", "label": "20-25" },
+          { "color": "#ef4444", "label": "25-30" },
+          { "color": "#991b1b", "label": "30+" }
+        ]
+      }
+    },
+    "ceiling_ft": {
+      "label": "Ceiling",
+      "color": { "kind": "band", "scale": "ceiling_ft", "field": "ceiling_ft", "fallback": null },
+      "legend": {
+        "title": "Ceiling (ft)",
+        "items": [
+          { "color": "#22c55e", "label": "> 3000 (VFR)" },
+          { "color": "#3b82f6", "label": "1000-3000 (MVFR)" },
+          { "color": "#ef4444", "label": "500-1000 (IFR)" },
+          { "color": "#a855f7", "label": "< 500 (LIFR)" }
+        ]
+      }
+    },
+    "cape_jkg": {
+      "label": "CAPE",
+      "color": { "kind": "band", "scale": "cape_jkg", "field": "cape_jkg", "fallback": 0 },
+      "legend": {
+        "title": "CAPE (J/kg)",
+        "items": [
+          { "color": "#22c55e", "label": "< 100" },
+          { "color": "#eab308", "label": "100-500" },
+          { "color": "#f97316", "label": "500-1000" },
+          { "color": "#ef4444", "label": "1000-2000" },
+          { "color": "#991b1b", "label": "2000+" }
+        ]
+      }
+    },
+    "convective_risk": {
+      "label": "Convective",
+      "color": { "kind": "categorical", "scale": "convective_risk", "default": "none", "fallback": "#888" },
+      "legend": {
+        "title": "Convective Risk",
+        "items": [
+          { "color": "#22c55e", "label": "none" },
+          { "color": "#eab308", "label": "marginal" },
+          { "color": "#facc15", "label": "low" },
+          { "color": "#f97316", "label": "moderate" },
+          { "color": "#ef4444", "label": "high" },
+          { "color": "#991b1b", "label": "extreme" }
+        ]
+      }
+    },
+    "visibility_m": {
+      "label": "Visibility",
+      "color": { "kind": "band", "scale": "visibility_m", "field": "visibility_m", "fallback": 99999 },
+      "legend": {
+        "title": "Visibility",
+        "items": [
+          { "color": "#22c55e", "label": ">= 5 SM (VFR)" },
+          { "color": "#3b82f6", "label": "3-5 SM (MVFR)" },
+          { "color": "#ef4444", "label": "1-3 SM (IFR)" },
+          { "color": "#a855f7", "label": "< 1 SM (LIFR)" }
+        ]
+      }
+    },
+    "cloud_cover_pct": {
+      "label": "Cloud cover",
+      "color": { "kind": "band", "scale": "cloud_cover_pct", "field": "cloud_cover_pct", "fallback": 0 },
+      "legend": {
+        "title": "Cloud Cover",
+        "items": [
+          { "color": "rgb(220,220,230)", "label": "Clear" },
+          { "color": "rgb(180,180,190)", "label": "25%" },
+          { "color": "rgb(140,140,150)", "label": "50%" },
+          { "color": "rgb(100,100,110)", "label": "75%" },
+          { "color": "rgb(60,60,70)", "label": "Overcast" }
+        ]
+      }
+    },
+    "alternate_needed": {
+      "label": "Alternate required?",
+      "color": { "kind": "alternate_needed", "fallback": "#888" },
+      "legend": {
+        "title": "Alternate required? (model estimate)",
+        "items": [
+          { "color": "#22c55e", "label": "Neither (FAA & EASA ok)" },
+          { "color": "#eab308", "label": "One regime (FAA or EASA)" },
+          { "color": "#ef4444", "label": "Both (FAA & EASA)" },
+          { "color": "#888", "label": "No data" }
+        ]
+      }
+    }
+  }
+}

--- a/web/ts/helpers/airport-summary.ts
+++ b/web/ts/helpers/airport-summary.ts
@@ -2,9 +2,9 @@
  *
  * Collapses the per-model `AirportModelCondition` list into one summary
  * condition under the user's aggregation mode. Extracted from `advisories-ui`
- * so the math is independently testable and mirrors the forecast-map consensus
- * (`weather-map-consensus.computeConsensus`) and the Python
- * `analysis.airport_consensus.consensus`.
+ * so the math is independently testable and mirrors the Python
+ * `analysis.airport_consensus.consensus` (the same rules the forecast map now
+ * reads server-baked; both are pinned to `tests/fixtures/consensus_vectors.json`).
  *
  * Numeric fields follow the category so they can never contradict the badge:
  *  - **worst**:    worst value across ALL models (min ceiling/vis, max wind).

--- a/web/ts/i18n/locales/de.json
+++ b/web/ts/i18n/locales/de.json
@@ -89,6 +89,7 @@
   "maps.shareLinkTitle": "Link zu dieser Ansicht kopieren",
   "maps.shareLinkCopied": "Link kopiert",
   "maps.shareLinkFallback": "Diesen Link zum Teilen kopieren:",
+  "maps.today": "Heute",
   "maps.dayNotForecast": "Noch nicht vorhergesagt",
   "maps.dayNotForecastDetail": "{date} ist noch nicht vorhergesagt — verfügbar nach dem nächsten Modelllauf (07Z/19Z).",
   "maps.dayModels": "Modelle für diesen Zeitraum: {models}",

--- a/web/ts/i18n/locales/en.json
+++ b/web/ts/i18n/locales/en.json
@@ -89,6 +89,7 @@
   "maps.shareLinkTitle": "Copy a link to this view",
   "maps.shareLinkCopied": "Link copied",
   "maps.shareLinkFallback": "Copy this link to share:",
+  "maps.today": "Today",
   "maps.dayNotForecast": "Not forecast yet",
   "maps.dayNotForecastDetail": "{date} isn't forecast yet — it becomes available after the next model run (07Z/19Z).",
   "maps.dayModels": "Models at this range: {models}",

--- a/web/ts/i18n/locales/es.json
+++ b/web/ts/i18n/locales/es.json
@@ -89,6 +89,7 @@
   "maps.shareLinkTitle": "Copiar un enlace a esta vista",
   "maps.shareLinkCopied": "Enlace copiado",
   "maps.shareLinkFallback": "Copia este enlace para compartir:",
+  "maps.today": "Hoy",
   "maps.dayNotForecast": "Aún sin pronóstico",
   "maps.dayNotForecastDetail": "{date} aún no tiene pronóstico — estará disponible tras la próxima pasada del modelo (07Z/19Z).",
   "maps.dayModels": "Modelos a este alcance: {models}",

--- a/web/ts/i18n/locales/fr.json
+++ b/web/ts/i18n/locales/fr.json
@@ -89,6 +89,7 @@
   "maps.shareLinkTitle": "Copier un lien vers cette vue",
   "maps.shareLinkCopied": "Lien copié",
   "maps.shareLinkFallback": "Copiez ce lien pour partager :",
+  "maps.today": "Aujourd'hui",
   "maps.dayNotForecast": "Pas encore prévu",
   "maps.dayNotForecastDetail": "{date} n'est pas encore prévu — disponible après la prochaine sortie du modèle (07Z/19Z).",
   "maps.dayModels": "Modèles à cette échéance : {models}",

--- a/web/ts/maps-main.ts
+++ b/web/ts/maps-main.ts
@@ -172,6 +172,19 @@ function dayDateLabel(day: number): string {
   return `${dow} ${dd}-${mon}-${yr}`;
 }
 
+/** Compact day-picker label: "Today" for D-0, else weekday + day-of-month
+ *  ("Thu 16"). A pilot planning a weekend thinks "Saturday", not "D+4"; the
+ *  URL state key `fc.day` stays a relative integer so share links still
+ *  resolve (#419, W1). Uses the same UTC `now + day` mapping as the data. */
+function dayTabLabel(day: number): string {
+  if (day === 0) return t('maps.today');
+  const now = new Date();
+  const target = new Date(Date.UTC(
+    now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() + day, 0, 0, 0,
+  ));
+  return `${_DAYS[target.getUTCDay()]} ${target.getUTCDate()}`;
+}
+
 function updateForecastDatetime(): void {
   const el = $('forecast-datetime');
   if (!el) return;
@@ -203,7 +216,7 @@ function renderDayPicker(): void {
     const btn = document.createElement('button');
     btn.className = 'btn-toggle';
     btn.dataset.day = String(d.day);
-    btn.textContent = `D-${d.day}`;
+    btn.textContent = dayTabLabel(d.day);
     if (d.day === fcDay) btn.classList.add('active');
     btn.classList.toggle('unavailable', !d.available);
     // Kept clickable (to explain itself when picked) so `disabled` isn't used;

--- a/web/ts/visualization/weather-map-consensus.ts
+++ b/web/ts/visualization/weather-map-consensus.ts
@@ -1,16 +1,14 @@
-/** Pure consensus aggregation for the forecast overview map.
+/** Shared consensus reduction helpers for the forecast overview map.
  *
- * Combines per-model forecast values into a single "worst" or "majority"
- * value used by consensus mode on the forecast map. Extracted from
- * weather-map.ts so the math is independently testable.
- *
- * Modes:
- *  - "worst":    most-adverse value (max wind, min ceiling, max risk).
- *  - "majority": modal/median value, with worst-case tiebreak for
- *                ordinal categories.
+ * The forecast map's worst/majority consensus is now baked server-side and
+ * read straight off the payload (`airport.consensus` / `consensus_majority`),
+ * so the client no longer recomputes it — see `weather-map-format.getConsensus`
+ * and issue #419. What remains here are the small pure reducers that other
+ * surfaces still share: the mode type-guard, the ordinal reducer used by the
+ * client-side FAA/EASA alternate-required aggregation
+ * (`weather-map-format.aggAltRequired`), and the `median`/`CAT_ORDER` helpers
+ * the briefing arrival card reuses (`helpers/airport-summary`).
  */
-
-import type { ForecastAirport, ConsensusForecast } from '../adapters/maps-adapter';
 
 export type ConsensusMode = 'worst' | 'majority';
 
@@ -37,26 +35,6 @@ export function circularMean(degs: number[]): number {
   return ((Math.atan2(sinSum, cosSum) * 180 / Math.PI) + 360) % 360;
 }
 
-const _max = (v: number[]) => Math.max(...v);
-const _min = (v: number[]) => Math.min(...v);
-
-/** Per-numeric-field worst/majority aggregators. */
-export const NUMERIC_CONSENSUS: Record<
-  'wind_speed_kt' | 'crosswind_kt' | 'headwind_kt' | 'ceiling_ft' | 'cape_jkg' | 'visibility_m' | 'cloud_cover_pct',
-  { worst: (v: number[]) => number; majority: (v: number[]) => number }
-> = {
-  wind_speed_kt:   { worst: _max, majority: median },
-  crosswind_kt:    { worst: _max, majority: median },
-  // Headwind is favourable, so the "worst" case is the WEAKEST headwind /
-  // strongest tailwind (min) — not the strongest headwind. Mirrors Python
-  // airport_consensus._WORST_IS_MIN (a positive headwind helps).
-  headwind_kt:     { worst: _min, majority: median },
-  ceiling_ft:      { worst: _min, majority: median },
-  cape_jkg:        { worst: _max, majority: median },
-  visibility_m:    { worst: _min, majority: median },
-  cloud_cover_pct: { worst: _max, majority: median },
-};
-
 /** Ordinal aggregation for categorical fields (flight_category, convective_risk).
  *
  * - worst: highest-ranked value.
@@ -80,51 +58,4 @@ export function ordinalConsensus(
   const maxCount = Math.max(...counts.values());
   const tied = [...counts.entries()].filter(([, n]) => n === maxCount).map(([v]) => v);
   return tied.reduce((a, b) => rank(a) >= rank(b) ? a : b);
-}
-
-/** Compute a single consensus forecast across all an airport's models.
- *
- * Numeric fields follow the category so they can never contradict the badge:
- *  - worst mode:    worst value across ALL models (min ceiling/vis, max wind…).
- *  - majority mode: MEDIAN within the winning-category pool (the models that
- *                   voted for the shown category). Mirrors the Python
- *                   `airport_consensus.consensus` exactly.
- * Wind direction is a circular mean of the same pool (never a min/max/median).
- */
-export function computeConsensus(airport: ForecastAirport, mode: ConsensusMode): ConsensusForecast {
-  const models = Object.values(airport.models);
-  if (models.length === 0) return { flight_category: 'VFR', agreement: {} };
-
-  const cats = models.map((m) => m.flight_category);
-  const risks = models.map((m) => m.convective_risk || 'none');
-
-  const flightCategory = ordinalConsensus(cats, CAT_ORDER, mode);
-  const result: ConsensusForecast = {
-    flight_category: flightCategory,
-    convective_risk: ordinalConsensus(risks, RISK_ORDER, mode),
-    agreement: airport.consensus.agreement,
-  };
-
-  // In majority mode restrict numeric reductions to the winning-category pool;
-  // in worst mode the pool is all models (the reduction is worst-across-all).
-  const pool = mode === 'majority'
-    ? models.filter((m) => m.flight_category === flightCategory)
-    : models;
-
-  for (const [field, fns] of Object.entries(NUMERIC_CONSENSUS) as Array<
-    [keyof typeof NUMERIC_CONSENSUS, (typeof NUMERIC_CONSENSUS)[keyof typeof NUMERIC_CONSENSUS]]
-  >) {
-    const vals = pool.map((m) => m[field]).filter((v): v is number => v != null);
-    if (!vals.length) continue;
-    const fn = mode === 'worst' ? fns.worst : fns.majority; // majority => median
-    (result as unknown as Record<string, unknown>)[field] = Math.round(fn(vals) * 10) / 10;
-  }
-
-  const dirs = pool.map((m) => m.wind_dir_deg).filter((v): v is number => v != null);
-  // Wind direction is reported in whole degrees by METAR/TAF — sub-degree
-  // precision is false, and serializing the raw float yields strings like
-  // "359.9999999999996". Round to the same convention as the source data.
-  if (dirs.length) result.wind_dir_deg = Math.round(circularMean(dirs));
-
-  return result;
 }

--- a/web/ts/visualization/weather-map-format.ts
+++ b/web/ts/visualization/weather-map-format.ts
@@ -11,79 +11,100 @@ import type {
 } from '../adapters/maps-adapter';
 import { formatVisibility, formatHeading } from '../units';
 import {
-  isConsensusMode, computeConsensus, ordinalConsensus, type ConsensusMode,
+  isConsensusMode, ordinalConsensus, type ConsensusMode,
 } from './weather-map-consensus';
+import catalog from '../data/map-metrics-catalog.json';
 
-// --- Color scales ---
+// --- Served catalog: colours, thresholds, labels, legends (B2, #419) ---
+//
+// The colour ramps and thresholds are no longer hardcoded here — they live in
+// `web/ts/data/map-metrics-catalog.json`, imported below and ALSO served
+// ETag-cacheable to iOS via `/api/help` (`maps` section). A threshold change is
+// a one-line JSON edit both clients pick up, so the same weather can never show
+// in two different colours on two devices. This module is now the JSON's
+// interpreter: it evaluates the band/categorical scales the catalog describes.
 
-export const CAT_COLORS: Record<string, string> = {
-  VFR: '#22c55e', MVFR: '#3b82f6', IFR: '#ef4444', LIFR: '#a855f7',
-};
+interface BandStop { lt?: number; gte?: number; color: string; }
+interface ThresholdScale {
+  kind: 'threshold_asc' | 'threshold_desc';
+  stops: BandStop[];
+  default: string;
+  null_color?: string;
+  convert?: 'm_to_sm';
+}
+interface GrayRampScale { kind: 'gray_ramp'; base: number; span: number; blue_boost: number; }
+type BandScale = ThresholdScale | GrayRampScale;
 
-export const RISK_COLORS: Record<string, string> = {
-  none: '#22c55e', marginal: '#eab308', low: '#facc15', moderate: '#f97316', high: '#ef4444', extreme: '#991b1b',
-};
+interface MetricColorSpec {
+  kind: 'categorical' | 'band' | 'alternate_needed';
+  scale?: string;
+  field?: string;
+  default?: string;
+  fallback: string | number | null;
+}
+interface MapLegendItem { color: string; label: string; }
+export interface MapLegend { title: string; items: MapLegendItem[]; }
+interface MetricSpec { label: string; color: MetricColorSpec; legend: MapLegend; }
+interface MapMetricsCatalog {
+  version: number;
+  scales: {
+    categorical: Record<string, Record<string, string>>;
+    bands: Record<string, BandScale>;
+  };
+  metrics: Record<string, MetricSpec>;
+}
 
+const CATALOG = catalog as unknown as MapMetricsCatalog;
+const CATEGORICAL = CATALOG.scales.categorical;
+const BANDS = CATALOG.scales.bands;
+
+/** Muted grey for missing data (unchanged from the previous hardcoded value). */
+const MUTED = '#888';
+
+// Re-exported categorical scales, sourced from the catalog so callers that
+// colour category / risk / agreement directly (markers, card, legends) share
+// the one table with the marker layer.
+export const CAT_COLORS: Record<string, string> = CATEGORICAL.flight_category;
+export const RISK_COLORS: Record<string, string> = CATEGORICAL.convective_risk;
 /** Border color per agreement bucket (consensus modes). Keys match the
  *  values the server bakes into `consensus.agreement[field]`. */
-export const AGREEMENT_COLORS: Record<string, string> = {
-  consistent: '#22c55e', mixed: '#f97316', divergent: '#ef4444',
-};
+export const AGREEMENT_COLORS: Record<string, string> = CATEGORICAL.agreement;
 
-function windSpeedColor(kt: number): string {
-  if (kt < 10) return '#22c55e';
-  if (kt < 15) return '#84cc16';
-  if (kt < 20) return '#eab308';
-  if (kt < 25) return '#f97316';
-  if (kt < 35) return '#ef4444';
-  return '#991b1b';
-}
-
-function crosswindColor(kt: number): string {
-  if (kt < 5) return '#22c55e';
-  if (kt < 10) return '#84cc16';
-  if (kt < 15) return '#eab308';
-  if (kt < 20) return '#f97316';
-  if (kt < 25) return '#ef4444';
-  return '#991b1b';
-}
-
-function headwindColor(kt: number): string {
-  if (kt < 10) return '#22c55e';
-  if (kt < 15) return '#84cc16';
-  if (kt < 20) return '#eab308';
-  if (kt < 25) return '#f97316';
-  if (kt < 30) return '#ef4444';
-  return '#991b1b';
-}
-
-function ceilingColor(ft: number | null): string {
-  if (ft === null) return '#888';
-  if (ft < 500) return '#a855f7';  // LIFR
-  if (ft < 1000) return '#ef4444'; // IFR
-  if (ft < 3000) return '#3b82f6'; // MVFR
-  return '#22c55e';                 // VFR
-}
-
-function capeColor(jkg: number): string {
-  if (jkg < 100) return '#22c55e';
-  if (jkg < 500) return '#eab308';
-  if (jkg < 1000) return '#f97316';
-  if (jkg < 2000) return '#ef4444';
-  return '#991b1b';
-}
-
-function visibilityColor(m: number): string {
-  const sm = m / 1609.34;
-  if (sm >= 5) return '#22c55e';   // VFR
-  if (sm >= 3) return '#3b82f6';   // MVFR
-  if (sm >= 1) return '#ef4444';   // IFR
-  return '#a855f7';                 // LIFR
+function grayRamp(scale: GrayRampScale, pct: number): string {
+  const g = Math.round(scale.base - (pct / 100) * scale.span);
+  return `rgb(${g},${g},${g + scale.blue_boost})`;
 }
 
 export function cloudCoverColor(pct: number): string {
-  const g = Math.round(220 - (pct / 100) * 160);
-  return `rgb(${g},${g},${g + 10})`;
+  return grayRamp(BANDS.cloud_cover_pct as GrayRampScale, pct);
+}
+
+/** Evaluate a value→colour band scale from the catalog.
+ *
+ * A missing value resolves in the same order the old per-metric functions did:
+ * a `null_color` (ceiling) wins; otherwise a `null` fallback → muted grey
+ * (crosswind/headwind), and a numeric fallback (wind/CAPE 0, visibility 99999,
+ * cloud 0) is substituted before banding. `threshold_asc` picks the first stop
+ * the value is below; `threshold_desc` (visibility, after m→SM) the first stop
+ * the value is at-or-above. */
+function bandColor(scaleKey: string, raw: number | null | undefined, fallback: string | number | null): string {
+  const scale = BANDS[scaleKey];
+  let v: number | null = raw ?? null;
+  if (v == null) {
+    const nullColor = (scale as ThresholdScale).null_color;
+    if (nullColor) return nullColor;
+    if (typeof fallback !== 'number') return MUTED;
+    v = fallback;
+  }
+  if (scale.kind === 'gray_ramp') return grayRamp(scale, v);
+  let val = v;
+  if (scale.convert === 'm_to_sm') val = val / 1609.34;
+  if (scale.kind === 'threshold_desc') {
+    for (const s of scale.stops) if (val >= (s.gte as number)) return s.color;
+    return scale.default;
+  }
+  for (const s of scale.stops) if (val < (s.lt as number)) return s.color;
+  return scale.default;
 }
 
 // --- Forecast metric extraction ---
@@ -124,37 +145,37 @@ export function altNeededColor(airport: ForecastAirport, model: string): string 
   return n === 0 ? '#22c55e' : n === 1 ? '#eab308' : '#ef4444'; // green / amber / red
 }
 
+/** The consensus block for the active mode. Both Worst (`consensus`) and
+ *  Majority (`consensus_majority`) are baked server-side (#419) so the client
+ *  carries no consensus math — it just picks the block. Falls back to the
+ *  worst block if a majority block is missing (e.g. an older cached payload). */
 export function getConsensus(airport: ForecastAirport, mode: ConsensusMode): ConsensusForecast {
-  return computeConsensus(airport, mode);
+  const baked = mode === 'majority' ? airport.consensus_majority : airport.consensus;
+  return baked ?? airport.consensus;
 }
 
 export function getForecastColor(airport: ForecastAirport, metric: ForecastMetric, model: string): string {
+  const spec = CATALOG.metrics[metric];
   const data = isConsensusMode(model) ? getConsensus(airport, model) : airport.models[model];
-  if (!data) return '#888';
+  if (!data) return MUTED;
 
-  switch (metric) {
-    case 'flight_category':
-      return CAT_COLORS[data.flight_category] || '#888';
-    case 'wind_speed_kt':
-      return windSpeedColor(data.wind_speed_kt ?? 0);
-    case 'crosswind_kt':
-      return data.crosswind_kt != null ? crosswindColor(data.crosswind_kt) : '#888';
-    case 'headwind_kt':
-      return data.headwind_kt != null ? headwindColor(data.headwind_kt) : '#888';
-    case 'ceiling_ft':
-      return ceilingColor(data.ceiling_ft ?? null);
-    case 'cape_jkg':
-      return capeColor(data.cape_jkg ?? 0);
-    case 'convective_risk':
-      return RISK_COLORS[data.convective_risk || 'none'] || '#888';
-    case 'visibility_m':
-      return visibilityColor(data.visibility_m ?? 99999);
-    case 'cloud_cover_pct':
-      return cloudCoverColor(data.cloud_cover_pct ?? 0);
+  const color = spec.color;
+  switch (color.kind) {
     case 'alternate_needed':
       return altNeededColor(airport, model);
+    case 'categorical': {
+      // For categorical metrics the scale name is also the data field
+      // ('flight_category' / 'convective_risk'). `default` maps a blank value
+      // to a sentinel key (convective '' → 'none').
+      const scaleMap = CATEGORICAL[color.scale!];
+      let key = (data as unknown as Record<string, unknown>)[color.scale!] as string | undefined;
+      if (color.default != null && !key) key = color.default;
+      return (key != null ? scaleMap[key] : undefined) ?? (color.fallback as string);
+    }
+    case 'band':
+      return bandColor(color.scale!, (data as unknown as Record<string, number | null>)[color.field!], color.fallback);
     default:
-      return '#888';
+      return MUTED;
   }
 }
 
@@ -175,18 +196,16 @@ function fmtWind(speed: number | null | undefined, dir: number | null | undefine
   return `${dirStr}${Math.round(speed)}${gustStr} kt`;
 }
 
-export const METRIC_LABEL: Record<ForecastMetric, string> = {
-  flight_category: 'Category',
-  wind_speed_kt: 'Wind',
-  crosswind_kt: 'Xwind',
-  headwind_kt: 'Headwind',
-  ceiling_ft: 'Ceiling',
-  cape_jkg: 'CAPE',
-  convective_risk: 'Convective',
-  visibility_m: 'Visibility',
-  cloud_cover_pct: 'Cloud cover',
-  alternate_needed: 'Alternate required?',
-};
+export const METRIC_LABEL: Record<ForecastMetric, string> = Object.fromEntries(
+  Object.entries(CATALOG.metrics).map(([k, m]) => [k, m.label]),
+) as Record<ForecastMetric, string>;
+
+/** Per-metric legend (title + colour rows), from the served catalog. The
+ *  marker layer renders these; visibility keeps a region-aware override for
+ *  its labels (SM vs km) in `weather-map.ts`. */
+export const MAP_LEGENDS: Record<ForecastMetric, MapLegend> = Object.fromEntries(
+  Object.entries(CATALOG.metrics).map(([k, m]) => [k, m.legend]),
+) as Record<ForecastMetric, MapLegend>;
 
 /** Format the value of a metric (no label) for tooltip / card display. */
 export function formatMetricValue(data: { [key: string]: any }, metric: ForecastMetric): string {

--- a/web/ts/visualization/weather-map.ts
+++ b/web/ts/visualization/weather-map.ts
@@ -9,7 +9,7 @@ import { isConsensusMode, type ConsensusMode } from './weather-map-consensus';
 import {
   getForecastColor, getConsensus, getAgreementForMetric, formatMetricValue,
   METRIC_LABEL, altLabel, aggAltRequired, AGREEMENT_COLORS,
-  CAT_COLORS, RISK_COLORS, cloudCoverColor,
+  MAP_LEGENDS,
   type ForecastMetric,
 } from './weather-map-format';
 
@@ -86,102 +86,10 @@ function getForecastTooltip(airport: ForecastAirport, model: string, metric: For
 }
 
 // --- Legend definitions ---
-
-const FORECAST_LEGENDS: Record<ForecastMetric, { title: string; items: Array<{ color: string; label: string }> }> = {
-  flight_category: {
-    title: 'Flight Category',
-    items: [
-      { color: CAT_COLORS.VFR, label: 'VFR' },
-      { color: CAT_COLORS.MVFR, label: 'MVFR' },
-      { color: CAT_COLORS.IFR, label: 'IFR' },
-      { color: CAT_COLORS.LIFR, label: 'LIFR' },
-    ],
-  },
-  wind_speed_kt: {
-    title: 'Wind Speed (kt)',
-    items: [
-      { color: '#22c55e', label: '< 10' },
-      { color: '#84cc16', label: '10-15' },
-      { color: '#eab308', label: '15-20' },
-      { color: '#f97316', label: '20-25' },
-      { color: '#ef4444', label: '25-35' },
-      { color: '#991b1b', label: '35+' },
-    ],
-  },
-  crosswind_kt: {
-    title: 'Best Rwy Crosswind (kt)',
-    items: [
-      { color: '#22c55e', label: '< 5' },
-      { color: '#84cc16', label: '5-10' },
-      { color: '#eab308', label: '10-15' },
-      { color: '#f97316', label: '15-20' },
-      { color: '#ef4444', label: '20-25' },
-      { color: '#991b1b', label: '25+' },
-    ],
-  },
-  headwind_kt: {
-    title: 'Best Rwy Headwind (kt)',
-    items: [
-      { color: '#22c55e', label: '< 10' },
-      { color: '#84cc16', label: '10-15' },
-      { color: '#eab308', label: '15-20' },
-      { color: '#f97316', label: '20-25' },
-      { color: '#ef4444', label: '25-30' },
-      { color: '#991b1b', label: '30+' },
-    ],
-  },
-  ceiling_ft: {
-    title: 'Ceiling (ft)',
-    items: [
-      { color: '#22c55e', label: '> 3000 (VFR)' },
-      { color: '#3b82f6', label: '1000-3000 (MVFR)' },
-      { color: '#ef4444', label: '500-1000 (IFR)' },
-      { color: '#a855f7', label: '< 500 (LIFR)' },
-    ],
-  },
-  cape_jkg: {
-    title: 'CAPE (J/kg)',
-    items: [
-      { color: '#22c55e', label: '< 100' },
-      { color: '#eab308', label: '100-500' },
-      { color: '#f97316', label: '500-1000' },
-      { color: '#ef4444', label: '1000-2000' },
-      { color: '#991b1b', label: '2000+' },
-    ],
-  },
-  convective_risk: {
-    title: 'Convective Risk',
-    items: Object.entries(RISK_COLORS).map(([k, c]) => ({ color: c, label: k })),
-  },
-  visibility_m: {
-    title: 'Visibility',
-    items: [
-      { color: '#22c55e', label: '>= 5 SM (VFR)' },
-      { color: '#3b82f6', label: '3-5 SM (MVFR)' },
-      { color: '#ef4444', label: '1-3 SM (IFR)' },
-      { color: '#a855f7', label: '< 1 SM (LIFR)' },
-    ],
-  },
-  cloud_cover_pct: {
-    title: 'Cloud Cover',
-    items: [
-      { color: cloudCoverColor(0), label: 'Clear' },
-      { color: cloudCoverColor(25), label: '25%' },
-      { color: cloudCoverColor(50), label: '50%' },
-      { color: cloudCoverColor(75), label: '75%' },
-      { color: cloudCoverColor(100), label: 'Overcast' },
-    ],
-  },
-  alternate_needed: {
-    title: 'Alternate required? (model estimate)',
-    items: [
-      { color: '#22c55e', label: 'Neither (FAA & EASA ok)' },
-      { color: '#eab308', label: 'One regime (FAA or EASA)' },
-      { color: '#ef4444', label: 'Both (FAA & EASA)' },
-      { color: '#888', label: 'No data' },
-    ],
-  },
-};
+//
+// Titles + colour rows come from the served map-metrics catalog (`MAP_LEGENDS`,
+// B2/#419) rather than being hardcoded here. Visibility keeps a region-aware
+// label override (SM vs km) applied at render time — see `visibilityLegendItems`.
 
 // --- Map class ---
 
@@ -338,8 +246,8 @@ export class WeatherMap {
 
     this.attachZoomHandler();
     const legend = metric === 'visibility_m'
-      ? { ...FORECAST_LEGENDS.visibility_m, items: visibilityLegendItems() }
-      : FORECAST_LEGENDS[metric];
+      ? { ...MAP_LEGENDS.visibility_m, items: visibilityLegendItems() }
+      : MAP_LEGENDS[metric];
     this.renderLegend(legend);
 
     // Re-apply highlight if the currently-highlighted airport is still on the map.


### PR DESCRIPTION
## What & why

This PR implements issue #419 (B2 & B3), moving the forecast-map colour scales, thresholds, and legends from hardcoded TypeScript into a served JSON catalog, and baking consensus aggregation server-side so both web and iOS clients read the same pre-computed values.

**Key changes:**

1. **New `web/ts/data/map-metrics-catalog.json`** — Single source of truth for all forecast-map metrics: colour scales (categorical, threshold bands, gray ramps), thresholds, labels, and legends. Imported by the web bundle and served ETag-cacheable to iOS via `/api/help` (`maps` section).

2. **Server-side consensus baking** — `airport_consensus.consensus()` now computes both worst-mode and majority-mode consensus blocks and bakes them into the forecast-map payload (`consensus` and `consensus_majority` fields). The client no longer recomputes; it just reads the pre-baked block matching the active mode.

3. **Catalog-driven colour evaluation** — `weather-map-format.ts` now interprets the JSON catalog instead of hardcoding colour functions. A single `bandColor()` function evaluates threshold/gray-ramp scales; categorical scales are looked up directly. Threshold changes are now one-line JSON edits both clients pick up.

4. **Retired client-side consensus math** — `weather-map-consensus.computeConsensus()` is removed. The small pure reducers (`median`, `circularMean`, `ordinalConsensus`) remain for the briefing arrival card's `computeSummaryCondition`, which still recomputes client-side.

5. **Frequent airports ranking** — New `compute_frequent_airports()` function derives the user's top-5 most-used departure and destination airports from flight history (first/last waypoints). Served at `GET /flights/frequent-airports` for iOS to centre the forecast map on cold open.

6. **Cache versioning** — Forecast-map cache keys now include a version segment (`forecast_map:{version}:{day}:{hour}`) so changes to the catalog or consensus logic invalidate old cached payloads.

**Why this matters:**
- **Consistency**: The same weather can never show in two different colours on two devices — both clients read the same catalog and baked consensus.
- **Maintainability**: Threshold changes are one JSON edit, not code changes in two languages.
- **Performance**: Consensus is computed once server-side, not recomputed by every client.
- **Discoverability**: iOS can fetch the catalog at startup and render the map without waiting for forecast data.

## Issue linkage

Closes #419

## Testing / verification

- **Consensus parity**: `tests/test_consensus_parity.py` pins the server's `airport_consensus.consensus()` to the reference vectors; `web/tests/unit/consensus-parity.test.ts` pins the briefing card's `computeSummaryCondition` to the same vectors.
- **Frequent airports**: New unit tests in `tests/test_frequent_airports.py` cover ranking, ICAO filtering, and top-N limits.
- **Catalog interpretation**: `web/tests/unit/weather-map-format.test.ts` verifies colour evaluation for all scale types (categorical, threshold_asc/desc, gray_ramp).
- **Existing forecast-map tests** pass with the new consensus-reading logic.

https://claude.ai/code/session_01NrFcKrXaRiJT1gVTnDt8gx