### PR TITLE
fix(ios): keep briefing section-nav bar visible on every open

### DIFF
--- a/app/flyfun-weather/flyfun-weather/Views/Shared/SectionSpyBar.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Shared/SectionSpyBar.swift
@@ -112,32 +112,41 @@ struct ScrollSpyScroll<Content: View>: View {
     @State private var scrollTarget: String?
 
     var body: some View {
-        // The pill bar sits OUTSIDE the ScrollViewReader; the reader wraps only
-        // the ScrollView and consumes a `scrollTarget` trigger via `.onChange`.
-        // (Driving `proxy.scrollTo` directly from a tap handler on a sibling of
-        // the ScrollView inside the same reader silently did nothing — this is
-        // the same reader+trigger shape CrossSectionView uses successfully.) (#3)
-        VStack(spacing: 0) {
-            if sections.count > 1 {
-                SectionSpyBar(sections: sections, active: active.isEmpty ? (sections.first?.id ?? "") : active) { id in
-                    scrollTarget = id
+        // The bar is a PINNED SECTION HEADER inside the vertical ScrollView, not a
+        // sibling pinned above it. On iPhone the briefing lives in a
+        // NavigationSplitView detail column that collapses to a stack and reuses
+        // its hosting container across pushes; a bar pinned OUTSIDE the scroll
+        // content composited zero pixels on every briefing opened after the first
+        // (correct frame, no draw). The scroll content itself always re-composites
+        // correctly, so the bar rides inside it as a pinned header — same sticky
+        // behaviour, immune to the reuse bug. Tap-to-scroll drives `scrollTarget`,
+        // consumed by the reader's `.onChange` (the reader+trigger shape
+        // CrossSectionView uses; driving `proxy.scrollTo` straight from the tap
+        // handler silently did nothing). (#3)
+        ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack(spacing: 0, pinnedViews: [.sectionHeaders]) {
+                    Section {
+                        content()
+                    } header: {
+                        if sections.count > 1 {
+                            SectionSpyBar(sections: sections, active: active.isEmpty ? (sections.first?.id ?? "") : active) { id in
+                                scrollTarget = id
+                            }
+                        }
+                    }
                 }
             }
-            ScrollViewReader { proxy in
-                ScrollView {
-                    content()
+            .coordinateSpace(name: Self.coordSpace)
+            .onPreferenceChange(SpyOffsetKey.self) { offsets in
+                active = Self.activeSection(sections: sections, offsets: offsets)
+            }
+            .onChange(of: scrollTarget) { _, target in
+                guard let target else { return }
+                withAnimation(.easeInOut(duration: 0.25)) {
+                    proxy.scrollTo(target, anchor: .top)
                 }
-                .coordinateSpace(name: Self.coordSpace)
-                .onPreferenceChange(SpyOffsetKey.self) { offsets in
-                    active = Self.activeSection(sections: sections, offsets: offsets)
-                }
-                .onChange(of: scrollTarget) { _, target in
-                    guard let target else { return }
-                    withAnimation(.easeInOut(duration: 0.25)) {
-                        proxy.scrollTo(target, anchor: .top)
-                    }
-                    scrollTarget = nil
-                }
+                scrollTarget = nil
             }
         }
     }


### PR DESCRIPTION
## Problem

The scroll-spy pill bar at the top of the briefing (the iOS equivalent of the web sidebar — `Summary · Advisories · Conditions · …`) **vanished on every briefing opened after the first** after launch. Even reopening the *same* flight showed no bar. Order-dependent, not flight-dependent.

## Root cause

The bar had a **correct layout frame but composited zero pixels**. On iPhone the briefing lives in a `NavigationSplitView` detail column that collapses to a stack and **reuses its hosting container across pushes**. A view pinned *outside* the scroll content (the old `VStack { bar; ScrollView }`) fails to composite on that reused container from the 2nd presentation onward — while the scroll **content** itself always re-composites correctly.

Confirmed by ruling out every view-level fix (`fixedSize`, `safeAreaInset`, `.regularMaterial`→solid, `zIndex`, and a fresh `.id()` on the whole detail subtree — none worked), and by instrumentation showing the bar's `body` runs with a correct frame (`minY=116, h=42`) yet draws nothing.

## Fix

Ride the bar **inside** the surviving scroll layer as a **pinned section header** (`LazyVStack(pinnedViews: [.sectionHeaders])`) instead of a sibling above the `ScrollView`. Same sticky behaviour, immune to the reuse bug. One structural change to `ScrollSpyScroll.body`; benefits both the Advisory and Discussion tabs (shared component).

## Verification

Reproduced deterministically on the simulator (open → switch → reopen) and confirmed the bar now renders on **first-open and every reopen**. Builds clean.

**Still to verify on-device (interactive, standard behaviour):** bar stays pinned while scrolling, tap-to-scroll, active-pill highlight. Note: the active-section threshold (`activeSection`, currently `12pt`) may want bumping to ~header height now that the bar pins *over* content — left untouched here to avoid tuning blind.

## Follow-ups (not in this PR)
- Possible UI-test coverage for the "reopen a briefing" regression.
- Optional: replace the `PreferenceKey` + shared-coordinate-space + nested-`ScrollViewReader` scroll-spy machinery with iOS 26 native scroll APIs (`scrollPosition` / `onScrollTargetVisibilityChange`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)