### PR TITLE
Flight list: red dot for flights with an unopened briefing

### DIFF
--- a/app/flyfun-weather/flyfun-weather/Models/API/FlightResponse.swift
+++ b/app/flyfun-weather/flyfun-weather/Models/API/FlightResponse.swift
@@ -292,6 +292,12 @@ struct BriefingStatusInfo: Codable, Sendable, Equatable {
     /// default — a `let` with a default would be dropped from the synthesized
     /// `Codable`, never decoding the field); absent on older servers → nil.
     let fetchTimestamp: String?
+    /// True when this flight has a notify-qualifying briefing update the pilot
+    /// hasn't opened yet — the same server predicate that drives the app-icon
+    /// badge. Drives the flight-row red "unseen" dot; the dot count matches the
+    /// badge. Optional (no default — like `fetchTimestamp`, so it still decodes)
+    /// and absent on older servers → nil (treated as not-unseen).
+    let unseen: Bool?
 }
 
 /// Compact RED/AMBER advisory breakdown for the flights-list card chips.

--- a/app/flyfun-weather/flyfun-weather/Views/Flights/FlightCardView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Flights/FlightCardView.swift
@@ -41,6 +41,16 @@ struct FlightCardView: View, Equatable {
             // Title row carries the status badge so the metadata row below can
             // use the full card width without being squeezed by the badge.
             HStack(spacing: 6) {
+                // Red "unseen" dot: a notify-qualifying briefing update the
+                // pilot hasn't opened yet (same predicate as the app-icon
+                // badge). Opening the briefing marks it seen and clears this.
+                if flight.latestBriefing?.unseen == true {
+                    Image(systemName: "circle.fill")
+                        .font(.system(size: 8))
+                        .foregroundStyle(.red)
+                        .accessibilityLabel("Unopened briefing update")
+                }
+
                 Text(flight.shortTitle)
                     .font(.headline)
                     .lineLimit(1)

--- a/app/flyfun-weather/flyfun-weatherTests/TestSupport.swift
+++ b/app/flyfun-weather/flyfun-weatherTests/TestSupport.swift
@@ -192,7 +192,8 @@ func makeBriefingStatus(
     outlookReason: String? = nil,
     hasAdvisories: Bool? = nil,
     advisorySummary: AdvisorySummary? = nil,
-    fetchTimestamp: String? = nil
+    fetchTimestamp: String? = nil,
+    unseen: Bool? = nil
 ) -> BriefingStatusInfo {
     BriefingStatusInfo(
         assessment: assessment,
@@ -201,7 +202,8 @@ func makeBriefingStatus(
         outlookReason: outlookReason,
         hasAdvisories: hasAdvisories,
         advisorySummary: advisorySummary,
-        fetchTimestamp: fetchTimestamp
+        fetchTimestamp: fetchTimestamp,
+        unseen: unseen
     )
 }
 

--- a/src/weatherbrief/api/flights.py
+++ b/src/weatherbrief/api/flights.py
@@ -26,6 +26,7 @@ from weatherbrief.fetch.variables import (
     is_beyond_forecast_horizon,
 )
 from weatherbrief.models import AdvisorySummary, Flight, FlightDebrief
+from weatherbrief.notify.badge import unseen_flight_ids
 from weatherbrief.storage.debriefs import bulk_get_debriefs, get_debrief as _get_debrief
 from weatherbrief.api.debriefs import DebriefResponse
 from weatherbrief.storage.flights import (
@@ -151,6 +152,12 @@ class BriefingStatusInfo(BaseModel):
     # flights-list card chips. Read straight from the denormalized pack column
     # (no per-flight route_advisories.json parse). None for old packs.
     advisory_summary: AdvisorySummary | None = None
+    # True when this flight has a notify-qualifying briefing update the viewer
+    # hasn't opened yet — the same server-derived predicate that drives the
+    # app-icon badge (notify/badge.py::_is_unseen). Lets the flight list mark
+    # unopened flights with a red dot, kept exactly consistent with the badge
+    # (dot count == badge count). Only set by the list endpoint; False elsewhere.
+    unseen: bool = False
 
 
 class CoveragePending(BaseModel):
@@ -443,6 +450,7 @@ def _flight_to_response(
     owner_display_name: str | None = None,
     debrief: FlightDebrief | None = None,
     section: Literal["future", "recent", "past"] | None = None,
+    unseen: bool = False,
 ) -> FlightResponse:
     # viewer_id is required: the role derivation below compares flight.user_id
     # against it, and with viewer_id=None we would silently classify the
@@ -477,6 +485,12 @@ def _flight_to_response(
             has_debrief=debrief is not None,
             recent_set=set(),  # single-flight call: no recent context available
         )
+
+    # Stamp the per-flight unseen flag onto the briefing summary (copy rather
+    # than mutate — the caller owns the passed-in object). Only the list
+    # endpoint passes unseen=True; single-flight callers leave it False.
+    if latest_briefing is not None and unseen:
+        latest_briefing = latest_briefing.model_copy(update={"unseen": True})
 
     return FlightResponse(
         id=flight.id,
@@ -637,6 +651,9 @@ def list_all_flights(
     paired = list_flights_with_role(db, user_id)
     pack_status = _get_latest_packs(db, [f.id for f, _, _ in paired])
     debrief_map = _bulk_debriefs_for_owned(db, paired, user_id)
+    # Flights with an unopened notify-qualifying update — drives the flight-list
+    # red dot, kept consistent with the app-icon badge. One cheap query.
+    unseen_ids = unseen_flight_ids(db, user_id)
 
     owned_pairs: list[tuple[Flight, FlightDebrief | None]] = [
         (f, debrief_map.get(f.id)) for f, role, _ in paired if role == "owner"
@@ -662,6 +679,7 @@ def list_all_flights(
             owner_display_name=owner_name,
             debrief=debrief,
             section=section,
+            unseen=f.id in unseen_ids,
         )
         (past if section == "past" else other).append(resp)
 

--- a/src/weatherbrief/notify/badge.py
+++ b/src/weatherbrief/notify/badge.py
@@ -81,12 +81,23 @@ def compute_badge_count(db: Session, user_id: str) -> int:
     Server-authoritative. Cheap: flights per user are few, so we load the
     user's seen rows and count in Python (tz-normalized comparison).
     """
+    return len(unseen_flight_ids(db, user_id))
+
+
+def unseen_flight_ids(db: Session, user_id: str) -> set[str]:
+    """Return the ids of the user's flights with an unseen briefing update.
+
+    Same predicate that drives the badge (``_is_unseen``), so the per-flight
+    dot on the flight list stays exactly consistent with the aggregate count
+    (``compute_badge_count`` is just ``len`` of this). One cheap query — flights
+    per user are few.
+    """
     rows = (
         db.query(FlightBriefingSeenRow)
         .filter(FlightBriefingSeenRow.user_id == user_id)
         .all()
     )
-    return sum(1 for r in rows if _is_unseen(r))
+    return {r.flight_id for r in rows if _is_unseen(r)}
 
 
 def record_notify_qualifying(

--- a/tests/test_briefing_notifications.py
+++ b/tests/test_briefing_notifications.py
@@ -229,6 +229,29 @@ def test_badge_multiple_flights(db_session, dev_user):
     assert badge_mod.compute_badge_count(db_session, DEV_USER_ID) == 1
 
 
+def test_unseen_flight_ids_matches_badge(db_session, dev_user):
+    # unseen_flight_ids is the per-flight set the badge counts — the two must
+    # stay consistent so the flight-list dots equal the app-icon badge.
+    _add_flight(db_session, "f1")
+    _add_flight(db_session, "f2")
+    _add_flight(db_session, "f3")
+    t0 = datetime(2026, 7, 8, 8, 0, tzinfo=timezone.utc)
+    for fid in ("f1", "f2", "f3"):
+        _add_pack(db_session, fid, t0)
+    badge_mod.record_notify_qualifying(db_session, DEV_USER_ID, "f1", t0)
+    badge_mod.record_notify_qualifying(db_session, DEV_USER_ID, "f2", t0)
+    db_session.flush()
+
+    ids = badge_mod.unseen_flight_ids(db_session, DEV_USER_ID)
+    assert ids == {"f1", "f2"}  # f3 was never notified
+    assert len(ids) == badge_mod.compute_badge_count(db_session, DEV_USER_ID)
+
+    # Opening f1 clears it from the set (and the badge).
+    badge_mod.mark_flight_seen(db_session, DEV_USER_ID, "f1")
+    db_session.flush()
+    assert badge_mod.unseen_flight_ids(db_session, DEV_USER_ID) == {"f2"}
+
+
 # ---------------------------------------------------------------------------
 # APNs sender: config, provider token, payloads
 # ---------------------------------------------------------------------------
@@ -728,6 +751,31 @@ def test_badge_and_seen_flow(client, app_db):
     r = client.post("/api/flights/f1/seen")
     assert r.status_code == 200 and r.json()["count"] == 0
     assert client.get("/api/flights/badge").json()["count"] == 0
+
+
+def test_flights_list_exposes_unseen_flag(client, app_db):
+    # The flight list carries a per-flight `unseen` flag (drives the red dot),
+    # kept consistent with the badge: true once a notify-qualifying refresh
+    # lands, false again after the briefing is opened.
+    def _unseen():
+        flights = client.get("/api/flights").json()
+        f1 = next(f for f in flights if f["id"] == "f1")
+        return f1["latest_briefing"]["unseen"]
+
+    assert _unseen() is False  # seeded pack, never notified
+
+    s = app_db()
+    badge_mod.record_notify_qualifying(
+        s, DEV_USER_ID, "f1", datetime(2026, 7, 8, 10, tzinfo=timezone.utc),
+    )
+    s.commit()
+    s.close()
+
+    assert _unseen() is True
+    assert client.get("/api/flights/badge").json()["count"] == 1
+
+    client.post("/api/flights/f1/seen")
+    assert _unseen() is False
 
 
 def test_badge_route_not_shadowed_by_flight_route(client):

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -2552,6 +2552,20 @@ label {
   display: inline-block;
 }
 
+/* Flight-card "unseen briefing" dot — this flight has a notify-qualifying
+   update the pilot hasn't opened yet (same predicate as the app-icon badge).
+   Rendered as a flex item in `.flight-header` (align-items: baseline), so it's
+   vertically centred with align-self and spaced by the header's flex gap. */
+.unseen-dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--red);
+  align-self: center;
+  flex-shrink: 0;
+}
+
 /* --- User info in header --- */
 
 .user-info {

--- a/web/ts/i18n/locales/de.json
+++ b/web/ts/i18n/locales/de.json
@@ -14,6 +14,7 @@
   "flights.showMorePast": "Mehr anzeigen ({count})",
   "flights.deleteConfirm": "Flug {id} löschen? Damit wird der gesamte Briefing-Verlauf entfernt.",
   "flights.noBriefings": "Noch keine Briefings vorhanden",
+  "flights.unseenDot": "Neue Briefing-Aktualisierung — noch nicht geöffnet",
   "flights.pendingAvailable": "Ausstehend · verfügbar {date}",
   "flights.pendingTitle": "Im Voraus gespeichert — noch keine Modelldaten; ein Briefing erscheint an diesem Datum.",
   "flights.advRedCount": "{count} RED",

--- a/web/ts/i18n/locales/en.json
+++ b/web/ts/i18n/locales/en.json
@@ -14,6 +14,7 @@
   "flights.showMorePast": "Show more ({count})",
   "flights.deleteConfirm": "Delete flight {id}? This removes all briefing history.",
   "flights.noBriefings": "No briefings yet",
+  "flights.unseenDot": "New briefing update — not opened yet",
   "flights.pendingAvailable": "Pending · available {date}",
   "flights.pendingTitle": "Saved ahead of the forecast — no model data yet; a briefing appears on this date.",
   "flights.advRedCount": "{count} RED",

--- a/web/ts/i18n/locales/es.json
+++ b/web/ts/i18n/locales/es.json
@@ -14,6 +14,7 @@
   "flights.showMorePast": "Mostrar más ({count})",
   "flights.deleteConfirm": "¿Eliminar el vuelo {id}? Se eliminará todo el historial de briefings.",
   "flights.noBriefings": "Aún no hay briefings",
+  "flights.unseenDot": "Nueva actualización del briefing — aún sin abrir",
   "flights.pendingAvailable": "Pendiente · disponible {date}",
   "flights.pendingTitle": "Guardado con antelación — aún sin datos de modelo; el briefing aparecerá en esa fecha.",
   "flights.advRedCount": "{count} RED",

--- a/web/ts/i18n/locales/fr.json
+++ b/web/ts/i18n/locales/fr.json
@@ -14,6 +14,7 @@
   "flights.showMorePast": "Afficher plus ({count})",
   "flights.deleteConfirm": "Supprimer le vol {id} ? Tout l'historique des briefings sera supprimé.",
   "flights.noBriefings": "Aucun briefing pour le moment",
+  "flights.unseenDot": "Nouvelle mise à jour du briefing — pas encore ouverte",
   "flights.pendingAvailable": "En attente · dispo {date}",
   "flights.pendingTitle": "Enregistré à l'avance — pas encore de données modèle ; un briefing apparaîtra à cette date.",
   "flights.advRedCount": "{count} RED",

--- a/web/ts/managers/flights-ui.ts
+++ b/web/ts/managers/flights-ui.ts
@@ -119,6 +119,14 @@ function renderFlightCard(
   const past = isFlightPast(f.target_date, f.target_time_utc, f.flight_duration_hours, f.departure_time);
   const pastBadge = past ? `<span class="badge badge-past">${t('flights.pastBadge')}</span> ` : '';
 
+  // Red "unseen" dot: this flight has a notify-qualifying briefing update the
+  // pilot hasn't opened yet (same server predicate as the app-icon badge).
+  // Clears naturally on the next flights load after the briefing is opened.
+  const unseenLabel = t('flights.unseenDot');
+  const unseenDot = f.latest_briefing?.unseen
+    ? `<span class="unseen-dot" role="img" title="${escapeHtml(unseenLabel)}" aria-label="${escapeHtml(unseenLabel)}"></span>`
+    : '';
+
   const isShared = f.role === 'subscriber';
   // When owner_display_name is null (no display_name set on the owner),
   // fall back to the generic shared-flight label instead of rendering
@@ -195,7 +203,7 @@ function renderFlightCard(
       <div class="flight-card-main">
         <div class="flight-card-body">
           <div class="flight-header">
-            ${sharedBadge}${pastBadge}<span class="flight-route">${escapeHtml(title)}</span>
+            ${sharedBadge}${pastBadge}${unseenDot}<span class="flight-route">${escapeHtml(title)}</span>
             <span class="flight-date">${formatDate(f.target_date)} ${formatDepartureTime(f.departure_time)}</span>
             <span class="flight-alt">${formatAlt(f.cruise_altitude_ft)}</span>${debriefPill}
           </div>

--- a/web/ts/store/types.ts
+++ b/web/ts/store/types.ts
@@ -39,6 +39,10 @@ export interface BriefingStatusInfo {
   // Compact RED/AMBER breakdown + top named categories for the card chips.
   // null for old packs (pre-#276 or not yet refreshed).
   advisory_summary?: AdvisorySummary | null;
+  // True when this flight has a notify-qualifying briefing update the viewer
+  // hasn't opened yet (same predicate as the app-icon badge). Drives the
+  // flight-card red "unseen" dot. Absent on older servers → treated as false.
+  unseen?: boolean;
 }
 
 /** Weather-coverage status for a flight saved beyond the forecast horizon.


### PR DESCRIPTION
## What & why

The unseen-briefing indicator (iOS app-icon badge + server-derived count) works, but when you open the flight list there's no way to tell **which** flights are unopened — only an aggregate number on the app icon.

The per-(user, flight) unseen state that drives the badge already exists server-side (`FlightBriefingSeenRow` + `notify/badge.py::_is_unseen`); it was just never exposed per-flight. This surfaces it on `GET /api/flights` and renders a small red dot on unopened flights in **both web and iOS**, reusing the **exact same predicate** as the badge so the dot count always equals the badge count (no new semantics, no migration, no new endpoint).

"Unseen" = an unopened *notify-qualifying* refresh (respects the user's Briefing-updates preference and doesn't light for a refresh you watched finish live) — deliberately identical to the badge, not a looser "newer pack than last opened".

**Server**
- `notify/badge.py`: add `unseen_flight_ids()`; `compute_badge_count()` is now `len()` of it, so the count and the per-flight set can never drift.
- `api/flights.py`: add `BriefingStatusInfo.unseen`, populated in the flights-list endpoint via one cheap query. `_flight_to_response` copies (not mutates) the summary to stamp the flag; single-flight callers leave it `False`.

**Web**
- `store/types.ts`: add `unseen` to `BriefingStatusInfo`.
- `flights-ui.ts`: render a red `.unseen-dot` in the flight-card header; new i18n label in en/es/fr/de. Clears on the next flights load after the briefing is opened (flights ↔ briefing are separate page loads).
- `style.css`: theme-aware dot via `var(--red)`, aligned as a flex item in `.flight-header`.

**iOS**
- `BriefingStatusInfo`: add optional `unseen` (mirrors the `fetchTimestamp` optional-`let` pattern, so it still decodes and is `nil` on older servers). `FlightCardView.==` already diffs `latestBriefing`, so the dot repaints without touching the Equatable.
- `FlightCardView`: red circle in the title row.

## Issue linkage

Closes #453

## Testing / verification

- `tests/test_briefing_notifications.py` (50 pass, +2 new): `unseen_flight_ids` matches the badge and clears on open; the `GET /api/flights` list exposes `latest_briefing.unseen` and it flips back to `false` after `POST /flights/{id}/seen`.
- `tests/test_flights_api_sections.py`, `test_flight_share_code.py`, `test_mcp_create_flight.py` (40 pass) — confirm the `_flight_to_response` signature change is safe.
- Web `tsc --noEmit`: no new errors in the changed files (the two remaining errors are pre-existing in `ts/eval/label-panel.ts`); `esbuild` bundles `flights-main.ts` cleanly.
- iOS not compiled here (no Xcode on Linux); verified the decoding contract by hand — no explicit `CodingKeys`, shared decoder uses `.convertFromSnakeCase`, and the `TestSupport` memberwise-init helper was updated for the new field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ENN29FS6pwmZRw3mGEd9AS

---
_Generated by [Claude Code](https://claude.ai/code/session_01ENN29FS6pwmZRw3mGEd9AS)_