### PR TITLE
ICON-EU: decode rain_con so the convective firing gate can evaluate ICON towers

### DIFF
--- a/designs/convective-analysis.md
+++ b/designs/convective-analysis.md
@@ -45,8 +45,9 @@ Tracked in `NWP_CAPE_TYPE` dict (`variables.py:84`), stored as `nwp_cape_type` o
 | **Convective cloud cover %** | ✓ (TCDC on convectiveCloudLayer) | ✗ | ✗ | ✗ |
 | **Convective cloud base** | ✓ (PRES → ft via std atm) | ✓ (hbas_con, m → ft) | ✗ | ✗ |
 | **Convective cloud top** | ✓ (PRES → ft via std atm) | ✓ (htop_con, m → ft) | ✓ (hcct, m → ft) | ✗ |
+| **Convective precip rate** | ✗ | ✓ (rain_con, mm, de-accum) | ✓ (cp, m we ×1000, de-accum) | ✗ |
 
-Stored in `NWPCloudDiagnostics.convective_{cover_pct,base_ft,top_ft}`.
+Stored in `NWPCloudDiagnostics.convective_{cover_pct,base_ft,top_ft}` and `convective_precip_mm_h`. ICON `rain_con` is already mm (kg/m² ≡ mm) so it is **not** ×1000, unlike ECMWF `cp` (m water equivalent); both are accumulated since init and de-accumulated in the enrichment loop.
 
 ### MetPy-Derived Thermodynamic Indices (all models with pressure levels)
 
@@ -67,7 +68,7 @@ These are derived from 13–28 pressure levels (model-dependent resolution). Ava
 | **GFS** | Open-Meteo | SB | ✓ | ✓ | Full (cover + base/top) | All | Complete |
 | **Best Match** | Open-Meteo | SB | ✓ | ✓ | Full (via GFS) | All | Complete |
 | **ECMWF** | Open-Meteo | MU | ✗ | ✗ | None | All | Good (MU-CAPE + MetPy) |
-| **ICON-EU** | Open-Meteo | ML | ✗ | ✗ | Partial (base/top only) | All | Good (base/top + MetPy) |
+| **ICON-EU** | Open-Meteo | ML | ✗ | ✗ | Partial (base/top + conv precip, no cover) | All | Good (base/top + conv precip + MetPy) |
 | **UKMO** | Open-Meteo | ? | ✓ | ✗ | None | All | Fair (MetPy-only risk) |
 | **MétéoFr** | ✗ | — | ✗ | ✗ | None | All | MetPy-only |
 | **GEM** | ✗ | — | ✗ | ✗ | None | All | MetPy-only |
@@ -88,6 +89,7 @@ GFS GRIB2 ──→ decode_cloud_diag_per_point()
 
 ICON-EU GRIB2 ──→ decode_icon_eu_cloud_diag_per_point()
               ──→ NWPCloudDiagnostics.convective_{base_ft,top_ft}  (no cover_pct)
