### PR TITLE
iOS: unify maps on MKMapView + airport forecast overlay on the briefing map (#428)

### DIFF
--- a/app/flyfun-weather/flyfun-weather/ViewModels/RouteForecastOverlayModel.swift
+++ b/app/flyfun-weather/flyfun-weather/ViewModels/RouteForecastOverlayModel.swift
@@ -26,12 +26,17 @@ final class RouteForecastOverlayModel {
 
     private let repository: any BriefingRepository
     private var daysLoading = false
-    private var sliceLoading = false
+    /// Slot key currently being fetched (nil = idle). Keyed by slot — not a bare
+    /// bool — so a same-slot re-entry dedupes while a *different* slot is never
+    /// blocked by an in-flight fetch for another slot. Mirrors the sibling
+    /// `ForecastMapViewModel`'s per-slot `inFlight` set (#429 review).
+    private var loadingSlotKey: String?
     /// Slot key the current `payload` belongs to (guards against showing a stale
     /// slice for a different slot).
     private var loadedSlotKey: String?
-    /// After a failure, back off rather than refetching on every re-render.
-    private var retryAt = Date.distantPast
+    /// Per-slot failure backoff (key → earliest retry). Per-slot so a failure on
+    /// one slot never stalls a legitimately different slot for the backoff window.
+    private var retryBySlot: [String: Date] = [:]
     private static let retryBackoff: TimeInterval = 30
 
     init(repository: any BriefingRepository) { self.repository = repository }
@@ -66,21 +71,25 @@ final class RouteForecastOverlayModel {
     /// when it's already current. Honours a short failure backoff.
     func ensureSlice(_ slot: RouteForecastSlot) async {
         if loadedSlotKey == slot.key, payload != nil { return }
-        guard !sliceLoading, Date() >= retryAt else { return }
-        sliceLoading = true
-        defer { sliceLoading = false }
+        if loadingSlotKey == slot.key { return }                       // this slot already loading
+        if let until = retryBySlot[slot.key], Date() < until { return } // this slot backing off
+        loadingSlotKey = slot.key
+        // Only clear if we still own the flag — a newer slot's fetch may have
+        // taken it over while this one was unwinding (task cancellation race).
+        defer { if loadingSlotKey == slot.key { loadingSlotKey = nil } }
         do {
             let resp = try await repository.forecastMap(day: slot.day, hour: slot.hour)
             payload = resp
             loadedSlotKey = slot.key
             payloadRevision &+= 1
+            retryBySlot[slot.key] = nil
         } catch let error as APIError where error.isCancellation {
             // Superseded by a newer slot (task cancellation) — benign, no backoff.
         } catch is CancellationError {
             // SwiftUI cancelled the `.task(id:)` on a slot change — benign.
         } catch {
             Self.logger.warning("forecast map \(slot.day)/\(slot.hour) failed: \(error.localizedDescription)")
-            retryAt = Date().addingTimeInterval(Self.retryBackoff)
+            retryBySlot[slot.key] = Date().addingTimeInterval(Self.retryBackoff)
         }
     }
 

--- a/app/flyfun-weather/flyfun-weather/ViewModels/RouteForecastOverlayModel.swift
+++ b/app/flyfun-weather/flyfun-weather/ViewModels/RouteForecastOverlayModel.swift
@@ -1,0 +1,92 @@
+import Foundation
+import OSLog
+
+/// Owns the airport-forecast overlay data for the briefing route map (#428): the
+/// server day/hour grid and the per-slot snapshot for the flight's nearest
+/// forecast time. `@Observable`, so mutating `days` / `payload` / `payloadRevision`
+/// re-renders the map view, which recolours from the already-fetched payload.
+///
+/// Only a new day/hour slice hits the network (`repository.forecastMap`); the
+/// payload holds every model per airport, so switching the briefing model or the
+/// overlay metric is a pure client recolour — mirroring the forecast map and the
+/// web overlay (`designs/forecast-page.md`).
+@Observable
+@MainActor
+final class RouteForecastOverlayModel {
+    private static let logger = Logger(subsystem: "aero.flyfun.weather", category: "RouteForecastOverlay")
+
+    /// The server day/hour/model grid (`/maps/forecast/days`), or nil until it
+    /// loads. Nil ⇒ the overlay is simply not offered yet.
+    private(set) var days: [ForecastDay]?
+    /// The snapshot for `loadedSlotKey`, or nil while none is loaded for the
+    /// current slot.
+    private(set) var payload: ForecastMapResponse?
+    /// Bumped on every payload change so the map rebuilds its airport markers.
+    private(set) var payloadRevision = 0
+
+    private let repository: any BriefingRepository
+    private var daysLoading = false
+    private var sliceLoading = false
+    /// Slot key the current `payload` belongs to (guards against showing a stale
+    /// slice for a different slot).
+    private var loadedSlotKey: String?
+    /// After a failure, back off rather than refetching on every re-render.
+    private var retryAt = Date.distantPast
+    private static let retryBackoff: TimeInterval = 30
+
+    init(repository: any BriefingRepository) { self.repository = repository }
+
+    /// The overlay slot for a flight's departure time against the loaded grid, or
+    /// nil when the grid hasn't loaded or the flight is outside the horizon.
+    func slot(departureTime: String?) -> RouteForecastSlot? {
+        guard let days else { return nil }
+        return RouteForecastOverlay.resolveSlot(departureIso: departureTime, days: days, now: Date())
+    }
+
+    /// Airports to draw for `slot`, or nil when the loaded payload is for a
+    /// different slot (so stale markers never linger through a slot change).
+    func airports(for slot: RouteForecastSlot) -> [ForecastAirport]? {
+        loadedSlotKey == slot.key ? payload?.airports : nil
+    }
+
+    /// Lazy-load the day grid once. A failure leaves `days` nil (overlay not
+    /// offered) and is retried on a later appear.
+    func loadDaysIfNeeded() async {
+        guard days == nil, !daysLoading else { return }
+        daysLoading = true
+        defer { daysLoading = false }
+        do {
+            days = try await repository.forecastDays().days
+        } catch {
+            Self.logger.warning("forecast days failed: \(error.localizedDescription)")
+        }
+    }
+
+    /// Ensure the snapshot for `slot` is loaded (cached by slot key). Cheap no-op
+    /// when it's already current. Honours a short failure backoff.
+    func ensureSlice(_ slot: RouteForecastSlot) async {
+        if loadedSlotKey == slot.key, payload != nil { return }
+        guard !sliceLoading, Date() >= retryAt else { return }
+        sliceLoading = true
+        defer { sliceLoading = false }
+        do {
+            let resp = try await repository.forecastMap(day: slot.day, hour: slot.hour)
+            payload = resp
+            loadedSlotKey = slot.key
+            payloadRevision &+= 1
+        } catch let error as APIError where error.isCancellation {
+            // Superseded by a newer slot (task cancellation) — benign, no backoff.
+        } catch is CancellationError {
+            // SwiftUI cancelled the `.task(id:)` on a slot change — benign.
+        } catch {
+            Self.logger.warning("forecast map \(slot.day)/\(slot.hour) failed: \(error.localizedDescription)")
+            retryAt = Date().addingTimeInterval(Self.retryBackoff)
+        }
+    }
+
+    /// The valid-time label of the loaded snapshot ("Wed 12Z"), empty until it
+    /// loads.
+    var forecastTimeLabel: String {
+        RouteForecastOverlay.formatForecastTime(payload?.forecastTime)
+    }
+}

--- a/app/flyfun-weather/flyfun-weather/Views/ForecastMap/ForecastMapKitView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/ForecastMap/ForecastMapKitView.swift
@@ -156,20 +156,10 @@ struct ForecastMapKitView: UIViewRepresentable {
         }
 
         /// Marker diameter from the map's zoom (web `markerRadius`: 5px at z≤4 →
-        /// 11px at z≥8), doubled to a diameter.
+        /// 11px at z≥8), doubled to a diameter. Shares the zoom formula with the
+        /// briefing route-map overlay via `AirportMarkerSizing` (#429 review).
         static func diameter(for map: MKMapView) -> CGFloat {
-            let span = map.region.span.longitudeDelta
-            guard span > 0 else { return 14 }
-            let zoom = log2(360 / span)
-            let radius: CGFloat
-            switch zoom {
-            case ..<4.5: radius = 5
-            case ..<5.5: radius = 6
-            case ..<6.5: radius = 7
-            case ..<7.5: radius = 9
-            default: radius = 11
-            }
-            return radius * 2
+            AirportMarkerSizing.diameter(for: map, radii: [5, 6, 7, 9, 11], fallback: 14)
         }
     }
 }

--- a/app/flyfun-weather/flyfun-weather/Views/Map/RouteForecastOverlay.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Map/RouteForecastOverlay.swift
@@ -1,0 +1,100 @@
+import Foundation
+
+/// Pure helpers for the briefing route-map airport-forecast overlay (#428, the
+/// iOS port of #424/#425). No MapKit / UIKit / side effects, so the day/hour
+/// boundary math, hour snapping and deep-link building are unit-testable.
+///
+/// The forecast horizon and the sample hours each day offers are read from the
+/// server's grid (`repository.forecastDays()`), never restated here — the grid is
+/// not rectangular (far days carry fewer models and coarser hours) and
+/// `designs/forecast-page.md` is explicit that the client must not hardcode it.
+/// This mirrors `web/ts/visualization/route-map/forecast-overlay.ts`.
+enum RouteForecastOverlay {
+    /// The individual forecast models the snapshot backend populates and the full
+    /// map's `fc.model` deep-link key accepts (matches web
+    /// `FORECAST_INDIVIDUAL_MODELS`). A consensus/other token falls back to the
+    /// full map's default (no `fc.model` in the link).
+    static let individualModels: Set<String> = ["gfs", "icon", "ecmwf"]
+
+    /// Relative (day, hour) in UTC for a departure ISO string, matching the
+    /// forecast endpoint's `now + day` date labelling. `nil` when unparseable.
+    /// `now` is injected so the boundary math is deterministic in tests.
+    static func relativeDayHour(departureIso: String?, now: Date) -> (day: Int, hour: Int)? {
+        guard let departureIso, let dep = parseISO(departureIso) else { return nil }
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = TimeZone(identifier: "UTC")!
+        let depDay = cal.startOfDay(for: dep)
+        let nowDay = cal.startOfDay(for: now)
+        guard let day = cal.dateComponents([.day], from: nowDay, to: depDay).day else { return nil }
+        let hour = cal.component(.hour, from: dep)
+        return (day, hour)
+    }
+
+    /// Nearest value in `hours` to `h`; ties resolve to the earlier hour. `nil`
+    /// for an empty list.
+    static func nearestHour(_ hours: [Int], _ h: Int) -> Int? {
+        guard !hours.isEmpty else { return nil }
+        // `min(by:)` keeps the first element on a tie, and `hours` is sorted
+        // ascending, so equidistant hours resolve to the earlier one.
+        return hours.min(by: { abs($0 - h) < abs($1 - h) })
+    }
+
+    /// Resolve the overlay slot for a flight against the server's advertised grid.
+    /// `nil` when the flight is outside the forecast horizon or the target day
+    /// carries no data — the overlay is then not offered. Offered hours come from
+    /// `days`, so the value always matches what the day actually holds (e.g. D+6's
+    /// coarse 6/12/18 rather than the fine near-day set).
+    static func resolveSlot(departureIso: String?, days: [ForecastDay], now: Date) -> RouteForecastSlot? {
+        guard let rel = relativeDayHour(departureIso: departureIso, now: now) else { return nil }
+        guard let entry = days.first(where: { $0.day == rel.day && $0.available && !$0.hours.isEmpty }),
+              let hour = nearestHour(entry.hours, rel.hour) else { return nil }
+        return RouteForecastSlot(day: rel.day, hour: hour, models: entry.models)
+    }
+
+    /// Short UTC label for a forecast valid-time ISO string, e.g. "Wed 12Z".
+    /// Empty for an unparseable / missing value.
+    static func formatForecastTime(_ iso: String?) -> String {
+        guard let iso, let d = parseISO(iso) else { return "" }
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = TimeZone(identifier: "UTC")!
+        let weekdays = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]
+        let wd = weekdays[(cal.component(.weekday, from: d) - 1) % 7]
+        let hour = cal.component(.hour, from: d)
+        return String(format: "%@ %02dZ", wd, hour)
+    }
+
+    /// Deep-link into the full forecast map seeded with the same slot/model/metric.
+    /// The model is passed through only for a supported individual model; a
+    /// consensus/other token is omitted so the full map uses its own default
+    /// (matches web `forecastMapUrl`).
+    static func deepLink(slot: RouteForecastSlot, model: String, metric: String) -> MapDeepLink {
+        MapDeepLink(
+            day: slot.day,
+            hour: slot.hour,
+            model: individualModels.contains(model) ? model : nil,
+            metric: metric,
+            airport: nil
+        )
+    }
+
+    /// Parse an ISO8601 instant, tolerating both the `…Z` and fractional-second
+    /// forms the API emits.
+    private static func parseISO(_ s: String) -> Date? {
+        let f = ISO8601DateFormatter()
+        if let d = f.date(from: s) { return d }
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return f.date(from: s)
+    }
+}
+
+/// The resolved overlay slot: the day/hour on the server grid nearest the flight,
+/// plus the models that carry airport data for it (used to decide whether the
+/// briefing's selected model can be drawn).
+struct RouteForecastSlot: Equatable {
+    let day: Int
+    let hour: Int
+    let models: [String]
+
+    /// Identity used to cache the fetched snapshot by slot.
+    var key: String { "\(day):\(hour)" }
+}

