### PR TITLE
perf(standalone): fix 40-min cache rebuild + cycle-aware post-tasks + verification indexes (PR A of #448)

### DIFF
--- a/alembic/versions/080_verification_perf_indexes.py
+++ b/alembic/versions/080_verification_perf_indexes.py
@@ -1,0 +1,51 @@
+"""Verification query-shape indexes for the standalone-cycle cache rebuild (#448).
+
+Two query families in the post-cycle cache rebuild had no index matching
+their filter shape:
+
+- ``verification_daily_stats``: the bias-leaderboard query filters
+  ``(source, model, days_out)`` as constants with a ``date`` range. The
+  existing indexes lead with ``date`` or ``icao``; the date-leading one only
+  helps narrow ranges, and at 30d/90d MySQL fell back to full scans of the
+  ~985K-row table (~9.5 s per key, 18 such keys per rebuild). The new index
+  puts the equality columns first and the range column last.
+
+- ``taf_verification_scores``: TAF pseudo-model stats are aggregated at query
+  time from raw rows (no rollup — key shape differs), always filtered by
+  ``(source, observation_time)``. Only ``observation_id`` and ``icao`` were
+  indexed, so every TAF aggregate was a ~287K-row full scan.
+
+Revision ID: 080
+Revises: 079
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "080"
+down_revision: Union[str, None] = "079"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_index(
+        "ix_vds_source_model_days_date",
+        "verification_daily_stats",
+        ["source", "model", "days_out", "date"],
+    )
+    op.create_index(
+        "ix_taf_verif_source_time",
+        "taf_verification_scores",
+        ["source", "observation_time"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_taf_verif_source_time", table_name="taf_verification_scores"
+    )
+    op.drop_index(
+        "ix_vds_source_model_days_date", table_name="verification_daily_stats"
+    )

--- a/src/weatherbrief/db/models.py
+++ b/src/weatherbrief/db/models.py
@@ -630,6 +630,10 @@ class TafVerificationScoreRow(Base):
         ),
         Index("ix_taf_verif_obs", "observation_id"),
         Index("ix_taf_verif_icao", "icao"),
+        # TAF pseudo-model stats are aggregated at query time from this table
+        # (no rollup — key shape differs); without a (source, observation_time)
+        # index every digest/dashboard TAF aggregate was a full scan (#448).
+        Index("ix_taf_verif_source_time", "source", "observation_time"),
     )
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
@@ -854,6 +858,11 @@ class VerificationDailyStatsRow(Base):
         ),
         Index("ix_vds_date_model", "date", "source", "model", "days_out"),
         Index("ix_vds_icao_model", "icao", "source", "model", "days_out"),
+        # The bias-leaderboard query filters (source, model, days_out) as
+        # constants with a date *range*. The date-leading index only works for
+        # narrow ranges; at 30d/90d MySQL fell back to full scans (~9.5 s per
+        # key × 18 keys per rebuild, #448). Equality columns first, range last.
+        Index("ix_vds_source_model_days_date", "source", "model", "days_out", "date"),
     )
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)

--- a/src/weatherbrief/db/models.py
+++ b/src/weatherbrief/db/models.py
@@ -567,6 +567,11 @@ class VerificationScoreRow(Base):
         Index("ix_verif_scores_icao", "icao"),
         Index("ix_verif_scores_lead", "lead_hours"),
         Index("ix_verif_scores_source_model_days", "source", "model", "days_out"),
+        # Created by migration 038; load-bearing since #448 — the activity
+        # COUNT(DISTINCT) queries FORCE INDEX it by name (hard SQL error on
+        # MySQL if dropped), so the model must declare it. See
+        # verification_stats._SCORES_SOURCE_TIME_HINT.
+        Index("ix_verif_scores_source_time", "source", "observation_time"),
         Index(
             "ix_verif_scores_source_days_time",
             "source", "days_out", "observation_time",

--- a/src/weatherbrief/tasks/cache_builder.py
+++ b/src/weatherbrief/tasks/cache_builder.py
@@ -183,6 +183,7 @@ def rebuild_stats_cache(db: Session) -> int:
     for source in _SOURCES:
         source_max = get_source_max_time(db, source)
         for period_label, hours in _PERIODS.items():
+            t_key = time.monotonic()
             since = now - timedelta(hours=hours)
             data = get_digest_data(
                 db, since, now,
@@ -193,6 +194,12 @@ def rebuild_stats_cache(db: Session) -> int:
             cache_key = f"stats:{source}:{period_label}"
             _upsert(db, cache_key, data.model_dump(mode="json"), source_max)
             count += 1
+            # Per-key timing: the 2026-07-17 cycles spent ~19 min EACH on the
+            # standalone 7d/30d keys with zero log output — never again.
+            logger.info(
+                "Cache rebuild: %s in %dms",
+                cache_key, int((time.monotonic() - t_key) * 1000),
+            )
 
     db.flush()
     return count
@@ -217,6 +224,7 @@ def rebuild_bias_leaderboard_cache(db: Session) -> int:
     count = 0
 
     for period_label, hours in _LEADERBOARD_PERIODS.items():
+        t_period = time.monotonic()
         since = now - timedelta(hours=hours)
         for model in _LEADERBOARD_MODELS:
             for days_out in _LEADERBOARD_DAYS_OUT:
@@ -229,6 +237,10 @@ def rebuild_bias_leaderboard_cache(db: Session) -> int:
                 cache_key = f"bias_leaderboard:{model}:{days_out}:{period_label}"
                 _upsert(db, cache_key, payload, source_max)
                 count += 1
+        logger.info(
+            "Cache rebuild: bias_leaderboard:*:%s (9 keys) in %dms",
+            period_label, int((time.monotonic() - t_period) * 1000),
+        )
 
     db.flush()
     return count
@@ -285,6 +297,7 @@ def rebuild_all(
     airports_db_path: str,
     *,
     include_forecast_map: bool = True,
+    include_score_stats: bool = True,
 ) -> dict:
     """Rebuild all caches. Called after standalone verification cycles.
 
@@ -292,34 +305,44 @@ def rebuild_all(
     light (score-only) cycles where snapshots haven't changed and the
     forecast_map cache would be regenerated to identical content.
 
-    Returns a summary dict with counts.
+    ``include_score_stats=False`` skips the stats + bias_leaderboard rebuilds —
+    used by forecast (fetch-only) cycles, which create no new scores, so those
+    caches' inputs are unchanged (and ``is_stale`` compares against
+    MAX(observation_time), which a forecast cycle doesn't move).
+
+    Returns a summary dict with counts and per-step timings.
     """
     t0 = time.monotonic()
 
-    stats_count = rebuild_stats_cache(db)
-    leaderboard_count = rebuild_bias_leaderboard_cache(db)
+    stats_count = leaderboard_count = forecast_map_count = 0
+    stats_ms = leaderboard_ms = forecast_map_ms = 0
+    if include_score_stats:
+        t = time.monotonic()
+        stats_count = rebuild_stats_cache(db)
+        stats_ms = int((time.monotonic() - t) * 1000)
+        t = time.monotonic()
+        leaderboard_count = rebuild_bias_leaderboard_cache(db)
+        leaderboard_ms = int((time.monotonic() - t) * 1000)
     if include_forecast_map:
+        t = time.monotonic()
         forecast_map_count = rebuild_forecast_map_cache(db, airports_db_path)
-    else:
-        forecast_map_count = 0
+        forecast_map_ms = int((time.monotonic() - t) * 1000)
 
     db.commit()
     duration_ms = int((time.monotonic() - t0) * 1000)
 
-    if include_forecast_map:
-        logger.info(
-            "Cache rebuild: %d stats + %d bias_leaderboard + %d forecast_map entries (%dms)",
-            stats_count, leaderboard_count, forecast_map_count, duration_ms,
-        )
-    else:
-        logger.info(
-            "Cache rebuild: %d stats + %d bias_leaderboard entries, "
-            "forecast_map skipped (%dms)",
-            stats_count, leaderboard_count, duration_ms,
-        )
+    logger.info(
+        "Cache rebuild: %d stats (%dms) + %d bias_leaderboard (%dms) + "
+        "%d forecast_map (%dms) entries (%dms total)",
+        stats_count, stats_ms, leaderboard_count, leaderboard_ms,
+        forecast_map_count, forecast_map_ms, duration_ms,
+    )
     return {
         "stats": stats_count,
         "bias_leaderboard": leaderboard_count,
         "forecast_map": forecast_map_count,
         "duration_ms": duration_ms,
+        "stats_ms": stats_ms,
+        "leaderboard_ms": leaderboard_ms,
+        "forecast_map_ms": forecast_map_ms,
     }

--- a/src/weatherbrief/tasks/standalone_verification.py
+++ b/src/weatherbrief/tasks/standalone_verification.py
@@ -18,7 +18,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 import requests
-from sqlalchemy import select, tuple_
+from sqlalchemy import insert, select, tuple_
 from sqlalchemy.orm import Session
 
 from weatherbrief.db.models import (
@@ -28,11 +28,9 @@ from weatherbrief.db.models import (
     VerificationObservationRow,
     VerificationScoreRow,
 )
-from weatherbrief.analysis.sounding.edr import EdrAccumulator
 from weatherbrief.process_memory_sampler import MemorySampler, MemoryPeaks
 from weatherbrief.process_rss import current_rss_mb, log_memory
 from weatherbrief.tasks.airport_watchlist import WatchlistAirport
-from weatherbrief.tasks.edr_calibration import flush_accumulator
 from weatherbrief.tasks.forecast_grid import (
     FINE_SAMPLE_HOURS,
     MAP_FORECAST_DAYS,
@@ -41,6 +39,7 @@ from weatherbrief.tasks.forecast_grid import (
 )
 
 if TYPE_CHECKING:
+    from weatherbrief.analysis.sounding.edr import EdrAccumulator
     from weatherbrief.fetch.grib import DecodePriority
 
 logger = logging.getLogger(__name__)
@@ -399,6 +398,10 @@ def _fetch_forecasts_for_model(
             model, chunk_num, total_chunks, len(chunk_list),
             time.monotonic() - chunk_started,
         )
+        # Time the post-fetch loop separately: sounding analysis is the
+        # dominant cycle cost (85–92% of each model leg, #448) and was
+        # previously log-silent.
+        analysis_started = time.monotonic()
         chunk_results: list[dict] = []
         init_date = init_time.date()
         for airport, wpf in zip(chunk_list, forecasts):
@@ -451,6 +454,11 @@ def _fetch_forecasts_for_model(
                 _enrich_with_sounding(snap, hourly, model, edr_acc=edr_acc)
 
                 chunk_results.append(snap)
+        logger.info(
+            "Model %s chunk %d/%d: analyzed %d snapshots in %.1fs",
+            model, chunk_num, total_chunks, len(chunk_results),
+            time.monotonic() - analysis_started,
+        )
         return chunk_results, client._thread_call_count()
 
     all_results: list[dict] = []
@@ -789,6 +797,10 @@ def fetch_ecmwf_grib_snapshots(
     snapshots: list[dict] = []
     max_step = max(files_by_step.keys())
     delivered_steps = sorted(files_by_step)
+    # Decode is logged per file by the worker; the per-step airport loop
+    # (sounding analysis, ~92% of this leg per #448) was log-silent — track it.
+    analysis_s = 0.0
+    steps_processed = 0
 
     def _previous_delivered_step(step_h: int) -> int | None:
         """Nearest delivered step before ``step_h``, for the accumulation diff.
@@ -837,6 +849,7 @@ def fetch_ecmwf_grib_snapshots(
                     )
                     pl_data = None
 
+            t_step = time.monotonic()
             for i, airport in enumerate(airports):
                 cur_raw = cur_a1[i] if i < len(cur_a1) else {}
                 snap_fields = build_ecmwf_surface_snapshot(cur_raw)
@@ -911,12 +924,19 @@ def fetch_ecmwf_grib_snapshots(
 
                 snapshots.append(snap)
 
+            analysis_s += time.monotonic() - t_step
+            steps_processed += 1
+
             # Drop the previous-step cache once we've moved past it; the
             # next iteration only re-reads (step_h, step_h-1).
             stale_keys = [k for k in a1_cache if k < step_h - 1]
             for k in stale_keys:
                 a1_cache.pop(k, None)
 
+    logger.info(
+        "ECMWF GRIB leg: %d steps, %d snapshots, sounding analysis %.0fs",
+        steps_processed, len(snapshots), analysis_s,
+    )
     return snapshots
 
 
@@ -969,8 +989,12 @@ def _store_snapshots(snapshots: list[dict], db) -> int:
         for r in rows:
             existing_keys.add(_normalize_key(*r))
 
-    stored = 0
+    # Bulk executemany insert (#448): building 15–20K ORM objects and pushing
+    # them through the unit-of-work cost ~1–2 min/cycle. The in-memory key
+    # dedup above already guarantees uniqueness (uq_afs_key backs it up), so
+    # plain dict rows through a Core insert are equivalent and far cheaper.
     now = datetime.now(timezone.utc)
+    rows: list[dict] = []
     for snap in snapshots:
         key = _normalize_key(
             snap["icao"], snap["model"],
@@ -978,42 +1002,41 @@ def _store_snapshots(snapshots: list[dict], db) -> int:
         )
         if key in existing_keys:
             continue
-
-        row = AirportForecastSnapshotRow(
-            icao=snap["icao"],
-            model=snap["model"],
-            model_init_time=snap["model_init_time"],
-            forecast_hour=snap["forecast_hour"],
-            fetched_at=now,
-            temperature_2m_c=snap.get("temperature_2m_c"),
-            dewpoint_2m_c=snap.get("dewpoint_2m_c"),
-            visibility_m=snap.get("visibility_m"),
-            wind_speed_10m_kt=snap.get("wind_speed_10m_kt"),
-            wind_direction_10m_deg=snap.get("wind_direction_10m_deg"),
-            wind_gusts_10m_kt=snap.get("wind_gusts_10m_kt"),
-            precipitation_mm=snap.get("precipitation_mm"),
-            snowfall_cm=snap.get("snowfall_cm"),
-            precip_period_h=snap.get("precip_period_h"),
-            cape_jkg=snap.get("cape_jkg"),
-            cloud_cover_pct=snap.get("cloud_cover_pct"),
-            cloud_cover_low_pct=snap.get("cloud_cover_low_pct"),
-            nwp_ceiling_ft=snap.get("nwp_ceiling_ft"),
-            cloud_base_ft=snap.get("cloud_base_ft"),
-            lcl_ft=snap.get("lcl_ft"),
-            sounding_ceiling_ft=snap.get("sounding_ceiling_ft"),
-            sounding_cloud_base_ft=snap.get("sounding_cloud_base_ft"),
-            freezing_level_ft=snap.get("freezing_level_ft"),
-            sounding_cape_jkg=snap.get("sounding_cape_jkg"),
-            sounding_cin_jkg=snap.get("sounding_cin_jkg"),
-            sounding_lifted_index=snap.get("sounding_lifted_index"),
-            sounding_convective_risk=snap.get("sounding_convective_risk"),
-        )
-        db.add(row)
         existing_keys.add(key)  # prevent duplicates within same batch
-        stored += 1
 
-    db.flush()
-    return stored
+        rows.append({
+            "icao": snap["icao"],
+            "model": snap["model"],
+            "model_init_time": snap["model_init_time"],
+            "forecast_hour": snap["forecast_hour"],
+            "fetched_at": now,
+            "temperature_2m_c": snap.get("temperature_2m_c"),
+            "dewpoint_2m_c": snap.get("dewpoint_2m_c"),
+            "visibility_m": snap.get("visibility_m"),
+            "wind_speed_10m_kt": snap.get("wind_speed_10m_kt"),
+            "wind_direction_10m_deg": snap.get("wind_direction_10m_deg"),
+            "wind_gusts_10m_kt": snap.get("wind_gusts_10m_kt"),
+            "precipitation_mm": snap.get("precipitation_mm"),
+            "snowfall_cm": snap.get("snowfall_cm"),
+            "precip_period_h": snap.get("precip_period_h"),
+            "cape_jkg": snap.get("cape_jkg"),
+            "cloud_cover_pct": snap.get("cloud_cover_pct"),
+            "cloud_cover_low_pct": snap.get("cloud_cover_low_pct"),
+            "nwp_ceiling_ft": snap.get("nwp_ceiling_ft"),
+            "cloud_base_ft": snap.get("cloud_base_ft"),
+            "lcl_ft": snap.get("lcl_ft"),
+            "sounding_ceiling_ft": snap.get("sounding_ceiling_ft"),
+            "sounding_cloud_base_ft": snap.get("sounding_cloud_base_ft"),
+            "freezing_level_ft": snap.get("freezing_level_ft"),
+            "sounding_cape_jkg": snap.get("sounding_cape_jkg"),
+            "sounding_cin_jkg": snap.get("sounding_cin_jkg"),
+            "sounding_lifted_index": snap.get("sounding_lifted_index"),
+            "sounding_convective_risk": snap.get("sounding_convective_risk"),
+        })
+
+    for i in range(0, len(rows), 1000):
+        db.execute(insert(AirportForecastSnapshotRow), rows[i : i + 1000])
+    return len(rows)
 
 
 # ---------------------------------------------------------------------------
@@ -1328,12 +1351,13 @@ def run_standalone_cycle(
         _rss_log(f"start ({cycle_type})")
 
         if fetch_forecasts:
-            # EDR calibration accumulator (issue #221). PARKED / INERT as of
-            # 2026-06-10: accumulates nothing because the standalone path uses
-            # `analyze_sounding_lite`, which skips Richardson computation. See
-            # the note at `observe_richardson_levels` call site for details.
-            # Kept wired (fail-silent, ~zero cost) pending a subsampling design.
-            edr_acc = EdrAccumulator()
+            # EDR calibration accumulator (issue #221) no longer instantiated
+            # (#448): it iterated every derived level of ~56K soundings per
+            # cycle while collecting nothing — `analyze_sounding_lite` never
+            # computes Richardson, so every level was dropped on arrival. The
+            # `edr_acc` plumbing below is retained for a future subsampled
+            # calibration design; passing None short-circuits it entirely.
+            edr_acc = None
 
             # Phase A+B: Fetch and store forecasts per model. One model at a
             # time to bound memory — each model's snapshots are stored and
@@ -1419,9 +1443,6 @@ def run_standalone_cycle(
                 models_fetched += 1
                 _rss_log(f"after {model}")
 
-            # Single batched, additive upsert of this run's EDR ln-moments.
-            # Fail-silent inside flush_accumulator — never aborts the cycle.
-            flush_accumulator(db, edr_acc)
         else:
             logger.info("Skipping forecast fetch (score-only cycle)")
 
@@ -1599,38 +1620,51 @@ def run_post_cycle_tasks(airports_db_path: str, cycle_type: str) -> None:
     behaviour identical. Each step is independently fail-safe — a rollup
     failure must not block the cache rebuild, and neither failure marks
     the cycle itself as failed.
+
+    Cycle-aware (#448): each cycle type only rebuilds what it can have
+    changed. Forecast cycles write snapshots but create no scores, so the
+    rollup and the stats/leaderboard caches are input-unchanged; light
+    cycles score but don't touch snapshots, so the forecast_map cache is
+    input-unchanged. The legacy combined ``full`` cycle rebuilds everything.
     """
     from flyfun_common.db import SessionLocal
+
+    include_score_stats = cycle_type != "forecast"
+    include_forecast_map = cycle_type != "light"
 
     # Roll up freshly-scored days into verification_daily_stats BEFORE the
     # cache rebuild so the cache reflects today's scores. Idempotent — re-
     # rolls "yesterday" once per cycle, plus any older missing days. Cheap
     # (~12K rows/day, pure SQL).
-    try:
-        from weatherbrief.tasks.verification_daily_rollup import (
-            rollup_today_and_pending,
+    if include_score_stats:
+        try:
+            from weatherbrief.tasks.verification_daily_rollup import (
+                rollup_today_and_pending,
+            )
+
+            rollup_db = SessionLocal()
+            try:
+                n_rows = rollup_today_and_pending(rollup_db)
+                rollup_db.commit()
+                if n_rows:
+                    logger.info(
+                        "Standalone %s cycle: %d daily-stats rows rolled up",
+                        cycle_type, n_rows,
+                    )
+            except Exception:
+                rollup_db.rollback()
+                raise
+            finally:
+                rollup_db.close()
+        except Exception:
+            logger.error("verification_daily_stats rollup failed", exc_info=True)
+    else:
+        logger.info(
+            "Standalone %s cycle: skipping rollup + stats/leaderboard cache "
+            "(cycle creates no scores)",
+            cycle_type,
         )
 
-        rollup_db = SessionLocal()
-        try:
-            n_rows = rollup_today_and_pending(rollup_db)
-            rollup_db.commit()
-            if n_rows:
-                logger.info(
-                    "Standalone %s cycle: %d daily-stats rows rolled up",
-                    cycle_type, n_rows,
-                )
-        except Exception:
-            rollup_db.rollback()
-            raise
-        finally:
-            rollup_db.close()
-    except Exception:
-        logger.error("verification_daily_stats rollup failed", exc_info=True)
-
-    # Light (score-only) cycles don't touch forecast snapshots, so the
-    # forecast_map cache would be regenerated to identical content — skip it
-    # to halve the rebuild cost on the hourly light cycles.
     try:
         from weatherbrief.tasks.cache_builder import rebuild_all
 
@@ -1638,7 +1672,8 @@ def run_post_cycle_tasks(airports_db_path: str, cycle_type: str) -> None:
         try:
             cache_result = rebuild_all(
                 cache_db, airports_db_path,
-                include_forecast_map=(cycle_type != "light"),
+                include_forecast_map=include_forecast_map,
+                include_score_stats=include_score_stats,
             )
             logger.info(
                 "Standalone %s cycle: cache rebuilt (%dms)",

--- a/src/weatherbrief/tasks/verification_stats.py
+++ b/src/weatherbrief/tasks/verification_stats.py
@@ -119,12 +119,31 @@ def get_activity_summary(
     # Two COUNT(DISTINCT) calls run as two separate queries (PR #150) so
     # MySQL can plan each with its own index instead of falling into a
     # tmp-table dedup.
+    #
+    # FORCE INDEX (#448): left to itself, MySQL picks
+    # ix_verif_scores_source_model_days with ref=const on `source` alone and
+    # scans every standalone row ever (3.8M at time of fix) — the time window
+    # never enters the plan, so 7d and 30d both took ~19 min while 24h (which
+    # got the range plan) took 2 s. Forcing the (source, observation_time)
+    # range index returns in ~6 s on the same data. SQLite ignores the hint.
     obs_count = db.execute(
         select(func.count(func.distinct(VerificationScoreRow.observation_id)))
+        .select_from(VerificationScoreRow)
+        .with_hint(
+            VerificationScoreRow,
+            "FORCE INDEX (ix_verif_scores_source_time)",
+            dialect_name="mysql",
+        )
         .where(*common_where)
     ).scalar() or 0
     airport_count = db.execute(
         select(func.count(func.distinct(VerificationScoreRow.icao)))
+        .select_from(VerificationScoreRow)
+        .with_hint(
+            VerificationScoreRow,
+            "FORCE INDEX (ix_verif_scores_source_time)",
+            dialect_name="mysql",
+        )
         .where(*common_where)
     ).scalar() or 0
 
@@ -625,17 +644,40 @@ def get_digest_data(
     icao_filter: list[str] | None = None,
 ) -> VerificationDigestData:
     """Build complete digest payload for email or web dashboard."""
-    activity = get_activity_summary(db, since, until, source, icao_filter)
-    category_today = get_category_accuracy(db, since, until, source, icao_filter)
-    notable = get_notable_misses(db, since, until, source, icao_filter)
-    bias = get_category_bias_stats(db, since, until, source, icao_filter)
-    wind = get_wind_advisory_accuracy(db, since, until, source, icao_filter)
-    missed = get_missed_warnings(db, since, until, source, icao_filter)
+    import time as _time
+
+    timings: dict[str, int] = {}
+
+    def _timed(label: str, fn, *args):
+        t = _time.monotonic()
+        result = fn(*args)
+        timings[label] = int((_time.monotonic() - t) * 1000)
+        return result
+
+    activity = _timed("activity", get_activity_summary, db, since, until, source, icao_filter)
+    category_today = _timed("category", get_category_accuracy, db, since, until, source, icao_filter)
+    notable = _timed("notable", get_notable_misses, db, since, until, source, icao_filter)
+    bias = _timed("bias", get_category_bias_stats, db, since, until, source, icao_filter)
+    wind = _timed("wind", get_wind_advisory_accuracy, db, since, until, source, icao_filter)
+    missed = _timed("missed", get_missed_warnings, db, since, until, source, icao_filter)
 
     category_7d: list[CategoryAccuracyRow] = []
     if include_7d:
         seven_days_ago = until - timedelta(days=7)
-        category_7d = get_category_accuracy(db, seven_days_ago, until, source, icao_filter)
+        category_7d = _timed(
+            "category_7d", get_category_accuracy, db, seven_days_ago, until, source, icao_filter,
+        )
+
+    # Sub-query breakdown so a pathological plan is visible in one log line
+    # (#448 — the activity COUNT(DISTINCT)s ran at ~9.5 min each for months
+    # with no trace). INFO when anything is meaningfully slow, DEBUG otherwise.
+    total_ms = sum(timings.values())
+    log = logger.info if total_ms > 5000 else logger.debug
+    log(
+        "get_digest_data(%s, %s): %dms total (%s)",
+        source, period_label or "-", total_ms,
+        " ".join(f"{k}={v}ms" for k, v in timings.items()),
+    )
 
     return VerificationDigestData(
         period_label=period_label,

--- a/src/weatherbrief/tasks/verification_stats.py
+++ b/src/weatherbrief/tasks/verification_stats.py
@@ -49,6 +49,13 @@ from weatherbrief.models.verification import (
 
 logger = logging.getLogger(__name__)
 
+# FORCE INDEX (#448): the activity COUNT(DISTINCT) queries name this index
+# explicitly (see get_activity_summary for why). FORCE INDEX raises a hard SQL
+# error on MySQL if the index is missing — it is declared on
+# VerificationScoreRow.__table_args__ and created by migration 038; keep the
+# three in sync.
+_SCORES_SOURCE_TIME_HINT = "FORCE INDEX (ix_verif_scores_source_time)"
+
 _DAYS_OUT_COLS = (0, 1, 2, 3)
 # Lead times a *miss* is worth surfacing at. An observation is scored once per
 # lead time, so without this scope one storm returns as one row per days_out —
@@ -129,21 +136,13 @@ def get_activity_summary(
     obs_count = db.execute(
         select(func.count(func.distinct(VerificationScoreRow.observation_id)))
         .select_from(VerificationScoreRow)
-        .with_hint(
-            VerificationScoreRow,
-            "FORCE INDEX (ix_verif_scores_source_time)",
-            dialect_name="mysql",
-        )
+        .with_hint(VerificationScoreRow, _SCORES_SOURCE_TIME_HINT, dialect_name="mysql")
         .where(*common_where)
     ).scalar() or 0
     airport_count = db.execute(
         select(func.count(func.distinct(VerificationScoreRow.icao)))
         .select_from(VerificationScoreRow)
-        .with_hint(
-            VerificationScoreRow,
-            "FORCE INDEX (ix_verif_scores_source_time)",
-            dialect_name="mysql",
-        )
+        .with_hint(VerificationScoreRow, _SCORES_SOURCE_TIME_HINT, dialect_name="mysql")
         .where(*common_where)
     ).scalar() or 0
 

--- a/src/weatherbrief/verify/__main__.py
+++ b/src/weatherbrief/verify/__main__.py
@@ -360,7 +360,15 @@ def cmd_standalone(args):
     print(f"  Duration: {result.get('duration_ms', 0)}ms")
 
     if args.with_rollup:
+        import time as _time
+
+        t_post = _time.monotonic()
         run_post_cycle_tasks(airports_db, result["cycle_type"])
+        post_ms = int((_time.monotonic() - t_post) * 1000)
+        # The cycle Duration above excludes post-cycle work, which historically
+        # hid a ~40-min cache rebuild (#448) — print the full picture.
+        print(f"  Post-cycle tasks (rollup + cache rebuild): {post_ms}ms")
+        print(f"  Total: {result.get('duration_ms', 0) + post_ms}ms")
 
 
 def cmd_rebuild_cache(args):

--- a/tests/test_cache_builder.py
+++ b/tests/test_cache_builder.py
@@ -264,3 +264,30 @@ class TestRebuildAllForecastMapSkip:
 
         assert forecast.called
         assert result["forecast_map"] == 20
+
+    def test_skip_score_stats_rebuilds_only_forecast_map(
+        self, db_session, mocker, tmp_path,
+    ):
+        """Forecast cycles create no scores → stats/leaderboard skipped (#448)."""
+        stats = mocker.patch(
+            "weatherbrief.tasks.cache_builder.rebuild_stats_cache",
+            return_value=6,
+        )
+        leaderboard = mocker.patch(
+            "weatherbrief.tasks.cache_builder.rebuild_bias_leaderboard_cache",
+            return_value=27,
+        )
+        forecast = mocker.patch(
+            "weatherbrief.tasks.cache_builder.rebuild_forecast_map_cache",
+            return_value=20,
+        )
+
+        result = rebuild_all(db_session, str(tmp_path / "nav.db"),
+                             include_score_stats=False)
+
+        assert not stats.called, "stats must be skipped on forecast cycles"
+        assert not leaderboard.called, "leaderboard must be skipped on forecast cycles"
+        assert forecast.called
+        assert result["stats"] == 0
+        assert result["bias_leaderboard"] == 0
+        assert result["forecast_map"] == 20

--- a/tests/test_standalone_verification.py
+++ b/tests/test_standalone_verification.py
@@ -797,3 +797,44 @@ class TestEnrichWithSounding:
 
         assert snap["temperature_2m_c"] == 15.0  # preserved
         assert "sounding_ceiling_ft" not in snap  # not added
+
+
+class TestRunPostCycleTasks:
+    """Cycle-aware post-cycle work (#448): rebuild only what the cycle changed."""
+
+    def _run(self, cycle_type):
+        from weatherbrief.tasks.standalone_verification import run_post_cycle_tasks
+
+        with patch("flyfun_common.db.SessionLocal") as sl, \
+             patch(
+                 "weatherbrief.tasks.verification_daily_rollup.rollup_today_and_pending",
+                 return_value=3,
+             ) as rollup, \
+             patch(
+                 "weatherbrief.tasks.cache_builder.rebuild_all",
+                 return_value={"duration_ms": 1},
+             ) as rebuild:
+            sl.return_value = MagicMock()
+            run_post_cycle_tasks("/fake/db", cycle_type)
+        return rollup, rebuild
+
+    def test_forecast_cycle_skips_rollup_and_score_stats(self):
+        rollup, rebuild = self._run("forecast")
+        assert not rollup.called, "forecast cycles create no scores — no rollup"
+        kwargs = rebuild.call_args.kwargs
+        assert kwargs["include_score_stats"] is False
+        assert kwargs["include_forecast_map"] is True
+
+    def test_light_cycle_skips_forecast_map(self):
+        rollup, rebuild = self._run("light")
+        assert rollup.called
+        kwargs = rebuild.call_args.kwargs
+        assert kwargs["include_score_stats"] is True
+        assert kwargs["include_forecast_map"] is False
+
+    def test_full_cycle_rebuilds_everything(self):
+        rollup, rebuild = self._run("full")
+        assert rollup.called
+        kwargs = rebuild.call_args.kwargs
+        assert kwargs["include_score_stats"] is True
+        assert kwargs["include_forecast_map"] is True


### PR DESCRIPTION
## Summary

PR A of #448 — removes the deterministic ~40-minute post-cycle cache rebuild and the smaller measured inefficiencies. Expected: forecast cycle **~110 → ~72 min**, light cycle **~40 → ~4 min**, ~4.5 h/day less MySQL load. (PR B will parallelize the sounding analysis that dominates the remaining fetch phase.)

## Changes

**1. `COUNT(DISTINCT)` query-plan fix (the 38-minute item)**
`get_activity_summary`'s two distinct-count queries let MySQL pick `ix_verif_scores_source_model_days` with `ref=const` on `source` alone — scanning all 3.8M standalone rows regardless of time window (7d and 30d each took ~19 min; 24h got the range plan and took 2 s). Verified on prod: `FORCE INDEX (ix_verif_scores_source_time)` → ~6 s. The hint is MySQL-only (`dialect_name="mysql"`); SQLite renders unchanged (compile-tested both dialects).

**2. Cycle-aware `run_post_cycle_tasks`**
Forecast cycles create no scores → skip rollup + stats/leaderboard caches, rebuild only the forecast map (~24 s). Light cycles keep skipping the map. `full` (CLI/legacy) rebuilds everything. `rebuild_all` gains `include_score_stats` mirroring the existing `include_forecast_map`.

**3. Migration 080 — two query-shape indexes**
- `verification_daily_stats (source, model, days_out, date)`: the bias-leaderboard filters equality columns with a date range; existing indexes lead with `date`/`icao`, so 30d/90d keys were 985K-row full scans (~9.5 s × 18 keys per rebuild).
- `taf_verification_scores (source, observation_time)`: TAF pseudo-model aggregates run at query time from raw and were 287K-row full scans.

**4. Bulk snapshot insert** — `_store_snapshots` now does chunked Core `executemany` instead of building 15–20K ORM objects (~1–2 min/cycle).

**5. Inert EDR pass removed** — the #221 accumulator iterated every derived level of ~56K soundings/cycle while collecting nothing (`analyze_sounding_lite` never computes Richardson). Plumbing kept; #221 stays parked.

**6. Instrumentation** — the 40-min rebuild ran with zero internal logging for months. Added: per-key stats timings, per-period leaderboard timings, `rebuild_all` per-step breakdown, `get_digest_data` sub-query breakdown (INFO when >5 s), per-chunk and ECMWF-leg sounding-analysis timings, and the CLI now prints post-cycle + total duration (the old `Duration:` line silently excluded ~42 min).

## Evidence

Full analysis in `scratch/standalone-cycle-debrief/ANALYSIS_optimization_review.md` (log mining of both 2026-07-17 cycles, prod EXPLAIN + timed probes, `verification_cache.computed_at` timeline).

## Testing

- `pytest tests/test_cache_builder.py tests/test_standalone_verification.py tests/test_standalone_subprocess.py tests/test_verification_stats_lead_scope.py tests/test_verification_stats_rollup_gate.py tests/test_verification_missed_warnings.py tests/test_verification_daily_rollup.py` → 101 passed (includes new pins: `include_score_stats` skip behavior + 3 cycle-awareness tests for `run_post_cycle_tasks`)
- `pytest tests/test_verification.py` → 28 passed
- Migration chain `base → 080` applied clean on scratch SQLite; both indexes present
- FORCE INDEX hint compile-verified on MySQL and SQLite dialects

Part of #448 — do not close on merge (PR B pending).

🤖 Generated with [Claude Code](https://claude.com/claude-code)