+              ──→ rain_con (accumulated) → convective_precip_mm_h (de-accum, #421)
 ```
 
 ### Stage 2: Temporal Forward-Fill
@@ -142,7 +144,7 @@ ICON-EU GRIB2 ──→ decode_icon_eu_cloud_diag_per_point()
   - **Primary scale — convective tower top** (`convective_top_ft`, the one native field common to GFS/ECMWF/ICON): `_CONV_TOP_FL_THRESHOLDS` (FL380 EXTREME / FL280 HIGH / FL200 MODERATE / FL120 LOW / present-but-shallow MARGINAL).
   - **Cover modifier** (GFS, where `convective_cover_pct` is present): numerous cover (≥35%) bumps the top-derived tier up one level, capped at HIGH. Cover-only (no top) sets a depth-unknown tier capped at MODERATE. The MODERATE cap is on the *base* tier only — Phase-2 corroboration (below) can still raise a strongly-realized cover-only MODERATE to HIGH when native precip/indices are strong. This can't fire today (GFS exposes no native `k_index`/`total_totals` and ECMWF takes the tower-top path), but the cap is intentionally not a hard ceiling against corroboration.
   - **Precip-rate fallback (Phase 3, method `"nwp_precip"`):** when the model emits *no* tower top and *no* cover fraction but `convective_precip_mm_h > 0.1` — the ECMWF marine / elevated-convection case, where `cp` lands but `hcct` is sentinel/absent — the tier comes from a convective-precip-rate ladder (`_CONV_PRECIP_MM_H_THRESHOLDS`: ≥2.0 → MODERATE, ≥0.5 → LOW, ≥0.1 → MARGINAL) instead of the old false NONE. Tower top stays primary whenever present; this is the geometry-absent fallback only. Depth is unknown from rate alone, so the ladder is capped at MODERATE. Realized by construction, so it skips the firing gate hold-down and the precip corroboration (which would double-count `cp`), and the strong-CIN suppression below (penalising a demonstrably-firing scheme on surface/ML CIN is circular). Rate is resolution-dependent → synoptic-scale v1.
-  - **Firing gate (Phase 2):** a MODERATE+ tower is only kept there when the scheme *realized* convection (`convective_precip_mm_h > 0.1` OR `convective_cover_pct > 15`); a deep-but-dry tower is held down one level. Missing-data-safe — held down only on positive dry evidence. **Known gap (ICON-EU):** ICON exposes neither `convective_cover_pct` nor (yet) `convective_precip_mm_h`, so realization can't be evaluated and every ICON tower is kept at full native tier — no dry-tower suppression until `rain_con` is decoded. Tracked as a calibration gap.
+  - **Firing gate (Phase 2):** a MODERATE+ tower is only kept there when the scheme *realized* convection (`convective_precip_mm_h > 0.1` OR `convective_cover_pct > 15`); a deep-but-dry tower is held down one level. Missing-data-safe — held down only on positive dry evidence. All three GRIB models can now be evaluated here: ICON gained a `convective_precip_mm_h` signal in #421 (DWD `RAIN_CON`, de-accumulated), so a deep-but-dry ICON tower is held down like GFS/ECMWF rather than kept at full native tier. Its only residual blind spot is a cold-air-mass **convective snow** shower (`RAIN_CON ≈ 0` but real `SNOW_CON`), which is safe by construction — the gate holds down only on positive dry evidence, so such a tower simply keeps its current tier (`SNOW_CON` deferred, see the code note in `icon_eu_fetch.py`).
   - **Native corroboration (Phase 2):** a realized MODERATE+ cell with strong native `k_index`/`total_totals`/conv-precip bumps up one level (capped HIGH). Thresholds (`_CORROB_K_INDEX=35`, `_CORROB_TOTAL_TOTALS=50`) are North-American severe-convection defaults; European environments (lower lapse rates, more modest moisture) often need TT ≥55, so this may fire readily over Europe — flagged for eval-digest calibration.
   - **Strong-CIN suppression** kept (prefers the model's own `ml_cin_jkg`, else DD `cin_surface_jkg`) — but *not* applied on the `"nwp_precip"` path (see Phase 3 above).
 
@@ -159,7 +161,7 @@ ICON-EU GRIB2 ──→ decode_icon_eu_cloud_diag_per_point()
 | Model | NWP Convective Result | Notes |
 |-------|----------------------|-------|
 | **GFS** | `method="nwp"` — risk from tower top + cover modifier; cover/base/top from GRIB | Only model with convective cover % |
-| **ICON-EU** | `method="nwp_hybrid"` — risk from tower top; GRIB base/top; `cape_ml`/`cin_ml` native | — |
+| **ICON-EU** | `method="nwp_hybrid"` — risk from tower top; GRIB base/top; `cape_ml`/`cin_ml` + `rain_con`→conv-precip native | Firing gate + native corroboration now evaluate ICON (#421) |
 | **ECMWF** | `method="nwp_lcl_top"` when `hcct` present; `method="nwp_precip"` (Phase 3) when `hcct` sentinel but `cp` fires — risk from the precip-rate ladder; `cp`/`kx`/`totalx`/`mlcape`/`mlcin` native | `hcct` is sparsely delivered (sentinel over marine/elevated convection), so `cp` is often the only firing signal |
 | **Others** | None | No diagnostics at all |
 
@@ -362,11 +364,13 @@ Advisory:
 
 ```
 Open-Meteo → cape_jkg (ML)
-GRIB2      → NWPCloudDiagnostics.convective_{base_ft,top_ft}  (no cover_pct)
+GRIB2      → NWPCloudDiagnostics.convective_{base_ft,top_ft}  (no cover_pct),
+             rain_con→convective_precip_mm_h (de-accumulated, #421)
 MetPy      → SB/MU/ML CAPE, CIN, LCL/LFC/EL, shear, K, TT
 Analysis:
   Thermo assessment  → risk from max(SB,MU,ML,NWP) CAPE, CIN suppression
-  NWP assessment     → Hybrid: tower-top risk + GRIB base/top + cape_ml/cin_ml (method="nwp_hybrid", #283)
+  NWP assessment     → Hybrid: tower-top risk + GRIB base/top + cape_ml/cin_ml +
+                       firing gate / corroboration from rain_con (method="nwp_hybrid", #283/#421)
 Visualization:
   Thermo towers      → LFC→EL (estimated if shallow), always available
   NWP towers         → GRIB convective base/top, available via hybrid path

--- a/designs/convective-analysis.md
+++ b/designs/convective-analysis.md
@@ -161,7 +161,7 @@ ICON-EU GRIB2 ──→ decode_icon_eu_cloud_diag_per_point()
 | Model | NWP Convective Result | Notes |
 |-------|----------------------|-------|
 | **GFS** | `method="nwp"` — risk from tower top + cover modifier; cover/base/top from GRIB | Only model with convective cover % |
-| **ICON-EU** | `method="nwp_hybrid"` — risk from tower top; GRIB base/top; `cape_ml`/`cin_ml` + `rain_con`→conv-precip native | Firing gate + native corroboration now evaluate ICON (#421) |
+| **ICON-EU** | `method="nwp_hybrid"` — risk from tower top; GRIB base/top; `cape_ml`/`cin_ml` + `rain_con`→conv-precip native | Firing gate + native corroboration now evaluate ICON (#421). ICON stays `nwp_hybrid` in practice: it emits `htop_con` whenever its scheme fires, so a firing point always has tower geometry and never falls through to the geometry-absent `nwp_precip` ladder (that branch is generic on field presence, not reachable for ICON when `rain_con` > 0). |
 | **ECMWF** | `method="nwp_lcl_top"` when `hcct` present; `method="nwp_precip"` (Phase 3) when `hcct` sentinel but `cp` fires — risk from the precip-rate ladder; `cp`/`kx`/`totalx`/`mlcape`/`mlcin` native | `hcct` is sparsely delivered (sentinel over marine/elevated convection), so `cp` is often the only firing signal |
 | **Others** | None | No diagnostics at all |
 

--- a/designs/meteorology-decisions.md
+++ b/designs/meteorology-decisions.md
@@ -1312,9 +1312,11 @@ when the model's own scheme *realized* convection — `convective_precip_mm_h >
 case) is held down one level. This is the native-side mirror of §6's parcel-EL
 over-read fix. Crucially it is **missing-data-safe**: a not-realized tower is
 held down only on *positive* dry evidence (precip ~0 or cover ≤ threshold), never
-on absent data — so a model that simply doesn't emit precip (ICON without
-`rain_con`, ECMWF before `cp` lands) keeps its tower-top tier rather than being
-wrongly suppressed (safety asymmetry).
+on absent data — so a model that simply doesn't emit precip (ECMWF before `cp`
+lands, or the first ICON window hour with no predecessor step to de-accumulate
+against) keeps its tower-top tier rather than being wrongly suppressed (safety
+asymmetry). (ICON gained a `convective_precip_mm_h` signal from `rain_con` in
+#421 — see "Remaining decode gaps" below.)
 
 **Native corroboration.** A *realized* MODERATE+ cell whose own model-native
 indices are strong (`k_index > 35`, `total_totals > 50`, or conv precip >
@@ -1353,11 +1355,14 @@ spatial-interp `_lerp_diagnostics`.
 
 ### Remaining decode gaps (small, low-risk)
 
-- **ICON `rain_con`** (convective rain) is accumulated since init and would need
-  new step-difference machinery in the ICON merge path (ICON has no accumulated
-  single-level field today). Deferred — needs real-GRIB validation of the
-  product/shortName and cadence. ICON's firing gate is missing-data-safe, so
-  ICON keeps its tower-top tier meanwhile.
+- **ICON `rain_con`** (convective rain) — ✅ RESOLVED (#421). Accumulated since
+  init (kg/m² ≡ mm, already mm so **no** ×1000, unlike ECMWF `cp`); the mm/h rate
+  is de-accumulated in the ICON cloud-diag merge loop, mirroring the ECMWF `cp`
+  path. ICON has no ±margin (fetched on-demand exactly on window hours), so the
+  merge prepends one leading single-level step (`icon_eu_previous_step`) to give
+  the first window hour a predecessor to difference against. The firing gate and
+  native corroboration now evaluate ICON towers. `SNOW_CON` (convective snow)
+  stays deferred — omitting it is safe by construction (positive-dry-evidence gate).
 - **GFS `CPRAT`/`ACPCP`** (convective precip): GFS always emits convective
   *cover*, which already drives the firing gate, so GFS precip is redundant for
   the gate. Deferred (the `.idx` byte-range + shortName needs validation).

--- a/designs/meteorology-decisions.md
+++ b/designs/meteorology-decisions.md
@@ -1363,6 +1363,13 @@ spatial-interp `_lerp_diagnostics`.
   the first window hour a predecessor to difference against. The firing gate and
   native corroboration now evaluate ICON towers. `SNOW_CON` (convective snow)
   stays deferred — omitting it is safe by construction (positive-dry-evidence gate).
+  Validation caveat: the DWD product/URL was verified live against the opendata
+  directory listing (per the issue), and the de-accumulation logic is covered by
+  unit + mocked-decode integration tests. The cfgrib **decoded shortName** (the
+  `rain_con` key the field map relies on) has not yet been confirmed against a
+  real DWD GRIB pull — worth a one-time live-decode check when convenient, though
+  it follows the same lowercased-shortName convention as the sibling single-level
+  fields (`ceiling`, `clcl`, …) that already decode correctly in production.
 - **GFS `CPRAT`/`ACPCP`** (convective precip): GFS always emits convective
   *cover*, which already drives the firing gate, so GFS precip is redundant for
   the gate. Deferred (the `.idx` byte-range + shortName needs validation).

--- a/designs/weather-engine-specs.md
+++ b/designs/weather-engine-specs.md
@@ -148,7 +148,7 @@ See [fetch.md](./fetch.md) for implementation details.
 - **Domain:** 29.5–70.5°N, 23.5°W–62.5°E
 - **Variables fetched:**
   - Model-level: QC, QI, CLC, P, T, QV, U, V, W — **full sounding replacement** (replaces Open-Meteo pressure levels entirely)
-  - Single-level: CEILING, HBAS_CON/HTOP_CON, CLCL/CLCM/CLCH/CLCT, **CAPE_ML/CIN_ML** → `NWPCloudDiagnostics` (cape_ml/cin_ml → `ml_cape_jkg`/`ml_cin_jkg`, instantaneous, feed the native convective track #283). RAIN_CON (convective rain, accumulated-since-init) is **not yet fetched** — it would need step-difference de-accumulation in the ICON merge path; the firing gate is missing-data-safe meanwhile.
+  - Single-level: CEILING, HBAS_CON/HTOP_CON, CLCL/CLCM/CLCH/CLCT, **CAPE_ML/CIN_ML**, **RAIN_CON** → `NWPCloudDiagnostics` (cape_ml/cin_ml → `ml_cape_jkg`/`ml_cin_jkg`, instantaneous, feed the native convective track #283; rain_con → `convective_precip_mm_h`, accumulated-since-init and de-accumulated in the merge loop, #421). rain_con is kg/m² ≡ mm — already mm, so **no** ×1000 (unlike ECMWF `cp`, m water equivalent). The ICON merge prepends one leading single-level step (`icon_eu_previous_step`) so the first window hour has a predecessor to difference against, and the cloud-diag cache key is bumped (`ICON_EU_CLOUD_DIAG_V2`) so warm caches re-fetch.
 - **Model levels → pressure levels:** Log-pressure interpolation using P field; 40 model levels → standard pressure levels (`EXTENDED_PRESSURE_LEVELS`, 28-level set)
 - **Single-level → NWPCloudDiagnostics:** Heights in meters converted to feet (× 3.28084)
 - **W → omega:** physical vertical velocity (m/s) converted to omega (`vertical_velocity_pa_s`) per level via −ρ·g·w

--- a/src/weatherbrief/fetch/grib/__init__.py
+++ b/src/weatherbrief/fetch/grib/__init__.py
@@ -2921,9 +2921,11 @@ def _prefetch_icon_eu_data_inner(ctx: _IconEuContext) -> None:
     completion.
     """
     from weatherbrief.fetch.grib.icon_eu_fetch import (
+        ICON_EU_CLOUD_DIAG_CACHE_KEY,
         ICON_EU_VARIABLES,
         fetch_icon_eu_per_variable,
         fetch_icon_eu_single_level,
+        icon_eu_previous_step,
     )
 
     outer = _icon_prefetch_workers()
@@ -2973,9 +2975,19 @@ def _prefetch_icon_eu_data_inner(ctx: _IconEuContext) -> None:
                     jobs.append((_fetch_var, fhour, var, ck))
 
         # Single-level cloud diagnostics
-        diag_ck = cache_key(fhour, "ICON_EU_CLOUD_DIAG")
+        diag_ck = cache_key(fhour, ICON_EU_CLOUD_DIAG_CACHE_KEY)
         if not is_cached(ctx.run_dir, diag_ck):
             jobs.append((_fetch_diag, fhour, diag_ck))
+
+    # One leading single-level step so the first window hour has a predecessor
+    # to de-accumulate rain_con against (#421). Cloud-diag fetch only — the
+    # model-level sounding list above is untouched.
+    if ctx.forecast_hours:
+        lead = icon_eu_previous_step(min(ctx.forecast_hours))
+        if lead is not None and lead not in ctx.forecast_hours:
+            lead_ck = cache_key(lead, ICON_EU_CLOUD_DIAG_CACHE_KEY)
+            if not is_cached(ctx.run_dir, lead_ck):
+                jobs.append((_fetch_diag, lead, lead_ck))
 
     if not jobs:
         return
@@ -3137,11 +3149,34 @@ def _enrich_icon_eu_cloud_diagnostics(
     NWPCloudLayerDiag are filled from it.
     """
     from weatherbrief.fetch.grib.decode import build_icon_cloud_diagnostics
-    from weatherbrief.fetch.grib.icon_eu_fetch import fetch_icon_eu_single_level
+    from weatherbrief.fetch.grib.icon_eu_fetch import (
+        ICON_EU_CLOUD_DIAG_CACHE_KEY,
+        fetch_icon_eu_single_level,
+        icon_eu_conv_rain_rate_mm_h,
+        icon_eu_previous_step,
+    )
+
+    # Prepend one leading step so the first window hour has a predecessor to
+    # de-accumulate rain_con against, then walk steps in sorted order carrying
+    # the previous accumulated value + valid time — a direct port of the ECMWF
+    # a1 loop (#421). The leading step is a harmless no-op for enrichment:
+    # _matches_valid_time never matches an out-of-window hourly, so it only
+    # seeds the de-accumulation state.
+    steps = sorted(set(forecast_hours))
+    if steps:
+        lead = icon_eu_previous_step(steps[0])
+        if lead is not None and lead not in steps:
+            steps.insert(0, lead)
+
+    n_points = len(point_lats)
+    # None = no prior step for that point (unknown, missing-data-safe for the
+    # firing gate). Not 0.0 — a real 0.0 would actively hold a tower down.
+    prev_rain_con_per_point: list[float | None] = [None] * n_points
+    prev_valid_utc: datetime | None = None
 
     total_enriched = 0
-    for fhour in forecast_hours:
-        ck = cache_key(fhour, "ICON_EU_CLOUD_DIAG")
+    for fhour in steps:
+        ck = cache_key(fhour, ICON_EU_CLOUD_DIAG_CACHE_KEY)
         if not is_cached(run_dir, ck):
             try:
                 fetched = fetch_icon_eu_single_level(
@@ -3167,6 +3202,41 @@ def _enrich_icon_eu_cloud_diagnostics(
 
         diagnostics_per_point = [build_icon_cloud_diagnostics(raw) for raw in decoded_points]
 
+        valid_utc = _forecast_hour_to_utc(init_date, init_hour, fhour)
+
+        # Convective precip rate (#421): rain_con is accumulated since init
+        # (kg/m² ≡ mm), so difference it against the previous step and inject the
+        # mm/h rate onto the just-built diagnostics so it rides the same
+        # forward-fill / spatial-interp path as the rest of the cloud
+        # diagnostics. Compute the window from the two valid times — ICON drops
+        # to 3-hourly past +78h. The rate helper does the mm/h conversion
+        # (already mm — NO ×1000, unlike ECMWF `cp`) and the None-vs-0.0
+        # missing-data handling.
+        window_h: float | None = None
+        if prev_valid_utc is not None:
+            _dh = (valid_utc - prev_valid_utc).total_seconds() / 3600.0
+            if _dh > 0:
+                window_h = _dh
+        for i, raw in enumerate(decoded_points):
+            diag_i = diagnostics_per_point[i]
+            if diag_i is None:
+                continue
+            rate = icon_eu_conv_rain_rate_mm_h(
+                raw.get("conv_rain_kg_m2"), prev_rain_con_per_point[i], window_h,
+            )
+            if rate is not None:
+                # Reconstruct rather than mutate so the NWPCloudDiagnostics
+                # immutability contract holds (review #284).
+                diagnostics_per_point[i] = diag_i.model_copy(
+                    update={"convective_precip_mm_h": rate}
+                )
+        # Carry this step's cumulative rain_con + valid time forward.
+        for i, raw in enumerate(decoded_points):
+            rc = raw.get("conv_rain_kg_m2")
+            if rc is not None:
+                prev_rain_con_per_point[i] = rc
+        prev_valid_utc = valid_utc
+
         # Fill missing layer base/top from CLC-derived boundaries
         if clc_layers_per_point:
             for pt_idx, diag in enumerate(diagnostics_per_point):
@@ -3181,8 +3251,6 @@ def _enrich_icon_eu_cloud_diagnostics(
                         layer.base_ft = clc[f"{band}_base_ft"]
                     if layer.top_ft is None and f"{band}_top_ft" in clc:
                         layer.top_ft = clc[f"{band}_top_ft"]
-
-        valid_utc = _forecast_hour_to_utc(init_date, init_hour, fhour)
 
         # Use _apply_cloud_diagnostics_to_sections with GFS-priority guard
         for cs in icon_sections:

--- a/src/weatherbrief/fetch/grib/__init__.py
+++ b/src/weatherbrief/fetch/grib/__init__.py
@@ -3230,11 +3230,17 @@ def _enrich_icon_eu_cloud_diagnostics(
                 diagnostics_per_point[i] = diag_i.model_copy(
                     update={"convective_precip_mm_h": rate}
                 )
-        # Carry this step's cumulative rain_con + valid time forward.
+        # Carry this step's cumulative rain_con + valid time forward. Assign
+        # unconditionally: a point that lacks rain_con at this step (e.g. the DWD
+        # rain_con file failed for this hour while the other cloud-diag vars
+        # succeeded, or the point is uncovered) resets its predecessor to None,
+        # so the NEXT step differences against nothing → None (missing-data-safe)
+        # rather than dividing a multi-step accumulation delta by a single-step
+        # window and silently inflating the rate. prev_valid_utc advances every
+        # processed step, so a stale predecessor value would otherwise desync
+        # from the window (review on 6c5555a).
         for i, raw in enumerate(decoded_points):
-            rc = raw.get("conv_rain_kg_m2")
-            if rc is not None:
-                prev_rain_con_per_point[i] = rc
+            prev_rain_con_per_point[i] = raw.get("conv_rain_kg_m2")
         prev_valid_utc = valid_utc
 
         # Fill missing layer base/top from CLC-derived boundaries

--- a/src/weatherbrief/fetch/grib/decode.py
+++ b/src/weatherbrief/fetch/grib/decode.py
@@ -125,6 +125,11 @@ _ICON_CLOUD_DIAG_FIELD_MAP: dict[str, str] = {
     "clct": "total_cover_pct",
     "cape_ml": "ml_cape_jkg",   # J/kg, mixed-layer CAPE (#283)
     "cin_ml": "ml_cin_jkg",     # J/kg, mixed-layer CIN (#283)
+    # Convective rain, kg/m² ≡ mm, ACCUMULATED since init (#421). The near-
+    # equivalent of ECMWF `cp`, but already mm (no ×1000). The rate is
+    # de-accumulated in the ICON enrichment loop (the only place that knows the
+    # previous step), so build_icon_cloud_diagnostics stays unaware of it.
+    "rain_con": "conv_rain_kg_m2",
 }
 
 # ECMWF single-level (a1) field mapping.

--- a/src/weatherbrief/fetch/grib/icon_eu_fetch.py
+++ b/src/weatherbrief/fetch/grib/icon_eu_fetch.py
@@ -113,6 +113,13 @@ ICON_EU_VARIABLES = ("qc", "qi", "clc", "p", "t", "qv", "u", "v", "w")
 # accumulated since init) added in #421 so the convective firing gate and
 # native corroboration can evaluate ICON towers — the rate is de-accumulated
 # in the enrichment loop, not here.
+# SNOW_CON (convective snow, also accumulated) is intentionally NOT fetched
+# (#421 scope decision): it would double the single-level file count for the
+# rare convective-snow-shower case, and omitting it is safe by construction —
+# the firing gate holds down only on positive dry evidence, so a winter ICON
+# tower with rain_con ~0 but real convective snow simply keeps its tier (no
+# regression, just an unclosed corner). If added, sum the two de-accumulated
+# rates before assigning convective_precip_mm_h.
 ICON_EU_CLOUD_DIAG_VARIABLES = (
     "ceiling", "hbas_con", "htop_con",
     "clcl", "clcm", "clch", "clct",

--- a/src/weatherbrief/fetch/grib/icon_eu_fetch.py
+++ b/src/weatherbrief/fetch/grib/icon_eu_fetch.py
@@ -109,14 +109,25 @@ ICON_EU_VARIABLES = ("qc", "qi", "clc", "p", "t", "qv", "u", "v", "w")
 
 # Single-level cloud diagnostic variables.
 # cape_ml / cin_ml (mixed-layer CAPE/CIN, instantaneous) added for the
-# native convective track (#283 Phase 2). rain_con (convective rain) is
-# accumulated since init and needs step-difference de-accumulation — deferred
-# (the firing gate is missing-data-safe, so ICON keeps its tower-top tier).
+# native convective track (#283 Phase 2). rain_con (convective rain,
+# accumulated since init) added in #421 so the convective firing gate and
+# native corroboration can evaluate ICON towers — the rate is de-accumulated
+# in the enrichment loop, not here.
 ICON_EU_CLOUD_DIAG_VARIABLES = (
     "ceiling", "hbas_con", "htop_con",
     "clcl", "clcm", "clch", "clct",
     "cape_ml", "cin_ml",
+    "rain_con",
 )
+
+# Cache-key label for the single-level cloud-diagnostic blob. Bumped to V2 in
+# #421 when rain_con was added: the blob is cached under ONE key for all
+# variables, so adding a variable changes the blob's *content* but not its key.
+# Bumping the label forces existing (rain_con-less) cached blobs to re-fetch —
+# without it a warm cache would silently keep the pre-#421 gate-less behaviour.
+# Referenced everywhere the blob is cached (prefetch, enrichment, precache,
+# standalone verification) so the four call sites can never drift apart.
+ICON_EU_CLOUD_DIAG_CACHE_KEY = "ICON_EU_CLOUD_DIAG_V2"
 
 # Parallel download settings
 MAX_DOWNLOAD_WORKERS = 8
@@ -393,6 +404,49 @@ def _snap_to_icon_eu_grid_floor(fhour: float) -> int:
         return int(fhour)
     base = 78 + int((fhour - 78) / 3) * 3
     return min(base, 120)
+
+
+def icon_eu_previous_step(fhour: int) -> int | None:
+    """Return the ICON-EU forecast hour immediately preceding *fhour*.
+
+    Respects the temporal grid — 1-hourly at or below 78h (step −1), 3-hourly
+    above it (step −3) — mirroring :func:`_snap_to_icon_eu_grid`. Returns
+    ``None`` for ``fhour == 0``: accumulation is 0 at init by definition, so
+    there is no earlier step to difference an accumulated field against.
+
+    Used to prepend one leading single-level step to the on-demand cloud-diag
+    fetch so the first flight-window hour has a predecessor to de-accumulate
+    ``rain_con`` against. ICON is downloaded exactly on the window hours (no
+    ±margin like the locally-mirrored ECMWF run), so without this the first
+    hour would have no rate (#421).
+    """
+    if fhour <= 0:
+        return None
+    if fhour <= 78:
+        return fhour - 1
+    return fhour - 3
+
+
+def icon_eu_conv_rain_rate_mm_h(
+    rain_con: float | None,
+    prev_rain_con: float | None,
+    window_h: float | None,
+) -> float | None:
+    """De-accumulate ICON ``rain_con`` into a convective-precip rate (mm/h).
+
+    ``rain_con`` is accumulated since init in kg/m² ≡ mm — **already mm**, so
+    there is NO ×1000 (that conversion is only for ECMWF ``cp``, which is m
+    water equivalent). Clamped at 0 so a decreasing accumulation (new run /
+    GRIB glitch) yields 0 rather than a negative rate.
+
+    Returns ``None`` — not ``0.0`` — when any input is missing (no predecessor
+    step, uncovered point, or non-positive window). ``None`` = unknown, which
+    the firing gate treats as missing-data-safe; ``0.0`` would actively hold a
+    tower down. The two are **not** interchangeable (#421).
+    """
+    if rain_con is None or prev_rain_con is None or window_h is None or window_h <= 0:
+        return None
+    return max(0.0, (rain_con - prev_rain_con) / window_h)
 
 
 def compute_icon_eu_flight_window_hours(

--- a/src/weatherbrief/fetch/grib/precache.py
+++ b/src/weatherbrief/fetch/grib/precache.py
@@ -126,6 +126,15 @@ def precache_icon_eu_run(init: datetime) -> dict[str, int]:
                     "Pre-cache ICON-EU f%03d %s failed", fhour, var, exc_info=True,
                 )
 
+        # Unlike the flight-briefing prefetch/enrichment paths, this warm-up
+        # does NOT prepend the rain_con de-accumulation predecessor step (#421).
+        # The airport-profile hour set is gappy across day boundaries, so a
+        # single leading step wouldn't give parity anyway, and warming every
+        # block's predecessor is not worth the complexity here: a briefing whose
+        # window starts on a boundary hour just fetches that one predecessor
+        # live in `_enrich_icon_eu_cloud_diagnostics`. The firing gate stays
+        # missing-data-safe throughout — this is a warm-path gap, not a
+        # correctness one.
         diag_ck = cache_key(fhour, ICON_EU_CLOUD_DIAG_CACHE_KEY)
         if not is_cached(run_dir, diag_ck):
             try:

--- a/src/weatherbrief/fetch/grib/precache.py
+++ b/src/weatherbrief/fetch/grib/precache.py
@@ -24,6 +24,7 @@ from weatherbrief.fetch.grib.cache import (
     put_cached,
 )
 from weatherbrief.fetch.grib.icon_eu_fetch import (
+    ICON_EU_CLOUD_DIAG_CACHE_KEY,
     ICON_EU_VARIABLES as ICON_EU_PRECACHE_VARS,
 )
 
@@ -125,7 +126,7 @@ def precache_icon_eu_run(init: datetime) -> dict[str, int]:
                     "Pre-cache ICON-EU f%03d %s failed", fhour, var, exc_info=True,
                 )
 
-        diag_ck = cache_key(fhour, "ICON_EU_CLOUD_DIAG")
+        diag_ck = cache_key(fhour, ICON_EU_CLOUD_DIAG_CACHE_KEY)
         if not is_cached(run_dir, diag_ck):
             try:
                 fetched = fetch_icon_eu_single_level(

--- a/src/weatherbrief/tasks/standalone_grib.py
+++ b/src/weatherbrief/tasks/standalone_grib.py
@@ -144,7 +144,10 @@ def fetch_icon_cloud_diag(
     """
     from weatherbrief.fetch.grib import _dispatch_decode
     from weatherbrief.fetch.grib.decode import build_icon_cloud_diagnostics
-    from weatherbrief.fetch.grib.icon_eu_fetch import fetch_icon_eu_single_level
+    from weatherbrief.fetch.grib.icon_eu_fetch import (
+        ICON_EU_CLOUD_DIAG_CACHE_KEY,
+        fetch_icon_eu_single_level,
+    )
 
     if data_dir is None:
         data_dir = Path(os.environ.get("DATA_DIR", "data"))
@@ -155,7 +158,7 @@ def fetch_icon_cloud_diag(
     result: dict[int, list[AirportCeilingData]] = {}
 
     for fhour in forecast_hours:
-        ck = cache_key(fhour, "ICON_EU_CLOUD_DIAG")
+        ck = cache_key(fhour, ICON_EU_CLOUD_DIAG_CACHE_KEY)
 
         if not is_cached(run_dir, ck):
             try:

--- a/tests/test_convective.py
+++ b/tests/test_convective.py
@@ -1070,6 +1070,44 @@ def test_nwp_firing_gate_realized_by_precip_keeps_tier():
     assert result.risk_level == ConvectiveRisk.HIGH
 
 
+def test_nwp_icon_dry_tower_held_down_by_rain_con():
+    """#421: a deep-but-dry ICON tower is now held down one level.
+
+    ICON's shape is base+top with no cover fraction → method `nwp_hybrid`. With
+    `convective_precip_mm_h` newly decoded from `rain_con`, a realized-dry tower
+    (rate 0.0, positive dry evidence) hits the firing gate and drops HIGH→MODERATE
+    — the behaviour ICON never got before this PR. The method must stay
+    `nwp_hybrid`: ICON has geometry, so it never falls through to `nwp_precip`.
+    """
+    indices = ThermodynamicIndices(cape_surface_jkg=40.0)
+    diag = NWPCloudDiagnostics(
+        convective_base_ft=4000.0, convective_top_ft=30000.0,  # FL300 → HIGH
+        convective_precip_mm_h=0.0,                            # realized dry
+    )
+    result = assess_convective_nwp(indices, diag)
+    assert result is not None
+    assert result.method == "nwp_hybrid"          # geometry present, NOT nwp_precip
+    assert result.risk_level == ConvectiveRisk.MODERATE  # HIGH held down one level
+    assert any("dry" in s for s in result.suppressors)
+
+
+def test_nwp_icon_wet_tower_stays_nwp_hybrid():
+    """#421: a firing ICON tower keeps its tier and stays `nwp_hybrid`.
+
+    Pins that a populated `convective_precip_mm_h` on an ICON-shaped diagnostic
+    does not reroute it onto the geometry-absent `nwp_precip` ladder.
+    """
+    indices = ThermodynamicIndices(cape_surface_jkg=40.0)
+    diag = NWPCloudDiagnostics(
+        convective_base_ft=4000.0, convective_top_ft=30000.0,
+        convective_precip_mm_h=1.5,
+    )
+    result = assess_convective_nwp(indices, diag)
+    assert result is not None
+    assert result.method == "nwp_hybrid"
+    assert result.risk_level == ConvectiveRisk.HIGH
+
+
 def test_nwp_corroboration_bumps_realized_cell():
     """A realized MODERATE cell with strong native K-index bumps to HIGH."""
     indices = ThermodynamicIndices(cape_surface_jkg=40.0)

--- a/tests/test_convective.py
+++ b/tests/test_convective.py
@@ -1044,9 +1044,11 @@ def test_nwp_firing_gate_holds_zero_precip_tower_down():
 
 
 def test_nwp_firing_gate_missing_data_keeps_tier():
-    """No cover and no precip (e.g. ICON deep tower, no rain_con) → keep tier.
+    """No cover and no precip field at all → keep tier.
 
-    Missing data must never hold down — safety asymmetry. (#283)
+    Missing data must never hold down — safety asymmetry. (#283) Post-#421 this
+    is the ICON first-window-hour case (no predecessor step to de-accumulate
+    rain_con against, so convective_precip_mm_h is None, not 0.0).
     """
     indices = ThermodynamicIndices(cape_surface_jkg=40.0)
     diag = NWPCloudDiagnostics(convective_base_ft=4000.0, convective_top_ft=30000.0)

--- a/tests/test_grib.py
+++ b/tests/test_grib.py
@@ -922,6 +922,8 @@ class TestIconEuDecode:
         assert _ICON_CLOUD_DIAG_FIELD_MAP["ceiling"] == "ceiling_m"
         assert _ICON_CLOUD_DIAG_FIELD_MAP["hbas_con"] == "convective_cloud_base_m"
         assert _ICON_CLOUD_DIAG_FIELD_MAP["htop_con"] == "convective_cloud_top_m"
+        # rain_con (convective rain, accumulated) decoded for the firing gate (#421)
+        assert _ICON_CLOUD_DIAG_FIELD_MAP["rain_con"] == "conv_rain_kg_m2"
 
 
 # --- ICON-EU single-level URL format tests ---
@@ -964,6 +966,77 @@ class TestIconEuSingleLevel:
 
         for var in ("clcl", "clcm", "clch", "clct"):
             assert var in ICON_EU_CLOUD_DIAG_VARIABLES, f"{var} missing"
+
+    def test_cloud_diag_variables_include_rain_con(self):
+        """rain_con is fetched so the firing gate can evaluate ICON (#421)."""
+        from weatherbrief.fetch.grib.icon_eu_fetch import ICON_EU_CLOUD_DIAG_VARIABLES
+
+        assert "rain_con" in ICON_EU_CLOUD_DIAG_VARIABLES
+
+    def test_cloud_diag_cache_key_bumped_to_v2(self):
+        """Adding rain_con changed the blob content → key bumped so warm caches
+        re-fetch instead of silently keeping the gate-less blob (#421)."""
+        from weatherbrief.fetch.grib.icon_eu_fetch import ICON_EU_CLOUD_DIAG_CACHE_KEY
+
+        assert ICON_EU_CLOUD_DIAG_CACHE_KEY == "ICON_EU_CLOUD_DIAG_V2"
+
+    def test_previous_step_hourly_grid(self):
+        """Below 78h the predecessor is one hour back (1-hourly grid)."""
+        from weatherbrief.fetch.grib.icon_eu_fetch import icon_eu_previous_step
+
+        assert icon_eu_previous_step(1) == 0
+        assert icon_eu_previous_step(6) == 5
+        assert icon_eu_previous_step(78) == 77
+
+    def test_previous_step_three_hourly_grid(self):
+        """Above 78h the predecessor is three hours back (3-hourly grid)."""
+        from weatherbrief.fetch.grib.icon_eu_fetch import icon_eu_previous_step
+
+        assert icon_eu_previous_step(81) == 78
+        assert icon_eu_previous_step(120) == 117
+
+    def test_previous_step_zero_has_no_predecessor(self):
+        """At init there is no earlier step — accumulation is 0 by definition."""
+        from weatherbrief.fetch.grib.icon_eu_fetch import icon_eu_previous_step
+
+        assert icon_eu_previous_step(0) is None
+
+    def test_conv_rain_rate_no_x1000(self):
+        """rain_con is already mm (kg/m² ≡ mm) — the rate is NOT ×1000.
+
+        The single highest-value regression: the ECMWF `cp` port multiplies by
+        1000 (m water equiv → mm); porting that here would over-read by 1000×.
+        """
+        from weatherbrief.fetch.grib.icon_eu_fetch import icon_eu_conv_rain_rate_mm_h
+
+        # 2.0 mm accumulated over 1h → 2.0 mm/h, not 2000.
+        assert icon_eu_conv_rain_rate_mm_h(3.0, 1.0, 1.0) == 2.0
+
+    def test_conv_rain_rate_three_hour_window(self):
+        """A 3-hourly step divides the accumulation delta by 3."""
+        from weatherbrief.fetch.grib.icon_eu_fetch import icon_eu_conv_rain_rate_mm_h
+
+        # 6.0 mm accumulated over the step, 3h window → 2.0 mm/h.
+        assert icon_eu_conv_rain_rate_mm_h(10.0, 4.0, 3.0) == 2.0
+
+    def test_conv_rain_rate_clamps_negative_to_zero(self):
+        """A decreasing accumulation (new run / GRIB glitch) clamps to 0."""
+        from weatherbrief.fetch.grib.icon_eu_fetch import icon_eu_conv_rain_rate_mm_h
+
+        assert icon_eu_conv_rain_rate_mm_h(1.0, 5.0, 1.0) == 0.0
+
+    def test_conv_rain_rate_missing_is_none_not_zero(self):
+        """Missing inputs → None (unknown, gate-safe), never 0.0 (holds down).
+
+        None and 0.0 are NOT interchangeable: 0.0 actively holds a tower down
+        one level, None is treated as missing-data-safe by the firing gate.
+        """
+        from weatherbrief.fetch.grib.icon_eu_fetch import icon_eu_conv_rain_rate_mm_h
+
+        assert icon_eu_conv_rain_rate_mm_h(None, 1.0, 1.0) is None   # no current
+        assert icon_eu_conv_rain_rate_mm_h(2.0, None, 1.0) is None   # no predecessor
+        assert icon_eu_conv_rain_rate_mm_h(2.0, 1.0, None) is None   # no window
+        assert icon_eu_conv_rain_rate_mm_h(2.0, 1.0, 0.0) is None    # zero window
 
     def test_single_level_url_no_level_number(self):
         """Single-level URLs have no level number (unlike model-level)."""
@@ -1060,6 +1133,27 @@ class TestBuildIconCloudDiagnostics:
         assert diag.ml_cape_jkg == 850.0
         assert diag.ml_cin_jkg == -120.0
 
+    def test_rain_con_not_surfaced_as_rate(self):
+        """build_icon_cloud_diagnostics stays unaware of rain_con (#421).
+
+        The accumulated conv_rain_kg_m2 rides through the decode but the mm/h
+        *rate* is computed in the enrichment loop (the only place that knows the
+        previous step), so the builder must leave convective_precip_mm_h None and
+        not treat the raw accumulation as a rate.
+        """
+        from weatherbrief.fetch.grib.decode import build_icon_cloud_diagnostics
+
+        # conv_rain_kg_m2 present alongside a real field — builds, rate stays None.
+        raw = {"convective_cloud_top_m": 10000.0, "conv_rain_kg_m2": 3.5}
+        diag = build_icon_cloud_diagnostics(raw)
+        assert diag is not None
+        assert diag.convective_top_ft is not None
+        assert diag.convective_precip_mm_h is None
+
+        # conv_rain_kg_m2 alone does not by itself make a diagnostics object —
+        # it is not one of the "has_any" fields the builder keys on.
+        assert build_icon_cloud_diagnostics({"conv_rain_kg_m2": 3.5}) is None
+
     def test_ecmwf_native_stability_surfaced(self):
         """ECMWF a1 native stability indices surfaced on the diag (#283).
 
@@ -1151,6 +1245,99 @@ class TestBuildIconCloudDiagnostics:
         assert _ICON_CLOUD_DIAG_FIELD_MAP["clcm"] == "mid_cover_pct"
         assert _ICON_CLOUD_DIAG_FIELD_MAP["clch"] == "high_cover_pct"
         assert _ICON_CLOUD_DIAG_FIELD_MAP["clct"] == "total_cover_pct"
+
+
+# --- ICON-EU convective-precip de-accumulation through the merge path ---
+
+
+class TestIconConvectivePrecipEnrichment:
+    """End-to-end de-accumulation in _enrich_icon_eu_cloud_diagnostics (#421).
+
+    Confirms the field actually *arrives populated* on ICON diagnostics: the
+    leading step seeds the accumulation state, the first window hour gets a real
+    mm/h rate (no ×1000), and each in-window step differences against its
+    predecessor.
+    """
+
+    @staticmethod
+    def _run(monkeypatch, accum_by_fhour, forecast_hours):
+        """Enrich a single-point ICON section; return {hour_utc: diag}."""
+        import re
+        from datetime import datetime, timezone
+
+        import weatherbrief.fetch.grib as grib_mod
+        from weatherbrief.models import (
+            HourlyForecast,
+            ModelSource,
+            PressureLevelData,
+            RoutePoint,
+            RouteCrossSection,
+            Waypoint,
+            WaypointForecast,
+        )
+
+        init_date, init_hour = "20260716", 0
+        now = datetime.now(tz=timezone.utc)
+
+        def _utc(h):
+            return datetime(2026, 7, 16, h, 0, tzinfo=timezone.utc)
+
+        hourly = [
+            HourlyForecast(time=_utc(h), pressure_levels=[PressureLevelData(pressure_hpa=500)])
+            for h in forecast_hours
+        ]
+        wpt = Waypoint(icao="XXXX", name="Test", lat=50.0, lon=0.0)
+        wf = WaypointForecast(
+            waypoint=wpt, model=ModelSource.ICON, fetched_at=now, hourly=hourly,
+        )
+        cs = RouteCrossSection(
+            model=ModelSource.ICON, route_points=[], fetched_at=now,
+            point_forecasts=[wf],
+        )
+
+        # Cache always "present" so no network; decode returns the accumulated
+        # rain_con for the fhour parsed from the cache path, plus a real field so
+        # build_icon_cloud_diagnostics yields a diagnostics object.
+        monkeypatch.setattr(grib_mod, "is_cached", lambda run_dir, ck: True)
+
+        def fake_dispatch(worker, path, lats, lons, **kw):
+            fh = int(re.search(r"f(\d{3})_", str(path)).group(1))
+            return [{
+                "convective_cloud_top_m": 8000.0,
+                "conv_rain_kg_m2": accum_by_fhour[fh],
+            }]
+
+        monkeypatch.setattr(grib_mod, "_dispatch_decode", fake_dispatch)
+
+        grib_mod._enrich_icon_eu_cloud_diagnostics(
+            [cs], [], [RoutePoint(lat=50.0, lon=0.0, distance_from_origin_nm=0.0)],
+            init_date, init_hour, list(forecast_hours),
+            Path("/unused"), [50.0], [0.0], session=None,
+        )
+        return {h.time.hour: h.nwp_cloud_diagnostics for h in wf.hourly}
+
+    def test_first_window_hour_gets_rate_from_leading_step(self, monkeypatch):
+        """The leading step (f005) seeds state so f006 gets a real mm/h rate."""
+        # f005=1.0 (lead), f006=3.0, f007=4.5 accumulated mm.
+        diags = self._run(
+            monkeypatch,
+            accum_by_fhour={5: 1.0, 6: 3.0, 7: 4.5},
+            forecast_hours=[6, 7],
+        )
+        # f006: (3.0 − 1.0) / 1h = 2.0 mm/h — NOT 2000 (no ×1000).
+        assert diags[6] is not None
+        assert diags[6].convective_precip_mm_h == 2.0
+        # f007: (4.5 − 3.0) / 1h = 1.5 mm/h.
+        assert diags[7].convective_precip_mm_h == 1.5
+
+    def test_rate_clamped_on_run_reset(self, monkeypatch):
+        """A decreasing accumulation across the window clamps to 0, not negative."""
+        diags = self._run(
+            monkeypatch,
+            accum_by_fhour={5: 5.0, 6: 2.0},  # accumulation dropped (new run)
+            forecast_hours=[6],
+        )
+        assert diags[6].convective_precip_mm_h == 0.0
 
 
 # --- Cache model parameter tests ---

--- a/tests/test_grib.py
+++ b/tests/test_grib.py
@@ -1302,10 +1302,11 @@ class TestIconConvectivePrecipEnrichment:
 
         def fake_dispatch(worker, path, lats, lons, **kw):
             fh = int(re.search(r"f(\d{3})_", str(path)).group(1))
-            return [{
-                "convective_cloud_top_m": 8000.0,
-                "conv_rain_kg_m2": accum_by_fhour[fh],
-            }]
+            raw = {"convective_cloud_top_m": 8000.0}
+            acc = accum_by_fhour[fh]
+            if acc is not None:  # None models a failed/absent rain_con file
+                raw["conv_rain_kg_m2"] = acc
+            return [raw]
 
         monkeypatch.setattr(grib_mod, "_dispatch_decode", fake_dispatch)
 
@@ -1338,6 +1339,27 @@ class TestIconConvectivePrecipEnrichment:
             forecast_hours=[6],
         )
         assert diags[6].convective_precip_mm_h == 0.0
+
+    def test_missing_rain_con_step_invalidates_predecessor(self, monkeypatch):
+        """A step whose rain_con file failed must not inflate the next step's rate.
+
+        If f006's rain_con is absent (file failed) but its geometry succeeded,
+        the step still advances prev_valid_utc. Differencing f007 against f005's
+        value over a single-step window would divide a 2h accumulation delta by
+        1h and inflate the rate. The predecessor must instead be invalidated to
+        None so f007 yields None (missing-data-safe), never a fabricated rate.
+        """
+        diags = self._run(
+            monkeypatch,
+            accum_by_fhour={5: 1.0, 6: None, 7: 4.5},  # f006 rain_con file failed
+            forecast_hours=[6, 7],
+        )
+        # f006 has no rain_con this step → rate unknown, not fabricated.
+        assert diags[6] is not None
+        assert diags[6].convective_precip_mm_h is None
+        # f007's predecessor was invalidated by the f006 miss → None,
+        # NOT the inflated (4.5 − 1.0) / 1h = 3.5.
+        assert diags[7].convective_precip_mm_h is None
 
 
 # --- Cache model parameter tests ---

--- a/tests/test_grib_precache.py
+++ b/tests/test_grib_precache.py
@@ -104,6 +104,7 @@ class TestPrecacheIconEuRun:
             put_cached,
         )
         from weatherbrief.fetch.grib.icon_eu_fetch import (
+            ICON_EU_CLOUD_DIAG_CACHE_KEY,
             ICON_EU_VARIABLES,
         )
 
@@ -120,7 +121,7 @@ class TestPrecacheIconEuRun:
                     cache_key(fhour, f"ICON_EU_{var.upper()}"),
                     b"x",  # marker bytes; not parsed
                 )
-            put_cached(run_dir, cache_key(fhour, "ICON_EU_CLOUD_DIAG"), b"x")
+            put_cached(run_dir, cache_key(fhour, ICON_EU_CLOUD_DIAG_CACHE_KEY), b"x")
 
         with patch(
             "weatherbrief.fetch.grib.icon_eu_fetch.fetch_icon_eu_per_variable"

--- a/tests/test_icon_prefetch.py
+++ b/tests/test_icon_prefetch.py
@@ -20,7 +20,10 @@ import weatherbrief.fetch.grib as grib_mod
 import weatherbrief.fetch.grib.icon_eu_fetch as icon_fetch_mod
 from weatherbrief.fetch.grib import _IconEuContext, _prefetch_icon_eu_data_inner
 from weatherbrief.fetch.grib.cache import cache_key, get_cached, put_cached
-from weatherbrief.fetch.grib.icon_eu_fetch import ICON_EU_VARIABLES
+from weatherbrief.fetch.grib.icon_eu_fetch import (
+    ICON_EU_CLOUD_DIAG_CACHE_KEY,
+    ICON_EU_VARIABLES,
+)
 
 
 def _make_ctx(tmp_path: Path, forecast_hours: list[int]) -> _IconEuContext:
@@ -96,18 +99,24 @@ def test_all_uncached_units_fetched_and_cached(tmp_path, tracker):
         (fh, var, tracker["var_calls"][0][2])
         for fh in (6, 9) for var in ICON_EU_VARIABLES
     )
-    assert sorted(fh for fh, _ in tracker["diag_calls"]) == [6, 9]
+    # Cloud-diag fetch also pulls the leading step (fhour 5 = min(6,9) − 1) so
+    # the first window hour can de-accumulate rain_con against it (#421).
+    assert sorted(fh for fh, _ in tracker["diag_calls"]) == [5, 6, 9]
     for fh in (6, 9):
         for var in ICON_EU_VARIABLES:
             ck = cache_key(fh, f"ICON_EU_{var.upper()}")
             assert get_cached(tmp_path, ck) == f"{fh}-{var}".encode()
-        assert get_cached(tmp_path, cache_key(fh, "ICON_EU_CLOUD_DIAG")) == f"diag-{fh}".encode()
+    for fh in (5, 6, 9):
+        assert (
+            get_cached(tmp_path, cache_key(fh, ICON_EU_CLOUD_DIAG_CACHE_KEY))
+            == f"diag-{fh}".encode()
+        )
 
 
 def test_cached_units_skipped(tmp_path, tracker):
     # fhour 6 fully covered by the legacy combined key; one var of fhour 9 cached.
     put_cached(tmp_path, cache_key(6, "ICON_EU_QC_QI_P"), b"legacy")
-    put_cached(tmp_path, cache_key(6, "ICON_EU_CLOUD_DIAG"), b"diag")
+    put_cached(tmp_path, cache_key(6, ICON_EU_CLOUD_DIAG_CACHE_KEY), b"diag")
     put_cached(tmp_path, cache_key(9, "ICON_EU_QC"), b"have-qc")
 
     ctx = _make_ctx(tmp_path, forecast_hours=[6, 9])
@@ -117,16 +126,18 @@ def test_cached_units_skipped(tmp_path, tracker):
     assert all(fh == 9 for fh, _ in fetched)
     assert (9, "qc") not in fetched
     assert {var for _, var in fetched} == set(ICON_EU_VARIABLES) - {"qc"}
-    assert [fh for fh, _ in tracker["diag_calls"]] == [9]
+    # fhour 6 diag already cached; the uncached diag steps are the leading
+    # step (5) and fhour 9 (#421).
+    assert sorted(fh for fh, _ in tracker["diag_calls"]) == [5, 9]
     # The pre-existing cache entry was not overwritten
     assert get_cached(tmp_path, cache_key(9, "ICON_EU_QC")) == b"have-qc"
 
 
 def test_units_run_concurrently(tmp_path, tracker, monkeypatch):
     monkeypatch.delenv("GRIB_ICON_PREFETCH_WORKERS", raising=False)
-    # 10 units (9 vars + diag) on a 4-worker outer pool, each sleeping 100ms:
-    # expected peak is 4. Assert only >= 2 (any overlap at all) so a starved
-    # CI host that staggers thread starts can't flake the test.
+    # 11 units (9 vars + diag f6 + leading diag f5) on a 4-worker outer pool,
+    # each sleeping 100ms: expected peak is 4. Assert only >= 2 (any overlap at
+    # all) so a starved CI host that staggers thread starts can't flake it.
     tracker["delay"] = 0.1
     ctx = _make_ctx(tmp_path, forecast_hours=[6])
     _prefetch_icon_eu_data_inner(ctx)


### PR DESCRIPTION
## What & why

The NWP convective track grades on the model's own convective scheme, and two of its safeguards — the **firing gate** (`_apply_firing_gate`) and **native corroboration** — need a *realization* signal, `convective_precip_mm_h`. ICON-EU exposed neither convective cloud cover nor convective precip, so the gate (deliberately missing-data-safe — it holds down only on *positive* dry evidence) could never fire for ICON. Every ICON MODERATE+ tower kept its full tower-top tier forever: a deep-but-dry `htop_con` read at full native risk with nothing able to contradict it, while GFS and ECMWF both got held down.

This closes that calibration gap by decoding DWD's `RAIN_CON`.

- **Fetch** `rain_con` on the single-level cloud-diag path. Introduce a shared `ICON_EU_CLOUD_DIAG_CACHE_KEY` (bumped to `..._V2`) referenced by all four cache-key call sites (prefetch, enrichment, precache, standalone verification) so adding a variable to the one-key-for-all-variables blob forces warm caches to re-fetch instead of silently keeping the gate-less behaviour.
- **Predecessor step.** ICON is fetched on-demand exactly on the window hours with no ±margin (unlike the locally-mirrored ECMWF run), so the first window hour has nothing to difference against. Added `icon_eu_previous_step` (respects the 1h≤78h / 3h grid, `None` at 0) and prepend one leading single-level step to the cloud-diag fetch only — the model-level sounding list is untouched.
- **De-accumulate & inject.** The ICON cloud-diag merge loop now walks steps in sorted order carrying the previous accumulated value + valid time and injects the mm/h rate via `model_copy`, a direct port of the ECMWF `cp` path. Crucial unit difference: `rain_con` is kg/m² ≡ mm (**already mm — no ×1000**, unlike ECMWF `cp` which is m water equivalent). Rate clamped at 0; `None` (not `0.0`) when no predecessor exists (`None` = missing-data-safe, `0.0` would actively hold a tower down). Extracted `icon_eu_conv_rain_rate_mm_h` as a pure, directly-tested helper.
- **No analysis change.** The field rides the existing forward-fill + spatial-interpolation paths, so the firing gate and native corroboration start evaluating ICON the moment it's populated. This is a behaviour change: some ICON MODERATE+ towers will now drop one level. `SNOW_CON` deferred (safe by construction — the positive-dry-evidence gate simply keeps the tier for a rare convective-snow tower).

Docs updated (`convective-analysis`, `weather-engine-specs`, `meteorology-decisions`): "Known gap (ICON-EU)" removed, per-model tables now show ICON convective precip, and the deferral code comment removed.

## Issue linkage

Closes #421

## Testing / verification

- **Unit** (`tests/test_grib.py`): `_ICON_CLOUD_DIAG_FIELD_MAP` maps `rain_con`; `ICON_EU_CLOUD_DIAG_VARIABLES` includes it; cache key is `..._V2`; `build_icon_cloud_diagnostics` stays unaware of the rate (leaves `convective_precip_mm_h` None); `icon_eu_previous_step` across the 1h/3h grid and `None` at 0; de-accumulation arithmetic — **no ×1000**, 3h window divides by 3, negative clamps to 0, and missing inputs return `None` not `0.0`.
- **Integration** (`tests/test_grib.py`): drives `_enrich_icon_eu_cloud_diagnostics` end-to-end with a mocked decode — the leading step seeds state, the first window hour gets a real mm/h rate, subsequent steps difference against their predecessor, and a run-reset accumulation clamps to 0.
- **Prefetch/precache** (`tests/test_icon_prefetch.py`, `tests/test_grib_precache.py`): updated for the V2 key and the leading-step diag fetch.
- Affected suites green locally: `test_grib`, `test_icon_prefetch`, `test_grib_precache`, `test_convective`, `test_grib_fill`, `test_spatial_interpolation`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AjaCg8x3iE1Gbokj1CxKhJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01AjaCg8x3iE1Gbokj1CxKhJ)_