### PR TITLE
feat(ios): debrief + digest thumbs feedback (#430)

### DIFF
--- a/.claude/skills/sync-ios-web/SKILL.md
+++ b/.claude/skills/sync-ios-web/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sync-ios-web
-description: Audit web↔iOS consistency for hand-copied surfaces (preset tables, metrics-catalog, API DTOs) and surface divergences as an actionable task list. Run after a feature that touched one platform, before merge, or any time the two clients may have drifted.
+description: Audit web↔iOS consistency for hand-copied surfaces (preset tables, metrics-catalog, debrief taxonomy, API DTOs) and surface divergences as an actionable task list. Run after a feature that touched one platform, before merge, or any time the two clients may have drifted.
 ---
 
 # Sync iOS ↔ Web
@@ -78,7 +78,30 @@ Report field name / optionality / nesting mismatches. Prioritise fields present
 in the backend (or web) but **missing or non-optional in Swift** — those are the
 runtime-decode hazards. A field the server may omit must be `Optional` on iOS.
 
-### 4. Known parity gaps (informational)
+### 4. Debrief taxonomy — three-way copy
+
+The debrief vocabulary (condition tags + labels/descriptions, decisions, outcome
+values, advisory→tag map, note limit) is a **three-way** copy. Python is the
+source of truth; it is *served* to iOS in the `/api/help/catalog` `debrief`
+section, but iOS also ships a hand-kept offline baseline and web keeps a
+build-time mirror:
+
+| Role | File | Symbols |
+|---|---|---|
+| Source of truth | `src/weatherbrief/debriefs/taxonomy.py` | `ConditionTag`, `TAG_LABELS`, `TAG_DESCRIPTIONS`, `DECISION_LABELS`, `OUTCOME_LABELS`, `ADVISORY_TAG_MAP`, `NOTE_MAX_LENGTH`, `build_taxonomy_catalog()` |
+| Web mirror (build-time) | `web/ts/components/debrief-taxonomy.ts` | `ALL_TAGS`, `TAG_LABELS`, `TAG_DESCRIPTIONS`, `OUTCOME_LABELS`, `KEYWORD_MAP`, `ADVISORY_TAG_MAP` |
+| iOS offline baseline | `app/flyfun-weather/flyfun-weather/Models/API/DebriefTaxonomy.swift` | `DebriefTaxonomy.bundledBaseline` |
+
+The live iOS path reads the *served* catalog, so the baseline only backstops a
+cold first launch — but it must still match. Cross-check the tag set, labels,
+descriptions, decision order, advisory→tag map, and the note limit across all
+three. Report any tag/label/mapping that exists in Python but is missing or
+different in the web mirror **or** the iOS baseline. Web is not served, so a
+Python edit needs a manual TS + Swift-baseline update (source of truth = Python).
+The `KEYWORD_MAP` matcher is web-only by design (iOS dropped `matchTagsInText` for
+v1) — don't flag its absence on iOS.
+
+### 5. Known parity gaps (informational)
 
 List these so they are **not** re-flagged as new divergences, and note any *new*
 gap the branch introduced:
@@ -87,7 +110,7 @@ gap the branch introduced:
   `sld-bands`, `surface-obscuration-bands`.
 - Cross-section color themes (web-only; tracked in #320).
 
-### 5. SYNC-comment integrity
+### 6. SYNC-comment integrity
 
 Verify reciprocity for each `SYNC`-commented file pair:
 

--- a/app/flyfun-weather/flyfun-weather/App/AppState.swift
+++ b/app/flyfun-weather/flyfun-weather/App/AppState.swift
@@ -72,6 +72,23 @@ final class AppState {
     /// the bundled baseline at init; refreshed opportunistically when online.
     let helpCatalog = HelpCatalogStore()
 
+    /// Digests the user has rated (👍/👎) this session, keyed
+    /// "flightId|packTimestamp" (per pack version). Session-only, matching the
+    /// web widget's in-memory dedup — there's no server read-back yet, so a
+    /// relaunch can re-prompt. Cross-session "already rated" state is a deferred
+    /// follow-up (needs a new server endpoint, on web too).
+    private(set) var ratedDigests: Set<String> = []
+
+    /// Whether this pack's digest has been rated this session.
+    func isDigestRated(flightId: String, packTimestamp: String) -> Bool {
+        ratedDigests.contains("\(flightId)|\(packTimestamp)")
+    }
+
+    /// Record that this pack's digest was rated (hides the thumb prompt).
+    func markDigestRated(flightId: String, packTimestamp: String) {
+        ratedDigests.insert("\(flightId)|\(packTimestamp)")
+    }
+
     /// External "server data changed" nudge (e.g. a refresh push). The flight list
     /// and any open briefing observe this and re-sync to the newest online pack —
     /// push is just one more sync trigger, not a special path. `token` makes every

--- a/app/flyfun-weather/flyfun-weather/Models/API/DebriefResponse.swift
+++ b/app/flyfun-weather/flyfun-weather/Models/API/DebriefResponse.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+/// A stored pilot debrief for a past flight (wire shape of
+/// `GET/PUT /api/flights/{id}/debrief`, and inlined on `/api/flights`).
+///
+/// ## Key-strategy note
+/// Decoded with the shared `JSONDecoder.weatherBrief` (`.convertFromSnakeCase`),
+/// both standalone and when inlined on `FlightResponse`. The scalar keys
+/// (`flight_id`, `created_at`, …) map to the camelCase properties via that
+/// strategy, so this type carries **no explicit snake `CodingKeys`** — adding
+/// them would break the nested decode (the strategy rewrites the wire key first,
+/// then fails to match a snake CodingKey).
+///
+/// `outcomes` is keyed by condition-tag ids (`IMC`, `ICE`, …). Those have no
+/// underscores, and `.convertFromSnakeCase` leaves single-word keys untouched,
+/// so the dict decodes verbatim. (Encoding is different — see `DebriefRequest`.)
+struct DebriefResponse: Codable, Sendable, Equatable {
+    let flightId: String
+    /// `flown` | `cancelled` | `monitoring`.
+    let decision: String
+    /// Cancel-reason tag ids (cancelled only).
+    let reasons: [String]
+    /// tag id → outcome value (`consistent` | `better` | `worse`), flown only.
+    let outcomes: [String: String]
+    let note: String?
+    let createdAt: String
+    let updatedAt: String
+}
+
+/// Upsert body for `PUT /api/flights/{id}/debrief`.
+///
+/// Encoded with a plain `JSONEncoder` (NOT `JSONEncoder.weatherBrief`): the
+/// shared `.convertToSnakeCase` strategy would lowercase the `outcomes` tag-id
+/// keys (`IMC` → `imc`) and the server would reject them. The field names are
+/// already the lowercase words the server expects, so a plain encoder is exact.
+struct DebriefRequest: Encodable, Sendable, Equatable {
+    let decision: String
+    let reasons: [String]
+    let outcomes: [String: String]
+    let note: String?
+
+    /// JSON body with tag-id dictionary keys preserved verbatim.
+    func encoded() throws -> Data {
+        try JSONEncoder().encode(self)
+    }
+}

--- a/app/flyfun-weather/flyfun-weather/Models/API/DebriefTaxonomy.swift
+++ b/app/flyfun-weather/flyfun-weather/Models/API/DebriefTaxonomy.swift
@@ -1,0 +1,127 @@
+import Foundation
+
+/// The debrief vocabulary served in the `debrief` section of
+/// `GET /api/help/catalog` — decision buttons, condition tags (cancel reasons +
+/// outcome categories), outcome values, and the advisory→tag map.
+///
+/// Python (`weatherbrief/debriefs/taxonomy.py`) is the single source of truth;
+/// the iOS debrief form renders straight from this so the tag set / labels can't
+/// drift from the backend or the web. Decoded with a plain `JSONDecoder` (no
+/// snake-case key conversion, like the rest of the help catalog), so the
+/// snake_case wire keys are mapped by explicit `CodingKeys`.
+struct DebriefTaxonomy: Codable, Sendable, Equatable {
+    /// One decision button (`flown` / `cancelled` / `monitoring`).
+    struct DecisionOption: Codable, Sendable, Equatable, Identifiable {
+        let id: String
+        let label: String
+    }
+
+    /// One condition tag: a cancel reason and (unless `outcomeCategory` is false,
+    /// i.e. OPS) a gradeable outcome category.
+    struct TagOption: Codable, Sendable, Equatable, Identifiable {
+        let id: String
+        let label: String
+        let description: String
+        let outcomeCategory: Bool
+
+        enum CodingKeys: String, CodingKey {
+            case id, label, description
+            case outcomeCategory = "outcome_category"
+        }
+    }
+
+    /// One outcome value (`consistent` / `better` / `worse`).
+    struct OutcomeOption: Codable, Sendable, Equatable, Identifiable {
+        let id: String
+        let label: String
+    }
+
+    let decisions: [DecisionOption]
+    let tags: [TagOption]
+    let outcomeValues: [OutcomeOption]
+    /// advisory_id → tag id, used to pre-select the flown-form outcome rows from
+    /// the flagged advisories on the open briefing.
+    let advisoryTagMap: [String: String]
+    /// Free-text note ceiling (characters).
+    let noteMaxLength: Int
+
+    enum CodingKeys: String, CodingKey {
+        case decisions, tags
+        case outcomeValues = "outcome_values"
+        case advisoryTagMap = "advisory_tag_map"
+        case noteMaxLength = "note_max_length"
+    }
+
+    // MARK: - Derived
+
+    /// Tags that can be graded as flown-outcome categories (everything but OPS).
+    var outcomeCategoryTags: [TagOption] { tags.filter { $0.outcomeCategory } }
+
+    /// Look up a tag by id.
+    func tag(_ id: String) -> TagOption? { tags.first { $0.id == id } }
+
+    /// Look up a decision by id.
+    func decision(_ id: String) -> DecisionOption? { decisions.first { $0.id == id } }
+
+    /// The tag ids whose advisory came back AMBER/RED on the open briefing, in
+    /// this taxonomy's tag order. GREEN/UNAVAILABLE don't count — there's nothing
+    /// to grade. Mirrors `flagged_tags_from_advisories` in the Python taxonomy;
+    /// drives which outcome rows the flown form shows.
+    ///
+    /// - Parameter advisories: `(advisoryId, aggregateStatus)` pairs from the
+    ///   loaded advisories manifest.
+    func flaggedTagIds(fromAdvisories advisories: [(id: String, status: String)]) -> [String] {
+        var flagged = Set<String>()
+        for advisory in advisories {
+            let s = advisory.status.lowercased()
+            guard s == "amber" || s == "red" else { continue }
+            if let tagId = advisoryTagMap[advisory.id] { flagged.insert(tagId) }
+        }
+        // Preserve taxonomy tag order for a stable form layout.
+        return tags.map(\.id).filter { flagged.contains($0) }
+    }
+
+    // MARK: - Offline fallback
+
+    /// Hand-maintained fallback used before the first online catalog sync (the
+    /// bundled metrics baseline carries no `debrief` section). Mirrors
+    /// `build_taxonomy_catalog()` in the Python taxonomy — the served copy is the
+    /// source of truth; this only backstops a cold first launch and is covered by
+    /// the sync-ios-web drift audit.
+    static let bundledBaseline = DebriefTaxonomy(
+        decisions: [
+            .init(id: "flown", label: "Flown"),
+            .init(id: "cancelled", label: "Cancelled"),
+            .init(id: "monitoring", label: "Monitor only"),
+        ],
+        tags: [
+            .init(id: "IMC", label: "IMC", description: "Low ceilings / IFR conditions", outcomeCategory: true),
+            .init(id: "ICE", label: "Icing", description: "Airframe icing", outcomeCategory: true),
+            .init(id: "WIND", label: "Wind", description: "Strong / gusty / crosswind", outcomeCategory: true),
+            .init(id: "TS", label: "Thunderstorm", description: "Thunderstorms or convective build-up", outcomeCategory: true),
+            .init(id: "TURB", label: "Turbulence", description: "Turbulence (any intensity)", outcomeCategory: true),
+            .init(id: "FRZ", label: "Freezing precip", description: "Freezing rain / sleet", outcomeCategory: true),
+            .init(id: "VIS", label: "Visibility", description: "Reduced visibility, fog, mist", outcomeCategory: true),
+            .init(id: "OPS", label: "Operational", description: "Non-weather (aircraft, pilot, NOTAM, fuel, …)", outcomeCategory: false),
+        ],
+        outcomeValues: [
+            .init(id: "consistent", label: "As forecast"),
+            .init(id: "better", label: "Better than forecast"),
+            .init(id: "worse", label: "Worse than forecast"),
+        ],
+        advisoryTagMap: [
+            "icing_escape": "ICE",
+            "fiki_icing": "ICE",
+            "vmc_cruise": "IMC",
+            "cloud_top": "IMC",
+            "vfr_feasibility": "IMC",
+            "ifr_feasibility": "IMC",
+            "flight_category": "IMC",
+            "turbulence": "TURB",
+            "mountain_wind": "TURB",
+            "convective": "TS",
+            "airport_wind": "WIND",
+        ],
+        noteMaxLength: 300
+    )
+}

--- a/app/flyfun-weather/flyfun-weather/Models/API/FeedbackRequest.swift
+++ b/app/flyfun-weather/flyfun-weather/Models/API/FeedbackRequest.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// A 👍 / 👎 rating on a briefing's AI digest, posted to `POST /api/feedback`
+/// with `category = "digest_rating"` (mirrors the web digest-feedback widget).
+///
+/// The comment is optional for a thumb — the server only requires text when
+/// there's no `sentiment`. Encoded with `JSONEncoder.weatherBrief`
+/// (`.convertToSnakeCase`), so the camelCase properties become `flight_id`,
+/// `pack_timestamp`, `contact_ok` on the wire. No dictionary keys here, so the
+/// snake strategy is safe (unlike `DebriefRequest`).
+struct DigestFeedbackRequest: Encodable, Sendable, Equatable {
+    /// The rated flight.
+    let flightId: String
+    /// The rated briefing pack's `fetch_timestamp` (ISO 8601) — the rating is
+    /// per-pack-version, so this pins which briefing the pilot judged.
+    let packTimestamp: String
+    /// Always `"digest_rating"` for the thumb path.
+    let category: String
+    /// Optional free-text (≤ 2000 chars). Empty is valid for a bare thumb.
+    let comment: String
+    /// `"up"` | `"down"`.
+    let sentiment: String
+    /// Always `"digest"` for the thumb path.
+    let target: String
+    /// Whether the pilot allows follow-up contact about this feedback.
+    let contactOk: Bool
+
+    init(flightId: String, packTimestamp: String, sentiment: String,
+         comment: String, contactOk: Bool) {
+        self.flightId = flightId
+        self.packTimestamp = packTimestamp
+        self.category = "digest_rating"
+        self.comment = comment
+        self.sentiment = sentiment
+        self.target = "digest"
+        self.contactOk = contactOk
+    }
+}

--- a/app/flyfun-weather/flyfun-weather/Models/API/FlightResponse.swift
+++ b/app/flyfun-weather/flyfun-weather/Models/API/FlightResponse.swift
@@ -60,11 +60,17 @@ struct FlightResponse: Codable, Identifiable, Sendable {
         FlightNotifyOverride(rawValue: notifyOverride ?? "default") ?? .default
     }
 
-    /// Logbook section folded to an enum. Absent/unknown → derived from
-    /// `departureDate` so a legacy server still groups sensibly.
+    /// Logbook section folded to an enum. On a legacy server that omits
+    /// `section`, mirror `FlightListView.groupedFlights`' date bucketing exactly
+    /// (Recent = departed within 7 days) so a card's Recent-debrief nudge matches
+    /// the list's Recent group instead of never appearing.
     var flightSection: FlightSection {
         if let section, let parsed = FlightSection(rawValue: section) { return parsed }
-        return isPast ? .past : .future
+        guard let dep = departureDate else { return .future }
+        let now = Date()
+        if dep >= now { return .future }
+        if dep >= now.addingTimeInterval(-7 * 24 * 3600) { return .recent }
+        return .past
     }
 
     /// Whether this flight already has a stored debrief.

--- a/app/flyfun-weather/flyfun-weather/Models/API/FlightResponse.swift
+++ b/app/flyfun-weather/flyfun-weather/Models/API/FlightResponse.swift
@@ -43,10 +43,32 @@ struct FlightResponse: Codable, Identifiable, Sendable {
     /// Absent on older servers → treated as "default".
     var notifyOverride: String? = nil
 
+    /// Server-assigned logbook bucket ("future" | "recent" | "past"). "recent" is
+    /// the debrief-nudge window (recent past flights not yet debriefed). Absent on
+    /// older servers → nil; the flight list then falls back to client-side date
+    /// bucketing. `var … = nil` (not `let`) so it decodes AND the synthesized
+    /// memberwise init keeps existing call sites unchanged.
+    var section: String? = nil
+    /// The pilot's stored debrief for this flight, inlined by `/api/flights` for
+    /// owned past flights only (nil otherwise / older servers). Lets the list show
+    /// a "debriefed ✓" glyph and the briefing seed its debrief card without a
+    /// per-flight round-trip.
+    var debrief: DebriefResponse? = nil
+
     /// Per-flight override folded to an enum, tolerant of unknown/absent values.
     var notifyOverrideMode: FlightNotifyOverride {
         FlightNotifyOverride(rawValue: notifyOverride ?? "default") ?? .default
     }
+
+    /// Logbook section folded to an enum. Absent/unknown → derived from
+    /// `departureDate` so a legacy server still groups sensibly.
+    var flightSection: FlightSection {
+        if let section, let parsed = FlightSection(rawValue: section) { return parsed }
+        return isPast ? .past : .future
+    }
+
+    /// Whether this flight already has a stored debrief.
+    var hasDebrief: Bool { debrief != nil }
 
     /// Parsed departure date for display.
     var departureDate: Date? {
@@ -86,6 +108,15 @@ struct FlightResponse: Codable, Identifiable, Sendable {
 enum FlightRole: String, Codable, Sendable {
     case owner
     case subscriber
+}
+
+/// Server-assigned logbook bucket for the flight list (mirrors the web
+/// `section`). `recent` is the debrief-nudge window: recent past flights not yet
+/// debriefed (bounded server-side), so a `recent` flight is the one to debrief.
+enum FlightSection: String, Codable, Sendable {
+    case future
+    case recent
+    case past
 }
 
 /// Per-flight briefing-notification override (mirrors the server

--- a/app/flyfun-weather/flyfun-weather/Models/API/HelpCatalogResponse.swift
+++ b/app/flyfun-weather/flyfun-weather/Models/API/HelpCatalogResponse.swift
@@ -32,16 +32,24 @@ struct HelpCatalogResponse: Sendable {
     /// O(1) advisory lookup by id, built once at construction — mirrors the
     /// metrics dict so both popup call sites have the same access cost.
     let advisoriesById: [String: AdvisoryCatalogEntry]
+    /// Debrief taxonomy (decision buttons, condition tags, outcome values,
+    /// advisory→tag map). Served so the iOS debrief form renders from the same
+    /// vocabulary the web bundle imports. nil on the bundled baseline (metrics
+    /// only) before the first online sync — callers fall back to
+    /// `DebriefTaxonomy.bundledBaseline`.
+    let debrief: DebriefTaxonomy?
 
-    init(version: String, metrics: [String: MetricHelp], maps: ForecastMapCatalog?, advisories: [AdvisoryCatalogEntry]) {
+    init(version: String, metrics: [String: MetricHelp], maps: ForecastMapCatalog?,
+         advisories: [AdvisoryCatalogEntry], debrief: DebriefTaxonomy?) {
         self.version = version
         self.metrics = metrics
         self.maps = maps
         self.advisories = advisories
         self.advisoriesById = Dictionary(advisories.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
+        self.debrief = debrief
     }
 
-    /// Decode a full server payload (`{version, metrics, maps, advisories}`).
+    /// Decode a full server payload (`{version, metrics, maps, advisories, debrief}`).
     static func decode(from data: Data) throws -> HelpCatalogResponse {
         let plain = JSONDecoder()  // no key strategy → metric/scale/field ids stay verbatim
         let envelope = try plain.decode(MetricsEnvelope.self, from: data)
@@ -52,7 +60,11 @@ struct HelpCatalogResponse: Sendable {
             version: envelope.version,
             metrics: envelope.metrics,
             maps: envelope.maps,
-            advisories: adv.advisories
+            advisories: adv.advisories,
+            // The debrief section carries snake_case keys (`outcome_category`,
+            // `advisory_tag_map`, …); it's decoded with the plain decoder and
+            // `DebriefTaxonomy`'s explicit CodingKeys, NOT the snake-converting one.
+            debrief: envelope.debrief
         )
     }
 
@@ -61,7 +73,7 @@ struct HelpCatalogResponse: Sendable {
     static func decodeBaseline(from data: Data) throws -> HelpCatalogResponse {
         let plain = JSONDecoder()
         let metrics = try plain.decode([String: MetricHelp].self, from: data)
-        return HelpCatalogResponse(version: "baseline", metrics: metrics, maps: nil, advisories: [])
+        return HelpCatalogResponse(version: "baseline", metrics: metrics, maps: nil, advisories: [], debrief: nil)
     }
 
     private struct MetricsEnvelope: Decodable {
@@ -69,6 +81,8 @@ struct HelpCatalogResponse: Sendable {
         let metrics: [String: MetricHelp]
         /// The `maps` section (#419); optional so an old server without it decodes.
         let maps: ForecastMapCatalog?
+        /// The `debrief` section; optional so an old server without it decodes.
+        let debrief: DebriefTaxonomy?
     }
 
     private struct AdvisoriesEnvelope: Decodable {

--- a/app/flyfun-weather/flyfun-weather/Services/BriefingRepository.swift
+++ b/app/flyfun-weather/flyfun-weather/Services/BriefingRepository.swift
@@ -70,6 +70,18 @@ protocol BriefingRepository: Sendable {
     func submitPirep(_ request: SubmitPirepRequest) async throws -> PirepResponse
     func submitPirepsBatch(_ requests: [SubmitPirepRequest]) async throws -> [PirepResponse]
     func fetchPireps(flightId: String) async throws -> PirepListResponse
+
+    // Debrief (post-flight judgement on a past flight, owner-only)
+    /// Load a flight's debrief. Throws `APIError.notFound` (404) when none exists.
+    func fetchDebrief(flightId: String) async throws -> DebriefResponse
+    /// Insert or update a flight's debrief.
+    func upsertDebrief(flightId: String, request: DebriefRequest) async throws -> DebriefResponse
+    /// Remove a flight's debrief. Idempotent.
+    func deleteDebrief(flightId: String) async throws
+
+    // Digest feedback (👍/👎 on the AI digest)
+    /// Submit a thumb rating (+ optional comment) for a briefing pack's digest.
+    func submitDigestFeedback(_ request: DigestFeedbackRequest) async throws
 }
 
 extension BriefingRepository {
@@ -276,6 +288,25 @@ final class OnlineBriefingRepository: BriefingRepository {
 
     func fetchPireps(flightId: String) async throws -> PirepListResponse {
         return try await client.requestURL("/api/pireps?flight_id=\(Self.queryValueEncoded(flightId))")
+    }
+
+    func fetchDebrief(flightId: String) async throws -> DebriefResponse {
+        try await client.request("/api/flights/\(flightId)/debrief")
+    }
+
+    func upsertDebrief(flightId: String, request: DebriefRequest) async throws -> DebriefResponse {
+        // Plain-encoded body so the `outcomes` tag-id keys aren't snake-cased.
+        let body = try request.encoded()
+        return try await client.request("/api/flights/\(flightId)/debrief", method: "PUT", body: body)
+    }
+
+    func deleteDebrief(flightId: String) async throws {
+        try await client.requestVoid("/api/flights/\(flightId)/debrief")
+    }
+
+    func submitDigestFeedback(_ request: DigestFeedbackRequest) async throws {
+        let body = try JSONEncoder.weatherBrief.encode(request)
+        _ = try await client.requestData("/api/feedback", method: "POST", body: body)
     }
 
     /// Percent-encode a query *value*. `.urlQueryAllowed` permits the `& = + ? #`

--- a/app/flyfun-weather/flyfun-weather/Services/CachingBriefingRepository.swift
+++ b/app/flyfun-weather/flyfun-weather/Services/CachingBriefingRepository.swift
@@ -243,6 +243,24 @@ final class CachingBriefingRepository: BriefingRepository, CacheStatusReporting 
         try await online.fetchPireps(flightId: flightId)
     }
 
+    // Debrief + digest feedback are always online (post-flight, on-the-ground
+    // actions — not part of the offline briefing bundle).
+    func fetchDebrief(flightId: String) async throws -> DebriefResponse {
+        try await online.fetchDebrief(flightId: flightId)
+    }
+
+    func upsertDebrief(flightId: String, request: DebriefRequest) async throws -> DebriefResponse {
+        try await online.upsertDebrief(flightId: flightId, request: request)
+    }
+
+    func deleteDebrief(flightId: String) async throws {
+        try await online.deleteDebrief(flightId: flightId)
+    }
+
+    func submitDigestFeedback(_ request: DigestFeedbackRequest) async throws {
+        try await online.submitDigestFeedback(request)
+    }
+
     // MARK: - Cache-aware data endpoints
 
     func advisories(flightId: String, timestamp: String) async throws -> AdvisoriesResponse {

--- a/app/flyfun-weather/flyfun-weather/Services/FixtureBriefingRepository.swift
+++ b/app/flyfun-weather/flyfun-weather/Services/FixtureBriefingRepository.swift
@@ -104,6 +104,12 @@ final class FixtureBriefingRepository: BriefingRepository, CacheStatusReporting 
     }
     func searchAircraftTypes(_ query: String) async throws -> [AircraftTypeResponse] { [] }
     func fetchPireps(flightId: String) async throws -> PirepListResponse { PirepListResponse(items: [], count: 0) }
+    func fetchDebrief(flightId: String) async throws -> DebriefResponse { throw APIError.notFound }
+    func upsertDebrief(flightId: String, request: DebriefRequest) async throws -> DebriefResponse {
+        throw FixtureError.notProvided("upsertDebrief")
+    }
+    func deleteDebrief(flightId: String) async throws {}
+    func submitDigestFeedback(_ request: DigestFeedbackRequest) async throws {}
     func refreshStream(flightId: String, source: RefreshSource) async -> AsyncThrowingStream<RefreshEvent, Error> {
         AsyncThrowingStream { $0.finish() }
     }

--- a/app/flyfun-weather/flyfun-weather/Services/HelpCatalogStore.swift
+++ b/app/flyfun-weather/flyfun-weather/Services/HelpCatalogStore.swift
@@ -36,6 +36,10 @@ final class HelpCatalogStore {
     /// else the bundled baseline so the map renders on a cold first launch.
     var mapsCatalog: ForecastMapCatalog? { catalog?.maps ?? ForecastMapCatalog.bundledBaseline }
 
+    /// The debrief taxonomy: the served `debrief` section if synced, else the
+    /// hand-maintained baseline so the debrief form works on a cold first launch.
+    var debriefTaxonomy: DebriefTaxonomy { catalog?.debrief ?? DebriefTaxonomy.bundledBaseline }
+
     // MARK: - Lookups (used by the (i) popups)
 
     func metric(_ id: String) -> MetricHelp? { catalog?.metrics[id] }

--- a/app/flyfun-weather/flyfun-weather/ViewModels/BriefingViewModel.swift
+++ b/app/flyfun-weather/flyfun-weather/ViewModels/BriefingViewModel.swift
@@ -98,6 +98,12 @@ final class BriefingViewModel {
     private(set) var pack: PackMetaResponse?
     private(set) var packHistory: [PackMetaResponse] = []
 
+    /// The pilot's post-flight debrief (past owned flights). Seeded from the
+    /// inlined `flight.debrief` and updated in place when the debrief sheet saves
+    /// or deletes, so the Advisory-tab card reflects the change without a list
+    /// reload and survives tab switches (this view model outlives the tab views).
+    private(set) var debrief: DebriefResponse?
+
     // Section states
     private(set) var advisoriesState: LoadingState<AdvisoriesResponse> = .idle
     private(set) var digestState: LoadingState<DigestResponse> = .idle
@@ -161,6 +167,12 @@ final class BriefingViewModel {
         self.repository = repository
         self.settings = settings
         self.networkMonitor = networkMonitor
+        self.debrief = flight.debrief
+    }
+
+    /// Adopt the saved (or deleted → nil) debrief so the Advisory card updates.
+    func setDebrief(_ debrief: DebriefResponse?) {
+        self.debrief = debrief
     }
 
     // MARK: - Deep-link focus (§4.6/§4.7/§4.9)

--- a/app/flyfun-weather/flyfun-weather/ViewModels/DebriefViewModel.swift
+++ b/app/flyfun-weather/flyfun-weather/ViewModels/DebriefViewModel.swift
@@ -10,7 +10,11 @@ import OSLog
 /// emits neither (the server's `_decision_shape` validator enforces that).
 @Observable
 @MainActor
-final class DebriefViewModel {
+final class DebriefViewModel: Identifiable {
+    /// Stable identity so the sheet can hold this in `@State` and drive
+    /// `.sheet(item:)` — the instance is created once per presentation, never
+    /// re-allocated on a parent `body` re-render.
+    nonisolated let id = UUID()
     let flight: FlightResponse
     let taxonomy: DebriefTaxonomy
     private let repository: any BriefingRepository

--- a/app/flyfun-weather/flyfun-weather/ViewModels/DebriefViewModel.swift
+++ b/app/flyfun-weather/flyfun-weather/ViewModels/DebriefViewModel.swift
@@ -1,0 +1,156 @@
+import Foundation
+import OSLog
+
+/// Drives the post-flight **debrief** form (past owned flights): a decision
+/// (flew / cancelled / monitoring) plus — depending on the decision —
+/// cancel-reason chips or per-category outcome grading, and a free-text note.
+///
+/// Data-shape parity with the web debrief form: cancelled emits `reasons`,
+/// flown emits `outcomes` for the flagged advisory categories only, monitoring
+/// emits neither (the server's `_decision_shape` validator enforces that).
+@Observable
+@MainActor
+final class DebriefViewModel {
+    let flight: FlightResponse
+    let taxonomy: DebriefTaxonomy
+    private let repository: any BriefingRepository
+    private static let logger = Logger(subsystem: "aero.flyfun.weather", category: "DebriefVM")
+
+    // Form state
+    var decision: String
+    var selectedReasons: Set<String> = []
+    /// tag id → outcome value, populated for the flagged categories on the flown
+    /// form (defaulting to "consistent" — the pilot flips only what differed).
+    var outcomes: [String: String] = [:]
+    var note: String = ""
+
+    /// The advisory categories flagged AMBER/RED on the open briefing, in
+    /// taxonomy order — the only outcome rows the flown form shows (matches web).
+    let flaggedTagIds: [String]
+
+    var submitState: LoadingState<DebriefResponse> = .idle
+    var errorMessage: String?
+    /// Whether a debrief already existed (drives "Edit" vs "Add" copy + delete).
+    private(set) var isEditing: Bool
+
+    init(flight: FlightResponse,
+         taxonomy: DebriefTaxonomy,
+         flaggedTagIds: [String],
+         repository: any BriefingRepository) {
+        self.flight = flight
+        self.taxonomy = taxonomy
+        self.flaggedTagIds = flaggedTagIds
+        self.repository = repository
+
+        // Seed from an existing debrief (inlined on the flight) if present.
+        if let existing = flight.debrief {
+            self.isEditing = true
+            self.decision = existing.decision
+            self.selectedReasons = Set(existing.reasons)
+            self.note = existing.note ?? ""
+            // Start every flagged category at its stored value, else "consistent".
+            var seeded: [String: String] = [:]
+            for tagId in flaggedTagIds { seeded[tagId] = existing.outcomes[tagId] ?? "consistent" }
+            self.outcomes = seeded
+        } else {
+            self.isEditing = false
+            // Flown is the common case — default to it (matches the web form).
+            self.decision = "flown"
+            var seeded: [String: String] = [:]
+            for tagId in flaggedTagIds { seeded[tagId] = "consistent" }
+            self.outcomes = seeded
+        }
+    }
+
+    // MARK: - Derived
+
+    /// Cancel-reason chips (all tags) — shown when decision == cancelled.
+    var reasonTags: [DebriefTaxonomy.TagOption] { taxonomy.tags }
+
+    /// Outcome rows (flagged categories only) — shown when decision == flown.
+    var outcomeTags: [DebriefTaxonomy.TagOption] {
+        taxonomy.tags.filter { flaggedTagIds.contains($0.id) }
+    }
+
+    var noteRemaining: Int { taxonomy.noteMaxLength - note.count }
+    var noteTooLong: Bool { noteRemaining < 0 }
+
+    var canSubmit: Bool {
+        guard !noteTooLong else { return false }
+        if case .loading = submitState { return false }
+        return true
+    }
+
+    // MARK: - Actions
+
+    func toggleReason(_ tagId: String) {
+        if selectedReasons.contains(tagId) { selectedReasons.remove(tagId) }
+        else { selectedReasons.insert(tagId) }
+    }
+
+    func setOutcome(_ tagId: String, _ value: String) {
+        outcomes[tagId] = value
+    }
+
+    /// Build the decision-appropriate request and upsert it.
+    func submit() async {
+        guard canSubmit else { return }
+        submitState = .loading
+        errorMessage = nil
+
+        let trimmedNote = note.trimmingCharacters(in: .whitespacesAndNewlines)
+        let request: DebriefRequest
+        switch decision {
+        case "cancelled":
+            request = DebriefRequest(
+                decision: "cancelled",
+                reasons: taxonomy.tags.map(\.id).filter { selectedReasons.contains($0) },
+                outcomes: [:],
+                note: trimmedNote.isEmpty ? nil : trimmedNote
+            )
+        case "monitoring":
+            // Watch-only: neither reasons nor outcomes (validator enforces empty).
+            request = DebriefRequest(decision: "monitoring", reasons: [], outcomes: [:],
+                                     note: trimmedNote.isEmpty ? nil : trimmedNote)
+        default: // "flown"
+            // Only emit outcomes for the flagged categories.
+            var flownOutcomes: [String: String] = [:]
+            for tagId in flaggedTagIds { flownOutcomes[tagId] = outcomes[tagId] ?? "consistent" }
+            request = DebriefRequest(
+                decision: "flown",
+                reasons: [],
+                outcomes: flownOutcomes,
+                note: trimmedNote.isEmpty ? nil : trimmedNote
+            )
+        }
+
+        do {
+            let saved = try await repository.upsertDebrief(flightId: flight.id, request: request)
+            submitState = .loaded(saved)
+            isEditing = true
+            Self.logger.info("Debrief saved for flight \(self.flight.id): \(saved.decision)")
+        } catch {
+            submitState = .error(error)
+            errorMessage = error.localizedDescription
+            Self.logger.error("Debrief submit failed: \(error)")
+        }
+    }
+
+    /// Remove the stored debrief (idempotent).
+    func delete() async {
+        submitState = .loading
+        errorMessage = nil
+        do {
+            try await repository.deleteDebrief(flightId: flight.id)
+            submitState = .idle
+            isEditing = false
+            selectedReasons = []
+            note = ""
+            Self.logger.info("Debrief deleted for flight \(self.flight.id)")
+        } catch {
+            submitState = .error(error)
+            errorMessage = error.localizedDescription
+            Self.logger.error("Debrief delete failed: \(error)")
+        }
+    }
+}

--- a/app/flyfun-weather/flyfun-weather/ViewModels/DebriefViewModel.swift
+++ b/app/flyfun-weather/flyfun-weather/ViewModels/DebriefViewModel.swift
@@ -25,8 +25,16 @@ final class DebriefViewModel {
     var note: String = ""
 
     /// The advisory categories flagged AMBER/RED on the open briefing, in
-    /// taxonomy order — the only outcome rows the flown form shows (matches web).
+    /// taxonomy order. Drives which outcome rows a *fresh* flown debrief shows.
     let flaggedTagIds: [String]
+
+    /// The outcome rows the flown form actually grades: the union of
+    /// `flaggedTagIds` and any category the stored debrief already recorded, in
+    /// taxonomy order. Using the union (not just `flaggedTagIds`) means editing an
+    /// existing flown debrief never drops a previously-graded category — even one
+    /// the briefing no longer flags, or when advisories haven't loaded yet and
+    /// `flaggedTagIds` is empty. Mirrors the web form's `initialState` union.
+    private(set) var outcomeTagIds: [String] = []
 
     var submitState: LoadingState<DebriefResponse> = .idle
     var errorMessage: String?
@@ -43,23 +51,26 @@ final class DebriefViewModel {
         self.repository = repository
 
         // Seed from an existing debrief (inlined on the flight) if present.
+        let existingOutcomes = flight.debrief?.outcomes ?? [:]
+        // Union the flagged categories with any the stored debrief already graded,
+        // in taxonomy order, so an edit can't silently drop a recorded outcome.
+        let union = Set(flaggedTagIds).union(existingOutcomes.keys)
+        self.outcomeTagIds = taxonomy.tags.map(\.id).filter { union.contains($0) }
+
         if let existing = flight.debrief {
             self.isEditing = true
             self.decision = existing.decision
             self.selectedReasons = Set(existing.reasons)
             self.note = existing.note ?? ""
-            // Start every flagged category at its stored value, else "consistent".
-            var seeded: [String: String] = [:]
-            for tagId in flaggedTagIds { seeded[tagId] = existing.outcomes[tagId] ?? "consistent" }
-            self.outcomes = seeded
         } else {
             self.isEditing = false
             // Flown is the common case — default to it (matches the web form).
             self.decision = "flown"
-            var seeded: [String: String] = [:]
-            for tagId in flaggedTagIds { seeded[tagId] = "consistent" }
-            self.outcomes = seeded
         }
+        // Each graded row starts at its stored value, else "consistent".
+        var seeded: [String: String] = [:]
+        for tagId in self.outcomeTagIds { seeded[tagId] = existingOutcomes[tagId] ?? "consistent" }
+        self.outcomes = seeded
     }
 
     // MARK: - Derived
@@ -67,9 +78,9 @@ final class DebriefViewModel {
     /// Cancel-reason chips (all tags) — shown when decision == cancelled.
     var reasonTags: [DebriefTaxonomy.TagOption] { taxonomy.tags }
 
-    /// Outcome rows (flagged categories only) — shown when decision == flown.
+    /// Outcome rows shown when decision == flown: the flagged-∪-stored set.
     var outcomeTags: [DebriefTaxonomy.TagOption] {
-        taxonomy.tags.filter { flaggedTagIds.contains($0.id) }
+        taxonomy.tags.filter { outcomeTagIds.contains($0.id) }
     }
 
     var noteRemaining: Int { taxonomy.noteMaxLength - note.count }
@@ -113,9 +124,10 @@ final class DebriefViewModel {
             request = DebriefRequest(decision: "monitoring", reasons: [], outcomes: [:],
                                      note: trimmedNote.isEmpty ? nil : trimmedNote)
         default: // "flown"
-            // Only emit outcomes for the flagged categories.
+            // Emit outcomes for the graded set (flagged ∪ previously-stored), so
+            // an edit preserves categories the current briefing no longer flags.
             var flownOutcomes: [String: String] = [:]
-            for tagId in flaggedTagIds { flownOutcomes[tagId] = outcomes[tagId] ?? "consistent" }
+            for tagId in outcomeTagIds { flownOutcomes[tagId] = outcomes[tagId] ?? "consistent" }
             request = DebriefRequest(
                 decision: "flown",
                 reasons: [],

--- a/app/flyfun-weather/flyfun-weather/Views/Briefing/AdvisoryTabView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Briefing/AdvisoryTabView.swift
@@ -52,9 +52,12 @@ struct AdvisoryTabView: View {
     }
 
     /// Build the debrief view model once, at tap time, from the current flagged
-    /// categories — then present it via `$debriefVM`.
+    /// categories — then present it via `$debriefVM`. A fresh add is only reached
+    /// once advisories are terminal (the button is disabled otherwise), so
+    /// `flaggedTagIds` is trustworthy here; the guard is belt-and-suspenders.
     private func presentDebrief() {
         guard let repo = appState.repository else { return }
+        guard viewModel.debrief != nil || advisoriesReady else { return }
         debriefVM = DebriefViewModel(
             flight: flightForDebrief,
             taxonomy: appState.helpCatalog.debriefTaxonomy,
@@ -94,10 +97,19 @@ struct AdvisoryTabView: View {
     @ViewBuilder
     private var debriefSection: some View {
         if viewModel.flight.isPast && viewModel.flight.isEditable {
-            DebriefCard(debrief: viewModel.debrief) {
+            DebriefCard(debrief: viewModel.debrief, advisoriesReady: advisoriesReady) {
                 presentDebrief()
             }
             .padding(.horizontal, Theme.cardPadding)
+        }
+    }
+
+    /// Advisories have reached a terminal state (loaded or failed) — the point at
+    /// which `flaggedTagIds` is trustworthy for a fresh debrief.
+    private var advisoriesReady: Bool {
+        switch viewModel.advisoriesState {
+        case .loaded, .error: return true
+        case .idle, .loading: return false
         }
     }
 

--- a/app/flyfun-weather/flyfun-weather/Views/Briefing/AdvisoryTabView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Briefing/AdvisoryTabView.swift
@@ -7,12 +7,16 @@ import SwiftUI
 /// packs — weather alternates. A sticky scroll-spy bar jumps between sections.
 struct AdvisoryTabView: View {
     let viewModel: BriefingViewModel
+    @Environment(AppState.self) private var appState
+    @State private var showingDebriefSheet = false
 
     var body: some View {
         ScrollSpyScroll(sections: spySections) {
             VStack(alignment: .leading, spacing: Theme.sectionSpacing) {
                 heroSection
                     .spyAnchor("hero")
+                digestFeedbackSection
+                debriefSection
                 advisoriesSection
                     .spyAnchor("advisories")
                 AirportConditionsView(viewModel: viewModel)
@@ -32,6 +36,65 @@ struct AdvisoryTabView: View {
             .padding(.vertical, Theme.cardPadding)
         }
         .background(Theme.bg)
+        .sheet(isPresented: $showingDebriefSheet) {
+            if let repo = appState.repository {
+                DebriefFormView(
+                    viewModel: DebriefViewModel(
+                        flight: flightForDebrief,
+                        taxonomy: appState.helpCatalog.debriefTaxonomy,
+                        flaggedTagIds: flaggedTagIds,
+                        repository: repo
+                    ),
+                    onFinished: { viewModel.setDebrief($0) }
+                )
+            }
+        }
+    }
+
+    /// The flight with the freshest known debrief folded in, so re-opening the
+    /// sheet after a save seeds from the just-saved debrief (the immutable
+    /// `viewModel.flight` still carries the list-load value).
+    private var flightForDebrief: FlightResponse {
+        var f = viewModel.flight
+        f.debrief = viewModel.debrief
+        return f
+    }
+
+    // MARK: Digest feedback (👍/👎) — below the hero, shown once a digest loads
+
+    @ViewBuilder
+    private var digestFeedbackSection: some View {
+        if hasDigest, let timestamp = viewModel.pack?.fetchTimestamp {
+            DigestFeedbackView(flightId: viewModel.flight.id, packTimestamp: timestamp)
+        }
+    }
+
+    private var hasDigest: Bool {
+        if case .loaded = viewModel.digestState { return true }
+        return false
+    }
+
+    // MARK: Debrief — post-flight judgement (past owned flights only)
+
+    /// The pilot's debrief card: an "Add debrief" prompt or a read-only summary
+    /// with "Edit". Only for owned flights that have already ended — matches the
+    /// web flight-detail placement (a section under the assessment).
+    @ViewBuilder
+    private var debriefSection: some View {
+        if viewModel.flight.isPast && viewModel.flight.isEditable {
+            DebriefCard(debrief: viewModel.debrief) {
+                showingDebriefSheet = true
+            }
+            .padding(.horizontal, Theme.cardPadding)
+        }
+    }
+
+    /// Advisory categories flagged AMBER/RED on the loaded briefing, mapped to
+    /// debrief tags — the flown-form outcome rows. Empty until advisories load.
+    private var flaggedTagIds: [String] {
+        guard case .loaded(let response) = viewModel.advisoriesState else { return [] }
+        let pairs = response.advisories.map { (id: $0.advisoryId, status: $0.aggregateStatus) }
+        return appState.helpCatalog.debriefTaxonomy.flaggedTagIds(fromAdvisories: pairs)
     }
 
     // MARK: Scroll-spy sections (only those present)

--- a/app/flyfun-weather/flyfun-weather/Views/Briefing/AdvisoryTabView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Briefing/AdvisoryTabView.swift
@@ -8,7 +8,11 @@ import SwiftUI
 struct AdvisoryTabView: View {
     let viewModel: BriefingViewModel
     @Environment(AppState.self) private var appState
-    @State private var showingDebriefSheet = false
+    /// Held in `@State` and created once (in the card's action) so a parent
+    /// `body` re-render — frequent during the SSE refresh stream — can't
+    /// re-allocate it and wipe in-progress form input. `.sheet(item:)` presents
+    /// while it's non-nil.
+    @State private var debriefVM: DebriefViewModel?
 
     var body: some View {
         ScrollSpyScroll(sections: spySections) {
@@ -36,19 +40,27 @@ struct AdvisoryTabView: View {
             .padding(.vertical, Theme.cardPadding)
         }
         .background(Theme.bg)
-        .sheet(isPresented: $showingDebriefSheet) {
-            if let repo = appState.repository {
-                DebriefFormView(
-                    viewModel: DebriefViewModel(
-                        flight: flightForDebrief,
-                        taxonomy: appState.helpCatalog.debriefTaxonomy,
-                        flaggedTagIds: flaggedTagIds,
-                        repository: repo
-                    ),
-                    onFinished: { viewModel.setDebrief($0) }
-                )
-            }
+        .sheet(item: $debriefVM) { vm in
+            DebriefFormView(viewModel: vm, onFinished: { saved in
+                viewModel.setDebrief(saved)
+                // Re-sync the flights list so the "Debriefed ✓" glyph and the
+                // Recent-debrief nudge update — the list VM persists across
+                // navigation, so it won't otherwise re-fetch until foreground.
+                appState.signalExternalSync(flightId: viewModel.flight.id)
+            })
         }
+    }
+
+    /// Build the debrief view model once, at tap time, from the current flagged
+    /// categories — then present it via `$debriefVM`.
+    private func presentDebrief() {
+        guard let repo = appState.repository else { return }
+        debriefVM = DebriefViewModel(
+            flight: flightForDebrief,
+            taxonomy: appState.helpCatalog.debriefTaxonomy,
+            flaggedTagIds: flaggedTagIds,
+            repository: repo
+        )
     }
 
     /// The flight with the freshest known debrief folded in, so re-opening the
@@ -83,7 +95,7 @@ struct AdvisoryTabView: View {
     private var debriefSection: some View {
         if viewModel.flight.isPast && viewModel.flight.isEditable {
             DebriefCard(debrief: viewModel.debrief) {
-                showingDebriefSheet = true
+                presentDebrief()
             }
             .padding(.horizontal, Theme.cardPadding)
         }

--- a/app/flyfun-weather/flyfun-weather/Views/Briefing/DebriefFormView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Briefing/DebriefFormView.swift
@@ -1,0 +1,315 @@
+import SwiftUI
+
+/// Post-flight debrief sheet (past owned flights). A decision segmented control,
+/// then — per decision — cancel-reason chips or per-category outcome grading,
+/// plus a note. Mirrors the web debrief form's choices; reuses the PIREP sheet's
+/// Form + submit-state shape.
+struct DebriefFormView: View {
+    @Bindable var viewModel: DebriefViewModel
+    /// Called with the saved debrief on save, or `nil` on delete, so the caller
+    /// can refresh its card without a round-trip.
+    var onFinished: (DebriefResponse?) -> Void
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                decisionSection
+                switch viewModel.decision {
+                case "cancelled": cancelledSection
+                case "monitoring": monitoringSection
+                default: flownSection
+                }
+                noteSection
+                submitSection
+            }
+            .navigationTitle(viewModel.isEditing ? "Edit Debrief" : "Add Debrief")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+            }
+        }
+    }
+
+    // MARK: - Decision
+
+    private var decisionSection: some View {
+        Section("What happened?") {
+            Picker("Decision", selection: $viewModel.decision) {
+                ForEach(viewModel.taxonomy.decisions) { option in
+                    Text(option.label).tag(option.id)
+                }
+            }
+            .pickerStyle(.segmented)
+        }
+    }
+
+    // MARK: - Cancelled → reason chips
+
+    private var cancelledSection: some View {
+        Section {
+            FlowChips(
+                tags: viewModel.reasonTags,
+                isSelected: { viewModel.selectedReasons.contains($0) },
+                toggle: { viewModel.toggleReason($0) }
+            )
+        } header: {
+            Text("Why did you cancel?")
+        } footer: {
+            Text("Tap every condition that contributed. These feed forecast calibration.")
+        }
+    }
+
+    // MARK: - Monitoring
+
+    private var monitoringSection: some View {
+        Section {
+            Text("This flight was set up to watch the weather, not to be flown. It won't count toward flown/cancelled stats — add a note if you want to remember why.")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    // MARK: - Flown → per-category outcomes
+
+    @ViewBuilder
+    private var flownSection: some View {
+        if viewModel.outcomeTags.isEmpty {
+            Section {
+                Text("No advisories were flagged on this briefing, so there's nothing to grade. Add a note if the weather differed from what you expected.")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+        } else {
+            Section {
+                ForEach(viewModel.outcomeTags) { tag in
+                    outcomeRow(tag)
+                }
+            } header: {
+                Text("How did the flagged conditions compare?")
+            } footer: {
+                Text("Everything defaults to “as forecast” — flip only what was different.")
+            }
+        }
+    }
+
+    private func outcomeRow(_ tag: DebriefTaxonomy.TagOption) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(tag.label)
+                .font(.subheadline.weight(.medium))
+            HStack(spacing: 6) {
+                ForEach(viewModel.taxonomy.outcomeValues) { value in
+                    let selected = (viewModel.outcomes[tag.id] ?? "consistent") == value.id
+                    Button(value.label) {
+                        viewModel.setOutcome(tag.id, value.id)
+                    }
+                    .buttonStyle(.bordered)
+                    .tint(selected ? Self.outcomeColor(value.id) : .gray)
+                    .font(.caption)
+                }
+            }
+        }
+        .padding(.vertical, 2)
+    }
+
+    /// Neutral-to-signal colouring: "as forecast" is neutral, "worse" reads red,
+    /// "better" green — never a go/no-go verdict, just a delta.
+    private static func outcomeColor(_ value: String) -> Color {
+        switch value {
+        case "worse": .red
+        case "better": .green
+        default: .blue
+        }
+    }
+
+    // MARK: - Note
+
+    private var noteSection: some View {
+        Section {
+            TextField("What happened? (optional)", text: $viewModel.note, axis: .vertical)
+                .lineLimit(2...5)
+        } header: {
+            Text("Note")
+        } footer: {
+            HStack {
+                Spacer()
+                Text("\(viewModel.noteRemaining)")
+                    .font(.caption2)
+                    .foregroundStyle(viewModel.noteTooLong ? .red : .secondary)
+            }
+        }
+    }
+
+    // MARK: - Submit
+
+    private var submitSection: some View {
+        Section {
+            switch viewModel.submitState {
+            case .idle, .error:
+                Button {
+                    Task {
+                        await viewModel.submit()
+                        if case .loaded(let saved) = viewModel.submitState {
+                            onFinished(saved)
+                            dismiss()
+                        }
+                    }
+                } label: {
+                    Label(viewModel.isEditing ? "Save Changes" : "Save Debrief",
+                          systemImage: "checkmark.circle.fill")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(!viewModel.canSubmit)
+
+                if let error = viewModel.errorMessage {
+                    Text(error)
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                }
+
+                if viewModel.isEditing {
+                    Button(role: .destructive) {
+                        Task {
+                            await viewModel.delete()
+                            if case .idle = viewModel.submitState {
+                                onFinished(nil)
+                                dismiss()
+                            }
+                        }
+                    } label: {
+                        Label("Delete Debrief", systemImage: "trash")
+                            .frame(maxWidth: .infinity)
+                    }
+                }
+
+            case .loading:
+                ProgressView("Saving…")
+                    .frame(maxWidth: .infinity)
+
+            case .loaded:
+                Label("Debrief saved", systemImage: "checkmark.circle.fill")
+                    .foregroundStyle(.green)
+                    .frame(maxWidth: .infinity)
+            }
+        } footer: {
+            Text("Your debrief is stored to improve future forecasts for flights like this one.")
+                .font(.caption2)
+        }
+    }
+}
+
+/// The debrief card shown below the hero on a past owned flight: an "Add
+/// debrief" prompt when none exists, or a read-only summary + "Edit" when it
+/// does. Tapping opens `DebriefFormView`.
+struct DebriefCard: View {
+    let debrief: DebriefResponse?
+    let onEdit: () -> Void
+    @Environment(AppState.self) private var appState
+
+    private var taxonomy: DebriefTaxonomy { appState.helpCatalog.debriefTaxonomy }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Theme.spacingS) {
+            HStack {
+                Label("Debrief", systemImage: "text.badge.checkmark")
+                    .font(.headline)
+                    .foregroundStyle(Theme.text)
+                Spacer()
+                Button(debrief == nil ? "Add" : "Edit", action: onEdit)
+                    .font(.subheadline.weight(.medium))
+            }
+            if let debrief {
+                summary(debrief)
+            } else {
+                Text("How did this flight go? A quick debrief helps calibrate future forecasts.")
+                    .font(.subheadline)
+                    .foregroundStyle(Theme.textMuted)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .padding(Theme.cardPadding)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Theme.surface, in: RoundedRectangle(cornerRadius: Theme.cornerRadius))
+        .overlay(RoundedRectangle(cornerRadius: Theme.cornerRadius).stroke(Theme.border, lineWidth: 0.5))
+    }
+
+    @ViewBuilder
+    private func summary(_ debrief: DebriefResponse) -> some View {
+        VStack(alignment: .leading, spacing: Theme.spacingXS) {
+            decisionPill(debrief.decision)
+            if debrief.decision == "cancelled", !debrief.reasons.isEmpty {
+                Text("Because: " + debrief.reasons.map(tagLabel).joined(separator: ", "))
+                    .font(.subheadline)
+                    .foregroundStyle(Theme.text)
+            } else if debrief.decision == "flown" {
+                let diffs = debrief.outcomes.filter { $0.value != "consistent" }
+                if diffs.isEmpty {
+                    Text("Conditions were as forecast.")
+                        .font(.subheadline)
+                        .foregroundStyle(Theme.textMuted)
+                } else {
+                    ForEach(diffs.sorted(by: { $0.key < $1.key }), id: \.key) { tagId, value in
+                        Text("\(tagLabel(tagId)): \(outcomeLabel(value))")
+                            .font(.subheadline)
+                            .foregroundStyle(value == "worse" ? Theme.red : Theme.text)
+                    }
+                }
+            }
+            if let note = debrief.note, !note.isEmpty {
+                Text(note)
+                    .font(.subheadline)
+                    .foregroundStyle(Theme.textMuted)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+
+    private func decisionPill(_ decision: String) -> some View {
+        let (label, tint): (String, Color) = switch decision {
+        case "cancelled": ("Cancelled", Theme.red)
+        case "monitoring": ("Monitor only", Theme.textMuted)
+        default: ("Flown", Theme.green)
+        }
+        return Text(label)
+            .font(.caption2.weight(.semibold))
+            .foregroundStyle(tint)
+            .padding(.horizontal, 8).padding(.vertical, 3)
+            .background(tint.opacity(0.15), in: Capsule())
+    }
+
+    private func tagLabel(_ id: String) -> String { taxonomy.tag(id)?.label ?? id }
+    private func outcomeLabel(_ id: String) -> String {
+        taxonomy.outcomeValues.first { $0.id == id }?.label ?? id
+    }
+}
+
+/// A simple wrapping row of selectable tag chips (cancel reasons). Uses a
+/// `LazyVGrid` with an adaptive column so chips flow onto multiple lines.
+private struct FlowChips: View {
+    let tags: [DebriefTaxonomy.TagOption]
+    let isSelected: (String) -> Bool
+    let toggle: (String) -> Void
+
+    var body: some View {
+        LazyVGrid(columns: [GridItem(.adaptive(minimum: 84), spacing: 8)], alignment: .leading, spacing: 8) {
+            ForEach(tags) { tag in
+                let selected = isSelected(tag.id)
+                Button {
+                    toggle(tag.id)
+                } label: {
+                    Text(tag.label)
+                        .font(.caption.weight(.medium))
+                        .frame(maxWidth: .infinity)
+                        .lineLimit(1)
+                }
+                .buttonStyle(.bordered)
+                .tint(selected ? .accentColor : .gray)
+                .accessibilityAddTraits(selected ? [.isSelected] : [])
+            }
+        }
+        .padding(.vertical, 4)
+    }
+}

--- a/app/flyfun-weather/flyfun-weather/Views/Briefing/DebriefFormView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Briefing/DebriefFormView.swift
@@ -245,13 +245,18 @@ struct DebriefCard: View {
                     .font(.subheadline)
                     .foregroundStyle(Theme.text)
             } else if debrief.decision == "flown" {
-                let diffs = debrief.outcomes.filter { $0.value != "consistent" }
+                // Non-consistent outcomes in taxonomy order (matches the chips /
+                // outcome rows), not alphabetical by tag id.
+                let diffs = taxonomy.tags.compactMap { tag -> (id: String, value: String)? in
+                    guard let value = debrief.outcomes[tag.id], value != "consistent" else { return nil }
+                    return (tag.id, value)
+                }
                 if diffs.isEmpty {
                     Text("Conditions were as forecast.")
                         .font(.subheadline)
                         .foregroundStyle(Theme.textMuted)
                 } else {
-                    ForEach(diffs.sorted(by: { $0.key < $1.key }), id: \.key) { tagId, value in
+                    ForEach(diffs, id: \.id) { tagId, value in
                         Text("\(tagLabel(tagId)): \(outcomeLabel(value))")
                             .font(.subheadline)
                             .foregroundStyle(value == "worse" ? Theme.red : Theme.text)

--- a/app/flyfun-weather/flyfun-weather/Views/Briefing/DebriefFormView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Briefing/DebriefFormView.swift
@@ -206,10 +206,20 @@ struct DebriefFormView: View {
 /// does. Tapping opens `DebriefFormView`.
 struct DebriefCard: View {
     let debrief: DebriefResponse?
+    /// Whether the briefing's advisories have reached a terminal state. A *fresh*
+    /// debrief derives its flown-outcome rows from the flagged advisories, so
+    /// "Add" is gated until they load — otherwise a tap during the load window
+    /// would grade zero categories and submit an empty `outcomes` dict even
+    /// though the briefing had flagged some. Edits are unaffected (the stored
+    /// outcomes carry through regardless).
+    var advisoriesReady: Bool = true
     let onEdit: () -> Void
     @Environment(AppState.self) private var appState
 
     private var taxonomy: DebriefTaxonomy { appState.helpCatalog.debriefTaxonomy }
+
+    /// Only a fresh add needs advisories; an edit is always allowed.
+    private var addDisabled: Bool { debrief == nil && !advisoriesReady }
 
     var body: some View {
         VStack(alignment: .leading, spacing: Theme.spacingS) {
@@ -220,9 +230,14 @@ struct DebriefCard: View {
                 Spacer()
                 Button(debrief == nil ? "Add" : "Edit", action: onEdit)
                     .font(.subheadline.weight(.medium))
+                    .disabled(addDisabled)
             }
             if let debrief {
                 summary(debrief)
+            } else if addDisabled {
+                Label("Checking advisories…", systemImage: "clock")
+                    .font(.subheadline)
+                    .foregroundStyle(Theme.textMuted)
             } else {
                 Text("How did this flight go? A quick debrief helps calibrate future forecasts.")
                     .font(.subheadline)

--- a/app/flyfun-weather/flyfun-weather/Views/Briefing/DigestFeedbackView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Briefing/DigestFeedbackView.swift
@@ -1,0 +1,172 @@
+import SwiftUI
+
+/// "Was this helpful? 👍 👎" strip shown below the hero for any briefing that
+/// has an AI digest. Tapping a thumb opens a sheet for an optional comment, then
+/// posts a digest rating (`POST /api/feedback`, category `digest_rating`).
+///
+/// Dedup is session-only via `AppState.ratedDigests` (matches the web widget) —
+/// after a rating the strip collapses to a thank-you for that pack version.
+struct DigestFeedbackView: View {
+    let flightId: String
+    let packTimestamp: String
+    @Environment(AppState.self) private var appState
+    @State private var pendingThumb: PendingThumb?
+
+    /// Identifiable wrapper so a thumb tap can drive `.sheet(item:)` without a
+    /// module-wide `String: Identifiable` conformance.
+    private struct PendingThumb: Identifiable {
+        let sentiment: String
+        var id: String { sentiment }
+    }
+
+    var body: some View {
+        Group {
+            if appState.isDigestRated(flightId: flightId, packTimestamp: packTimestamp) {
+                thanksStrip
+            } else {
+                promptStrip
+            }
+        }
+        .padding(.horizontal, Theme.cardPadding)
+        .sheet(item: $pendingThumb) { thumb in
+            DigestFeedbackCommentSheet(
+                flightId: flightId,
+                packTimestamp: packTimestamp,
+                sentiment: thumb.sentiment
+            ) {
+                appState.markDigestRated(flightId: flightId, packTimestamp: packTimestamp)
+            }
+        }
+    }
+
+    private var promptStrip: some View {
+        HStack(spacing: Theme.spacingM) {
+            Text("Was this briefing helpful?")
+                .font(.subheadline)
+                .foregroundStyle(Theme.textMuted)
+            Spacer()
+            thumbButton(sentiment: "up", systemImage: "hand.thumbsup", tint: Theme.green)
+            thumbButton(sentiment: "down", systemImage: "hand.thumbsdown", tint: Theme.red)
+        }
+        .padding(.vertical, Theme.spacingS)
+    }
+
+    private func thumbButton(sentiment: String, systemImage: String, tint: Color) -> some View {
+        Button {
+            pendingThumb = PendingThumb(sentiment: sentiment)
+        } label: {
+            Image(systemName: systemImage)
+                .font(.title3)
+                .foregroundStyle(tint)
+                .frame(width: 44, height: 44)
+                .background(tint.opacity(0.12), in: Circle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(sentiment == "up" ? "Helpful" : "Not helpful")
+    }
+
+    private var thanksStrip: some View {
+        HStack(spacing: Theme.spacingS) {
+            Image(systemName: "checkmark.circle.fill")
+                .foregroundStyle(Theme.green)
+            Text("Thanks for the feedback!")
+                .font(.subheadline)
+                .foregroundStyle(Theme.textMuted)
+            Spacer()
+        }
+        .padding(.vertical, Theme.spacingS)
+    }
+}
+
+/// Optional-comment sheet shown after a thumb tap. Comment is optional (a bare
+/// thumb is valid); the consent toggle mirrors the web "you can contact me" box.
+private struct DigestFeedbackCommentSheet: View {
+    let flightId: String
+    let packTimestamp: String
+    let sentiment: String
+    /// Called after a successful submit so the caller can mark the pack rated.
+    let onRated: () -> Void
+
+    @Environment(AppState.self) private var appState
+    @Environment(\.dismiss) private var dismiss
+    @State private var comment: String = ""
+    @State private var contactOk: Bool = true
+    @State private var state: SubmitState = .idle
+
+    private enum SubmitState: Equatable { case idle, sending, failed(String) }
+
+    private var isPositive: Bool { sentiment == "up" }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    Label(isPositive ? "Marked helpful" : "Marked not helpful",
+                          systemImage: isPositive ? "hand.thumbsup.fill" : "hand.thumbsdown.fill")
+                        .foregroundStyle(isPositive ? Theme.green : Theme.red)
+                }
+                Section {
+                    TextField(isPositive ? "What worked well? (optional)"
+                                         : "What was off or missing? (optional)",
+                              text: $comment, axis: .vertical)
+                        .lineLimit(3...6)
+                } header: {
+                    Text("Comment")
+                } footer: {
+                    Text("Optional — a thumb on its own is still useful.")
+                }
+                Section {
+                    Toggle("You can contact me about this", isOn: $contactOk)
+                }
+                Section {
+                    if case .failed(let message) = state {
+                        Text(message)
+                            .font(.caption)
+                            .foregroundStyle(.red)
+                    }
+                    Button {
+                        Task { await send() }
+                    } label: {
+                        if state == .sending {
+                            ProgressView().frame(maxWidth: .infinity)
+                        } else {
+                            Label("Send", systemImage: "paperplane.fill")
+                                .frame(maxWidth: .infinity)
+                        }
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(state == .sending)
+                }
+            }
+            .navigationTitle("Feedback")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+            }
+        }
+    }
+
+    private func send() async {
+        guard let repo = appState.repository else {
+            state = .failed("Not signed in.")
+            return
+        }
+        state = .sending
+        let request = DigestFeedbackRequest(
+            flightId: flightId,
+            packTimestamp: packTimestamp,
+            sentiment: sentiment,
+            comment: comment.trimmingCharacters(in: .whitespacesAndNewlines),
+            contactOk: contactOk
+        )
+        do {
+            try await repo.submitDigestFeedback(request)
+            onRated()
+            dismiss()
+        } catch {
+            state = .failed(error.localizedDescription)
+        }
+    }
+}

--- a/app/flyfun-weather/flyfun-weather/Views/Briefing/DigestFeedbackView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Briefing/DigestFeedbackView.swift
@@ -95,6 +95,11 @@ private struct DigestFeedbackCommentSheet: View {
 
     private enum SubmitState: Equatable { case idle, sending, failed(String) }
 
+    /// Server caps the feedback comment at 2000 chars (`FeedbackRequest.comment`);
+    /// mirror it client-side so a long paste is caught before submit.
+    private static let commentMaxLength = 2000
+    private var commentTooLong: Bool { comment.count > Self.commentMaxLength }
+
     private var isPositive: Bool { sentiment == "up" }
 
     var body: some View {
@@ -113,7 +118,14 @@ private struct DigestFeedbackCommentSheet: View {
                 } header: {
                     Text("Comment")
                 } footer: {
-                    Text("Optional — a thumb on its own is still useful.")
+                    HStack {
+                        Text("Optional — a thumb on its own is still useful.")
+                        Spacer()
+                        if comment.count > Self.commentMaxLength - 200 {
+                            Text("\(Self.commentMaxLength - comment.count)")
+                                .foregroundStyle(commentTooLong ? .red : .secondary)
+                        }
+                    }
                 }
                 Section {
                     Toggle("You can contact me about this", isOn: $contactOk)
@@ -135,7 +147,7 @@ private struct DigestFeedbackCommentSheet: View {
                         }
                     }
                     .buttonStyle(.borderedProminent)
-                    .disabled(state == .sending)
+                    .disabled(state == .sending || commentTooLong)
                 }
             }
             .navigationTitle("Feedback")

--- a/app/flyfun-weather/flyfun-weather/Views/Flights/FlightCardView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Flights/FlightCardView.swift
@@ -109,8 +109,11 @@ struct FlightCardView: View, Equatable {
 
                 // Nudge to debrief a recent flight (server "recent" bucket = a
                 // recent past flight not yet debriefed). Tapping the row opens the
-                // briefing, where the debrief card lives.
-                if flight.flightSection == .recent && !flight.hasDebrief {
+                // briefing, where the debrief card lives. Also require `isEditable`:
+                // debrief is owner-only, and on the legacy-server date fallback a
+                // subscriber's recent shared flight would otherwise show a nudge
+                // that dead-ends (the briefing's debrief card is owner-gated).
+                if flight.flightSection == .recent && !flight.hasDebrief && flight.isEditable {
                     Spacer(minLength: 0)
                     Label("Debrief", systemImage: "square.and.pencil")
                         .font(.caption2.weight(.semibold))

--- a/app/flyfun-weather/flyfun-weather/Views/Flights/FlightCardView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Flights/FlightCardView.swift
@@ -32,6 +32,8 @@ struct FlightCardView: View, Equatable {
             && lhs.flight.role == rhs.flight.role
             && lhs.flight.coverage == rhs.flight.coverage
             && lhs.flight.latestBriefing == rhs.flight.latestBriefing
+            && lhs.flight.section == rhs.flight.section
+            && lhs.flight.debrief == rhs.flight.debrief
     }
 
     var body: some View {
@@ -69,6 +71,13 @@ struct FlightCardView: View, Equatable {
                     .accessibilityLabel("Briefing refreshing")
                 }
 
+                if flight.hasDebrief {
+                    Image(systemName: "checkmark.seal.fill")
+                        .font(.caption)
+                        .foregroundStyle(.green)
+                        .accessibilityLabel("Debriefed")
+                }
+
                 statusBadge
             }
 
@@ -96,6 +105,20 @@ struct FlightCardView: View, Equatable {
                         .font(.caption)
                         .foregroundStyle(.secondary)
                         .lineLimit(1)
+                }
+
+                // Nudge to debrief a recent flight (server "recent" bucket = a
+                // recent past flight not yet debriefed). Tapping the row opens the
+                // briefing, where the debrief card lives.
+                if flight.flightSection == .recent && !flight.hasDebrief {
+                    Spacer(minLength: 0)
+                    Label("Debrief", systemImage: "square.and.pencil")
+                        .font(.caption2.weight(.semibold))
+                        .foregroundStyle(.orange)
+                        .padding(.horizontal, 7)
+                        .padding(.vertical, 2)
+                        .background(Color.orange.opacity(0.14), in: Capsule())
+                        .accessibilityLabel("Needs debrief")
                 }
             }
             .lineLimit(1)

--- a/app/flyfun-weather/flyfun-weather/Views/Flights/FlightListView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Flights/FlightListView.swift
@@ -383,10 +383,33 @@ struct FlightListView: View {
 
     struct FlightGroup { let title: String; let flights: [FlightResponse] }
 
-    /// Group flights into Future (upcoming), Recent (flown in the last 7 days),
-    /// and Past. All sorted most-recent-first (latest departure at top). Empty
+    /// Group flights into Future · Recent · Past, sorted most-recent-first. Empty
     /// groups are dropped.
+    ///
+    /// Prefers the server's `section` (the authoritative debrief-nudge window:
+    /// `recent` = recent past flights not yet debriefed, bounded server-side). A
+    /// legacy server that omits `section` falls back to client-side date
+    /// bucketing (Recent = departed within 7 days) so the list still groups.
     static func groupedFlights(_ flights: [FlightResponse], now: Date = Date()) -> [FlightGroup] {
+        func date(_ f: FlightResponse) -> Date { f.departureDate ?? now }
+        func bucketed(_ future: [FlightResponse], _ recent: [FlightResponse], _ past: [FlightResponse]) -> [FlightGroup] {
+            [
+                FlightGroup(title: "Future", flights: future.sorted { date($0) > date($1) }),
+                FlightGroup(title: "Recent", flights: recent.sorted { date($0) > date($1) }),
+                FlightGroup(title: "Past", flights: past.sorted { date($0) > date($1) }),
+            ].filter { !$0.flights.isEmpty }
+        }
+
+        // Server-driven grouping when any flight carries a section.
+        if flights.contains(where: { $0.section != nil }) {
+            return bucketed(
+                flights.filter { $0.flightSection == .future },
+                flights.filter { $0.flightSection == .recent },
+                flights.filter { $0.flightSection == .past }
+            )
+        }
+
+        // Legacy fallback: client-side date bucketing.
         let recentCutoff = now.addingTimeInterval(-7 * 24 * 3600)
         var future: [FlightResponse] = []
         var recent: [FlightResponse] = []
@@ -397,15 +420,7 @@ struct FlightListView: View {
             else if dep >= recentCutoff { recent.append(f) }
             else { past.append(f) }
         }
-        func date(_ f: FlightResponse) -> Date { f.departureDate ?? now }
-        future.sort { date($0) > date($1) }
-        recent.sort { date($0) > date($1) }
-        past.sort { date($0) > date($1) }
-        return [
-            FlightGroup(title: "Future", flights: future),
-            FlightGroup(title: "Recent", flights: recent),
-            FlightGroup(title: "Past", flights: past),
-        ].filter { !$0.flights.isEmpty }
+        return bucketed(future, recent, past)
     }
 
     private var emptyStateView: some View {

--- a/app/flyfun-weather/flyfun-weatherTests/DebriefTaxonomyTests.swift
+++ b/app/flyfun-weather/flyfun-weatherTests/DebriefTaxonomyTests.swift
@@ -1,0 +1,110 @@
+//
+//  DebriefTaxonomyTests.swift
+//  flyfun-weatherTests
+//
+//  Decode/encode regression tests for the debrief feature (#430). The key risk,
+//  mirrored from ForecastMapTests, is the JSON key strategy mangling dictionary
+//  keys: `advisory_tag_map` ids (icing_escape, vfr_feasibility) contain
+//  underscores, and `outcomes` is keyed by tag ids that must NOT be lowercased
+//  (IMC → imc) on the way out. These tests pin that behaviour.
+//
+
+import Foundation
+import Testing
+@testable import flyfun_weather
+
+@Suite("DebriefTaxonomy")
+struct DebriefTaxonomyTests {
+
+    /// A help-catalog payload carrying a `debrief` section (metrics/advisories
+    /// trimmed to the minimum each decode path needs).
+    static let catalogJSON = """
+    {
+      "version": "deadbeef",
+      "metrics": { "cape_surface_jkg": { "name": "CAPE" } },
+      "advisories": [],
+      "debrief": {
+        "decisions": [
+          { "id": "flown", "label": "Flown" },
+          { "id": "cancelled", "label": "Cancelled" },
+          { "id": "monitoring", "label": "Monitor only" }
+        ],
+        "tags": [
+          { "id": "IMC", "label": "IMC", "description": "Low ceilings", "outcome_category": true },
+          { "id": "OPS", "label": "Operational", "description": "Non-weather", "outcome_category": false }
+        ],
+        "outcome_values": [
+          { "id": "consistent", "label": "As forecast" },
+          { "id": "worse", "label": "Worse than forecast" }
+        ],
+        "advisory_tag_map": { "icing_escape": "ICE", "vfr_feasibility": "IMC" },
+        "note_max_length": 300
+      }
+    }
+    """
+
+    @Test("Help catalog decodes the debrief section with underscored map keys intact")
+    func decodesDebriefSection() throws {
+        let catalog = try HelpCatalogResponse.decode(from: Data(Self.catalogJSON.utf8))
+        let debrief = try #require(catalog.debrief)
+
+        #expect(debrief.decisions.map(\.id) == ["flown", "cancelled", "monitoring"])
+        #expect(debrief.noteMaxLength == 300)
+
+        // outcome_category → outcomeCategory via explicit CodingKeys.
+        #expect(debrief.tag("IMC")?.outcomeCategory == true)
+        #expect(debrief.tag("OPS")?.outcomeCategory == false)
+        #expect(debrief.outcomeCategoryTags.map(\.id) == ["IMC"])
+
+        // The underscored advisory-map keys must survive verbatim (the plain
+        // decoder path); a snake→camel strategy would break the lookup.
+        #expect(debrief.advisoryTagMap["icing_escape"] == "ICE")
+        #expect(debrief.advisoryTagMap["vfr_feasibility"] == "IMC")
+    }
+
+    @Test("Missing debrief key decodes to nil (old cached payload)")
+    func backwardCompatibleWithoutDebrief() throws {
+        let json = #"{ "version": "v", "metrics": { "x": { "name": "X" } }, "advisories": [] }"#
+        let catalog = try HelpCatalogResponse.decode(from: Data(json.utf8))
+        #expect(catalog.debrief == nil)
+    }
+
+    @Test("flaggedTagIds maps AMBER/RED advisories to tags in taxonomy order")
+    func flaggedTags() {
+        let taxonomy = DebriefTaxonomy.bundledBaseline
+        let flagged = taxonomy.flaggedTagIds(fromAdvisories: [
+            (id: "convective", status: "red"),
+            (id: "icing_escape", status: "amber"),
+            (id: "vmc_cruise", status: "green"),   // green → ignored
+            (id: "unknown_id", status: "red"),      // unmapped → ignored
+        ])
+        // ICE precedes TS in the taxonomy tag order.
+        #expect(flagged == ["ICE", "TS"])
+    }
+
+    @Test("DebriefResponse decode keeps tag-keyed outcomes verbatim")
+    func decodesOutcomesDict() throws {
+        let json = """
+        { "flight_id": "f1", "decision": "flown", "reasons": [],
+          "outcomes": { "IMC": "worse", "ICE": "consistent" }, "note": null,
+          "created_at": "2026-07-15T10:00:00Z", "updated_at": "2026-07-15T10:00:00Z" }
+        """
+        let d = try JSONDecoder.weatherBrief.decode(DebriefResponse.self, from: Data(json.utf8))
+        #expect(d.flightId == "f1")
+        // Single-word keys must NOT be lowercased by .convertFromSnakeCase.
+        #expect(d.outcomes["IMC"] == "worse")
+        #expect(d.outcomes["ICE"] == "consistent")
+    }
+
+    @Test("DebriefRequest encodes tag-id keys without snake-casing")
+    func encodesOutcomeKeysVerbatim() throws {
+        let req = DebriefRequest(decision: "flown", reasons: [], outcomes: ["IMC": "worse"], note: nil)
+        let data = try req.encoded()
+        let obj = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        let outcomes = try #require(obj?["outcomes"] as? [String: Any])
+        // Must be "IMC", never "imc" — a snake-casing encoder would break server
+        // enum validation.
+        #expect(outcomes["IMC"] as? String == "worse")
+        #expect(outcomes["imc"] == nil)
+    }
+}

--- a/app/flyfun-weather/flyfun-weatherTests/FlightGroupingTests.swift
+++ b/app/flyfun-weather/flyfun-weatherTests/FlightGroupingTests.swift
@@ -1,0 +1,80 @@
+//
+//  FlightGroupingTests.swift
+//  flyfun-weatherTests
+//
+//  Covers the two branches added with the debrief feature (#430):
+//  `FlightListView.groupedFlights` (server-`section`-driven vs. legacy 7-day
+//  date fallback) and `FlightResponse.flightSection` (the per-card fallback).
+//
+
+import Foundation
+import Testing
+@testable import flyfun_weather
+
+@Suite("FlightGrouping")
+struct FlightGroupingTests {
+
+    static let now = ISO8601DateFormatter().date(from: "2026-07-15T12:00:00Z")!
+    static func iso(_ offsetDays: Double) -> String {
+        ISO8601DateFormatter().string(from: now.addingTimeInterval(offsetDays * 86400))
+    }
+
+    private func flight(_ id: String, days: Double, section: String? = nil) -> FlightResponse {
+        var f = makeFlight(id: id, departureTime: Self.iso(days))
+        f.section = section
+        return f
+    }
+
+    private func titles(_ groups: [FlightListView.FlightGroup]) -> [String] { groups.map(\.title) }
+    private func ids(_ group: FlightListView.FlightGroup?) -> [String] { group?.flights.map(\.id) ?? [] }
+
+    // MARK: - Legacy fallback (no server section)
+
+    @Test("Legacy grouping buckets by date; Recent = departed within 7 days")
+    func legacyBuckets() {
+        let groups = FlightListView.groupedFlights(
+            [flight("future", days: 1), flight("recent", days: -2), flight("old", days: -30)],
+            now: Self.now
+        )
+        #expect(titles(groups) == ["Future", "Recent", "Past"])
+        #expect(ids(groups.first { $0.title == "Recent" }) == ["recent"])
+        #expect(ids(groups.first { $0.title == "Past" }) == ["old"])
+    }
+
+    @Test("Empty groups are dropped")
+    func dropsEmptyGroups() {
+        let groups = FlightListView.groupedFlights([flight("a", days: 2)], now: Self.now)
+        #expect(titles(groups) == ["Future"])
+    }
+
+    // MARK: - Server-section driven
+
+    @Test("Server `section` wins over date bucketing")
+    func serverSectionWins() {
+        // A long-past departure the server nonetheless marks "recent" (e.g. still
+        // within the debrief-nudge window) must land in Recent, not Past.
+        let groups = FlightListView.groupedFlights(
+            [flight("a", days: -100, section: "recent"), flight("b", days: 5, section: "past")],
+            now: Self.now
+        )
+        #expect(ids(groups.first { $0.title == "Recent" }) == ["a"])
+        #expect(ids(groups.first { $0.title == "Past" }) == ["b"])
+    }
+
+    // MARK: - flightSection computed fallback (uses real `Date()`)
+
+    @Test("flightSection: server value wins; else 7-day date fallback")
+    func flightSectionFallback() {
+        // Relative to the live clock so the fallback's `Date()` agrees.
+        let fmt = ISO8601DateFormatter()
+        var recent = makeFlight(id: "r", departureTime: fmt.string(from: Date().addingTimeInterval(-2 * 86400)))
+        #expect(recent.flightSection == .recent)   // legacy fallback
+        recent.section = "past"
+        #expect(recent.flightSection == .past)      // server value wins
+
+        let future = makeFlight(id: "f", departureTime: fmt.string(from: Date().addingTimeInterval(3 * 86400)))
+        #expect(future.flightSection == .future)
+        let old = makeFlight(id: "o", departureTime: fmt.string(from: Date().addingTimeInterval(-30 * 86400)))
+        #expect(old.flightSection == .past)
+    }
+}

--- a/app/flyfun-weather/flyfun-weatherTests/TestSupport.swift
+++ b/app/flyfun-weather/flyfun-weatherTests/TestSupport.swift
@@ -126,6 +126,10 @@ final class MockBriefingRepository: BriefingRepository, @unchecked Sendable {
         return try submitPirepsBatchResult.get()
     }
     func fetchPireps(flightId: String) async throws -> PirepListResponse { throw MockError.notStubbed("fetchPireps") }
+    func fetchDebrief(flightId: String) async throws -> DebriefResponse { throw MockError.notStubbed("fetchDebrief") }
+    func upsertDebrief(flightId: String, request: DebriefRequest) async throws -> DebriefResponse { throw MockError.notStubbed("upsertDebrief") }
+    func deleteDebrief(flightId: String) async throws { throw MockError.notStubbed("deleteDebrief") }
+    func submitDigestFeedback(_ request: DigestFeedbackRequest) async throws { throw MockError.notStubbed("submitDigestFeedback") }
 }
 
 // MARK: - Fixture factories

--- a/src/weatherbrief/api/help.py
+++ b/src/weatherbrief/api/help.py
@@ -14,6 +14,12 @@ text. Two sections in one versioned, ETag-cacheable payload:
   folded into the version hash so any edit re-validates the ETag.
 - ``advisories`` — the existing advisory catalog (``get_catalog()``), the same
   data already served at ``/user/preferences/advisories/catalog``.
+- ``debrief`` — the debrief taxonomy (decision buttons, cancel-reason chips,
+  per-category outcome rows, advisory→tag map). Python is the single source of
+  truth (``debriefs.taxonomy.build_taxonomy_catalog``); the iOS app renders its
+  debrief form straight from here instead of hand-copying a Swift third copy of
+  the vocabulary. Language-independent for now (English labels), but folded into
+  the version hash so any edit re-validates the ETag.
 
 ``lang`` contract: the param is accepted and threaded through now so no client
 or endpoint change is needed once content is translated. Today both the metrics
@@ -36,6 +42,7 @@ from typing import Any
 from fastapi import APIRouter, Header, Response
 
 from weatherbrief.analysis.advisories import get_catalog
+from weatherbrief.debriefs.taxonomy import build_taxonomy_catalog
 from weatherbrief.models import AdvisoryCatalogEntry
 
 logger = logging.getLogger(__name__)
@@ -119,6 +126,7 @@ def _build_payload(lang: str) -> tuple[bytes, str]:
         "metrics": _load_metrics_catalog(),
         "maps": _load_map_metrics_catalog(),
         "advisories": _localize_advisories(get_catalog(), lang),
+        "debrief": build_taxonomy_catalog(),
     }
     canonical = json.dumps(core, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
     version = hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:16]
@@ -128,6 +136,7 @@ def _build_payload(lang: str) -> tuple[bytes, str]:
         "metrics": core["metrics"],
         "maps": core["maps"],
         "advisories": core["advisories"],
+        "debrief": core["debrief"],
     }
     body = json.dumps(payload, ensure_ascii=False).encode("utf-8")
 

--- a/src/weatherbrief/debriefs/taxonomy.py
+++ b/src/weatherbrief/debriefs/taxonomy.py
@@ -43,6 +43,121 @@ class OutcomeValue(str, Enum):
 OUTCOME_CATEGORIES: list[ConditionTag] = [t for t in ConditionTag if t != ConditionTag.OPS]
 
 
+# --- Display metadata (single source of truth; served to iOS, mirrored in TS) ---
+#
+# The labels/descriptions below and ``ADVISORY_TAG_MAP`` historically lived only
+# in ``web/ts/components/debrief-taxonomy.ts``. They now live here so Python is
+# the *complete* source of truth and ``build_taxonomy_catalog()`` can serve them
+# in the ``/api/help/catalog`` payload (the iOS client renders the debrief form
+# straight from that catalog rather than hand-copying a Swift third copy). The TS
+# mirror stays for the web build; keep all three in step.
+
+# Decision display order (Flown first — the common case), with labels.
+DECISION_ORDER: list[Decision] = [Decision.FLOWN, Decision.CANCELLED, Decision.MONITORING]
+
+DECISION_LABELS: dict[Decision, str] = {
+    Decision.FLOWN: "Flown",
+    Decision.CANCELLED: "Cancelled",
+    Decision.MONITORING: "Monitor only",
+}
+
+TAG_LABELS: dict[ConditionTag, str] = {
+    ConditionTag.IMC: "IMC",
+    ConditionTag.ICE: "Icing",
+    ConditionTag.WIND: "Wind",
+    ConditionTag.TS: "Thunderstorm",
+    ConditionTag.TURB: "Turbulence",
+    ConditionTag.FRZ: "Freezing precip",
+    ConditionTag.VIS: "Visibility",
+    ConditionTag.OPS: "Operational",
+}
+
+TAG_DESCRIPTIONS: dict[ConditionTag, str] = {
+    ConditionTag.IMC: "Low ceilings / IFR conditions",
+    ConditionTag.ICE: "Airframe icing",
+    ConditionTag.WIND: "Strong / gusty / crosswind",
+    ConditionTag.TS: "Thunderstorms or convective build-up",
+    ConditionTag.TURB: "Turbulence (any intensity)",
+    ConditionTag.FRZ: "Freezing rain / sleet",
+    ConditionTag.VIS: "Reduced visibility, fog, mist",
+    ConditionTag.OPS: "Non-weather (aircraft, pilot, NOTAM, fuel, …)",
+}
+
+OUTCOME_LABELS: dict[OutcomeValue, str] = {
+    OutcomeValue.CONSISTENT: "As forecast",
+    OutcomeValue.BETTER: "Better than forecast",
+    OutcomeValue.WORSE: "Worse than forecast",
+}
+
+# Free-text note ceiling, shared by both the cancel and flown forms.
+NOTE_MAX_LENGTH = 300
+
+# Advisory id → debrief tag. Per-id (not per-category) because some categories
+# cover more than one phenomenon. ``model`` advisories aren't weather → no entry.
+# Mirrors ADVISORY_TAG_MAP in ``web/ts/components/debrief-taxonomy.ts``.
+ADVISORY_TAG_MAP: dict[str, ConditionTag] = {
+    "icing_escape": ConditionTag.ICE,
+    "fiki_icing": ConditionTag.ICE,
+    "vmc_cruise": ConditionTag.IMC,
+    "cloud_top": ConditionTag.IMC,
+    "vfr_feasibility": ConditionTag.IMC,
+    "ifr_feasibility": ConditionTag.IMC,
+    "flight_category": ConditionTag.IMC,
+    "turbulence": ConditionTag.TURB,
+    "mountain_wind": ConditionTag.TURB,
+    "convective": ConditionTag.TS,
+    "airport_wind": ConditionTag.WIND,
+}
+
+
+def build_taxonomy_catalog() -> dict:
+    """JSON-able debrief taxonomy for the served ``/api/help/catalog`` payload.
+
+    iOS renders the debrief form (decision buttons, cancel-reason chips, per-
+    category outcome rows) purely from this, so a taxonomy edit is one Python
+    change both the web (build-time TS mirror) and iOS (this catalog) pick up.
+    Keys are snake_case to match the rest of the catalog's wire convention.
+    """
+    return {
+        "decisions": [
+            {"id": d.value, "label": DECISION_LABELS[d]} for d in DECISION_ORDER
+        ],
+        "tags": [
+            {
+                "id": t.value,
+                "label": TAG_LABELS[t],
+                "description": TAG_DESCRIPTIONS[t],
+                "outcome_category": t in OUTCOME_CATEGORIES,
+            }
+            for t in ConditionTag
+        ],
+        "outcome_values": [
+            {"id": v.value, "label": OUTCOME_LABELS[v]} for v in OutcomeValue
+        ],
+        "advisory_tag_map": {aid: tag.value for aid, tag in ADVISORY_TAG_MAP.items()},
+        "note_max_length": NOTE_MAX_LENGTH,
+    }
+
+
+def flagged_tags_from_advisories(
+    advisories: list[tuple[str, str]],
+) -> list[ConditionTag]:
+    """Tags whose advisory came back AMBER/RED, in ``ConditionTag`` order.
+
+    ``advisories`` is a list of ``(advisory_id, aggregate_status)`` pairs.
+    GREEN/UNAVAILABLE don't count — there's nothing for the pilot to grade.
+    Mirrors ``flaggedTagsFromAdvisories`` in the TS taxonomy.
+    """
+    flagged: set[ConditionTag] = set()
+    for advisory_id, status in advisories:
+        if status.lower() not in ("amber", "red"):
+            continue
+        tag = ADVISORY_TAG_MAP.get(advisory_id)
+        if tag is not None:
+            flagged.add(tag)
+    return [t for t in ConditionTag if t in flagged]
+
+
 # Phrases scanned in the free-text note to auto-toggle matching chips.
 # Lowercase, whole-word-ish matches (see _build_pattern). Conservative on purpose;
 # the chip is the source of truth — pilots can untoggle if a match is unwanted.

--- a/src/weatherbrief/models/storage.py
+++ b/src/weatherbrief/models/storage.py
@@ -8,6 +8,7 @@ from typing import Literal, Optional
 from pydantic import BaseModel, Field, computed_field, field_validator, model_validator
 
 from weatherbrief.debriefs.taxonomy import (
+    NOTE_MAX_LENGTH,
     OUTCOME_CATEGORIES,
     ConditionTag,
     Decision,
@@ -183,7 +184,11 @@ class BriefingPackMeta(BaseModel):
         return self.days_out < 0
 
 
-NOTE_MAX_LEN = 300
+# Single source of truth is `debriefs.taxonomy.NOTE_MAX_LENGTH` (also served to
+# iOS/mirrored in TS as the pilot-facing counter/gate). Kept as an alias so the
+# server-enforced limit can't drift from what clients display, and so the
+# existing `models.NOTE_MAX_LEN` export keeps resolving.
+NOTE_MAX_LEN = NOTE_MAX_LENGTH
 
 
 class FlightDebrief(BaseModel):
@@ -225,8 +230,8 @@ class FlightDebrief(BaseModel):
         v = v.strip()
         if not v:
             return None
-        if len(v) > NOTE_MAX_LEN:
-            raise ValueError(f"note must be at most {NOTE_MAX_LEN} characters")
+        if len(v) > NOTE_MAX_LENGTH:
+            raise ValueError(f"note must be at most {NOTE_MAX_LENGTH} characters")
         return v
 
     @model_validator(mode="after")

--- a/tests/test_debrief_taxonomy.py
+++ b/tests/test_debrief_taxonomy.py
@@ -5,10 +5,13 @@ from __future__ import annotations
 import pytest
 
 from weatherbrief.debriefs.taxonomy import (
+    ADVISORY_TAG_MAP,
     OUTCOME_CATEGORIES,
     ConditionTag,
     Decision,
     OutcomeValue,
+    build_taxonomy_catalog,
+    flagged_tags_from_advisories,
     match_tags_in_text,
 )
 
@@ -27,6 +30,53 @@ class TestEnums:
         for t in ConditionTag:
             if t is not ConditionTag.OPS:
                 assert t in OUTCOME_CATEGORIES
+
+
+class TestServedCatalog:
+    def test_catalog_shape(self):
+        cat = build_taxonomy_catalog()
+        assert [d["id"] for d in cat["decisions"]] == ["flown", "cancelled", "monitoring"]
+        # Every tag carries id/label/description + outcome flag.
+        ids = {t["id"] for t in cat["tags"]}
+        assert ids == {t.value for t in ConditionTag}
+        for t in cat["tags"]:
+            assert {"id", "label", "description", "outcome_category"} <= set(t)
+        # OPS is the only non-outcome category.
+        non_outcome = {t["id"] for t in cat["tags"] if not t["outcome_category"]}
+        assert non_outcome == {"OPS"}
+        assert cat["note_max_length"] == 300
+
+    def test_advisory_map_serialises_tag_values(self):
+        cat = build_taxonomy_catalog()
+        assert cat["advisory_tag_map"]["icing_escape"] == "ICE"
+        # Every mapped value is a real ConditionTag value.
+        valid = {t.value for t in ConditionTag}
+        assert all(v in valid for v in cat["advisory_tag_map"].values())
+
+
+class TestFlaggedTags:
+    def test_amber_red_flag_their_tag(self):
+        flagged = flagged_tags_from_advisories(
+            [("icing_escape", "red"), ("turbulence", "amber"), ("vmc_cruise", "green")]
+        )
+        assert ConditionTag.ICE in flagged
+        assert ConditionTag.TURB in flagged
+        assert ConditionTag.IMC not in flagged  # green → not flagged
+
+    def test_unknown_advisory_ignored(self):
+        assert flagged_tags_from_advisories([("model_quality", "red")]) == []
+
+    def test_result_in_condition_tag_order(self):
+        flagged = flagged_tags_from_advisories(
+            [("convective", "red"), ("icing_escape", "red")]
+        )
+        # ICE precedes TS in ConditionTag declaration order.
+        assert flagged == [ConditionTag.ICE, ConditionTag.TS]
+
+    def test_every_mapped_id_resolves(self):
+        # Guards the map against a typo'd tag.
+        for tag in ADVISORY_TAG_MAP.values():
+            assert isinstance(tag, ConditionTag)
 
 
 class TestKeywordMatching:

--- a/tests/test_help_catalog.py
+++ b/tests/test_help_catalog.py
@@ -71,6 +71,37 @@ class TestPayloadBuilding:
         assert "wind_speed_kt" in maps["scales"]["bands"]
         assert maps["metrics"]["flight_category"]["label"] == "Category"
 
+    def test_payload_carries_the_debrief_taxonomy(self):
+        # The debrief taxonomy is served here so iOS renders the debrief form
+        # from the same vocabulary the web bundle imports at build time.
+        payload = json.loads(help_module._build_payload("en")[0])
+        debrief = payload["debrief"]
+        # Decisions in display order, Flown first.
+        assert [d["id"] for d in debrief["decisions"]] == ["flown", "cancelled", "monitoring"]
+        # Every ConditionTag present; OPS is not an outcome category, IMC is.
+        tags = {t["id"]: t for t in debrief["tags"]}
+        assert set(tags) == {"IMC", "ICE", "WIND", "TS", "TURB", "FRZ", "VIS", "OPS"}
+        assert tags["OPS"]["outcome_category"] is False
+        assert tags["ICE"]["outcome_category"] is True
+        assert tags["ICE"]["label"] == "Icing"
+        assert [v["id"] for v in debrief["outcome_values"]] == ["consistent", "better", "worse"]
+        assert debrief["advisory_tag_map"]["convective"] == "TS"
+        assert debrief["note_max_length"] == 300
+
+    def test_debrief_taxonomy_folded_into_version(self):
+        # A taxonomy edit must re-validate the ETag (it's part of the hash).
+        import weatherbrief.debriefs.taxonomy as tax
+
+        _, v1 = help_module._build_payload("en")
+        original = tax.TAG_LABELS[tax.ConditionTag.ICE]
+        tax.TAG_LABELS[tax.ConditionTag.ICE] = "Rime & clear ice"
+        try:
+            help_module._payload_cache.clear()
+            _, v2 = help_module._build_payload("en")
+        finally:
+            tax.TAG_LABELS[tax.ConditionTag.ICE] = original
+        assert v1 != v2
+
     def test_version_is_stable(self):
         _, v1 = help_module._build_payload("en")
         help_module._payload_cache.clear()
@@ -125,6 +156,8 @@ class TestEndpoint:
         assert data["version"]
         assert data["metrics"]["cape_surface_jkg"]["name"] == "CAPE"
         assert any(a["id"] == "convective" for a in data["advisories"])
+        # Debrief taxonomy rides in the same payload.
+        assert [d["id"] for d in data["debrief"]["decisions"]] == ["flown", "cancelled", "monitoring"]
         # ETag wraps the version exactly.
         assert resp.headers["ETag"] == f'"{data["version"]}"'
 

--- a/web/ts/components/debrief-taxonomy.ts
+++ b/web/ts/components/debrief-taxonomy.ts
@@ -1,8 +1,12 @@
 /** TS mirror of src/weatherbrief/debriefs/taxonomy.py.
  *
- * Keep in sync — both define the canonical condition tags and keyword
- * map. Drift is caught at code review (small file, no obvious harm
- * mechanism) since runtime cross-validation would mean an extra fetch.
+ * Keep in sync — both define the canonical condition tags, labels and
+ * keyword map. Python is the single source of truth: it also serves this
+ * vocabulary in the `debrief` section of `/api/help/catalog`, which the iOS
+ * app renders from (so iOS never hand-copies a third Swift copy). The web
+ * bundle keeps this build-time mirror rather than fetching, so the labels
+ * here must match `TAG_LABELS`/`TAG_DESCRIPTIONS`/`ADVISORY_TAG_MAP` in the
+ * Python module. Drift is caught at code review + the sync-ios-web audit.
  */
 
 import type { ConditionTagId, OutcomeValue } from '../store/types';


### PR DESCRIPTION
Closes #430

Brings the web **post-flight debrief** and **digest 👍/👎** feedback surfaces to iOS at capture parity, and consolidates the debrief taxonomy so Python is the single source of truth (served in the help catalog, no third hand-copied Swift copy).

Both feature backends already existed — this is a client build plus one small backend consolidation.

## Backend
- `debriefs/taxonomy.py` gains the display labels/descriptions, decision order, `ADVISORY_TAG_MAP`, and `build_taxonomy_catalog()` / `flagged_tags_from_advisories()` that previously lived only in the web TS mirror — so the vocabulary lives in one place.
- `/api/help/catalog` now carries a `debrief` section (folded into the version hash → ETag re-validates on any edit). The web bundle keeps its build-time TS mirror; iOS renders the form from the served catalog.

## iOS
- **Models/repo**: `DebriefTaxonomy` (served + offline baseline mirroring the Python catalog), `DebriefResponse`/`DebriefRequest`, `DigestFeedbackRequest`; `section` + `debrief` added to `FlightResponse` (tolerant optionals); repository methods for the three debrief verbs + `POST /feedback`.
  - Dict-key hazard handled: the `outcomes` map is keyed by tag ids (`IMC`, …). Decode is safe under `.convertFromSnakeCase` (single-word keys pass through); the request body uses a **plain** encoder so `.convertToSnakeCase` can't lowercase the keys.
- **Advisory tab, below the hero**: a digest thumbs strip → optional-comment sheet (consent toggle, per-pack-version), and — for past owned flights — a debrief card (Add / summary + Edit) → sheet form modeled on `PirepReportingView`. Decision → cancel-reason chips / per-category outcomes (flagged advisories only) / monitoring. Debrief state lives in `BriefingViewModel` so it survives tab switches; monitoring sends empty arrays as the server validator requires.
- **Flight list**: groups by the server `section` (recent = the debrief-nudge window), with a Recent "Debrief" chip and a debriefed ✓ glyph. Legacy servers fall back to date bucketing.

## Deferred (both platforms, separate follow-up)
- Cross-session "already rated" thumb state — today web + iOS dedup only in-session (no server read-back). Needs a new endpoint.
- Debrief stats on iOS — web-only by design.
- `matchTagsInText` auto-chip highlight and an offline queue for debrief/thumbs — not needed for v1.

## Testing
- Backend: `test_help_catalog.py` + `test_debrief_taxonomy.py` extended (served section shape, version folding, flagged-tag logic). Full debrief/feedback/help suite green (110 passed).
- iOS: `xcodebuild … build` succeeds. On-device verification of the sheets still TODO (mock mode can't render the briefing — see the sim-verify note).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
