### PR TITLE
iOS flight sharing: /s/ deep links, resolver endpoint, subscribe-with-preview

### DIFF
--- a/app/flyfun-weather/flyfun-weather/App/AppState.swift
+++ b/app/flyfun-weather/flyfun-weather/App/AppState.swift
@@ -410,8 +410,24 @@ final class AppState {
         case "/maps.html":
             return .forecastMap(mapDeepLink(from: comps.queryItems ?? []))
         default:
+            // Short share link `/s/{code}` → preview-before-subscribe (#446). The
+            // code is the single path component after `/s/`. Validate its shape
+            // (matching the server's `/s/{code}` route + by-share resolver) so a
+            // stray `/s/` path can't route to an empty preview.
+            if comps.path.hasPrefix("/s/") {
+                let code = String(comps.path.dropFirst("/s/".count))
+                if isValidShareCode(code) { return .share(code: code) }
+            }
             return nil
         }
+    }
+
+    /// Whether a string matches the share-code shape (`^[0-9A-Za-z]{4,16}$`),
+    /// kept in lock-step with the server's `_SHARE_CODE_RE`. Pure + `nonisolated`
+    /// so the routing parser stays unit-testable off the MainActor.
+    nonisolated static func isValidShareCode(_ code: String) -> Bool {
+        (4...16).contains(code.count)
+            && code.allSatisfy { $0.isASCII && ($0.isLetter || $0.isNumber) }
     }
 
     /// Read the forecast map's `fc.*` share-state keys from a `/maps.html` query.

