### PR TITLE
feat(ios): forecast map — pan-European overview + airport card (#420)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ debug
 .claude/worktrees
 .claude/projects
 .claude/scheduled_tasks.lock
+.claude/settings.local.json
 
 # Xcode
 xcuserdata/

--- a/app/flyfun-weather/flyfun-weather/App/AppState.swift
+++ b/app/flyfun-weather/flyfun-weather/App/AppState.swift
@@ -375,20 +375,42 @@ final class AppState {
 
     /// Parse an inbound Universal Link into a navigation target, if it names one.
     ///
-    /// Recognizes only `https://weather.flyfun.aero/briefing.html?flight=<id>` —
-    /// the same URL the web Smart App Banner carries as its `app-argument`. The
-    /// auth callback (`/auth/callback`), unknown hosts/paths, and a missing or
-    /// empty `flight` param all return nil so the caller routes them elsewhere.
-    /// Pure + `nonisolated` so the path/param logic is unit-testable off the
-    /// MainActor and can't silently regress.
+    /// Recognizes `https://weather.flyfun.aero/briefing.html?flight=<id>` (the
+    /// Smart App Banner's `app-argument`) and `https://weather.flyfun.aero/maps.html`
+    /// with the web's `fc.*` share state (#420) — a desktop-shared map link opens
+    /// the phone on the same day/hour/metric/airport. The auth callback
+    /// (`/auth/callback`) and unknown hosts/paths return nil so the caller routes
+    /// them elsewhere. Pure + `nonisolated` so the path/param logic is
+    /// unit-testable off the MainActor and can't silently regress.
     nonisolated static func navigationTarget(for url: URL) -> PendingNavigation? {
         guard let comps = URLComponents(url: url, resolvingAgainstBaseURL: false),
-              comps.host == "weather.flyfun.aero",
-              comps.path == "/briefing.html",
-              let flight = comps.queryItems?.first(where: { $0.name == "flight" })?.value,
-              !flight.isEmpty
-        else { return nil }
-        return .briefing(flightId: flight)
+              comps.host == "weather.flyfun.aero" else { return nil }
+        switch comps.path {
+        case "/briefing.html":
+            guard let flight = comps.queryItems?.first(where: { $0.name == "flight" })?.value,
+                  !flight.isEmpty else { return nil }
+            return .briefing(flightId: flight)
+        case "/maps.html":
+            return .forecastMap(mapDeepLink(from: comps.queryItems ?? []))
+        default:
+            return nil
+        }
+    }
+
+    /// Read the forecast map's `fc.*` share-state keys from a `/maps.html` query.
+    /// `fc.day`/`fc.hour` stay relative integers so existing share links resolve.
+    nonisolated static func mapDeepLink(from items: [URLQueryItem]) -> MapDeepLink {
+        func value(_ name: String) -> String? {
+            let v = items.first { $0.name == name }?.value
+            return (v?.isEmpty == false) ? v : nil
+        }
+        return MapDeepLink(
+            day: value("fc.day").flatMap(Int.init),
+            hour: value("fc.hour").flatMap(Int.init),
+            model: value("fc.model"),
+            metric: value("fc.metric"),
+            airport: value("fc.apt")
+        )
     }
 
     // MARK: - Push notifications & badge

--- a/app/flyfun-weather/flyfun-weather/AppIntents/PendingNavigation.swift
+++ b/app/flyfun-weather/flyfun-weather/AppIntents/PendingNavigation.swift
@@ -9,11 +9,28 @@ enum PendingNavigation: Equatable, Sendable {
     case flightList
     /// Open a specific flight's briefing by id.
     case briefing(flightId: String)
+    /// Open the forecast map, optionally in a shared `fc.*` state (#420). A map
+    /// link shared from desktop opens the phone on the same day/hour/metric/airport.
+    case forecastMap(MapDeepLink)
 
     /// The target flight id, when this navigation names one.
     var flightId: String? {
         if case .briefing(let id) = self { return id }
         return nil
+    }
+}
+
+/// Forecast-map deep-link state parsed from `/maps.html?fc.*`. All fields are
+/// optional — an unqualified `/maps.html` opens the map at its cold-open default.
+struct MapDeepLink: Equatable, Sendable {
+    var day: Int?
+    var hour: Int?
+    var model: String?
+    var metric: String?
+    var airport: String?
+
+    var isEmpty: Bool {
+        day == nil && hour == nil && model == nil && metric == nil && airport == nil
     }
 }
 
@@ -47,11 +64,12 @@ enum PendingNavigationStore {
         return decode(raw)
     }
 
-    // Compact string encoding (no Codable ceremony for two cases).
+    // Compact string encoding (no Codable ceremony for a few cases).
     private static func encode(_ nav: PendingNavigation) -> String {
         switch nav {
         case .flightList: "flightList"
         case .briefing(let id): "briefing:\(id)"
+        case .forecastMap(let dl): "forecastMap:" + encodeMap(dl)
         }
     }
 
@@ -61,6 +79,37 @@ enum PendingNavigationStore {
             let id = String(raw.dropFirst("briefing:".count))
             return id.isEmpty ? nil : .briefing(flightId: id)
         }
+        if raw.hasPrefix("forecastMap:") {
+            return .forecastMap(decodeMap(String(raw.dropFirst("forecastMap:".count))))
+        }
         return nil
+    }
+
+    private static func encodeMap(_ dl: MapDeepLink) -> String {
+        var parts: [String] = []
+        if let d = dl.day { parts.append("day=\(d)") }
+        if let h = dl.hour { parts.append("hour=\(h)") }
+        if let m = dl.model { parts.append("model=\(m)") }
+        if let mt = dl.metric { parts.append("metric=\(mt)") }
+        if let a = dl.airport { parts.append("apt=\(a)") }
+        return parts.joined(separator: "&")
+    }
+
+    private static func decodeMap(_ query: String) -> MapDeepLink {
+        var dl = MapDeepLink()
+        for pair in query.split(separator: "&") {
+            let kv = pair.split(separator: "=", maxSplits: 1)
+            guard kv.count == 2 else { continue }
+            let value = String(kv[1])
+            switch String(kv[0]) {
+            case "day": dl.day = Int(value)
+            case "hour": dl.hour = Int(value)
+            case "model": dl.model = value
+            case "metric": dl.metric = value
+            case "apt": dl.airport = value
+            default: break
+            }
+        }
+        return dl
     }
 }

--- a/app/flyfun-weather/flyfun-weather/Models/API/ForecastDaysResponse.swift
+++ b/app/flyfun-weather/flyfun-weather/Models/API/ForecastDaysResponse.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+/// Response of `GET /api/maps/forecast/days` — the ragged day/hour/model grid the
+/// pickers are drawn from. **Never hardcode the grid**: the horizon runs D+0…D+6,
+/// sample hours are `06/09/12/15/18Z` on the near days but only `06/12/18Z` on
+/// D+6, and ICON is absent on D+5/D+6. Each day reports exactly what it holds so
+/// a model that can't reach the selected day reads as "greyed, not agreement".
+///
+/// Decoded with `JSONDecoder.weatherBrief` (snake→camel) — no dynamic-key dicts
+/// here, so the key-conversion trap that bites `ForecastMapResponse` doesn't apply.
+struct ForecastDaysResponse: Decodable, Sendable {
+    let days: [ForecastDay]
+    let maxDay: Int
+}
+
+/// One relative day's availability. `day` is a relative integer (0 = today) —
+/// the same value `fc.day` carries in a share link, so links keep resolving.
+struct ForecastDay: Decodable, Sendable, Identifiable {
+    /// Relative day offset, 0 = today.
+    let day: Int
+    /// ISO date "YYYY-MM-DD".
+    let date: String
+    /// False when the day is beyond the current model horizon.
+    let available: Bool
+    /// Sorted UTC sample hours that actually have data.
+    let hours: [Int]
+    /// Sorted distinct model names present across those hours (gfs/icon/ecmwf).
+    let models: [String]
+
+    var id: Int { day }
+}

--- a/app/flyfun-weather/flyfun-weather/Models/API/ForecastMapResponse.swift
+++ b/app/flyfun-weather/flyfun-weather/Models/API/ForecastMapResponse.swift
@@ -153,6 +153,10 @@ struct ForecastModelEntry: Decodable, Sendable, ForecastCellData {
         case "cloud_cover_pct": return cloudCoverPct
         case "wind_dir_deg": return windDirDeg
         case "temperature_c": return temperatureC
+        // Gusts — the card renders these alongside the steady value (as web does).
+        case "wind_gust_kt": return windGustKt
+        case "gust_crosswind_kt": return gustCrosswindKt
+        case "gust_headwind_kt": return gustHeadwindKt
         default: return nil
         }
     }

