### PR TITLE
ios: native scroll-spy + native tabs + scroll modernization (no merge until device review)

### DIFF
--- a/app/flyfun-weather/flyfun-weather/Views/Briefing/BriefingContainerView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Briefing/BriefingContainerView.swift
@@ -486,10 +486,11 @@ private struct DownloadBannerView: View {
 }
 
 /// Inner content once the view model is ready (#310). Tabs: Advisory ·
-/// Discussion · Cross-Section · Map (+ gated PIREPs). On regular width (iPad)
-/// they render as a custom top pill band with switched content; on compact
-/// width (iPhone) they collapse to a native bottom tab bar. Both drive
-/// `viewModel.selectedTab`, so deep-links behave identically.
+/// Discussion · Cross-Section · Map (+ gated PIREPs), rendered by a native
+/// `TabView` on both idioms — a bottom tab bar on iPhone (compact), a top tab
+/// bar on iPad (regular). Both drive `viewModel.selectedTab`, so deep-links
+/// behave identically. (The custom iPad pill band this replaced hit the same
+/// NavigationSplitView-reuse compositing bug as the section spy bar — #437.)
 private struct BriefingContentView: View {
     @Bindable var viewModel: BriefingViewModel
     var trackingService: FlightTrackingService

--- a/app/flyfun-weather/flyfun-weather/Views/Briefing/BriefingContainerView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Briefing/BriefingContainerView.swift
@@ -494,7 +494,6 @@ private struct BriefingContentView: View {
     @Bindable var viewModel: BriefingViewModel
     var trackingService: FlightTrackingService
     @Environment(AppState.self) private var appState
-    @Environment(\.horizontalSizeClass) private var sizeClass
 
     private var tabs: [BriefingTab] {
         var tabs = BriefingTab.core
@@ -511,20 +510,18 @@ private struct BriefingContentView: View {
             .refreshable { await viewModel.syncLatestPack() }
     }
 
-    @ViewBuilder
     private var content: some View {
-        if sizeClass == .regular {
-            VStack(spacing: 0) {
-                BriefingTabBand(tabs: tabs, selection: $viewModel.selectedTab)
-                tabContent(viewModel.selectedTab)
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-            }
-        } else {
-            TabView(selection: $viewModel.selectedTab) {
-                ForEach(tabs, id: \.self) { tab in
-                    Tab(tab.title, systemImage: tab.systemImage, value: tab) {
-                        tabContent(tab)
-                    }
+        // Native TabView on BOTH idioms: iPhone renders a bottom tab bar, iPad a
+        // top tab bar. This replaced a custom `BriefingTabBand` (a horizontally-
+        // scrolling pill bar pinned as a sibling above the tab content on regular
+        // width) which — like the section spy bar (#436) — composited zero pixels
+        // when the reused NavigationSplitView detail column re-presented on iPad,
+        // leaving the briefing with no way to switch tabs. The system-hosted tab
+        // bar isn't a custom sibling of the scroll content, so it is immune.
+        TabView(selection: $viewModel.selectedTab) {
+            ForEach(tabs, id: \.self) { tab in
+                Tab(tab.title, systemImage: tab.systemImage, value: tab) {
+                    tabContent(tab)
                 }
             }
         }
@@ -545,46 +542,6 @@ private struct BriefingContentView: View {
             PirepListView(pirepsState: viewModel.pirepsState) {
                 await viewModel.loadPireps()
             }
-        }
-    }
-}
-
-/// Custom top tab band (iPad / regular width, #310): pill-styled tabs driving
-/// the selection, behaving identically nested in the split-view detail.
-private struct BriefingTabBand: View {
-    let tabs: [BriefingTab]
-    @Binding var selection: BriefingTab
-
-    var body: some View {
-        ScrollViewReader { proxy in
-            ScrollView(.horizontal, showsIndicators: false) {
-                HStack(spacing: Theme.spacingS) {
-                    ForEach(tabs, id: \.self) { tab in
-                        let active = tab == selection
-                        Button { selection = tab } label: {
-                            Label(tab.title, systemImage: tab.systemImage)
-                                .font(.subheadline.weight(active ? .semibold : .regular))
-                                .foregroundStyle(active ? Theme.primary : Theme.textMuted)
-                                .padding(.horizontal, 14).padding(.vertical, 8)
-                                .background(active ? Theme.primary.opacity(0.12) : Color.clear, in: Capsule())
-                        }
-                        .buttonStyle(.plain)
-                        .id(tab)
-                    }
-                    Spacer(minLength: 0)
-                }
-                .padding(.horizontal, Theme.cardPadding)
-                .padding(.vertical, Theme.spacingS)
-            }
-            // Keep the active tab visible if a deep-link switches tabs while the
-            // band is scrolled (robust if the tab set ever overflows).
-            .onChange(of: selection) { _, newValue in
-                withAnimation(.easeInOut(duration: 0.2)) { proxy.scrollTo(newValue, anchor: .center) }
-            }
-        }
-        .background(Theme.surface)
-        .overlay(alignment: .bottom) {
-            Rectangle().fill(Theme.border).frame(height: 0.5)
         }
     }
 }

--- a/app/flyfun-weather/flyfun-weather/Views/CrossSection/CrossSectionView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/CrossSection/CrossSectionView.swift
@@ -21,9 +21,11 @@ struct CrossSectionView: View {
     @AppStorage("crossSectionGraphLeftMetric") private var graphLeftMetricId = "headwind"
     @AppStorage("crossSectionGraphRightMetric") private var graphRightMetricId = "cloud-cover"
     /// Scroll-to target inside the tab (#310): the "Sounding ›" deep-link and a
-    /// `FocusIntent.target == .skewT` set this to "skewt"; the ScrollViewReader
-    /// scrolls to the embedded Skew-T and resets it to nil.
+    /// `FocusIntent.target == .skewT` set this to "skewt"; the portrait scroll
+    /// view scrolls to the embedded Skew-T and resets it to nil.
     @State private var scrollTarget: String?
+    /// Native scroll position for the portrait layout (replaces `ScrollViewReader`).
+    @State private var scrollPosition = ScrollPosition(idType: String.self)
     @Environment(\.verticalSizeClass) private var vSizeClass
 
     // Contextual tips (#312), gated on this tab being visible.
@@ -75,47 +77,47 @@ struct CrossSectionView: View {
     // MARK: Portrait layout
 
     private var portrait: some View {
-        ScrollViewReader { proxy in
-            ScrollView {
-                VStack(spacing: 0) {
-                    chromeBar
-                    CrossSectionReadoutView(
-                        vizData: csVM.vizData ?? Self.emptyViz,
-                        scrubDistanceNm: scrubDistanceNm,
-                        scrubAltitudeFt: scrubAltitudeFt,
-                        onSounding: goToSounding,
-                        routeGraphMetricIds: [graphLeftMetricId, graphRightMetricId]
-                    )
-                    // "Tap any point" coachmark above the canvas (#312); cleared
-                    // on the first scrub via `updateScrub`. Only render once
-                    // there's a canvas to interact with — otherwise the tip
-                    // would be consumed coaching against a loading/error
-                    // placeholder.
-                    if csVM.vizData != nil {
-                        TipView(scrubTip)
-                            .padding(.horizontal, Theme.cardPadding)
-                    }
-                    crossSectionCanvas
-                    RouteGraphView(viewModel: viewModel, vizData: csVM.vizData, scrubDistanceNm: scrubDistanceNm,
-                                   leftMetricId: $graphLeftMetricId, rightMetricId: $graphRightMetricId)
-                    skewTSection
+        ScrollView {
+            VStack(spacing: 0) {
+                chromeBar
+                CrossSectionReadoutView(
+                    vizData: csVM.vizData ?? Self.emptyViz,
+                    scrubDistanceNm: scrubDistanceNm,
+                    scrubAltitudeFt: scrubAltitudeFt,
+                    onSounding: goToSounding,
+                    routeGraphMetricIds: [graphLeftMetricId, graphRightMetricId]
+                )
+                // "Tap any point" coachmark above the canvas (#312); cleared
+                // on the first scrub via `updateScrub`. Only render once
+                // there's a canvas to interact with — otherwise the tip
+                // would be consumed coaching against a loading/error
+                // placeholder.
+                if csVM.vizData != nil {
+                    TipView(scrubTip)
+                        .padding(.horizontal, Theme.cardPadding)
                 }
+                crossSectionCanvas
+                RouteGraphView(viewModel: viewModel, vizData: csVM.vizData, scrubDistanceNm: scrubDistanceNm,
+                               leftMetricId: $graphLeftMetricId, rightMetricId: $graphRightMetricId)
+                skewTSection
             }
-            .background(Theme.bg)
-            .onChange(of: scrollTarget) { _, target in
-                guard let target else { return }
-                withAnimation(.easeInOut(duration: 0.3)) { proxy.scrollTo(target, anchor: .top) }
+            .scrollTargetLayout()
+        }
+        .scrollPosition($scrollPosition)
+        .background(Theme.bg)
+        .onChange(of: scrollTarget) { _, target in
+            guard let target else { return }
+            withAnimation(.easeInOut(duration: 0.3)) { scrollPosition.scrollTo(id: target, anchor: .top) }
+            scrollTarget = nil
+        }
+        .onAppear {
+            // The landscape-immersive layout has no portrait scroll view, so a
+            // "Sounding ›" tap there sets `scrollTarget` with nothing to consume
+            // it. Returning to portrait re-mounts this scroll view — honor the
+            // pending target here (onChange won't fire: unchanged).
+            if let target = scrollTarget {
+                scrollPosition.scrollTo(id: target, anchor: .top)
                 scrollTarget = nil
-            }
-            .onAppear {
-                // The landscape-immersive layout has no ScrollViewReader, so a
-                // "Sounding ›" tap there sets `scrollTarget` with nothing to
-                // consume it. Returning to portrait re-mounts this scroll view —
-                // honor the pending target here (onChange won't fire: unchanged).
-                if let target = scrollTarget {
-                    proxy.scrollTo(target, anchor: .top)
-                    scrollTarget = nil
-                }
             }
         }
     }
@@ -231,10 +233,7 @@ struct CrossSectionView: View {
                 .overlay {
                     CrossSectionCursorOverlay(data: vizData, cursorDistanceNm: cursor, aircraft: aircraft)
                 }
-                .background(GeometryReader { geo in
-                    Color.clear.onAppear { canvasSize = geo.size }
-                        .onChange(of: geo.size) { _, newSize in canvasSize = newSize }
-                })
+                .onGeometryChange(for: CGSize.self) { $0.size } action: { canvasSize = $0 }
                 .gesture(scrubGesture)
                 // A Canvas has no intrinsic a11y children, so expose it as a
                 // single element with a stable id. The XCUITest cross-section

--- a/app/flyfun-weather/flyfun-weather/Views/Shared/SectionSpyBar.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Shared/SectionSpyBar.swift
@@ -118,8 +118,11 @@ struct ScrollSpyScroll<Content: View>: View {
         }
         .scrollPosition($position)
         .onScrollTargetVisibilityChange(idType: String.self) { visible in
-            // Topmost visible anchored section is the active one. Ordered top→bottom.
-            if let first = visible.first { active = first }
+            // Derive the topmost visible section from our own top→bottom `sections`
+            // order rather than trusting the callback array to be position-ordered.
+            if let top = sections.first(where: { visible.contains($0.id) })?.id {
+                active = top
+            }
         }
     }
 }

--- a/app/flyfun-weather/flyfun-weather/Views/Shared/SectionSpyBar.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Shared/SectionSpyBar.swift
@@ -1,12 +1,5 @@
 import SwiftUI
 
-/// Shared coordinate-space name for scroll-spy offset reporting. Kept on a
-/// non-generic type so `spyAnchor` can reference it without `ScrollSpyScroll`'s
-/// generic parameter.
-private enum SpyConstants {
-    static let coordSpace = "spyScroll"
-}
-
 /// One registrable section in a scroll-spy tab (#310 item 5).
 struct SpySection: Identifiable, Equatable {
     let id: String
@@ -18,34 +11,15 @@ struct SpySection: Identifiable, Equatable {
     }
 }
 
-/// Reports each anchored section's top offset within the scroll coordinate
-/// space so `ScrollSpyScroll` can decide which section is currently "active".
-private struct SpyOffsetKey: PreferenceKey {
-    static let defaultValue: [String: CGFloat] = [:]
-    static func reduce(value: inout [String: CGFloat], nextValue: () -> [String: CGFloat]) {
-        value.merge(nextValue()) { _, new in new }
-    }
-}
-
 extension View {
-    /// Mark a scroll target and report its top offset for scroll-spy tracking.
-    /// Pair with `ScrollSpyScroll`; the `id` must match a `SpySection.id`.
-    ///
-    /// `.id()` is applied LAST (outermost): `ScrollViewReader.scrollTo` only
-    /// finds a target whose `.id` is on the outermost layout view, so applying it
-    /// before `.background(GeometryReader…)` left tap-to-scroll a silent no-op
-    /// (scroll-position tracking still worked, masking it). (#3)
+    /// Mark a scroll target for scroll-spy tracking. Pair with `ScrollSpyScroll`;
+    /// the `id` must match a `SpySection.id`. It is a plain `.id(id)` — the native
+    /// scroll APIs (`scrollPosition` for tap-to-scroll, `onScrollTargetVisibilityChange`
+    /// for the active section) key off the target's id directly, so no offset
+    /// plumbing is needed. `ScrollSpyScroll` marks the enclosing layout with
+    /// `.scrollTargetLayout()`, which is what promotes these to scroll targets.
     func spyAnchor(_ id: String) -> some View {
-        self
-            .background(
-                GeometryReader { geo in
-                    Color.clear.preference(
-                        key: SpyOffsetKey.self,
-                        value: [id: geo.frame(in: .named(SpyConstants.coordSpace)).minY]
-                    )
-                }
-            )
-            .id(id)
+        self.id(id)
     }
 }
 
@@ -103,13 +77,16 @@ struct SectionSpyBar: View {
 /// nearest the top and taps scroll to it. The bar is suppressed when there is
 /// only one section, so single-concept tabs pay nothing.
 struct ScrollSpyScroll<Content: View>: View {
-    static var coordSpace: String { SpyConstants.coordSpace }
-
     let sections: [SpySection]
     @ViewBuilder var content: () -> Content
 
-    @State private var active: String = ""
-    @State private var scrollTarget: String?
+    /// Active section id (nil until the first visibility report), and the scroll
+    /// position we drive on a pill tap. Native iOS 18+ scroll state — this
+    /// replaced a `PreferenceKey` + `GeometryReader` offset reporter, a shared
+    /// hardcoded coordinate-space name, a hand-rolled active-section reducer, and
+    /// a `ScrollViewReader`.
+    @State private var active: String?
+    @State private var position = ScrollPosition(idType: String.self)
 
     var body: some View {
         // The bar is a PINNED SECTION HEADER inside the vertical ScrollView, not a
@@ -119,55 +96,30 @@ struct ScrollSpyScroll<Content: View>: View {
         // content composited zero pixels on every briefing opened after the first
         // (correct frame, no draw). The scroll content itself always re-composites
         // correctly, so the bar rides inside it as a pinned header — same sticky
-        // behaviour, immune to the reuse bug. Tap-to-scroll drives `scrollTarget`,
-        // consumed by the reader's `.onChange` (the reader+trigger shape
-        // CrossSectionView uses; driving `proxy.scrollTo` straight from the tap
-        // handler silently did nothing). (#3)
-        ScrollViewReader { proxy in
-            ScrollView {
-                LazyVStack(spacing: 0, pinnedViews: [.sectionHeaders]) {
-                    Section {
-                        content()
-                    } header: {
-                        if sections.count > 1 {
-                            SectionSpyBar(sections: sections, active: active.isEmpty ? (sections.first?.id ?? "") : active) { id in
-                                scrollTarget = id
+        // behaviour, immune to the reuse bug. (#436)
+        ScrollView {
+            LazyVStack(spacing: 0, pinnedViews: [.sectionHeaders]) {
+                Section {
+                    // `.scrollTargetLayout()` promotes the content's `.spyAnchor`'d
+                    // children to scroll targets, so `onScrollTargetVisibilityChange`
+                    // and `scrollPosition` can address them by id.
+                    content()
+                        .scrollTargetLayout()
+                } header: {
+                    if sections.count > 1 {
+                        SectionSpyBar(sections: sections, active: active ?? sections.first?.id ?? "") { id in
+                            withAnimation(.easeInOut(duration: 0.25)) {
+                                position.scrollTo(id: id, anchor: .top)
                             }
                         }
                     }
                 }
             }
-            .coordinateSpace(name: Self.coordSpace)
-            .onPreferenceChange(SpyOffsetKey.self) { offsets in
-                active = Self.activeSection(sections: sections, offsets: offsets)
-            }
-            .onChange(of: scrollTarget) { _, target in
-                guard let target else { return }
-                withAnimation(.easeInOut(duration: 0.25)) {
-                    proxy.scrollTo(target, anchor: .top)
-                }
-                scrollTarget = nil
-            }
         }
-    }
-
-    /// Active = the last section whose top has scrolled up to (or behind) the
-    /// pinned bar's bottom edge. Falls back to the first known section before any
-    /// offsets arrive.
-    ///
-    /// The bar is now a pinned header INSIDE the scroll view, overlapping the top
-    /// ~44pt of the viewport, so a section's offset (measured from the raw
-    /// viewport top) reaches 0 while it is still hidden behind the bar. The
-    /// threshold therefore matches the bar's height, so a section flips to active
-    /// as its top clears the bar — not one bar-height early. (Approximate height;
-    /// the pending native-scroll rewrite replaces this reducer with
-    /// `onScrollTargetVisibilityChange`, which needs no threshold at all.)
-    private static func activeSection(sections: [SpySection], offsets: [String: CGFloat]) -> String {
-        let threshold: CGFloat = 44
-        var current = sections.first(where: { offsets[$0.id] != nil })?.id ?? sections.first?.id ?? ""
-        for section in sections {
-            if let y = offsets[section.id], y <= threshold { current = section.id }
+        .scrollPosition($position)
+        .onScrollTargetVisibilityChange(idType: String.self) { visible in
+            // Topmost visible anchored section is the active one. Ordered top→bottom.
+            if let first = visible.first { active = first }
         }
-        return current
     }
 }

--- a/app/flyfun-weather/flyfun-weather/Views/Shared/SectionSpyBar.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Shared/SectionSpyBar.swift
@@ -31,38 +31,42 @@ struct SectionSpyBar: View {
     let active: String
     let onTap: (String) -> Void
 
+    /// Native scroll position to keep the active pill centered (replaces a
+    /// `ScrollViewReader`). Ids are the plain `section.id` (no `"pill-"` prefix).
+    @State private var pillPosition = ScrollPosition(idType: String.self)
+
     var body: some View {
-        ScrollViewReader { proxy in
-            ScrollView(.horizontal, showsIndicators: false) {
-                HStack(spacing: Theme.spacingS) {
-                    ForEach(sections) { section in
-                        let isActive = section.id == active
-                        Button { onTap(section.id) } label: {
-                            Text(section.title)
-                                .font(.caption.weight(isActive ? .semibold : .regular))
-                                .foregroundStyle(isActive ? Theme.primary : Theme.textMuted)
-                                .padding(.horizontal, 12)
-                                .padding(.vertical, 6)
-                                .background(
-                                    isActive ? Theme.primary.opacity(0.14) : Theme.surface,
-                                    in: Capsule()
-                                )
-                                .overlay(
-                                    Capsule().stroke(Theme.border, lineWidth: isActive ? 0 : 0.5)
-                                )
-                        }
-                        .buttonStyle(.plain)
-                        .id("pill-\(section.id)")
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: Theme.spacingS) {
+                ForEach(sections) { section in
+                    let isActive = section.id == active
+                    Button { onTap(section.id) } label: {
+                        Text(section.title)
+                            .font(.caption.weight(isActive ? .semibold : .regular))
+                            .foregroundStyle(isActive ? Theme.primary : Theme.textMuted)
+                            .padding(.horizontal, 12)
+                            .padding(.vertical, 6)
+                            .background(
+                                isActive ? Theme.primary.opacity(0.14) : Theme.surface,
+                                in: Capsule()
+                            )
+                            .overlay(
+                                Capsule().stroke(Theme.border, lineWidth: isActive ? 0 : 0.5)
+                            )
                     }
+                    .buttonStyle(.plain)
+                    .id(section.id)
                 }
-                .padding(.horizontal, Theme.cardPadding)
-                .padding(.vertical, Theme.spacingS)
             }
-            .onChange(of: active) { _, newValue in
-                // Keep the active pill in view as the user scrolls content.
-                withAnimation(.easeInOut(duration: 0.2)) {
-                    proxy.scrollTo("pill-\(newValue)", anchor: .center)
-                }
+            .padding(.horizontal, Theme.cardPadding)
+            .padding(.vertical, Theme.spacingS)
+            .scrollTargetLayout()
+        }
+        .scrollPosition($pillPosition)
+        .onChange(of: active) { _, newValue in
+            // Keep the active pill in view as the user scrolls content.
+            withAnimation(.easeInOut(duration: 0.2)) {
+                pillPosition.scrollTo(id: newValue, anchor: .center)
             }
         }
         .background(.regularMaterial)

--- a/designs/ios-app-ui.md
+++ b/designs/ios-app-ui.md
@@ -89,19 +89,25 @@ band is gone: route identity moved to `navigationTitle` + `.navigationSubtitle`
 (iOS 26), and the freshness chip + pack-history (D-N) picker merged into one
 `BriefingPackToolbar` menu in the nav-bar toolbar.
 
-**Tab presentation is size-class adaptive** (`BriefingContentView`): on **regular
-width (iPad)** the tabs render as a custom top pill band (`BriefingTabBand`) with
-switched content below; on **compact width (iPhone)** they collapse to a native
-bottom `TabView`. Both drive `viewModel.selectedTab`, so all deep-links
-(watch chips, advisory detail → cross-section) behave identically. iPad keeps the
-`NavigationSplitView` sidebar.
+**Tab presentation is a native `TabView`** (`BriefingContentView`) on both idioms:
+a bottom tab bar on **compact width (iPhone)**, a top tab bar on **regular width
+(iPad)**. Both drive `viewModel.selectedTab`, so all deep-links (watch chips,
+advisory detail → cross-section) behave identically. iPad keeps the
+`NavigationSplitView` sidebar. (A custom iPad pill band, `BriefingTabBand`, was
+removed in #437: pinned as a sibling above the tab content it composited zero
+pixels when the reused split-view detail column re-presented — the same bug as
+the scroll-spy bar below. The system-hosted `TabView` is immune.)
 
 **Intra-tab scroll-spy (#310 item 5).** Multi-section tabs (Advisory; reusable on
-Discussion/Cross-Section) wrap their scroll in `ScrollSpyScroll`, which pins a
-sticky horizontally-scrollable `SectionSpyBar` of section pills, highlights the
-section nearest the top, and jumps on tap. Sections register via the `.spyAnchor(id)`
-modifier (a `GeometryReader` + `PreferenceKey` reporting each section's top
-offset); the bar suppresses itself when there is only one section.
+Discussion/Cross-Section) wrap their scroll in `ScrollSpyScroll`, which shows a
+`SectionSpyBar` of section pills as a **pinned `Section` header inside the
+`ScrollView`** (#436 — a bar pinned *outside* the scroll drew zero pixels on
+re-presentation in the reused split-view detail column), highlights the section
+nearest the top, and jumps on tap. Sections register with `.spyAnchor(id)` (a
+plain `.id`); the active section comes from `onScrollTargetVisibilityChange` and
+taps drive `ScrollPosition.scrollTo(id:)` — native iOS 18 scroll APIs that
+replaced a `GeometryReader`/`PreferenceKey`/coordinate-space offset reporter
+(#437). The bar suppresses itself when there is only one section.
 
 ## In-Flight Mode (Phase 3 vision — NOT built as drawn)
 


### PR DESCRIPTION
Follow-up to #436. Bundles the scroll-spy fix, the iPad tab fix, the review-bot fixes, and a full sweep-driven native-scroll modernization. **Do not merge until the on-device visual review (iPhone + iPad) below is done.**

## Changes

1. **Scroll-spy → native iOS 18 APIs** (`SectionSpyBar.swift`): `onScrollTargetVisibilityChange` (active section, derived from our own ordered `sections`) + `ScrollPosition`/`scrollTo(id:)` (tap-to-scroll) replace a `PreferenceKey`/`GeometryReader`/hardcoded-`coordinateSpace`/manual-reducer/`ScrollViewReader` stack. Keeps the #436 pinned-section-header layout.
2. **iPad tab navigator → native `TabView`** (`BriefingContainerView.swift`): the custom `BriefingTabBand` (pill bar pinned as a sibling above the tab content) hit the same reuse-composite bug — it drew **zero pixels** on iPad, so the tab bar vanished (confirmed on iPad sim). Now both idioms use the native `TabView` (bottom bar iPhone, top bar iPad). System-hosted → immune.
3. **Review-bot fixes**: defensive topmost-section derivation; stale `BriefingContentView` comment + `designs/ios-app-ui.md` updated.
4. **Native-scroll modernization** (independent sweep): `CrossSectionView` — `ScrollViewReader`→`ScrollPosition` (skew-T deep-link), `GeometryReader`→`onGeometryChange` (canvas size); `SectionSpyBar` horizontal pill strip — residual `ScrollViewReader`→`ScrollPosition`.

Net: deletes ~3 pieces of fragile custom chrome + all remaining hand-rolled scroll machinery. No `PreferenceKey`/`coordinateSpace`/manual-offset patterns remain in the app.

## Verified headlessly (simulator, render only)
- iPhone: section bar + bottom tabs render on first-open and reopen; `onScrollTargetVisibilityChange` fires with the right section ids.
- iPad: native top tab bar + section bar render on first-open and reopen; tabs switchable.

## On-device visual review REQUIRED before merge

### iPhone
- [ ] Open a briefing → section bar (`Summary · Advisories · …`) shows; go back → open another (and re-open the first) → bar still shows every time (#436 regression guard)
- [ ] Scroll the Advisory tab: bar stays pinned; the **active pill tracks** the visible section (watch timing vs. the pinned bar)
- [ ] **Tap** a pill → scrolls to that section
- [ ] Bottom tab bar switches Advisory/Discussion/Cross-Section/Map
- [ ] Cross-Section tab: "On cross-section" and "Sounding ›" deep-links scroll to the right place; **scrub** the canvas works; **rotate to landscape and back**, then tap "Sounding ›" (the landscape→portrait pending-scroll path)
- [ ] **Offline diagnostic:** turn on Airplane Mode, open a downloaded flight, go back → is the **offline banner** still visible? (If it vanishes, that's the last compositing instance — quick known fix.)

### iPad
- [ ] Open a briefing → **native top tab bar** shows (Advisory/Discussion/…); switch flights in the sidebar and re-open → tab bar still shows every time (previously vanished)
- [ ] Tab bar look/feel acceptable vs. the old custom pill band
- [ ] Section bar within Advisory: renders, sticky, active-tracking, tap-to-jump
- [ ] Cross-Section deep-links + scrub + rotate
- [ ] Switch to the **Map** tab, open another flight, back to Map → the map's control capsules still draw (eyeball; expected fine — ZStack over MapKit, not a scroll sibling)

🤖 Generated with [Claude Code](https://claude.com/claude-code)