--- a/app/flyfun-weather/flyfun-weather/App/AppState.swift
+++ b/app/flyfun-weather/flyfun-weather/App/AppState.swift
@@ -123,6 +123,13 @@ final class AppState {
 
     static let productionBaseURL = URL(string: "https://weather.flyfun.aero")!
 
+    /// The canonical share URL for a flight's share code (`/s/{code}`, #446).
+    /// Always production — a shared link must open for the recipient regardless
+    /// of which server the sender's DEBUG build points at.
+    static func shareURL(forShareCode code: String) -> URL {
+        productionBaseURL.appendingPathComponent("s").appendingPathComponent(code)
+    }
+
     #if DEBUG
     @ObservationIgnored
     static var serverEnvironment: ServerEnvironment {

--- a/app/flyfun-weather/flyfun-weather/AppIntents/PendingNavigation.swift
+++ b/app/flyfun-weather/flyfun-weather/AppIntents/PendingNavigation.swift
@@ -12,6 +12,10 @@ enum PendingNavigation: Equatable, Sendable {
     /// Open the forecast map, optionally in a shared `fc.*` state (#420). A map
     /// link shared from desktop opens the phone on the same day/hour/metric/airport.
     case forecastMap(MapDeepLink)
+    /// Open a shared flight by its share code (`/s/{code}`) as a preview with a
+    /// Subscribe banner (#446). The flight isn't in `/api/flights` until the
+    /// viewer subscribes, so the UI resolves the code via the by-share endpoint.
+    case share(code: String)
 
     /// The target flight id, when this navigation names one.
     var flightId: String? {
@@ -70,6 +74,7 @@ enum PendingNavigationStore {
         case .flightList: "flightList"
         case .briefing(let id): "briefing:\(id)"
         case .forecastMap(let dl): "forecastMap:" + encodeMap(dl)
+        case .share(let code): "share:\(code)"
         }
     }
 
@@ -81,6 +86,10 @@ enum PendingNavigationStore {
         }
         if raw.hasPrefix("forecastMap:") {
             return .forecastMap(decodeMap(String(raw.dropFirst("forecastMap:".count))))
+        }
+        if raw.hasPrefix("share:") {
+            let code = String(raw.dropFirst("share:".count))
+            return code.isEmpty ? nil : .share(code: code)
         }
         return nil
     }

--- a/app/flyfun-weather/flyfun-weather/Models/API/FlightResponse.swift
+++ b/app/flyfun-weather/flyfun-weather/Models/API/FlightResponse.swift
@@ -55,6 +55,14 @@ struct FlightResponse: Codable, Identifiable, Sendable {
     /// per-flight round-trip.
     var debrief: DebriefResponse? = nil
 
+    /// Short base62 token for the flight's share link (`/s/{shareCode}`). The
+    /// server emits `share_code` on every flight created after migration 049; the
+    /// app uses it to build the ShareLink URL (owner) and it round-trips through
+    /// the by-share resolver (subscriber preview). `var … = nil` so it decodes
+    /// AND the synthesized memberwise init keeps existing call sites unchanged;
+    /// absent on very old rows → nil (no share affordance).
+    var shareCode: String? = nil
+
     /// Per-flight override folded to an enum, tolerant of unknown/absent values.
     var notifyOverrideMode: FlightNotifyOverride {
         FlightNotifyOverride(rawValue: notifyOverride ?? "default") ?? .default

--- a/app/flyfun-weather/flyfun-weather/Models/API/FlightResponse.swift
+++ b/app/flyfun-weather/flyfun-weather/Models/API/FlightResponse.swift
@@ -63,6 +63,29 @@ struct FlightResponse: Codable, Identifiable, Sendable {
     /// absent on very old rows → nil (no share affordance).
     var shareCode: String? = nil
 
+    /// The flight owner's display name — set by the server only on the subscriber
+    /// view (`role == .subscriber`). Drives the "Shared by …" preview banner; nil
+    /// falls back to a generic "Shared flight" label (server never sends the
+    /// owner's email). `var … = nil` so it decodes AND keeps memberwise-init call
+    /// sites unchanged; absent on older servers / the owner's own view → nil.
+    var ownerDisplayName: String? = nil
+
+    /// Whether the viewer has already subscribed to this (someone else's) flight.
+    /// Flips the shared-flight preview banner button Subscribe ↔ Unsubscribe.
+    /// `var … = nil` so it decodes AND keeps memberwise-init call sites unchanged;
+    /// absent on older servers → treated as not-subscribed via `hasSubscribed`.
+    var isSubscribed: Bool? = nil
+
+    /// `isSubscribed` folded to a plain Bool so callers never juggle the optional.
+    var hasSubscribed: Bool { isSubscribed ?? false }
+
+    /// Whether this flight can be shared: only the owner, and only when it isn't
+    /// private (recipients of a private link would 404), and only once the server
+    /// has minted a share code. Mirrors the web share-affordance gate.
+    var isShareable: Bool {
+        isEditable && !`private` && !(shareCode ?? "").isEmpty
+    }
+
     /// Per-flight override folded to an enum, tolerant of unknown/absent values.
     var notifyOverrideMode: FlightNotifyOverride {
         FlightNotifyOverride(rawValue: notifyOverride ?? "default") ?? .default

--- a/app/flyfun-weather/flyfun-weather/Services/BriefingRepository.swift
+++ b/app/flyfun-weather/flyfun-weather/Services/BriefingRepository.swift
@@ -27,6 +27,19 @@ protocol BriefingRepository: Sendable {
     func autorouterRoutes(limit: Int) async throws -> [AutorouterRoute]
     func packs(flightId: String) async throws -> [PackMetaResponse]
     func latestPack(flightId: String) async throws -> PackMetaResponse
+    // Flight sharing (#446) — all online-only.
+    /// Resolve a share code (`/s/{code}`) to its flight for the preview-before-
+    /// subscribe on-ramp. Throws `APIError.notFound` (404) for an unknown/invalid
+    /// code or a private flight the viewer can't see. A non-owner gets a
+    /// `FlightResponse` with `role == .subscriber`, `ownerDisplayName`, and
+    /// `isSubscribed`.
+    func flightByShareCode(_ code: String) async throws -> FlightResponse
+    /// Subscribe the viewer to another pilot's flight. Idempotent 200; throws
+    /// `APIError.notFound` (404 private/not-visible) or `APIError.serverError(409,…)`
+    /// (own flight).
+    func subscribeFlight(id: String) async throws
+    /// Remove the viewer's subscription. Idempotent (204 either way).
+    func unsubscribeFlight(id: String) async throws
     /// Quick forecast + observation for one airport (mirrors the MCP
     /// `get_airport_weather` tool). Online-only — not part of the offline bundle.
     /// `day`: 0=today…3, `hour`: forecast hour UTC (snapped server-side).
@@ -165,6 +178,20 @@ final class OnlineBriefingRepository: BriefingRepository {
 
     func latestPack(flightId: String) async throws -> PackMetaResponse {
         try await client.request("/api/flights/\(flightId)/packs/latest")
+    }
+
+    func flightByShareCode(_ code: String) async throws -> FlightResponse {
+        // The code is validated client-side before we get here (deep-link parse),
+        // but percent-encode it anyway so it's a single opaque path segment.
+        try await client.requestURL("/api/flights/by-share/\(Self.queryValueEncoded(code))")
+    }
+
+    func subscribeFlight(id: String) async throws {
+        _ = try await client.requestData("/api/flights/\(id)/subscribe", method: "POST")
+    }
+
+    func unsubscribeFlight(id: String) async throws {
+        try await client.requestVoid("/api/flights/\(id)/subscribe")
     }
 
     func airportWeather(icao: String, day: Int, hour: Int) async throws -> AirportWeatherResponse {

--- a/app/flyfun-weather/flyfun-weather/Services/CachingBriefingRepository.swift
+++ b/app/flyfun-weather/flyfun-weather/Services/CachingBriefingRepository.swift
@@ -217,6 +217,20 @@ final class CachingBriefingRepository: BriefingRepository, CacheStatusReporting 
         try await online.frequentAirports()
     }
 
+    // Flight sharing (#446) — always online: resolving a code, subscribing, and
+    // unsubscribing are live account actions, never part of the offline bundle.
+    func flightByShareCode(_ code: String) async throws -> FlightResponse {
+        try await online.flightByShareCode(code)
+    }
+
+    func subscribeFlight(id: String) async throws {
+        try await online.subscribeFlight(id: id)
+    }
+
+    func unsubscribeFlight(id: String) async throws {
+        try await online.unsubscribeFlight(id: id)
+    }
+
     func refreshStream(flightId: String, source: RefreshSource) async -> AsyncThrowingStream<RefreshEvent, Error> {
         await online.refreshStream(flightId: flightId, source: source)
     }

--- a/app/flyfun-weather/flyfun-weather/Services/FixtureBriefingRepository.swift
+++ b/app/flyfun-weather/flyfun-weather/Services/FixtureBriefingRepository.swift
@@ -193,6 +193,9 @@ final class FixtureBriefingRepository: BriefingRepository, CacheStatusReporting 
             waypoints: waypoints
         )
     }
+    func flightByShareCode(_ code: String) async throws -> FlightResponse { throw FixtureError.notProvided("flightByShareCode") }
+    func subscribeFlight(id: String) async throws { throw FixtureError.notProvided("subscribeFlight") }
+    func unsubscribeFlight(id: String) async throws { throw FixtureError.notProvided("unsubscribeFlight") }
     func routeDistance(waypoints: [String]) async throws -> RouteDistanceResponse { throw FixtureError.notProvided("routeDistance") }
     func autorouterRoutes(limit: Int) async throws -> [AutorouterRoute] { [] }
     func recalculateAdvisories(flightId: String, timestamp: String, cruiseAltitudeFt: Int?) async throws { throw FixtureError.notProvided("recalculateAdvisories") }

--- a/app/flyfun-weather/flyfun-weather/Views/Briefing/BriefingContainerView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Briefing/BriefingContainerView.swift
@@ -78,6 +78,16 @@ struct BriefingContainerView: View {
                 }
                 ToolbarItem(placement: .topBarTrailing) {
                     HStack(spacing: 12) {
+                        // Owner sharing (#446): a ShareLink to the short /s/{code}
+                        // URL. Only the owner sees it, and only for a non-private
+                        // flight with a minted code (isShareable) — a private link
+                        // would 404 for the recipient, matching the web gate.
+                        if flight.isShareable, let code = flight.shareCode {
+                            ShareLink(item: AppState.shareURL(forShareCode: code)) {
+                                Label("Share", systemImage: "square.and.arrow.up")
+                                    .font(.caption)
+                            }
+                        }
                         if isInFlightWindow && appState.userPreferences.preferences.pirepCanPublish {
                             Button {
                                 showingPirepSheet = true

--- a/app/flyfun-weather/flyfun-weather/Views/Briefing/SharedFlightPreviewView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Briefing/SharedFlightPreviewView.swift
@@ -1,0 +1,104 @@
+import SwiftUI
+
+/// Preview of a shared flight opened from a `/s/{code}` link (#446).
+///
+/// Shows the full briefing (reusing `BriefingContainerView`) beneath a banner
+/// that names the owner and offers a Subscribe / Unsubscribe button. Opening a
+/// shared link deliberately does **not** auto-subscribe — it's common to look
+/// once without adding the flight to your list — so the resolved flight lives in
+/// local `@State` and the banner button flips on `is_subscribed` without
+/// re-resolving. Owner-gating in `BriefingContainerView` (`isEditable`) already
+/// hides refresh/edit for the subscriber role.
+struct SharedFlightPreviewView: View {
+    @Environment(AppState.self) private var appState
+    @Environment(\.dismiss) private var dismiss
+
+    /// The resolved shared flight. Local so a subscribe/unsubscribe can flip the
+    /// banner's `hasSubscribed` state in place.
+    @State private var flight: FlightResponse
+    @State private var busy = false
+    @State private var errorMessage: String?
+
+    /// Invoked after a successful subscribe/unsubscribe so the caller can reload
+    /// `/api/flights` (the card badge + `isEditable` gating are handled there).
+    private let onSubscriptionChanged: () -> Void
+
+    init(flight: FlightResponse, onSubscriptionChanged: @escaping () -> Void) {
+        _flight = State(initialValue: flight)
+        self.onSubscriptionChanged = onSubscriptionChanged
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            banner
+            BriefingContainerView(flight: flight)
+        }
+        .toolbar {
+            ToolbarItem(placement: .cancellationAction) {
+                Button("Done") { dismiss() }
+            }
+        }
+        .alert(
+            "Couldn’t update",
+            isPresented: Binding(get: { errorMessage != nil },
+                                 set: { if !$0 { errorMessage = nil } })
+        ) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(errorMessage ?? "")
+        }
+    }
+
+    /// "Shared by {owner} · Subscribe" banner. Falls back to a generic label when
+    /// the owner has no display name (never the owner's email — the server omits it).
+    private var banner: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "person.2.fill")
+                .foregroundStyle(.secondary)
+            Text(ownerLabel)
+                .font(.subheadline.weight(.medium))
+                .lineLimit(1)
+            Spacer()
+            Button(flight.hasSubscribed ? "Unsubscribe" : "Subscribe") {
+                toggleSubscription()
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.small)
+            .disabled(busy || appState.repository == nil)
+        }
+        .padding(.horizontal, Theme.cardPadding)
+        .padding(.vertical, 10)
+        .frame(maxWidth: .infinity)
+        .background(.regularMaterial)
+    }
+
+    private var ownerLabel: String {
+        if let owner = flight.ownerDisplayName, !owner.isEmpty {
+            return "Shared by \(owner)"
+        }
+        return "Shared flight"
+    }
+
+    /// Subscribe or unsubscribe (whichever the banner currently offers) and flip
+    /// the button optimistically on success. A 409 (own flight) or 404
+    /// (private/not-visible) surfaces in the alert.
+    private func toggleSubscription() {
+        guard let repo = appState.repository, !busy else { return }
+        let subscribing = !flight.hasSubscribed
+        busy = true
+        Task {
+            do {
+                if subscribing {
+                    try await repo.subscribeFlight(id: flight.id)
+                } else {
+                    try await repo.unsubscribeFlight(id: flight.id)
+                }
+                flight.isSubscribed = subscribing
+                onSubscriptionChanged()
+            } catch {
+                errorMessage = (error as? APIError)?.errorDescription ?? error.localizedDescription
+            }
+            busy = false
+        }
+    }
+}

--- a/app/flyfun-weather/flyfun-weather/Views/Flights/FlightListView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Flights/FlightListView.swift
@@ -490,6 +490,14 @@ struct FlightListView: View {
                     Label("Edit Flight", systemImage: "pencil")
                 }
             }
+            // Owner sharing (#446): share the short /s/{code} link. Hidden for
+            // private flights and subscribers (isShareable) — recipients of a
+            // private link would 404, mirroring the web share gate.
+            if flight.isShareable, let code = flight.shareCode {
+                ShareLink(item: AppState.shareURL(forShareCode: code)) {
+                    Label("Share Flight", systemImage: "square.and.arrow.up")
+                }
+            }
             if !viewModel.isOffline && flight.role == .subscriber {
                 Button(role: .destructive) {
                     unsubscribe(flight, viewModel: viewModel)

--- a/app/flyfun-weather/flyfun-weather/Views/Flights/FlightListView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Flights/FlightListView.swift
@@ -26,6 +26,12 @@ struct FlightListView: View {
     /// the deep-link state it opens with.
     @State private var showMapCover = false
     @State private var mapDeepLink: MapDeepLink?
+    /// A shared flight resolved from a `/s/{code}` deep link, presented as a
+    /// preview-before-subscribe cover (#446). nil when no shared link is open.
+    @State private var sharedPreviewFlight: FlightResponse?
+    /// Error surfaced when a `/s/{code}` link can't be resolved (unknown code,
+    /// private flight, or the owner's own private link).
+    @State private var shareResolveError: String?
     /// Bumped on every `openForecastMap`, used as the map view's `.id` so a *new*
     /// inbound deep link while the map is already open re-creates the view (the
     /// deep link is applied only at `ForecastMapViewModel.init`).
@@ -243,6 +249,25 @@ struct FlightListView: View {
                 .id(mapOpenToken)
             }
         }
+        .fullScreenCover(item: $sharedPreviewFlight) { flight in
+            // Shared-flight preview (#446): the flight isn't in /api/flights until
+            // the viewer subscribes, so it's presented on its own rather than via
+            // the sidebar selection. Reload the list on any subscribe change so a
+            // now-subscribed flight appears (and an unsubscribe drops it).
+            NavigationStack {
+                SharedFlightPreviewView(flight: flight) {
+                    Task { await viewModel?.loadFlights() }
+                }
+            }
+        }
+        .alert("Shared flight unavailable", isPresented: Binding(
+            get: { shareResolveError != nil },
+            set: { if !$0 { shareResolveError = nil } }
+        )) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(shareResolveError ?? "")
+        }
         .task {
             guard let repo = appState.repository else { return }
             let vm = FlightListViewModel(repository: repo, networkMonitor: appState.networkMonitor)
@@ -330,6 +355,27 @@ struct FlightListView: View {
         case .forecastMap(let deepLink):
             openForecastMap(deepLink: deepLink.isEmpty ? nil : deepLink)
             appState.clearPendingNavigation()
+        case .share(let code):
+            // Resolve the share code to a flight and present the preview. Keep the
+            // pending target when the repository isn't ready yet (e.g. the link
+            // arrived while signed out) so it re-applies once the list appears
+            // authenticated — that's the sign-in resumption path (#446).
+            guard let repo = appState.repository else { return }
+            appState.clearPendingNavigation()
+            Task {
+                do {
+                    sharedPreviewFlight = try await repo.flightByShareCode(code)
+                } catch let error as APIError {
+                    shareResolveError = {
+                        if case .notFound = error {
+                            return "This shared flight isn’t available. The link may be wrong, or the owner made it private."
+                        }
+                        return error.errorDescription ?? "Couldn’t open the shared flight."
+                    }()
+                } catch {
+                    shareResolveError = error.localizedDescription
+                }
+            }
         case .briefing(let flightId):
             guard let vm = viewModel, case .loaded(let flights) = vm.state else { return }
             if let match = flights.first(where: { $0.id == flightId }) {
@@ -357,6 +403,18 @@ struct FlightListView: View {
                 reloadRetryFlightId = nil
                 appState.clearPendingNavigation()
             }
+        }
+    }
+
+    /// Drop the viewer's subscription to a shared flight, then reload the list so
+    /// the row disappears. If the just-unsubscribed flight is the current detail
+    /// selection (iPad), clear it so the detail pane doesn't dangle on a flight no
+    /// longer in the list.
+    private func unsubscribe(_ flight: FlightResponse, viewModel: FlightListViewModel) {
+        Task {
+            try? await appState.repository?.unsubscribeFlight(id: flight.id)
+            if selection == .flight(flight) { selection = nil }
+            await viewModel.loadFlights()
         }
     }
 
@@ -414,6 +472,15 @@ struct FlightListView: View {
                 }
                 .tint(.blue)
             }
+            // Unsubscribe from a shared flight — the first row-removal flow on iOS
+            // (#446). Online-only; drops the viewer's subscription then reloads.
+            if !viewModel.isOffline && flight.role == .subscriber {
+                Button(role: .destructive) {
+                    unsubscribe(flight, viewModel: viewModel)
+                } label: {
+                    Label("Unsubscribe", systemImage: "person.badge.minus")
+                }
+            }
         }
         .contextMenu {
             if !viewModel.isOffline && flight.isEditable {
@@ -421,6 +488,13 @@ struct FlightListView: View {
                     editingFlight = flight
                 } label: {
                     Label("Edit Flight", systemImage: "pencil")
+                }
+            }
+            if !viewModel.isOffline && flight.role == .subscriber {
+                Button(role: .destructive) {
+                    unsubscribe(flight, viewModel: viewModel)
+                } label: {
+                    Label("Unsubscribe", systemImage: "person.badge.minus")
                 }
             }
         }

--- a/app/flyfun-weather/flyfun-weatherTests/TestSupport.swift
+++ b/app/flyfun-weather/flyfun-weatherTests/TestSupport.swift
@@ -91,6 +91,9 @@ final class MockBriefingRepository: BriefingRepository, @unchecked Sendable {
     func createAircraft(_ request: CreateAircraftRequest) async throws -> AircraftResponse { throw MockError.notStubbed("createAircraft") }
     func parseFpl(_ text: String) async throws -> ParseFplResponse { throw MockError.notStubbed("parseFpl") }
     func packs(flightId: String) async throws -> [PackMetaResponse] { throw MockError.notStubbed("packs") }
+    func flightByShareCode(_ code: String) async throws -> FlightResponse { throw MockError.notStubbed("flightByShareCode") }
+    func subscribeFlight(id: String) async throws { throw MockError.notStubbed("subscribeFlight") }
+    func unsubscribeFlight(id: String) async throws { throw MockError.notStubbed("unsubscribeFlight") }
     func latestPack(flightId: String) async throws -> PackMetaResponse {
         if let h = latestPackHandler { return try h() }
         throw MockError.notStubbed("latestPack")

--- a/app/flyfun-weather/flyfun-weatherTests/UniversalLinkRoutingTests.swift
+++ b/app/flyfun-weather/flyfun-weatherTests/UniversalLinkRoutingTests.swift
@@ -70,4 +70,53 @@ struct UniversalLinkRoutingTests {
         #expect(AppState.navigationTarget(
             for: url("flyfunweather://auth?token=abc")) == nil)
     }
+
+    // MARK: - Share links (#446)
+
+    @Test func routesShareLinkToShareCode() {
+        let target = AppState.navigationTarget(
+            for: url("https://weather.flyfun.aero/s/aB3xy7Q9"))
+        #expect(target == .share(code: "aB3xy7Q9"))
+    }
+
+    @Test func shareLinkWithPackQueryStillRoutes() {
+        // The web appends `?pack=` to pin a specific briefing; the code parse
+        // ignores the query, and the preview loads the latest pack anyway.
+        let target = AppState.navigationTarget(
+            for: url("https://weather.flyfun.aero/s/aB3xy7Q9?pack=2026-04-30T08:00:00Z"))
+        #expect(target == .share(code: "aB3xy7Q9"))
+    }
+
+    @Test func shortShareCodeReturnsNil() {
+        // Below the 4-char minimum — reject before presenting an empty preview.
+        #expect(AppState.navigationTarget(
+            for: url("https://weather.flyfun.aero/s/ab")) == nil)
+    }
+
+    @Test func shareCodeWithExtraPathSegmentReturnsNil() {
+        // A nested path isn't a valid single-segment code.
+        #expect(AppState.navigationTarget(
+            for: url("https://weather.flyfun.aero/s/abc/def")) == nil)
+    }
+
+    @Test func shareLinkOnForeignHostReturnsNil() {
+        #expect(AppState.navigationTarget(
+            for: url("https://evil.example.com/s/aB3xy7Q9")) == nil)
+    }
+
+    @Test func pendingNavigationRoundTripsShare() {
+        // The cold-launch-safe store must round-trip a share target so a link
+        // that arrives before AppState/list exists (or across a sign-in) resumes.
+        PendingNavigationStore.set(.share(code: "aB3xy7Q9"))
+        #expect(PendingNavigationStore.take() == .share(code: "aB3xy7Q9"))
+    }
+
+    @Test func shareCodeShapeValidation() {
+        #expect(AppState.isValidShareCode("aB3xy7Q9"))
+        #expect(AppState.isValidShareCode("abcd"))
+        #expect(!AppState.isValidShareCode("abc"))          // too short
+        #expect(!AppState.isValidShareCode(String(repeating: "a", count: 17)))  // too long
+        #expect(!AppState.isValidShareCode("abc-123"))      // illegal char
+        #expect(!AppState.isValidShareCode("abc/def"))      // path separator
+    }
 }

