### PR TITLE
Timing scan: persist all graded candidates + disposition (show-all / rejected UI)

### DIFF
--- a/designs/plans/timing-scenario-plan.md
+++ b/designs/plans/timing-scenario-plan.md
@@ -482,6 +482,14 @@ a prev-day scan that graded 07-17 midday convective-worse just went empty).
 - **iOS** mirrors the DTO fields in a separate PR (contract change), defaulting
   the panel filter to improving+neutral so it doesn't suddenly show worse rows.
 
+**Rollout note (transient):** `disposition` defaults to `neutral`, so a
+`time_options.json` persisted **before** this change reloads with every swept
+candidate marked `neutral` rather than the `improving` it was (pre-#434, only
+improving rows were persisted at all). Until that pack's next rescan (a new
+ECMWF run, or an explicit "Set as alternate" / rescan), the "N departure windows
+look smoother" headline **undercounts** for it. Self-healing on the next scan,
+and it never over-claims (undercount only) — no data fix needed.
+
 Out of scope (unchanged): per-model per-advisory *detail* per candidate (too
 large; stays gated), and the confirm/rescan flow.
 

--- a/designs/plans/timing-scenario-plan.md
+++ b/designs/plans/timing-scenario-plan.md
@@ -300,6 +300,8 @@ TimeWindowScan {
      departure_shift, valid_times[],                   # a shift propagates per-point ETAs
      ecmwf_assessment,                                 # GREEN/AMBER/RED
      improves: [advisory_ids], worsens: [...],         # FULL-picture diff vs baseline
+     disposition: "improving" | "neutral" | "worse",   # #434 — every candidate kept + tagged
+     advisory_status: {adv_id: {model: status}},       # #434 — coverage-scoped per-model map
      confidence: "confirmed_in_window" | "ecmwf_only" | "confirmed",
      confirmed: TimeConfirmation | null                # filled on tap (or free in-window)
   } ]
@@ -445,8 +447,47 @@ user to the app rather than exposing half a workflow.
   `cost(check)` vs `cost(full scan) × skip_rate` — and keep whichever (if
   either) pays for itself.
 
+## Follow-up: persist all graded candidates + disposition (#434)
+
+The original scan graded every candidate on the full advisory set but only
+**persisted** improving windows (+ baseline + pinned alternate). Green-but-not-
+better and — the honesty gap — **worse (AMBER/RED) alternate hours** were computed
+and silently discarded, so the feature could *offer* a smoother day but never
+*show* that another day is worse (observed live on `egtf_big_lfat_lfqa-2026-07-18`:
+a prev-day scan that graded 07-17 midday convective-worse just went empty).
+
+**Decision — persist everything, cut at the display layer:**
+
+- `TimeCandidate` gains `disposition: "improving" | "neutral" | "worse"`
+  (orthogonal to `is_baseline` / `is_alternate`) — `worse` = any regression or
+  negative scan-class margin; `improving` = clears the margin with nothing
+  worsened; else `neutral`. `refused_times` (ungradable, no coverage) stays
+  distinct from `worse` (graded, but worse weather).
+- `TimeCandidate` gains `advisory_status: {advisory_id: {model: status}}` — a
+  **coverage-scoped per-model status map**. It carries exactly the models
+  actually graded: `{ecmwf: …}` for the ±day sweep, filling out to the full set
+  on an on-tap confirm — no schema change between provisional and confirmed.
+  Records GREEN too (unlike the RED/AMBER-only `assessment_reason`), so a client
+  reconstructs any advisory's per-model dot row at any candidate time without
+  re-grading. Full `per_model` detail (prose/ribbon/geometry, ~41 KB) stays
+  gated to the baseline manifest + confirm. Storage: ~550 B (sweep) to ~2.7 KB
+  (confirmed) per candidate; the 24-row grid stays well under ~70 KB/pack.
+- `run_time_scan` stops filtering: it appends **all** graded rows (free tier +
+  ECMWF-only tier) tagged with a computed disposition, ranked
+  improving→neutral→worse. `_MAX_IMPROVING_KEPT` is retired — persistence is
+  bounded by `_MAX_GRID`; the improving-only cut is now the client's job.
+- **Web** shows same-or-better (improving+neutral) + baseline/alternate by
+  default; a **"Show all"** toggle reveals `worse` rows (real chips) and refused
+  times (greyed, UNAVAILABLE chip). `advisory_status` mirrored on the DTO.
+- **iOS** mirrors the DTO fields in a separate PR (contract change), defaulting
+  the panel filter to improving+neutral so it doesn't suddenly show worse rows.
+
+Out of scope (unchanged): per-model per-advisory *detail* per candidate (too
+large; stays gated), and the confirm/rescan flow.
+
 ## References
 
+- Persist-all follow-up: #434 (`models/time_scan.py` `disposition`/`advisory_status`, `tasks/time_scan.py` unfiltered persistence, `tasks/advise.py::per_model_status_from_manifest`, web `renderTimeScenarios` show-all)
 - Mitigation framework + `MitigationKind.TIMING` (reserved): [advisories.md](../advisories.md) *Mitigations* section, #328/#330
 - Reuse machinery: `run_alt_from_pack` (`tasks/advise.py:704`), `AdvisoryCatalogEntry` (`models/advisories.py:144`, `altitude_dependent` `:153`), registry helper pattern (`analysis/advisories/registry.py:31`)
 - Enrichment windows: ECMWF ±3h (`fetch/grib/__init__.py:2071-2077`); GFS forward window (`grib_fetch.py:176`); ICON forward window (`icon_eu_fetch.py:361`); silent clamp (`models/analysis.py:329-342`); accumulated-field step-differencing (`grib/__init__.py:2067,2205`)