--- a/app/flyfun-weather/flyfun-weather/Views/Map/RouteMapKitView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Map/RouteMapKitView.swift
@@ -295,19 +295,9 @@ struct RouteMapKitView: UIViewRepresentable {
 
         /// Marker diameter from zoom — one step smaller than the full forecast
         /// map's so the airport dots stay secondary to the route (web parity).
+        /// Shares the zoom formula with the forecast map via `AirportMarkerSizing`.
         func forecastDiameter(for map: MKMapView) -> CGFloat {
-            let span = map.region.span.longitudeDelta
-            guard span > 0 else { return 12 }
-            let zoom = log2(360 / span)
-            let radius: CGFloat
-            switch zoom {
-            case ..<4.5: radius = 4
-            case ..<5.5: radius = 5
-            case ..<6.5: radius = 6
-            case ..<7.5: radius = 8
-            default: radius = 10
-            }
-            return radius * 2
+            AirportMarkerSizing.diameter(for: map, radii: [4, 5, 6, 8, 10], fallback: 12)
         }
     }
 }

--- a/app/flyfun-weather/flyfun-weather/Views/Map/RouteMapKitView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Map/RouteMapKitView.swift
@@ -61,6 +61,29 @@ struct RouteMapKitView: UIViewRepresentable {
     /// A waypoint marker was tapped (reports its ICAO).
     let onSelectWaypoint: (String) -> Void
 
+    // MARK: Airport-forecast overlay (#428)
+    //
+    // The per-airport forecast markers for the flight's nearest snapshot time,
+    // reusing the forecast map's `ForecastAnnotation` / `AirportMarkerView` and
+    // colour catalog so the two views can't disagree. Empty / hidden in commit 1.
+
+    /// Watchlist airports to draw (empty ⇒ nothing). Already filtered to the
+    /// current slot by `RouteMapView`; drawn only when `showForecastOverlay`.
+    let forecastAirports: [ForecastAirport]
+    /// Served colour/legend catalog; nil ⇒ overlay can't colour, so it's skipped.
+    let forecastCatalog: ForecastMapCatalog?
+    /// Active overlay metric (a `FORECAST_METRICS` id), independent of the
+    /// route-segment colour metric.
+    let forecastMetric: String
+    /// The briefing's selected individual model (gfs/icon/ecmwf) — the overlay
+    /// follows it, as on the web.
+    let forecastModel: String
+    /// User show/hide preference AND within-horizon+model-supported gating.
+    let showForecastOverlay: Bool
+    /// Bumped when the snapshot payload changes; markers rebuild on change. A
+    /// metric/model switch leaves it and is a pure recolour.
+    let forecastRevision: Int
+
     func makeCoordinator() -> Coordinator { Coordinator(self) }
 
     func makeUIView(context: Context) -> MKMapView {
@@ -74,6 +97,9 @@ struct RouteMapKitView: UIViewRepresentable {
                      forAnnotationViewWithReuseIdentifier: RouteActiveMarkerView.reuseID)
         map.register(RouteAircraftMarkerView.self,
                      forAnnotationViewWithReuseIdentifier: RouteAircraftMarkerView.reuseID)
+        // Airport-forecast markers reuse the forecast map's view class (#428).
+        map.register(AirportMarkerView.self,
+                     forAnnotationViewWithReuseIdentifier: AirportMarkerView.reuseID)
         map.setRegion(initialRegion, animated: false)
         context.coordinator.map = map
         return map
@@ -95,12 +121,29 @@ struct RouteMapKitView: UIViewRepresentable {
         private var activeAnnotation: RouteActiveAnnotation?
         private var aircraftAnnotation: RouteAircraftAnnotation?
 
+        // Airport-forecast overlay state (#428).
+        private var renderedForecastRevision: Int?
+        private var appliedForecastColorKey: ForecastColorKey?
+        private var currentForecastDiameter: CGFloat = 12
+        /// Whether airport markers are currently on the map — so a re-show after
+        /// the model regained data rebuilds even when the payload is unchanged.
+        private var markersShown = false
+
+        /// The inputs the airport markers colour from — a recolour is only needed
+        /// when one of these changes (not on every unrelated re-render).
+        private struct ForecastColorKey: Equatable {
+            let metric: String
+            let model: String
+            let visible: Bool
+        }
+
         init(_ parent: RouteMapKitView) { self.parent = parent }
 
         func update(parent: RouteMapKitView) {
             self.parent = parent
             guard let map else { return }
             updateRoute(on: map)
+            updateForecastOverlay(on: map)
             updateWaypoints(on: map)
             updateActivePoint(on: map)
             updateAircraft(on: map)
@@ -178,6 +221,94 @@ struct RouteMapKitView: UIViewRepresentable {
                 map.addAnnotation(a)
             }
         }
+
+        // MARK: Airport-forecast overlay (#428)
+
+        private func updateForecastOverlay(on map: MKMapView) {
+            let wantMarkers = parent.showForecastOverlay && !parent.forecastAirports.isEmpty
+            let payloadChanged = renderedForecastRevision != parent.forecastRevision
+            renderedForecastRevision = parent.forecastRevision
+
+            // Tear down when not wanted (toggled off, or the selected model lost
+            // data for this day). Rebuild when wanted and either the payload
+            // changed (new slot) or the markers aren't currently on the map (first
+            // show, or re-show after the model regained data). Otherwise leave the
+            // ~620 annotations in place — a metric/model change is a pure recolour.
+            if !wantMarkers {
+                if markersShown {
+                    let existing = map.annotations.compactMap { $0 as? ForecastAnnotation }
+                    map.removeAnnotations(existing)
+                    markersShown = false
+                }
+                return
+            }
+            if payloadChanged || !markersShown {
+                let existing = map.annotations.compactMap { $0 as? ForecastAnnotation }
+                map.removeAnnotations(existing)
+                map.addAnnotations(parent.forecastAirports.map(ForecastAnnotation.init))
+                markersShown = true
+                appliedForecastColorKey = nil  // fresh markers must be coloured
+            }
+
+            currentForecastDiameter = forecastDiameter(for: map)
+            let colorKey = ForecastColorKey(metric: parent.forecastMetric,
+                                            model: parent.forecastModel, visible: true)
+            if colorKey != appliedForecastColorKey {
+                appliedForecastColorKey = colorKey
+                recolorForecast(on: map)
+            }
+        }
+
+        /// Resize the airport dots to a new zoom without recolouring (web parity).
+        func resizeForecastMarkers(on map: MKMapView) {
+            let d = forecastDiameter(for: map)
+            guard d != currentForecastDiameter else { return }
+            currentForecastDiameter = d
+            for annotation in map.annotations {
+                guard let a = annotation as? ForecastAnnotation,
+                      let v = map.view(for: a) as? AirportMarkerView else { continue }
+                v.resize(diameter: d)
+            }
+        }
+
+        private func recolorForecast(on map: MKMapView) {
+            let mode = ForecastModelMode.model(parent.forecastModel)
+            for annotation in map.annotations {
+                guard let a = annotation as? ForecastAnnotation,
+                      let view = map.view(for: a) as? AirportMarkerView else { continue }
+                configureForecast(view, airport: a.airport, mode: mode)
+            }
+        }
+
+        /// One airport marker: the metric fill for the briefing's selected model,
+        /// with a matching hairline border (no agreement ring — that's a consensus
+        /// concept and the briefing overlay is always an individual model).
+        func configureForecast(_ view: AirportMarkerView, airport: ForecastAirport, mode: ForecastModelMode) {
+            let fill = parent.forecastCatalog?.color(metric: parent.forecastMetric, airport: airport, mode: mode)
+                ?? ForecastMapCatalog.muted
+            // Non-interactive on the briefing map so an airport dot never swallows
+            // a tap meant for a waypoint (the full forecast map owns tap-to-card).
+            view.isEnabled = false
+            view.apply(fill: fill, border: fill, borderWidth: 1,
+                       diameter: currentForecastDiameter, bringToFront: false)
+        }
+
+        /// Marker diameter from zoom — one step smaller than the full forecast
+        /// map's so the airport dots stay secondary to the route (web parity).
+        func forecastDiameter(for map: MKMapView) -> CGFloat {
+            let span = map.region.span.longitudeDelta
+            guard span > 0 else { return 12 }
+            let zoom = log2(360 / span)
+            let radius: CGFloat
+            switch zoom {
+            case ..<4.5: radius = 4
+            case ..<5.5: radius = 5
+            case ..<6.5: radius = 6
+            case ..<7.5: radius = 8
+            default: radius = 10
+            }
+            return radius * 2
+        }
     }
 }
 
@@ -212,6 +343,13 @@ extension RouteMapKitView.Coordinator: @preconcurrency MKMapViewDelegate {
                 withIdentifier: RouteAircraftMarkerView.reuseID, for: aircraft)
             (view as? RouteAircraftMarkerView)?.apply(headingDeg: aircraft.headingDeg, opacity: aircraft.opacity)
             return view
+        case let apt as ForecastAnnotation:
+            let view = mapView.dequeueReusableAnnotationView(
+                withIdentifier: AirportMarkerView.reuseID, for: apt)
+            if let marker = view as? AirportMarkerView {
+                configureForecast(marker, airport: apt.airport, mode: .model(parent.forecastModel))
+            }
+            return view
         default:
             return nil
         }