--- a/src/weatherbrief/api/flights.py
+++ b/src/weatherbrief/api/flights.py
@@ -35,6 +35,7 @@ from weatherbrief.storage.flights import (
     is_subscribed,
     list_flights_with_role,
     load_flight,
+    lookup_flight_id_by_share_code,
     pack_has_advisories,
     parse_advisory_summary,
     safe_path_component,
@@ -58,6 +59,11 @@ if TYPE_CHECKING:
 # the cap only guards against pathological input. Shared by the create and
 # update request models so the two paths stay in lock-step.
 MAX_ROUTE_WAYPOINTS = 32
+
+# Shape of a share code, kept in lock-step with the ``/s/{code}`` redirect route
+# in ``api/app.py``. Validated before any DB hit so scanner/injection-shaped
+# strings never reach the lookup.
+_SHARE_CODE_RE = re.compile(r"^[0-9A-Za-z]{4,16}$")
 
 
 class CreateFlightRequest(BaseModel):
@@ -1627,6 +1633,37 @@ def get_frequent_airports(
     Add-Flight prefill. See ``compute_frequent_airports``.
     """
     return compute_frequent_airports(db, user_id)
+
+
+@router.get("/by-share/{code}", response_model=FlightResponse)
+def get_flight_by_share_code(
+    code: str,
+    user_id: str = Depends(current_user_id),
+    db: Session = Depends(get_db),
+):
+    """Resolve a share code to a flight — the iOS preview-before-subscribe on-ramp.
+
+    The web ``/s/{code}`` link 302-redirects a *browser* to the briefing page;
+    the app can't follow that redirect, so it resolves the code to a flight
+    itself. Authenticated like every other ``/api/flights`` route (unauth → 401,
+    which the app handles via ``handleUnauthorized``). Visibility is enforced
+    identically to ``get_flight`` by delegating to ``_load_flight_or_404`` with
+    ``viewer_id``: a private flight owned by someone else — or an unknown/invalid
+    code — is a 404. A non-owner viewer gets a normal ``FlightResponse`` with
+    ``role: subscriber`` / ``is_subscribed`` / ``owner_display_name`` so the app
+    can render the Subscribe affordance.
+
+    Registered before ``/{flight_id}`` so ``by-share`` can never be swallowed as
+    a flight id (e.g. a share code that happens to spell ``export``).
+    """
+    if not _SHARE_CODE_RE.match(code):
+        # Reject obviously-bogus codes before the DB hit (mirrors /s/{code}).
+        raise HTTPException(status_code=404, detail="Unknown share link")
+    flight_id = lookup_flight_id_by_share_code(db, code)
+    if flight_id is None:
+        raise HTTPException(status_code=404, detail="Unknown share link")
+    flight = _load_flight_or_404(db, flight_id, viewer_id=user_id)
+    return _flight_to_response(flight, db, viewer_id=user_id)
 
 
 @router.get("/{flight_id}", response_model=FlightResponse)

--- a/tests/test_flight_share_code.py
+++ b/tests/test_flight_share_code.py
@@ -183,3 +183,89 @@ class TestShareRedirect:
         resp = client.get("/s/../etc/passwd", follow_redirects=False)
         # Path normalization may even 404 earlier; either way, never 302.
         assert resp.status_code != 302
+
+
+# --- JSON resolver endpoint (iOS preview-before-subscribe on-ramp) ---
+
+
+def _seed_other_owner_flight(
+    app_db,
+    *,
+    idx: int,
+    share_code: str,
+    private: bool = False,
+    owner_id: str = "owner-user",
+    owner_name: str = "Flight Owner",
+) -> Flight:
+    """Seed a flight owned by a *different* user than the DEV viewer.
+
+    Lets the resolver tests exercise the subscriber view (role/owner name) and
+    the private-flight 404, which a self-owned flight can't.
+    """
+    s = app_db()
+    if s.get(UserRow, owner_id) is None:
+        s.add(UserRow(
+            id=owner_id, provider="local", provider_sub=owner_id,
+            email=f"{owner_id}@example.com", display_name=owner_name, approved=True,
+        ))
+        s.flush()
+    f = _make_flight(idx, share_code=share_code)
+    f.id = f"{f.id}-{owner_id}"
+    f.user_id = owner_id
+    f.private = private
+    save_flight(s, f, owner_id)
+    s.commit()
+    s.close()
+    return f
+
+
+class TestShareResolver:
+    def test_public_flight_returns_subscriber_view(self, client, app_db):
+        # A public flight owned by someone else resolves to a normal
+        # FlightResponse with the subscriber-facing fields the preview reads.
+        f = _seed_other_owner_flight(app_db, idx=20, share_code="Pub12345")
+        resp = client.get(f"/api/flights/by-share/{f.share_code}")
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["id"] == f.id
+        assert body["role"] == "subscriber"
+        assert body["is_subscribed"] is False
+        assert body["owner_display_name"] == "Flight Owner"
+        assert body["share_code"] == f.share_code
+
+    def test_owner_view_when_viewer_owns_flight(self, client, app_db):
+        # The DEV viewer resolving their own flight's code sees the owner view.
+        f = _seed_flight(app_db, idx=21, share_code="Own12345")
+        resp = client.get(f"/api/flights/by-share/{f.share_code}")
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["role"] == "owner"
+        assert body["is_subscribed"] is False
+
+    def test_unknown_code_returns_404(self, client):
+        resp = client.get("/api/flights/by-share/nope0000")
+        assert resp.status_code == 404
+
+    def test_invalid_shape_returns_404_without_db_hit(self, client):
+        # Too short / illegal chars are rejected by the regex before the lookup.
+        assert client.get("/api/flights/by-share/ab").status_code == 404
+        assert client.get("/api/flights/by-share/has spaces").status_code == 404
+
+    def test_private_flight_hidden_from_non_owner(self, client, app_db):
+        # Private + non-owner → 404, identical to GET /{flight_id}.
+        f = _seed_other_owner_flight(app_db, idx=22, share_code="Prv12345", private=True)
+        resp = client.get(f"/api/flights/by-share/{f.share_code}")
+        assert resp.status_code == 404
+
+    def test_owner_can_resolve_own_private_flight(self, client, app_db):
+        # A private flight the viewer owns still resolves for them.
+        f = _seed_flight(app_db, idx=23, share_code="PrvOwn12")
+        s = app_db()
+        loaded = load_flight(s, f.id)
+        loaded.private = True
+        save_flight(s, loaded, DEV_USER_ID)
+        s.commit()
+        s.close()
+        resp = client.get(f"/api/flights/by-share/{f.share_code}")
+        assert resp.status_code == 200
+        assert resp.json()["role"] == "owner"


### PR DESCRIPTION
## What & why

Ports web flight sharing (#74, #65) to the iOS app. The receiving-list half was already partly built (`role`, `private`, `isEditable`, the shared badge, Universal Links); what was missing was the **on-ramp** (getting a shared flight into your list) and the **sharing gesture** (producing a link). One commit per phase, as scoped in the issue.

**Phase 0 — infra + model prerequisite**
- New `GET /api/flights/by-share/{code}` resolver (`api/flights.py`): the JSON endpoint the app uses because it can't follow the browser-only `/s/{code}` 302. Authenticated like the rest of `/api/flights`; validates the code shape (`^[0-9A-Za-z]{4,16}$`) before the DB hit and delegates to `_load_flight_or_404` with `viewer_id` so privacy is enforced identically (private+non-owner → 404, unknown/invalid → 404). Returns a normal `FlightResponse` (subscriber gets `role: subscriber` / `is_subscribed: false` / `owner_display_name`). Registered before `/{flight_id}` so a code can't be swallowed as a sub-route.
- Decode `share_code` on the iOS `FlightResponse` (server already emits it).
- AASA `/s/*` whitelisting is a **deploy step** in the private Caddy config repo — out of scope for this code PR (see the issue's deploy checklist).

**Phase 1 — receive & subscribe (preview-before-subscribe)**
- `/s/{code}` → `AppState.navigationTarget` → new `PendingNavigation.share(code:)`, reusing the cold-launch-safe store so a link arriving while signed out resumes to the preview after sign-in.
- `flightByShareCode(_:)` repository method resolves the code and presents `SharedFlightPreviewView` — the full briefing under a "Shared by {owner} · Subscribe" banner (generic "Shared flight" fallback when the owner has no display name; never the email). Owner-gating (`isEditable`) already hides refresh/edit.
- `subscribeFlight(id:)` / `unsubscribeFlight(id:)`; banner button flips Subscribe ↔ Unsubscribe on `is_subscribed` and reloads the list. Unsubscribe is also a destructive swipe action + context-menu item on subscriber cards (first row-removal flow on iOS).

**Phase 2 — send (owner sharing gesture)**
- `ShareLink` (first use in the app) in the briefing toolbar and flight-row context menu, sharing the short `https://weather.flyfun.aero/s/{code}` URL. Gated by `FlightResponse.isShareable` — owner-only, non-private, code present — mirroring the web share gate (a private link would 404).

## Issue linkage

Closes #446

## Testing / verification

- **Backend:** added resolver tests to `tests/test_flight_share_code.py` (public → subscriber view, owner view, unknown code → 404, invalid shape → 404 without DB hit, private+non-owner → 404, owner resolves own private flight). ⚠️ The suite could **not be executed in this sandbox** — `euro-aip` (a private, non-PyPI dependency) can't be installed here, so `weatherbrief.api.app` won't import. Verified via `py_compile`, route-ordering, and by mirroring the existing sharing suites; please run `pytest tests/test_flight_share_code.py tests/test_api.py::TestFlightSubscriptions` in a full env.
- **iOS:** added `UniversalLinkRoutingTests` cases (`/s/{code}` routing, share-code shape validation, pending-nav round-trip). Not compiled here (no Xcode on this Linux runner). Per the issue, the deep-link + subscribe flows need a real authenticated session on device to fully verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KHi3RnTypQABnsiUp114uD

---
_Generated by [Claude Code](https://claude.ai/code/session_01KHi3RnTypQABnsiUp114uD)_