### PR TITLE
feat(profiles): sparsify stored settings — drop values equal to default (#405)

### DIFF
--- a/alembic/versions/079_sparsify_profile_settings.py
+++ b/alembic/versions/079_sparsify_profile_settings.py
@@ -1,0 +1,138 @@
+"""Sparsify stored profile settings: drop values equal to the default (#405 / #402 S2).
+
+The one-time backfill that makes the sparse-persist design (#403) real for the
+profiles that predate it. Slice 2 of #402.
+
+**Rule** (identical to the client's ``profile-sparsify.ts`` and the server helper
+:mod:`weatherbrief.analysis.advisories.profile_sparsify` — imported here, not
+re-implemented):
+
+* delete any ``advisories.params[id][key]`` whose value equals the **current
+  catalog default** (imported live, never snapshotted, so a default that moved
+  between merge and deploy cannot turn this no-op into a data change);
+* reduce a legacy fused ``cloud_method`` to its bare source — NWP (the default)
+  drops the key, DD rewrites it to the canonical ``cloud_source: "dd"`` so the
+  override survives;
+* delete ``icing_method`` / ``cloud_source`` / ``convective_method`` equal to
+  :data:`ENGINE_METHOD_DEFAULTS`.
+
+``advisories.enabled`` is **never touched** (#402: ``fronts: false`` equals the
+catalog ``default_enabled`` yet is a real opt-out).
+
+**Why lossless.** The #402 prod audit found every template-seeded param already
+*differs* from its catalog default, so "delete == default" can only reach the
+redundant copies of the default the engine applies anyway — never a template or
+pilot override. The accompanying test asserts byte-identical resolved settings
+before/after on prod-shaped fixtures.
+
+**Sequencing.** Must run *after* the #403 code is live (the deploy path already
+orders ``docker compose up`` before ``alembic upgrade head``). Pre-#403 code read
+an absent engine method as DD via a falsy fall-through, so sparsifying against it
+would silently revert profiles to DD.
+
+**Dry-run.** Set ``SPARSIFY_DRY_RUN=1`` to compute and print the per-profile +
+total blast radius and then **abort before commit** (raises, so alembic rolls the
+transaction back and does not stamp the revision). Use it to reproduce the
+expected counts against a prod snapshot before the real write. The richer offline
+report lives in ``scripts/sparsify_profiles_dryrun.py``.
+
+Pure Python data update over the JSON ``settings_json`` Text column (cf.
+migrations 069 / 078) — raw SQL with named binds, dialect-agnostic (SQLite dev /
+MySQL prod), no ALTER / batch mode. ``updated_at`` is deliberately left untouched:
+a raw UPDATE does not fire the ORM ``onupdate`` hook, and this is a system-driven
+correction, not a user edit.
+
+Revision ID: 079
+Revises: 078
+Create Date: 2026-07-15
+"""
+from __future__ import annotations
+
+import json
+import os
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "079"
+down_revision: Union[str, None] = "078"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Import live at migration time (never snapshot the defaults as a literal) —
+    # this is what guarantees the rule stays a no-op if a default moved between
+    # merge and deploy. Imports are inside upgrade() so a bare `alembic history`
+    # never imports the app.
+    from weatherbrief.analysis.advisories.profile_sparsify import (
+        build_param_defaults,
+        sparsify_settings,
+    )
+    from weatherbrief.analysis.advisories.registry import get_catalog
+
+    dry_run = os.environ.get("SPARSIFY_DRY_RUN") == "1"
+    param_defaults = build_param_defaults(get_catalog())
+
+    conn = op.get_bind()
+    rows = conn.execute(
+        sa.text("SELECT id, settings_json FROM flight_profiles")
+    ).fetchall()
+
+    profiles_touched = 0
+    totals = {
+        "params_deleted": 0,
+        "engine_deleted": 0,
+        "cloud_method_dropped": 0,
+        "cloud_method_rewritten": 0,
+    }
+    for row_id, raw in rows:
+        settings = json.loads(raw) if raw else {}
+        new_settings, stats = sparsify_settings(settings, param_defaults)
+        if not stats.touched:
+            continue
+        profiles_touched += 1
+        totals["params_deleted"] += stats.params_deleted
+        totals["engine_deleted"] += stats.engine_deleted
+        totals["cloud_method_dropped"] += stats.cloud_method_dropped
+        totals["cloud_method_rewritten"] += stats.cloud_method_rewritten
+        if dry_run:
+            print(
+                f"[079][dry-run] profile {row_id}: "
+                f"-{stats.params_deleted} params, "
+                f"-{stats.engine_deleted} engine, "
+                f"cloud_method drop={stats.cloud_method_dropped} "
+                f"rewrite={stats.cloud_method_rewritten}"
+            )
+        else:
+            conn.execute(
+                sa.text(
+                    "UPDATE flight_profiles SET settings_json = :s WHERE id = :id"
+                ),
+                {"s": json.dumps(new_settings), "id": row_id},
+            )
+
+    # Alembic captures stdout in the migration log — record the blast radius so
+    # the deploy log can be compared against the pre-write dry-run numbers.
+    print(
+        f"[079] sparsified {profiles_touched} profiles "
+        f"({totals['params_deleted']} params, {totals['engine_deleted']} engine, "
+        f"{totals['cloud_method_dropped']} legacy cloud_method dropped, "
+        f"{totals['cloud_method_rewritten']} rewritten to cloud_source)"
+    )
+
+    if dry_run:
+        # Abort so the transaction rolls back and the revision is NOT stamped.
+        raise RuntimeError(
+            "[079] SPARSIFY_DRY_RUN=1 — aborting before commit; no rows written."
+        )
+
+
+def downgrade() -> None:
+    """Irreversible: the redundant values were deleted, not archived, and a
+    sparsified profile is indistinguishable from one born sparse. Re-densifying
+    would wrongly freeze today's defaults onto every profile (the exact thing
+    #402 exists to undo) and over-densify profiles that were already sparse.
+    Rollback is the pre-write ``flight_profiles`` snapshot, not this downgrade."""
+    pass

--- a/scripts/sparsify_profiles_dryrun.py
+++ b/scripts/sparsify_profiles_dryrun.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python
+"""Read-only dry-run of the #405 profile sparsify — reports the blast radius.
+
+Runs the exact rule the ``079`` migration will apply (same
+``profile_sparsify.sparsify_settings`` helper, same live catalog) against a
+database WITHOUT writing anything, and prints per-profile + total counts. Use it
+to reproduce/refresh the expected numbers against a production snapshot before
+committing to the real write.
+
+Usage::
+
+    # against the current dev DB (DATABASE_URL from .env)
+    python scripts/sparsify_profiles_dryrun.py
+
+    # against a snapshot loaded into a local sqlite file
+    python scripts/sparsify_profiles_dryrun.py --db sqlite:////tmp/prod_profiles.db
+
+    # verbose: one line per touched profile
+    python scripts/sparsify_profiles_dryrun.py -v
+
+Deliberately takes a DB URL and touches nothing else — no server host, no
+credentials, no environment assumptions baked in.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+
+import sqlalchemy as sa
+
+from weatherbrief.analysis.advisories.profile_sparsify import (
+    build_param_defaults,
+    sparsify_settings,
+)
+from weatherbrief.analysis.advisories.registry import get_catalog
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--db",
+        default=os.environ.get("DATABASE_URL"),
+        help="SQLAlchemy DB URL (default: $DATABASE_URL)",
+    )
+    ap.add_argument(
+        "-v", "--verbose", action="store_true", help="one line per touched profile"
+    )
+    args = ap.parse_args()
+    if not args.db:
+        ap.error("no database URL: pass --db or set DATABASE_URL")
+
+    param_defaults = build_param_defaults(get_catalog())
+    engine = sa.create_engine(args.db)
+
+    profiles_total = 0
+    profiles_touched = 0
+    totals = {
+        "params_deleted": 0,
+        "engine_deleted": 0,
+        "cloud_method_dropped": 0,
+        "cloud_method_rewritten": 0,
+    }
+    with engine.connect() as conn:
+        rows = conn.execute(
+            sa.text("SELECT id, settings_json FROM flight_profiles")
+        ).fetchall()
+        for row_id, raw in rows:
+            profiles_total += 1
+            settings = json.loads(raw) if raw else {}
+            _, stats = sparsify_settings(settings, param_defaults)
+            if not stats.touched:
+                continue
+            profiles_touched += 1
+            totals["params_deleted"] += stats.params_deleted
+            totals["engine_deleted"] += stats.engine_deleted
+            totals["cloud_method_dropped"] += stats.cloud_method_dropped
+            totals["cloud_method_rewritten"] += stats.cloud_method_rewritten
+            if args.verbose:
+                print(
+                    f"  profile {row_id}: "
+                    f"-{stats.params_deleted} params, "
+                    f"-{stats.engine_deleted} engine, "
+                    f"cloud_method drop={stats.cloud_method_dropped} "
+                    f"rewrite={stats.cloud_method_rewritten}"
+                )
+
+    print(f"\nprofiles scanned : {profiles_total}")
+    print(f"profiles touched : {profiles_touched}")
+    print(f"params deleted   : {totals['params_deleted']}")
+    print(f"engine deleted   : {totals['engine_deleted']}")
+    print(f"cloud_method drop: {totals['cloud_method_dropped']}")
+    print(f"cloud_method rewr: {totals['cloud_method_rewritten']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/weatherbrief/analysis/advisories/profile_sparsify.py
+++ b/src/weatherbrief/analysis/advisories/profile_sparsify.py
@@ -1,0 +1,136 @@
+"""Server-side sparsify of stored profile settings (#405 / #402 slice 2).
+
+The Python sibling of ``web/ts/helpers/profile-sparsify.ts``. Both implement the
+same rule so the client's save path and the one-time backfill migration converge
+on an identical stored shape: **persist only what differs from the default.**
+
+Absence resolves to the same default at grading time — advisory params via
+``evaluate_all``'s ``{**catalog_defaults, **user_params}`` merge, engine methods
+via :data:`ENGINE_METHOD_DEFAULTS` — so pruning a value equal to its default is
+lossless for grading and lets an already-dense profile shrink.
+
+Three things are swept, and **nothing else is touched**:
+
+1. **Advisory params** (``advisories.params[id][key]``): a stored param is
+   dropped only when the catalog declares a default for that exact ``id:key``
+   *and* the stored value equals it. A param with no catalog default (unknown /
+   legacy key) is kept — we never delete a value we cannot prove is a default.
+2. **Legacy ``cloud_method``** (pre-#410 fused ``<style>_<source>`` key): reduced
+   to its bare source. NWP (the default) → the key is dropped (absence follows
+   the default); DD (**not** the default) → rewritten to the canonical
+   ``cloud_source: "dd"`` so the DD grade is preserved exactly. Either way the
+   fused key is removed, which is what lets the #410 read-path fallback be
+   deleted.
+3. **Engine methods** (``icing_method`` / ``cloud_source`` / ``convective_method``):
+   dropped when equal to :data:`ENGINE_METHOD_DEFAULTS`; a differing value is a
+   deliberate override and is kept.
+
+**``advisories.enabled`` is never touched** (#402): ``fronts`` declares
+``default_enabled=False`` yet is injected by default when the
+``auto_front_detection`` artifact exists, so an explicit ``fronts: false`` is a
+real opt-out that a naive "equals default" rule would wrongly delete. Enable
+flags are already centrally switchable via ``resolve_enabled_ids`` and stay out
+of the sparsify entirely.
+"""
+
+from __future__ import annotations
+
+import copy
+from dataclasses import dataclass
+
+from weatherbrief.analysis.advisories.engine_methods import (
+    ENGINE_METHOD_DEFAULTS,
+    legacy_cloud_source,
+)
+
+
+@dataclass
+class SparsifyStats:
+    """Per-profile blast radius, summed by the migration for its dry-run report."""
+
+    params_deleted: int = 0
+    engine_deleted: int = 0
+    cloud_method_dropped: int = 0  # legacy NWP/redundant key removed outright
+    cloud_method_rewritten: int = 0  # legacy DD key canonicalized to cloud_source
+
+    @property
+    def touched(self) -> bool:
+        return bool(
+            self.params_deleted
+            or self.engine_deleted
+            or self.cloud_method_dropped
+            or self.cloud_method_rewritten
+        )
+
+
+def build_param_defaults(catalog) -> dict[tuple[str, str], float]:
+    """Lookup of catalog default keyed ``(advisory_id, param_key)``.
+
+    ``catalog`` is the live ``get_catalog()`` list — imported at migration time
+    (never snapshotted as a literal) so a default that moves between merge and
+    deploy cannot silently turn the backfill from a no-op into a data change.
+    """
+    out: dict[tuple[str, str], float] = {}
+    for entry in catalog:
+        for p in entry.parameters:
+            out[(entry.id, p.key)] = p.default
+    return out
+
+
+def sparsify_settings(
+    settings: dict,
+    param_defaults: dict[tuple[str, str], float],
+) -> tuple[dict, SparsifyStats]:
+    """Return a sparsified copy of ``settings`` plus a :class:`SparsifyStats`.
+
+    Pure — the input dict is never mutated (the byte-identical test relies on
+    comparing the original against the sparsified copy). Order matters: the
+    legacy ``cloud_method`` sweep runs *before* the engine-method prune so a
+    rewritten ``cloud_source: "dd"`` (an override) survives while a redundant
+    ``cloud_source: "nwp"`` (the default) is then dropped.
+    """
+    out = copy.deepcopy(settings)
+    stats = SparsifyStats()
+
+    # 1. Advisory params equal to the catalog default.
+    adv = out.get("advisories")
+    if isinstance(adv, dict) and isinstance(adv.get("params"), dict):
+        pruned: dict[str, dict] = {}
+        for adv_id, params in adv["params"].items():
+            if not isinstance(params, dict):
+                pruned[adv_id] = params
+                continue
+            kept: dict[str, float] = {}
+            for key, val in params.items():
+                dflt = param_defaults.get((adv_id, key))
+                if dflt is not None and val == dflt:
+                    stats.params_deleted += 1
+                    continue  # equals default → prune
+                kept[key] = val
+            if kept:
+                pruned[adv_id] = kept
+        adv["params"] = pruned
+
+    # 2. Legacy fused ``cloud_method`` → canonical ``cloud_source`` (or dropped).
+    if "cloud_method" in out:
+        legacy = out.pop("cloud_method")
+        if "cloud_source" in out:
+            # New key already present and authoritative → the legacy key is
+            # redundant regardless of its value.
+            stats.cloud_method_dropped += 1
+        else:
+            source = legacy_cloud_source(legacy)
+            if source is not None and source != ENGINE_METHOD_DEFAULTS["cloud_source"]:
+                out["cloud_source"] = source  # DD: preserve the override
+                stats.cloud_method_rewritten += 1
+            else:
+                # NWP (the default) or unparseable → absence follows the default.
+                stats.cloud_method_dropped += 1
+
+    # 3. Engine methods equal to their declared default.
+    for key, dflt in ENGINE_METHOD_DEFAULTS.items():
+        if out.get(key) == dflt:
+            out.pop(key, None)
+            stats.engine_deleted += 1
+
+    return out, stats

--- a/tests/test_sparsify_profile_settings.py
+++ b/tests/test_sparsify_profile_settings.py
@@ -1,0 +1,209 @@
+"""Sparsify rule + byte-identical guarantee for the #405 profile backfill.
+
+The migration (``079``) and the client (``profile-sparsify.ts``) share one rule:
+persist only what differs from the default. These tests pin the rule against the
+live catalog and, crucially, assert the backfill is a **no-op for grading** — the
+resolved effective settings (what actually feeds the evaluator) are identical
+before and after sparsifying, for a spread of prod-shaped profiles.
+
+Fixtures are built from the known template seeds (``configs/system_profiles.json``)
+and the documented legacy shapes — never real user data.
+"""
+
+from __future__ import annotations
+
+import copy
+
+from weatherbrief.analysis.advisories.engine_methods import (
+    ENGINE_METHOD_DEFAULTS,
+    cloud_source_from_settings,
+)
+from weatherbrief.analysis.advisories.profile_sparsify import (
+    build_param_defaults,
+    sparsify_settings,
+)
+from weatherbrief.analysis.advisories.registry import get_catalog
+
+
+def _param_defaults():
+    return build_param_defaults(get_catalog())
+
+
+def _resolve_effective(settings: dict, param_defaults) -> dict:
+    """The grading-relevant projection of a profile: the merged advisory params
+    (``{**catalog_defaults, **user}``), the resolved enable map is untouched by
+    sparsify so it is excluded, and the three engine axes resolved through their
+    defaults exactly as ``_resolve_analyses`` does. If this is identical before
+    and after sparsify, no grade can move."""
+    # Advisory params, catalog-merged per advisory.
+    catalog_by_adv: dict[str, dict] = {}
+    for (adv_id, key), dflt in param_defaults.items():
+        catalog_by_adv.setdefault(adv_id, {})[key] = dflt
+    user_params = (settings.get("advisories") or {}).get("params") or {}
+    merged = {}
+    for adv_id, defaults in catalog_by_adv.items():
+        merged[adv_id] = {**defaults, **user_params.get(adv_id, {})}
+
+    # Engine axes: absence → default; legacy cloud_method honoured via the
+    # read-path fallback (still present this slice).
+    return {
+        "params": merged,
+        "icing_method": settings.get("icing_method")
+        or ENGINE_METHOD_DEFAULTS["icing_method"],
+        "cloud_source": cloud_source_from_settings(settings)
+        or ENGINE_METHOD_DEFAULTS["cloud_source"],
+        "convective_method": settings.get("convective_method")
+        or ENGINE_METHOD_DEFAULTS["convective_method"],
+    }
+
+
+# --- prod-shaped fixtures -------------------------------------------------
+
+def _vfr_only_dense():
+    """A settings-page Save densified this vfr_only profile: every engine method
+    and a full slab of advisory params frozen at the default. The two real
+    template overrides (vmc_cruise / vfr_feasibility) must survive."""
+    return {
+        "cruise_altitude_ft": 5500,
+        "flight_rules": "vfr_only",
+        # engine methods frozen at the default by the dense save → all prunable
+        "icing_method": "ogimet_nwp",
+        "cloud_source": "nwp",
+        "convective_method": "nwp",
+        "advisories": {
+            "enabled": {"fronts": False, "ifr_feasibility": False},
+            "params": {
+                # real template overrides — differ from catalog default → KEEP
+                "vmc_cruise": {"bkn_pct_amber": 5, "ovc_pct_red": 10},
+                "vfr_feasibility": {"imc_pct_amber": 5, "imc_pct_red": 10},
+            },
+            "aggregation": "majority",
+        },
+    }
+
+
+def test_enable_flags_are_never_touched():
+    pd = _param_defaults()
+    settings = {
+        "advisories": {"enabled": {"fronts": False, "convective": True}, "params": {}}
+    }
+    out, stats = sparsify_settings(settings, pd)
+    assert out["advisories"]["enabled"] == {"fronts": False, "convective": True}
+    assert stats.params_deleted == 0
+
+
+def test_param_equal_to_default_is_pruned_override_is_kept():
+    pd = _param_defaults()
+    # Find a real (advisory, key, default) from the live catalog to build on.
+    (adv_id, key), dflt = next(iter(pd.items()))
+    settings = {
+        "advisories": {
+            "params": {
+                adv_id: {key: dflt},  # equals default → prune
+            }
+        }
+    }
+    out, stats = sparsify_settings(settings, pd)
+    assert stats.params_deleted == 1
+    assert adv_id not in out["advisories"]["params"]
+
+    # A value one step off the default is an override → kept untouched.
+    off = (dflt + 1) if isinstance(dflt, (int, float)) else dflt
+    settings2 = {"advisories": {"params": {adv_id: {key: off}}}}
+    out2, stats2 = sparsify_settings(settings2, pd)
+    assert stats2.params_deleted == 0
+    assert out2["advisories"]["params"][adv_id][key] == off
+
+
+def test_unknown_param_key_is_never_deleted():
+    pd = _param_defaults()
+    settings = {"advisories": {"params": {"made_up_adv": {"mystery": 42}}}}
+    out, stats = sparsify_settings(settings, pd)
+    assert stats.params_deleted == 0
+    assert out["advisories"]["params"]["made_up_adv"]["mystery"] == 42
+
+
+def test_engine_methods_equal_to_default_pruned():
+    pd = _param_defaults()
+    settings = dict(ENGINE_METHOD_DEFAULTS)  # all three at default
+    out, stats = sparsify_settings(settings, pd)
+    assert stats.engine_deleted == 3
+    assert "icing_method" not in out
+    assert "cloud_source" not in out
+    assert "convective_method" not in out
+
+
+def test_engine_override_kept():
+    pd = _param_defaults()
+    settings = {
+        "icing_method": "ogimet_dd",  # override
+        "cloud_source": "dd",  # override
+        "convective_method": "thermo",  # override
+    }
+    out, stats = sparsify_settings(settings, pd)
+    assert stats.engine_deleted == 0
+    assert out == settings
+
+
+def test_legacy_cloud_method_nwp_is_dropped():
+    pd = _param_defaults()
+    out, stats = sparsify_settings({"cloud_method": "soft_nwp"}, pd)
+    assert "cloud_method" not in out
+    assert "cloud_source" not in out  # absence → nwp default
+    assert stats.cloud_method_dropped == 1
+    assert stats.cloud_method_rewritten == 0
+
+
+def test_legacy_cloud_method_dd_is_rewritten_to_cloud_source():
+    pd = _param_defaults()
+    out, stats = sparsify_settings({"cloud_method": "square_dd"}, pd)
+    assert "cloud_method" not in out
+    assert out["cloud_source"] == "dd"  # override preserved
+    assert stats.cloud_method_rewritten == 1
+    assert stats.cloud_method_dropped == 0
+
+
+def test_legacy_cloud_method_redundant_with_cloud_source_is_dropped():
+    pd = _param_defaults()
+    out, stats = sparsify_settings(
+        {"cloud_source": "dd", "cloud_method": "square_nwp"}, pd
+    )
+    assert "cloud_method" not in out
+    assert out["cloud_source"] == "dd"  # new key is authoritative
+    assert stats.cloud_method_dropped == 1
+
+
+def test_input_is_not_mutated():
+    pd = _param_defaults()
+    settings = _vfr_only_dense()
+    before = copy.deepcopy(settings)
+    sparsify_settings(settings, pd)
+    assert settings == before
+
+
+def test_byte_identical_resolved_settings_over_prod_shapes():
+    """The core no-op guarantee: resolving the effective grading settings yields
+    an identical projection before and after sparsify, across a spread of
+    prod-shaped profiles."""
+    pd = _param_defaults()
+    fixtures = [
+        _vfr_only_dense(),
+        dict(ENGINE_METHOD_DEFAULTS),
+        {"icing_method": "ogimet_dd", "cloud_source": "dd", "convective_method": "thermo"},
+        {"cloud_method": "soft_nwp", "cruise_altitude_ft": 5500},
+        {"cloud_method": "square_dd", "cruise_altitude_ft": 5500},
+        {"cloud_source": "dd", "cloud_method": "natural_nwp"},
+        {},  # a born-sparse profile — must be a strict no-op
+    ]
+    for settings in fixtures:
+        before = _resolve_effective(settings, pd)
+        sparsified, _ = sparsify_settings(settings, pd)
+        after = _resolve_effective(sparsified, pd)
+        assert before == after, f"grading projection moved for {settings!r}"
+
+
+def test_born_sparse_profile_is_untouched():
+    pd = _param_defaults()
+    out, stats = sparsify_settings({}, pd)
+    assert out == {}
+    assert not stats.touched


### PR DESCRIPTION
## What & why

Slice 2 of #402. A one-time alembic backfill (`079`) that makes the sparse-persist design (#403) real for the ~500 profiles that predate it: **persist only what differs from the default**, so a future engine-default change reaches every user who never deliberately chose otherwise.

The rule (identical to the client's `profile-sparsify.ts`, factored into a reusable server helper `profile_sparsify.py` that imports the **live** catalog):

- delete any `advisories.params[id][key]` equal to the current catalog default;
- delete `icing_method` / `cloud_source` / `convective_method` equal to `ENGINE_METHOD_DEFAULTS`;
- sweep the pre-#410 fused `cloud_method`: NWP (the default) → drop; **DD → rewrite to the canonical `cloud_source:"dd"`** so the override is preserved, never deleted.

`advisories.enabled` is **never touched** (#402: `fronts:false` equals its catalog `default_enabled` yet is a real opt-out).

**Provably lossless for grading.** The #402 audit found every template-seeded param already differs from its catalog default, so "delete == default" cannot reach an override. Confirmed empirically: resolved effective grading (param merge + all three engine axes + enable resolution) is **byte-identical before/after across all 1,434 real prod profiles — 0 mismatches**. The one grading change in the whole #402 initiative already shipped in #410's migration `078`.

The fallback deletion (`cloud_source_from_settings` + its call sites) is **deferred to a follow-up** so this special deploy is purely additive and the fallback keeps guarding the ~15 legacy-DD profiles *during* the write.

### Refreshed prod dry-run (replaces the stale 95 / 5,149 in the issue)

| metric | count |
|---|---|
| profiles scanned | 1,434 |
| profiles touched | 520 |
| advisory params deleted | 4,974 |
| engine methods deleted | 911 |
| legacy `cloud_method` dropped (NWP/redundant) | 458 |
| legacy `cloud_method` rewritten to `cloud_source:dd` | 15 |

## Issue linkage

Closes #405

## Testing / verification

- New `tests/test_sparsify_profile_settings.py` (11 tests): rule coverage (params/engine/enable/legacy-cloud), input-not-mutated, and the byte-identical resolved-grading guarantee on prod-shaped fixtures. Green, plus `test_profile_sparse_persistence` + `test_clouds` (46 total).
- Migration exercised on dev: upgrade writes, `SPARSIFY_DRY_RUN=1` prints the blast radius and aborts-before-commit (revision unstamped), downgrade→upgrade cycles cleanly, single alembic head `079`, idempotent (re-run touches 0).
- Byte-identical resolved grading verified over **all 1,434 real prod profiles** (offline, read-only): 0 mismatches.

### Deploy runbook (special, staged)

1. Refresh dry-run numbers (`scripts/sparsify_profiles_dryrun.py` or in-container `SPARSIFY_DRY_RUN=1`).
2. Snapshot `flight_profiles` as the rollback artifact (downgrade is a no-op by design — deleted-because-equal-to-default can't be reconstructed without over-densifying already-sparse profiles).
3. Deploy code → `docker exec ... alembic upgrade head` runs `079`; compare its logged blast radius to the dry-run.
4. #402 acceptance: move one real default, confirm via advisory-preview that untouched profiles follow it and customized ones don't.