--- a/src/weatherbrief/models/__init__.py
+++ b/src/weatherbrief/models/__init__.py
@@ -105,6 +105,7 @@ from weatherbrief.models.advisories import (  # noqa: F401
     RouteAdvisoryResult,
 )
 from weatherbrief.models.time_scan import (  # noqa: F401
+    Disposition,
     FlexibilityMode,
     ModelCoverage,
     TimeCandidate,

--- a/src/weatherbrief/models/time_scan.py
+++ b/src/weatherbrief/models/time_scan.py
@@ -30,6 +30,17 @@ FlexibilityMode = Literal["none", "alternate", "same_day", "prev_day", "next_day
 #: Candidate model-coverage labels — see module docstring.
 TimeConfidence = Literal["confirmed_in_window", "ecmwf_only", "confirmed"]
 
+#: Disposition of a candidate vs the like-coverage baseline (#434) — orthogonal
+#: to ``is_baseline`` / ``is_alternate``. The scan now persists *every* graded
+#: candidate tagged with one of these; the improving-only cut moved to the
+#: display layer so the UI can honestly surface worse alternate times behind a
+#: "show all" toggle instead of the scan silently discarding them:
+#:
+#: * ``improving`` — clears the ranking margin with nothing worsened.
+#: * ``neutral``   — no qualifying improvement and no regression (same-ish).
+#: * ``worse``     — something worsened, or a scan-class regression.
+Disposition = Literal["improving", "neutral", "worse"]
+
 
 class TimeConfirmation(BaseModel):
     """Result of a multi-model check of one candidate (slice 3 on-tap confirm,
@@ -73,6 +84,19 @@ class TimeCandidate(BaseModel):
     # Net severity drop summed over the scan-class advisory set (the ranking
     # objective; decision D). Positive == better on the timing-sensitive axes.
     margin: float = 0.0
+    # How this candidate compares to the (like-coverage) baseline (#434). The
+    # scan persists all three; the client shows improving+neutral by default and
+    # reveals ``worse`` rows behind a "show all" toggle.
+    disposition: Disposition = "neutral"
+    # Per-advisory, per-model status the grade actually produced:
+    # ``{advisory_id: {model: "GREEN"|"AMBER"|"RED"|"UNAVAILABLE"}}``.
+    # Coverage-scoped (decision, #434): just ``{ecmwf: …}`` for the ±day sweep,
+    # the full graded set after an on-tap confirm — no schema change between
+    # provisional and confirmed. Lets the UI reconstruct any advisory's dot row
+    # at any candidate time without re-grading; ``improves``/``worsens`` are a
+    # diff and can't reconstruct the absolute per-model statuses. ~550 B (sweep)
+    # to ~2.7 KB (confirmed) per candidate; the ~41 KB full detail stays gated.
+    advisory_status: dict[str, dict[str, str]] = Field(default_factory=dict)
 
     confidence: TimeConfidence
     is_baseline: bool = False   # the planned departure, graded identically

--- a/src/weatherbrief/tasks/advise.py
+++ b/src/weatherbrief/tasks/advise.py
@@ -759,6 +759,27 @@ def per_model_reasons_from_manifest(
     return {model: ", ".join(parts) for model, parts in per_model.items()}
 
 
+def per_model_status_from_manifest(
+    manifest: RouteAdvisoriesManifest,
+) -> dict[str, dict[str, str]]:
+    """Full per-(advisory, model) status map — ``{advisory_id: {model: STATUS}}``.
+
+    Unlike :func:`per_model_reasons_from_manifest` (a compact RED/AMBER-only
+    reason string), this records **every** graded status including GREEN and
+    UNAVAILABLE, so the timing-scan artifact can reconstruct any advisory's
+    per-model dot row at any candidate time without re-grading (#434). The map
+    is coverage-scoped by construction — it carries exactly the models the
+    manifest was graded on (ECMWF-only for the ±day sweep, the full set after a
+    confirm). ``STATUS`` is upper-cased to match the ``assessment`` fields.
+    """
+    out: dict[str, dict[str, str]] = {}
+    for adv in manifest.advisories:
+        model_map = {m.model: m.status.value.upper() for m in adv.per_model}
+        if model_map:
+            out[adv.advisory_id] = model_map
+    return out
+
+
 # Cap on the number of named category chips surfaced on the flights-list card.
 # Mirrors the briefing-page glance summary's intent: a few "what to look at"
 # cues, not an exhaustive list.

--- a/src/weatherbrief/tasks/time_scan.py
+++ b/src/weatherbrief/tasks/time_scan.py
@@ -86,9 +86,16 @@ def _disposition(margin: float, worsens: list[str]) -> str:
     """Classify a candidate vs the like-coverage baseline (#434 taxonomy).
 
     ``worsens`` spans the **full** advisory set (never call a window that
-    quietly introduced a crosswind "improving"), so any regression — or a
-    negative scan-class margin — makes it ``worse``. Otherwise it's
-    ``improving`` when it clears the ranking margin, else ``neutral``.
+    quietly introduced a crosswind "improving"), so any regression makes it
+    ``worse``. Otherwise it's ``improving`` when it clears the ranking margin,
+    else ``neutral``.
+
+    The ``margin < 0`` clause is a defensive backstop: ``_diff_manifests``
+    already appends every negative-delta advisory to ``worsens`` before the
+    scan-class margin sum, so a negative ``margin`` cannot occur with an empty
+    ``worsens`` today. It's kept because "negative margin ⇒ worse" is the
+    taxonomy the issue states, so the classifier stays correct even if the
+    diff's ordering is ever refactored.
     """
     if worsens or margin < 0:
         return "worse"
@@ -536,11 +543,16 @@ def confirm_candidate(
     Ephemeral throughout (decision G): enrichment mutates a freshly loaded
     copy; the caller persists only the updated ``time_options.json``.
 
-    Returns ``(confirmation, advisory_status)`` — the second element is the
-    now-multi-model per-(advisory, model) status map, so the caller can fill
-    out the candidate's provisional ECMWF-only ``advisory_status`` to the full
-    graded set (#434, "the same map fills out on confirm"). ``None`` when
-    grading fails outright.
+    Returns ``(confirmation, advisory_status, disposition)``:
+
+    * ``advisory_status`` — the now-multi-model per-(advisory, model) status
+      map, so the caller can fill out the candidate's provisional ECMWF-only
+      map to the full graded set (#434, "the same map fills out on confirm").
+    * ``disposition`` — re-derived from the multi-model diff, so a confirm
+      up/downgrade updates what the client shows (the display partition and
+      headline are keyed off ``disposition``, not the confirmation — #435).
+
+    ``None`` when grading fails outright.
     """
     from weatherbrief.fetch.grib import DecodePriority, enrich_forecasts
     from weatherbrief.models import TimeConfirmation
@@ -630,7 +642,14 @@ def confirm_candidate(
         worsens=worsens,
         confirmed_at=datetime.now(timezone.utc),
     )
-    return confirmation, per_model_status_from_manifest(candidate_manifest)
+    # Re-derive disposition from the multi-model diff (same _disposition the
+    # sweep used) so a confirm up/downgrade updates what the client shows — the
+    # display partition + headline key off `disposition`, not the confirmation.
+    return (
+        confirmation,
+        per_model_status_from_manifest(candidate_manifest),
+        _disposition(margin, worsens),
+    )
 
 
 def _aware_pack_departure(pack_dir: Path) -> datetime | None:

--- a/src/weatherbrief/tasks/time_scan.py
+++ b/src/weatherbrief/tasks/time_scan.py
@@ -45,6 +45,7 @@ from typing import Callable
 from weatherbrief.fetch.grib import ECMWF_FLIGHT_WINDOW_MARGIN
 from weatherbrief.models import (
     AdvisoryAggregation,
+    Disposition,
     ModelCoverage,
     ModelSource,
     RouteAdvisoriesManifest,
@@ -82,7 +83,7 @@ _MIN_MARGIN = 1
 _DISPOSITION_RANK = {"improving": 0, "neutral": 1, "worse": 2}
 
 
-def _disposition(margin: float, worsens: list[str]) -> str:
+def _disposition(margin: float, worsens: list[str]) -> Disposition:
     """Classify a candidate vs the like-coverage baseline (#434 taxonomy).
 
     ``worsens`` spans the **full** advisory set (never call a window that

--- a/src/weatherbrief/tasks/time_scan.py
+++ b/src/weatherbrief/tasks/time_scan.py
@@ -70,12 +70,31 @@ _MAX_GRID = 24
 # Severity ranking for the improve/worsen diff.
 _SEV = {"green": 0, "amber": 1, "red": 2}
 
-# A candidate surfaces only if the net severity drop over the scan-class set
-# reaches this margin with no offsetting scan-class regression (decision D).
+# A candidate is "improving" only if the net severity drop over the scan-class
+# set reaches this margin with no offsetting regression (decision D). This is
+# now the disposition threshold, not a persistence filter — every graded
+# candidate is kept and tagged (#434).
 _MIN_MARGIN = 1
 
-# Improving windows kept in the artifact (the UI caps display at ~3).
-_MAX_IMPROVING_KEPT = 5
+# Rank order for persisting candidates: improving first, then neutral, then
+# worse — so the client can slice "same-or-better" off the front and reveal
+# ``worse`` rows behind a "show all" toggle (#434).
+_DISPOSITION_RANK = {"improving": 0, "neutral": 1, "worse": 2}
+
+
+def _disposition(margin: float, worsens: list[str]) -> str:
+    """Classify a candidate vs the like-coverage baseline (#434 taxonomy).
+
+    ``worsens`` spans the **full** advisory set (never call a window that
+    quietly introduced a crosswind "improving"), so any regression — or a
+    negative scan-class margin — makes it ``worse``. Otherwise it's
+    ``improving`` when it clears the ranking margin, else ``neutral``.
+    """
+    if worsens or margin < 0:
+        return "worse"
+    if margin >= _MIN_MARGIN:
+        return "improving"
+    return "neutral"
 
 #: GRIB-enriched models — coverage is windowed; everything else is uniform OM.
 _GRIB_MODELS = {ModelSource.ECMWF, ModelSource.GFS, ModelSource.ICON}
@@ -516,13 +535,19 @@ def confirm_candidate(
 
     Ephemeral throughout (decision G): enrichment mutates a freshly loaded
     copy; the caller persists only the updated ``time_options.json``.
-    Returns ``None`` when grading fails outright.
+
+    Returns ``(confirmation, advisory_status)`` — the second element is the
+    now-multi-model per-(advisory, model) status map, so the caller can fill
+    out the candidate's provisional ECMWF-only ``advisory_status`` to the full
+    graded set (#434, "the same map fills out on confirm"). ``None`` when
+    grading fails outright.
     """
     from weatherbrief.fetch.grib import DecodePriority, enrich_forecasts
     from weatherbrief.models import TimeConfirmation
     from weatherbrief.tasks.advise import (
         derive_assessment_from_advisories,
         per_model_reasons_from_manifest,
+        per_model_status_from_manifest,
         run_alt_from_pack,
     )
     from weatherbrief.tasks.artifacts import load_cross_sections, load_route_points
@@ -595,7 +620,7 @@ def confirm_candidate(
         baseline_manifest, candidate_manifest, get_scan_class_ids(),
     )
     assess, reason = derive_assessment_from_advisories(candidate_manifest)
-    return TimeConfirmation(
+    confirmation = TimeConfirmation(
         models_checked=candidate_manifest.models,
         assessment=assess,
         assessment_reason=reason,
@@ -605,6 +630,7 @@ def confirm_candidate(
         worsens=worsens,
         confirmed_at=datetime.now(timezone.utc),
     )
+    return confirmation, per_model_status_from_manifest(candidate_manifest)
 
 
 def _aware_pack_departure(pack_dir: Path) -> datetime | None:
@@ -773,6 +799,7 @@ def run_time_scan(
     from weatherbrief.tasks.advise import (
         _compute_advisory_model_names,
         derive_assessment_from_advisories,
+        per_model_status_from_manifest,
         run_alt_from_pack,
     )
     from weatherbrief.tasks.artifacts import load_cross_sections, load_route_points
@@ -905,11 +932,14 @@ def run_time_scan(
         assessment=base_assess,
         assessment_reason=base_reason,
         models_used=graded_models,
+        advisory_status=per_model_status_from_manifest(baseline_manifest),
         confidence="confirmed_in_window",
         is_baseline=True,
     )
 
-    improving: list[TimeCandidate] = []
+    # Every graded swept candidate (all dispositions) — the improving-only cut
+    # moved to the display layer (#434). Bounded by _MAX_GRID up front.
+    graded: list[TimeCandidate] = []
     alternate_row: TimeCandidate | None = None
     # (time, is_alternate) pairs the free tier couldn't grade — the daylight
     # ECMWF extension (below) gives them a second, provisional chance.
@@ -946,13 +976,17 @@ def run_time_scan(
             improves=improves,
             worsens=worsens,
             margin=float(margin),
+            disposition=_disposition(margin, worsens),
+            advisory_status=per_model_status_from_manifest(manifest),
             confidence="confirmed_in_window",
             is_alternate=is_alt,
         )
         if is_alt:
             alternate_row = row
-        elif margin >= _MIN_MARGIN and not worsens:
-            improving.append(row)
+        else:
+            # Persist every disposition (#434) — the display layer, not the
+            # scan, applies the improving-only cut.
+            graded.append(row)
 
     # --- Slice 2: ECMWF-only provisional tier for the deferred hours.
     # Decode the daylight ECMWF fhours (local disk, BACKGROUND priority,
@@ -1013,6 +1047,8 @@ def run_time_scan(
                         improves=improves,
                         worsens=worsens,
                         margin=float(margin),
+                        disposition=_disposition(margin, worsens),
+                        advisory_status=per_model_status_from_manifest(manifest),
                         confidence="ecmwf_only",
                         is_alternate=is_alt,
                     )
@@ -1021,8 +1057,10 @@ def run_time_scan(
                         # persisted from the ECMWF-only manifest (its `models`
                         # field carries the honest coverage).
                         alternate_row = row
-                    elif margin >= _MIN_MARGIN and not worsens:
-                        improving.append(row)
+                    else:
+                        # Persist every disposition — including provisional
+                        # ``worse`` ±day rows, the honesty gap this closes (#434).
+                        graded.append(row)
             else:
                 refused.extend(t for t, _, _ in deferred)
         else:
@@ -1031,23 +1069,27 @@ def run_time_scan(
     else:
         refused.extend(t for t, _, _ in deferred)
 
-    # Rank: best margin first, then confirmed over provisional, ties broken by
-    # proximity to the alternate time (the pilot's stated preference) or else
-    # the planned time.
+    # Rank: same-or-better first (improving, then neutral, then worse), best
+    # margin first within a disposition, confirmed over provisional, ties broken
+    # by proximity to the alternate time (the pilot's stated preference) or else
+    # the planned time. No persistence cap — every graded candidate is kept
+    # (#434); the display layer slices the front and gates ``worse`` behind
+    # "show all". _MAX_GRID already bounds the count.
     anchor = _aware(alt_departure_time) if alt_departure_time else dep
-    improving.sort(
+    graded.sort(
         key=lambda r: (
+            _DISPOSITION_RANK.get(r.disposition, 1),
             -r.margin,
             0 if r.confidence == "confirmed_in_window" else 1,
             abs((r.departure_time - anchor).total_seconds()),
         ),
     )
-    improving = improving[:_MAX_IMPROVING_KEPT]
+    n_improving = sum(1 for r in graded if r.disposition == "improving")
 
     out_candidates = [baseline_row]
     if alternate_row is not None:
         out_candidates.append(alternate_row)
-    out_candidates.extend(improving)
+    out_candidates.extend(graded)
 
     if window_model is not None:
         window_model.horizon_clipped = horizon_clipped
@@ -1072,7 +1114,7 @@ def run_time_scan(
     )
     logger.info(
         "time-scan[%s]: %d graded (%d improving), %d refused in %.1fs",
-        flexibility, len(out_candidates), len(improving), len(refused),
+        flexibility, len(out_candidates), n_improving, len(refused),
         perf_counter() - t0,
     )
     return scan

--- a/src/weatherbrief/tasks/time_scan_runner.py
+++ b/src/weatherbrief/tasks/time_scan_runner.py
@@ -308,15 +308,7 @@ def _run_confirm_job(
                     flight_id, candidate_time,
                 )
                 return
-            cand.confirm_pending = False
-            if result is not None:
-                confirmation, advisory_status = result
-                cand.confirmed = confirmation
-                cand.confidence = "confirmed"
-                # The provisional ECMWF-only per-model map fills out to the full
-                # graded model set on confirm — same schema, more coverage (#434).
-                if advisory_status:
-                    cand.advisory_status = advisory_status
+            _apply_confirmation(cand, result)
             save_time_options(pack_dir, scan)
 
             # Usage accounting: one row per confirm attempt (the GFS+ICON
@@ -350,6 +342,32 @@ def _run_confirm_job(
     finally:
         with _inflight_lock:
             _inflight.discard(key)
+
+
+def _apply_confirmation(cand, result) -> None:
+    """Fold an on-tap confirm result onto its candidate.
+
+    Clears ``confirm_pending`` regardless; on a real result folds in the
+    multi-model verdict, the widened per-model ``advisory_status`` map, and —
+    crucially — the **re-derived disposition** (#435). The web layer's show/hide
+    split and "N look smoother" headline key off ``disposition``, so a confirm
+    that downgrades a provisional ``improving`` to "not clearly better" (or
+    upgrades a ``worse`` row) must move it between buckets, not just change its
+    verdict text. ``result`` is ``confirm_candidate``'s
+    ``(confirmation, advisory_status, disposition)`` tuple, or ``None`` on a
+    grading failure.
+    """
+    cand.confirm_pending = False
+    if result is None:
+        return
+    confirmation, advisory_status, disposition = result
+    cand.confirmed = confirmation
+    cand.confidence = "confirmed"
+    cand.disposition = disposition
+    # The provisional ECMWF-only per-model map fills out to the full graded
+    # model set on confirm — same schema, more coverage (#434).
+    if advisory_status:
+        cand.advisory_status = advisory_status
 
 
 def reconcile_stale_scan(pack_dir: Path) -> bool:
@@ -394,6 +412,13 @@ def merge_confirmed(old: "TimeWindowScan | None", new: "TimeWindowScan") -> None
         if prev is not None and prev.confirmed is not None and cand.confirmed is None:
             cand.confirmed = prev.confirmed
             cand.confidence = "confirmed"
+            # The paid confirm widened advisory_status to the full model set and
+            # re-derived disposition from the multi-model diff (#434/#435). A
+            # same-run rescan grades fresh ECMWF-only, so carry both — else the
+            # richer map narrows back to ~550 B and the confirm-derived bucket is
+            # lost while the verdict text still says "checked with all models".
+            cand.advisory_status = prev.advisory_status
+            cand.disposition = prev.disposition
 
 
 def reconcile_stale_confirms(pack_dir: Path) -> bool:

--- a/src/weatherbrief/tasks/time_scan_runner.py
+++ b/src/weatherbrief/tasks/time_scan_runner.py
@@ -277,7 +277,7 @@ def _run_confirm_job(
                 db, flight, flight.user_id, None, pack_dir, db_path=db_path,
             )
 
-            confirmation = confirm_candidate(
+            result = confirm_candidate(
                 pack_dir, route, candidate_time,
                 data_dir=Path(os.environ.get("DATA_DIR", "data")),
                 advisory_models=adv_models,
@@ -309,9 +309,14 @@ def _run_confirm_job(
                 )
                 return
             cand.confirm_pending = False
-            if confirmation is not None:
+            if result is not None:
+                confirmation, advisory_status = result
                 cand.confirmed = confirmation
                 cand.confidence = "confirmed"
+                # The provisional ECMWF-only per-model map fills out to the full
+                # graded model set on confirm — same schema, more coverage (#434).
+                if advisory_status:
+                    cand.advisory_status = advisory_status
             save_time_options(pack_dir, scan)
 
             # Usage accounting: one row per confirm attempt (the GFS+ICON
@@ -326,7 +331,7 @@ def _run_confirm_job(
             db.commit()
             logger.info(
                 "time-scan: confirm %s for %s @ %s",
-                "ok" if confirmation else "failed", flight_id, candidate_time,
+                "ok" if result else "failed", flight_id, candidate_time,
             )
         finally:
             db.close()

--- a/tests/test_time_scan.py
+++ b/tests/test_time_scan.py
@@ -190,6 +190,62 @@ class TestPerModelReasons:
 
         assert per_model_reasons_from_manifest(RouteAdvisoriesManifest()) == {}
 
+    def test_per_model_status_includes_green(self):
+        """#434: the full per-(advisory, model) status map records EVERY graded
+        status (GREEN too), so the UI can reconstruct dot rows without
+        re-grading — unlike the RED/AMBER-only reason string."""
+        from weatherbrief.models import ModelAdvisoryResult
+        from weatherbrief.tasks.advise import per_model_status_from_manifest
+
+        manifest = RouteAdvisoriesManifest(advisories=[
+            RouteAdvisoryResult(
+                advisory_id="convective",
+                aggregate_status=AdvisoryStatus.RED,
+                per_model=[
+                    ModelAdvisoryResult(model="ecmwf", status=AdvisoryStatus.RED),
+                    ModelAdvisoryResult(model="gfs", status=AdvisoryStatus.GREEN),
+                ],
+            ),
+        ])
+        assert per_model_status_from_manifest(manifest) == {
+            "convective": {"ecmwf": "RED", "gfs": "GREEN"},
+        }
+
+    def test_per_model_status_empty_without_per_model(self):
+        # An aggregate-only advisory (no per-model breakdown) contributes nothing.
+        from weatherbrief.tasks.advise import per_model_status_from_manifest
+
+        manifest = RouteAdvisoriesManifest(advisories=[
+            RouteAdvisoryResult(advisory_id="convective", aggregate_status=AdvisoryStatus.RED),
+        ])
+        assert per_model_status_from_manifest(manifest) == {}
+
+
+class TestDisposition:
+    """#434 taxonomy: improving / neutral / worse vs the like-coverage baseline."""
+
+    def test_improving_when_margin_clears_and_nothing_worsens(self):
+        from weatherbrief.tasks.time_scan import _disposition
+
+        assert _disposition(2, []) == "improving"
+
+    def test_neutral_when_no_gain_no_regression(self):
+        from weatherbrief.tasks.time_scan import _disposition
+
+        assert _disposition(0, []) == "neutral"
+
+    def test_worse_when_something_worsens_even_with_positive_margin(self):
+        # A full-set regression trumps a scan-class gain — never call a window
+        # that introduced a crosswind "improving".
+        from weatherbrief.tasks.time_scan import _disposition
+
+        assert _disposition(2, ["airport_wind"]) == "worse"
+
+    def test_worse_on_negative_margin(self):
+        from weatherbrief.tasks.time_scan import _disposition
+
+        assert _disposition(-1, []) == "worse"
+
     def test_confirmation_round_trips_field(self):
         from weatherbrief.models import TimeConfirmation
 
@@ -517,6 +573,147 @@ class TestProvisionalTier:
             if not c.is_baseline:
                 assert c.confidence == "ecmwf_only"
                 assert c.departure_time.date() > DEP.date()
+
+
+# ---------------------------------------------------------------------------
+# Persist all dispositions (#434): worse/neutral rows kept + tagged, not dropped
+# ---------------------------------------------------------------------------
+
+
+class TestPersistAllDispositions:
+    """The scan now persists every graded candidate with a disposition — the
+    improving-only cut moved to the display layer. Closes the honesty gap: a
+    worse alternate day is surfaced (behind the client's "show all"), never
+    silently discarded."""
+
+    def _write_pack(self, tmp_path: Path) -> None:
+        import json
+
+        cs_ecmwf = _cs(ModelSource.ECMWF, [_wf(ModelSource.ECMWF, enriched_hours=set(range(6, 12)))])
+        cs_gfs = _cs(ModelSource.GFS, [_wf(ModelSource.GFS, gfs_marked_hours=set(range(7, 11)))])
+        (tmp_path / "cross_section.json").write_text(json.dumps({
+            "cross_sections": [cs.model_dump(mode="json") for cs in (cs_ecmwf, cs_gfs)],
+        }, default=str))
+        (tmp_path / "route_points.json").write_text(json.dumps(
+            [rp.model_dump(mode="json") for rp in cs_ecmwf.route_points], default=str,
+        ))
+
+    def _route(self):
+        from weatherbrief.models import RouteConfig, Waypoint
+
+        return RouteConfig(
+            name="t",
+            waypoints=[
+                Waypoint(icao="AAAA", name="A", lat=51.0, lon=0.0),
+                Waypoint(icao="BBBB", name="B", lat=51.0, lon=1.0),
+            ],
+            flight_duration_hours=1.0,
+        )
+
+    def _full_day_extension(self):
+        def fake_extend(cross_sections, route_points, w_lo, w_hi, dur, *, as_of_time=None):
+            for cs in cross_sections:
+                if cs.model == ModelSource.ECMWF:
+                    for wf in cs.point_forecasts:
+                        for h in wf.hourly:
+                            h.pressure_levels = _levels(28)
+            return 1234567890, [(DAY, DAY + timedelta(hours=23))]
+
+        return fake_extend
+
+    def test_neutral_candidates_persisted_and_tagged(self, tmp_path, monkeypatch):
+        """Synthetic data grades identically at every hour → margin 0 → neutral.
+        Before #434 these were dropped entirely; now they're kept and tagged so
+        the UI can show "same conditions" times, not just better ones."""
+        import weatherbrief.tasks.time_scan as ts
+
+        self._write_pack(tmp_path)
+        monkeypatch.setattr(ts, "extend_ecmwf_daylight", self._full_day_extension())
+
+        scan = ts.run_time_scan(tmp_path, self._route(), DEP, flexibility="same_day")
+        assert scan is not None
+        swept = [c for c in scan.candidates if not c.is_baseline]
+        assert swept, "graded candidates must be persisted, not discarded"
+        assert all(c.disposition in {"improving", "neutral", "worse"} for c in swept)
+        assert any(c.disposition == "neutral" for c in swept)
+        # The baseline carries its own full per-model status map.
+        base = next(c for c in scan.candidates if c.is_baseline)
+        assert base.advisory_status, "baseline advisory_status map recorded"
+
+    def test_worse_candidates_persisted_and_tagged(self, tmp_path, monkeypatch):
+        """Force every diff to a regression: the swept rows must all be tagged
+        ``worse`` and still be persisted (the exact rows the old code threw
+        away). advisory_status is coverage-scoped to what was graded."""
+        import weatherbrief.tasks.time_scan as ts
+
+        self._write_pack(tmp_path)
+        monkeypatch.setattr(ts, "extend_ecmwf_daylight", self._full_day_extension())
+        # A regression on a non-scan advisory + negative scan margin → worse.
+        monkeypatch.setattr(
+            ts, "_diff_manifests",
+            lambda *a, **k: (["convective"], ["airport_wind"], -1),
+        )
+
+        scan = ts.run_time_scan(tmp_path, self._route(), DEP, flexibility="same_day")
+        assert scan is not None
+        swept = [c for c in scan.candidates if not c.is_baseline]
+        assert swept, "worse candidates must be persisted, not silently discarded"
+        assert all(c.disposition == "worse" for c in swept)
+        # Each ecmwf-only worse row carries a coverage-scoped per-model map:
+        # only ECMWF (and model-agnostic "all" advisories) were graded — the
+        # other weather models were never fetched for the sweep.
+        for c in swept:
+            assert isinstance(c.advisory_status, dict)
+            for model_map in c.advisory_status.values():
+                assert "gfs" not in model_map and "icon" not in model_map
+
+    def test_persistence_stays_bounded(self, tmp_path, monkeypatch):
+        """Size guardrail: keeping all dispositions must stay bounded by the
+        grid cap, and each candidate's per-model status map stays compact
+        (~KB, never the ~41 KB full detail which stays gated)."""
+        import json
+
+        import weatherbrief.tasks.time_scan as ts
+        from weatherbrief.tasks.time_scan import _MAX_GRID
+
+        self._write_pack(tmp_path)
+        monkeypatch.setattr(ts, "extend_ecmwf_daylight", self._full_day_extension())
+
+        scan = ts.run_time_scan(tmp_path, self._route(), DEP, flexibility="same_day")
+        assert scan is not None
+        swept = [c for c in scan.candidates if not c.is_baseline]
+        assert len(swept) <= _MAX_GRID
+        for c in scan.candidates:
+            size = len(json.dumps(c.advisory_status))
+            assert size < 5000, f"per-candidate advisory_status too large: {size} B"
+
+    def test_ranking_orders_improving_then_neutral_then_worse(self, tmp_path, monkeypatch):
+        """The persisted order lets the client slice same-or-better off the
+        front: improving first, neutral next, worse last."""
+        import weatherbrief.tasks.time_scan as ts
+
+        self._write_pack(tmp_path)
+        monkeypatch.setattr(ts, "extend_ecmwf_daylight", self._full_day_extension())
+
+        # Deterministically stamp a disposition per candidate hour so the
+        # ordering assertion doesn't depend on the synthetic grades: alternate
+        # improving / worse / neutral by hour.
+        real_diff = ts._diff_manifests
+        seq = iter([(["a"], [], 2), ([], ["b"], -1), ([], [], 0)] * 20)
+
+        def fake_diff(base, cand, scan_ids):
+            try:
+                return next(seq)
+            except StopIteration:
+                return real_diff(base, cand, scan_ids)
+
+        monkeypatch.setattr(ts, "_diff_manifests", fake_diff)
+        scan = ts.run_time_scan(tmp_path, self._route(), DEP, flexibility="same_day")
+        assert scan is not None
+        swept = [c for c in scan.candidates if not c.is_baseline]
+        ranks = {"improving": 0, "neutral": 1, "worse": 2}
+        order = [ranks[c.disposition] for c in swept]
+        assert order == sorted(order), "candidates must be ordered improving→neutral→worse"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_time_scan.py
+++ b/tests/test_time_scan.py
@@ -918,10 +918,18 @@ class TestMergeConfirmed:
             departure_shift_hours=hours,
             assessment="AMBER",
             confidence="ecmwf_only",
+            # A confirmed prev carries the widened multi-model map + a
+            # confirm-derived disposition (here: downgraded to worse).
+            disposition="worse" if confirmed else "improving",
+            advisory_status=(
+                {"convective": {"ecmwf": "RED", "gfs": "AMBER", "icon": "RED"}}
+                if confirmed else {"convective": {"ecmwf": "AMBER"}}
+            ),
             confirmed=TimeConfirmation(
                 models_checked=["ecmwf", "gfs", "icon"],
                 assessment="RED",
                 better_than_baseline=False,
+                worsens=["convective"],
                 confirmed_at=DEP,
             ) if confirmed else None,
         )
@@ -933,13 +941,18 @@ class TestMergeConfirmed:
         new = TimeWindowScan(
             flexibility="same_day",
             baseline=TimeScanBaseline(departure_time=DEP, assessment="RED"),
-            candidates=[self._cand(3)],
+            candidates=[self._cand(3)],  # fresh ECMWF-only regrade
             ecmwf_run_ts=111,
             generated_at=DEP,
         )
         merge_confirmed(old, new)
-        assert new.candidates[0].confirmed is not None
-        assert new.candidates[0].confidence == "confirmed"
+        merged = new.candidates[0]
+        assert merged.confirmed is not None
+        assert merged.confidence == "confirmed"
+        # #435 finding 2: the paid confirm's widened map + confirm-derived
+        # disposition survive the rescan, not just the verdict object.
+        assert merged.advisory_status == {"convective": {"ecmwf": "RED", "gfs": "AMBER", "icon": "RED"}}
+        assert merged.disposition == "worse"
 
     def test_new_run_drops_stale_confirms(self, tmp_path):
         from weatherbrief.tasks.time_scan_runner import merge_confirmed
@@ -954,6 +967,63 @@ class TestMergeConfirmed:
         )
         merge_confirmed(old, new)
         assert new.candidates[0].confirmed is None
+
+
+class TestApplyConfirmation:
+    """#435 finding 1: a confirm must move a candidate between display buckets
+    by re-deriving disposition, not merely swap its verdict text — the web
+    show/hide split and "N look smoother" headline key off disposition."""
+
+    def _pending(self, disposition: str) -> TimeCandidate:
+        return TimeCandidate(
+            departure_time=DEP + timedelta(hours=3),
+            departure_shift_hours=3.0,
+            assessment="AMBER",
+            confidence="ecmwf_only",
+            disposition=disposition,
+            advisory_status={"convective": {"ecmwf": "GREEN"}},
+            confirm_pending=True,
+        )
+
+    def _result(self, disposition: str, *, better: bool, worsens):
+        from weatherbrief.models import TimeConfirmation
+
+        conf = TimeConfirmation(
+            models_checked=["ecmwf", "gfs", "icon"],
+            assessment="AMBER",
+            better_than_baseline=better,
+            worsens=worsens,
+            confirmed_at=DEP,
+        )
+        status = {"convective": {"ecmwf": "AMBER", "gfs": "GREEN", "icon": "AMBER"}}
+        return conf, status, disposition
+
+    def test_confirm_downgrades_improving_to_worse(self):
+        from weatherbrief.tasks.time_scan_runner import _apply_confirmation
+
+        cand = self._pending("improving")
+        _apply_confirmation(cand, self._result("worse", better=False, worsens=["airport_wind"]))
+        assert cand.disposition == "worse"  # moved out of the default view
+        assert cand.confidence == "confirmed"
+        assert cand.confirm_pending is False
+        # The map widened to the full graded set on confirm.
+        assert cand.advisory_status["convective"] == {"ecmwf": "AMBER", "gfs": "GREEN", "icon": "AMBER"}
+
+    def test_confirm_upgrades_worse_to_improving(self):
+        from weatherbrief.tasks.time_scan_runner import _apply_confirmation
+
+        cand = self._pending("worse")
+        _apply_confirmation(cand, self._result("improving", better=True, worsens=[]))
+        assert cand.disposition == "improving"  # revealed into the default view
+
+    def test_failed_confirm_only_clears_pending(self):
+        from weatherbrief.tasks.time_scan_runner import _apply_confirmation
+
+        cand = self._pending("improving")
+        _apply_confirmation(cand, None)
+        assert cand.confirm_pending is False
+        assert cand.disposition == "improving"  # unchanged
+        assert cand.confirmed is None
 
 
 # ---------------------------------------------------------------------------

--- a/web/tests/unit/time-scenario-display.test.ts
+++ b/web/tests/unit/time-scenario-display.test.ts
@@ -1,0 +1,101 @@
+/** Tests for the timing-scenario display helpers (#434/#435).
+ *
+ * Locks the partition rules (confirmed-never-hidden, old-artifact-not-worse)
+ * and the advisory_status → per-model-dot inversion, which drive the show-all
+ * split, the "N look smoother" headline, and the candidate detail column.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  isWorseCandidate,
+  improvingCount,
+  invertAdvisoryStatus,
+} from '../../ts/helpers/time-scenario-display';
+import type { TimeCandidateDTO, TimeConfirmationDTO } from '../../ts/adapters/api-adapter';
+
+function cand(overrides: Partial<TimeCandidateDTO>): TimeCandidateDTO {
+  return {
+    departure_time: '2026-07-18T09:00:00Z',
+    departure_shift_hours: 1,
+    valid_times: [],
+    assessment: 'AMBER',
+    assessment_reason: '',
+    models_used: ['ecmwf'],
+    improves: [],
+    worsens: [],
+    margin: 0,
+    disposition: 'neutral',
+    advisory_status: {},
+    confidence: 'ecmwf_only',
+    is_baseline: false,
+    is_alternate: false,
+    confirmed: null,
+    confirm_pending: false,
+    ...overrides,
+  };
+}
+
+const confirmation = (over: Partial<TimeConfirmationDTO> = {}): TimeConfirmationDTO => ({
+  models_checked: ['ecmwf', 'gfs', 'icon'],
+  assessment: 'AMBER',
+  assessment_reason: '',
+  better_than_baseline: false,
+  improves: [],
+  worsens: [],
+  confirmed_at: '2026-07-18T09:00:00Z',
+  ...over,
+});
+
+describe('isWorseCandidate', () => {
+  it('hides an unconfirmed graded-worse sweep row', () => {
+    expect(isWorseCandidate(cand({ disposition: 'worse' }))).toBe(true);
+  });
+
+  it('never hides a confirmed row (user paid for the check)', () => {
+    expect(isWorseCandidate(cand({ disposition: 'worse', confirmed: confirmation() }))).toBe(false);
+  });
+
+  it('does not hide baseline / alternate / improving / neutral', () => {
+    expect(isWorseCandidate(cand({ disposition: 'worse', is_baseline: true }))).toBe(false);
+    expect(isWorseCandidate(cand({ disposition: 'worse', is_alternate: true }))).toBe(false);
+    expect(isWorseCandidate(cand({ disposition: 'improving' }))).toBe(false);
+    expect(isWorseCandidate(cand({ disposition: 'neutral' }))).toBe(false);
+  });
+
+  it('treats an old artifact (no disposition) as not-worse', () => {
+    expect(isWorseCandidate(cand({ disposition: undefined }))).toBe(false);
+  });
+});
+
+describe('improvingCount', () => {
+  it('counts only improving swept candidates', () => {
+    const list = [
+      cand({ is_baseline: true, disposition: 'improving' }), // baseline excluded
+      cand({ is_alternate: true, disposition: 'improving' }), // alternate excluded
+      cand({ disposition: 'improving' }),
+      cand({ disposition: 'improving' }),
+      cand({ disposition: 'neutral' }),
+      cand({ disposition: 'worse' }),
+    ];
+    expect(improvingCount(list)).toBe(2);
+  });
+});
+
+describe('invertAdvisoryStatus', () => {
+  it('inverts to per-model maps, keeping GREEN, scoped to models_used', () => {
+    const as = {
+      convective: { ecmwf: 'RED', gfs: 'GREEN', all: 'AMBER' },
+      icing_escape: { ecmwf: 'AMBER' },
+    };
+    const out = invertAdvisoryStatus(as, ['ecmwf', 'gfs']);
+    const byModel = Object.fromEntries(out.map((pm) => [pm.model, pm.map]));
+    expect(Object.keys(byModel).sort()).toEqual(['ecmwf', 'gfs']); // "all" filtered out
+    expect(byModel.ecmwf.get('convective')).toBe('RED');
+    expect(byModel.ecmwf.get('icing_escape')).toBe('AMBER');
+    expect(byModel.gfs.get('convective')).toBe('GREEN'); // GREEN preserved
+  });
+
+  it('returns empty for an absent map', () => {
+    expect(invertAdvisoryStatus(undefined, ['ecmwf'])).toEqual([]);
+  });
+});

--- a/web/tests/unit/time-scenario-display.test.ts
+++ b/web/tests/unit/time-scenario-display.test.ts
@@ -95,6 +95,17 @@ describe('invertAdvisoryStatus', () => {
     expect(byModel.gfs.get('convective')).toBe('GREEN'); // GREEN preserved
   });
 
+  it('surfaces the full confirmed model set from a widened map (#435 round-3)', () => {
+    // Post-confirm, advisory_status is widened to every checked model. Scoped
+    // by confirmed.models_checked it must surface all of them — including the
+    // GFS/ICON disagreement that flipped the disposition — not be filtered back
+    // down to the sweep's stale ['ecmwf'].
+    const widened = { convective: { ecmwf: 'AMBER', gfs: 'RED', icon: 'AMBER' } };
+    const out = invertAdvisoryStatus(widened, ['ecmwf', 'gfs', 'icon']);
+    const byModel = Object.fromEntries(out.map((pm) => [pm.model, pm.map.get('convective')]));
+    expect(byModel).toEqual({ ecmwf: 'AMBER', gfs: 'RED', icon: 'AMBER' });
+  });
+
   it('returns empty for an absent map', () => {
     expect(invertAdvisoryStatus(undefined, ['ecmwf'])).toEqual([]);
   });

--- a/web/ts/adapters/api-adapter.ts
+++ b/web/ts/adapters/api-adapter.ts
@@ -609,6 +609,15 @@ export interface TimeCandidateDTO {
   improves: string[];
   worsens: string[];
   margin: number;
+  /** Disposition vs the like-coverage baseline (#434). The client shows
+   *  improving+neutral by default and reveals `worse` rows behind "show all".
+   *  Optional for old artifacts (pre-#434 packs default to neutral). */
+  disposition?: 'improving' | 'neutral' | 'worse';
+  /** Per-(advisory, model) status this grade produced —
+   *  {advisory_id: {model: STATUS}}. Coverage-scoped: ECMWF-only for the ±day
+   *  sweep, the full graded set after a confirm. Lets a client reconstruct any
+   *  advisory's per-model dot row without re-grading. */
+  advisory_status?: Record<string, Record<string, string>>;
   confidence: 'confirmed_in_window' | 'ecmwf_only' | 'confirmed';
   is_baseline: boolean;
   is_alternate: boolean;

--- a/web/ts/briefing-main.ts
+++ b/web/ts/briefing-main.ts
@@ -746,9 +746,16 @@ async function init(): Promise<void> {
     }
   }
 
+  // "Show all" reveals worse rows + not-checkable (refused) times (#434).
+  // A view-only toggle kept in the init closure so it survives re-renders
+  // (the section replaces its innerHTML on every store update).
+  let timeScenariosShowAll = false;
+
   /** Timing-scenario section (Flexibility) — attention-director framing:
    *  candidates are "what changes if you leave at X", never a go/no-go.
-   *  Data arrives from the background scan via the polled store state. */
+   *  Data arrives from the background scan via the polled store state.
+   *  Default view is same-or-better (improving+neutral); worse alternate
+   *  hours and not-checkable times hide behind a "show all" toggle (#434). */
   function renderTimeScenarios(state: BriefingState): void {
     const wrapper = document.getElementById('time-scenarios-wrapper');
     const section = document.getElementById('time-scenarios-section');
@@ -816,7 +823,7 @@ async function init(): Promise<void> {
       return ` · ${diff > 0 ? '+' : ''}${diff} days`;
     };
 
-    const rows = scan.candidates.map((c) => {
+    const renderRow = (c: api.TimeCandidateDTO): string => {
       const time = formatDepartureTime(c.departure_time) + dayLabelFor(c.departure_time);
       const shift = c.is_baseline
         ? 'as planned'
@@ -969,15 +976,55 @@ async function init(): Promise<void> {
             </details>
           </span>
         </div>`;
+    };
+
+    // Partition (#434). scan.candidates already arrives ranked
+    // improving→neutral→worse; keep baseline + alternate + same-or-better in the
+    // default view and hide graded-worse alternate hours behind "show all", so
+    // the section can honestly say "the previous day is worse" without leading
+    // with it. Old artifacts have no disposition — treat them as not-worse.
+    const isWorse = (c: api.TimeCandidateDTO) =>
+      !c.is_baseline && !c.is_alternate && c.disposition === 'worse';
+    const defaultCandidates = scan.candidates.filter((c) => !isWorse(c));
+    const worseCandidates = scan.candidates.filter(isWorse);
+
+    const improvingCount = scan.candidates.filter(
+      (c) => !c.is_baseline && !c.is_alternate && c.disposition === 'improving',
+    ).length;
+    const headline = improvingCount > 0
+      ? `${improvingCount} departure window${improvingCount > 1 ? 's' : ''} look${improvingCount === 1 ? 's' : ''} smoother than the planned time — worth a look, not a verdict.`
+      : 'No clearly better window found in the hours checkable from this briefing.';
+
+    // Not-checkable (refused) hours — revealed greyed under "show all". The
+    // honesty guardrail made visible ("couldn't grade this time"), kept
+    // distinct from a graded-worse row (which carries a real RED/AMBER chip).
+    const refusedRows = scan.refused_times.map((t) => {
+      const rt = formatDepartureTime(t) + dayLabelFor(t);
+      return `<div class="info-row time-scenario-row" style="opacity:0.55;">
+          <span class="info-label">${escapeHtml(rt)}</span>
+          <span class="info-value">
+            ${chip('UNAVAILABLE')}
+            <span class="muted" style="font-size:0.8em;">not checkable — outside this briefing’s fetched forecast window</span>
+          </span>
+        </div>`;
     }).join('');
 
-    const better = scan.candidates.filter((c) => !c.is_baseline && !c.is_alternate).length;
-    const headline = better > 0
-      ? `${better} departure window${better > 1 ? 's' : ''} look${better === 1 ? 's' : ''} smoother than the planned time — worth a look, not a verdict.`
-      : 'No clearly better window found in the hours checkable from this briefing.';
-    const refusedNote = scan.refused_times.length
-      ? `<p class="muted" style="font-size:0.85em;">${scan.refused_times.length} daylight hour${scan.refused_times.length > 1 ? 's' : ''} couldn’t be checked from this briefing’s data (outside the fetched forecast window).</p>`
+    const hiddenWorse = worseCandidates.length;
+    const hiddenRefused = scan.refused_times.length;
+    const hasHidden = hiddenWorse > 0 || hiddenRefused > 0;
+    const hiddenSummary = [
+      hiddenWorse ? `${hiddenWorse} worse` : '',
+      hiddenRefused ? `${hiddenRefused} not checkable` : '',
+    ].filter(Boolean).join(' · ');
+    const showAllBtn = hasHidden
+      ? `<button type="button" class="btn btn-link btn-sm time-showall-btn">${
+          timeScenariosShowAll ? 'Show fewer' : `Show all (${escapeHtml(hiddenSummary)})`
+        }</button>`
       : '';
+    const hiddenRows = (hasHidden && timeScenariosShowAll)
+      ? worseCandidates.map(renderRow).join('') + refusedRows
+      : '';
+
     // ±day edges (slice 4): explain why the window stops where it does, so a
     // clipped prev/next-day scan doesn't read as a data gap.
     const win = scan.window;
@@ -988,7 +1035,12 @@ async function init(): Promise<void> {
       ? `<p class="muted" style="font-size:0.85em;">The window stops where ECMWF forecast fidelity ends — later hours aren’t checkable yet.</p>`
       : '';
 
-    section.innerHTML = `<p>${escapeHtml(headline)}</p>${rows}${refusedNote}${pastNote}${horizonNote}`;
+    section.innerHTML =
+      `<p>${escapeHtml(headline)}</p>`
+      + defaultCandidates.map(renderRow).join('')
+      + (showAllBtn ? `<div style="margin-top:0.4rem;">${showAllBtn}</div>` : '')
+      + hiddenRows
+      + pastNote + horizonNote;
 
     // Product-analytics signal (#352): flexibility used, counted once per
     // briefing and only when actual scan results render (the pending / failed /
@@ -1007,6 +1059,12 @@ async function init(): Promise<void> {
         const dep = btn.dataset.departure;
         if (dep) void store.getState().setScenarioAsAlternate(dep);
       });
+    });
+    // "Show all" reveals graded-worse + not-checkable rows (#434). View-only —
+    // flip the closure flag and re-render (which re-wires fresh handlers).
+    section.querySelector<HTMLButtonElement>('.time-showall-btn')?.addEventListener('click', () => {
+      timeScenariosShowAll = !timeScenariosShowAll;
+      renderTimeScenarios(store.getState());
     });
   }
 

--- a/web/ts/briefing-main.ts
+++ b/web/ts/briefing-main.ts
@@ -983,8 +983,12 @@ async function init(): Promise<void> {
     // default view and hide graded-worse alternate hours behind "show all", so
     // the section can honestly say "the previous day is worse" without leading
     // with it. Old artifacts have no disposition — treat them as not-worse.
+    // A *confirmed* row is never hidden: the user paid a tap + a full model
+    // check for it, so a confirm-downgrade (disposition flips to worse, #435)
+    // stays visible with its "not clearly better after all" verdict rather than
+    // vanishing into "show all".
     const isWorse = (c: api.TimeCandidateDTO) =>
-      !c.is_baseline && !c.is_alternate && c.disposition === 'worse';
+      !c.is_baseline && !c.is_alternate && c.disposition === 'worse' && !c.confirmed;
     const defaultCandidates = scan.candidates.filter((c) => !isWorse(c));
     const worseCandidates = scan.candidates.filter(isWorse);
 

--- a/web/ts/briefing-main.ts
+++ b/web/ts/briefing-main.ts
@@ -8,6 +8,7 @@ import { fetchPirepsByFlight } from './adapters/pirep-adapter';
 import { renderPirepList } from './managers/pirep-ui';
 import { renderAdvisories, renderAltitudeTablePopup, setLiveAdvisoryCatalog, type AltitudeOverrideConfig, type AltTimeToggleConfig, type ProfileSelectorConfig } from './managers/advisories-ui';
 import { overlayAltitudeStatuses } from './helpers/altitude-diff';
+import { improvingCount, invertAdvisoryStatus, isWorseCandidate } from './helpers/time-scenario-display';
 import { fetchProfiles, type ProfileResponse } from './adapters/profiles-adapter';
 import { fetchAdvisoryCatalog, foldBriefingUpdates, ENGINE_METHOD_DEFAULTS_FALLBACK, type BriefingUpdates, type EngineMethodDefaults } from './adapters/preferences-adapter';
 import type { DisplayMode } from './types/metrics';
@@ -912,10 +913,15 @@ async function init(): Promise<void> {
       ];
       if (!c.is_baseline) {
         // The provisional grade is the ECMWF-extension view unless the free
-        // tier already covered this hour with every model in-window.
+        // tier already covered this hour with every model in-window. Its
+        // per-model dot breakdown is reconstructed from the persisted
+        // advisory_status map (coverage-scoped: ECMWF-only for the sweep, the
+        // full set after a confirm) — #434/#435, no re-grade needed.
+        const candPerModel = invertAdvisoryStatus(c.advisory_status, c.models_used);
         cols.push({
           label: c.confirmed || c.confidence === 'ecmwf_only' ? 'ECMWF only' : 'All models',
           map: parseReason(c.assessment_reason),
+          perModel: candPerModel.length ? candPerModel : undefined,
         });
         if (c.confirmed) {
           cols.push({
@@ -986,17 +992,13 @@ async function init(): Promise<void> {
     // A *confirmed* row is never hidden: the user paid a tap + a full model
     // check for it, so a confirm-downgrade (disposition flips to worse, #435)
     // stays visible with its "not clearly better after all" verdict rather than
-    // vanishing into "show all".
-    const isWorse = (c: api.TimeCandidateDTO) =>
-      !c.is_baseline && !c.is_alternate && c.disposition === 'worse' && !c.confirmed;
-    const defaultCandidates = scan.candidates.filter((c) => !isWorse(c));
-    const worseCandidates = scan.candidates.filter(isWorse);
+    // vanishing into "show all". Partition rules live in a tested helper.
+    const defaultCandidates = scan.candidates.filter((c) => !isWorseCandidate(c));
+    const worseCandidates = scan.candidates.filter(isWorseCandidate);
 
-    const improvingCount = scan.candidates.filter(
-      (c) => !c.is_baseline && !c.is_alternate && c.disposition === 'improving',
-    ).length;
-    const headline = improvingCount > 0
-      ? `${improvingCount} departure window${improvingCount > 1 ? 's' : ''} look${improvingCount === 1 ? 's' : ''} smoother than the planned time — worth a look, not a verdict.`
+    const nImproving = improvingCount(scan.candidates);
+    const headline = nImproving > 0
+      ? `${nImproving} departure window${nImproving > 1 ? 's' : ''} look${nImproving === 1 ? 's' : ''} smoother than the planned time — worth a look, not a verdict.`
       : 'No clearly better window found in the hours checkable from this briefing.';
 
     // Not-checkable (refused) hours — revealed greyed under "show all". The

--- a/web/ts/briefing-main.ts
+++ b/web/ts/briefing-main.ts
@@ -912,25 +912,42 @@ async function init(): Promise<void> {
         { label: 'Current', map: parseReason(baselineReason), perModel: currentPerModel },
       ];
       if (!c.is_baseline) {
-        // The provisional grade is the ECMWF-extension view unless the free
-        // tier already covered this hour with every model in-window. Its
-        // per-model dot breakdown is reconstructed from the persisted
-        // advisory_status map (coverage-scoped: ECMWF-only for the sweep, the
-        // full set after a confirm) — #434/#435, no re-grade needed.
-        const candPerModel = invertAdvisoryStatus(c.advisory_status, c.models_used);
+        // Middle column = this candidate's own grade, per-model dots
+        // reconstructed from the persisted advisory_status map (#434/#435).
+        // While NOT confirmed the map is the candidate's coverage (ECMWF-only
+        // for the sweep, or the full in-window set). Once confirmed the map has
+        // been WIDENED to the multi-model set and the provisional ECMWF-only
+        // snapshot is gone — so this "ECMWF only" column keeps its aggregate
+        // row-status but drops the now-mismatched tooltip; the widened dots move
+        // to the "All models" column below (round-3 fix: previously the widened
+        // map was filtered back to ['ecmwf'] by a stale models_used and never
+        // rendered).
+        const midPerModel = c.confirmed
+          ? undefined
+          : invertAdvisoryStatus(c.advisory_status, c.models_used);
         cols.push({
           label: c.confirmed || c.confidence === 'ecmwf_only' ? 'ECMWF only' : 'All models',
           map: parseReason(c.assessment_reason),
-          perModel: candPerModel.length ? candPerModel : undefined,
+          perModel: midPerModel && midPerModel.length ? midPerModel : undefined,
         });
         if (c.confirmed) {
+          // Surface the confirm-widened advisory_status (green included) so the
+          // multi-model disagreement that flipped the disposition is visible in
+          // the dot table a pilot expands to ask "why was this downgraded?"
+          // Fall back to the confirmation's RED/AMBER reason strings for a
+          // legacy artifact whose map wasn't widened.
+          const confirmedPerModel = invertAdvisoryStatus(
+            c.advisory_status, c.confirmed.models_checked,
+          );
           cols.push({
             label: 'All models',
             map: parseReason(c.confirmed.assessment_reason),
-            perModel: c.confirmed.models_checked.map((model) => ({
-              model,
-              map: parseReason(c.confirmed?.per_model_reasons?.[model] ?? ''),
-            })),
+            perModel: confirmedPerModel.length
+              ? confirmedPerModel
+              : c.confirmed.models_checked.map((model) => ({
+                  model,
+                  map: parseReason(c.confirmed?.per_model_reasons?.[model] ?? ''),
+                })),
           });
         }
       }
@@ -950,10 +967,15 @@ async function init(): Promise<void> {
       const etaSpan = c.valid_times.length
         ? `${formatDepartureTime(c.valid_times[0])} → ${formatDepartureTime(c.valid_times[c.valid_times.length - 1])}`
         : '';
+      // models_used is the sweep-time set and isn't updated on confirm; show
+      // the confirmed model set once a check has run, so the footer doesn't say
+      // "Graded with ECMWF" for a multi-model-confirmed row (#435 round-3).
+      const gradedWith = (c.confirmed?.models_checked ?? c.models_used)
+        .map((m) => m.toUpperCase()).join(', ');
       const detailHtml = `
         <div class="time-detail-box">
           ${tableHtml}
-          <div class="muted" style="font-size:0.85em; margin-top:0.35rem;">Graded with ${escapeHtml(c.models_used.map((m) => m.toUpperCase()).join(', '))}${etaSpan ? ` · route ETAs ${escapeHtml(etaSpan)}` : ''}</div>
+          <div class="muted" style="font-size:0.85em; margin-top:0.35rem;">Graded with ${escapeHtml(gradedWith)}${etaSpan ? ` · route ETAs ${escapeHtml(etaSpan)}` : ''}</div>
         </div>`;
 
       // "Set as alternate time" — pins this scenario so the full per-advisory

--- a/web/ts/helpers/time-scenario-display.ts
+++ b/web/ts/helpers/time-scenario-display.ts
@@ -1,0 +1,53 @@
+/** Pure display helpers for the timing-scenario section (#434/#435).
+ *
+ * Extracted from `renderTimeScenarios` so the partition rules and the
+ * `advisory_status` → per-model-dot inversion are unit-testable in isolation —
+ * the branching (confirmed-never-hidden, old-artifact-treated-as-not-worse,
+ * coverage-scoped per-model map) is exactly the kind of logic that regresses
+ * silently otherwise.
+ */
+import type { TimeCandidateDTO } from '../adapters/api-adapter';
+
+/** True when a candidate belongs behind the "show all" toggle.
+ *
+ *  Only an **unconfirmed** graded-worse sweep row hides. A confirmed row is
+ *  never hidden — the user paid a tap + a full multi-model check for it, so a
+ *  confirm-downgrade stays visible with its honest verdict rather than
+ *  vanishing (#435). Old artifacts have no `disposition` (defaults absent) and
+ *  are treated as not-worse. */
+export function isWorseCandidate(c: TimeCandidateDTO): boolean {
+  return !c.is_baseline && !c.is_alternate && c.disposition === 'worse' && !c.confirmed;
+}
+
+/** Count of candidates that look smoother than the plan — drives the headline.
+ *  Keyed off `disposition`, so it's confirm-aware once the scan re-derives it. */
+export function improvingCount(candidates: TimeCandidateDTO[]): number {
+  return candidates.filter(
+    (c) => !c.is_baseline && !c.is_alternate && c.disposition === 'improving',
+  ).length;
+}
+
+/** Invert a candidate's `advisory_status` ({advisory_id: {model: STATUS}}) into
+ *  the per-model dot-column shape ({model, map: advisory_id → STATUS}).
+ *
+ *  `models` (the candidate's `models_used`) filters the result to what was
+ *  actually graded, so a model-agnostic "all" entry — or any model not in the
+ *  candidate's coverage — never implies a per-model check we didn't run. The
+ *  map keeps GREEN statuses too, which is the whole point: it reconstructs the
+ *  dot row at any coverage without re-grading. */
+export function invertAdvisoryStatus(
+  advisoryStatus: Record<string, Record<string, string>> | undefined,
+  models: string[],
+): { model: string; map: Map<string, string> }[] {
+  const allow = new Set(models);
+  const byModel = new Map<string, Map<string, string>>();
+  for (const [advId, modelMap] of Object.entries(advisoryStatus ?? {})) {
+    for (const [model, status] of Object.entries(modelMap)) {
+      if (!allow.has(model)) continue;
+      let m = byModel.get(model);
+      if (!m) { m = new Map(); byModel.set(model, m); }
+      m.set(advId, status);
+    }
+  }
+  return [...byModel.entries()].map(([model, map]) => ({ model, map }));
+}


### PR DESCRIPTION
## What & why

The Flexibility timing scan grades every candidate departure time on the full
advisory set, but `run_time_scan` only **persisted** three kinds of row:
baseline, the pinned alternate, and up to 5 *improving* candidates. Everything
else — green-but-not-better, and importantly **worse (AMBER/RED) alternate
hours** — was computed and silently discarded. So the feature could *offer* a
smoother day but would never *show* that another day is worse (observed live on
`egtf_big_lfat_lfqa-2026-07-18`: a prev-day scan that graded 07-17 midday
convective-worse just went empty). This closes that honesty gap.

Per the issue's FINAL DECISION, keep **every graded candidate** tagged with a
`disposition`, store a **coverage-scoped per-model status map**, and move the
improving-only cut to the display layer.

Slices, one commit each on this branch:

- **Backend** (`models/time_scan.py`, `tasks/time_scan.py`, `tasks/advise.py`,
  `tasks/time_scan_runner.py`)
  - `TimeCandidate` gains `disposition: "improving" | "neutral" | "worse"`
    (orthogonal to `is_baseline`/`is_alternate`) and
    `advisory_status: {advisory_id: {model: status}}`.
  - `per_model_status_from_manifest` — sibling of the RED/AMBER reasons helper,
    but records GREEN too, so a client can reconstruct any advisory's per-model
    dot row without re-grading.
  - `run_time_scan` stops filtering — appends all graded rows (free + ECMWF-only
    tier) with a computed disposition, ranked improving→neutral→worse.
    Persistence is bounded by `_MAX_GRID`; the improving cap moved to the client.
  - On confirm the candidate's provisional ECMWF-only map fills out to the full
    graded model set — same schema, more coverage.
- **Web** (`api-adapter.ts` DTO, `briefing-main.ts` `renderTimeScenarios`)
  - Mirror `disposition` + `advisory_status`.
  - Default view = same-or-better (baseline + alternate + improving + neutral).
  - **"Show all"** toggle reveals `worse` rows (real chips) and not-checkable /
    refused times (greyed, UNAVAILABLE chip).
- **Docs** — update the timing-scenario plan's artifact sketch + a follow-up
  section.

iOS mirroring of the new DTO fields is a separate PR (contract change), as the
issue specifies; not included here.

Coverage-scoped storage is ~550 B (sweep) to ~2.7 KB (confirmed) per candidate;
the 24-row grid stays well under ~70 KB/pack. The ~41 KB full `per_model` detail
stays gated to the baseline manifest + on-tap confirm.

## Issue linkage

Closes #434

## Testing / verification

- `pytest tests/test_time_scan.py` — 52 passed (adds disposition taxonomy,
  `per_model_status_from_manifest`, and integration tests that worse/neutral
  rows are now persisted + tagged and that size stays bounded).
- `pytest tests/test_summarize_advisories.py tests/test_altitude_table_diff.py
  tests/test_advise_front_context.py` — 24 passed.
- Web: `npx tsc --noEmit` clean for the touched files (only pre-existing
  `eval/label-panel.ts` errors remain), `npm run build` succeeds, `npm run test`
  — 528 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0145vVuhkbSmMrLssRn3oqDC

---
_Generated by [Claude Code](https://claude.ai/code/session_0145vVuhkbSmMrLssRn3oqDC)_