--- a/app/flyfun-weather/flyfun-weather/Models/API/ForecastMapResponse.swift
+++ b/app/flyfun-weather/flyfun-weather/Models/API/ForecastMapResponse.swift
@@ -73,6 +73,21 @@ struct ForecastAirport: Decodable, Sendable, Identifiable {
         case consensusMajority = "consensus_majority"
     }
 
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        icao = try c.decode(String.self, forKey: .icao)
+        lat = try c.decode(Double.self, forKey: .lat)
+        lon = try c.decode(Double.self, forKey: .lon)
+        approachType = try c.decodeIfPresent(String.self, forKey: .approachType)
+        models = try c.decodeIfPresent([String: ForecastModelEntry].self, forKey: .models) ?? [:]
+        consensus = try c.decode(ForecastConsensus.self, forKey: .consensus)
+        // Degrade gracefully if an (older/partial) payload omits the majority
+        // block — fall back to worst rather than failing the whole map, mirroring
+        // the web `getConsensus`. Today the versioned cache key guarantees it.
+        consensusMajority = try c.decodeIfPresent(ForecastConsensus.self, forKey: .consensusMajority) ?? consensus
+        observation = try c.decodeIfPresent(ForecastObservation.self, forKey: .observation)
+    }
+
     /// The consensus block for a mode; falls back to worst when majority absent
     /// (mirrors the web `getConsensus`).
     func consensus(mode: ForecastModelMode) -> ForecastConsensus {

--- a/app/flyfun-weather/flyfun-weather/Models/API/ForecastMapResponse.swift
+++ b/app/flyfun-weather/flyfun-weather/Models/API/ForecastMapResponse.swift
@@ -1,0 +1,311 @@
+import Foundation
+
+/// Response of `GET /api/maps/forecast?day=&hour=` — every watchlist airport
+/// (~619) with per-model forecasts plus **both** server-baked consensus blocks
+/// (worst + majority). This is the one payload the forecast map colours from; a
+/// metric or model switch is a pure client recolour off this data, only a
+/// day/hour change refetches (see `designs/forecast-page.md`).
+///
+/// A superset of the trimmed `AirportWeatherResponse` (the Siri intent shape):
+/// same airport object, widened with the full per-model block and the two
+/// consensus blocks (#420).
+///
+/// ## Decoding note
+/// Decode with a **plain** `JSONDecoder` (`ForecastMapResponse.decode(from:)`),
+/// NOT `JSONDecoder.weatherBrief`. The `.convertFromSnakeCase` strategy rewrites
+/// **dictionary keys**, which would turn the `agreement` map's field keys
+/// (`wind_speed_kt` → `windSpeedKt`) and break the per-metric agreement lookup —
+/// the same trap `HelpCatalogResponse` documents. Every struct here carries
+/// explicit snake_case `CodingKeys` so a plain decoder reads it verbatim.
+struct ForecastMapResponse: Decodable, Sendable {
+    /// Valid time of this slot (ISO8601 UTC).
+    let forecastTime: String?
+    /// Per-model init time (ISO8601 UTC); keys are a subset of gfs/icon/ecmwf.
+    let modelInitTimes: [String: String]
+    let airports: [ForecastAirport]
+
+    enum CodingKeys: String, CodingKey {
+        case forecastTime = "forecast_time"
+        case modelInitTimes = "model_init_times"
+        case airports
+    }
+
+    init(forecastTime: String?, modelInitTimes: [String: String], airports: [ForecastAirport]) {
+        self.forecastTime = forecastTime
+        self.modelInitTimes = modelInitTimes
+        self.airports = airports
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        forecastTime = try c.decodeIfPresent(String.self, forKey: .forecastTime)
+        modelInitTimes = try c.decodeIfPresent([String: String].self, forKey: .modelInitTimes) ?? [:]
+        airports = try c.decodeIfPresent([ForecastAirport].self, forKey: .airports) ?? []
+    }
+
+    /// Decode a raw `/maps/forecast` body with keys preserved verbatim.
+    static func decode(from data: Data) throws -> ForecastMapResponse {
+        try JSONDecoder().decode(ForecastMapResponse.self, from: data)
+    }
+}
+
+/// One airport in the forecast map payload.
+struct ForecastAirport: Decodable, Sendable, Identifiable {
+    let icao: String
+    let lat: Double
+    let lon: Double
+    /// Most-precise approach type, or nil when the field has no IAP/nav data.
+    let approachType: String?
+    /// Present models only (ICON is absent on D+5/D+6). Keys: gfs/icon/ecmwf.
+    let models: [String: ForecastModelEntry]
+    /// Worst-mode consensus (always present).
+    let consensus: ForecastConsensus
+    /// Majority-mode consensus (always present).
+    let consensusMajority: ForecastConsensus
+    /// D-0 only; carried on the wire but not rendered in v1.
+    let observation: ForecastObservation?
+
+    var id: String { icao }
+
+    enum CodingKeys: String, CodingKey {
+        case icao, lat, lon, models, consensus, observation
+        case approachType = "approach_type"
+        case consensusMajority = "consensus_majority"
+    }
+
+    /// The consensus block for a mode; falls back to worst when majority absent
+    /// (mirrors the web `getConsensus`).
+    func consensus(mode: ForecastModelMode) -> ForecastConsensus {
+        mode == .majority ? consensusMajority : consensus
+    }
+
+    /// The cell data the active model/mode reads: a consensus block in a
+    /// consensus mode, else the individual model entry (nil when that model is
+    /// absent for this airport/hour).
+    func cell(for mode: ForecastModelMode) -> (any ForecastCellData)? {
+        switch mode {
+        case .worst: return consensus
+        case .majority: return consensusMajority
+        case .model(let name): return models[name].map { $0 as any ForecastCellData }
+        }
+    }
+}
+
+/// Fields common to a per-model entry and a consensus block, addressed by the
+/// catalog's string field names so colour evaluation is data-driven.
+protocol ForecastCellData: Sendable {
+    /// A banded numeric field (wind_speed_kt, ceiling_ft, …), nil when absent.
+    func numericField(_ name: String) -> Double?
+    /// A categorical field (flight_category / convective_risk).
+    func categoryField(_ name: String) -> String?
+    /// FAA/EASA alternate-required flags for this cell, nil when unknown.
+    var altRequired: AltRequired? { get }
+}
+
+/// One model's forecast for an airport. Numeric fields are nullable; the wind
+/// components and `alt_required` are key-absent (not null) when unavailable.
+struct ForecastModelEntry: Decodable, Sendable, ForecastCellData {
+    let ceilingFt: Double?
+    let visibilityM: Double?
+    let windSpeedKt: Double?
+    let windDirDeg: Double?
+    let windGustKt: Double?
+    let cloudCoverPct: Double?
+    let capeJkg: Double?
+    /// Never null server-side ("none" fallback).
+    let convectiveRisk: String?
+    let temperatureC: Double?
+    let flightCategory: String?
+    let crosswindKt: Double?
+    let headwindKt: Double?
+    let bestRunwayId: String?
+    let gustCrosswindKt: Double?
+    let gustHeadwindKt: Double?
+    let altRequired: AltRequired?
+
+    enum CodingKeys: String, CodingKey {
+        case ceilingFt = "ceiling_ft"
+        case visibilityM = "visibility_m"
+        case windSpeedKt = "wind_speed_kt"
+        case windDirDeg = "wind_dir_deg"
+        case windGustKt = "wind_gust_kt"
+        case cloudCoverPct = "cloud_cover_pct"
+        case capeJkg = "cape_jkg"
+        case convectiveRisk = "convective_risk"
+        case temperatureC = "temperature_c"
+        case flightCategory = "flight_category"
+        case crosswindKt = "crosswind_kt"
+        case headwindKt = "headwind_kt"
+        case bestRunwayId = "best_runway_id"
+        case gustCrosswindKt = "gust_crosswind_kt"
+        case gustHeadwindKt = "gust_headwind_kt"
+        case altRequired = "alt_required"
+    }
+
+    func numericField(_ name: String) -> Double? {
+        switch name {
+        case "wind_speed_kt": return windSpeedKt
+        case "crosswind_kt": return crosswindKt
+        case "headwind_kt": return headwindKt
+        case "ceiling_ft": return ceilingFt
+        case "cape_jkg": return capeJkg
+        case "visibility_m": return visibilityM
+        case "cloud_cover_pct": return cloudCoverPct
+        case "wind_dir_deg": return windDirDeg
+        case "temperature_c": return temperatureC
+        default: return nil
+        }
+    }
+
+    func categoryField(_ name: String) -> String? {
+        switch name {
+        case "flight_category": return flightCategory
+        case "convective_risk": return convectiveRisk
+        default: return nil
+        }
+    }
+}
+
+/// Cross-model consensus (worst or majority, both baked server-side). Numeric
+/// fields are key-absent when no model supplied the value; `flight_category`
+/// and `agreement` are always present.
+struct ForecastConsensus: Decodable, Sendable, ForecastCellData {
+    let flightCategory: String?
+    /// field name → "consistent" | "mixed" | "divergent"; variable key set.
+    let agreement: [String: String]
+    let convectiveRisk: String?
+    let windSpeedKt: Double?
+    let ceilingFt: Double?
+    let capeJkg: Double?
+    let visibilityM: Double?
+    let crosswindKt: Double?
+    let headwindKt: Double?
+    let cloudCoverPct: Double?
+    let windDirDeg: Double?
+
+    var altRequired: AltRequired? { nil }  // aggregated from models, not baked here
+
+    enum CodingKeys: String, CodingKey {
+        case flightCategory = "flight_category"
+        case agreement
+        case convectiveRisk = "convective_risk"
+        case windSpeedKt = "wind_speed_kt"
+        case ceilingFt = "ceiling_ft"
+        case capeJkg = "cape_jkg"
+        case visibilityM = "visibility_m"
+        case crosswindKt = "crosswind_kt"
+        case headwindKt = "headwind_kt"
+        case cloudCoverPct = "cloud_cover_pct"
+        case windDirDeg = "wind_dir_deg"
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        flightCategory = try c.decodeIfPresent(String.self, forKey: .flightCategory)
+        agreement = try c.decodeIfPresent([String: String].self, forKey: .agreement) ?? [:]
+        convectiveRisk = try c.decodeIfPresent(String.self, forKey: .convectiveRisk)
+        windSpeedKt = try c.decodeIfPresent(Double.self, forKey: .windSpeedKt)
+        ceilingFt = try c.decodeIfPresent(Double.self, forKey: .ceilingFt)
+        capeJkg = try c.decodeIfPresent(Double.self, forKey: .capeJkg)
+        visibilityM = try c.decodeIfPresent(Double.self, forKey: .visibilityM)
+        crosswindKt = try c.decodeIfPresent(Double.self, forKey: .crosswindKt)
+        headwindKt = try c.decodeIfPresent(Double.self, forKey: .headwindKt)
+        cloudCoverPct = try c.decodeIfPresent(Double.self, forKey: .cloudCoverPct)
+        windDirDeg = try c.decodeIfPresent(Double.self, forKey: .windDirDeg)
+    }
+
+    func numericField(_ name: String) -> Double? {
+        switch name {
+        case "wind_speed_kt": return windSpeedKt
+        case "crosswind_kt": return crosswindKt
+        case "headwind_kt": return headwindKt
+        case "ceiling_ft": return ceilingFt
+        case "cape_jkg": return capeJkg
+        case "visibility_m": return visibilityM
+        case "cloud_cover_pct": return cloudCoverPct
+        case "wind_dir_deg": return windDirDeg
+        default: return nil
+        }
+    }
+
+    func categoryField(_ name: String) -> String? {
+        switch name {
+        case "flight_category": return flightCategory
+        case "convective_risk": return convectiveRisk
+        default: return nil
+        }
+    }
+
+    /// Agreement bucket for a metric (per-active-metric ring). nil when the
+    /// consensus carries no agreement label for the metric's proxy field.
+    func agreement(forMetric metric: String) -> String? {
+        agreement[ForecastMapCatalog.agreementKey(forMetric: metric)]
+    }
+}
+
+/// FAA/EASA alternate-required flags.
+struct AltRequired: Decodable, Sendable {
+    let faa: Bool
+    let easa: Bool
+}
+
+/// D-0 METAR/TAF block carried on the wire. Decoded for a future card row
+/// (see design "Free data already on the wire"); not rendered in v1.
+struct ForecastObservation: Decodable, Sendable {
+    let metarRaw: String?
+    let observationTime: String?
+    let flightCategory: String?
+    let windSpeedKt: Double?
+    let windDirDeg: Double?
+    let tafRaw: String?
+
+    enum CodingKeys: String, CodingKey {
+        case metarRaw = "metar_raw"
+        case observationTime = "observation_time"
+        case flightCategory = "flight_category"
+        case windSpeedKt = "wind_speed_kt"
+        case windDirDeg = "wind_dir_deg"
+        case tafRaw = "taf_raw"
+    }
+}
+
+// MARK: - Model mode
+
+/// How the map/card colours: a consensus reduction or one individual model.
+/// Raw values are the wire/URL tokens (`fc.model`): worst/majority/gfs/icon/ecmwf.
+enum ForecastModelMode: Equatable, Sendable, Hashable {
+    case worst
+    case majority
+    case model(String)
+
+    /// The `fc.model` token.
+    var token: String {
+        switch self {
+        case .worst: return "worst"
+        case .majority: return "majority"
+        case .model(let m): return m
+        }
+    }
+
+    init(token: String) {
+        switch token {
+        case "worst": self = .worst
+        case "majority": self = .majority
+        default: self = .model(token)
+        }
+    }
+
+    /// Worst/majority are consensus modes (agreement ring shown).
+    var isConsensus: Bool {
+        switch self {
+        case .worst, .majority: return true
+        case .model: return false
+        }
+    }
+
+    /// The card's consensus column mirrors the map mode, falling back to worst
+    /// when an individual model is active (web `panelConsensusMode`).
+    var consensusMode: ForecastModelMode {
+        isConsensus ? self : .worst
+    }
+}

--- a/app/flyfun-weather/flyfun-weather/Models/API/FrequentAirportsResponse.swift
+++ b/app/flyfun-weather/flyfun-weather/Models/API/FrequentAirportsResponse.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// Response of `GET /api/flights/frequent-airports` — the user's top-5 departure
+/// and top-5 destination airports, derived from flight history (#419, B3). There
+/// is no `home_base` concept in the app; the forecast map uses this to centre on
+/// cold open on the pilot's usual departure area. Either array may be empty.
+///
+/// Decoded with `JSONDecoder.weatherBrief` (snake→camel); no dynamic-key dicts.
+struct FrequentAirportsResponse: Decodable, Sendable {
+    let departures: [FrequentAirport]
+    let destinations: [FrequentAirport]
+}
+
+/// One ranked airport: ICAO plus how many of the user's flights used it.
+struct FrequentAirport: Decodable, Sendable, Identifiable {
+    let icao: String
+    let count: Int
+
+    var id: String { icao }
+}

--- a/app/flyfun-weather/flyfun-weather/Models/API/HelpCatalogResponse.swift
+++ b/app/flyfun-weather/flyfun-weather/Models/API/HelpCatalogResponse.swift
@@ -23,22 +23,27 @@ struct HelpCatalogResponse: Sendable {
     let version: String
     /// Metric help keyed by metric id.
     let metrics: [String: MetricHelp]
+    /// Forecast-map metric catalog (colours/thresholds/labels/legends), served in
+    /// the `maps` section (#419, B2). nil on the bundled baseline before first
+    /// sync — the forecast map falls back to `ForecastMapCatalog.bundledBaseline`.
+    let maps: ForecastMapCatalog?
     /// Advisory help (same shape as `AdvisoriesResponse.catalog`).
     let advisories: [AdvisoryCatalogEntry]
     /// O(1) advisory lookup by id, built once at construction — mirrors the
     /// metrics dict so both popup call sites have the same access cost.
     let advisoriesById: [String: AdvisoryCatalogEntry]
 
-    init(version: String, metrics: [String: MetricHelp], advisories: [AdvisoryCatalogEntry]) {
+    init(version: String, metrics: [String: MetricHelp], maps: ForecastMapCatalog?, advisories: [AdvisoryCatalogEntry]) {
         self.version = version
         self.metrics = metrics
+        self.maps = maps
         self.advisories = advisories
         self.advisoriesById = Dictionary(advisories.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
     }
 
-    /// Decode a full server payload (`{version, metrics, advisories}`).
+    /// Decode a full server payload (`{version, metrics, maps, advisories}`).
     static func decode(from data: Data) throws -> HelpCatalogResponse {
-        let plain = JSONDecoder()  // no key strategy → metric ids stay verbatim
+        let plain = JSONDecoder()  // no key strategy → metric/scale/field ids stay verbatim
         let envelope = try plain.decode(MetricsEnvelope.self, from: data)
         // Advisory property names need snake→camel; the weatherBrief decoder only
         // touches the `advisories` key here (this struct ignores metrics/version).
@@ -46,6 +51,7 @@ struct HelpCatalogResponse: Sendable {
         return HelpCatalogResponse(
             version: envelope.version,
             metrics: envelope.metrics,
+            maps: envelope.maps,
             advisories: adv.advisories
         )
     }
@@ -55,12 +61,14 @@ struct HelpCatalogResponse: Sendable {
     static func decodeBaseline(from data: Data) throws -> HelpCatalogResponse {
         let plain = JSONDecoder()
         let metrics = try plain.decode([String: MetricHelp].self, from: data)
-        return HelpCatalogResponse(version: "baseline", metrics: metrics, advisories: [])
+        return HelpCatalogResponse(version: "baseline", metrics: metrics, maps: nil, advisories: [])
     }
 
     private struct MetricsEnvelope: Decodable {
         let version: String
         let metrics: [String: MetricHelp]
+        /// The `maps` section (#419); optional so an old server without it decodes.
+        let maps: ForecastMapCatalog?
     }
 
     private struct AdvisoriesEnvelope: Decodable {

--- a/app/flyfun-weather/flyfun-weather/Resources/map-metrics-catalog.json
+++ b/app/flyfun-weather/flyfun-weather/Resources/map-metrics-catalog.json
@@ -1,0 +1,219 @@
+{
+  "_comment": "Forecast-map metric catalog: colour scales, thresholds, labels and legends for the pan-European overview map. Single source of truth imported by the web bundle (web/ts/visualization/weather-map-format.ts) and served ETag-cacheable to iOS via /api/help (api/help.py, `maps` section). A threshold or colour change is a one-line edit here that both clients pick up — see issue #419 (B2). `scales.categorical` maps a discrete value to a hex; `scales.bands` is a value→colour function: kind `threshold_asc` returns the first stop whose value is `< lt` else `default` (with `convert:\"m_to_sm\"` applied first for visibility, and `null_color` for a missing value); kind `gray_ramp` is the continuous cloud ramp rgb(g,g,g+blue_boost) with g=round(base-(pct/100)*span). `metrics` gives each map metric its label, how it is coloured, and its legend rows.",
+  "version": 1,
+  "scales": {
+    "categorical": {
+      "flight_category": { "VFR": "#22c55e", "MVFR": "#3b82f6", "IFR": "#ef4444", "LIFR": "#a855f7" },
+      "convective_risk": { "none": "#22c55e", "marginal": "#eab308", "low": "#facc15", "moderate": "#f97316", "high": "#ef4444", "extreme": "#991b1b" },
+      "agreement": { "consistent": "#22c55e", "mixed": "#f97316", "divergent": "#ef4444" }
+    },
+    "bands": {
+      "wind_speed_kt": {
+        "kind": "threshold_asc",
+        "stops": [
+          { "lt": 10, "color": "#22c55e" },
+          { "lt": 15, "color": "#84cc16" },
+          { "lt": 20, "color": "#eab308" },
+          { "lt": 25, "color": "#f97316" },
+          { "lt": 35, "color": "#ef4444" }
+        ],
+        "default": "#991b1b"
+      },
+      "crosswind_kt": {
+        "kind": "threshold_asc",
+        "stops": [
+          { "lt": 5, "color": "#22c55e" },
+          { "lt": 10, "color": "#84cc16" },
+          { "lt": 15, "color": "#eab308" },
+          { "lt": 20, "color": "#f97316" },
+          { "lt": 25, "color": "#ef4444" }
+        ],
+        "default": "#991b1b"
+      },
+      "headwind_kt": {
+        "kind": "threshold_asc",
+        "stops": [
+          { "lt": 10, "color": "#22c55e" },
+          { "lt": 15, "color": "#84cc16" },
+          { "lt": 20, "color": "#eab308" },
+          { "lt": 25, "color": "#f97316" },
+          { "lt": 30, "color": "#ef4444" }
+        ],
+        "default": "#991b1b"
+      },
+      "ceiling_ft": {
+        "kind": "threshold_asc",
+        "null_color": "#888",
+        "stops": [
+          { "lt": 500, "color": "#a855f7" },
+          { "lt": 1000, "color": "#ef4444" },
+          { "lt": 3000, "color": "#3b82f6" }
+        ],
+        "default": "#22c55e"
+      },
+      "cape_jkg": {
+        "kind": "threshold_asc",
+        "stops": [
+          { "lt": 100, "color": "#22c55e" },
+          { "lt": 500, "color": "#eab308" },
+          { "lt": 1000, "color": "#f97316" },
+          { "lt": 2000, "color": "#ef4444" }
+        ],
+        "default": "#991b1b"
+      },
+      "visibility_m": {
+        "kind": "threshold_desc",
+        "convert": "m_to_sm",
+        "stops": [
+          { "gte": 5, "color": "#22c55e" },
+          { "gte": 3, "color": "#3b82f6" },
+          { "gte": 1, "color": "#ef4444" }
+        ],
+        "default": "#a855f7"
+      },
+      "cloud_cover_pct": { "kind": "gray_ramp", "base": 220, "span": 160, "blue_boost": 10 }
+    }
+  },
+  "metrics": {
+    "flight_category": {
+      "label": "Category",
+      "color": { "kind": "categorical", "scale": "flight_category", "fallback": "#888" },
+      "legend": {
+        "title": "Flight Category",
+        "items": [
+          { "color": "#22c55e", "label": "VFR" },
+          { "color": "#3b82f6", "label": "MVFR" },
+          { "color": "#ef4444", "label": "IFR" },
+          { "color": "#a855f7", "label": "LIFR" }
+        ]
+      }
+    },
+    "wind_speed_kt": {
+      "label": "Wind",
+      "color": { "kind": "band", "scale": "wind_speed_kt", "field": "wind_speed_kt", "fallback": 0 },
+      "legend": {
+        "title": "Wind Speed (kt)",
+        "items": [
+          { "color": "#22c55e", "label": "< 10" },
+          { "color": "#84cc16", "label": "10-15" },
+          { "color": "#eab308", "label": "15-20" },
+          { "color": "#f97316", "label": "20-25" },
+          { "color": "#ef4444", "label": "25-35" },
+          { "color": "#991b1b", "label": "35+" }
+        ]
+      }
+    },
+    "crosswind_kt": {
+      "label": "Xwind",
+      "color": { "kind": "band", "scale": "crosswind_kt", "field": "crosswind_kt", "fallback": null },
+      "legend": {
+        "title": "Best Rwy Crosswind (kt)",
+        "items": [
+          { "color": "#22c55e", "label": "< 5" },
+          { "color": "#84cc16", "label": "5-10" },
+          { "color": "#eab308", "label": "10-15" },
+          { "color": "#f97316", "label": "15-20" },
+          { "color": "#ef4444", "label": "20-25" },
+          { "color": "#991b1b", "label": "25+" }
+        ]
+      }
+    },
+    "headwind_kt": {
+      "label": "Headwind",
+      "color": { "kind": "band", "scale": "headwind_kt", "field": "headwind_kt", "fallback": null },
+      "legend": {
+        "title": "Best Rwy Headwind (kt)",
+        "items": [
+          { "color": "#22c55e", "label": "< 10" },
+          { "color": "#84cc16", "label": "10-15" },
+          { "color": "#eab308", "label": "15-20" },
+          { "color": "#f97316", "label": "20-25" },
+          { "color": "#ef4444", "label": "25-30" },
+          { "color": "#991b1b", "label": "30+" }
+        ]
+      }
+    },
+    "ceiling_ft": {
+      "label": "Ceiling",
+      "color": { "kind": "band", "scale": "ceiling_ft", "field": "ceiling_ft", "fallback": null },
+      "legend": {
+        "title": "Ceiling (ft)",
+        "items": [
+          { "color": "#22c55e", "label": "> 3000 (VFR)" },
+          { "color": "#3b82f6", "label": "1000-3000 (MVFR)" },
+          { "color": "#ef4444", "label": "500-1000 (IFR)" },
+          { "color": "#a855f7", "label": "< 500 (LIFR)" }
+        ]
+      }
+    },
+    "cape_jkg": {
+      "label": "CAPE",
+      "color": { "kind": "band", "scale": "cape_jkg", "field": "cape_jkg", "fallback": 0 },
+      "legend": {
+        "title": "CAPE (J/kg)",
+        "items": [
+          { "color": "#22c55e", "label": "< 100" },
+          { "color": "#eab308", "label": "100-500" },
+          { "color": "#f97316", "label": "500-1000" },
+          { "color": "#ef4444", "label": "1000-2000" },
+          { "color": "#991b1b", "label": "2000+" }
+        ]
+      }
+    },
+    "convective_risk": {
+      "label": "Convective",
+      "color": { "kind": "categorical", "scale": "convective_risk", "default": "none", "fallback": "#888" },
+      "legend": {
+        "title": "Convective Risk",
+        "items": [
+          { "color": "#22c55e", "label": "none" },
+          { "color": "#eab308", "label": "marginal" },
+          { "color": "#facc15", "label": "low" },
+          { "color": "#f97316", "label": "moderate" },
+          { "color": "#ef4444", "label": "high" },
+          { "color": "#991b1b", "label": "extreme" }
+        ]
+      }
+    },
+    "visibility_m": {
+      "label": "Visibility",
+      "color": { "kind": "band", "scale": "visibility_m", "field": "visibility_m", "fallback": 99999 },
+      "legend": {
+        "title": "Visibility",
+        "items": [
+          { "color": "#22c55e", "label": ">= 5 SM (VFR)" },
+          { "color": "#3b82f6", "label": "3-5 SM (MVFR)" },
+          { "color": "#ef4444", "label": "1-3 SM (IFR)" },
+          { "color": "#a855f7", "label": "< 1 SM (LIFR)" }
+        ]
+      }
+    },
+    "cloud_cover_pct": {
+      "label": "Cloud cover",
+      "color": { "kind": "band", "scale": "cloud_cover_pct", "field": "cloud_cover_pct", "fallback": 0 },
+      "legend": {
+        "title": "Cloud Cover",
+        "items": [
+          { "color": "rgb(220,220,230)", "label": "Clear" },
+          { "color": "rgb(180,180,190)", "label": "25%" },
+          { "color": "rgb(140,140,150)", "label": "50%" },
+          { "color": "rgb(100,100,110)", "label": "75%" },
+          { "color": "rgb(60,60,70)", "label": "Overcast" }
+        ]
+      }
+    },
+    "alternate_needed": {
+      "label": "Alternate required?",
+      "color": { "kind": "alternate_needed", "fallback": "#888" },
+      "legend": {
+        "title": "Alternate required? (model estimate)",
+        "items": [
+          { "color": "#22c55e", "label": "Neither (FAA & EASA ok)" },
+          { "color": "#eab308", "label": "One regime (FAA or EASA)" },
+          { "color": "#ef4444", "label": "Both (FAA & EASA)" },
+          { "color": "#888", "label": "No data" }
+        ]
+      }
+    }
+  }
+}

--- a/app/flyfun-weather/flyfun-weather/Services/BriefingRepository.swift
+++ b/app/flyfun-weather/flyfun-weather/Services/BriefingRepository.swift
@@ -31,6 +31,15 @@ protocol BriefingRepository: Sendable {
     /// `get_airport_weather` tool). Online-only — not part of the offline bundle.
     /// `day`: 0=today…3, `hour`: forecast hour UTC (snapped server-side).
     func airportWeather(icao: String, day: Int, hour: Int) async throws -> AirportWeatherResponse
+    // Forecast map (#420) — all online-only, one payload per (day, hour).
+    /// Every watchlist airport with per-model + baked consensus for one slot. The
+    /// only call that hits the network on a day/hour change (metric/model switches
+    /// are a pure client recolour).
+    func forecastMap(day: Int, hour: Int) async throws -> ForecastMapResponse
+    /// The ragged day/hour/model grid the pickers are drawn from. Never hardcode it.
+    func forecastDays() async throws -> ForecastDaysResponse
+    /// Top-5 departure/destination airports from history — cold-open map centring (#419).
+    func frequentAirports() async throws -> FrequentAirportsResponse
     func advisories(flightId: String, timestamp: String) async throws -> AdvisoriesResponse
     func advisoryDetail(flightId: String, timestamp: String, advisoryId: String) async throws -> AdvisoryDetailResponse
     func recalculateAdvisories(flightId: String, timestamp: String, cruiseAltitudeFt: Int?) async throws
@@ -149,6 +158,26 @@ final class OnlineBriefingRepository: BriefingRepository {
     func airportWeather(icao: String, day: Int, hour: Int) async throws -> AirportWeatherResponse {
         let code = Self.queryValueEncoded(icao)
         return try await client.requestURL("/api/maps/airport-weather?icao=\(code)&day=\(day)&hour=\(hour)")
+    }
+
+    func forecastMap(day: Int, hour: Int) async throws -> ForecastMapResponse {
+        // Decode with a plain decoder (NOT weatherBrief): `.convertFromSnakeCase`
+        // would rewrite the `agreement`/`models` dictionary keys. See
+        // `ForecastMapResponse.decode(from:)`.
+        let data = try await client.requestDataURL("/api/maps/forecast?day=\(day)&hour=\(hour)")
+        do {
+            return try ForecastMapResponse.decode(from: data)
+        } catch {
+            throw APIError.decodingError(error)
+        }
+    }
+
+    func forecastDays() async throws -> ForecastDaysResponse {
+        try await client.request("/api/maps/forecast/days")
+    }
+
+    func frequentAirports() async throws -> FrequentAirportsResponse {
+        try await client.request("/api/flights/frequent-airports")
     }
 
     func advisories(flightId: String, timestamp: String) async throws -> AdvisoriesResponse {

--- a/app/flyfun-weather/flyfun-weather/Services/CachingBriefingRepository.swift
+++ b/app/flyfun-weather/flyfun-weather/Services/CachingBriefingRepository.swift
@@ -203,6 +203,20 @@ final class CachingBriefingRepository: BriefingRepository, CacheStatusReporting 
         try await online.airportWeather(icao: icao, day: day, hour: hour)
     }
 
+    // Forecast map (#420) — all online-only; the map VM keeps its own in-memory
+    // (day, hour) LRU, so there's nothing for the disk cache to add here.
+    func forecastMap(day: Int, hour: Int) async throws -> ForecastMapResponse {
+        try await online.forecastMap(day: day, hour: hour)
+    }
+
+    func forecastDays() async throws -> ForecastDaysResponse {
+        try await online.forecastDays()
+    }
+
+    func frequentAirports() async throws -> FrequentAirportsResponse {
+        try await online.frequentAirports()
+    }
+
     func refreshStream(flightId: String, source: RefreshSource) async -> AsyncThrowingStream<RefreshEvent, Error> {
         await online.refreshStream(flightId: flightId, source: source)
     }

--- a/app/flyfun-weather/flyfun-weather/Services/FixtureBriefingRepository.swift
+++ b/app/flyfun-weather/flyfun-weather/Services/FixtureBriefingRepository.swift
@@ -126,6 +126,15 @@ final class FixtureBriefingRepository: BriefingRepository, CacheStatusReporting 
     func airportWeather(icao: String, day: Int, hour: Int) async throws -> AirportWeatherResponse {
         throw FixtureError.notProvided("airportWeather")
     }
+    func forecastMap(day: Int, hour: Int) async throws -> ForecastMapResponse {
+        throw FixtureError.notProvided("forecastMap")
+    }
+    func forecastDays() async throws -> ForecastDaysResponse {
+        throw FixtureError.notProvided("forecastDays")
+    }
+    func frequentAirports() async throws -> FrequentAirportsResponse {
+        throw FixtureError.notProvided("frequentAirports")
+    }
     func advisories(flightId: String, timestamp: String) async throws -> AdvisoriesResponse {
         guard isBriefed(flightId) else { throw APIError.notFound }
         return FixtureBriefingData.advisories

--- a/app/flyfun-weather/flyfun-weather/Services/HelpCatalogStore.swift
+++ b/app/flyfun-weather/flyfun-weather/Services/HelpCatalogStore.swift
@@ -32,6 +32,10 @@ final class HelpCatalogStore {
         catalog = Self.loadFromDisk(fileURL) ?? Self.loadBaseline()
     }
 
+    /// The forecast-map metric catalog: the served `maps` section if synced,
+    /// else the bundled baseline so the map renders on a cold first launch.
+    var mapsCatalog: ForecastMapCatalog? { catalog?.maps ?? ForecastMapCatalog.bundledBaseline }
+
     // MARK: - Lookups (used by the (i) popups)
 
     func metric(_ id: String) -> MetricHelp? { catalog?.metrics[id] }

--- a/app/flyfun-weather/flyfun-weather/ViewModels/ForecastMapViewModel.swift
+++ b/app/flyfun-weather/flyfun-weather/ViewModels/ForecastMapViewModel.swift
@@ -47,6 +47,11 @@ final class ForecastMapViewModel {
 
     /// Current slot's payload (nil until first load).
     private(set) var payload: ForecastMapResponse?
+    /// Bumped on every payload assignment. The map rebuilds its annotations when
+    /// this changes (NOT on the day/hour string), so the nil→populated transition
+    /// on cold open and every slot swap both repopulate markers; a metric/model
+    /// switch leaves it unchanged and is a pure recolour.
+    private(set) var payloadRevision = 0
     private(set) var isLoading = false
     private(set) var loadError: String?
     /// True once the grid + first payload have loaded (drives the placeholder).
@@ -71,9 +76,19 @@ final class ForecastMapViewModel {
     private var pendingOpenIcao: String?
     /// Suppresses cold-open centring when a deep link already set the view.
     private var hasExplicitLocation = false
+    /// Set once the user pans/zooms the map, so a late-resolving cold-open target
+    /// never yanks the camera out from under them.
+    private var userDidInteract = false
+    /// Slots with a fetch in flight, so a `selectHour` and a prefetch racing on the
+    /// same (day, hour) don't both hit the network.
+    private var inFlight: Set<SlotKey> = []
     private var loadTask: Task<Void, Never>?
 
-    init(repository: any BriefingRepository, deepLink: DeepLink? = nil) {
+    /// `deepLink` is the parsed `/maps.html?fc.*` share state (`MapDeepLink`), or
+    /// nil for a plain "open the map" (toolbar button). It's applied once at init;
+    /// a *new* inbound deep link re-creates the view (`.id` on the container) so a
+    /// re-entrant link isn't dropped.
+    init(repository: any BriefingRepository, deepLink: MapDeepLink? = nil) {
         self.repository = repository
         if let deepLink {
             hasExplicitLocation = true
@@ -83,15 +98,6 @@ final class ForecastMapViewModel {
             if let mt = deepLink.metric { metric = mt }
             pendingOpenIcao = deepLink.airport
         }
-    }
-
-    /// Deep-link state parsed from a `/maps.html?...` universal link (`fc.*`).
-    struct DeepLink: Equatable, Sendable {
-        var day: Int?
-        var hour: Int?
-        var model: String?
-        var metric: String?
-        var airport: String?
     }
 
     // MARK: - Loading
@@ -126,9 +132,10 @@ final class ForecastMapViewModel {
         didLoadOnce = true
         isLoading = false
         loadTask = nil
-        // 5. Open a deep-linked airport once its data is present.
+        // 5. Open (and centre on) a deep-linked airport once its data is present,
+        //    so a shared link lands on that airport, not just its day/hour/metric.
         if let apt = pendingOpenIcao, payload?.airports.contains(where: { $0.icao == apt }) == true {
-            selectedIcao = apt
+            select(icao: apt, biasForSheet: false)
             pendingOpenIcao = nil
         }
         prefetchAdjacentHours()
@@ -180,20 +187,22 @@ final class ForecastMapViewModel {
         let key = SlotKey(day: day, hour: hour)
         if let cached = slots[key] {
             touchLRU(key)
-            payload = cached
+            setPayload(cached)
             prefetchAdjacentHours()
             return
         }
+        guard !inFlight.contains(key) else { return }  // a prefetch already owns it
+        inFlight.insert(key)
+        defer { inFlight.remove(key) }
         isLoading = true
         loadError = nil
         do {
             let resp = try await repository.forecastMap(day: day, hour: hour)
-            // A late-arriving fetch for a slot the user already scrubbed past must
-            // not clobber the current view.
+            // `store` publishes the payload iff this slot is still the selected one,
+            // so a late fetch for a scrubbed-past slot doesn't clobber the view, and
+            // an in-flight *prefetch* the user then selects still shows (loadSlot
+            // may have bailed on the in-flight guard above — store is the one seam).
             store(resp, for: key)
-            if selectedDay == day, selectedHour == hour {
-                payload = resp
-            }
         } catch let error as APIError where error.isCancellation {
             // benign
         } catch {
@@ -213,9 +222,11 @@ final class ForecastMapViewModel {
         guard let idx = hrs.firstIndex(of: selectedHour) else { return }
         for neighbour in [idx - 1, idx + 1] where hrs.indices.contains(neighbour) {
             let key = SlotKey(day: selectedDay, hour: hrs[neighbour])
-            guard slots[key] == nil else { continue }
+            guard slots[key] == nil, !inFlight.contains(key) else { continue }
+            inFlight.insert(key)
             Task { [weak self] in
                 guard let self else { return }
+                defer { self.inFlight.remove(key) }
                 if let resp = try? await self.repository.forecastMap(day: key.day, hour: key.hour) {
                     self.store(resp, for: key)
                 }
@@ -303,8 +314,11 @@ final class ForecastMapViewModel {
         applyColdOpenIfPossible()
     }
 
+    /// The user panned/zoomed — freeze cold-open so it can't recentre later.
+    func markUserInteracted() { userDidInteract = true }
+
     private func applyColdOpenIfPossible() {
-        guard !hasExplicitLocation, let icao = coldOpenIcao,
+        guard !hasExplicitLocation, !userDidInteract, let icao = coldOpenIcao,
               let apt = payload?.airports.first(where: { $0.icao == icao }) else { return }
         initialRegion = MKCoordinateRegion(
             center: CLLocationCoordinate2D(latitude: apt.lat, longitude: apt.lon),
@@ -315,16 +329,33 @@ final class ForecastMapViewModel {
         coldOpenIcao = nil
     }
 
+    /// Publish a payload and bump the revision so the map rebuilds its markers.
+    private func setPayload(_ resp: ForecastMapResponse) {
+        payload = resp
+        payloadRevision &+= 1
+    }
+
     // MARK: - LRU
 
     private func store(_ resp: ForecastMapResponse, for key: SlotKey) {
         slots[key] = resp
         touchLRU(key)
+        let current = SlotKey(day: selectedDay, hour: selectedHour)
+        // Publish only when this is the on-screen slot (covers both the user-driven
+        // loadSlot and a prefetch the user has since navigated onto).
+        if key == current { setPayload(resp) }
         // A payload may arrive before the cold-open target resolved.
         applyColdOpenIfPossible()
         while lruOrder.count > Self.lruCapacity {
             let evict = lruOrder.removeFirst()
-            if evict != SlotKey(day: selectedDay, hour: selectedHour) { slots[evict] = nil }
+            if evict == current {
+                // Never drop the on-screen slot — re-queue it as most-recent so it
+                // stays tracked (dropping it from lruOrder while keeping it in
+                // `slots` leaked the entry and pinned stale data).
+                lruOrder.append(evict)
+            } else {
+                slots[evict] = nil
+            }
         }
     }
 
@@ -347,12 +378,5 @@ final class ForecastMapViewModel {
             ForecastDay(day: d, date: "", available: true,
                         hours: [6, 9, 12, 15, 18], models: ["ecmwf", "gfs", "icon"])
         }
-    }
-}
-
-extension MapDeepLink {
-    /// Bridge the universal-link deep-link into the map view model's own type.
-    var asViewModelDeepLink: ForecastMapViewModel.DeepLink {
-        ForecastMapViewModel.DeepLink(day: day, hour: hour, model: model, metric: metric, airport: airport)
     }
 }

--- a/app/flyfun-weather/flyfun-weather/ViewModels/ForecastMapViewModel.swift
+++ b/app/flyfun-weather/flyfun-weather/ViewModels/ForecastMapViewModel.swift
@@ -1,0 +1,358 @@
+import Foundation
+import MapKit
+import OSLog
+
+/// State for the pan-European forecast map (#420): the day/hour/metric/model
+/// selection, the per-(day, hour) payload with an in-memory LRU + adjacent-hour
+/// prefetch, and the tapped-airport selection. One instance is shared by the
+/// iPhone `fullScreenCover` and iPad detail-pane containers, so the map view
+/// itself stays container-agnostic.
+///
+/// Metric and model switches are a **pure recolour** — they mutate published
+/// state and the map re-reads the already-fetched payload. Only a day/hour
+/// change hits the network.
+@Observable
+@MainActor
+final class ForecastMapViewModel {
+    private static let logger = Logger(subsystem: "aero.flyfun.weather", category: "ForecastMap")
+
+    /// Identity of one payload slot.
+    struct SlotKey: Hashable { let day: Int; let hour: Int }
+
+    /// A camera move the map view should apply once, then clear.
+    struct FocusRequest: Equatable {
+        let center: CLLocationCoordinate2D
+        /// Zoom span (nil = keep current zoom).
+        let span: MKCoordinateSpan?
+        /// Bias the centre latitude down so the airport sits above a bottom sheet.
+        let biasForSheet: Bool
+
+        static func == (l: FocusRequest, r: FocusRequest) -> Bool {
+            l.center.latitude == r.center.latitude && l.center.longitude == r.center.longitude
+                && l.span?.latitudeDelta == r.span?.latitudeDelta && l.biasForSheet == r.biasForSheet
+        }
+    }
+
+    // MARK: - Published state
+
+    /// The ragged day/hour/model grid, drawn from `/maps/forecast/days`.
+    private(set) var days: [ForecastDay] = []
+    private(set) var maxDay = 6
+
+    private(set) var selectedDay = 0
+    private(set) var selectedHour = 12
+    var metric = "flight_category"
+    var mode: ForecastModelMode = .worst
+    private(set) var selectedIcao: String?
+
+    /// Current slot's payload (nil until first load).
+    private(set) var payload: ForecastMapResponse?
+    private(set) var isLoading = false
+    private(set) var loadError: String?
+    /// True once the grid + first payload have loaded (drives the placeholder).
+    private(set) var didLoadOnce = false
+
+    /// Initial camera region (Europe, or centred on the pilot's usual departure
+    /// area once frequent airports resolve). Consumed by the map on first appear.
+    private(set) var initialRegion = ForecastMapViewModel.europeRegion
+    /// A one-shot camera move (hour step recolour never moves; selection nudges).
+    var focusRequest: FocusRequest?
+
+    // MARK: - Private
+
+    private let repository: any BriefingRepository
+    private var slots: [SlotKey: ForecastMapResponse] = [:]
+    private var lruOrder: [SlotKey] = []
+    private static let lruCapacity = 8
+    /// Cold-open target from frequent airports; resolved to a region once a
+    /// payload with coordinates arrives. Cleared after it's applied once.
+    private var coldOpenIcao: String?
+    /// A deep-link may pin an airport to open once the payload loads.
+    private var pendingOpenIcao: String?
+    /// Suppresses cold-open centring when a deep link already set the view.
+    private var hasExplicitLocation = false
+    private var loadTask: Task<Void, Never>?
+
+    init(repository: any BriefingRepository, deepLink: DeepLink? = nil) {
+        self.repository = repository
+        if let deepLink {
+            hasExplicitLocation = true
+            if let d = deepLink.day { selectedDay = d }
+            if let h = deepLink.hour { selectedHour = h }
+            if let m = deepLink.model { mode = ForecastModelMode(token: m) }
+            if let mt = deepLink.metric { metric = mt }
+            pendingOpenIcao = deepLink.airport
+        }
+    }
+
+    /// Deep-link state parsed from a `/maps.html?...` universal link (`fc.*`).
+    struct DeepLink: Equatable, Sendable {
+        var day: Int?
+        var hour: Int?
+        var model: String?
+        var metric: String?
+        var airport: String?
+    }
+
+    // MARK: - Loading
+
+    /// Load the grid, resolve the initial slot, then fetch it. Idempotent — safe
+    /// to call on appear.
+    func start() {
+        guard !didLoadOnce, loadTask == nil else { return }
+        loadTask = Task { await initialLoad() }
+    }
+
+    private func initialLoad() async {
+        isLoading = true
+        loadError = nil
+        // 1. The grid (best-effort; a failure falls back to a near-days default).
+        do {
+            let resp = try await repository.forecastDays()
+            days = resp.days
+            maxDay = resp.maxDay
+        } catch {
+            Self.logger.warning("forecast days failed: \(error.localizedDescription)")
+            days = Self.fallbackDays()
+        }
+        // 2. Snap the selection into the real grid (deep link may be off-grid).
+        snapSelectionIntoGrid(smartDefaultHour: !hasExplicitLocation)
+        // 3. Cold-open centring target (non-blocking, non-fatal).
+        if !hasExplicitLocation {
+            Task { await resolveColdOpenTarget() }
+        }
+        // 4. First payload.
+        await loadSlot(day: selectedDay, hour: selectedHour, moveCamera: false)
+        didLoadOnce = true
+        isLoading = false
+        loadTask = nil
+        // 5. Open a deep-linked airport once its data is present.
+        if let apt = pendingOpenIcao, payload?.airports.contains(where: { $0.icao == apt }) == true {
+            selectedIcao = apt
+            pendingOpenIcao = nil
+        }
+        prefetchAdjacentHours()
+    }
+
+    /// Change day: snap the hour into the new day's grid, snap the model if the
+    /// active one can't reach it, then fetch.
+    func selectDay(_ day: Int) {
+        guard day != selectedDay else { return }
+        selectedDay = day
+        selectedHour = Self.snapHour(selectedHour, into: hours(forDay: day))
+        snapModeIntoDay()
+        Task { await loadSlot(day: selectedDay, hour: selectedHour, moveCamera: false) }
+    }
+
+    func selectHour(_ hour: Int) {
+        guard hour != selectedHour else { return }
+        selectedHour = Self.snapHour(hour, into: hours(forDay: selectedDay))
+        Task { await loadSlot(day: selectedDay, hour: selectedHour, moveCamera: false) }
+    }
+
+    /// Step the hour by ±1 within the current day's sample hours (the `‹ ›` feel).
+    func stepHour(_ delta: Int) {
+        let hrs = hours(forDay: selectedDay)
+        guard let idx = hrs.firstIndex(of: selectedHour) else {
+            if let first = hrs.first { selectHour(first) }
+            return
+        }
+        let next = idx + delta
+        guard hrs.indices.contains(next) else { return }
+        selectHour(hrs[next])
+    }
+
+    var canStepHourBack: Bool {
+        let hrs = hours(forDay: selectedDay)
+        guard let idx = hrs.firstIndex(of: selectedHour) else { return false }
+        return idx > 0
+    }
+
+    var canStepHourForward: Bool {
+        let hrs = hours(forDay: selectedDay)
+        guard let idx = hrs.firstIndex(of: selectedHour) else { return false }
+        return idx < hrs.count - 1
+    }
+
+    /// Fetch a slot from the LRU or the network and publish it. `moveCamera`
+    /// stays false — a day/hour change recolours in place, it never re-centres.
+    private func loadSlot(day: Int, hour: Int, moveCamera: Bool) async {
+        let key = SlotKey(day: day, hour: hour)
+        if let cached = slots[key] {
+            touchLRU(key)
+            payload = cached
+            prefetchAdjacentHours()
+            return
+        }
+        isLoading = true
+        loadError = nil
+        do {
+            let resp = try await repository.forecastMap(day: day, hour: hour)
+            // A late-arriving fetch for a slot the user already scrubbed past must
+            // not clobber the current view.
+            store(resp, for: key)
+            if selectedDay == day, selectedHour == hour {
+                payload = resp
+            }
+        } catch let error as APIError where error.isCancellation {
+            // benign
+        } catch {
+            Self.logger.warning("forecast map \(day)/\(hour) failed: \(error.localizedDescription)")
+            if selectedDay == day, selectedHour == hour, payload == nil {
+                loadError = error.localizedDescription
+            }
+        }
+        isLoading = false
+        prefetchAdjacentHours()
+    }
+
+    /// Prefetch the current day's neighbouring hours (server-cached, so cheap) so
+    /// `‹ ›` stepping feels instant.
+    private func prefetchAdjacentHours() {
+        let hrs = hours(forDay: selectedDay)
+        guard let idx = hrs.firstIndex(of: selectedHour) else { return }
+        for neighbour in [idx - 1, idx + 1] where hrs.indices.contains(neighbour) {
+            let key = SlotKey(day: selectedDay, hour: hrs[neighbour])
+            guard slots[key] == nil else { continue }
+            Task { [weak self] in
+                guard let self else { return }
+                if let resp = try? await self.repository.forecastMap(day: key.day, hour: key.hour) {
+                    self.store(resp, for: key)
+                }
+            }
+        }
+    }
+
+    // MARK: - Selection
+
+    func select(icao: String, biasForSheet: Bool) {
+        selectedIcao = icao
+        if let apt = payload?.airports.first(where: { $0.icao == icao }) {
+            focusRequest = FocusRequest(
+                center: CLLocationCoordinate2D(latitude: apt.lat, longitude: apt.lon),
+                span: nil, biasForSheet: biasForSheet
+            )
+        }
+    }
+
+    func deselect() { selectedIcao = nil }
+
+    var selectedAirport: ForecastAirport? {
+        guard let selectedIcao else { return nil }
+        return payload?.airports.first { $0.icao == selectedIcao }
+    }
+
+    // MARK: - Grid helpers
+
+    /// Sample hours available for a day, from the grid (falls back to the fine set).
+    func hours(forDay day: Int) -> [Int] {
+        if let entry = days.first(where: { $0.day == day }), !entry.hours.isEmpty {
+            return entry.hours
+        }
+        return day >= 6 ? [6, 12, 18] : [6, 9, 12, 15, 18]
+    }
+
+    /// Models present for a day (empty → assume all three, pre-grid).
+    func models(forDay day: Int) -> [String] {
+        days.first(where: { $0.day == day })?.models ?? ["gfs", "icon", "ecmwf"]
+    }
+
+    /// Whether a model can reach a day — greyed-but-tappable models must never
+    /// read as agreement, so the picker disables (not hides) absent ones.
+    func modelAvailable(_ model: String, day: Int) -> Bool {
+        models(forDay: day).contains(model)
+    }
+
+    private func snapSelectionIntoGrid(smartDefaultHour: Bool) {
+        selectedDay = min(max(selectedDay, 0), maxDay)
+        let hrs = hours(forDay: selectedDay)
+        if smartDefaultHour {
+            // Cold open: nearest sample hour to the current UTC hour, not always 12Z.
+            selectedHour = Self.snapHour(Self.currentUTCHour(), into: hrs)
+        } else {
+            selectedHour = Self.snapHour(selectedHour, into: hrs)
+        }
+        snapModeIntoDay()
+    }
+
+    /// Fall back to worst consensus when the active individual model can't reach
+    /// the selected day (web behaviour).
+    private func snapModeIntoDay() {
+        if case .model(let m) = mode, !modelAvailable(m, day: selectedDay) {
+            mode = .worst
+        }
+    }
+
+    private static func snapHour(_ hour: Int, into hours: [Int]) -> Int {
+        guard !hours.isEmpty else { return hour }
+        if hours.contains(hour) { return hour }
+        return hours.min(by: { abs($0 - hour) < abs($1 - hour) }) ?? hour
+    }
+
+    private static func currentUTCHour() -> Int {
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = TimeZone(identifier: "UTC")!
+        return cal.component(.hour, from: Date())
+    }
+
+    // MARK: - Cold-open centring
+
+    private func resolveColdOpenTarget() async {
+        guard let freq = try? await repository.frequentAirports() else { return }
+        coldOpenIcao = freq.departures.first?.icao ?? freq.destinations.first?.icao
+        applyColdOpenIfPossible()
+    }
+
+    private func applyColdOpenIfPossible() {
+        guard !hasExplicitLocation, let icao = coldOpenIcao,
+              let apt = payload?.airports.first(where: { $0.icao == icao }) else { return }
+        initialRegion = MKCoordinateRegion(
+            center: CLLocationCoordinate2D(latitude: apt.lat, longitude: apt.lon),
+            span: MKCoordinateSpan(latitudeDelta: 8, longitudeDelta: 10)
+        )
+        focusRequest = FocusRequest(
+            center: initialRegion.center, span: initialRegion.span, biasForSheet: false)
+        coldOpenIcao = nil
+    }
+
+    // MARK: - LRU
+
+    private func store(_ resp: ForecastMapResponse, for key: SlotKey) {
+        slots[key] = resp
+        touchLRU(key)
+        // A payload may arrive before the cold-open target resolved.
+        applyColdOpenIfPossible()
+        while lruOrder.count > Self.lruCapacity {
+            let evict = lruOrder.removeFirst()
+            if evict != SlotKey(day: selectedDay, hour: selectedHour) { slots[evict] = nil }
+        }
+    }
+
+    private func touchLRU(_ key: SlotKey) {
+        lruOrder.removeAll { $0 == key }
+        lruOrder.append(key)
+    }
+
+    // MARK: - Regions & defaults
+
+    static let europeRegion = MKCoordinateRegion(
+        center: CLLocationCoordinate2D(latitude: 48, longitude: 10),
+        span: MKCoordinateSpan(latitudeDelta: 22, longitudeDelta: 26)
+    )
+
+    /// Near-days fallback grid when `/maps/forecast/days` is unreachable (mirrors
+    /// the web `fallbackDayGrid`): D+0…D+3, five hours, all three models.
+    private static func fallbackDays() -> [ForecastDay] {
+        (0...3).map { d in
+            ForecastDay(day: d, date: "", available: true,
+                        hours: [6, 9, 12, 15, 18], models: ["ecmwf", "gfs", "icon"])
+        }
+    }
+}
+
+extension MapDeepLink {
+    /// Bridge the universal-link deep-link into the map view model's own type.
+    var asViewModelDeepLink: ForecastMapViewModel.DeepLink {
+        ForecastMapViewModel.DeepLink(day: day, hour: hour, model: model, metric: metric, airport: airport)
+    }
+}

--- a/app/flyfun-weather/flyfun-weather/Views/Flights/FlightListView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Flights/FlightListView.swift
@@ -24,7 +24,11 @@ struct FlightListView: View {
     /// Compact-width forecast-map cover (the app's first `fullScreenCover`) and
     /// the deep-link state it opens with.
     @State private var showMapCover = false
-    @State private var mapDeepLink: ForecastMapViewModel.DeepLink?
+    @State private var mapDeepLink: MapDeepLink?
+    /// Bumped on every `openForecastMap`, used as the map view's `.id` so a *new*
+    /// inbound deep link while the map is already open re-creates the view (the
+    /// deep link is applied only at `ForecastMapViewModel.init`).
+    @State private var mapOpenToken = 0
 
     private var isCompact: Bool { horizontalSizeClass == .compact }
     // Guards the one authoritative-reload retry in `applyPendingNavigation` so a
@@ -213,6 +217,7 @@ struct FlightListView: View {
                 // fullScreenCover instead — see `openForecastMap`.
                 if let repo = appState.repository {
                     ForecastMapView(repository: repo, deepLink: mapDeepLink)
+                        .id(mapOpenToken)
                 }
             case nil:
                 ContentUnavailableView("Select a Flight", systemImage: "airplane",
@@ -224,6 +229,7 @@ struct FlightListView: View {
                 ForecastMapView(repository: repo, deepLink: mapDeepLink) {
                     showMapCover = false
                 }
+                .id(mapOpenToken)
             }
         }
         .task {
@@ -275,7 +281,7 @@ struct FlightListView: View {
             selection = nil
             appState.clearPendingNavigation()
         case .forecastMap(let deepLink):
-            openForecastMap(deepLink: deepLink.isEmpty ? nil : deepLink.asViewModelDeepLink)
+            openForecastMap(deepLink: deepLink.isEmpty ? nil : deepLink)
             appState.clearPendingNavigation()
         case .briefing(let flightId):
             guard let vm = viewModel, case .loaded(let flights) = vm.state else { return }
@@ -310,8 +316,11 @@ struct FlightListView: View {
     /// Open the forecast map: an iPad detail pane (regular width) or an iPhone
     /// `fullScreenCover` (compact) — retrofitting the sidebar later is expensive,
     /// so iPad is done from the start (#420).
-    private func openForecastMap(deepLink: ForecastMapViewModel.DeepLink?) {
+    private func openForecastMap(deepLink: MapDeepLink?) {
         mapDeepLink = deepLink
+        // Bump the id so a re-entrant deep link (map already open) re-creates the
+        // view/VM and actually applies the new day/hour/model/metric/airport.
+        mapOpenToken &+= 1
         if isCompact {
             showMapCover = true
         } else {

--- a/app/flyfun-weather/flyfun-weather/Views/Flights/FlightListView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Flights/FlightListView.swift
@@ -1,17 +1,32 @@
 import SwiftUI
 
+/// What the sidebar has selected: the pan-European forecast map, or a flight's
+/// briefing (#420). The map is an iPad detail pane / iPhone `fullScreenCover`;
+/// the flight case drives the briefing detail as before.
+enum SidebarSelection: Hashable {
+    case forecastMap
+    case flight(FlightResponse)
+}
+
 /// Main screen showing the user's saved flights with sidebar/detail split on iPad.
 struct FlightListView: View {
     @Environment(AppState.self) private var appState
     @Environment(\.openURL) private var openURL
     @Environment(\.scenePhase) private var scenePhase
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @State private var viewModel: FlightListViewModel?
-    @State private var selectedFlight: FlightResponse?
+    @State private var selection: SidebarSelection?
     @State private var columnVisibility: NavigationSplitViewVisibility = .automatic
     @State private var showAddFlight = false
     @State private var showSettings = false
     @State private var showSignOutWarning = false
     @State private var editingFlight: FlightResponse?
+    /// Compact-width forecast-map cover (the app's first `fullScreenCover`) and
+    /// the deep-link state it opens with.
+    @State private var showMapCover = false
+    @State private var mapDeepLink: ForecastMapViewModel.DeepLink?
+
+    private var isCompact: Bool { horizontalSizeClass == .compact }
     // Guards the one authoritative-reload retry in `applyPendingNavigation` so a
     // deep-link to a just-created flight (push tap / Universal Link) isn't dropped
     // against a stale cache-first list. Holds the flight id we've already retried.
@@ -38,7 +53,7 @@ struct FlightListView: View {
                             }
                             // Utility logbook (§4.4): Future · Recent · Past.
                             // Past is collapsible (collapsed by default).
-                            List(selection: $selectedFlight) {
+                            List(selection: $selection) {
                                 ForEach(Self.groupedFlights(flights), id: \.title) { group in
                                     if group.title == "Past" {
                                         Section {
@@ -119,6 +134,12 @@ struct FlightListView: View {
                             Label("Add Flight", systemImage: "plus")
                         }
                         .accessibilityIdentifier("addFlightButton")
+                        Button {
+                            openForecastMap(deepLink: nil)
+                        } label: {
+                            Label("Forecast Map", systemImage: "map")
+                        }
+                        .accessibilityIdentifier("forecastMapButton")
                         Menu {
                             Button {
                                 showSettings = true
@@ -157,7 +178,7 @@ struct FlightListView: View {
                     AddFlightView(repository: repo) { flight in
                         Task {
                             await viewModel?.loadFlights()
-                            selectedFlight = flight
+                            selection = .flight(flight)
                         }
                     }
                 }
@@ -171,7 +192,7 @@ struct FlightListView: View {
                         Task {
                             await viewModel?.loadFlights()
                             // Re-open the (regenerated) briefing.
-                            selectedFlight = updated
+                            selection = .flight(updated)
                         }
                     }
                 }
@@ -183,12 +204,26 @@ struct FlightListView: View {
                 Text("You have downloaded packs. They won't be accessible until you sign in again.")
             }
         } detail: {
-            if let selectedFlight {
-                BriefingContainerView(flight: selectedFlight)
-                    .id(selectedFlight.id)
-            } else {
+            switch selection {
+            case .flight(let flight):
+                BriefingContainerView(flight: flight)
+                    .id(flight.id)
+            case .forecastMap:
+                // iPad detail pane (regular width). On compact the map opens as a
+                // fullScreenCover instead — see `openForecastMap`.
+                if let repo = appState.repository {
+                    ForecastMapView(repository: repo, deepLink: mapDeepLink)
+                }
+            case nil:
                 ContentUnavailableView("Select a Flight", systemImage: "airplane",
-                                       description: Text("Choose a flight from the list to view its briefing."))
+                                       description: Text("Choose a flight from the list, or open the forecast map."))
+            }
+        }
+        .fullScreenCover(isPresented: $showMapCover) {
+            if let repo = appState.repository {
+                ForecastMapView(repository: repo, deepLink: mapDeepLink) {
+                    showMapCover = false
+                }
             }
         }
         .task {
@@ -237,12 +272,15 @@ struct FlightListView: View {
         guard let nav = appState.pendingNavigation else { return }
         switch nav {
         case .flightList:
-            selectedFlight = nil
+            selection = nil
+            appState.clearPendingNavigation()
+        case .forecastMap(let deepLink):
+            openForecastMap(deepLink: deepLink.isEmpty ? nil : deepLink.asViewModelDeepLink)
             appState.clearPendingNavigation()
         case .briefing(let flightId):
             guard let vm = viewModel, case .loaded(let flights) = vm.state else { return }
             if let match = flights.first(where: { $0.id == flightId }) {
-                selectedFlight = match
+                selection = .flight(match)
                 appState.clearPendingNavigation()
                 reloadRetryFlightId = nil
             } else if vm.isOffline || vm.isRefreshing {
@@ -269,12 +307,24 @@ struct FlightListView: View {
         }
     }
 
+    /// Open the forecast map: an iPad detail pane (regular width) or an iPhone
+    /// `fullScreenCover` (compact) — retrofitting the sidebar later is expensive,
+    /// so iPad is done from the start (#420).
+    private func openForecastMap(deepLink: ForecastMapViewModel.DeepLink?) {
+        mapDeepLink = deepLink
+        if isCompact {
+            showMapCover = true
+        } else {
+            selection = .forecastMap
+        }
+    }
+
     /// One flight row (navigation + edit swipe/context menu). Shared by every
     /// section so the collapsible Past section renders identical rows.
     @ViewBuilder
     private func flightRow(_ flight: FlightResponse, viewModel: FlightListViewModel) -> some View {
         let hasCached = viewModel.cachedFlightIds.contains(flight.id)
-        NavigationLink(value: flight) {
+        NavigationLink(value: SidebarSelection.flight(flight)) {
             FlightCardView(flight: flight, hasCachedData: hasCached,
                            isOffline: viewModel.isOffline,
                            isRefreshing: viewModel.refreshingFlightIds.contains(flight.id))

--- a/app/flyfun-weather/flyfun-weather/Views/Flights/FlightListView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Flights/FlightListView.swift
@@ -317,10 +317,17 @@ struct FlightListView: View {
     /// `fullScreenCover` (compact) — retrofitting the sidebar later is expensive,
     /// so iPad is done from the start (#420).
     private func openForecastMap(deepLink: MapDeepLink?) {
+        // Only force a fresh view (new `.id`) when a *new* deep link arrives while
+        // the map is ALREADY open — that's the only case where the view is reused
+        // and wouldn't otherwise apply the new state. A plain re-open (toolbar
+        // button, or opening from closed) must NOT bump the token: doing so would
+        // tear down the VM and its (day,hour) LRU cache — the thing that makes
+        // `‹ ›` stepping instant — and re-fetch on a no-op tap.
+        let alreadyOpen = selection == .forecastMap || showMapCover
+        if deepLink != nil, alreadyOpen {
+            mapOpenToken &+= 1
+        }
         mapDeepLink = deepLink
-        // Bump the id so a re-entrant deep link (map already open) re-creates the
-        // view/VM and actually applies the new day/hour/model/metric/airport.
-        mapOpenToken &+= 1
         if isCompact {
             showMapCover = true
         } else {

--- a/app/flyfun-weather/flyfun-weather/Views/ForecastMap/ForecastAirportCard.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/ForecastMap/ForecastAirportCard.swift
@@ -270,7 +270,8 @@ struct ForecastAirportCard: View {
             guard let s = data.numericField("wind_speed_kt") else { return "—" }
             let dir = data.numericField("wind_dir_deg").map { "\(Int($0.rounded()))/" } ?? ""
             // Gust as `Ggust` (web `dir/speedGgust`); consensus has no gust → omitted.
-            let gust = data.numericField("wind_gust_kt").map { "G\(Int($0.rounded()))" } ?? ""
+            // Web uses a truthy check on this field, so a literal 0 gust is omitted.
+            let gust = data.numericField("wind_gust_kt").flatMap { $0 != 0 ? "G\(Int($0.rounded()))" : nil } ?? ""
             return "\(dir)\(Int(s.rounded()))\(gust)"
         case "crosswind_kt":
             guard let v = data.numericField("crosswind_kt") else { return "—" }

--- a/app/flyfun-weather/flyfun-weather/Views/ForecastMap/ForecastAirportCard.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/ForecastMap/ForecastAirportCard.swift
@@ -269,13 +269,17 @@ struct ForecastAirportCard: View {
         case "wind_speed_kt":
             guard let s = data.numericField("wind_speed_kt") else { return "—" }
             let dir = data.numericField("wind_dir_deg").map { "\(Int($0.rounded()))/" } ?? ""
-            return "\(dir)\(Int(s.rounded()))"
+            // Gust as `Ggust` (web `dir/speedGgust`); consensus has no gust → omitted.
+            let gust = data.numericField("wind_gust_kt").map { "G\(Int($0.rounded()))" } ?? ""
+            return "\(dir)\(Int(s.rounded()))\(gust)"
         case "crosswind_kt":
             guard let v = data.numericField("crosswind_kt") else { return "—" }
-            return "\(Int(v.rounded()))"
+            let gust = data.numericField("gust_crosswind_kt").map { " (\(Int($0.rounded())))" } ?? ""
+            return "\(Int(v.rounded()))\(gust)"
         case "headwind_kt":
             guard let v = data.numericField("headwind_kt") else { return "—" }
-            return "\(Int(v.rounded()))"
+            let gust = data.numericField("gust_headwind_kt").map { " (\(Int($0.rounded())))" } ?? ""
+            return "\(Int(v.rounded()))\(gust)"
         case "cape_jkg":
             guard let v = data.numericField("cape_jkg") else { return "—" }
             return "\(Int(v.rounded()))"

--- a/app/flyfun-weather/flyfun-weather/Views/ForecastMap/ForecastAirportCard.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/ForecastMap/ForecastAirportCard.swift
@@ -1,0 +1,311 @@
+import SwiftUI
+import UIKit
+
+/// The tapped-airport card (#420, PR2). A pure function of data the map already
+/// holds — zero network. Mirrors the web `airport-summary-card.ts`: verdict
+/// header, alternate-required row, a metric × model matrix, and an init-times
+/// footnote. Tapping a metric row switches the map's colour metric (already the
+/// shipped web behaviour), and the header carries a duplicate hour stepper so you
+/// can step time and watch the map *and* the card update together.
+struct ForecastAirportCard: View {
+    let viewModel: ForecastMapViewModel
+    let airport: ForecastAirport
+    let catalog: ForecastMapCatalog
+
+    /// The card's consensus column mirrors the map mode, falling back to worst
+    /// when an individual model is active.
+    private var consensusMode: ForecastModelMode { viewModel.mode.consensusMode }
+    private var consensus: ForecastConsensus { airport.consensus(mode: consensusMode) }
+    private var modeLabel: String { consensusMode == .majority ? "Majority" : "Worst" }
+
+    /// Model columns: fixed order, present models only.
+    private var presentModels: [String] {
+        ["gfs", "icon", "ecmwf"].filter { airport.models[$0] != nil }
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: Theme.spacingM) {
+                verdictHeader
+                alternateRow
+                matrix
+                footer
+            }
+            .padding(Theme.cardPadding)
+        }
+        .background(Theme.bg)
+    }
+
+    // MARK: - Verdict header
+
+    private var verdictHeader: some View {
+        HStack(alignment: .center, spacing: Theme.spacingM) {
+            categoryBadge
+            VStack(alignment: .leading, spacing: 2) {
+                Text(airport.icao).font(.title3.bold()).foregroundStyle(Theme.text)
+                Text(validTimeLabel).font(.caption).foregroundStyle(Theme.textMuted).monospacedDigit()
+                if let chip = agreementChip { agreementChipView(chip) }
+            }
+            Spacer()
+            headerHourStepper
+        }
+    }
+
+    private var categoryBadge: some View {
+        let bg = catalog.color(metric: "flight_category", airport: airport, mode: consensusMode)
+        return Text(consensus.flightCategory ?? "—")
+            .font(.headline.weight(.bold))
+            .foregroundStyle(Color(uiColor: bg.readableText))
+            .padding(.horizontal, 12).padding(.vertical, 8)
+            .background(Color(uiColor: bg), in: RoundedRectangle(cornerRadius: 10))
+    }
+
+    private var headerHourStepper: some View {
+        HStack(spacing: 6) {
+            Button { viewModel.stepHour(-1) } label: { Image(systemName: "chevron.left") }
+                .disabled(!viewModel.canStepHourBack)
+            Text(String(format: "%02dZ", viewModel.selectedHour))
+                .font(.subheadline.weight(.medium)).monospacedDigit()
+            Button { viewModel.stepHour(1) } label: { Image(systemName: "chevron.right") }
+                .disabled(!viewModel.canStepHourForward)
+        }
+        .padding(.horizontal, 10).padding(.vertical, 6)
+        .background(.thinMaterial, in: Capsule())
+    }
+
+    private struct AgreementChip { let text: String; let color: Color }
+
+    private var agreementChip: AgreementChip? {
+        guard let bucket = consensus.agreement(forMetric: "flight_category") else { return nil }
+        let text: String
+        switch bucket {
+        case "divergent": text = "Models split"
+        case "mixed": text = "Some disagreement"
+        case "consistent": text = "Models agree"
+        default: return nil
+        }
+        return AgreementChip(text: text, color: Color(uiColor: catalog.agreementColor(bucket)))
+    }
+
+    private func agreementChipView(_ chip: AgreementChip) -> some View {
+        HStack(spacing: 4) {
+            Circle().fill(chip.color).frame(width: 7, height: 7)
+            Text(chip.text).font(.caption2).foregroundStyle(Theme.textMuted)
+        }
+    }
+
+    // MARK: - Alternate-required row
+
+    private var alternateRow: some View {
+        let alt = airport.aggregatedAltRequired(mode: consensusMode)
+        let required = (alt?.faa ?? false) || (alt?.easa ?? false)
+        return HStack {
+            Text("Alternate required").font(.subheadline).foregroundStyle(Theme.textMuted)
+            Spacer()
+            Text(Self.altLabel(alt))
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(required ? Theme.red : Theme.green)
+            Text(modeLabel)
+                .font(.caption2).foregroundStyle(Theme.textMuted)
+                .padding(.horizontal, 6).padding(.vertical, 2)
+                .background(Theme.surface, in: Capsule())
+        }
+        .padding(.vertical, 6)
+        .overlay(Divider(), alignment: .bottom)
+    }
+
+    // MARK: - Metric × model matrix
+
+    private struct MatrixRow { let metric: String; let label: String; let unit: String? }
+    private static let matrixRows: [MatrixRow] = [
+        .init(metric: "flight_category", label: "Category", unit: nil),
+        .init(metric: "ceiling_ft", label: "Ceiling", unit: "ft"),
+        .init(metric: "visibility_m", label: "Visibility", unit: nil),
+        .init(metric: "wind_speed_kt", label: "Wind", unit: "kt"),
+        .init(metric: "crosswind_kt", label: "Xwind", unit: "kt"),
+        .init(metric: "headwind_kt", label: "Headwind", unit: "kt"),
+        .init(metric: "convective_risk", label: "Convective", unit: nil),
+        .init(metric: "cape_jkg", label: "CAPE", unit: "J/kg"),
+        .init(metric: "cloud_cover_pct", label: "Cloud cover", unit: nil),
+    ]
+
+    private var matrix: some View {
+        let cols = presentModels
+        return VStack(spacing: 0) {
+            // Header row.
+            HStack(spacing: 0) {
+                Text("").frame(maxWidth: .infinity, alignment: .leading)
+                ForEach(cols, id: \.self) { m in
+                    Text(m.uppercased()).font(.caption2.weight(.semibold)).foregroundStyle(Theme.textMuted)
+                        .frame(width: 56)
+                }
+                Text(modeLabel).font(.caption2.weight(.semibold)).foregroundStyle(Theme.textMuted)
+                    .frame(width: 56)
+            }
+            .padding(.vertical, 4)
+
+            ForEach(Self.matrixRows, id: \.metric) { row in
+                metricRow(row, cols: cols)
+            }
+            tempRow(cols: cols)
+        }
+    }
+
+    private func metricRow(_ row: MatrixRow, cols: [String]) -> some View {
+        let diverging = consensus.agreement(forMetric: row.metric) == "divergent"
+        let isActive = viewModel.metric == row.metric
+        return Button {
+            viewModel.metric = row.metric  // row-tap switches the map's colour metric
+        } label: {
+            HStack(spacing: 0) {
+                HStack(spacing: 4) {
+                    if isActive { Image(systemName: "map.fill").font(.system(size: 9)).foregroundStyle(Theme.primary) }
+                    if diverging { Image(systemName: "exclamationmark.triangle.fill").font(.system(size: 9)).foregroundStyle(Theme.amber) }
+                    Text(rowLabel(row)).font(.caption).foregroundStyle(Theme.text)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+                ForEach(cols, id: \.self) { m in
+                    cell(metric: row.metric, data: airport.models[m].map { $0 as any ForecastCellData }, mode: .model(m))
+                }
+                cell(metric: row.metric, data: consensus, mode: consensusMode)
+            }
+            .padding(.vertical, 3)
+            .background(isActive ? Theme.primary.opacity(0.08) : .clear)
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Colour the map by \(row.label.lowercased())")
+    }
+
+    /// The bottom Temp row — plain (uncoloured) per-model, consensus "—". Not a
+    /// colour metric, so it isn't tappable.
+    private func tempRow(cols: [String]) -> some View {
+        let anyTemp = cols.contains { airport.models[$0]?.temperatureC != nil }
+        return Group {
+            if anyTemp {
+                HStack(spacing: 0) {
+                    Text("Temp").font(.caption).foregroundStyle(Theme.textMuted)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    ForEach(cols, id: \.self) { m in
+                        Text(airport.models[m]?.temperatureC.map { "\(Int($0.rounded()))°" } ?? "—")
+                            .font(.caption2).monospacedDigit().foregroundStyle(Theme.text)
+                            .frame(width: 56)
+                    }
+                    Text("—").font(.caption2).foregroundStyle(Theme.textMuted).frame(width: 56)
+                }
+                .padding(.vertical, 3)
+            }
+        }
+    }
+
+    private func cell(metric: String, data: (any ForecastCellData)?, mode: ForecastModelMode) -> some View {
+        let bg = catalog.color(metric: metric, cell: data, airport: airport, mode: mode)
+        return Text(Self.compactCell(data, metric: metric))
+            .font(.caption2).monospacedDigit()
+            .foregroundStyle(Color(uiColor: bg.readableText))
+            .frame(width: 56, height: 22)
+            .background(Color(uiColor: bg))
+    }
+
+    private func rowLabel(_ row: MatrixRow) -> String {
+        var label = row.label
+        if let unit = row.unit { label += " (\(unit))" }
+        // Name the best runway on the wind-component rows.
+        if row.metric == "crosswind_kt" || row.metric == "headwind_kt",
+           let rwy = presentModels.compactMap({ airport.models[$0]?.bestRunwayId }).first {
+            label += " · RWY \(rwy)"
+        }
+        return label
+    }
+
+    // MARK: - Footer
+
+    private var footer: some View {
+        Text(initTimesLabel)
+            .font(.caption2).foregroundStyle(Theme.textMuted)
+            .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var validTimeLabel: String {
+        guard let iso = viewModel.payload?.forecastTime,
+              let date = Self.isoFormatter.date(from: iso) else { return "" }
+        return Self.validTimeFormatter.string(from: date)
+    }
+
+    private var initTimesLabel: String {
+        guard let inits = viewModel.payload?.modelInitTimes else { return "" }
+        let parts = presentModels.compactMap { m -> String? in
+            guard let iso = inits[m], let d = Self.isoFormatter.date(from: iso) else { return nil }
+            return "\(m.uppercased()) \(Self.hourFormatter.string(from: d))Z"
+        }
+        return parts.isEmpty ? "" : "Init: " + parts.joined(separator: " · ")
+    }
+
+    // MARK: - Formatting
+
+    static func altLabel(_ f: AltRequired?) -> String {
+        guard let f else { return "—" }
+        if f.faa && f.easa { return "FAA + EASA" }
+        if f.easa { return "EASA" }
+        if f.faa { return "FAA" }
+        return "None"
+    }
+
+    /// Narrow matrix-cell value (units live in the row label). Port of `compactCell`.
+    static func compactCell(_ data: (any ForecastCellData)?, metric: String) -> String {
+        guard let data else { return "—" }
+        switch metric {
+        case "flight_category":
+            return data.categoryField("flight_category") ?? "—"
+        case "convective_risk":
+            return data.categoryField("convective_risk") ?? "none"
+        case "ceiling_ft":
+            guard let v = data.numericField("ceiling_ft") else { return "—" }
+            return v >= 10000 ? "CAVOK" : "\(Int(v.rounded()))"
+        case "visibility_m":
+            guard let m = data.numericField("visibility_m") else { return "—" }
+            if m >= 9999 { return "10+km" }
+            return m >= 5000 ? "\(Int((m / 1000).rounded()))km" : "\(Int(m.rounded()))m"
+        case "wind_speed_kt":
+            guard let s = data.numericField("wind_speed_kt") else { return "—" }
+            let dir = data.numericField("wind_dir_deg").map { "\(Int($0.rounded()))/" } ?? ""
+            return "\(dir)\(Int(s.rounded()))"
+        case "crosswind_kt":
+            guard let v = data.numericField("crosswind_kt") else { return "—" }
+            return "\(Int(v.rounded()))"
+        case "headwind_kt":
+            guard let v = data.numericField("headwind_kt") else { return "—" }
+            return "\(Int(v.rounded()))"
+        case "cape_jkg":
+            guard let v = data.numericField("cape_jkg") else { return "—" }
+            return "\(Int(v.rounded()))"
+        case "cloud_cover_pct":
+            guard let v = data.numericField("cloud_cover_pct") else { return "—" }
+            return "\(Int(v.rounded()))%"
+        default:
+            return "—"
+        }
+    }
+
+    private static let isoFormatter = ISO8601DateFormatter()
+    private static let validTimeFormatter: DateFormatter = {
+        let f = DateFormatter(); f.timeZone = TimeZone(identifier: "UTC")
+        f.locale = Locale(identifier: "en_US_POSIX"); f.dateFormat = "EEE HH:mm'Z'"; return f
+    }()
+    private static let hourFormatter: DateFormatter = {
+        let f = DateFormatter(); f.timeZone = TimeZone(identifier: "UTC")
+        f.locale = Locale(identifier: "en_US_POSIX"); f.dateFormat = "HH"; return f
+    }()
+}
+
+// MARK: - Readable text on a coloured cell (textOn)
+
+extension UIColor {
+    /// Black or white, whichever reads on this background (luminance > 0.6 → dark).
+    var readableText: UIColor {
+        var r: CGFloat = 0, g: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0
+        getRed(&r, green: &g, blue: &b, alpha: &a)
+        let luminance = 0.299 * r + 0.587 * g + 0.114 * b
+        return luminance > 0.6 ? UIColor(white: 0.07, alpha: 1) : .white
+    }
+}

--- a/app/flyfun-weather/flyfun-weather/Views/ForecastMap/ForecastMapKitView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/ForecastMap/ForecastMapKitView.swift
@@ -1,0 +1,224 @@
+import MapKit
+import SwiftUI
+
+/// The forecast-map canvas: `MKMapView` via `UIViewRepresentable`, **no
+/// clustering**. 619 `MKAnnotationView`s (reused, `displayPriority = .required`
+/// so MapKit never declutters them) are comfortable where 619 SwiftUI
+/// `Annotation`s would jank, and clustering is rejected on semantics — a cluster
+/// can't be both "the best airport here" (where can I fly) and "the worst" (what's
+/// dangerous), so every airport always shows (#420).
+///
+/// A metric or model switch is a **pure recolour** of the existing views — no
+/// annotation rebuild, no refetch. Only a day/hour change (new `slotID`) rebuilds
+/// annotations.
+struct ForecastMapKitView: UIViewRepresentable {
+    let payload: ForecastMapResponse?
+    let catalog: ForecastMapCatalog?
+    let metric: String
+    let mode: ForecastModelMode
+    let selectedIcao: String?
+    /// Identity of the current (day, hour) slot — rebuild annotations when it changes.
+    let slotID: String
+    let initialRegion: MKCoordinateRegion
+    let focusRequest: ForecastMapViewModel.FocusRequest?
+    let onSelect: (String) -> Void
+    let onFocusApplied: () -> Void
+
+    func makeCoordinator() -> Coordinator { Coordinator(self) }
+
+    func makeUIView(context: Context) -> MKMapView {
+        let map = MKMapView()
+        map.delegate = context.coordinator
+        map.pointOfInterestFilter = .excludingAll
+        map.showsUserLocation = true
+        map.showsCompass = true
+        map.register(AirportMarkerView.self,
+                     forAnnotationViewWithReuseIdentifier: AirportMarkerView.reuseID)
+        map.setRegion(initialRegion, animated: false)
+        context.coordinator.map = map
+        context.coordinator.currentDiameter = Coordinator.diameter(for: map)
+        return map
+    }
+
+    func updateUIView(_ map: MKMapView, context: Context) {
+        context.coordinator.update(parent: self)
+    }
+
+    // MARK: - Coordinator
+
+    @MainActor
+    final class Coordinator: NSObject {
+        private var parent: ForecastMapKitView
+        weak var map: MKMapView?
+        private var renderedSlotID: String?
+        private var appliedFocus: ForecastMapViewModel.FocusRequest?
+        var currentDiameter: CGFloat = 14
+
+        init(_ parent: ForecastMapKitView) {
+            self.parent = parent
+        }
+
+        func update(parent: ForecastMapKitView) {
+            self.parent = parent
+            guard let map else { return }
+
+            if renderedSlotID != parent.slotID {
+                renderedSlotID = parent.slotID
+                rebuildAnnotations(on: map)
+            }
+            recolorVisible(on: map)
+
+            if let focus = parent.focusRequest, focus != appliedFocus {
+                appliedFocus = focus
+                apply(focus: focus, on: map)
+                let cb = parent.onFocusApplied
+                DispatchQueue.main.async { cb() }
+            }
+        }
+
+        // MARK: Annotations
+
+        private func rebuildAnnotations(on map: MKMapView) {
+            let existing = map.annotations.compactMap { $0 as? ForecastAnnotation }
+            map.removeAnnotations(existing)
+            guard let airports = parent.payload?.airports else { return }
+            map.addAnnotations(airports.map(ForecastAnnotation.init))
+        }
+
+        private func recolorVisible(on map: MKMapView) {
+            for annotation in map.annotations {
+                guard let a = annotation as? ForecastAnnotation,
+                      let view = map.view(for: a) as? AirportMarkerView else { continue }
+                configure(view, airport: a.airport)
+            }
+        }
+
+        /// Fill + border encode (active metric colour + per-metric agreement ring).
+        private func configure(_ view: AirportMarkerView, airport: ForecastAirport) {
+            let fill = parent.catalog?.color(metric: parent.metric, airport: airport, mode: parent.mode)
+                ?? ForecastMapCatalog.muted
+            let isSelected = airport.icao == parent.selectedIcao
+
+            let border: UIColor
+            let weight: CGFloat
+            if isSelected {
+                border = UIColor(rgbHex: 0xfbbf24)  // amber
+                weight = 4
+            } else if parent.mode.isConsensus {
+                // Ring = "the models disagree about the thing you're looking at".
+                let label = airport.consensus(mode: parent.mode).agreement(forMetric: parent.metric)
+                border = parent.catalog?.agreementColor(label) ?? ForecastMapCatalog.muted
+                weight = 2
+            } else {
+                border = fill
+                weight = 1
+            }
+            view.apply(fill: fill, border: border, borderWidth: weight,
+                       diameter: currentDiameter, bringToFront: isSelected)
+        }
+
+        // MARK: Camera
+
+        private func apply(focus: ForecastMapViewModel.FocusRequest, on map: MKMapView) {
+            var center = focus.center
+            let span = focus.span ?? map.region.span
+            if focus.biasForSheet {
+                // Nudge the airport up so it doesn't land under the bottom sheet.
+                center.latitude -= span.latitudeDelta * 0.25
+            }
+            map.setRegion(MKCoordinateRegion(center: center, span: span), animated: true)
+        }
+
+        /// Marker diameter from the map's zoom (web `markerRadius`: 5px at z≤4 →
+        /// 11px at z≥8), doubled to a diameter.
+        static func diameter(for map: MKMapView) -> CGFloat {
+            let span = map.region.span.longitudeDelta
+            guard span > 0 else { return 14 }
+            let zoom = log2(360 / span)
+            let radius: CGFloat
+            switch zoom {
+            case ..<4.5: radius = 5
+            case ..<5.5: radius = 6
+            case ..<6.5: radius = 7
+            case ..<7.5: radius = 9
+            default: radius = 11
+            }
+            return radius * 2
+        }
+    }
+}
+
+// MapKit calls these on the main thread; `@preconcurrency` lets the `@MainActor`
+// coordinator satisfy the (non-isolated) delegate protocol (same pattern as
+// `FlightTrackingService`'s `CLLocationManagerDelegate`).
+extension ForecastMapKitView.Coordinator: @preconcurrency MKMapViewDelegate {
+    func mapView(_ mapView: MKMapView, viewFor annotation: MKAnnotation) -> MKAnnotationView? {
+        guard let a = annotation as? ForecastAnnotation else { return nil }  // user location → default
+        let view = mapView.dequeueReusableAnnotationView(
+            withIdentifier: AirportMarkerView.reuseID, for: a) as! AirportMarkerView
+        view.annotation = a
+        configure(view, airport: a.airport)
+        return view
+    }
+
+    func mapView(_ mapView: MKMapView, didSelect view: MKAnnotationView) {
+        guard let a = view.annotation as? ForecastAnnotation else { return }
+        // Drive selection purely from our VM, not MapKit's own selection state,
+        // so re-tapping the same marker always re-fires.
+        mapView.deselectAnnotation(a, animated: false)
+        parent.onSelect(a.airport.icao)
+    }
+
+    func mapView(_ mapView: MKMapView, regionDidChangeAnimated animated: Bool) {
+        let d = Self.diameter(for: mapView)
+        guard d != currentDiameter else { return }
+        currentDiameter = d
+        // Resize visible markers to the new zoom (radius scales with zoom, as web).
+        for annotation in mapView.annotations {
+            guard let a = annotation as? ForecastAnnotation,
+                  let v = mapView.view(for: a) as? AirportMarkerView else { continue }
+            v.resize(diameter: d)
+        }
+    }
+}
+
+/// One airport marker annotation.
+final class ForecastAnnotation: NSObject, MKAnnotation {
+    let airport: ForecastAirport
+    var coordinate: CLLocationCoordinate2D { CLLocationCoordinate2D(latitude: airport.lat, longitude: airport.lon) }
+    var title: String? { airport.icao }
+
+    init(_ airport: ForecastAirport) { self.airport = airport }
+}
+
+/// A filled circle marker with a coloured ring. `displayPriority = .required` so
+/// MapKit never hides one behind another (no decluttering — every airport shows).
+final class AirportMarkerView: MKAnnotationView {
+    static let reuseID = "airportMarker"
+
+    override init(annotation: MKAnnotation?, reuseIdentifier: String?) {
+        super.init(annotation: annotation, reuseIdentifier: reuseIdentifier)
+        displayPriority = .required
+        collisionMode = .none
+        canShowCallout = false
+        centerOffset = .zero
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    func apply(fill: UIColor, border: UIColor, borderWidth: CGFloat, diameter: CGFloat, bringToFront: Bool) {
+        resize(diameter: diameter)
+        backgroundColor = fill.withAlphaComponent(0.85)
+        layer.borderColor = border.cgColor
+        layer.borderWidth = borderWidth
+        layer.zPosition = bringToFront ? 1000 : 0
+    }
+
+    /// Set the circle size (called on zoom change without recolouring).
+    func resize(diameter: CGFloat) {
+        bounds = CGRect(x: 0, y: 0, width: diameter, height: diameter)
+        layer.cornerRadius = diameter / 2
+        layer.masksToBounds = true
+    }
+}

--- a/app/flyfun-weather/flyfun-weather/Views/ForecastMap/ForecastMapKitView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/ForecastMap/ForecastMapKitView.swift
@@ -1,5 +1,6 @@
 import MapKit
 import SwiftUI
+import UIKit
 
 /// The forecast-map canvas: `MKMapView` via `UIViewRepresentable`, **no
 /// clustering**. 619 `MKAnnotationView`s (reused, `displayPriority = .required`
@@ -9,20 +10,25 @@ import SwiftUI
 /// dangerous), so every airport always shows (#420).
 ///
 /// A metric or model switch is a **pure recolour** of the existing views — no
-/// annotation rebuild, no refetch. Only a day/hour change (new `slotID`) rebuilds
-/// annotations.
+/// annotation rebuild, no refetch. Only a new payload (`payloadRevision` bump:
+/// cold-open first load or a day/hour swap) rebuilds annotations.
 struct ForecastMapKitView: UIViewRepresentable {
     let payload: ForecastMapResponse?
     let catalog: ForecastMapCatalog?
     let metric: String
     let mode: ForecastModelMode
     let selectedIcao: String?
-    /// Identity of the current (day, hour) slot — rebuild annotations when it changes.
-    let slotID: String
+    /// Revision of the current payload — annotations rebuild when this changes, so
+    /// the nil→populated transition on cold open and every slot swap both
+    /// repopulate. (Gating on a day/hour string missed the cold-open payload,
+    /// which arrives *after* the first `updateUIView` for the same slot.)
+    let payloadRevision: Int
     let initialRegion: MKCoordinateRegion
     let focusRequest: ForecastMapViewModel.FocusRequest?
     let onSelect: (String) -> Void
     let onFocusApplied: () -> Void
+    /// The user panned/zoomed the map (freezes cold-open recentring).
+    let onUserInteraction: () -> Void
 
     func makeCoordinator() -> Coordinator { Coordinator(self) }
 
@@ -50,7 +56,7 @@ struct ForecastMapKitView: UIViewRepresentable {
     final class Coordinator: NSObject {
         private var parent: ForecastMapKitView
         weak var map: MKMapView?
-        private var renderedSlotID: String?
+        private var renderedRevision: Int?
         private var appliedFocus: ForecastMapViewModel.FocusRequest?
         var currentDiameter: CGFloat = 14
 
@@ -62,8 +68,8 @@ struct ForecastMapKitView: UIViewRepresentable {
             self.parent = parent
             guard let map else { return }
 
-            if renderedSlotID != parent.slotID {
-                renderedSlotID = parent.slotID
+            if renderedRevision != parent.payloadRevision {
+                renderedRevision = parent.payloadRevision
                 rebuildAnnotations(on: map)
             }
             recolorVisible(on: map)
@@ -154,11 +160,21 @@ struct ForecastMapKitView: UIViewRepresentable {
 extension ForecastMapKitView.Coordinator: @preconcurrency MKMapViewDelegate {
     func mapView(_ mapView: MKMapView, viewFor annotation: MKAnnotation) -> MKAnnotationView? {
         guard let a = annotation as? ForecastAnnotation else { return nil }  // user location → default
-        let view = mapView.dequeueReusableAnnotationView(
-            withIdentifier: AirportMarkerView.reuseID, for: a) as! AirportMarkerView
+        guard let view = mapView.dequeueReusableAnnotationView(
+            withIdentifier: AirportMarkerView.reuseID, for: a) as? AirportMarkerView else { return nil }
         view.annotation = a
         configure(view, airport: a.airport)
         return view
+    }
+
+    func mapView(_ mapView: MKMapView, regionWillChangeAnimated animated: Bool) {
+        // Flag a user-initiated pan/zoom (an active gesture on the map's internal
+        // container) so a late-resolving cold-open recentre doesn't fight it. Our
+        // own `setRegion` moves carry no active gesture, so they don't trip this.
+        guard let recognizers = mapView.subviews.first?.gestureRecognizers else { return }
+        if recognizers.contains(where: { [.began, .changed, .ended].contains($0.state) }) {
+            parent.onUserInteraction()
+        }
     }
 
     func mapView(_ mapView: MKMapView, didSelect view: MKAnnotationView) {

--- a/app/flyfun-weather/flyfun-weather/Views/ForecastMap/ForecastMapKitView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/ForecastMap/ForecastMapKitView.swift
@@ -168,9 +168,19 @@ extension ForecastMapKitView.Coordinator: @preconcurrency MKMapViewDelegate {
     }
 
     func mapView(_ mapView: MKMapView, regionWillChangeAnimated animated: Bool) {
-        // Flag a user-initiated pan/zoom (an active gesture on the map's internal
-        // container) so a late-resolving cold-open recentre doesn't fight it. Our
-        // own `setRegion` moves carry no active gesture, so they don't trip this.
+        // Flag a user-initiated pan/zoom so a late-resolving cold-open recentre
+        // doesn't fight it. We infer "user" from an active gesture recognizer on
+        // the map's first internal subview — our own `setRegion` moves carry no
+        // active gesture, so they don't trip this.
+        //
+        // FRAGILITY: `subviews.first?.gestureRecognizers` reads MapKit's private
+        // view hierarchy — a known but *unsupported* trick. If a future iOS
+        // reshapes `MKMapView`'s subviews this silently stops matching (cold-open
+        // can yank the camera again) or, worse, could false-positive on a
+        // programmatic move (cold-open never applies). There's no compiler/test
+        // signal, so revisit here if cold-open recentring misbehaves; a hardened
+        // version would subclass `MKMapView` and track pan/pinch recognizer state
+        // directly, or compare the new region against the last `setRegion` target.
         guard let recognizers = mapView.subviews.first?.gestureRecognizers else { return }
         if recognizers.contains(where: { [.began, .changed, .ended].contains($0.state) }) {
             parent.onUserInteraction()

--- a/app/flyfun-weather/flyfun-weather/Views/ForecastMap/ForecastMapView+Support.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/ForecastMap/ForecastMapView+Support.swift
@@ -1,0 +1,183 @@
+import CoreLocation
+import SwiftUI
+
+// MARK: - Metric picker: "a list of questions, not variable names" (#420)
+
+extension ForecastMapView {
+    /// One entry in the metric menu.
+    struct MetricItem { let label: String; let metric: String }
+    /// A question the map answers, grouping one or two metrics (design table).
+    struct MetricSection { let title: String; let items: [MetricItem] }
+
+    /// The picker frames each metric as a pilot's question — what makes this map
+    /// different from Windy. Metric ids match the served catalog; entries whose
+    /// metric the catalog doesn't define are filtered out at render time.
+    static let metricSections: [MetricSection] = [
+        MetricSection(title: "Can I get in?", items: [
+            MetricItem(label: "Flight category", metric: "flight_category"),
+        ]),
+        MetricSection(title: "Can I land?", items: [
+            MetricItem(label: "Crosswind (best runway)", metric: "crosswind_kt"),
+        ]),
+        MetricSection(title: "Will I see the ground?", items: [
+            MetricItem(label: "Ceiling", metric: "ceiling_ft"),
+            MetricItem(label: "Visibility", metric: "visibility_m"),
+        ]),
+        MetricSection(title: "Will it be rough?", items: [
+            MetricItem(label: "Convective risk", metric: "convective_risk"),
+            MetricItem(label: "CAPE", metric: "cape_jkg"),
+        ]),
+        MetricSection(title: "Will it take forever?", items: [
+            MetricItem(label: "Headwind", metric: "headwind_kt"),
+        ]),
+        MetricSection(title: "Do I need an alternate?", items: [
+            MetricItem(label: "FAA / EASA", metric: "alternate_needed"),
+        ]),
+        MetricSection(title: "More", items: [
+            MetricItem(label: "Wind", metric: "wind_speed_kt"),
+            MetricItem(label: "Cloud cover", metric: "cloud_cover_pct"),
+        ]),
+    ]
+
+    // MARK: - Day labels (weekday + date, never D-N — #419 W1)
+
+    private static func date(for day: ForecastDay?, dayOffset: Int) -> Date {
+        if let iso = day?.date, !iso.isEmpty, let d = isoDayFormatter.date(from: iso) { return d }
+        // Fallback (grid unavailable): today + offset, in UTC.
+        return Calendar.utc.date(byAdding: .day, value: dayOffset, to: Date()) ?? Date()
+    }
+
+    /// Short capsule label: "Today" for D+0, else "Sat 18".
+    static func shortDayLabel(day: Int, days: [ForecastDay]) -> String {
+        if day == 0 { return "Today" }
+        return shortFormatter.string(from: date(for: days.first { $0.day == day }, dayOffset: day))
+    }
+
+    /// Nav-title label: "Sat 18 Jul 2026" (D+0 prefixed "Today · ").
+    static func fullDayLabel(day: Int, days: [ForecastDay]) -> String {
+        let full = fullFormatter.string(from: date(for: days.first { $0.day == day }, dayOffset: day))
+        return day == 0 ? "Today · \(full)" : full
+    }
+
+    /// Menu-row label: "Today · Sat 18" / "Sat 18 Jul".
+    static func dayMenuLabel(_ day: ForecastDay) -> String {
+        let d = date(for: day, dayOffset: day.day)
+        let short = menuFormatter.string(from: d)
+        return day.day == 0 ? "Today · \(short)" : short
+    }
+
+    // Formatters (UTC — the grid's dates are UTC forecast dates).
+    private static let isoDayFormatter: DateFormatter = {
+        let f = DateFormatter(); f.calendar = Calendar.utc; f.timeZone = .utc
+        f.dateFormat = "yyyy-MM-dd"; f.locale = Locale(identifier: "en_US_POSIX"); return f
+    }()
+    private static let shortFormatter = makeFormatter("EEE d")
+    private static let menuFormatter = makeFormatter("EEE d MMM")
+    private static let fullFormatter = makeFormatter("EEE d MMM yyyy")
+
+    private static func makeFormatter(_ format: String) -> DateFormatter {
+        let f = DateFormatter(); f.calendar = Calendar.utc; f.timeZone = .utc
+        f.setLocalizedDateFormatFromTemplate(format); f.dateFormat = format
+        return f
+    }
+}
+
+private extension Calendar {
+    static var utc: Calendar {
+        var c = Calendar(identifier: .gregorian); c.timeZone = .utc; return c
+    }
+}
+
+private extension TimeZone {
+    static let utc = TimeZone(identifier: "UTC")!
+}
+
+// MARK: - Airport-card presentation (iPad inspector · iPhone bottom sheet)
+
+/// Presents the tapped-airport card as a trailing `.inspector` column on iPad
+/// (regular width) and a bottom sheet on iPhone. The compact sheet keeps the map
+/// pannable + live-recolouring underneath via
+/// `.presentationBackgroundInteraction(.enabled(upThrough: .fraction(0.45)))` —
+/// the whole "step the hour and watch both update" interaction depends on it.
+struct AirportCardPresenter: ViewModifier {
+    let viewModel: ForecastMapViewModel
+    let catalog: ForecastMapCatalog?
+    let isCompact: Bool
+
+    func body(content: Content) -> some View {
+        let isPresented = Binding(
+            get: { viewModel.selectedIcao != nil },
+            set: { if !$0 { viewModel.deselect() } }
+        )
+        if isCompact {
+            content.sheet(isPresented: isPresented) {
+                card
+                    .presentationDetents([.fraction(0.45), .large])
+                    .presentationBackgroundInteraction(.enabled(upThrough: .fraction(0.45)))
+                    .presentationDragIndicator(.visible)
+            }
+        } else {
+            content.inspector(isPresented: isPresented) {
+                card.inspectorColumnWidth(min: 320, ideal: 360, max: 440)
+            }
+        }
+    }
+
+    @ViewBuilder private var card: some View {
+        if let airport = viewModel.selectedAirport, let catalog {
+            ForecastAirportCard(viewModel: viewModel, airport: airport, catalog: catalog)
+        } else {
+            Color.clear
+        }
+    }
+}
+
+// MARK: - One-shot user location (locate-me)
+
+/// A single-fix location request for the "centre on me" button — lighter than
+/// wiring `FlightTrackingService` (which is for continuous route tracking). The
+/// app already declares `NSLocationWhenInUseUsageDescription`.
+@Observable
+@MainActor
+final class OneShotLocator: NSObject {
+    /// Equatable so SwiftUI `onChange` fires once per fresh fix.
+    struct Fix: Equatable { let lat: Double; let lon: Double }
+
+    private(set) var located: Fix?
+    private let manager = CLLocationManager()
+
+    override init() {
+        super.init()
+        manager.delegate = self
+        manager.desiredAccuracy = kCLLocationAccuracyKilometer
+    }
+
+    func request() {
+        switch manager.authorizationStatus {
+        case .notDetermined:
+            manager.requestWhenInUseAuthorization()
+        case .authorizedWhenInUse, .authorizedAlways:
+            manager.requestLocation()
+        default:
+            break  // denied/restricted — nothing to do
+        }
+    }
+}
+
+extension OneShotLocator: @preconcurrency CLLocationManagerDelegate {
+    nonisolated func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
+        let status = manager.authorizationStatus
+        if status == .authorizedWhenInUse || status == .authorizedAlways {
+            manager.requestLocation()
+        }
+    }
+
+    nonisolated func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+        guard let c = locations.last?.coordinate else { return }
+        Task { @MainActor in self.located = Fix(lat: c.latitude, lon: c.longitude) }
+    }
+
+    nonisolated func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
+        // Best-effort; a locate failure is a silent no-op.
+    }
+}

--- a/app/flyfun-weather/flyfun-weather/Views/ForecastMap/ForecastMapView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/ForecastMap/ForecastMapView.swift
@@ -16,10 +16,13 @@ struct ForecastMapView: View {
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @State private var viewModel: ForecastMapViewModel
     @State private var locator = OneShotLocator()
+    /// Set when the user taps a model that can't reach the selected day, to show
+    /// the "why" instead of switching to an unreachable model.
+    @State private var unavailableModel: String?
     /// nil on the iPad detail pane; set on the iPhone cover so it can dismiss.
     private let onClose: (() -> Void)?
 
-    init(repository: any BriefingRepository, deepLink: ForecastMapViewModel.DeepLink? = nil, onClose: (() -> Void)? = nil) {
+    init(repository: any BriefingRepository, deepLink: MapDeepLink? = nil, onClose: (() -> Void)? = nil) {
         _viewModel = State(initialValue: ForecastMapViewModel(repository: repository, deepLink: deepLink))
         self.onClose = onClose
     }
@@ -44,6 +47,14 @@ struct ForecastMapView: View {
                 span: MKCoordinateSpan(latitudeDelta: 4, longitudeDelta: 5), biasForSheet: false)
         }
         .modifier(AirportCardPresenter(viewModel: viewModel, catalog: catalog, isCompact: isCompact))
+        .alert("No \(unavailableModel ?? "") data", isPresented: Binding(
+            get: { unavailableModel != nil },
+            set: { if !$0 { unavailableModel = nil } }
+        )) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text("This model doesn't reach \(shortDayLabel). Two- and three-model days differ by design — the consensus still shows what the models that do reach it agree on.")
+        }
     }
 
     // MARK: - Map
@@ -55,11 +66,12 @@ struct ForecastMapView: View {
             metric: viewModel.metric,
             mode: viewModel.mode,
             selectedIcao: viewModel.selectedIcao,
-            slotID: "\(viewModel.selectedDay)-\(viewModel.selectedHour)",
+            payloadRevision: viewModel.payloadRevision,
             initialRegion: viewModel.initialRegion,
             focusRequest: viewModel.focusRequest,
             onSelect: { viewModel.select(icao: $0, biasForSheet: isCompact) },
-            onFocusApplied: { viewModel.focusRequest = nil }
+            onFocusApplied: { viewModel.focusRequest = nil },
+            onUserInteraction: { viewModel.markUserInteracted() }
         )
         .ignoresSafeArea(edges: isCompact ? .all : [])
     }
@@ -90,6 +102,11 @@ struct ForecastMapView: View {
             HStack(spacing: Theme.spacingS) {
                 dayCapsule
                 hourStepper
+                // A slot switch that misses the LRU shows a subtle in-flight spinner
+                // (the full-screen overlay only covers the very first load).
+                if viewModel.isLoading, viewModel.didLoadOnce {
+                    ProgressView().controlSize(.small)
+                }
                 Spacer()
             }
         }
@@ -192,13 +209,19 @@ struct ForecastMapView: View {
             Section("Individual model") {
                 ForEach(["gfs", "icon", "ecmwf"], id: \.self) { m in
                     let available = viewModel.modelAvailable(m, day: viewModel.selectedDay)
+                    // Greyed-but-still-tappable: an unreachable model must explain
+                    // itself on tap, not sit inert (design Gotchas). Only fully
+                    // disable a day that has no data at all (dayCapsule does that).
                     Button {
-                        viewModel.mode = .model(m)
+                        if available {
+                            viewModel.mode = .model(m)
+                        } else {
+                            unavailableModel = m.uppercased()
+                        }
                     } label: {
-                        menuRow(m.uppercased() + (available ? "" : " (n/a this day)"),
+                        menuRow(m.uppercased() + (available ? "" : " (no data this day)"),
                                 selected: viewModel.mode == .model(m))
                     }
-                    .disabled(!available)
                 }
             }
         } label: {

--- a/app/flyfun-weather/flyfun-weather/Views/ForecastMap/ForecastMapView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/ForecastMap/ForecastMapView.swift
@@ -1,0 +1,294 @@
+import CoreLocation
+import MapKit
+import SwiftUI
+
+/// The forecast-map screen (#420): a pan-European overview coloured by a
+/// pilot-question metric, with the day/hour grid drawn from the server and a
+/// tap-to-card interaction. Container-agnostic — the same view is the iPad detail
+/// pane and the iPhone `fullScreenCover`; only the airport-card presentation
+/// differs (inspector vs bottom sheet), keyed off size class.
+///
+/// "When" lives on top (the bottom belongs to the airport sheet, which would
+/// otherwise cover the hour stepper); "what" (metric/legend/locate) sits
+/// bottom-right, above the sheet.
+struct ForecastMapView: View {
+    @Environment(AppState.self) private var appState
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+    @State private var viewModel: ForecastMapViewModel
+    @State private var locator = OneShotLocator()
+    /// nil on the iPad detail pane; set on the iPhone cover so it can dismiss.
+    private let onClose: (() -> Void)?
+
+    init(repository: any BriefingRepository, deepLink: ForecastMapViewModel.DeepLink? = nil, onClose: (() -> Void)? = nil) {
+        _viewModel = State(initialValue: ForecastMapViewModel(repository: repository, deepLink: deepLink))
+        self.onClose = onClose
+    }
+
+    private var isCompact: Bool { horizontalSizeClass == .compact }
+    private var catalog: ForecastMapCatalog? { appState.helpCatalog.mapsCatalog }
+
+    var body: some View {
+        ZStack(alignment: .top) {
+            mapLayer
+            topControls
+            bottomControls
+            if !viewModel.didLoadOnce, viewModel.payload == nil {
+                loadingOverlay
+            }
+        }
+        .task { viewModel.start() }
+        .onChange(of: locator.located) {
+            guard let c = locator.located else { return }
+            viewModel.focusRequest = ForecastMapViewModel.FocusRequest(
+                center: CLLocationCoordinate2D(latitude: c.lat, longitude: c.lon),
+                span: MKCoordinateSpan(latitudeDelta: 4, longitudeDelta: 5), biasForSheet: false)
+        }
+        .modifier(AirportCardPresenter(viewModel: viewModel, catalog: catalog, isCompact: isCompact))
+    }
+
+    // MARK: - Map
+
+    private var mapLayer: some View {
+        ForecastMapKitView(
+            payload: viewModel.payload,
+            catalog: catalog,
+            metric: viewModel.metric,
+            mode: viewModel.mode,
+            selectedIcao: viewModel.selectedIcao,
+            slotID: "\(viewModel.selectedDay)-\(viewModel.selectedHour)",
+            initialRegion: viewModel.initialRegion,
+            focusRequest: viewModel.focusRequest,
+            onSelect: { viewModel.select(icao: $0, biasForSheet: isCompact) },
+            onFocusApplied: { viewModel.focusRequest = nil }
+        )
+        .ignoresSafeArea(edges: isCompact ? .all : [])
+    }
+
+    // MARK: - Top controls ("when")
+
+    private var topControls: some View {
+        VStack(spacing: Theme.spacingS) {
+            HStack(alignment: .top) {
+                if isCompact, let onClose {
+                    Button { onClose() } label: {
+                        Image(systemName: "xmark")
+                            .font(.headline)
+                            .padding(8)
+                            .background(.ultraThinMaterial, in: Circle())
+                    }
+                    .accessibilityLabel("Close map")
+                }
+                Spacer()
+                VStack(spacing: 2) {
+                    Text(navTitle).font(.headline)
+                    Text(navSubtitle).font(.caption).foregroundStyle(Theme.textMuted)
+                }
+                Spacer()
+                // Balance the leading close button so the title stays centred.
+                if isCompact, onClose != nil { Color.clear.frame(width: 36, height: 36) }
+            }
+            HStack(spacing: Theme.spacingS) {
+                dayCapsule
+                hourStepper
+                Spacer()
+            }
+        }
+        .padding(.horizontal, Theme.spacingM)
+        .padding(.top, isCompact ? Theme.spacingM : Theme.spacingS)
+    }
+
+    /// Menu row with a leading checkmark only when selected (avoids a blank SF
+    /// Symbol slot for the unselected rows).
+    @ViewBuilder private func menuRow(_ title: String, selected: Bool) -> some View {
+        if selected { Label(title, systemImage: "checkmark") } else { Text(title) }
+    }
+
+    private var dayCapsule: some View {
+        Menu {
+            ForEach(viewModel.days) { day in
+                Button {
+                    viewModel.selectDay(day.day)
+                } label: {
+                    menuRow(Self.dayMenuLabel(day), selected: day.day == viewModel.selectedDay)
+                }
+                .disabled(!day.available)
+            }
+        } label: {
+            capsuleLabel(text: shortDayLabel, systemImage: "calendar")
+        }
+    }
+
+    private var hourStepper: some View {
+        HStack(spacing: 6) {
+            Button { viewModel.stepHour(-1) } label: { Image(systemName: "chevron.left") }
+                .disabled(!viewModel.canStepHourBack)
+            Menu {
+                ForEach(viewModel.hours(forDay: viewModel.selectedDay), id: \.self) { hr in
+                    Button {
+                        viewModel.selectHour(hr)
+                    } label: {
+                        menuRow(String(format: "%02dZ", hr), selected: hr == viewModel.selectedHour)
+                    }
+                }
+            } label: {
+                Text(String(format: "%02dZ", viewModel.selectedHour))
+                    .font(.subheadline.weight(.medium)).monospacedDigit()
+            }
+            Button { viewModel.stepHour(1) } label: { Image(systemName: "chevron.right") }
+                .disabled(!viewModel.canStepHourForward)
+        }
+        .padding(.horizontal, 12).padding(.vertical, 7)
+        .background(.ultraThinMaterial, in: Capsule())
+    }
+
+    // MARK: - Bottom-right controls ("what")
+
+    private var bottomControls: some View {
+        VStack {
+            Spacer()
+            HStack(alignment: .bottom) {
+                if let cat = catalog, let legend = cat.legend(metric: viewModel.metric) {
+                    legendCapsule(legend)
+                }
+                Spacer()
+                VStack(alignment: .trailing, spacing: Theme.spacingS) {
+                    modelMenu
+                    metricMenu
+                    locateButton
+                }
+            }
+        }
+        .padding(Theme.spacingM)
+    }
+
+    private var metricMenu: some View {
+        Menu {
+            ForEach(Self.metricSections, id: \.title) { section in
+                Section(section.title) {
+                    ForEach(section.items, id: \.metric) { item in
+                        if catalog?.metrics[item.metric] != nil {
+                            Button {
+                                viewModel.metric = item.metric
+                            } label: {
+                                menuRow(item.label, selected: item.metric == viewModel.metric)
+                            }
+                        }
+                    }
+                }
+            }
+        } label: {
+            capsuleLabel(text: catalog?.label(metric: viewModel.metric) ?? "Metric", systemImage: "paintpalette")
+        }
+    }
+
+    private var modelMenu: some View {
+        Menu {
+            Button { viewModel.mode = .worst } label: {
+                menuRow("Worst of models", selected: viewModel.mode == .worst)
+            }
+            Button { viewModel.mode = .majority } label: {
+                menuRow("Majority of models", selected: viewModel.mode == .majority)
+            }
+            Section("Individual model") {
+                ForEach(["gfs", "icon", "ecmwf"], id: \.self) { m in
+                    let available = viewModel.modelAvailable(m, day: viewModel.selectedDay)
+                    Button {
+                        viewModel.mode = .model(m)
+                    } label: {
+                        menuRow(m.uppercased() + (available ? "" : " (n/a this day)"),
+                                selected: viewModel.mode == .model(m))
+                    }
+                    .disabled(!available)
+                }
+            }
+        } label: {
+            capsuleLabel(text: modeShortLabel, systemImage: "square.stack.3d.up")
+        }
+    }
+
+    private var locateButton: some View {
+        Button {
+            locator.request()
+        } label: {
+            Image(systemName: "location")
+                .font(.subheadline.weight(.medium))
+                .padding(10)
+                .background(.ultraThinMaterial, in: Circle())
+        }
+        .accessibilityLabel("Centre on my location")
+    }
+
+    private func legendCapsule(_ legend: ForecastMapCatalog.Legend) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(legend.title).font(.caption2.weight(.semibold)).foregroundStyle(Theme.textMuted)
+            // Wrap the swatches so a long ramp doesn't overflow narrow phones.
+            FlowLayout(spacing: 6) {
+                ForEach(legend.items) { item in
+                    HStack(spacing: 3) {
+                        RoundedRectangle(cornerRadius: 2)
+                            .fill(Color.catalog(item.color))
+                            .frame(width: 12, height: 8)
+                        Text(item.label).font(.system(size: 10)).foregroundStyle(Theme.text)
+                    }
+                }
+            }
+        }
+        .padding(.horizontal, 10).padding(.vertical, 7)
+        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 10))
+        .frame(maxWidth: 220, alignment: .leading)
+    }
+
+    private func capsuleLabel(text: String, systemImage: String) -> some View {
+        HStack(spacing: 4) {
+            Image(systemName: systemImage)
+            Text(text)
+            Image(systemName: "chevron.down").font(.caption2)
+        }
+        .font(.subheadline.weight(.medium))
+        .padding(.horizontal, 12).padding(.vertical, 7)
+        .background(.ultraThinMaterial, in: Capsule())
+    }
+
+    private var loadingOverlay: some View {
+        VStack(spacing: Theme.spacingM) {
+            if let err = viewModel.loadError {
+                ContentUnavailableView("Map Unavailable", systemImage: "map", description: Text(err))
+            } else {
+                ProgressView("Loading forecast map…")
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Theme.bg.opacity(0.6))
+    }
+
+    // MARK: - Labels
+
+    private var navTitle: String {
+        Self.fullDayLabel(day: viewModel.selectedDay, days: viewModel.days)
+    }
+
+    private var navSubtitle: String {
+        let n = viewModel.models(forDay: viewModel.selectedDay).count
+        return String(format: "%02dZ · %@", viewModel.selectedHour, modeLongLabel(modelCount: n))
+    }
+
+    private var shortDayLabel: String {
+        Self.shortDayLabel(day: viewModel.selectedDay, days: viewModel.days)
+    }
+
+    private var modeShortLabel: String {
+        switch viewModel.mode {
+        case .worst: return "Worst"
+        case .majority: return "Majority"
+        case .model(let m): return m.uppercased()
+        }
+    }
+
+    private func modeLongLabel(modelCount: Int) -> String {
+        switch viewModel.mode {
+        case .worst: return "Worst of \(modelCount) model\(modelCount == 1 ? "" : "s")"
+        case .majority: return "Majority of \(modelCount) model\(modelCount == 1 ? "" : "s")"
+        case .model(let m): return m.uppercased()
+        }
+    }
+}

--- a/app/flyfun-weather/flyfun-weather/Views/ForecastMap/MapMetricsCatalog.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/ForecastMap/MapMetricsCatalog.swift
@@ -1,0 +1,329 @@
+import SwiftUI
+import UIKit
+
+/// Swift interpreter of the **served** forecast-map metric catalog
+/// (`web/ts/data/map-metrics-catalog.json`, delivered in the `maps` section of
+/// `/api/help/catalog`). This is the iOS half of the #419 "clients render, server
+/// decides" contract: colour ramps, thresholds, labels and legends are data, not
+/// code, so the same weather can never show in two colours on two devices and a
+/// threshold change is a one-line JSON edit both clients pick up.
+///
+/// A faithful port of `weather-map-format.ts` — `bandColor`, the categorical
+/// lookup, the gray ramp, `m_to_sm`, `alternate_needed`, and the per-metric
+/// agreement key. Decode with a **plain** `JSONDecoder` (keys are snake_case
+/// field names used verbatim as dictionary keys); see `ForecastMapResponse`.
+struct ForecastMapCatalog: Decodable, Sendable {
+    let version: Int
+    let scales: Scales
+    let metrics: [String: MetricSpec]
+
+    /// Canonical metric order for the map's colour picker (web `FORECAST_METRICS`).
+    static let metricOrder = [
+        "flight_category", "alternate_needed", "wind_speed_kt", "crosswind_kt",
+        "headwind_kt", "ceiling_ft", "visibility_m", "cape_jkg",
+        "convective_risk", "cloud_cover_pct",
+    ]
+
+    /// Fallback grey for missing data / unknown scale (web `MUTED`).
+    static var muted: UIColor { UIColor(rgbHex: 0x888888) }
+
+    // MARK: - Nested catalog shapes
+
+    struct Scales: Decodable, Sendable {
+        let categorical: [String: [String: String]]
+        let bands: [String: BandScale]
+    }
+
+    struct BandScale: Decodable, Sendable {
+        let kind: String
+        let nullColor: String?
+        let convert: String?
+        let stops: [BandStop]?
+        let defaultColor: String?
+        let base: Double?
+        let span: Double?
+        let blueBoost: Double?
+
+        enum CodingKeys: String, CodingKey {
+            case kind, convert, stops, base
+            case nullColor = "null_color"
+            case defaultColor = "default"
+            case span
+            case blueBoost = "blue_boost"
+        }
+    }
+
+    struct BandStop: Decodable, Sendable {
+        let lt: Double?
+        let gte: Double?
+        let color: String
+    }
+
+    struct MetricSpec: Decodable, Sendable {
+        let label: String
+        let color: ColorSpec
+        let legend: Legend
+    }
+
+    struct ColorSpec: Decodable, Sendable {
+        let kind: String
+        let scale: String?
+        let field: String?
+        let defaultValue: String?
+        /// `fallback` when it is a hex string (categorical / alternate_needed).
+        let fallbackColor: String?
+        /// `fallback` when it is a number (band substitution before banding).
+        let fallbackNumber: Double?
+
+        enum CodingKeys: String, CodingKey {
+            case kind, scale, field, fallback
+            case defaultValue = "default"
+        }
+
+        init(from decoder: Decoder) throws {
+            let c = try decoder.container(keyedBy: CodingKeys.self)
+            kind = try c.decode(String.self, forKey: .kind)
+            scale = try c.decodeIfPresent(String.self, forKey: .scale)
+            field = try c.decodeIfPresent(String.self, forKey: .field)
+            defaultValue = try c.decodeIfPresent(String.self, forKey: .defaultValue)
+            // `fallback` is polymorphic: a hex string for categorical/alt, a
+            // number (or null) for bands. Try string first, then number, else nil.
+            if let hex = (try? c.decodeIfPresent(String.self, forKey: .fallback)) ?? nil {
+                fallbackColor = hex
+                fallbackNumber = nil
+            } else if let num = (try? c.decodeIfPresent(Double.self, forKey: .fallback)) ?? nil {
+                fallbackColor = nil
+                fallbackNumber = num
+            } else {
+                fallbackColor = nil
+                fallbackNumber = nil
+            }
+        }
+    }
+
+    struct Legend: Decodable, Sendable {
+        let title: String
+        let items: [LegendItem]
+    }
+
+    // MARK: - Bundled baseline
+
+    /// The bundled copy of `map-metrics-catalog.json`, used before the first
+    /// online `/api/help/catalog` sync (and if that sync ever fails). Decoded
+    /// once; a plain decoder keeps the snake_case scale/field keys verbatim.
+    static let bundledBaseline: ForecastMapCatalog? = {
+        guard let url = Bundle.main.url(forResource: "map-metrics-catalog", withExtension: "json"),
+              let data = try? Data(contentsOf: url) else { return nil }
+        return try? JSONDecoder().decode(ForecastMapCatalog.self, from: data)
+    }()
+
+    struct LegendItem: Decodable, Sendable, Identifiable {
+        let color: String
+        let label: String
+        var id: String { "\(color)-\(label)" }
+    }
+}
+
+// MARK: - Colour evaluation (port of getForecastColor / bandColor)
+
+extension ForecastMapCatalog {
+    /// The fill colour for one airport under the active metric + model mode —
+    /// the single function markers, card cells and legends all agree on.
+    func color(metric: String, airport: ForecastAirport, mode: ForecastModelMode) -> UIColor {
+        guard let spec = metrics[metric] else { return Self.muted }
+        switch spec.color.kind {
+        case "alternate_needed":
+            return alternateColor(airport: airport, mode: mode)
+        case "categorical":
+            return categoricalColor(spec.color, cell: airport.cell(for: mode))
+        case "band":
+            return bandColorFor(spec.color, cell: airport.cell(for: mode))
+        default:
+            return Self.muted
+        }
+    }
+
+    /// Colour a bare consensus/model cell (used by the card's matrix cells, which
+    /// colour a single already-selected cell rather than an airport+mode).
+    func color(metric: String, cell: (any ForecastCellData)?, airport: ForecastAirport, mode: ForecastModelMode) -> UIColor {
+        guard let spec = metrics[metric] else { return Self.muted }
+        switch spec.color.kind {
+        case "alternate_needed":
+            return alternateColor(airport: airport, mode: mode)
+        case "categorical":
+            return categoricalColor(spec.color, cell: cell)
+        case "band":
+            return bandColorFor(spec.color, cell: cell)
+        default:
+            return Self.muted
+        }
+    }
+
+    private func categoricalColor(_ color: ColorSpec, cell: (any ForecastCellData)?) -> UIColor {
+        guard let cell, let scale = color.scale else { return Self.muted }
+        var key = cell.categoryField(scale)
+        if (key == nil || key?.isEmpty == true), let def = color.defaultValue { key = def }
+        guard let key, let table = scales.categorical[scale] else { return color.fallbackUIColor }
+        return table[key].flatMap(UIColor.parse) ?? color.fallbackUIColor
+    }
+
+    private func bandColorFor(_ color: ColorSpec, cell: (any ForecastCellData)?) -> UIColor {
+        guard let cell, let scaleKey = color.scale, let field = color.field,
+              let band = scales.bands[scaleKey] else { return Self.muted }
+        return bandColor(band: band, raw: cell.numericField(field), fallbackNumber: color.fallbackNumber)
+    }
+
+    /// Value → colour for a band scale (`bandColor` in the web).
+    func bandColor(band: BandScale, raw: Double?, fallbackNumber: Double?) -> UIColor {
+        var v = raw
+        if v == nil {
+            if let nc = band.nullColor { return UIColor.parse(nc) ?? Self.muted }
+            guard let fb = fallbackNumber else { return Self.muted }
+            v = fb
+        }
+        guard let value = v else { return Self.muted }
+        if band.kind == "gray_ramp" { return grayRamp(band, value) }
+        let val = band.convert == "m_to_sm" ? value / 1609.34 : value
+        if band.kind == "threshold_desc" {
+            for s in band.stops ?? [] where s.gte.map({ val >= $0 }) == true {
+                return UIColor.parse(s.color) ?? Self.muted
+            }
+            return band.defaultColor.flatMap(UIColor.parse) ?? Self.muted
+        }
+        // threshold_asc (default)
+        for s in band.stops ?? [] where s.lt.map({ val < $0 }) == true {
+            return UIColor.parse(s.color) ?? Self.muted
+        }
+        return band.defaultColor.flatMap(UIColor.parse) ?? Self.muted
+    }
+
+    private func grayRamp(_ band: BandScale, _ pct: Double) -> UIColor {
+        let base = band.base ?? 220
+        let span = band.span ?? 160
+        let boost = band.blueBoost ?? 10
+        let g = (base - (pct / 100) * span).rounded()
+        let clamp: (Double) -> CGFloat = { CGFloat(min(255, max(0, $0)) / 255) }
+        return UIColor(red: clamp(g), green: clamp(g), blue: clamp(g + boost), alpha: 1)
+    }
+
+    private func alternateColor(airport: ForecastAirport, mode: ForecastModelMode) -> UIColor {
+        let flag: AltRequired?
+        if mode.isConsensus {
+            flag = airport.aggregatedAltRequired(mode: mode)
+        } else if case .model(let name) = mode {
+            flag = airport.models[name]?.altRequired
+        } else {
+            flag = nil
+        }
+        guard let flag else { return Self.muted }
+        let n = (flag.faa ? 1 : 0) + (flag.easa ? 1 : 0)
+        switch n {
+        case 0: return UIColor(rgbHex: 0x22c55e)
+        case 1: return UIColor(rgbHex: 0xeab308)
+        default: return UIColor(rgbHex: 0xef4444)
+        }
+    }
+
+    // MARK: - Labels, legends, agreement
+
+    func label(metric: String) -> String { metrics[metric]?.label ?? metric }
+
+    func legend(metric: String) -> Legend? { metrics[metric]?.legend }
+
+    /// The agreement bucket colour for a label (categorical `agreement` scale).
+    func agreementColor(_ label: String?) -> UIColor {
+        guard let label, let hex = scales.categorical["agreement"]?[label] else { return Self.muted }
+        return UIColor.parse(hex) ?? Self.muted
+    }
+
+    /// Which `consensus.agreement` key a metric reads — the per-active-metric ring
+    /// ("do the models disagree about the thing you're looking at"). Crosswind and
+    /// headwind proxy to wind, convective to CAPE (web `metricAgreementKey`).
+    static func agreementKey(forMetric metric: String) -> String {
+        switch metric {
+        case "flight_category": return "flight_category"
+        case "wind_speed_kt", "crosswind_kt", "headwind_kt": return "wind_speed_kt"
+        case "ceiling_ft": return "ceiling_ft"
+        case "cape_jkg", "convective_risk": return "cape_jkg"
+        case "visibility_m": return "visibility_m"
+        case "cloud_cover_pct": return "cloud_cover_pct"
+        default: return "flight_category"
+        }
+    }
+}
+
+extension ForecastMapCatalog.ColorSpec {
+    var fallbackUIColor: UIColor {
+        fallbackColor.flatMap(UIColor.parse) ?? ForecastMapCatalog.muted
+    }
+}
+
+// MARK: - Alt-required aggregation (aggAltRequired)
+
+extension ForecastAirport {
+    /// Aggregate per-model FAA/EASA alternate-required flags for a consensus mode
+    /// (`aggAltRequired`): worst = any model says yes; majority = modal with a
+    /// worst tiebreak. nil when no present model carries the flag.
+    func aggregatedAltRequired(mode: ForecastModelMode) -> AltRequired? {
+        let flags = models.values.compactMap { $0.altRequired }
+        guard !flags.isEmpty else { return nil }
+        let majority = mode == .majority
+        return AltRequired(
+            faa: Self.ordinalYes(flags.map { $0.faa }, majority: majority),
+            easa: Self.ordinalYes(flags.map { $0.easa }, majority: majority)
+        )
+    }
+
+    private static func ordinalYes(_ bools: [Bool], majority: Bool) -> Bool {
+        guard majority else { return bools.contains(true) }
+        let yes = bools.filter { $0 }.count
+        let no = bools.count - yes
+        // Modal; ties break to the worst ordinal (yes).
+        return yes >= no
+    }
+}
+
+// MARK: - Colour parsing (hex + rgb())
+
+extension UIColor {
+    convenience init(rgbHex: UInt32) {
+        self.init(
+            red: CGFloat((rgbHex >> 16) & 0xff) / 255,
+            green: CGFloat((rgbHex >> 8) & 0xff) / 255,
+            blue: CGFloat(rgbHex & 0xff) / 255,
+            alpha: 1
+        )
+    }
+
+    /// Parse a catalog colour string: `#rgb`, `#rrggbb`, or `rgb(r,g,b)`.
+    static func parse(_ string: String) -> UIColor? {
+        let s = string.trimmingCharacters(in: .whitespaces)
+        if s.hasPrefix("#") {
+            let hex = String(s.dropFirst())
+            if hex.count == 3 {
+                // #rgb → #rrggbb
+                let chars = Array(hex)
+                let expanded = chars.map { "\($0)\($0)" }.joined()
+                guard let v = UInt32(expanded, radix: 16) else { return nil }
+                return UIColor(rgbHex: v)
+            }
+            guard hex.count == 6, let v = UInt32(hex, radix: 16) else { return nil }
+            return UIColor(rgbHex: v)
+        }
+        if s.lowercased().hasPrefix("rgb(") {
+            let inner = s.dropFirst(4).dropLast()
+            let parts = inner.split(separator: ",").compactMap { Double($0.trimmingCharacters(in: .whitespaces)) }
+            guard parts.count == 3 else { return nil }
+            return UIColor(red: CGFloat(parts[0] / 255), green: CGFloat(parts[1] / 255),
+                           blue: CGFloat(parts[2] / 255), alpha: 1)
+        }
+        return nil
+    }
+}
+
+extension Color {
+    /// SwiftUI wrapper for a parsed catalog colour, muted grey on failure.
+    static func catalog(_ hex: String) -> Color {
+        Color(uiColor: UIColor.parse(hex) ?? ForecastMapCatalog.muted)
+    }
+}

--- a/app/flyfun-weather/flyfun-weatherTests/ForecastMapTests.swift
+++ b/app/flyfun-weather/flyfun-weatherTests/ForecastMapTests.swift
@@ -222,6 +222,19 @@ struct ForecastMapTests {
         #expect(PendingNavigationStore.take() == .forecastMap(dl))
     }
 
+    /// The VM applies a `MapDeepLink` at init — the consumption end of the shared
+    /// `fc.*` state (the map's `.id` re-creates the VM for a re-entrant link).
+    @MainActor
+    @Test func viewModelAppliesDeepLinkAtInit() {
+        let vm = ForecastMapViewModel(
+            repository: MockBriefingRepository(),
+            deepLink: MapDeepLink(day: 3, hour: 15, model: "majority", metric: "crosswind_kt", airport: "LFMD"))
+        #expect(vm.selectedDay == 3)
+        #expect(vm.selectedHour == 15)
+        #expect(vm.mode == .majority)
+        #expect(vm.metric == "crosswind_kt")
+    }
+
     // MARK: - Fixtures
 
     private static func airport(consensusCategory: String) throws -> ForecastAirport {

--- a/app/flyfun-weather/flyfun-weatherTests/ForecastMapTests.swift
+++ b/app/flyfun-weather/flyfun-weatherTests/ForecastMapTests.swift
@@ -1,0 +1,235 @@
+//
+//  ForecastMapTests.swift
+//  flyfun-weatherTests
+//
+//  Unit tests for the iOS forecast map (#420): the served map-metrics catalog
+//  colour evaluation (the "clients render, server decides" contract — colours
+//  must match the web/catalog exactly), consensus-block reading, alt-required
+//  aggregation, the per-metric agreement key, /maps.html universal-link routing,
+//  and the PendingNavigation round-trip for a shared map link.
+//
+
+import Foundation
+import Testing
+import UIKit
+@testable import flyfun_weather
+
+@Suite("ForecastMap")
+struct ForecastMapTests {
+
+    // A representative slice of web/ts/data/map-metrics-catalog.json (embedded so
+    // the test doesn't depend on bundle packaging). Values match the shipped file.
+    static let catalogJSON = """
+    {
+      "version": 1,
+      "scales": {
+        "categorical": {
+          "flight_category": { "VFR": "#22c55e", "MVFR": "#3b82f6", "IFR": "#ef4444", "LIFR": "#a855f7" },
+          "convective_risk": { "none": "#22c55e", "marginal": "#eab308", "low": "#facc15", "moderate": "#f97316", "high": "#ef4444", "extreme": "#991b1b" },
+          "agreement": { "consistent": "#22c55e", "mixed": "#f97316", "divergent": "#ef4444" }
+        },
+        "bands": {
+          "wind_speed_kt": { "kind": "threshold_asc", "stops": [ { "lt": 10, "color": "#22c55e" }, { "lt": 15, "color": "#84cc16" }, { "lt": 20, "color": "#eab308" }, { "lt": 25, "color": "#f97316" }, { "lt": 35, "color": "#ef4444" } ], "default": "#991b1b" },
+          "crosswind_kt": { "kind": "threshold_asc", "stops": [ { "lt": 5, "color": "#22c55e" }, { "lt": 10, "color": "#84cc16" }, { "lt": 15, "color": "#eab308" }, { "lt": 20, "color": "#f97316" }, { "lt": 25, "color": "#ef4444" } ], "default": "#991b1b" },
+          "ceiling_ft": { "kind": "threshold_asc", "null_color": "#888", "stops": [ { "lt": 500, "color": "#a855f7" }, { "lt": 1000, "color": "#ef4444" }, { "lt": 3000, "color": "#3b82f6" } ], "default": "#22c55e" },
+          "visibility_m": { "kind": "threshold_desc", "convert": "m_to_sm", "stops": [ { "gte": 5, "color": "#22c55e" }, { "gte": 3, "color": "#3b82f6" }, { "gte": 1, "color": "#ef4444" } ], "default": "#a855f7" },
+          "cloud_cover_pct": { "kind": "gray_ramp", "base": 220, "span": 160, "blue_boost": 10 }
+        }
+      },
+      "metrics": {
+        "flight_category": { "label": "Category", "color": { "kind": "categorical", "scale": "flight_category", "fallback": "#888" }, "legend": { "title": "Flight Category", "items": [ { "color": "#22c55e", "label": "VFR" } ] } },
+        "wind_speed_kt": { "label": "Wind", "color": { "kind": "band", "scale": "wind_speed_kt", "field": "wind_speed_kt", "fallback": 0 }, "legend": { "title": "Wind Speed (kt)", "items": [] } },
+        "crosswind_kt": { "label": "Xwind", "color": { "kind": "band", "scale": "crosswind_kt", "field": "crosswind_kt", "fallback": null }, "legend": { "title": "Xwind", "items": [] } },
+        "ceiling_ft": { "label": "Ceiling", "color": { "kind": "band", "scale": "ceiling_ft", "field": "ceiling_ft", "fallback": null }, "legend": { "title": "Ceiling", "items": [] } },
+        "visibility_m": { "label": "Visibility", "color": { "kind": "band", "scale": "visibility_m", "field": "visibility_m", "fallback": 99999 }, "legend": { "title": "Visibility", "items": [] } },
+        "cloud_cover_pct": { "label": "Cloud cover", "color": { "kind": "band", "scale": "cloud_cover_pct", "field": "cloud_cover_pct", "fallback": 0 }, "legend": { "title": "Cloud Cover", "items": [] } },
+        "alternate_needed": { "label": "Alternate required?", "color": { "kind": "alternate_needed", "fallback": "#888" }, "legend": { "title": "Alt", "items": [] } }
+      }
+    }
+    """
+
+    static func catalog() throws -> ForecastMapCatalog {
+        try JSONDecoder().decode(ForecastMapCatalog.self, from: Data(catalogJSON.utf8))
+    }
+
+    /// UIColor → "#rrggbb" for exact comparison against the catalog hexes.
+    static func hex(_ c: UIColor) -> String {
+        var r: CGFloat = 0, g: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0
+        c.getRed(&r, green: &g, blue: &b, alpha: &a)
+        return String(format: "#%02x%02x%02x",
+                      Int((r * 255).rounded()), Int((g * 255).rounded()), Int((b * 255).rounded()))
+    }
+
+    // MARK: - Band colour evaluation
+
+    @Test func windSpeedThresholdBands() throws {
+        let cat = try Self.catalog()
+        let band = cat.scales.bands["wind_speed_kt"]!
+        #expect(Self.hex(cat.bandColor(band: band, raw: 5, fallbackNumber: 0)) == "#22c55e")   // <10
+        #expect(Self.hex(cat.bandColor(band: band, raw: 12, fallbackNumber: 0)) == "#84cc16")  // <15
+        #expect(Self.hex(cat.bandColor(band: band, raw: 24, fallbackNumber: 0)) == "#f97316")  // <25
+        #expect(Self.hex(cat.bandColor(band: band, raw: 40, fallbackNumber: 0)) == "#991b1b")  // default
+    }
+
+    @Test func ceilingNullUsesNullColor() throws {
+        let cat = try Self.catalog()
+        let band = cat.scales.bands["ceiling_ft"]!
+        // Missing ceiling → the scale's null_color (#888), not the default green.
+        #expect(Self.hex(cat.bandColor(band: band, raw: nil, fallbackNumber: nil)) == "#888888")
+        #expect(Self.hex(cat.bandColor(band: band, raw: 5000, fallbackNumber: nil)) == "#22c55e")
+        #expect(Self.hex(cat.bandColor(band: band, raw: 800, fallbackNumber: nil)) == "#ef4444")
+    }
+
+    @Test func visibilityConvertsMetresToStatuteMiles() throws {
+        let cat = try Self.catalog()
+        let band = cat.scales.bands["visibility_m"]!
+        // threshold_desc on SM: 10000 m ≈ 6.2 SM (≥5) → VFR green.
+        #expect(Self.hex(cat.bandColor(band: band, raw: 10000, fallbackNumber: 99999)) == "#22c55e")
+        // 6000 m ≈ 3.7 SM (≥3) → MVFR blue.
+        #expect(Self.hex(cat.bandColor(band: band, raw: 6000, fallbackNumber: 99999)) == "#3b82f6")
+        // 800 m ≈ 0.5 SM (<1) → LIFR purple (default).
+        #expect(Self.hex(cat.bandColor(band: band, raw: 800, fallbackNumber: 99999)) == "#a855f7")
+    }
+
+    @Test func cloudCoverGrayRamp() throws {
+        let cat = try Self.catalog()
+        let band = cat.scales.bands["cloud_cover_pct"]!
+        // g = base - pct/100*span; rgb(g, g, g+blue_boost).
+        #expect(Self.hex(cat.bandColor(band: band, raw: 0, fallbackNumber: 0)) == "#dcdce6")    // 220,220,230
+        #expect(Self.hex(cat.bandColor(band: band, raw: 100, fallbackNumber: 0)) == "#3c3c46")  // 60,60,70
+    }
+
+    @Test func crosswindMissingIsMutedNotBanded() throws {
+        let cat = try Self.catalog()
+        let band = cat.scales.bands["crosswind_kt"]!
+        // fallback is null (not a number) → a missing crosswind is muted, never
+        // coloured as calm-green.
+        #expect(Self.hex(cat.bandColor(band: band, raw: nil, fallbackNumber: nil)) == "#888888")
+    }
+
+    // MARK: - Categorical + alternate
+
+    @Test func categoricalFlightCategory() throws {
+        let cat = try Self.catalog()
+        let airport = try Self.airport(consensusCategory: "IFR")
+        #expect(Self.hex(cat.color(metric: "flight_category", airport: airport, mode: .worst)) == "#ef4444")
+    }
+
+    @Test func alternateAggregationWorstVsMajority() throws {
+        let cat = try Self.catalog()
+        // Three models: two say "neither", one says "FAA+EASA".
+        let airport = try Self.airport(alt: [
+            AltRequired(faa: false, easa: false),
+            AltRequired(faa: false, easa: false),
+            AltRequired(faa: true, easa: true),
+        ])
+        // Worst = any yes → both → red.
+        #expect(Self.hex(cat.color(metric: "alternate_needed", airport: airport, mode: .worst)) == "#ef4444")
+        // Majority = modal → neither → green.
+        #expect(Self.hex(cat.color(metric: "alternate_needed", airport: airport, mode: .majority)) == "#22c55e")
+    }
+
+    // MARK: - Agreement key (per-active-metric ring)
+
+    @Test func agreementKeyProxies() {
+        #expect(ForecastMapCatalog.agreementKey(forMetric: "crosswind_kt") == "wind_speed_kt")
+        #expect(ForecastMapCatalog.agreementKey(forMetric: "headwind_kt") == "wind_speed_kt")
+        #expect(ForecastMapCatalog.agreementKey(forMetric: "convective_risk") == "cape_jkg")
+        #expect(ForecastMapCatalog.agreementKey(forMetric: "ceiling_ft") == "ceiling_ft")
+        #expect(ForecastMapCatalog.agreementKey(forMetric: "alternate_needed") == "flight_category")
+    }
+
+    // MARK: - Consensus block selection + decoding
+
+    @Test func consensusModePicksMajorityBlock() throws {
+        let airport = try Self.airportWithBothConsensus(worst: "IFR", majority: "MVFR")
+        #expect(airport.consensus(mode: .worst).flightCategory == "IFR")
+        #expect(airport.consensus(mode: .majority).flightCategory == "MVFR")
+    }
+
+    @Test func agreementKeyIsPreservedThroughDecode() throws {
+        // The decoder must NOT snake→camel the `agreement` dict keys, or the
+        // per-metric ring lookup silently misses. Uses a plain decoder in prod.
+        let json = """
+        { "forecast_time": "2026-07-15T12:00:00+00:00", "model_init_times": {},
+          "airports": [ { "icao": "EGKB", "lat": 51.3, "lon": 0.03, "models": {},
+            "consensus": { "flight_category": "MVFR", "agreement": { "wind_speed_kt": "divergent" } },
+            "consensus_majority": { "flight_category": "MVFR", "agreement": {} } } ] }
+        """
+        let resp = try ForecastMapResponse.decode(from: Data(json.utf8))
+        let apt = resp.airports[0]
+        #expect(apt.consensus.agreement["wind_speed_kt"] == "divergent")
+        // crosswind proxies to the wind agreement key.
+        #expect(apt.consensus.agreement(forMetric: "crosswind_kt") == "divergent")
+    }
+
+    // MARK: - Model mode token round-trip
+
+    @Test func modelModeTokens() {
+        #expect(ForecastModelMode(token: "worst") == .worst)
+        #expect(ForecastModelMode(token: "majority") == .majority)
+        #expect(ForecastModelMode(token: "gfs") == .model("gfs"))
+        #expect(ForecastModelMode.model("ecmwf").token == "ecmwf")
+        #expect(ForecastModelMode.worst.isConsensus)
+        #expect(!ForecastModelMode.model("gfs").isConsensus)
+        #expect(ForecastModelMode.model("gfs").consensusMode == .worst)
+    }
+
+    // MARK: - Universal link routing (/maps.html)
+
+    @Test func mapsLinkRoutesWithState() {
+        let url = URL(string: "https://weather.flyfun.aero/maps.html?fc.day=3&fc.hour=15&fc.model=majority&fc.metric=crosswind_kt&fc.apt=LFMD")!
+        let target = AppState.navigationTarget(for: url)
+        #expect(target == .forecastMap(MapDeepLink(day: 3, hour: 15, model: "majority", metric: "crosswind_kt", airport: "LFMD")))
+    }
+
+    @Test func bareMapsLinkIsEmptyDeepLink() {
+        let target = AppState.navigationTarget(for: URL(string: "https://weather.flyfun.aero/maps.html")!)
+        guard case .forecastMap(let dl) = target else { Issue.record("expected forecastMap"); return }
+        #expect(dl.isEmpty)
+    }
+
+    @Test func briefingLinkStillRoutes() {
+        let target = AppState.navigationTarget(for: URL(string: "https://weather.flyfun.aero/briefing.html?flight=abc")!)
+        #expect(target == .briefing(flightId: "abc"))
+    }
+
+    @Test func pendingNavigationRoundTripsForecastMap() {
+        let dl = MapDeepLink(day: 2, hour: 6, model: "gfs", metric: "ceiling_ft", airport: "EGLL")
+        PendingNavigationStore.set(.forecastMap(dl))
+        #expect(PendingNavigationStore.take() == .forecastMap(dl))
+    }
+
+    // MARK: - Fixtures
+
+    private static func airport(consensusCategory: String) throws -> ForecastAirport {
+        let json = """
+        { "icao": "EGKB", "lat": 51.3, "lon": 0.03, "models": {},
+          "consensus": { "flight_category": "\(consensusCategory)", "agreement": {} },
+          "consensus_majority": { "flight_category": "\(consensusCategory)", "agreement": {} } }
+        """
+        return try JSONDecoder().decode(ForecastAirport.self, from: Data(json.utf8))
+    }
+
+    private static func airportWithBothConsensus(worst: String, majority: String) throws -> ForecastAirport {
+        let json = """
+        { "icao": "EGKB", "lat": 51.3, "lon": 0.03, "models": {},
+          "consensus": { "flight_category": "\(worst)", "agreement": {} },
+          "consensus_majority": { "flight_category": "\(majority)", "agreement": {} } }
+        """
+        return try JSONDecoder().decode(ForecastAirport.self, from: Data(json.utf8))
+    }
+
+    private static func airport(alt: [AltRequired]) throws -> ForecastAirport {
+        let modelKeys = ["gfs", "icon", "ecmwf"]
+        let models = zip(modelKeys, alt).map { key, a in
+            "\"\(key)\": { \"convective_risk\": \"none\", \"flight_category\": \"VFR\", \"alt_required\": { \"faa\": \(a.faa), \"easa\": \(a.easa) } }"
+        }.joined(separator: ", ")
+        let json = """
+        { "icao": "EGKB", "lat": 51.3, "lon": 0.03, "models": { \(models) },
+          "consensus": { "flight_category": "VFR", "agreement": {} },
+          "consensus_majority": { "flight_category": "VFR", "agreement": {} } }
+        """
+        return try JSONDecoder().decode(ForecastAirport.self, from: Data(json.utf8))
+    }
+}

--- a/app/flyfun-weather/flyfun-weatherTests/ForecastMapTests.swift
+++ b/app/flyfun-weather/flyfun-weatherTests/ForecastMapTests.swift
@@ -163,6 +163,28 @@ struct ForecastMapTests {
         #expect(apt.consensus.agreement(forMetric: "crosswind_kt") == "divergent")
     }
 
+    // MARK: - Card cell formatting (gust parity with web)
+
+    @Test func compactCellRendersGusts() throws {
+        let json = """
+        { "icao": "EGKB", "lat": 51.3, "lon": 0.03,
+          "models": { "gfs": { "convective_risk": "none", "flight_category": "VFR",
+            "wind_speed_kt": 15, "wind_dir_deg": 270, "wind_gust_kt": 22,
+            "crosswind_kt": 12, "gust_crosswind_kt": 18,
+            "headwind_kt": 8, "gust_headwind_kt": 14 } },
+          "consensus": { "flight_category": "VFR", "agreement": {}, "wind_speed_kt": 15, "wind_dir_deg": 270 },
+          "consensus_majority": { "flight_category": "VFR", "agreement": {} } }
+        """
+        let apt = try JSONDecoder().decode(ForecastAirport.self, from: Data(json.utf8))
+        let m = apt.models["gfs"].map { $0 as any ForecastCellData }
+        // Web: dir/speedGgust, value (gust) — the gust must not be silently dropped.
+        #expect(ForecastAirportCard.compactCell(m, metric: "wind_speed_kt") == "270/15G22")
+        #expect(ForecastAirportCard.compactCell(m, metric: "crosswind_kt") == "12 (18)")
+        #expect(ForecastAirportCard.compactCell(m, metric: "headwind_kt") == "8 (14)")
+        // The consensus block carries no gust field → steady value only, no "G".
+        #expect(ForecastAirportCard.compactCell(apt.consensus, metric: "wind_speed_kt") == "270/15")
+    }
+
     // MARK: - Model mode token round-trip
 
     @Test func modelModeTokens() {

--- a/app/flyfun-weather/flyfun-weatherTests/TestSupport.swift
+++ b/app/flyfun-weather/flyfun-weatherTests/TestSupport.swift
@@ -96,6 +96,9 @@ final class MockBriefingRepository: BriefingRepository, @unchecked Sendable {
         throw MockError.notStubbed("latestPack")
     }
     func airportWeather(icao: String, day: Int, hour: Int) async throws -> AirportWeatherResponse { throw MockError.notStubbed("airportWeather") }
+    func forecastMap(day: Int, hour: Int) async throws -> ForecastMapResponse { throw MockError.notStubbed("forecastMap") }
+    func forecastDays() async throws -> ForecastDaysResponse { throw MockError.notStubbed("forecastDays") }
+    func frequentAirports() async throws -> FrequentAirportsResponse { throw MockError.notStubbed("frequentAirports") }
     func advisories(flightId: String, timestamp: String) async throws -> AdvisoriesResponse {
         if let h = advisoriesHandler { return try h() }
         throw MockError.notStubbed("advisories")

--- a/deploy/weather.flyfun.aero.caddy
+++ b/deploy/weather.flyfun.aero.caddy
@@ -14,7 +14,7 @@ weather.flyfun.aero {
     # Apple Universal Links — associate app with this domain
     handle /.well-known/apple-app-site-association {
         header Content-Type application/json
-        respond `{"applinks":{"apps":[],"details":[{"appID":"M7QSSF3624.net.ro-z.flyfun-weather","paths":["/auth/callback","/briefing.html"]}]}}`
+        respond `{"applinks":{"apps":[],"details":[{"appID":"M7QSSF3624.net.ro-z.flyfun-weather","paths":["/auth/callback","/briefing.html","/maps.html"]}]}}`
     }
 
     # OAuth 2.1 Authorization Server metadata (RFC 8414) — lets native/third-party

--- a/designs/future/ios-forecast-map.md
+++ b/designs/future/ios-forecast-map.md
@@ -3,7 +3,9 @@
 > Porting the pan-European forecast overview map (`maps.html`, forecast tab) to
 > the iOS/iPad app — as a **pilot-framed** weather map, not a generic one.
 
-**Status:** design, not built. Agreed in a design session 2026-07-14.
+**Status:** backend (#419) shipped in PR #422; iOS client (#420) implemented —
+map + airport card + universal links, under `app/flyfun-weather/flyfun-weather/Views/ForecastMap/`.
+Agreed in a design session 2026-07-14.
 Related: [forecast-page.md](../forecast-page.md) (the web feature this ports),
 [ios-app-ui.md](../ios-app-ui.md), [ios-app-architecture.md](../ios-app-architecture.md),
 [ios-web-known-gaps.md](./ios-web-known-gaps.md).
@@ -373,7 +375,25 @@ they are what makes the iOS client logic-free.
 - W1 — weekday+date day labels; `fc.day` stays a relative integer so share links
   still resolve.
 
-### Issue 2 (#420) — iOS: the forecast map *(two PRs)*
+### Issue 2 (#420) — iOS: the forecast map *(two PRs)* — implemented
+
+As built (`app/flyfun-weather/flyfun-weather/`):
+- **DTOs** `Models/API/ForecastMapResponse.swift` (plain-decoder, verbatim keys so
+  the `agreement` map survives), `ForecastDaysResponse.swift`,
+  `FrequentAirportsResponse.swift`; `HelpCatalogResponse` widened with the `maps`
+  section; catalog interpreter `Views/ForecastMap/MapMetricsCatalog.swift`
+  (`bandColor`, categorical, gray-ramp, `m_to_sm`, `alternate_needed`,
+  `agreementKey`) with a bundled `Resources/map-metrics-catalog.json` baseline.
+- **Repository** `forecastMap/forecastDays/frequentAirports` (online-only).
+- **VM** `ViewModels/ForecastMapViewModel.swift` — day/hour/metric/mode/selection,
+  `(day,hour)` LRU + adjacent-hour prefetch, cold-open centring, deep-link.
+- **Views** `Views/ForecastMap/ForecastMapKitView.swift` (MKMapView representable,
+  no clustering, pure recolour, zoom-scaled radius, agreement ring),
+  `ForecastMapView.swift` (+`+Support`), `ForecastAirportCard.swift`.
+- **Nav** `FlightListView` `SidebarSelection` enum + Map toolbar button (iPad
+  detail pane / iPhone `fullScreenCover`); `/maps.html` universal link →
+  `PendingNavigation.forecastMap(MapDeepLink)`; AASA path added in
+  `deploy/weather.flyfun.aero.caddy`. Tests: `flyfun-weatherTests/ForecastMapTests.swift`.
 
 **PR 1 — the map.** Sidebar-selection enum + toolbar Map button (iPad detail pane /
 iPhone `fullScreenCover`); `MKMapView` representable with 619 markers coloured from


### PR DESCRIPTION
Port the web forecast map (maps.html) to the iOS/iPad app as a
pilot-framed weather map. Builds on the server-side judgement moved in
#419/PR #422: the client reads the served map-metrics catalog and the
baked worst/majority consensus, so it carries zero colour or consensus
logic and the two clients cannot drift.

The map (PR-1 scope):
- DTOs ForecastMapResponse / ForecastDaysResponse / FrequentAirportsResponse.
  ForecastMapResponse decodes with a plain decoder + explicit snake_case keys
  so `.convertFromSnakeCase` never rewrites the `agreement`/`models` dict keys.
- MapMetricsCatalog: Swift interpreter of the served catalog (categorical /
  threshold_asc / threshold_desc + m_to_sm / gray_ramp / alternate_needed,
  per-metric agreement key). HelpCatalogResponse widened with the `maps`
  section; bundled Resources/map-metrics-catalog.json baseline.
- Repository: forecastMap / forecastDays / frequentAirports (online-only).
- ForecastMapViewModel: day/hour/metric/model-mode/selection, (day,hour) LRU
  + adjacent-hour prefetch, cold-open centring from frequent airports.
- ForecastMapKitView: MKMapView via UIViewRepresentable, no clustering, 619
  markers with displayPriority=.required, zoom-scaled radius, per-active-metric
  agreement ring; metric/model switches are a pure recolour (no refetch/rebuild).
- FlightListView: selectedFlight → SidebarSelection enum + a Map toolbar button
  (iPad detail pane / iPhone fullScreenCover); day/hour/metric/model controls
  drawn from /maps/forecast/days (never hardcoded, greyed-but-tappable models).

The card + deep links (PR-2 scope):
- ForecastAirportCard: verdict header, alternate row, metric×model matrix,
  init-times footnote; row-tap switches the map's colour metric; duplicate hour
  stepper in the header. iPhone bottom sheet keeps the map pannable +
  live-recolouring via presentationBackgroundInteraction; iPad uses .inspector.
- Universal links: /maps.html → PendingNavigation.forecastMap(MapDeepLink) with
  the web's fc.* share state; /maps.html added to the AASA paths.

Tests: ForecastMapTests covers catalog colour evaluation (bands, m_to_sm,
gray ramp, null_color, categorical, alt-required aggregation), the agreement
key, consensus-block selection, model-mode tokens, and /maps.html routing.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01M2TC1wErZ1QTDyeyM2M88U