### PR TITLE
fix(ios): repaint flight-list rows when a briefing updates on the server

### DIFF
--- a/app/flyfun-weather/flyfun-weather/Models/API/FlightResponse.swift
+++ b/app/flyfun-weather/flyfun-weather/Models/API/FlightResponse.swift
@@ -157,7 +157,8 @@ enum FlexibilityMode: String, Codable, Sendable, CaseIterable {
 /// Weather-coverage status for a flight saved beyond the forecast horizon.
 /// Present on `FlightResponse.coverage` only while no model reaches the flight
 /// date yet; the UI shows a neutral pending state instead of an assessment.
-struct CoveragePending: Codable, Sendable {
+/// `Equatable` so `FlightCardView` can diff on it (see its `==`).
+struct CoveragePending: Codable, Sendable, Equatable {
     /// ISO date (yyyy-MM-dd) — first (early-outlook) briefing appears.
     let availableDate: String
     /// ISO date — full GRIB briefing, if resolved. nil when unresolved.
@@ -201,7 +202,10 @@ struct AircraftInfo: Codable, Hashable, Sendable {
 /// each card can render a status tag from the single `/api/flights` response
 /// (mirrors the web `BriefingStatusInfo`). Scalar fields are optional so a
 /// partial/legacy payload decodes rather than failing the whole flight.
-struct BriefingStatusInfo: Codable, Sendable {
+/// `Equatable` so `FlightCardView` diffs on the briefing content (the card's
+/// only source of truth) rather than `FlightResponse`'s id-only identity, which
+/// would otherwise make a same-id/new-briefing update look unchanged (#426).
+struct BriefingStatusInfo: Codable, Sendable, Equatable {
     /// GREEN / AMBER / RED traffic-light verdict (short-range, within the GRIB
     /// horizon). nil when only a long-range `outlook` is available.
     let assessment: String?
@@ -213,10 +217,17 @@ struct BriefingStatusInfo: Codable, Sendable {
     let outlookReason: String?
     let hasAdvisories: Bool?
     let advisorySummary: AdvisorySummary?
+    /// The latest pack's fetch timestamp (ISO 8601), as the server sends it in
+    /// `latest_briefing.fetch_timestamp`. Used by the flight list's
+    /// level-triggered reconcile to detect that a briefing advanced even when
+    /// the active-refresh poll never observed the refresh (#426). Optional (no
+    /// default — a `let` with a default would be dropped from the synthesized
+    /// `Codable`, never decoding the field); absent on older servers → nil.
+    let fetchTimestamp: String?
 }
 
 /// Compact RED/AMBER advisory breakdown for the flights-list card chips.
-struct AdvisorySummary: Codable, Sendable {
+struct AdvisorySummary: Codable, Sendable, Equatable {
     let red: Int
     let amber: Int
     /// Severity-ordered named concerns, capped at 3 server-side.
@@ -224,7 +235,7 @@ struct AdvisorySummary: Codable, Sendable {
 }
 
 /// One named advisory concern for the summary chips.
-struct AdvisoryChip: Codable, Sendable {
+struct AdvisoryChip: Codable, Sendable, Equatable {
     let status: String  // "RED" | "AMBER"
     let name: String
 }

--- a/app/flyfun-weather/flyfun-weather/ViewModels/FlightListViewModel.swift
+++ b/app/flyfun-weather/flyfun-weather/ViewModels/FlightListViewModel.swift
@@ -45,6 +45,13 @@ final class FlightListViewModel {
     /// load. The level-triggered reconcile compares against this to tell whether
     /// a briefing actually advanced (#426).
     private var lastPackTimestamps: [String: String] = [:]
+    /// Monotonic counter bumped on every authoritative list commit (a completed
+    /// `loadFlights()` or a `reconcileLatestPacks()` write). The reconcile — which
+    /// runs on `@MainActor` but suspends across its `repository.flights()` fetch —
+    /// captures this before awaiting and drops its result if it changed, so a
+    /// slow background reconcile can never clobber a fresher `loadFlights()` that
+    /// completed during that suspension (#427 review).
+    private var loadGeneration = 0
     /// The active-refresh poll loop (one at a time). Detached from any `.task`, so
     /// the view must start/stop it explicitly around visibility.
     @ObservationIgnored private var refreshPollTask: Task<Void, Never>?
@@ -106,6 +113,7 @@ final class FlightListViewModel {
             }
             state = .loaded(flights)
             lastPackTimestamps = Self.packTimestampMap(flights)
+            loadGeneration &+= 1   // authoritative commit — see reconcileLatestPacks
             // Keep Spotlight / Siri's flight index in sync with the server truth.
             // Fire-and-forget — never block the list on indexing (Decision 8).
             // Only when online: an offline cache snapshot can be stale/partial
@@ -221,9 +229,18 @@ final class FlightListViewModel {
     /// repainted, for tests. Failures are swallowed — the next tick retries.
     @discardableResult
     func reconcileLatestPacks() async -> Bool {
+        let generation = loadGeneration
         guard let flights = try? await repository.flights() else { return false }
+        // An authoritative load (pull-to-refresh, foreground, external sync, the
+        // completion edge, or a prior reconcile) committed while our fetch was in
+        // flight — its result is at least as fresh as ours, so drop instead of
+        // clobbering it back to stale data (#427 review). `loadGeneration` and
+        // `state` only change on the main actor between our suspension points, so
+        // this comparison is race-free.
+        guard generation == loadGeneration else { return false }
         let fresh = Self.packTimestampMap(flights)
         guard fresh != lastPackTimestamps else { return false }
+        loadGeneration &+= 1
         state = .loaded(flights)
         lastPackTimestamps = fresh
         // Keep the offline/cached-badge state consistent with the fresh list, the

--- a/app/flyfun-weather/flyfun-weather/ViewModels/FlightListViewModel.swift
+++ b/app/flyfun-weather/flyfun-weather/ViewModels/FlightListViewModel.swift
@@ -41,6 +41,10 @@ final class FlightListViewModel {
     /// always attempts, relying on error backoff).
     private let networkMonitor: NetworkMonitor?
     private var isLoading = false
+    /// Per-flight latest-pack `fetchTimestamp`, snapshotted on every successful
+    /// load. The level-triggered reconcile compares against this to tell whether
+    /// a briefing actually advanced (#426).
+    private var lastPackTimestamps: [String: String] = [:]
     /// The active-refresh poll loop (one at a time). Detached from any `.task`, so
     /// the view must start/stop it explicitly around visibility.
     @ObservationIgnored private var refreshPollTask: Task<Void, Never>?
@@ -101,6 +105,7 @@ final class FlightListViewModel {
                 await refreshCachedFlightIds(reporter)
             }
             state = .loaded(flights)
+            lastPackTimestamps = Self.packTimestampMap(flights)
             // Keep Spotlight / Siri's flight index in sync with the server truth.
             // Fire-and-forget — never block the list on indexing (Decision 8).
             // Only when online: an offline cache snapshot can be stale/partial
@@ -157,9 +162,17 @@ final class FlightListViewModel {
 
     /// Healthy poll cadence (matches the web's flat 5s).
     private static let refreshPollBaseDelay: Double = 5
+    /// Full-reconcile cadence, in healthy poll ticks (6 × 5s ≈ 30s). A level-
+    /// triggered safety net for the active-set edge below: a refresh that begins
+    /// *and* finishes between two polls — a fast refresh, or one started on the
+    /// web / another device / by auto-refresh — never enters `refreshingFlightIds`,
+    /// so the `finished` edge never fires and the row would stay stale until the
+    /// next foreground / pull-to-refresh. Reconciling on this cadence catches it.
+    private static let reconcileEveryTicks = 6
 
     private func pollActiveRefreshesLoop() async {
         var delay = Self.refreshPollBaseDelay
+        var ticksSinceReconcile = 0
         while !Task.isCancelled {
             if networkMonitor?.isConnected == false {
                 // Offline: don't even attempt the round-trip — no point waking the
@@ -177,7 +190,14 @@ final class FlightListViewModel {
                     let finished = refreshingFlightIds.subtracting(newIds)
                     refreshingFlightIds = newIds
                     if !finished.isEmpty {
-                        await loadFlights()
+                        await loadFlights()          // edge-triggered completion
+                        ticksSinceReconcile = 0      // loadFlights already reconciled
+                    } else {
+                        ticksSinceReconcile += 1
+                        if ticksSinceReconcile >= Self.reconcileEveryTicks {
+                            ticksSinceReconcile = 0
+                            await reconcileLatestPacks()   // level-triggered catch-up
+                        }
                     }
                     delay = Self.refreshPollBaseDelay   // healthy — reset cadence
                 } catch {
@@ -189,6 +209,44 @@ final class FlightListViewModel {
             }
             try? await Task.sleep(for: .seconds(delay))
         }
+    }
+
+    /// Level-triggered reconcile: re-fetch the flights list and repaint only when
+    /// a flight's latest-pack `fetchTimestamp` has advanced since the last load.
+    /// This is the completion signal the active-refresh edge can miss (#426) — a
+    /// refresh whose whole active lifetime fell between two polls still lands here
+    /// once its new pack timestamp shows up. Quiet by design: it never flips the
+    /// full-screen spinner or the `isRefreshing` indicator, and does nothing
+    /// (beyond one cheap list fetch) when no briefing changed. Returns whether it
+    /// repainted, for tests. Failures are swallowed — the next tick retries.
+    @discardableResult
+    func reconcileLatestPacks() async -> Bool {
+        guard let flights = try? await repository.flights() else { return false }
+        let fresh = Self.packTimestampMap(flights)
+        guard fresh != lastPackTimestamps else { return false }
+        state = .loaded(flights)
+        lastPackTimestamps = fresh
+        // Keep the offline/cached-badge state consistent with the fresh list, the
+        // same way loadFlights does (disk-only, no extra network).
+        if let reporter = repository as? CacheStatusReporting {
+            isOffline = reporter.isServingCachedFlights
+            await refreshCachedFlightIds(reporter)
+        }
+        Self.logger.info("Reconcile repainted flight list (pack timestamps advanced)")
+        return true
+    }
+
+    /// Per-flight latest-pack `fetchTimestamp`, keyed by flight id. Flights whose
+    /// latest briefing carries no timestamp (never briefed, or a legacy server
+    /// that omits the field) are absent from the map.
+    static func packTimestampMap(_ flights: [FlightResponse]) -> [String: String] {
+        var map: [String: String] = [:]
+        for flight in flights {
+            if let ts = flight.latestBriefing?.fetchTimestamp {
+                map[flight.id] = ts
+            }
+        }
+        return map
     }
 
     /// Refresh the "available offline" badge set from the offline-ready flights.

--- a/app/flyfun-weather/flyfun-weather/Views/Flights/FlightCardView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Flights/FlightCardView.swift
@@ -1,13 +1,38 @@
 import SwiftUI
 
 /// Card displaying a flight summary in the list.
-struct FlightCardView: View {
+///
+/// `Equatable` (applied via `.equatable()` at the call site) is load-bearing:
+/// `FlightResponse` is `Hashable` by `id` only — deliberately, so `List`
+/// selection stays stable when a flight's briefing changes — but SwiftUI reuses
+/// that same id-only `==` when diffing this row, so a same-id/new-briefing
+/// update would look unchanged and the card would keep its stale badge until the
+/// view tree is rebuilt (app relaunch). Diffing on the exact fields the card
+/// draws instead makes a changed briefing repaint immediately (#426).
+struct FlightCardView: View, Equatable {
     let flight: FlightResponse
     var hasCachedData: Bool = false
     var isOffline: Bool = false
     /// The flight's briefing is queued/refreshing server-side — show a live
     /// "Updating…" tag alongside the (still-current) assessment badge.
     var isRefreshing: Bool = false
+
+    static func == (lhs: FlightCardView, rhs: FlightCardView) -> Bool {
+        lhs.hasCachedData == rhs.hasCachedData
+            && lhs.isOffline == rhs.isOffline
+            && lhs.isRefreshing == rhs.isRefreshing
+            // Everything below is a field the body actually renders. `flight`'s
+            // own `==` is id-only and must not be used here.
+            && lhs.flight.id == rhs.flight.id
+            && lhs.flight.shortTitle == rhs.flight.shortTitle
+            && lhs.flight.waypoints == rhs.flight.waypoints
+            && lhs.flight.departureTime == rhs.flight.departureTime
+            && lhs.flight.cruiseAltitudeFt == rhs.flight.cruiseAltitudeFt
+            && lhs.flight.aircraft == rhs.flight.aircraft
+            && lhs.flight.role == rhs.flight.role
+            && lhs.flight.coverage == rhs.flight.coverage
+            && lhs.flight.latestBriefing == rhs.flight.latestBriefing
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {

--- a/app/flyfun-weather/flyfun-weather/Views/Flights/FlightListView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Flights/FlightListView.swift
@@ -347,9 +347,13 @@ struct FlightListView: View {
     private func flightRow(_ flight: FlightResponse, viewModel: FlightListViewModel) -> some View {
         let hasCached = viewModel.cachedFlightIds.contains(flight.id)
         NavigationLink(value: SidebarSelection.flight(flight)) {
+            // `.equatable()` so the row diffs on the briefing content it draws,
+            // not `FlightResponse`'s id-only `==` — otherwise a same-id briefing
+            // update wouldn't repaint the card until app relaunch (#426).
             FlightCardView(flight: flight, hasCachedData: hasCached,
                            isOffline: viewModel.isOffline,
                            isRefreshing: viewModel.refreshingFlightIds.contains(flight.id))
+                .equatable()
         }
         .disabled(viewModel.isOffline && !hasCached)
         .swipeActions(edge: .trailing, allowsFullSwipe: false) {

--- a/app/flyfun-weather/flyfun-weatherTests/AppIntentsResolverTests.swift
+++ b/app/flyfun-weather/flyfun-weatherTests/AppIntentsResolverTests.swift
@@ -273,9 +273,8 @@ struct DialogTests {
 
     @Test("check summary: assessment + top concerns")
     func check() {
-        let briefing = BriefingStatusInfo(
-            assessment: "AMBER", assessmentReason: nil, outlook: nil, outlookReason: nil,
-            hasAdvisories: true,
+        let briefing = makeBriefingStatus(
+            assessment: "AMBER", hasAdvisories: true,
             advisorySummary: AdvisorySummary(red: 0, amber: 2, top: [
                 AdvisoryChip(status: "AMBER", name: "convective"),
                 AdvisoryChip(status: "AMBER", name: "icing"),
@@ -293,9 +292,7 @@ struct DialogTests {
 
     @Test("overview: one upcoming flight")
     func overview() {
-        let briefing = BriefingStatusInfo(
-            assessment: "GREEN", assessmentReason: nil, outlook: nil, outlookReason: nil,
-            hasAdvisories: false, advisorySummary: nil)
+        let briefing = makeBriefingStatus(assessment: "GREEN", hasAdvisories: false)
         let flight = makeFlight(waypoints: ["EGKB", "EGTF"], departureTime: "2026-08-01T12:00:00Z", latestBriefing: briefing)
         #expect(IntentDialogs.overviewSummary([flight], now: now)
             == "You have 1 upcoming flight: EGKB → EGTF, green.")

--- a/app/flyfun-weather/flyfun-weatherTests/TestSupport.swift
+++ b/app/flyfun-weather/flyfun-weatherTests/TestSupport.swift
@@ -168,6 +168,29 @@ func makeFlight(
     )
 }
 
+/// Build a `BriefingStatusInfo` fixture — the latest-pack summary inlined into a
+/// flight-list row. Centralizes construction so adding wire fields (e.g.
+/// `fetchTimestamp`) touches one call site, not every test.
+func makeBriefingStatus(
+    assessment: String? = nil,
+    assessmentReason: String? = nil,
+    outlook: String? = nil,
+    outlookReason: String? = nil,
+    hasAdvisories: Bool? = nil,
+    advisorySummary: AdvisorySummary? = nil,
+    fetchTimestamp: String? = nil
+) -> BriefingStatusInfo {
+    BriefingStatusInfo(
+        assessment: assessment,
+        assessmentReason: assessmentReason,
+        outlook: outlook,
+        outlookReason: outlookReason,
+        hasAdvisories: hasAdvisories,
+        advisorySummary: advisorySummary,
+        fetchTimestamp: fetchTimestamp
+    )
+}
+
 /// Build an `UpdateFlightResponse` fixture (Decodable-only, so assembled via
 /// JSON) for stubbing `MockBriefingRepository.updateFlightResult`.
 func makeUpdateResponse(

--- a/app/flyfun-weather/flyfun-weatherTests/ViewModelTests.swift
+++ b/app/flyfun-weather/flyfun-weatherTests/ViewModelTests.swift
@@ -307,6 +307,47 @@ import MapKit
         let repainted = await vm.reconcileLatestPacks()   // same timestamp
         #expect(repainted == false)
     }
+
+    /// A slow reconcile must not clobber a fresher `loadFlights()` that completed
+    /// while the reconcile was suspended in its own fetch (#427 review). Both run
+    /// on `@MainActor` but interleave across `await`, so the reconcile captures a
+    /// load generation and drops its write when an authoritative load bumps it.
+    @Test func reconcileDropsStaleWriteWhenLoadFlightsWins() async {
+        let repo = MockBriefingRepository()
+        repo.flightsResult = .success([
+            makeFlight(id: "a", latestBriefing: makeBriefingStatus(assessment: "GREEN", fetchTimestamp: "2026-07-15T10:00:00Z")),
+        ])
+        let vm = FlightListViewModel(repository: repo)
+        await vm.loadFlights()                         // baseline (generation → 1)
+
+        // Park the reconcile inside its `repository.flights()` fetch.
+        let gate = TestGate()
+        repo.beforeFlightsReturn = { await gate.wait() }
+        let reconcileTask = Task { await vm.reconcileLatestPacks() }
+
+        // Wait until the reconcile has entered flights() (2nd call) and is parked
+        // on the gate — by then it has already captured the load generation.
+        for _ in 0..<1000 where repo.flightsCallCount < 2 { await Task.yield() }
+        #expect(repo.flightsCallCount == 2)
+
+        // A pull-to-refresh lands a newer briefing while the reconcile is suspended.
+        repo.beforeFlightsReturn = nil
+        repo.flightsResult = .success([
+            makeFlight(id: "a", latestBriefing: makeBriefingStatus(assessment: "RED", fetchTimestamp: "2026-07-15T10:05:00Z")),
+        ])
+        await vm.loadFlights()                         // wins (generation → 2), state = RED
+
+        // Release the stale reconcile; it must detect it lost and drop its write.
+        await gate.open()
+        let repainted = await reconcileTask.value
+        #expect(repainted == false)
+
+        guard case .loaded(let flights) = vm.state else {
+            Issue.record("expected .loaded, got \(vm.state)")
+            return
+        }
+        #expect(flights.first?.latestBriefing?.assessment == "RED")   // fresh load preserved
+    }
 }
 
 // MARK: - FlightCardView content equality (#426)

--- a/app/flyfun-weather/flyfun-weatherTests/ViewModelTests.swift
+++ b/app/flyfun-weather/flyfun-weatherTests/ViewModelTests.swift
@@ -266,6 +266,103 @@ import MapKit
         #expect(vm.isOffline == true)
         #expect(vm.isRefreshing == false)
     }
+
+    // MARK: Level-triggered reconcile (#426)
+
+    /// A briefing that advanced on the server (new pack `fetchTimestamp`) repaints
+    /// the list via the quiet reconcile — the completion path the active-refresh
+    /// edge can miss when a refresh starts *and* finishes between two polls.
+    @Test func reconcileRepaintsWhenPackTimestampAdvances() async {
+        let repo = MockBriefingRepository()
+        repo.flightsResult = .success([
+            makeFlight(id: "a", latestBriefing: makeBriefingStatus(assessment: "GREEN", fetchTimestamp: "2026-07-15T10:00:00Z")),
+        ])
+        let vm = FlightListViewModel(repository: repo)
+        await vm.loadFlights()                 // baseline snapshot @ T1
+
+        // Server now has a newer pack for the same flight.
+        repo.flightsResult = .success([
+            makeFlight(id: "a", latestBriefing: makeBriefingStatus(assessment: "RED", fetchTimestamp: "2026-07-15T10:05:00Z")),
+        ])
+        let repainted = await vm.reconcileLatestPacks()
+
+        #expect(repainted)
+        guard case .loaded(let flights) = vm.state else {
+            Issue.record("expected .loaded, got \(vm.state)")
+            return
+        }
+        #expect(flights.first?.latestBriefing?.assessment == "RED")
+    }
+
+    /// No pack change → the reconcile is a no-op (one cheap fetch, no repaint), so
+    /// it can run on a steady cadence without churning the list.
+    @Test func reconcileIsNoopWhenPackUnchanged() async {
+        let repo = MockBriefingRepository()
+        repo.flightsResult = .success([
+            makeFlight(id: "a", latestBriefing: makeBriefingStatus(assessment: "GREEN", fetchTimestamp: "2026-07-15T10:00:00Z")),
+        ])
+        let vm = FlightListViewModel(repository: repo)
+        await vm.loadFlights()
+
+        let repainted = await vm.reconcileLatestPacks()   // same timestamp
+        #expect(repainted == false)
+    }
+}
+
+// MARK: - FlightCardView content equality (#426)
+
+/// The row must diff on the briefing content it draws, not `FlightResponse`'s
+/// id-only identity — otherwise a same-id/new-briefing update would look
+/// unchanged and the card would keep its stale badge until app relaunch.
+@MainActor
+@Suite struct FlightCardEquatableTests {
+
+    @Test func sameIdDifferentBriefingIsNotEqual() {
+        let green = makeFlight(id: "a", latestBriefing: makeBriefingStatus(assessment: "GREEN", fetchTimestamp: "T1"))
+        let red = makeFlight(id: "a", latestBriefing: makeBriefingStatus(assessment: "RED", fetchTimestamp: "T2"))
+
+        // The underlying model is *equal* by its id-only identity conformance…
+        #expect(green == red)
+        // …but the cards must compare *unequal* so SwiftUI repaints the row.
+        #expect(FlightCardView(flight: green) != FlightCardView(flight: red))
+    }
+
+    @Test func identicalContentIsEqual() {
+        let a = makeFlight(id: "a", latestBriefing: makeBriefingStatus(assessment: "AMBER", fetchTimestamp: "T1"))
+        let b = makeFlight(id: "a", latestBriefing: makeBriefingStatus(assessment: "AMBER", fetchTimestamp: "T1"))
+        #expect(FlightCardView(flight: a) == FlightCardView(flight: b))
+    }
+
+    @Test func refreshingFlagBreaksEquality() {
+        let a = makeFlight(id: "a", latestBriefing: makeBriefingStatus(assessment: "GREEN"))
+        #expect(FlightCardView(flight: a, isRefreshing: false) != FlightCardView(flight: a, isRefreshing: true))
+    }
+}
+
+// MARK: - BriefingStatusInfo wire decoding (#426)
+
+@Suite struct BriefingStatusDecodeTests {
+
+    /// The server's `latest_briefing.fetch_timestamp` decodes onto
+    /// `fetchTimestamp` via the shared snake-case decoder.
+    @Test func decodesFetchTimestamp() throws {
+        let json = Data("""
+        {"assessment": "GREEN", "fetch_timestamp": "2026-07-15T10:00:00Z"}
+        """.utf8)
+        let status = try JSONDecoder.weatherBrief.decode(BriefingStatusInfo.self, from: json)
+        #expect(status.assessment == "GREEN")
+        #expect(status.fetchTimestamp == "2026-07-15T10:00:00Z")
+    }
+
+    /// A legacy payload without the field decodes with `fetchTimestamp == nil`
+    /// (optional `let`, no default → `decodeIfPresent`).
+    @Test func toleratesMissingFetchTimestamp() throws {
+        let json = Data("""
+        {"assessment": "AMBER"}
+        """.utf8)
+        let status = try JSONDecoder.weatherBrief.decode(BriefingStatusInfo.self, from: json)
+        #expect(status.fetchTimestamp == nil)
+    }
 }
 
 // MARK: - RouteMapViewModel (waypoint extraction + fit-region math)


### PR DESCRIPTION
## What & why

The iOS flight-list card wasn't reliably updating its traffic-light badge / advisory chips when a flight's briefing changed on the server — force-quitting and reopening the app showed the correct state. Two causes, one primary and one secondary:

**1. Stale row (primary).** The card renders from `flight.latestBriefing`, which `/api/flights` inlines into each `FlightResponse`. `FlightResponse` is `Hashable` by `id` **only** — deliberately, so `List` selection stays stable when a flight's briefing changes. But SwiftUI reuses that same id-only `==` when diffing the row, so a same-id / new-briefing update compared *equal* and SwiftUI skipped re-rendering `FlightCardView`. `loadFlights()` fetched the fresh data, but the visible card kept its old badge until the view tree was rebuilt (relaunch). It was *intermittent* because the active-refresh poll toggling `isRefreshing` sometimes forced an incidental re-render that pulled in the fresh briefing.

**2. Edge-triggered completion detection (secondary).** `pollActiveRefreshesLoop()` reloaded only when a flight *left* the `/api/refresh/active` set. A refresh whose whole active lifetime fell between two 5 s polls (fast refresh, or one started on the web / another device / by auto-refresh) was never observed, so no reload fired at all until the next foreground / pull-to-refresh.

### Fixes

1. **Content-based row repaint.** `FlightCardView` now conforms to `Equatable` over exactly the fields it draws and is rendered via `.equatable()`, so a changed briefing repaints the row while the id-only identity stays for `List` selection. Adds `Equatable` to `BriefingStatusInfo` / `AdvisorySummary` / `AdvisoryChip` / `CoveragePending`.
2. **Level-triggered reconcile.** Decode the `fetch_timestamp` the server already sends in `latest_briefing`, and add a periodic reconcile (~30 s) in the active-refresh poll that repaints only when a flight's latest pack timestamp advanced — catching the missed-between-polls case the active-set edge can't see. Quiet by design: one cheap list fetch, no spinner, no-op when nothing changed.

## Issue linkage

Closes #426

## Testing / verification

Added unit tests (Swift Testing, via the injected `MockBriefingRepository`, no network):
- `FlightCardEquatableTests` — same-id / different-briefing cards compare **unequal** (while the underlying `FlightResponse` stays id-equal), identical content is equal, and the `isRefreshing` flag breaks equality.
- `reconcileRepaintsWhenPackTimestampAdvances` / `reconcileIsNoopWhenPackUnchanged` — the reconcile repaints only on a real pack-timestamp advance.
- `BriefingStatusDecodeTests` — `fetch_timestamp` decodes onto `fetchTimestamp` via the shared snake-case decoder, and a legacy payload without it decodes as `nil`.

Note: this is an iOS/Xcode target, which can't be built or run in the web environment — the tests above are written against the existing `flyfun-weatherTests` harness but were not executed here. Worth a local `xcodebuild test` (or a simulator pass on the flight list) before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NadGSq5EEvte2RyLUvDqNk

---
_Generated by [Claude Code](https://claude.ai/code/session_01NadGSq5EEvte2RyLUvDqNk)_