@@ -220,9 +358,15 @@ extension RouteMapKitView.Coordinator: @preconcurrency MKMapViewDelegate {
     func mapView(_ mapView: MKMapView, didSelect view: MKAnnotationView) {
         guard let wp = view.annotation as? RouteWaypointAnnotation else { return }
         // Drive selection from our callback, not MapKit's own selection state, so
-        // re-tapping the same waypoint always re-fires.
+        // re-tapping the same waypoint always re-fires. Airport-forecast dots are
+        // non-interactive here (the full forecast map owns tap-to-card).
         mapView.deselectAnnotation(wp, animated: false)
         parent.onSelectWaypoint(wp.icao)
+    }
+
+    func mapView(_ mapView: MKMapView, regionDidChangeAnimated animated: Bool) {
+        // Keep the airport dots legibly sized as the user zooms (web parity).
+        resizeForecastMarkers(on: mapView)
     }
 }
 

--- a/app/flyfun-weather/flyfun-weather/Views/Map/RouteMapKitView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Map/RouteMapKitView.swift
@@ -1,0 +1,362 @@
+import MapKit
+import SwiftUI
+import UIKit
+
+/// The briefing route map's rendering substrate, on **MKMapView** (`#428`).
+///
+/// The route map used to be a SwiftUI declarative `Map`; the forecast map is an
+/// imperative `MKMapView` (a deliberate choice — 619 SwiftUI `Annotation`s jank).
+/// To let the briefing map reuse the forecast map's marker machinery for the
+/// airport-forecast overlay (the iOS port of #424/#425) instead of a second,
+/// divergent renderer, both maps converge on `MKMapView` — mirroring the web,
+/// where both maps are one Leaflet `RouteMapRenderer`.
+///
+/// This view owns only the *rendering*; all the controls (metric picker(s),
+/// legend, altitude slider, waypoint sheet, deep-link focus) stay in
+/// `RouteMapView` as SwiftUI overlaid on top.
+///
+/// Layer order (bottom → top): base tiles · route overlays (grey base line + the
+/// metric-coloured segments) · annotations (waypoints, active point, aircraft,
+/// and — in commit 2 — the airport-forecast dots). NOTE: MapKit always draws
+/// annotations above overlay renderers, so the airport dots added later sit
+/// *above* the route line, the inverse of the web (which draws them beneath);
+/// they're kept small + semi-transparent so the route stays visually primary.
+struct RouteMapKitView: UIViewRepresentable {
+    /// One metric-coloured route segment (already reduced from its two endpoints
+    /// in `RouteMapView`, so this view stays pure rendering).
+    struct Segment {
+        let coords: [CLLocationCoordinate2D]
+        let color: UIColor
+        let width: CGFloat
+    }
+
+    /// Live aircraft state during in-flight tracking (nil when not tracking).
+    struct AircraftState: Equatable {
+        let coordinate: CLLocationCoordinate2D
+        let headingDeg: Double
+        let opacity: Double
+
+        static func == (l: AircraftState, r: AircraftState) -> Bool {
+            l.coordinate.latitude == r.coordinate.latitude
+                && l.coordinate.longitude == r.coordinate.longitude
+                && l.headingDeg == r.headingDeg && l.opacity == r.opacity
+        }
+    }
+
+    let routeCoordinates: [CLLocationCoordinate2D]
+    let segments: [Segment]
+    /// Cheap signature of the route overlays; they rebuild only when this changes,
+    /// so the many SwiftUI re-renders that don't touch the route (e.g. a tracking
+    /// tick moving only the aircraft) skip the overlay teardown/rebuild.
+    let routeSignature: String
+    let waypoints: [RouteMapViewModel.WaypointAnnotation]
+    let initialRegion: MKCoordinateRegion
+
+    /// Shared active route point (§4.7) — reflects the scrub point set on the
+    /// cross-section / Skew-T or by tapping a waypoint here. nil = none.
+    let activePoint: CLLocationCoordinate2D?
+    /// Live aircraft during tracking, or nil.
+    let aircraft: AircraftState?
+
+    /// A waypoint marker was tapped (reports its ICAO).
+    let onSelectWaypoint: (String) -> Void
+
+    func makeCoordinator() -> Coordinator { Coordinator(self) }
+
+    func makeUIView(context: Context) -> MKMapView {
+        let map = MKMapView()
+        map.delegate = context.coordinator
+        map.pointOfInterestFilter = .excludingAll
+        map.showsCompass = false
+        map.register(RouteWaypointMarkerView.self,
+                     forAnnotationViewWithReuseIdentifier: RouteWaypointMarkerView.reuseID)
+        map.register(RouteActiveMarkerView.self,
+                     forAnnotationViewWithReuseIdentifier: RouteActiveMarkerView.reuseID)
+        map.register(RouteAircraftMarkerView.self,
+                     forAnnotationViewWithReuseIdentifier: RouteAircraftMarkerView.reuseID)
+        map.setRegion(initialRegion, animated: false)
+        context.coordinator.map = map
+        return map
+    }
+
+    func updateUIView(_ map: MKMapView, context: Context) {
+        context.coordinator.update(parent: self)
+    }
+
+    // MARK: - Coordinator
+
+    @MainActor
+    final class Coordinator: NSObject {
+        var parent: RouteMapKitView
+        weak var map: MKMapView?
+
+        private var renderedRouteSignature: String?
+        private var renderedWaypointSignature: String?
+        private var activeAnnotation: RouteActiveAnnotation?
+        private var aircraftAnnotation: RouteAircraftAnnotation?
+
+        init(_ parent: RouteMapKitView) { self.parent = parent }
+
+        func update(parent: RouteMapKitView) {
+            self.parent = parent
+            guard let map else { return }
+            updateRoute(on: map)
+            updateWaypoints(on: map)
+            updateActivePoint(on: map)
+            updateAircraft(on: map)
+        }
+
+        // MARK: Route overlays
+
+        private func updateRoute(on map: MKMapView) {
+            guard renderedRouteSignature != parent.routeSignature else { return }
+            renderedRouteSignature = parent.routeSignature
+            map.removeOverlays(map.overlays)
+
+            if parent.routeCoordinates.count >= 2 {
+                let base = ColoredPolyline(coordinates: parent.routeCoordinates,
+                                           count: parent.routeCoordinates.count)
+                base.color = UIColor.systemGray.withAlphaComponent(0.4)
+                base.width = 2
+                map.addOverlay(base, level: .aboveRoads)
+            }
+            for seg in parent.segments where seg.coords.count >= 2 {
+                let line = ColoredPolyline(coordinates: seg.coords, count: seg.coords.count)
+                line.color = seg.color
+                line.width = seg.width
+                map.addOverlay(line, level: .aboveRoads)
+            }
+        }
+
+        // MARK: Waypoint annotations
+
+        private func updateWaypoints(on map: MKMapView) {
+            let sig = parent.waypoints.map(\.id).joined(separator: ",")
+            guard renderedWaypointSignature != sig else { return }
+            renderedWaypointSignature = sig
+            let existing = map.annotations.compactMap { $0 as? RouteWaypointAnnotation }
+            map.removeAnnotations(existing)
+            map.addAnnotations(parent.waypoints.map {
+                RouteWaypointAnnotation(icao: $0.id, coordinate: $0.coordinate)
+            })
+        }
+
+        // MARK: Active point (added / moved / removed in place)
+
+        private func updateActivePoint(on map: MKMapView) {
+            guard let coord = parent.activePoint else {
+                if let a = activeAnnotation { map.removeAnnotation(a); activeAnnotation = nil }
+                return
+            }
+            if let a = activeAnnotation {
+                a.coordinate = coord
+            } else {
+                let a = RouteActiveAnnotation(coordinate: coord)
+                activeAnnotation = a
+                map.addAnnotation(a)
+            }
+        }
+
+        // MARK: Aircraft (added / moved / removed in place)
+
+        private func updateAircraft(on map: MKMapView) {
+            guard let state = parent.aircraft else {
+                if let a = aircraftAnnotation { map.removeAnnotation(a); aircraftAnnotation = nil }
+                return
+            }
+            if let a = aircraftAnnotation {
+                a.coordinate = state.coordinate
+                a.headingDeg = state.headingDeg
+                a.opacity = state.opacity
+                if let v = map.view(for: a) as? RouteAircraftMarkerView {
+                    v.apply(headingDeg: state.headingDeg, opacity: state.opacity)
+                }
+            } else {
+                let a = RouteAircraftAnnotation(coordinate: state.coordinate,
+                                                headingDeg: state.headingDeg, opacity: state.opacity)
+                aircraftAnnotation = a
+                map.addAnnotation(a)
+            }
+        }
+    }
+}
+
+// MapKit calls the delegate on the main thread; `@preconcurrency` lets the
+// `@MainActor` coordinator satisfy the non-isolated delegate protocol (same
+// pattern as `ForecastMapKitView` / `FlightTrackingService`).
+extension RouteMapKitView.Coordinator: @preconcurrency MKMapViewDelegate {
+    func mapView(_ mapView: MKMapView, rendererFor overlay: MKOverlay) -> MKOverlayRenderer {
+        guard let line = overlay as? ColoredPolyline else {
+            return MKOverlayRenderer(overlay: overlay)
+        }
+        let r = MKPolylineRenderer(polyline: line)
+        r.strokeColor = line.color
+        r.lineWidth = line.width
+        r.lineCap = .round
+        r.lineJoin = .round
+        return r
+    }
+
+    func mapView(_ mapView: MKMapView, viewFor annotation: MKAnnotation) -> MKAnnotationView? {
+        switch annotation {
+        case let wp as RouteWaypointAnnotation:
+            let view = mapView.dequeueReusableAnnotationView(
+                withIdentifier: RouteWaypointMarkerView.reuseID, for: wp)
+            (view as? RouteWaypointMarkerView)?.configure(text: wp.icao)
+            return view
+        case is RouteActiveAnnotation:
+            return mapView.dequeueReusableAnnotationView(
+                withIdentifier: RouteActiveMarkerView.reuseID, for: annotation)
+        case let aircraft as RouteAircraftAnnotation:
+            let view = mapView.dequeueReusableAnnotationView(
+                withIdentifier: RouteAircraftMarkerView.reuseID, for: aircraft)
+            (view as? RouteAircraftMarkerView)?.apply(headingDeg: aircraft.headingDeg, opacity: aircraft.opacity)
+            return view
+        default:
+            return nil
+        }
+    }
+
+    func mapView(_ mapView: MKMapView, didSelect view: MKAnnotationView) {
+        guard let wp = view.annotation as? RouteWaypointAnnotation else { return }
+        // Drive selection from our callback, not MapKit's own selection state, so
+        // re-tapping the same waypoint always re-fires.
+        mapView.deselectAnnotation(wp, animated: false)
+        parent.onSelectWaypoint(wp.icao)
+    }
+}
+
+// MARK: - Overlay model
+
+/// An `MKPolyline` carrying its own stroke colour + width, so a single renderer
+/// draws both the grey base line and each metric-coloured segment.
+final class ColoredPolyline: MKPolyline {
+    var color: UIColor = .systemGray
+    var width: CGFloat = 8
+}
+
+// MARK: - Annotations
+
+/// A route waypoint (departure / turning point / destination).
+final class RouteWaypointAnnotation: NSObject, MKAnnotation {
+    let icao: String
+    @objc dynamic var coordinate: CLLocationCoordinate2D
+    var title: String? { icao }
+    init(icao: String, coordinate: CLLocationCoordinate2D) {
+        self.icao = icao
+        self.coordinate = coordinate
+    }
+}
+
+/// The shared active route point (orange ring).
+final class RouteActiveAnnotation: NSObject, MKAnnotation {
+    @objc dynamic var coordinate: CLLocationCoordinate2D
+    init(coordinate: CLLocationCoordinate2D) { self.coordinate = coordinate }
+}
+
+/// The live aircraft position during in-flight tracking.
+final class RouteAircraftAnnotation: NSObject, MKAnnotation {
+    @objc dynamic var coordinate: CLLocationCoordinate2D
+    var headingDeg: Double
+    var opacity: Double
+    init(coordinate: CLLocationCoordinate2D, headingDeg: Double, opacity: Double) {
+        self.coordinate = coordinate
+        self.headingDeg = headingDeg
+        self.opacity = opacity
+    }
+}
+
+// MARK: - Annotation views
+
+/// A small ICAO capsule marking a waypoint. `displayPriority = .required` so
+/// MapKit never declutters it (parity with the SwiftUI `Annotation` it replaces).
+final class RouteWaypointMarkerView: MKAnnotationView {
+    static let reuseID = "routeWaypoint"
+    private let label = UILabel()
+    private let background = UIView()
+
+    override init(annotation: MKAnnotation?, reuseIdentifier: String?) {
+        super.init(annotation: annotation, reuseIdentifier: reuseIdentifier)
+        canShowCallout = false
+        displayPriority = .required
+        collisionMode = .none
+        background.backgroundColor = UIColor.secondarySystemBackground.withAlphaComponent(0.92)
+        background.layer.cornerRadius = 6
+        background.layer.borderWidth = 1
+        background.layer.borderColor = UIColor.separator.cgColor
+        label.font = .systemFont(ofSize: 11, weight: .semibold)
+        label.textColor = .label
+        label.textAlignment = .center
+        addSubview(background)
+        addSubview(label)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    /// Manual layout (no Auto Layout — annotation views resize awkwardly under it).
+    func configure(text: String) {
+        label.text = text
+        label.sizeToFit()
+        let padX: CGFloat = 6, padY: CGFloat = 3
+        let w = label.bounds.width + padX * 2
+        let h = label.bounds.height + padY * 2
+        bounds = CGRect(x: 0, y: 0, width: w, height: h)
+        background.frame = bounds
+        label.frame = CGRect(x: padX, y: padY, width: label.bounds.width, height: label.bounds.height)
+        centerOffset = .zero
+    }
+}
+
+/// The shared active point: a translucent orange disc with a bold orange ring.
+final class RouteActiveMarkerView: MKAnnotationView {
+    static let reuseID = "routeActive"
+
+    override init(annotation: MKAnnotation?, reuseIdentifier: String?) {
+        super.init(annotation: annotation, reuseIdentifier: reuseIdentifier)
+        canShowCallout = false
+        isUserInteractionEnabled = false
+        displayPriority = .required
+        collisionMode = .none
+        bounds = CGRect(x: 0, y: 0, width: 22, height: 22)
+        backgroundColor = UIColor.systemOrange.withAlphaComponent(0.20)
+        layer.cornerRadius = 11
+        layer.borderColor = UIColor.systemOrange.cgColor
+        layer.borderWidth = 3
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+}
+
+/// The live aircraft glyph, rotated to track heading and faded by projection
+/// confidence (opacity), matching the SwiftUI version it replaces.
+final class RouteAircraftMarkerView: MKAnnotationView {
+    static let reuseID = "routeAircraft"
+    private let imageView = UIImageView()
+
+    override init(annotation: MKAnnotation?, reuseIdentifier: String?) {
+        super.init(annotation: annotation, reuseIdentifier: reuseIdentifier)
+        canShowCallout = false
+        isUserInteractionEnabled = false
+        displayPriority = .required
+        collisionMode = .none
+        bounds = CGRect(x: 0, y: 0, width: 34, height: 34)
+        let cfg = UIImage.SymbolConfiguration(pointSize: 26, weight: .bold)
+        imageView.image = UIImage(systemName: "airplane", withConfiguration: cfg)
+        imageView.tintColor = .systemOrange
+        imageView.contentMode = .center
+        imageView.frame = bounds
+        addSubview(imageView)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    /// Rotate the glyph (heading is degrees true; the symbol points up = 90°) and
+    /// fade it to the projection opacity.
+    func apply(headingDeg: Double, opacity: Double) {
+        imageView.transform = CGAffineTransform(rotationAngle: CGFloat((headingDeg - 90) * .pi / 180))
+        alpha = CGFloat(opacity)
+    }
+}

--- a/app/flyfun-weather/flyfun-weather/Views/Map/RouteMapView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Map/RouteMapView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import MapKit
+import UIKit
 
 /// Native MapKit map (§4.9). Earns its tab by being geographic — *where* along
 /// the route a hazard sits, on real terrain. Tier 1: per-segment metric overlay
@@ -92,66 +93,39 @@ struct RouteMapView: View {
     // MARK: Map
 
     private var mapContent: some View {
+        // Reading the tracking count keeps SwiftUI re-rendering (hence pushing a
+        // fresh `aircraft` into the representable) as the position updates.
         let _ = trackingService.locationUpdateCount
-        let isTracking = trackingService.isTracking
-        let aircraftLocation = trackingService.currentLocation
-        let aircraftOpacity = trackingService.projectedPosition?.opacity ?? 0.3
-        let aircraftHeading = trackingService.projectedPosition?.headingDeg ?? 0
-        let segs = segments()
-        let activeCoord = activePointCoordinate
-
-        return Map(initialPosition: .region(mapVM.mapRegion)) {
-            // Base route line under the metric segments.
-            MapPolyline(coordinates: mapVM.routeCoordinates)
-                .stroke(.gray.opacity(0.4), lineWidth: 2)
-
-            // Metric-coloured segments (colour + width = the metric).
-            ForEach(segs) { seg in
-                MapPolyline(coordinates: seg.coords)
-                    .stroke(seg.color, style: StrokeStyle(lineWidth: seg.width, lineCap: .round))
+        return RouteMapKitView(
+            routeCoordinates: mapVM.routeCoordinates,
+            segments: segments(),
+            routeSignature: routeSignature,
+            waypoints: mapVM.waypoints,
+            initialRegion: mapVM.mapRegion,
+            activePoint: activePointCoordinate,
+            aircraft: aircraftState,
+            onSelectWaypoint: { icao in
+                if let wp = mapVM.waypoints.first(where: { $0.id == icao }) { selectWaypoint(wp) }
             }
+        )
+        .ignoresSafeArea(edges: .bottom)
+    }
 
-            ForEach(mapVM.waypoints) { wp in
-                Annotation(wp.id, coordinate: wp.coordinate) {
-                    Button { selectWaypoint(wp) } label: {
-                        VStack(spacing: 2) {
-                            Text(wp.id)
-                                .font(.caption2.bold())
-                                .padding(.horizontal, 4).padding(.vertical, 2)
-                                .background(.ultraThinMaterial, in: Capsule())
-                            Circle().fill(Theme.primary).frame(width: 8, height: 8)
-                        }
-                    }
-                    .buttonStyle(.plain)
-                }
-            }
+    /// Live aircraft state for the representable, or nil when not tracking.
+    private var aircraftState: RouteMapKitView.AircraftState? {
+        guard trackingService.isTracking, let location = trackingService.currentLocation else { return nil }
+        return RouteMapKitView.AircraftState(
+            coordinate: location.coordinate,
+            headingDeg: trackingService.projectedPosition?.headingDeg ?? 0,
+            opacity: trackingService.projectedPosition?.opacity ?? 0.3
+        )
+    }
 
-            // Shared active point (§4.7) — reflects the scrub point set on the
-            // cross-section / Skew-T or by tapping a waypoint here.
-            if let activeCoord {
-                Annotation("", coordinate: activeCoord, anchor: .center) {
-                    ZStack {
-                        Circle().fill(.orange.opacity(0.20))
-                        Circle().stroke(.orange, lineWidth: 3)
-                    }
-                    .frame(width: 22, height: 22)
-                }
-                .annotationTitles(.hidden)
-            }
-
-            if isTracking, let location = aircraftLocation {
-                Annotation("", coordinate: location.coordinate, anchor: .center) {
-                    Image(systemName: "airplane")
-                        .font(.system(size: 28, weight: .bold))
-                        .foregroundStyle(.orange)
-                        .rotationEffect(.degrees(aircraftHeading - 90))
-                        .opacity(aircraftOpacity)
-                        .shadow(color: .black.opacity(0.5), radius: 3)
-                }
-                .annotationTitles(.hidden)
-            }
-        }
-        .mapStyle(.standard)  // follows the app's light/dark appearance natively
+    /// Cheap identity of the route overlays — the representable rebuilds segment
+    /// overlays only when this changes (not on every unrelated re-render, e.g. a
+    /// tracking tick that moves only the aircraft).
+    private var routeSignature: String {
+        "\(colorMetricId)|\(usesDualMetrics ? widthMetricId : colorMetricId)|\(Int(effectiveAltitudeFt))|\(viewModel.selectedModel)|\(vizData?.points.count ?? 0)"
     }
 
     // MARK: Controls (metric picker(s) · legend · altitude slider)
@@ -243,34 +217,26 @@ struct RouteMapView: View {
 
     // MARK: Segment building
 
-    private struct MapSegment: Identifiable {
-        let id: Int
-        let coords: [CLLocationCoordinate2D]
-        let color: Color
-        let width: Double
-    }
-
-    private func segments() -> [MapSegment] {
+    private func segments() -> [RouteMapKitView.Segment] {
         guard let colorMetric, let points = vizData?.points, points.count >= 2 else { return [] }
         let widthMetric = self.widthMetric
         let colorAlt: Double? = colorMetric.altitudeDependent ? effectiveAltitudeFt : nil
         let widthAlt: Double? = (widthMetric?.altitudeDependent ?? false) ? effectiveAltitudeFt : nil
 
-        var out: [MapSegment] = []
+        var out: [RouteMapKitView.Segment] = []
         for i in 0..<(points.count - 1) {
             let a = points[i], b = points[i + 1]
             // Risk/ordinal metrics take the worst endpoint (never average the
             // peak away); continuous metrics average — see MapMetric.aggregation.
             guard let colorValue = colorMetric.segmentValue(a, b, altitudeFt: colorAlt) else { continue }
             let widthValue = widthMetric?.segmentValue(a, b, altitudeFt: widthAlt)
-            out.append(MapSegment(
-                id: i,
+            out.append(RouteMapKitView.Segment(
                 coords: [
                     CLLocationCoordinate2D(latitude: a.lat, longitude: a.lon),
                     CLLocationCoordinate2D(latitude: b.lat, longitude: b.lon),
                 ],
-                color: colorMetric.color(colorValue),
-                width: widthMetric.flatMap { m in widthValue.map { m.width($0) } } ?? 8
+                color: UIColor(colorMetric.color(colorValue)),
+                width: widthMetric.flatMap { m in widthValue.map { CGFloat(m.width($0)) } } ?? 8
             ))
         }
         return out

--- a/app/flyfun-weather/flyfun-weather/Views/Map/RouteMapView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Map/RouteMapView.swift
@@ -23,6 +23,15 @@ struct RouteMapView: View {
     /// drags don't re-run the full route-analysis mapping on every render.
     @State private var vizData: VizRouteData?
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+    @Environment(AppState.self) private var appState
+
+    // Airport-forecast overlay (#428): the same per-airport markers the full
+    // forecast map draws, for the snapshot nearest the flight time.
+    /// Day grid + per-slot snapshot; created on appear from the repository.
+    @State private var overlayModel: RouteForecastOverlayModel?
+    /// Persisted overlay prefs (mirror the web localStorage keys). Default on.
+    @AppStorage("mapForecastOverlayVisible") private var forecastOverlayVisible = true
+    @AppStorage("mapForecastMetric") private var forecastMetricRaw = "flight_category"
 
     /// iPad (regular width) drives colour and width from independent metrics.
     private var usesDualMetrics: Bool { horizontalSizeClass == .regular }
@@ -88,6 +97,18 @@ struct RouteMapView: View {
             applyFocusIntent()
         }
         .sheet(item: $selectedWaypoint) { waypointSheet($0) }
+        .task {
+            // Create the overlay model + lazy-load the server day grid once; when it
+            // lands, `overlaySlot` resolves and the slice task below fires.
+            if overlayModel == nil, let repo = appState.repository {
+                overlayModel = RouteForecastOverlayModel(repository: repo)
+            }
+            await overlayModel?.loadDaysIfNeeded()
+        }
+        .task(id: overlaySliceKey) {
+            guard forecastOverlayVisible, let slot = overlaySlot else { return }
+            await overlayModel?.ensureSlice(slot)
+        }
     }
 
     // MARK: Map
@@ -106,7 +127,13 @@ struct RouteMapView: View {
             aircraft: aircraftState,
             onSelectWaypoint: { icao in
                 if let wp = mapVM.waypoints.first(where: { $0.id == icao }) { selectWaypoint(wp) }
-            }
+            },
+            forecastAirports: overlayAirports,
+            forecastCatalog: overlayCatalog,
+            forecastMetric: overlayMetric,
+            forecastModel: viewModel.selectedModel,
+            showForecastOverlay: forecastOverlayVisible && overlayModelSupported,
+            forecastRevision: overlayModel?.payloadRevision ?? 0
         )
         .ignoresSafeArea(edges: .bottom)
     }
@@ -128,6 +155,48 @@ struct RouteMapView: View {
         "\(colorMetricId)|\(usesDualMetrics ? widthMetricId : colorMetricId)|\(Int(effectiveAltitudeFt))|\(viewModel.selectedModel)|\(vizData?.points.count ?? 0)"
     }
 
+    // MARK: Airport-forecast overlay (#428)
+
+    /// Served colour/legend catalog (bundled fallback until the first sync).
+    private var overlayCatalog: ForecastMapCatalog? { appState.helpCatalog.mapsCatalog }
+
+    /// The overlay slot for this flight, or nil when the grid hasn't loaded or the
+    /// flight is outside the server-advertised D-0..D-6 horizon (overlay not offered).
+    private var overlaySlot: RouteForecastSlot? {
+        overlayModel?.slot(departureTime: viewModel.flight.departureTime)
+    }
+
+    /// The overlay metric, validated against the served catalog — a stale persisted
+    /// id falls back to flight_category rather than colouring nothing.
+    private var overlayMetric: String {
+        guard let catalog = overlayCatalog, catalog.metrics[forecastMetricRaw] != nil else { return "flight_category" }
+        return forecastMetricRaw
+    }
+
+    /// The briefing's selected model has airport data for this day. When false the
+    /// overlay is empty because of the model, not the weather — the controls show a
+    /// note instead of the metric/time so a blank map never reads as "all clear".
+    private var overlayModelSupported: Bool {
+        guard let slot = overlaySlot else { return false }
+        return slot.models.contains(viewModel.selectedModel)
+    }
+
+    /// Airports to draw — only within the horizon, toggled on, and with model data;
+    /// otherwise empty (hidden), never muted-grey.
+    private var overlayAirports: [ForecastAirport] {
+        guard forecastOverlayVisible, overlayModelSupported, let slot = overlaySlot,
+              let airports = overlayModel?.airports(for: slot) else { return [] }
+        return airports
+    }
+
+    /// `.task(id:)` key for lazily fetching the slice: changes when the slot first
+    /// resolves (grid lands) or the toggle flips on. Metric/model changes don't
+    /// refetch (the payload holds every model — a pure recolour).
+    private var overlaySliceKey: String {
+        guard forecastOverlayVisible, let slot = overlaySlot else { return "off" }
+        return slot.key
+    }
+
     // MARK: Controls (metric picker(s) · legend · altitude slider)
 
     private var controls: some View {
@@ -140,6 +209,9 @@ struct RouteMapView: View {
                 Spacer()
             }
 
+            // Airport-forecast overlay controls — only within the forecast horizon.
+            if overlaySlot != nil { forecastOverlayControls }
+
             if let colorMetric {
                 legend(colorMetric)
                 if needsAltitude { altitudeSlider }
@@ -147,6 +219,91 @@ struct RouteMapView: View {
             Spacer()
         }
         .padding(Theme.spacingM)
+    }
+
+    /// Airport-forecast overlay controls (#428): toggle · metric picker + valid-time
+    /// label (or a "no model data" note) · open-full-forecast-map deep link.
+    private var forecastOverlayControls: some View {
+        HStack(spacing: Theme.spacingS) {
+            Button {
+                forecastOverlayVisible.toggle()
+            } label: {
+                HStack(spacing: 4) {
+                    Image(systemName: forecastOverlayVisible ? "checkmark.circle.fill" : "circle")
+                    Text("Airports")
+                }
+                .font(.caption.weight(.medium))
+                .padding(.horizontal, 10).padding(.vertical, 6)
+                .background(.ultraThinMaterial, in: Capsule())
+            }
+            .buttonStyle(.plain)
+
+            if forecastOverlayVisible {
+                if overlayModelSupported {
+                    overlayMetricMenu
+                    let timeLabel = overlayModel?.forecastTimeLabel ?? ""
+                    Text(timeLabel.isEmpty ? "…" : timeLabel)
+                        .font(.tabularData(.caption2)).foregroundStyle(Theme.textMuted)
+                } else {
+                    // Empty because the selected model has no airport data for this
+                    // day, not because the weather is clear — say so.
+                    Text("No \(viewModel.selectedModel.uppercased()) data")
+                        .font(.caption2).italic().foregroundStyle(Theme.textMuted)
+                }
+            }
+
+            Spacer()
+
+            Button { openFullForecastMap() } label: {
+                Image(systemName: "map")
+                    .font(.caption.weight(.medium))
+                    .padding(8)
+                    .background(.ultraThinMaterial, in: Circle())
+            }
+            .accessibilityLabel("Open full forecast map")
+        }
+    }
+
+    /// Overlay metric picker — reuses the forecast map's "question" sections,
+    /// filtered to metrics the served catalog defines. Independent of the
+    /// route-segment colour metric.
+    private var overlayMetricMenu: some View {
+        Menu {
+            ForEach(ForecastMapView.metricSections, id: \.title) { section in
+                Section(section.title) {
+                    ForEach(section.items, id: \.metric) { item in
+                        if overlayCatalog?.metrics[item.metric] != nil {
+                            Button {
+                                forecastMetricRaw = item.metric
+                            } label: {
+                                if item.metric == overlayMetric {
+                                    Label(item.label, systemImage: "checkmark")
+                                } else {
+                                    Text(item.label)
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        } label: {
+            HStack(spacing: 4) {
+                Image(systemName: "cloud.sun")
+                Text(overlayCatalog?.label(metric: overlayMetric) ?? "Metric")
+                Image(systemName: "chevron.down").font(.caption2)
+            }
+            .font(.caption.weight(.medium))
+            .padding(.horizontal, 10).padding(.vertical, 6)
+            .background(.ultraThinMaterial, in: Capsule())
+        }
+    }
+
+    /// Deep-link into the full forecast map seeded with this slot/model/metric,
+    /// via the existing `PendingNavigation.forecastMap` seam.
+    private func openFullForecastMap() {
+        guard let slot = overlaySlot else { return }
+        let link = RouteForecastOverlay.deepLink(slot: slot, model: viewModel.selectedModel, metric: overlayMetric)
+        appState.pendingNavigation = .forecastMap(link)
     }
 
     private func metricMenu(title: String, systemImage: String, selection: Binding<String>) -> some View {

--- a/app/flyfun-weather/flyfun-weather/Views/Shared/AirportMarkerSizing.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Shared/AirportMarkerSizing.swift
@@ -1,0 +1,26 @@
+import MapKit
+import UIKit
+
+/// Shared zoom→marker-diameter bucketing for the airport dots, so the full
+/// forecast map (`ForecastMapKitView`) and the briefing route-map overlay
+/// (`RouteMapKitView`) can't drift on the `log2(360/span)` zoom formula — they
+/// only differ in the per-bucket radii (#429 review).
+///
+/// `radii` are the five per-bucket radii, smallest→largest zoom; `fallback` is
+/// the diameter used before the map has a valid span.
+enum AirportMarkerSizing {
+    static func diameter(for map: MKMapView, radii: [CGFloat], fallback: CGFloat) -> CGFloat {
+        let span = map.region.span.longitudeDelta
+        guard span > 0, radii.count == 5 else { return fallback }
+        let zoom = log2(360 / span)
+        let idx: Int
+        switch zoom {
+        case ..<4.5: idx = 0
+        case ..<5.5: idx = 1
+        case ..<6.5: idx = 2
+        case ..<7.5: idx = 3
+        default: idx = 4
+        }
+        return radii[idx] * 2
+    }
+}

--- a/app/flyfun-weather/flyfun-weatherTests/RouteForecastOverlayTests.swift
+++ b/app/flyfun-weather/flyfun-weatherTests/RouteForecastOverlayTests.swift
@@ -1,0 +1,149 @@
+//
+//  RouteForecastOverlayTests.swift
+//  flyfun-weatherTests
+//
+//  Unit tests for the briefing route-map airport-forecast overlay slot helpers
+//  (#428) — the iOS mirror of web/tests/unit/forecast-overlay.test.ts: relative
+//  UTC-day computation, nearest-sample-hour snapping honouring the ragged grid,
+//  valid-time formatting, and full-map deep-link building.
+//
+
+import Foundation
+import Testing
+@testable import flyfun_weather
+
+@Suite("RouteForecastOverlay")
+struct RouteForecastOverlayTests {
+
+    // 2026-07-15T08:00Z, matching the web test's NOW.
+    static let now = Date(timeIntervalSince1970: 1_784_102_400)
+
+    // A representative (non-rectangular) grid: near days carry the fine hour set
+    // and all three models; D+6 is coarse (6/12/18) with ICON dropped; D+5 absent.
+    static let days: [ForecastDay] = [
+        ForecastDay(day: 0, date: "2026-07-15", available: true, hours: [6, 9, 12, 15, 18], models: ["gfs", "icon", "ecmwf"]),
+        ForecastDay(day: 3, date: "2026-07-18", available: true, hours: [6, 9, 12, 15, 18], models: ["gfs", "icon", "ecmwf"]),
+        ForecastDay(day: 5, date: "2026-07-20", available: false, hours: [], models: []),
+        ForecastDay(day: 6, date: "2026-07-21", available: true, hours: [6, 12, 18], models: ["gfs", "ecmwf"]),
+    ]
+
+    // MARK: relativeDayHour
+
+    @Test("today → day 0, UTC hour")
+    func relativeToday() {
+        let r = RouteForecastOverlay.relativeDayHour(departureIso: "2026-07-15T14:30:00Z", now: Self.now)
+        #expect(r?.day == 0)
+        #expect(r?.hour == 14)
+    }
+
+    @Test("future day difference in UTC calendar days")
+    func relativeFuture() {
+        let r = RouteForecastOverlay.relativeDayHour(departureIso: "2026-07-18T09:00:00Z", now: Self.now)
+        #expect(r?.day == 3)
+        #expect(r?.hour == 9)
+    }
+
+    @Test("past flight → negative day")
+    func relativePast() {
+        let r = RouteForecastOverlay.relativeDayHour(departureIso: "2026-07-14T12:00:00Z", now: Self.now)
+        #expect(r?.day == -1)
+        #expect(r?.hour == 12)
+    }
+
+    @Test("nil / garbage → nil")
+    func relativeNil() {
+        #expect(RouteForecastOverlay.relativeDayHour(departureIso: nil, now: Self.now) == nil)
+        #expect(RouteForecastOverlay.relativeDayHour(departureIso: "not-a-date", now: Self.now) == nil)
+    }
+
+    // MARK: nearestHour
+
+    @Test("snaps to the closest offered hour")
+    func nearestSnaps() {
+        #expect(RouteForecastOverlay.nearestHour([6, 12, 18], 14) == 12)
+        #expect(RouteForecastOverlay.nearestHour([6, 9, 12, 15, 18], 13) == 12)
+        #expect(RouteForecastOverlay.nearestHour([6, 9, 12, 15, 18], 0) == 6)
+        #expect(RouteForecastOverlay.nearestHour([6, 9, 12, 15, 18], 23) == 18)
+    }
+
+    @Test("ties resolve to the earlier hour")
+    func nearestTie() {
+        #expect(RouteForecastOverlay.nearestHour([6, 12, 18], 15) == 12) // equidistant 12/18 → 12
+    }
+
+    @Test("empty list → nil")
+    func nearestEmpty() {
+        #expect(RouteForecastOverlay.nearestHour([], 12) == nil)
+    }
+
+    // MARK: resolveSlot
+
+    @Test("snaps the departure hour to the day's offered hours")
+    func resolveNearDay() {
+        let slot = RouteForecastOverlay.resolveSlot(departureIso: "2026-07-15T14:00:00Z", days: Self.days, now: Self.now)
+        #expect(slot?.day == 0)
+        #expect(slot?.hour == 15)
+        #expect(slot?.models == ["gfs", "icon", "ecmwf"])
+    }
+
+    @Test("honours the coarse hour grid on the far day (not the fine set)")
+    func resolveFarDay() {
+        // A D+6 flight at 14Z must snap to 12 (the coarse grid), never 15.
+        let slot = RouteForecastOverlay.resolveSlot(departureIso: "2026-07-21T14:00:00Z", days: Self.days, now: Self.now)
+        #expect(slot?.day == 6)
+        #expect(slot?.hour == 12)
+        #expect(slot?.models == ["gfs", "ecmwf"])
+    }
+
+    @Test("returns nil beyond the advertised horizon")
+    func resolveBeyondHorizon() {
+        #expect(RouteForecastOverlay.resolveSlot(departureIso: "2026-07-22T12:00:00Z", days: Self.days, now: Self.now) == nil) // day 7 absent
+    }
+
+    @Test("returns nil for a day present but not available")
+    func resolveUnavailableDay() {
+        #expect(RouteForecastOverlay.resolveSlot(departureIso: "2026-07-20T12:00:00Z", days: Self.days, now: Self.now) == nil) // day 5 available:false
+    }
+
+    @Test("returns nil for a past flight")
+    func resolvePast() {
+        #expect(RouteForecastOverlay.resolveSlot(departureIso: "2026-07-14T12:00:00Z", days: Self.days, now: Self.now) == nil)
+    }
+
+    // MARK: formatForecastTime
+
+    @Test("formats as \"<weekday> <HH>Z\" in UTC")
+    func formatTime() {
+        #expect(RouteForecastOverlay.formatForecastTime("1970-01-01T00:00:00Z") == "Thu 00Z") // epoch = Thursday
+        #expect(RouteForecastOverlay.formatForecastTime("1970-01-04T15:00:00Z") == "Sun 15Z")
+    }
+
+    @Test("empty string for an unparseable / nil value")
+    func formatTimeInvalid() {
+        #expect(RouteForecastOverlay.formatForecastTime("nope") == "")
+        #expect(RouteForecastOverlay.formatForecastTime(nil) == "")
+    }
+
+    // MARK: deepLink
+
+    @Test("passes a supported individual model through as fc.model")
+    func deepLinkIndividual() {
+        let slot = RouteForecastSlot(day: 2, hour: 12, models: ["gfs", "icon", "ecmwf"])
+        let link = RouteForecastOverlay.deepLink(slot: slot, model: "ecmwf", metric: "flight_category")
+        #expect(link.day == 2)
+        #expect(link.hour == 12)
+        #expect(link.model == "ecmwf")
+        #expect(link.metric == "flight_category")
+        #expect(link.airport == nil)
+    }
+
+    @Test("omits fc.model for an unsupported model (full map uses its default)")
+    func deepLinkUnsupported() {
+        let slot = RouteForecastSlot(day: 2, hour: 12, models: ["gfs", "icon", "ecmwf"])
+        let ukmo = RouteForecastOverlay.deepLink(slot: slot, model: "ukmo", metric: "wind_speed_kt")
+        #expect(ukmo.model == nil)
+        #expect(ukmo.metric == "wind_speed_kt")
+        let worst = RouteForecastOverlay.deepLink(slot: slot, model: "worst", metric: "flight_category")
+        #expect(worst.model == nil)
+    }
+}

--- a/designs/ios-app-architecture.md
+++ b/designs/ios-app-architecture.md
@@ -10,7 +10,7 @@
 | **UI** | **SwiftUI** | Native, declarative. No UIKit wrappers unless absolutely necessary. |
 | **Persistence** | **File-based JSON + UserDefaults** | No SwiftData. `BriefingCacheStore` (actor, on-disk pack cache under Application Support), `PirepOfflineStore` (JSON queue in Documents), `UserPreferencesStore` (UserDefaults). Simpler than a DB for our cache-the-pack model. |
 | **Networking** | **URLSession + async/await** | Built-in, no third-party dep. SSE refresh via `URLSession.bytes`. |
-| **Maps** | **MapKit (SwiftUI Map)** | iOS 17+ API, offline tiles, sufficient. |
+| **Maps** | **MapKit (`MKMapView` via `UIViewRepresentable`)** | Both the briefing route map and the forecast map are `MKMapView`-backed (converged in #428) so the airport-forecast marker layer is shared, not duplicated per map — the SwiftUI `Map` API janks at the forecast map's ~620-annotation scale. |
 | **Architecture** | **MVVM + Repository** | Natural fit for SwiftUI. Repos abstract API vs cache — offline-ready from day one. |
 | **Cross-section** | **SwiftUI Canvas** | Immediate-mode 2D, equivalent to HTML Canvas. No WKWebView. |
 | **Route graph** | **Swift Charts** | 2D charts, dual axes, extensible. |


### PR DESCRIPTION
## What & why

Brings the web briefing-map airport-forecast overlay (#424 / #425) to the iOS app: the same per-airport forecast markers the forecast map draws, overlaid on the **briefing route map** for the forecast snapshot nearest the flight — a geographic, at-a-glance picture of conditions around the flight without leaving the briefing.

On the web this was cheap because both maps are one Leaflet renderer, so the overlay is a shared layer. On iOS the two maps were on **different MapKit APIs** (briefing = SwiftUI `Map`; forecast = imperative `MKMapView`), so the reuse had to start by converging them. This PR does that, then adds the feature — as **two commits**:

### Commit 1 — migrate the briefing route map to MKMapView (parity)
New `RouteMapKitView` (`UIViewRepresentable` + coordinator, mirroring `ForecastMapKitView`). Route drawn as overlays (grey base line + metric-coloured/width segments via a `ColoredPolyline`); waypoints, shared active point, and live aircraft as annotations. `RouteMapView` keeps every existing SwiftUI control (metric picker(s), legend, altitude slider, waypoint sheet, deep-link focus intent). No behaviour change intended — this is the groundwork that lets both maps share one renderer, matching the web.

We converged on **MKMapView** (not SwiftUI `Map`) because it's the framework that already solves the dense-marker workload the feature needs — 619 markers, tappable, recolourable, zoom-scaled. Moving the simpler map onto the more capable one is the low-risk direction.

### Commit 2 — airport forecast overlay (the #424 feature)
A new airport-marker layer on `RouteMapKitView` reuses the forecast map's `ForecastAnnotation` / `AirportMarkerView` and the served `ForecastMapCatalog` for colours, so the two views can't disagree. Snapshot fetched via the existing `repository.forecastMap(day:hour:)` / `forecastDays()` (**no backend change**), cached by slot; switching the briefing model or the overlay metric is a pure client recolour off the one payload.

- Follows the briefing's selected **individual model** (gfs/icon/ecmwf). When that model has no airport data for the day, the overlay hides with a note rather than rendering muted-grey (matches web / `forecast-page.md`).
- Offered only within the server-advertised **D-0…D-6** horizon (read from `forecastDays()`, never hardcoded); outside it the control cluster is hidden and nothing is drawn.
- Controls: on/off toggle (default on, persisted via `@AppStorage`), a metric picker independent of the route-segment colour metric, a forecast valid-time label, and an **open full forecast map** button that deep-links via the existing `PendingNavigation.forecastMap(MapDeepLink)` seam seeded with day/hour/model/metric.
- New pure slot helper `RouteForecastOverlay` (port of `web/ts/visualization/route-map/forecast-overlay.ts`): relative-UTC-day math, nearest-sample-hour snapping on the ragged grid, valid-time formatting, deep-link building.

**Reuse (no backend changes):** `ForecastMapResponse` / `ForecastDaysResponse` models, `forecastMap`/`forecastDays` repository methods (online + cached + fixture), `ForecastMapCatalog` (served `/api/help/catalog` colour catalog), the forecast map's metric "question" sections, and the `MapDeepLink` / `openForecastMap` navigation path.

**Note (z-order):** MapKit always draws annotations above overlay renderers, so the airport dots sit *above* the route line on iOS — the inverse of the web, which draws them beneath. They're kept small + semi-transparent so the route stays visually primary. **Deferred** (as on web): swapping the overlay to current METAR when the flight time is effectively *now*. **Scoped out of v1:** a separate floating overlay legend (the route already shows a segment legend; the full map — one tap away — carries the overlay legend).

## Issue linkage

Closes #428

## Testing / verification

- **⚠️ Not compiled in this environment** — there is no Swift/Xcode toolchain on the Linux session this was written in. The code follows the existing `ForecastMapKitView` / forecast-map patterns closely, but it **needs an Xcode build + simulator/device pass** before merge. Please build and exercise: briefing map renders at parity (segments, waypoints, active-point sync with the cross-section, live aircraft during a tracked flight), then the overlay (toggle, metric switch = instant recolour, model switch, out-of-horizon flight hides the cluster, "open full forecast map" lands on the seeded day/hour/model/metric).
- Added `RouteForecastOverlayTests` (Swift Testing) mirroring the web's `forecast-overlay.test.ts` — relative UTC day, nearest-hour snapping on the ragged grid (incl. the D+6 coarse-grid case and past/beyond-horizon nils), valid-time formatting, and deep-link building. Not run here (no toolchain).
- New files land automatically via the project's `PBXFileSystemSynchronizedRootGroup` (no `.pbxproj` edit needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FCoEeCAGHg4CaebKVzG1YJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01FCoEeCAGHg4CaebKVzG1YJ)_