### PR TITLE
fix(grib): GRIB decode correctness batch — ICON clamp, CIN sign, wind/gust, GFS avg, CLC per-hour (#441)

### DIFF
--- a/src/weatherbrief/fetch/grib/__init__.py
+++ b/src/weatherbrief/fetch/grib/__init__.py
@@ -3016,11 +3016,12 @@ def _decode_and_merge_icon_eu(
 
     icon_sections = [cs for cs in cross_sections if cs.model == ModelSource.ICON]
 
-    # Collect CLC-derived cloud layers across forecast hours.
-    # Use the last non-empty result per point (layers are time-invariant for
-    # a given ICON run, so any forecast hour's CLC works).
+    # CLC-derived cloud layers are a time-VARYING forecast field, so keep each
+    # forecast hour's own geometry (keyed by fhour) instead of collapsing to a
+    # single per-point set. Each valid time is enriched with its own layers
+    # below — reusing one hour's clouds for every hour was stale. (#441 #4)
     n_points = len(ctx.point_lats)
-    clc_layers_per_point: list[dict[str, float]] = [{} for _ in range(n_points)]
+    clc_layers_by_fhour: dict[int, list[dict[str, float]]] = {}
 
     # Build per-fhour decode jobs up-front. A given fhour either has the
     # legacy combined cache (one ``decode_icon_legacy`` job) or per-variable
@@ -3086,10 +3087,9 @@ def _decode_and_merge_icon_eu(
         if not decoded_points:
             continue
 
-        # Keep CLC-derived layers (first non-empty wins per point)
-        for i, layers in enumerate(clc_layers):
-            if layers and not clc_layers_per_point[i]:
-                clc_layers_per_point[i] = layers
+        # Keep THIS forecast hour's own CLC-derived layers (per valid time).
+        if any(clc_layers):
+            clc_layers_by_fhour[fhour] = clc_layers
 
         valid_utc = _forecast_hour_to_utc(ctx.init_date, ctx.init_hour, fhour)
         replaced = _replace_pressure_levels_from_grib(
@@ -3098,11 +3098,9 @@ def _decode_and_merge_icon_eu(
         )
         total_enriched += replaced
         del decoded_points
-        # Replace the tuple to release both the decoded_points reference
-        # (already del'd locally) and the clc_layers reference (already
-        # accumulated into clc_layers_per_point above). The local
-        # ``clc_layers`` stays alive for the rest of this iteration; no
-        # further reader needs the dict entry.
+        # Release the decoded_points reference (already del'd locally). The
+        # clc_layers list is now owned by ``clc_layers_by_fhour`` (small: a few
+        # float bases/tops per point), so it stays alive until enrichment.
         decoded_by_fhour[fhour] = None
     _grib_gc()
     _grib_rss_mark("icon_fhour_post_gc")
@@ -3122,7 +3120,7 @@ def _decode_and_merge_icon_eu(
         icon_sections, all_forecasts, route_points,
         ctx.init_date, ctx.init_hour, ctx.forecast_hours,
         ctx.run_dir, ctx.point_lats, ctx.point_lons, ctx.session,
-        clc_layers_per_point=clc_layers_per_point,
+        clc_layers_by_fhour=clc_layers_by_fhour,
     )
 
     return _run_info_to_timestamp(ctx.init_date, ctx.init_hour), None
@@ -3140,13 +3138,14 @@ def _enrich_icon_eu_cloud_diagnostics(
     point_lons: list[float],
     session: requests.Session,
     *,
-    clc_layers_per_point: list[dict[str, float]] | None = None,
+    clc_layers_by_fhour: dict[int, list[dict[str, float]]] | None = None,
 ) -> None:
     """Enrich ICON forecasts with single-level cloud diagnostics (ceiling, etc.).
 
-    If *clc_layers_per_point* is provided (CLC-derived cloud layer boundaries
-    from model-level data), missing ``base_ft``/``top_ft`` on low/mid/high
-    NWPCloudLayerDiag are filled from it.
+    If *clc_layers_by_fhour* is provided (CLC-derived cloud layer boundaries
+    from model-level data, keyed by forecast hour), missing ``base_ft``/
+    ``top_ft`` on low/mid/high NWPCloudLayerDiag are filled from THAT forecast
+    hour's geometry — clouds evolve over time, so each valid time uses its own.
     """
     from weatherbrief.fetch.grib.decode import build_icon_cloud_diagnostics
     from weatherbrief.fetch.grib.icon_eu_fetch import (
@@ -3243,12 +3242,13 @@ def _enrich_icon_eu_cloud_diagnostics(
             prev_rain_con_per_point[i] = raw.get("conv_rain_kg_m2")
         prev_valid_utc = valid_utc
 
-        # Fill missing layer base/top from CLC-derived boundaries
-        if clc_layers_per_point:
+        # Fill missing layer base/top from THIS forecast hour's CLC geometry.
+        clc_for_hour = clc_layers_by_fhour.get(fhour) if clc_layers_by_fhour else None
+        if clc_for_hour:
             for pt_idx, diag in enumerate(diagnostics_per_point):
-                if diag is None or pt_idx >= len(clc_layers_per_point):
+                if diag is None or pt_idx >= len(clc_for_hour):
                     continue
-                clc = clc_layers_per_point[pt_idx]
+                clc = clc_for_hour[pt_idx]
                 if not clc:
                     continue
                 for band in ("low", "mid", "high"):

--- a/src/weatherbrief/fetch/grib/decode.py
+++ b/src/weatherbrief/fetch/grib/decode.py
@@ -1276,6 +1276,43 @@ def _opt_float(raw: dict[str, float], key: str) -> float | None:
     return float(val) if val is not None else None
 
 
+def _normalize_model_cin(
+    raw: dict[str, float],
+    key: str,
+    *,
+    drop_at_or_below: float | None = None,
+    drop_at_or_above: float | None = None,
+) -> float | None:
+    """Normalize a model CIN magnitude to the app's internal signed convention.
+
+    Both ECMWF ``mlcin100`` and DWD ICON ``CIN_ML`` report convective
+    inhibition as a NON-NEGATIVE magnitude in J/kg (larger = stronger cap;
+    verified against cached GRIB — ECMWF values ≥ 0, ICON up to +1585 J/kg).
+    The rest of the app — MetPy sounding CIN and the convective suppression
+    gate (``eff_cin < -200``) — uses the opposite sign: CIN is NEGATIVE, more
+    negative = stronger cap. Passing the raw positive magnitude straight
+    through meant genuine strong model caps never suppressed. (#441 finding #2)
+
+    Normalization:
+    - Provider "undefined" sentinels are dropped to None: ECMWF ``9999``
+      (``drop_at_or_above=9998``; usually already masked to NaN by cfgrib, this
+      is a defensive net) and ICON ``-999.9`` (``drop_at_or_below=-900``).
+    - Any residual negative (ICON packed-zero ≈ -0.025, or an interpolation
+      artifact where a sentinel bled into a neighbour) is floored to 0 — no
+      cap — rather than read as an implausibly strong one.
+    - The remaining non-negative magnitude is negated to the internal
+      convention: ``+1585 → -1585``.
+    """
+    val = raw.get(key)
+    if val is None:
+        return None
+    if drop_at_or_below is not None and val <= drop_at_or_below:
+        return None
+    if drop_at_or_above is not None and val >= drop_at_or_above:
+        return None
+    return -max(0.0, float(val))
+
+
 def _k_index_to_c(raw: dict[str, float], key: str) -> float | None:
     """K-index normalized to °C.
 
@@ -1337,7 +1374,9 @@ def build_icon_cloud_diagnostics(
     high_cover = _pct("high_cover_pct")
     total_cover = _pct("total_cover_pct")
     ml_cape = _opt_float(raw, "ml_cape_jkg")  # instantaneous (#283)
-    ml_cin = _opt_float(raw, "ml_cin_jkg")    # instantaneous (#283)
+    # ICON CIN_ML is a positive magnitude with -999.9 as the undefined
+    # sentinel → convert to internal negative convention. (#441 finding #2)
+    ml_cin = _normalize_model_cin(raw, "ml_cin_jkg", drop_at_or_below=-900.0)
 
     # Only create diagnostics if at least one field is populated
     has_any = (
@@ -1720,7 +1759,9 @@ def build_ecmwf_cloud_diagnostics(
     k_index = _k_index_to_c(raw, "k_index_c")
     total_totals = _opt_float(raw, "total_totals_c")
     ml_cape = _opt_float(raw, "ml_cape_jkg")
-    ml_cin = _opt_float(raw, "ml_cin_jkg")
+    # ECMWF mlcin100 is a positive magnitude with 9999 as the missing
+    # sentinel (usually already NaN-masked by cfgrib) → internal negative. (#441)
+    ml_cin = _normalize_model_cin(raw, "ml_cin_jkg", drop_at_or_above=9998.0)
 
     has_any = (
         ceiling_ft is not None

--- a/src/weatherbrief/fetch/grib/decode.py
+++ b/src/weatherbrief/fetch/grib/decode.py
@@ -218,7 +218,10 @@ def decode_grib_to_points(
         tmp_path = Path(tmp.name)
 
     try:
-        datasets = cfgrib.open_datasets(str(tmp_path))
+        # indexpath="" disables cfgrib's on-disk .idx sidecar. These are
+        # one-shot temp files: only the .grib2 gets unlinked, so a written
+        # .idx would be orphaned (604 found in the wild). (#441 efficiency)
+        datasets = cfgrib.open_datasets(str(tmp_path), backend_kwargs={"indexpath": ""})
 
         result: dict[int, dict[str, float]] = {}
 
@@ -567,7 +570,10 @@ def decode_grib_per_point(
         tmp_path = Path(tmp.name)
 
     try:
-        datasets = cfgrib.open_datasets(str(tmp_path))
+        # indexpath="" disables cfgrib's on-disk .idx sidecar. These are
+        # one-shot temp files: only the .grib2 gets unlinked, so a written
+        # .idx would be orphaned (604 found in the wild). (#441 efficiency)
+        datasets = cfgrib.open_datasets(str(tmp_path), backend_kwargs={"indexpath": ""})
 
         # Normalize longitudes to 0–360 (GFS convention)
         target_lons = [(lon % 360) for lon in longitudes]
@@ -652,7 +658,10 @@ def decode_cloud_diag_per_point(
         tmp_path = Path(tmp.name)
 
     try:
-        datasets = cfgrib.open_datasets(str(tmp_path))
+        # indexpath="" disables cfgrib's on-disk .idx sidecar. These are
+        # one-shot temp files: only the .grib2 gets unlinked, so a written
+        # .idx would be orphaned (604 found in the wild). (#441 efficiency)
+        datasets = cfgrib.open_datasets(str(tmp_path), backend_kwargs={"indexpath": ""})
         target_lons = [(lon % 360) for lon in longitudes]
         results: list[dict[str, float]] = [{} for _ in range(n_points)]
 
@@ -708,7 +717,10 @@ def _decode_icon_eu_single_var(
         tmp_path = Path(tmp.name)
 
     try:
-        datasets = cfgrib.open_datasets(str(tmp_path))
+        # indexpath="" disables cfgrib's on-disk .idx sidecar. These are
+        # one-shot temp files: only the .grib2 gets unlinked, so a written
+        # .idx would be orphaned (604 found in the wild). (#441 efficiency)
+        datasets = cfgrib.open_datasets(str(tmp_path), backend_kwargs={"indexpath": ""})
         # ICON-EU uses -180 to +180 longitude convention
         target_lons = list(longitudes)
         level_values: dict[int, list[float | None]] = {}
@@ -894,8 +906,11 @@ def decode_icon_eu_per_point_chunked(
 
     n_points = len(latitudes)
 
-    # Step 1: Decode P (pressure) variable — needed for vertical interpolation
-    p_bytes = var_bytes.get("p", b"")
+    # Step 1: Decode P (pressure) variable — needed for vertical interpolation.
+    # pop() (not get()) so the dict releases the compressed bytes as each
+    # variable is consumed — otherwise the whole ~260 MB/hour input set stays
+    # resident and the later `del` frees nothing. (#441 efficiency)
+    p_bytes = var_bytes.pop("p", b"")
     pressure_data = _decode_icon_eu_single_var(p_bytes, latitudes, longitudes)
     del p_bytes
     gc.collect()
@@ -923,7 +938,7 @@ def decode_icon_eu_per_point_chunked(
         ("v", "raw_v_wind_m_s"),
         ("w", "raw_w_m_s"),
     ):
-        raw = var_bytes.get(var_name, b"")
+        raw = var_bytes.pop(var_name, b"")  # release bytes as consumed (#441)
         if not raw:
             continue
         field_data = _decode_icon_eu_single_var(raw, latitudes, longitudes)
@@ -1012,7 +1027,10 @@ def decode_icon_eu_per_point(
         tmp_path = Path(tmp.name)
 
     try:
-        datasets = cfgrib.open_datasets(str(tmp_path))
+        # indexpath="" disables cfgrib's on-disk .idx sidecar. These are
+        # one-shot temp files: only the .grib2 gets unlinked, so a written
+        # .idx would be orphaned (604 found in the wild). (#441 efficiency)
+        datasets = cfgrib.open_datasets(str(tmp_path), backend_kwargs={"indexpath": ""})
 
         # ICON-EU uses -180 to +180 longitude convention (no normalization needed)
         target_lons = list(longitudes)
@@ -1237,7 +1255,10 @@ def decode_icon_eu_cloud_diag_per_point(
         tmp_path = Path(tmp.name)
 
     try:
-        datasets = cfgrib.open_datasets(str(tmp_path))
+        # indexpath="" disables cfgrib's on-disk .idx sidecar. These are
+        # one-shot temp files: only the .grib2 gets unlinked, so a written
+        # .idx would be orphaned (604 found in the wild). (#441 efficiency)
+        datasets = cfgrib.open_datasets(str(tmp_path), backend_kwargs={"indexpath": ""})
         # ICON-EU uses -180 to +180 (same as route points)
         target_lons = list(longitudes)
         results: list[dict[str, float]] = [{} for _ in range(n_points)]

--- a/src/weatherbrief/fetch/grib/decode.py
+++ b/src/weatherbrief/fetch/grib/decode.py
@@ -881,6 +881,7 @@ def decode_icon_eu_per_point_chunked(
 
     from weatherbrief.fetch.grib.icon_eu_levels import (
         TARGET_PRESSURE_LEVELS_HPA,
+        bounds_for_field,
         interpolate_model_to_pressure_levels,
     )
 
@@ -950,6 +951,7 @@ def decode_icon_eu_per_point_chunked(
 
             interp_result = interpolate_model_to_pressure_levels(
                 model_pressures, model_values, target_pressures_hpa,
+                bounds=bounds_for_field(field_key),
             )
             for p_hpa, val in interp_result.items():
                 results[pt_idx].setdefault(p_hpa, {})[field_key] = val
@@ -990,6 +992,7 @@ def decode_icon_eu_per_point(
 
     from weatherbrief.fetch.grib.icon_eu_levels import (
         TARGET_PRESSURE_LEVELS_HPA,
+        bounds_for_field,
         interpolate_model_to_pressure_levels,
     )
 
@@ -1112,6 +1115,7 @@ def decode_icon_eu_per_point(
 
                 interp_result = interpolate_model_to_pressure_levels(
                     model_pressures, model_values, target_pressures_hpa,
+                    bounds=bounds_for_field(field_key),
                 )
                 for p_hpa, val in interp_result.items():
                     results[pt_idx].setdefault(p_hpa, {})[field_key] = val

--- a/src/weatherbrief/fetch/grib/decode.py
+++ b/src/weatherbrief/fetch/grib/decode.py
@@ -147,11 +147,15 @@ _ICON_CLOUD_DIAG_FIELD_MAP: dict[str, str] = {
 # cares about, so adding entries here is non-invasive.
 # cfgrib shortName → internal raw field name.
 _ECMWF_CLOUD_DIAG_FIELD_MAP: dict[str, str] = {
-    # Cloud diagnostics (used by build_ecmwf_cloud_diagnostics)
-    "ceil": "ceiling_m",                   # meters, 9999 = no cloud sentinel
-    "cbh": "cloud_base_height_m",          # meters, 9999 = no cloud sentinel
-    "hcct": "convective_cloud_top_m",      # meters, 9999 = no cloud sentinel
-    "deg0l": "freezing_level_m",           # meters (geopotential height above MSL)
+    # Cloud diagnostics (used by build_ecmwf_cloud_diagnostics).
+    # DATUM: ECMWF ceil/cbh/hcct/deg0l are all metres ABOVE GROUND (AGL),
+    # confirmed against eccodes names + the ECMWF Parameter DB — NOT MSL. See
+    # issue #441 finding #3 (datum normalization for airport-vs-en-route use is
+    # a separate follow-up; these are AGL as delivered).
+    "ceil": "ceiling_m",                   # meters AGL, 9999 = no cloud sentinel
+    "cbh": "cloud_base_height_m",          # meters AGL, 9999 = no cloud sentinel
+    "hcct": "convective_cloud_top_m",      # meters AGL, 9999 = no cloud sentinel
+    "deg0l": "freezing_level_m",           # meters AGL (geometric height above ground, not MSL)
     # Native convective realization + stability (#283 Phase 2, delivered in a1).
     "cp": "conv_precip_m",                 # m water equiv, ACCUMULATED since init
     "kx": "k_index_c",                     # °C (K-index)

--- a/src/weatherbrief/fetch/grib/fill.py
+++ b/src/weatherbrief/fetch/grib/fill.py
@@ -41,6 +41,7 @@ Interpolation rules (see also spatial_interpolation.py for the spatial axis):
 from __future__ import annotations
 
 import logging
+import math
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING
 
@@ -715,6 +716,49 @@ def _lerp_circ(a: float | None, b: float | None, frac: float) -> float | None:
     return (a + diff * frac) % 360
 
 
+def _wind_uv(speed_kt: float, direction_deg: float) -> tuple[float, float]:
+    """Meteorological (speed, from-direction) → (u, v) components.
+
+    Direction is where the wind comes FROM, so the vector points the opposite
+    way: u = -speed·sin(dir), v = -speed·cos(dir).
+    """
+    rad = math.radians(direction_deg)
+    return -speed_kt * math.sin(rad), -speed_kt * math.cos(rad)
+
+
+def _lerp_wind(
+    speed_a: float | None,
+    dir_a: float | None,
+    speed_b: float | None,
+    dir_b: float | None,
+    frac: float,
+) -> tuple[float | None, float | None]:
+    """Vector-correct temporal interpolation of a wind → (speed_kt, dir_deg).
+
+    Interpolating scalar speed and circular direction independently is wrong:
+    10 kt @ 090° → 10 kt @ 270° would hold 10 kt through an intermediate
+    bearing instead of passing through near-calm. Reconstruct U/V, interpolate
+    the components, then derive speed and direction. (#441 finding #7)
+
+    When an endpoint lacks a direction (calm), fall back to scalar speed interp
+    and keep whichever direction is defined. When the interpolated vector is
+    near-calm, direction is ill-defined so copy the nearer anchor's direction.
+    """
+    if speed_a is None or speed_b is None:
+        return None, None
+    if dir_a is None or dir_b is None:
+        spd = speed_a + (speed_b - speed_a) * frac
+        return spd, (dir_a if dir_a is not None else dir_b)
+    ua, va = _wind_uv(speed_a, dir_a)
+    ub, vb = _wind_uv(speed_b, dir_b)
+    u = ua + (ub - ua) * frac
+    v = va + (vb - va) * frac
+    spd = math.hypot(u, v)
+    if spd < _CALM_WIND_KT:
+        return spd, (dir_a if frac < 0.5 else dir_b)
+    return spd, math.degrees(math.atan2(-u, -v)) % 360.0
+
+
 # ---------------------------------------------------------------------------
 # ECMWF surface scalars (HourlyForecast surface fields) — linear interp
 # ---------------------------------------------------------------------------
@@ -722,10 +766,11 @@ def _lerp_circ(a: float | None, b: float | None, frac: float) -> float | None:
 # Instantaneous fields written by ``_apply_ecmwf_surface_to_hourly``.
 # Precip/snow are *window-rate* — distributed at apply time across every hour
 # in the differencing window, so they don't need temporal interpolation.
+# Wind speed/direction are interpolated together as U/V components by
+# ``_lerp_wind`` (not scalar-interpolated), so they are NOT listed here. (#441)
 _ECMWF_SURFACE_INSTANT_FIELDS: tuple[str, ...] = (
     "temperature_2m_c",
     "dewpoint_2m_c",
-    "wind_speed_10m_kt",
     "wind_gusts_10m_kt",
     "visibility_m",
     "cape_jkg",
@@ -819,17 +864,16 @@ def _interp_surface_hourly(hourly_list: list[HourlyForecast]) -> int:
                 v = _lerp(getattr(prev_h, f), getattr(next_h, f), frac)
                 if v is not None:
                     setattr(h, f, v)
-            # Wind direction: circular interp, gated by interpolated speed
-            wd = _lerp_circ(prev_h.wind_direction_10m_deg, next_h.wind_direction_10m_deg, frac)
-            ws = h.wind_speed_10m_kt
+            # Wind: interpolate as U/V components, then derive speed + direction.
+            ws, wd = _lerp_wind(
+                prev_h.wind_speed_10m_kt, prev_h.wind_direction_10m_deg,
+                next_h.wind_speed_10m_kt, next_h.wind_direction_10m_deg,
+                frac,
+            )
+            if ws is not None:
+                h.wind_speed_10m_kt = ws
             if wd is not None:
-                if ws is not None and ws < _CALM_WIND_KT:
-                    # Calm: pick the closer anchor's direction (avoids a
-                    # spurious mid-arc direction when both endpoints are calm).
-                    nearer = prev_h if frac < 0.5 else next_h
-                    h.wind_direction_10m_deg = nearer.wind_direction_10m_deg
-                else:
-                    h.wind_direction_10m_deg = wd
+                h.wind_direction_10m_deg = wd
             filled += 1
     return filled
 
@@ -949,8 +993,12 @@ def _interp_levels_at(
         else:
             td_c = _lerp(prev.dewpoint_c, nxt.dewpoint_c, frac)
 
-        ws = _lerp(prev.wind_speed_kt, nxt.wind_speed_kt, frac)
-        wd = _lerp_circ(prev.wind_direction_deg, nxt.wind_direction_deg, frac)
+        # Wind: U/V-component interpolation (see _lerp_wind), not scalar. (#441)
+        ws, wd = _lerp_wind(
+            prev.wind_speed_kt, prev.wind_direction_deg,
+            nxt.wind_speed_kt, nxt.wind_direction_deg,
+            frac,
+        )
 
         out.append(PressureLevelData(
             pressure_hpa=prev.pressure_hpa,

--- a/src/weatherbrief/fetch/grib/fill.py
+++ b/src/weatherbrief/fetch/grib/fill.py
@@ -285,10 +285,10 @@ def _interp_diag_at(
 ) -> NWPCloudDiagnostics:
     """Build an interpolated NWPCloudDiagnostics for one gap hour.
 
-    ``mid_frac`` is the interpolation fraction in window-midpoint space —
-    used for low/mid/high cover_pct (the averaged-window fields).
-    ``step_frac`` is the fraction in step-time space — used for
-    instantaneous fields (convective, boundary, total, ceiling, etc.).
+    ``mid_frac`` is the interpolation fraction in window-midpoint space — used
+    for the AVERAGED-window fields (low/mid/high cover and boundary-layer
+    cover). ``step_frac`` is the fraction in step-time space — used for the
+    instantaneous fields (convective, total, ceiling, etc.). (#441 finding #5)
     """
     from weatherbrief.models import NWPCloudDiagnostics
 
@@ -312,8 +312,9 @@ def _interp_diag_at(
         total_cover_pct=_lerp(
             prev_diag.total_cover_pct, next_diag.total_cover_pct, step_frac,
         ),
+        # Boundary-layer cover is published averaged-only → midpoint align.
         boundary_cover_pct=_lerp(
-            prev_diag.boundary_cover_pct, next_diag.boundary_cover_pct, step_frac,
+            prev_diag.boundary_cover_pct, next_diag.boundary_cover_pct, mid_frac,
         ),
         ceiling_ft=_lerp(prev_diag.ceiling_ft, next_diag.ceiling_ft, step_frac),
         freezing_level_ft=_lerp(

--- a/src/weatherbrief/fetch/grib/fill.py
+++ b/src/weatherbrief/fetch/grib/fill.py
@@ -766,12 +766,13 @@ def _lerp_wind(
 # Instantaneous fields written by ``_apply_ecmwf_surface_to_hourly``.
 # Precip/snow are *window-rate* — distributed at apply time across every hour
 # in the differencing window, so they don't need temporal interpolation.
-# Wind speed/direction are interpolated together as U/V components by
-# ``_lerp_wind`` (not scalar-interpolated), so they are NOT listed here. (#441)
+# Genuinely instantaneous surface scalars — linearly interpolable across gaps.
+# NOT listed here (handled specially in _interp_surface_hourly):
+#  - wind speed/direction → U/V-component interp (_lerp_wind)  (#441 #7)
+#  - wind gust → window MAXIMUM, held over the covering interval (#441 #6)
 _ECMWF_SURFACE_INSTANT_FIELDS: tuple[str, ...] = (
     "temperature_2m_c",
     "dewpoint_2m_c",
-    "wind_gusts_10m_kt",
     "visibility_m",
     "cape_jkg",
     "surface_pressure_hpa",
@@ -808,9 +809,9 @@ def _linear_interp_ecmwf_surface(
     the two writes coupled, or replace this detector with an explicit
     anchor list passed from the caller.
 
-    Wind direction uses circular linear interpolation (shortest arc); when the
-    interpolated speed is below ``_CALM_WIND_KT``, direction is copied from
-    the nearest anchor since the interpolated direction would be meaningless.
+    Wind speed/direction are interpolated as U/V components (``_lerp_wind``),
+    not as scalars. Gust is a window maximum and is held over the covering
+    interval rather than linearly interpolated. See findings #6/#7.
     """
     total = 0
     for cs in sections:
@@ -874,6 +875,12 @@ def _interp_surface_hourly(hourly_list: list[HourlyForecast]) -> int:
                 h.wind_speed_10m_kt = ws
             if wd is not None:
                 h.wind_direction_10m_deg = wd
+            # Gust (10fg) is a window MAXIMUM ("max gust since previous
+            # post-processing"), not an instantaneous value — a max is not
+            # linearly interpolable. Hold the reported max of the covering
+            # interval: the next anchor's window contains this gap hour. (#441 #6)
+            if next_h.wind_gusts_10m_kt is not None:
+                h.wind_gusts_10m_kt = next_h.wind_gusts_10m_kt
             filled += 1
     return filled
 

--- a/src/weatherbrief/fetch/grib/gfs_idx.py
+++ b/src/weatherbrief/fetch/grib/gfs_idx.py
@@ -156,13 +156,29 @@ def parse_idx(text: str) -> list[IdxEntry]:
     return entries
 
 
+# Cover fields whose paired geometry (PRES cloud bottom/top, TMP cloud-top
+# temperature) NCEP publishes ONLY as a time-average. The cover MUST use the
+# averaged form too, so cover and geometry share the same statistical
+# processing and temporal (window-midpoint) alignment. Everything else
+# (TCDC entire-atmosphere total, TCDC convective) prefers the instantaneous
+# snapshot. Boundary-layer TCDC is averaged-only, so its preference is moot
+# here — but it is aligned as averaged downstream. (#441 finding #5)
+_PREFER_AVERAGED_PAIRS: set[tuple[str, str]] = {
+    ("LCDC", "low cloud layer"),
+    ("MCDC", "middle cloud layer"),
+    ("HCDC", "high cloud layer"),
+}
+
+
 def parse_cloud_diag_idx(text: str) -> list[CloudDiagIdxEntry]:
     """Parse a GFS .idx file for cloud diagnostic entries.
 
     Returns entries matching CLOUD_DIAG_VARIABLES at their accepted levels.
-    Prefers instantaneous ("N hour fcst") over averaged ("0-N hour ave fcst")
-    when both exist, by returning only instantaneous entries for variables
-    where an instantaneous version is available.
+    For each (variable, level) that has both an instantaneous ("N hour fcst")
+    and an averaged ("0-N hour ave fcst") form, selection is per-field:
+    low/mid/high cover (``_PREFER_AVERAGED_PAIRS``) keep the AVERAGED entry to
+    match their averaged-only geometry; all other fields keep the
+    instantaneous entry. (#441 finding #5)
     """
     all_entries: list[CloudDiagIdxEntry] = []
     for line in text.strip().splitlines():
@@ -189,18 +205,28 @@ def parse_cloud_diag_idx(text: str) -> list[CloudDiagIdxEntry]:
             logger.debug("Skipping malformed cloud diag .idx line: %s", line)
             continue
 
-    # Prefer instantaneous over averaged: for each (var, level_str) if we
-    # have an instant entry, drop the averaged one.
+    # Per-field selection between instantaneous and averaged forms.
+    avg_keys: set[tuple[str, str]] = set()
     instant_keys: set[tuple[str, str]] = set()
     for e in all_entries:
-        if "ave" not in e.forecast_step:
-            instant_keys.add((e.variable, e.level_str))
+        key = (e.variable, e.level_str)
+        if "ave" in e.forecast_step:
+            avg_keys.add(key)
+        else:
+            instant_keys.add(key)
 
     result: list[CloudDiagIdxEntry] = []
     for e in all_entries:
         key = (e.variable, e.level_str)
-        if "ave" in e.forecast_step and key in instant_keys:
-            continue  # Skip averaged when instant is available
+        is_avg = "ave" in e.forecast_step
+        if key in _PREFER_AVERAGED_PAIRS:
+            # Keep averaged; drop the instant form when an averaged one exists.
+            if not is_avg and key in avg_keys:
+                continue
+        else:
+            # Keep instantaneous; drop averaged when an instant one exists.
+            if is_avg and key in instant_keys:
+                continue
         result.append(e)
 
     return result

--- a/src/weatherbrief/fetch/grib/icon_eu_levels.py
+++ b/src/weatherbrief/fetch/grib/icon_eu_levels.py
@@ -22,11 +22,37 @@ logger = logging.getLogger(__name__)
 # ICON-EU's 40 model levels provide enough resolution to support this.
 TARGET_PRESSURE_LEVELS_HPA = EXTENDED_PRESSURE_LEVELS
 
+# Physical bounds per interpolated field, applied after interpolation.
+# A field absent from this map is SIGNED and must not be clamped.
+#
+# Temperature and the wind components U/V/W are signed: clamping a negative
+# U or V corrupts wind speed AND direction, and clamping negative (downward)
+# W destroys subsidence — which then zeroes the omega derived from it. Only
+# genuinely non-negative quantities (condensate mixing ratios, specific
+# humidity) and the bounded cloud-fraction percentage are clamped here.
+# See issue #441 finding #1.
+_FIELD_BOUNDS: dict[str, tuple[float | None, float | None]] = {
+    "cloud_liquid_water_kg_kg": (0.0, None),
+    "ice_mixing_ratio_kg_kg": (0.0, None),
+    "raw_specific_humidity_kg_kg": (0.0, None),
+    "cloud_area_fraction_pct": (0.0, 100.0),
+}
+
+
+def bounds_for_field(field_key: str) -> tuple[float | None, float | None] | None:
+    """Return (min, max) physical bounds for an interpolated ICON field.
+
+    Returns None for signed fields (temperature, wind components) that must
+    not be clamped.
+    """
+    return _FIELD_BOUNDS.get(field_key)
+
 
 def interpolate_model_to_pressure_levels(
     model_pressures_pa: list[float],
     model_values: list[float],
     target_pressures_hpa: list[int] | None = None,
+    bounds: tuple[float | None, float | None] | None = None,
 ) -> dict[int, float]:
     """Interpolate a variable from model levels to standard pressure levels.
 
@@ -39,6 +65,10 @@ def interpolate_model_to_pressure_levels(
         model_values: Variable values at each model level.
         target_pressures_hpa: Target pressure levels in hPa.
             Defaults to ICON_PRESSURE_LEVELS.
+        bounds: Optional ``(min, max)`` clamp applied to each interpolated
+            value; either side may be None to leave it unbounded. Defaults to
+            None (no clamping) so signed fields (T, U, V, W) pass through
+            unchanged. Use :func:`bounds_for_field` to pick per-field bounds.
 
     Returns:
         Dict mapping pressure_hpa to interpolated value. Levels outside
@@ -80,6 +110,8 @@ def interpolate_model_to_pressure_levels(
     p_min_pa = p_pa[0]
     p_max_pa = p_pa[-1]
 
+    lo, hi = (None, None) if bounds is None else bounds
+
     result: dict[int, float] = {}
     for target_hpa in target_pressures_hpa:
         target_pa = target_hpa * 100.0
@@ -88,7 +120,10 @@ def interpolate_model_to_pressure_levels(
             continue
         ln_target = np.log(target_pa)
         interp_val = float(np.interp(ln_target, ln_p, vals))
-        # Cloud water values should not be negative
-        result[target_hpa] = max(0.0, interp_val)
+        if lo is not None and interp_val < lo:
+            interp_val = lo
+        if hi is not None and interp_val > hi:
+            interp_val = hi
+        result[target_hpa] = interp_val
 
     return result

--- a/src/weatherbrief/models/analysis.py
+++ b/src/weatherbrief/models/analysis.py
@@ -161,7 +161,10 @@ class NWPCloudDiagnostics(BaseModel):
     k_index: Optional[float] = None                 # model-native K-index (°C)
     total_totals: Optional[float] = None            # model-native Total Totals (°C)
     ml_cape_jkg: Optional[float] = None             # mixed-layer CAPE (J/kg)
-    ml_cin_jkg: Optional[float] = None              # mixed-layer CIN (J/kg)
+    # Mixed-layer CIN (J/kg), NEGATIVE convention: more negative = stronger
+    # cap (matches MetPy sounding CIN and the `eff_cin < -200` gate). Provider
+    # magnitudes are normalized at decode by `_normalize_model_cin`. (#441)
+    ml_cin_jkg: Optional[float] = None
 
     total_cover_pct: Optional[float] = None
     boundary_cover_pct: Optional[float] = None

--- a/tests/test_grib.py
+++ b/tests/test_grib.py
@@ -398,13 +398,22 @@ def test_parse_cloud_diag_idx_returns_correct_entries():
     assert ("TMP", "2 m above ground") not in vars_found
 
 
-def test_parse_cloud_diag_idx_prefers_instant_over_avg():
-    """When both instant and averaged entries exist, only instant is kept."""
+def test_parse_cloud_diag_idx_low_mid_high_prefer_averaged():
+    """#441: low/mid/high cover keep the AVERAGED form (to match averaged
+    geometry); TCDC total/convective keep the instantaneous form."""
     entries = parse_cloud_diag_idx(CLOUD_DIAG_IDX)
-    # LCDC has both "6 hour fcst" and "0-6 hour ave fcst"
-    lcdc_entries = [e for e in entries if e.variable == "LCDC"]
-    assert len(lcdc_entries) == 1
-    assert "ave" not in lcdc_entries[0].forecast_step
+
+    # LCDC / MCDC both have instant + averaged → averaged is kept.
+    for var in ("LCDC", "MCDC"):
+        got = [e for e in entries if e.variable == var]
+        assert len(got) == 1, var
+        assert "ave" in got[0].forecast_step, var
+
+    # TCDC entire atmosphere (total) has only instant here → instant kept.
+    total = [e for e in entries
+             if e.variable == "TCDC" and e.level_str == "entire atmosphere"]
+    assert len(total) == 1
+    assert "ave" not in total[0].forecast_step
 
 
 def test_parse_cloud_diag_idx_keeps_avg_when_no_instant():
@@ -423,11 +432,12 @@ def test_plan_cloud_diag_byte_ranges():
     assert len(ranges) > 0
     assert all(isinstance(r, CloudDiagByteRange) for r in ranges)
 
-    # Check specific range: LCDC instant at offset 437912319
+    # #441: LCDC now selects the AVERAGED message at offset 438715784
+    # (matching its averaged geometry), not the instant one at 437912319.
     lcdc = [r for r in ranges if r.variable == "LCDC"][0]
-    assert lcdc.start == 437912319
-    # Next entry is LCDC ave at 438715784
-    assert lcdc.end == 438715784 - 1
+    assert lcdc.start == 438715784
+    # Next sequential idx offset is MCDC instant at 439598564.
+    assert lcdc.end == 439598564 - 1
 
     # HGT cloud ceiling
     hgt = [r for r in ranges if r.variable == "HGT" and r.level_str == "cloud ceiling"][0]

--- a/tests/test_grib.py
+++ b/tests/test_grib.py
@@ -1187,14 +1187,34 @@ class TestBuildIconCloudDiagnostics:
         assert diag.low.cover_pct is None
 
     def test_ml_cape_cin_surfaced(self):
-        """ICON mixed-layer CAPE/CIN (cape_ml/cin_ml) surfaced on the diag (#283)."""
+        """ICON mixed-layer CAPE/CIN (cape_ml/cin_ml) surfaced on the diag (#283).
+
+        #441: ICON CIN_ML is a POSITIVE magnitude (larger = stronger cap) and
+        is normalized to the app's internal negative convention.
+        """
         from weatherbrief.fetch.grib.decode import build_icon_cloud_diagnostics
 
-        raw = {"ml_cape_jkg": 850.0, "ml_cin_jkg": -120.0}
+        raw = {"ml_cape_jkg": 850.0, "ml_cin_jkg": 120.0}
         diag = build_icon_cloud_diagnostics(raw)
         assert diag is not None
         assert diag.ml_cape_jkg == 850.0
-        assert diag.ml_cin_jkg == -120.0
+        assert diag.ml_cin_jkg == -120.0  # positive magnitude → internal negative
+
+    def test_icon_cin_sentinel_and_sign(self):
+        """#441: ICON -999.9 sentinel → None; packed-zero → 0; magnitude → negative."""
+        from weatherbrief.fetch.grib.decode import build_icon_cloud_diagnostics
+
+        # A strong cap (+1585 J/kg) must become a strong internal negative cap.
+        diag = build_icon_cloud_diagnostics({"ml_cape_jkg": 10.0, "ml_cin_jkg": 1585.0})
+        assert diag.ml_cin_jkg == -1585.0
+
+        # The -999.9 "undefined" sentinel is dropped, NOT read as a huge cap.
+        diag = build_icon_cloud_diagnostics({"ml_cape_jkg": 10.0, "ml_cin_jkg": -999.9})
+        assert diag.ml_cin_jkg is None
+
+        # Packed near-zero negative → no cap (0).
+        diag = build_icon_cloud_diagnostics({"ml_cape_jkg": 10.0, "ml_cin_jkg": -0.025})
+        assert diag.ml_cin_jkg == 0.0
 
     def test_rain_con_not_surfaced_as_rate(self):
         """build_icon_cloud_diagnostics stays unaware of rain_con (#421).
@@ -1229,14 +1249,21 @@ class TestBuildIconCloudDiagnostics:
             "k_index_c": 38.0,
             "total_totals_c": 52.0,
             "ml_cape_jkg": 1200.0,
-            "ml_cin_jkg": -45.0,
+            "ml_cin_jkg": 45.0,  # #441: mlcin100 is a positive magnitude
         }
         diag = build_ecmwf_cloud_diagnostics(raw)
         assert diag is not None
         assert diag.k_index == 38.0
         assert diag.total_totals == 52.0
         assert diag.ml_cape_jkg == 1200.0
-        assert diag.ml_cin_jkg == -45.0
+        assert diag.ml_cin_jkg == -45.0  # normalized to internal negative
+
+    def test_ecmwf_cin_9999_sentinel_dropped(self):
+        """#441: ECMWF 9999 CIN sentinel (if not NaN-masked) is dropped, not read as a cap."""
+        from weatherbrief.fetch.grib.decode import build_ecmwf_cloud_diagnostics
+
+        diag = build_ecmwf_cloud_diagnostics({"ml_cape_jkg": 10.0, "ml_cin_jkg": 9999.0})
+        assert diag.ml_cin_jkg is None
 
     def test_ecmwf_k_index_kelvin_normalized(self):
         """ECMWF kx arrives in Kelvin → normalized to °C (#283 review).

--- a/tests/test_grib.py
+++ b/tests/test_grib.py
@@ -771,16 +771,46 @@ class TestIconEuLevels:
         assert 300 not in result
         assert 1000 not in result
 
-    def test_negative_values_clamped(self):
-        """Negative interpolation results clamped to zero."""
+    def test_bounds_clamp_when_requested(self):
+        """A (min, max) bound clamps interpolated values."""
         from weatherbrief.fetch.grib.icon_eu_levels import interpolate_model_to_pressure_levels
 
-        # Values that could produce negative interpolation
+        # Negative inputs → negative interpolation; clamp floor at 0.
         model_p = [50000.0, 60000.0, 70000.0]
-        model_v = [0.0, 0.0, 0.0]
+        model_v = [-0.5, -0.5, -0.5]
+
+        result = interpolate_model_to_pressure_levels(
+            model_p, model_v, [600], bounds=(0.0, None),
+        )
+        assert result[600] == 0.0
+
+        # Cloud-fraction ceiling at 100.
+        result = interpolate_model_to_pressure_levels(
+            [50000.0, 70000.0], [150.0, 150.0], [600], bounds=(0.0, 100.0),
+        )
+        assert result[600] == 100.0
+
+    def test_signed_values_preserved_by_default(self):
+        """#441: with no bounds, negative values (T/U/V/W) pass through unclamped."""
+        from weatherbrief.fetch.grib.icon_eu_levels import interpolate_model_to_pressure_levels
+
+        # Wind component swinging negative (e.g. easterly U) must survive.
+        model_p = [50000.0, 60000.0, 70000.0]
+        model_v = [-12.0, -8.0, -4.0]
 
         result = interpolate_model_to_pressure_levels(model_p, model_v, [600])
-        assert result.get(600, 0.0) >= 0.0
+        assert result[600] < 0.0  # NOT clamped to 0
+
+    def test_wind_fields_are_unbounded(self):
+        """#441: U/V/W/T map to no bounds; condensate/fraction map to clamps."""
+        from weatherbrief.fetch.grib.icon_eu_levels import bounds_for_field
+
+        assert bounds_for_field("raw_u_wind_m_s") is None
+        assert bounds_for_field("raw_v_wind_m_s") is None
+        assert bounds_for_field("raw_w_m_s") is None
+        assert bounds_for_field("raw_temperature_k") is None
+        assert bounds_for_field("cloud_liquid_water_kg_kg") == (0.0, None)
+        assert bounds_for_field("cloud_area_fraction_pct") == (0.0, 100.0)
 
     def test_insufficient_data(self):
         """Less than 2 valid points returns empty."""

--- a/tests/test_grib.py
+++ b/tests/test_grib.py
@@ -1968,3 +1968,61 @@ class TestGribSkipDiagnostics:
         generic = [d for d in diags if d.code == FetchCode.GRIB_UNAVAILABLE_FOR_MODEL]
         assert len(generic) == 1
         assert generic[0].level == "warn"
+
+
+class TestIconClcGeometryPerForecastHour:
+    """#441 finding #4: CLC-derived layer geometry is applied per forecast
+    hour (each valid time uses its own), not reused from the first hour."""
+
+    def test_each_hour_uses_its_own_clc_geometry(self, monkeypatch):
+        import re
+        from datetime import datetime, timezone
+        from pathlib import Path
+
+        import weatherbrief.fetch.grib as grib_mod
+        from weatherbrief.models import (
+            HourlyForecast, ModelSource, PressureLevelData, RoutePoint,
+            RouteCrossSection, Waypoint, WaypointForecast,
+        )
+
+        def _utc(h):
+            return datetime(2026, 7, 16, h, 0, tzinfo=timezone.utc)
+
+        forecast_hours = [6, 7]
+        hourly = [
+            HourlyForecast(time=_utc(h), pressure_levels=[PressureLevelData(pressure_hpa=500)])
+            for h in forecast_hours
+        ]
+        wf = WaypointForecast(
+            waypoint=Waypoint(icao="XXXX", name="Test", lat=50.0, lon=0.0),
+            model=ModelSource.ICON,
+            fetched_at=datetime.now(tz=timezone.utc), hourly=hourly,
+        )
+        cs = RouteCrossSection(
+            model=ModelSource.ICON, route_points=[], fetched_at=wf.fetched_at,
+            point_forecasts=[wf],
+        )
+
+        monkeypatch.setattr(grib_mod, "is_cached", lambda run_dir, ck: True)
+
+        # Each hour decodes a low deck with NO base (so CLC fills base_ft).
+        def fake_dispatch(worker, path, lats, lons, **kw):
+            return [{"low_cover_pct": 60.0}]
+        monkeypatch.setattr(grib_mod, "_dispatch_decode", fake_dispatch)
+
+        # Distinct CLC geometry per forecast hour.
+        clc_by_fhour = {
+            6: [{"low_base_ft": 2000.0}],
+            7: [{"low_base_ft": 8000.0}],
+        }
+
+        grib_mod._enrich_icon_eu_cloud_diagnostics(
+            [cs], [], [RoutePoint(lat=50.0, lon=0.0, distance_from_origin_nm=0.0)],
+            "20260716", 0, list(forecast_hours),
+            Path("/unused"), [50.0], [0.0], session=None,
+            clc_layers_by_fhour=clc_by_fhour,
+        )
+
+        by_hour = {h.time.hour: h.nwp_cloud_diagnostics for h in wf.hourly}
+        assert by_hour[6].low.base_ft == 2000.0
+        assert by_hour[7].low.base_ft == 8000.0  # NOT reused from f006

--- a/tests/test_grib_fill.py
+++ b/tests/test_grib_fill.py
@@ -788,3 +788,30 @@ class TestLerpWind:
         spd, wd = _lerp_wind(10.0, None, 20.0, 90.0, 0.5)
         assert spd == pytest.approx(15.0)
         assert wd == 90.0
+
+
+class TestGustWindowMax:
+    """#441 finding #6: ECMWF gust (10fg) is a window maximum, held over the
+    covering interval on gap hours — not linearly interpolated."""
+
+    def test_gust_held_not_interpolated(self):
+        from weatherbrief.fetch.grib.fill import _interp_surface_hourly
+
+        t0 = datetime(2026, 7, 16, 12, tzinfo=timezone.utc)
+        # Anchors at index 0 and 2 (diag set), gap hour at index 1.
+        anchor0 = HourlyForecast(
+            time=t0, nwp_cloud_diagnostics=NWPCloudDiagnostics(total_cover_pct=50.0),
+            wind_gusts_10m_kt=20.0, temperature_2m_c=15.0,
+        )
+        gap = HourlyForecast(time=t0 + timedelta(hours=1))
+        anchor2 = HourlyForecast(
+            time=t0 + timedelta(hours=2),
+            nwp_cloud_diagnostics=NWPCloudDiagnostics(total_cover_pct=50.0),
+            wind_gusts_10m_kt=35.0, temperature_2m_c=17.0,
+        )
+        filled = _interp_surface_hourly([anchor0, gap, anchor2])
+        assert filled == 1
+        # Gust holds the covering interval's max (next anchor), NOT ~27.5 lerp.
+        assert gap.wind_gusts_10m_kt == 35.0
+        # A genuinely instantaneous scalar IS linearly interpolated.
+        assert gap.temperature_2m_c == pytest.approx(16.0)

--- a/tests/test_grib_fill.py
+++ b/tests/test_grib_fill.py
@@ -815,3 +815,18 @@ class TestGustWindowMax:
         assert gap.wind_gusts_10m_kt == 35.0
         # A genuinely instantaneous scalar IS linearly interpolated.
         assert gap.temperature_2m_c == pytest.approx(16.0)
+
+
+class TestBoundaryCoverAlignment:
+    """#441 finding #5: boundary-layer cover is averaged-only, so it aligns at
+    the window midpoint (mid_frac), while total cover is instantaneous
+    (step_frac)."""
+
+    def test_boundary_uses_mid_frac_total_uses_step_frac(self):
+        from weatherbrief.fetch.grib.fill import _interp_diag_at
+
+        prev = NWPCloudDiagnostics(boundary_cover_pct=0.0, total_cover_pct=0.0)
+        nxt = NWPCloudDiagnostics(boundary_cover_pct=100.0, total_cover_pct=100.0)
+        out = _interp_diag_at(prev, nxt, mid_frac=0.25, step_frac=0.75)
+        assert out.boundary_cover_pct == pytest.approx(25.0)  # averaged → mid_frac
+        assert out.total_cover_pct == pytest.approx(75.0)     # instant → step_frac

--- a/tests/test_grib_fill.py
+++ b/tests/test_grib_fill.py
@@ -10,6 +10,7 @@ from weatherbrief.analysis.spatial_interpolation import (
 )
 from weatherbrief.fetch.grib.fill import (
     _gfs_window_length_hours,
+    _lerp_wind,
     apply_gfs_rh_condensate_gate,
     propagate_all,
 )
@@ -757,3 +758,33 @@ class TestGfsRhCondensateGate:
         assert h.nwp_cloud_diagnostics.mid.cover_pct is None
         assert h.nwp_cloud_diagnostics.convective_cover_pct == 55.0
         assert h.nwp_cloud_diagnostics.convective_base_ft == 2665.0
+
+
+class TestLerpWind:
+    """#441 finding #7: temporal wind interp uses U/V components, not scalar
+    speed + circular direction."""
+
+    def test_opposing_winds_pass_through_calm(self):
+        # 10 kt @ 090° → 10 kt @ 270°: the U/V midpoint is near-calm, NOT 10 kt
+        # at some intermediate bearing (which naive scalar interp would give).
+        spd, _ = _lerp_wind(10.0, 90.0, 10.0, 270.0, 0.5)
+        assert spd < 1.0
+
+    def test_same_direction_preserves(self):
+        spd, wd = _lerp_wind(10.0, 270.0, 20.0, 270.0, 0.5)
+        assert spd == pytest.approx(15.0)
+        assert wd == pytest.approx(270.0)
+
+    def test_veering_midpoint(self):
+        # 10 kt from 270° (westerly) → 10 kt from 360° (northerly): the vector
+        # midpoint is a NW wind of reduced speed, bearing between 270 and 360.
+        spd, wd = _lerp_wind(10.0, 270.0, 10.0, 360.0, 0.5)
+        assert spd == pytest.approx(10.0 * (2 ** 0.5) / 2, abs=0.1)  # ~7.07 kt
+        assert 270.0 < wd < 360.0
+
+    def test_none_endpoints(self):
+        assert _lerp_wind(None, 90.0, 10.0, 90.0, 0.5) == (None, None)
+        # Missing direction on one side → scalar speed, keep defined direction.
+        spd, wd = _lerp_wind(10.0, None, 20.0, 90.0, 0.5)
+        assert spd == pytest.approx(15.0)
+        assert wd == 90.0


### PR DESCRIPTION
Backend GRIB decode audit (ECMWF / GFS / ICON) — the correctness batch from #441, one commit per finding. Every convention/interpretation claim was grounded on ground truth (decoded from our own cached GRIB via eccodes + provider param DB); see #441 for the full evidence trail.

**Addresses #441.** Not a full close — the datum terrain-normalization refactor and three efficiency optimizations are deferred to follow-ups (see below); #441 stays open to track them.

## Commits

| Finding | Commit | What & why |
|---|---|---|
| #1 | `stop zeroing negative ICON U/V/W` | The model-level interpolator's blanket `max(0.0, …)` clamped T/QV/U/V/W. Made it variable-specific — condensate/fraction clamp, T/U/V/W stay **signed** (clamping U/V corrupts wind dir; clamping W destroys subsidence → omega). |
| #2 | `normalize model CIN sign + sentinels` | ECMWF `mlcin100`/ICON `CIN_ML` are **positive** magnitudes; the gate is `eff_cin < -200` (negative), so strong model caps never suppressed. Normalize at decode; drop `9999`/`-999.9` sentinels. |
| #7 | `interpolate wind as U/V components` | Temporal interp of scalar speed + circular dir isn't vector-correct (10 kt@090→10 kt@270 should pass through calm). Added `_lerp_wind`. |
| #6 | `hold ECMWF gust as window max` | `10fg` is `stepType=max`, not instantaneous → held over the covering interval on gap hours instead of linear-interpolated. |
| #5 | `match GFS cover statistical processing to geometry` | Select **averaged** LCDC/MCDC/HCDC to match their averaged-only geometry; align boundary-layer cover at window midpoint. |
| #4 | `apply ICON CLC geometry per forecast hour` | CLC cloud layers were collapsed to one per-point set and reused for all hours ("time-invariant" — false). Key by forecast hour. |
| #3 (doc) | `correct ECMWF height-field datum labels to AGL` | `deg0l` comment said MSL; it's geometric **AGL**. ceil/cbh/hcct likewise AGL. Documentation only. |
| eff. | `stop orphaning .idx; free ICON buffers` | `indexpath=""` on temp opens (604 orphan `.idx` reproduced); `pop()` ICON input bytes as consumed. |

## Grounding (from #441, re-verified against real cached GRIB)

- ICON `CIN_ML` max **+1585 J/kg** (positive magnitude), `-999.9` sentinel leaks (would falsely suppress); ECMWF `mlcin100` all **≥ 0**, `9999` already NaN-masked by cfgrib. `18/150` EU points carried a real ≥200 J/kg cap the old gate silently ignored.
- ICON `u` ~21% negative, `wz` majority negative — the clamp was corrupting real data.
- ECMWF `10fg` eccodes name = "**Maximum** … since previous post-processing", `stepType=max`.
- `deg0l` eccodes name = "Geometric height … **above ground**".

## Testing

`3599 passed, 8 skipped, 0 failed` (full suite). New tests cover: signed passthrough + per-field bounds; CIN sign/sentinel (both models); `_lerp_wind` through-calm; gust window-max hold; GFS averaged selection + boundary midpoint; per-forecast-hour CLC geometry.

## Deferred to follow-ups (tracked in #441)

- **#3 datum terrain-normalization** — converting AGL (ECMWF) vs MSL (ICON/GFS/sounding) heights against field elevation for airport-category (AGL) vs en-route (MSL) consumers. Changes **safety-adjacent airport flight-category output** and needs field-elevation plumbing + replay validation, so it gets its own PR.
- **Efficiency #2/#4/#5** — per-model-level interp vectorization, scalar-coordinate caching, and ECMWF multi-grid first-wins → explicit grid priority (behaviour-affecting).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01225CifyZ4VTSQyUDJJ6GMq
