### PR TITLE
ICON-D2 short-range upgrade: source the icon slot from ICON-D2 on domain + 48h fit

### DIFF
--- a/designs/fetch.md
+++ b/designs/fetch.md
@@ -192,7 +192,7 @@ if not status.fresh:
     schedule_refresh()
 ```
 
-Nine tracked source/model pairs (`SOURCE_REGISTRY` in `fetch/freshness/registry.py`): 3 direct GRIB (`ecmwf:direct`, `gfs:noaa`, `icon_eu:dwd`) + 6 Open-Meteo republishes (`gfs/ecmwf/icon/meteofrance/ukmo/gem:openmeteo`). Each `SourceConfig` carries schedule (cycles, delivery_offset, horizon) plus descriptive metadata (model/provider label, role, resolution, coverage, pressure_levels) feeding `/api/data-sources` and the help-page table.
+Ten tracked source/model pairs (`SOURCE_REGISTRY` in `fetch/freshness/registry.py`): 4 direct GRIB (`ecmwf:direct`, `gfs:noaa`, `icon_eu:dwd`, `icon_d2:dwd`) + 6 Open-Meteo republishes (`gfs/ecmwf/icon/meteofrance/ukmo/gem:openmeteo`). Each `SourceConfig` carries schedule (cycles, delivery_offset, horizon) plus descriptive metadata (model/provider label, role, resolution, coverage, pressure_levels) feeding `/api/data-sources` and the help-page table.
 
 The legacy `fetch/model_status.py` module (`fetch_model_metadata`, `check_freshness`, `compute_next_update`) is no longer consumed by the freshness endpoint's per-request path. `fetch_model_metadata` survives as a direct Open-Meteo init-time probe: it backs the Open-Meteo marker population in `fetch/freshness/sources.py` (background loop, not per-call) and is called directly by `tasks/alternates.py`, `tasks/standalone_verification.py`, `hewson/precompute.py`, `frontal/` (grid + CLI), and pack building in `api/packs.py`.
 
@@ -219,7 +219,7 @@ grib_init_times, grib_skip_reasons = enrich_forecasts(
 |--------|---------|
 | `gfs_idx.py` | Parse `.idx` files, plan HTTP byte ranges for CLMR/ICMR and cloud diagnostic variables |
 | `grib_fetch.py` | Find latest GFS run, bracket forecast hours, download via HTTP Range from S3 |
-| `icon_eu_fetch.py` | Find latest ICON-EU run, download model-level (QC/QI/P) and single-level diagnostics from DWD. Per-variable download for memory-efficient chunked decode |
+| `icon_eu_fetch.py` | Find latest DWD ICON run + download model-level (QC/QI/P) and single-level diagnostics. Parametrized by `IconVariant` (`ICON_EU` / `ICON_D2`) — one code path, two variants differing in domain, cycles, horizon, level slice, filename conventions, cache slug and freshness source key (#456). Per-variable download for memory-efficient chunked decode |
 | `icon_eu_levels.py` | Log-pressure interpolation from ICON-EU model levels to pressure levels |
 | `ecmwf_fetch.py` | Parse ECPDS filenames, scan delivery directory, find latest run. No HTTP — files land on local disk via ECPDS push |
 | `decode.py` | cfgrib → xarray decode, bilinear interpolation to route points. Chunked ICON-EU decoder (`decode_icon_eu_per_point_chunked()`) processes one variable at a time with explicit `gc.collect()` between — peak ~270MB vs ~800MB. ECMWF decoders handle multi-grid files (first-wins per point) |
@@ -240,9 +240,10 @@ grib_init_times, grib_skip_reasons = enrich_forecasts(
 6. Merge CLWMR/ICMR into `PressureLevelData` objects in-place
 7. Attach `NWPCloudDiagnostics` and override Open-Meteo cloud cover with GRIB values
 
-**ICON-EU enrichment** (two-phase sequential decode for memory safety):
-1. Check route is within ICON-EU domain (29.5–70.5°N, 23.5°W–62.5°E) — silently skip if outside
-2. Find latest ICON-EU run (3h cycles, ~3h publication delay)
+**ICON enrichment — EU or D2** (two-phase sequential decode for memory safety):
+0. **Variant gate (#456):** if the *whole* route fits the ICON-D2 domain (43.18–58.08°N, 3.94°W–20.34°E) AND a complete D2 run's 48h horizon reaches the flight-window end, source the icon slot from **ICON-D2** (2.2 km); otherwise **ICON-EU** (6.5 km). All-or-nothing, never a per-point mix. `_prepare_icon_eu` resolves the D2 run inline while gating so it never picks D2 without a usable run; on total D2 failure the slot re-runs cleanly on ICON-EU. The chosen source is reported out of `enrich_forecasts` via `grib_sources` and recorded on the pack (`model_sources["icon"]` = `icon_eu:dwd` / `icon_d2:dwd`) so the freshness bar can badge `ICON (D2)`.
+1. Check route is within the chosen variant's domain — silently skip if outside
+2. Find latest run (3h cycles; EU ~3h / D2 ~2h publication delay)
 3. **Phase 1 (parallel with GFS):** Download model-level files (QC/QI/P levels 35–74) and single-level diagnostics (CEILING, CLCL/CLCM/CLCH/CLCT, HBAS_CON, HTOP_CON) to disk cache
 4. **Phase 2 (after GFS completes):** Chunked decode — process one variable at a time via `decode_icon_eu_per_point_chunked()`, explicitly freeing memory between variables. Log-pressure interpolate to ICON pressure levels
 5. Merge QC→CLWMR, QI→ICMR into pressure-level data

--- a/designs/weather-engine-specs.md
+++ b/designs/weather-engine-specs.md
@@ -94,16 +94,19 @@ Via `fetch/grib/` (ecmwf_fetch.py, decode.py):
 - No HTTP, no cache — local disk I/O
 - Unit conversions: K→°C, m²/s²→m (geopotential), 0–1→% (cloud fractions), m/s→kt (wind)
 
-### ICON-EU GRIB2 enrichment
+### ICON-EU / ICON-D2 GRIB2 enrichment (the `icon` slot)
 Via `fetch/grib/` (icon_eu_fetch.py, icon_eu_levels.py, decode.py):
-- **Full sounding replacement** — model levels 35–74: t, qv, u, v, qc, qi, clc, p, w. Log-pressure interpolated to standard pressure levels. **Replaces entire `pressure_levels` list**. `w` (m/s) is converted to omega (`vertical_velocity_pa_s`) per level via −ρ·g·w.
-- **Cloud diagnostics** — single-level: ceiling, hbas_con, htop_con, clcl, clcm, clch, clct → `NWPCloudDiagnostics`
-- Source: `opendata.dwd.de/weather/nwp/icon-eu/grib/` (public, no auth)
+- **Full sounding replacement** — model levels 35–74 (EU) / 25–65 (D2): t, qv, u, v, qc, qi, clc, p, w. Log-pressure interpolated to standard pressure levels. **Replaces entire `pressure_levels` list**. `w` (m/s) is converted to omega (`vertical_velocity_pa_s`) per level via −ρ·g·w.
+- **Cloud diagnostics** — single-level: ceiling, hbas_con, htop_con, clcl, clcm, clch, clct, cape_ml, cin_ml, rain_con → `NWPCloudDiagnostics`
+- Source: `opendata.dwd.de/weather/nwp/{icon-eu,icon-d2}/grib/` (public, no auth)
 - Individual bz2-compressed files per variable/level/timestep
 - Parallel download with ThreadPoolExecutor (8 workers)
-- Domain: 29.5–70.5°N, 23.5°W–62.5°E (Europe) — routes outside skip silently
-- Cycles: every 3h (00–21z), ~3h publication delay
-- Disk cache (12h TTL) at `data/.cache/grib/icon-eu/{date}_{cycle}z/`
+- **Variant selection (issue #456):** the `icon` slot is served by **ICON-D2** (2.2 km, convection-permitting) when the *whole* route fits the D2 domain (43.18–58.08°N, 3.94°W–20.34°E) AND a complete D2 run's 48h horizon reaches the flight-window end; otherwise by **ICON-EU** (6.5 km, all-Europe) exactly as before. All-or-nothing — never a per-point mix of D2 and EU within one briefing. On total D2 failure the icon slot re-runs cleanly on ICON-EU (never a half-D2 pack).
+- The two variants share the whole download/decode path via `IconVariant` (a config object holding domain, cycles, horizon, level slice, filename conventions, cache slug and freshness source key). ICON-D2 filename quirks: model token `icon-d2`, region token `germany`, **lowercase** variable suffix (`…_60_t`), and a `_2d_` segment on single-level files (`…_006_2d_ceiling`).
+- Domain: EU 29.5–70.5°N, 23.5°W–62.5°E; D2 43.18–58.08°N, 3.94°W–20.34°E. Routes outside the chosen domain skip silently.
+- Cycles: both every 3h (00–21z). EU ~3h publication delay, hourly to 78h then 3-hourly to 120h. D2 ~2h delay, hourly to 48h.
+- Disk cache at `data/.cache/grib/{icon-eu,icon-d2}/{date}_{cycle}z/` (EU 12h TTL, D2 6h TTL). Per-variant cache-key prefix (`ICON_EU_*` / `ICON_D2_*`) keeps them distinct.
+- Pack metadata records which source produced the icon slot via `model_sources["icon"]` = `icon_eu:dwd` or `icon_d2:dwd`; the freshness bar badges `ICON (D2)` when D2 supplied the run.
 
 See [fetch.md](./fetch.md) for implementation details.
 
@@ -156,6 +159,19 @@ See [fetch.md](./fetch.md) for implementation details.
 - **Publication delay:** ~3h after init time
 - **Data retention:** DWD deletes files after ~24h (only latest run available per cycle)
 - **Download:** Individual bz2-compressed files, parallel with 8 workers
+
+### C.2 DWD ICON-D2 (Central Europe, convection-permitting) — IMPLEMENTED (full sounding, #456)
+- **Server:** `https://opendata.dwd.de/weather/nwp/icon-d2/grib/`
+- **Model-level path:** `{HH}/{var}/icon-d2_germany_regular-lat-lon_model-level_{YYYYMMDDHH}_{FFF}_{LL}_{var}.grib2.bz2` — note **lowercase** variable suffix (vs ICON-EU's uppercase).
+- **Single-level path:** `{HH}/{var}/icon-d2_germany_regular-lat-lon_single-level_{YYYYMMDDHH}_{FFF}_2d_{var}.grib2.bz2` — note the `2d` segment (vs ICON-EU's absent segment).
+- **Resolution:** ~2.2 km, regular lat-lon grid (same grid *type* as ICON-EU → existing bilinear interpolation works unchanged).
+- **Domain:** 43.18–58.08°N, 3.94°W–20.34°E (Germany, Alps, Benelux, most of France, SE England; excludes Brittany, Scotland, Spain). ~906 k grid points ≈ ICON-EU's ~905 k, so no new download-volume / memory / decode-time concern.
+- **Model levels:** 65 total (bottom = 65). Aviation slice **25–65** (41 levels) — a deliberately conservative top so the log-p interpolation's fetched column spans surface→~FL300; validate against DWD's D2 HHL table when the feed is reachable.
+- **Cycles/horizon:** 8 runs/day (00–21z every 3h), hourly steps to **48h** (no coarse tail). Publication delay ~1–2h.
+- **Variables:** identical set + names to ICON-EU (model-level `t, qv, u, v, p, w, qc, qi, clc`; single-level `ceiling, hbas_con, htop_con, clcl/clcm/clch/clct, cape_ml/cin_ml, rain_con`).
+- **Gating (all-or-nothing):** used for the `icon` slot only when every route point is inside the D2 domain AND `flight_window_end ≤ selected_run_init + 48h`. If either fails → pure ICON-EU. If the freshest complete D2 run doesn't cover the window, fall back to ICON-EU rather than a stale D2 run.
+- **Freshness:** source key `icon_d2:dwd` in `SOURCE_REGISTRY` (readiness check `icon_d2_dwd`), cache dir `data/.cache/grib/icon-d2/{date}_{cycle}z/` (6h TTL).
+- **Out of scope:** per-point D2/EU mixing, D2's 15-min sub-hourly output, ICON-D2-EPS ensemble.
 
 ### ICON-EU Variable Reference
 

--- a/designs/weather-engine-specs.md
+++ b/designs/weather-engine-specs.md
@@ -96,7 +96,7 @@ Via `fetch/grib/` (ecmwf_fetch.py, decode.py):
 
 ### ICON-EU / ICON-D2 GRIB2 enrichment (the `icon` slot)
 Via `fetch/grib/` (icon_eu_fetch.py, icon_eu_levels.py, decode.py):
-- **Full sounding replacement** — model levels 35–74 (EU) / 25–65 (D2): t, qv, u, v, qc, qi, clc, p, w. Log-pressure interpolated to standard pressure levels. **Replaces entire `pressure_levels` list**. `w` (m/s) is converted to omega (`vertical_velocity_pa_s`) per level via −ρ·g·w.
+- **Full sounding replacement** — model levels 35–74 (EU) / 16–65 (D2): t, qv, u, v, qc, qi, clc, p, w. Log-pressure interpolated to standard pressure levels. **Replaces entire `pressure_levels` list**. `w` (m/s) is converted to omega (`vertical_velocity_pa_s`) per level via −ρ·g·w.
 - **Cloud diagnostics** — single-level: ceiling, hbas_con, htop_con, clcl, clcm, clch, clct, cape_ml, cin_ml, rain_con → `NWPCloudDiagnostics`
 - Source: `opendata.dwd.de/weather/nwp/{icon-eu,icon-d2}/grib/` (public, no auth)
 - Individual bz2-compressed files per variable/level/timestep
@@ -166,9 +166,9 @@ See [fetch.md](./fetch.md) for implementation details.
 - **Single-level path:** `{HH}/{var}/icon-d2_germany_regular-lat-lon_single-level_{YYYYMMDDHH}_{FFF}_2d_{var}.grib2.bz2` — note the `2d` segment (vs ICON-EU's absent segment).
 - **Resolution:** ~2.2 km, regular lat-lon grid (same grid *type* as ICON-EU → existing bilinear interpolation works unchanged).
 - **Domain:** 43.18–58.08°N, 3.94°W–20.34°E (Germany, Alps, Benelux, most of France, SE England; excludes Brittany, Scotland, Spain). ~906 k grid points ≈ ICON-EU's ~905 k, so no new download-volume / memory / decode-time concern.
-- **Model levels:** 65 total (bottom = 65). Aviation slice **25–65** (41 levels) — a deliberately conservative top so the log-p interpolation's fetched column spans surface→~FL300; validate against DWD's D2 HHL table when the feed is reachable.
+- **Model levels:** 65 total (bottom = 65; numbering NOT comparable to ICON-EU's 74). Aviation slice **16–65** (50 levels) — level 16 ≈ 9,460 m ≈ FL310, matching ICON-EU's level-35 (~300 hPa) top. Validated against DWD's HHL (half-level height) field decoded from the live feed 2026-07-21; the original guess of 25 sat at ~6,300 m ≈ FL207 and would have truncated every D2 sounding.
 - **Cycles/horizon:** 8 runs/day (00–21z every 3h), hourly steps to **48h** (no coarse tail). Publication delay ~1–2h.
-- **Variables:** identical set + names to ICON-EU (model-level `t, qv, u, v, p, w, qc, qi, clc`; single-level `ceiling, hbas_con, htop_con, clcl/clcm/clch/clct, cape_ml/cin_ml, rain_con`).
+- **Variables:** model-level set identical to ICON-EU (`t, qv, u, v, p, w, qc, qi, clc` — all verified live). Single-level set is **smaller**: `ceiling, clcl/clcm/clch/clct, cape_ml/cin_ml` only. D2 runs no deep-convection scheme, so `hbas_con`/`htop_con` don't exist (404; the shallow-only `hbas_sc`/`htop_sc` would mislead) and `rain_con` is near-zero even in explicit storms — all three deliberately unfetched → downstream fields **None** (missing-data semantics). Issue #462 adds the convection-permitting replacements (`dbz_cmax`, `echotop`, `lpi`, `uh_max`, `prg_gsp`).
 - **Gating (all-or-nothing):** used for the `icon` slot only when every route point is inside the D2 domain AND `flight_window_end ≤ selected_run_init + 48h`. If either fails → pure ICON-EU. If the freshest complete D2 run doesn't cover the window, fall back to ICON-EU rather than a stale D2 run.
 - **Freshness:** source key `icon_d2:dwd` in `SOURCE_REGISTRY` (readiness check `icon_d2_dwd`), cache dir `data/.cache/grib/icon-d2/{date}_{cycle}z/` (6h TTL).
 - **Out of scope:** per-point D2/EU mixing, D2's 15-min sub-hourly output, ICON-D2-EPS ensemble.

--- a/src/weatherbrief/api/airport_profile.py
+++ b/src/weatherbrief/api/airport_profile.py
@@ -478,7 +478,7 @@ def _grib_enrich_levels(
     duration_h = (hours[-1] - hours[0]).total_seconds() / 3600.0
 
     try:
-        grib_init_times, grib_skip_reasons = enrich_forecasts(
+        grib_init_times, grib_skip_reasons, grib_sources = enrich_forecasts(
             cross_sections=[cs],
             all_forecasts=[waypoint_forecast],
             route_points=[point],
@@ -493,7 +493,13 @@ def _grib_enrich_levels(
 
     sources: dict[str, dict[str, Any]] = {}
     for m, ts in grib_init_times.items():
-        sources[m] = {"init_time_unix": ts}
+        entry: dict[str, Any] = {"init_time_unix": ts}
+        # Which direct-GRIB source produced this model's run — lets the icon
+        # slot report ICON-D2 vs ICON-EU (issue #456).
+        src = grib_sources.get(m)
+        if src:
+            entry["source"] = src
+        sources[m] = entry
     skipped = {m: reason for m, reason in grib_skip_reasons.items()}
     return {"sources": sources, "skipped": skipped}
 

--- a/src/weatherbrief/api/packs.py
+++ b/src/weatherbrief/api/packs.py
@@ -501,6 +501,12 @@ def get_freshness(
 # that model.  Single source of truth: used by both ``_finalize_refresh``
 # (records ``model_sources`` on new packs) and ``_backfill_sources`` (infers
 # source for legacy packs missing the column).
+#
+# The icon slot's default here is ICON-EU; when a briefing was actually
+# enriched from ICON-D2 the pipeline reports it via ``result.grib_sources``,
+# which ``_finalize_refresh`` prefers over this static map (issue #456).
+# Legacy packs (pre-#456) predate ICON-D2, so ``icon → icon_eu:dwd`` remains
+# correct for ``_backfill_sources``.
 _DIRECT_SOURCE_KEYS: dict[str, str] = {
     "ecmwf": "ecmwf:direct",
     "gfs": "gfs:noaa",
@@ -1315,8 +1321,11 @@ def _build_pack_meta(
     # direct-GRIB source where GRIB enrichment succeeded.  Used by the
     # marker-based freshness check (issue #108).
     model_sources: dict[str, str] = {m: f"{m}:openmeteo" for m in init_times}
+    grib_sources = getattr(result, "grib_sources", None) or {}
     for m in result.grib_init_times:
-        key = _DIRECT_SOURCE_KEYS.get(m)
+        # Prefer the source the enrichment actually used (icon may be D2 or EU,
+        # #456); fall back to the static default for legacy results.
+        key = grib_sources.get(m) or _DIRECT_SOURCE_KEYS.get(m)
         if key:
             model_sources[m] = key
 

--- a/src/weatherbrief/fetch/freshness/registry.py
+++ b/src/weatherbrief/fetch/freshness/registry.py
@@ -165,6 +165,13 @@ _ICON_EU_HORIZON: dict[int, timedelta] = {
     for h in (0, 3, 6, 9, 12, 15, 18, 21)
 }
 
+# ICON-D2: 2.2 km convection-permitting, 8 runs/day (every 3h), all cycles
+# hourly to 48h. Publication delay ~1–2h — 2h with margin (ICON_D2.publish_
+# delay_hours in icon_eu_fetch.py). Used in place of ICON-EU for the icon slot
+# on short, central-European flights (issue #456).
+_ICON_D2_OFFSET = timedelta(hours=2)
+_ICON_D2_HORIZON = timedelta(hours=48)
+
 # Open-Meteo offsets — calibrated against meta.json observation 2026-05-03.
 # Open-Meteo republishes other providers' models with notable lag; the figures
 # in issue #108's table (sourced from OM docs) underestimate real delivery.
@@ -251,6 +258,28 @@ SOURCE_REGISTRY: dict[str, SourceConfig] = {
             "cycles 00/06/12/18 reach 120h, intermediate cycles reach 78h."
         ),
     ),
+    "icon_d2:dwd": SourceConfig(
+        key="icon_d2:dwd",
+        cycles=(0, 3, 6, 9, 12, 15, 18, 21),
+        delivery_offset=_ICON_D2_OFFSET,
+        horizon=_ICON_D2_HORIZON,
+        readiness_check="icon_d2_dwd",
+        model_label="ICON-D2",
+        provider_label="DWD",
+        provider_url="https://www.dwd.de/EN/ourservices/opendata/opendata.html",
+        role="primary-sounding",
+        resolution="~2.2 km",
+        coverage="Central Europe (43.18–58.08°N, 3.94°W–20.34°E)",
+        pressure_levels=41,
+        description=(
+            "Direct GRIB from DWD ICON-D2 opendata (2.2 km, convection-"
+            "permitting). 65 model levels interpolated to pressure levels — "
+            "full sounding replacement plus cloud microphysics and "
+            "diagnostics. 8 cycles/day (every 3h), hourly to 48h. Serves the "
+            "icon slot in place of ICON-EU when the whole route fits the D2 "
+            "domain and the flight window is within 48h; otherwise ICON-EU."
+        ),
+    ),
     "gfs:openmeteo": SourceConfig(
         key="gfs:openmeteo",
         cycles=(0, 6, 12, 18),
@@ -313,8 +342,8 @@ SOURCE_REGISTRY: dict[str, SourceConfig] = {
         description=(
             "Open-Meteo's ICON seamless feed (19 pressure levels). Serves "
             "the global ICON-Global variant; over Europe the regional "
-            "ICON-EU GRIB from DWD takes over as the primary sounding. "
-            "Note: ICON-D2 (2.2 km, central Europe, 27h) is not yet fetched."
+            "ICON-EU GRIB from DWD takes over as the primary sounding, and "
+            "ICON-D2 (2.2 km) supersedes it on short central-European routes."
         ),
     ),
     "meteofrance:openmeteo": SourceConfig(

--- a/src/weatherbrief/fetch/freshness/registry.py
+++ b/src/weatherbrief/fetch/freshness/registry.py
@@ -270,14 +270,16 @@ SOURCE_REGISTRY: dict[str, SourceConfig] = {
         role="primary-sounding",
         resolution="~2.2 km",
         coverage="Central Europe (43.18–58.08°N, 3.94°W–20.34°E)",
-        pressure_levels=41,
+        pressure_levels=50,
         description=(
             "Direct GRIB from DWD ICON-D2 opendata (2.2 km, convection-"
-            "permitting). 65 model levels interpolated to pressure levels — "
-            "full sounding replacement plus cloud microphysics and "
+            "permitting). Model levels 16–65 interpolated to pressure levels "
+            "— full sounding replacement plus cloud microphysics and "
             "diagnostics. 8 cycles/day (every 3h), hourly to 48h. Serves the "
             "icon slot in place of ICON-EU when the whole route fits the D2 "
-            "domain and the flight window is within 48h; otherwise ICON-EU."
+            "domain and the flight window is within 48h; otherwise ICON-EU. "
+            "No deep-convection scheme: convective base/top and rain_con are "
+            "absent by design (see #462 for the native replacements)."
         ),
     ),
     "gfs:openmeteo": SourceConfig(

--- a/src/weatherbrief/fetch/freshness/sources.py
+++ b/src/weatherbrief/fetch/freshness/sources.py
@@ -122,6 +122,34 @@ def _check_icon_eu_dwd(model: str) -> Observation | None:
     )
 
 
+def _check_icon_d2_dwd(model: str) -> Observation | None:
+    """Return latest ICON-D2 run whose bottom-level P file responds 200 on HEAD.
+
+    Same shape as :func:`_check_icon_eu_dwd` but for the ICON-D2 variant — the
+    run-finder is parametrized on ``ICON_D2`` so it probes the D2 filename and
+    honours D2's 8-cycle / 2h-delay schedule. As with ICON-EU the marker itself
+    is horizon-agnostic; the freshness check applies horizon-awareness later.
+    """
+    from weatherbrief.fetch.grib.icon_eu_fetch import (
+        ICON_D2,
+        find_latest_icon_eu_run_with_response,
+    )
+    now = datetime.now(timezone.utc)
+    result = find_latest_icon_eu_run_with_response(
+        target_time=now, cover_until=now, variant=ICON_D2,
+    )
+    if result is None:
+        return None
+    init_date, init_hour, resp = result
+    init = datetime.strptime(f"{init_date}{init_hour:02d}", "%Y%m%d%H").replace(
+        tzinfo=timezone.utc,
+    )
+    return Observation(
+        init=init,
+        published_at=_parse_last_modified(resp.headers.get("Last-Modified")),
+    )
+
+
 def _parse_last_modified(header: str | None) -> datetime | None:
     """Parse a ``Last-Modified`` HTTP header into an aware UTC datetime.
 
@@ -174,6 +202,7 @@ _DISPATCH = {
     "ecmwf_direct": _check_ecmwf_direct,
     "gfs_noaa": _check_gfs_noaa,
     "icon_eu_dwd": _check_icon_eu_dwd,
+    "icon_d2_dwd": _check_icon_d2_dwd,
     "om_meta": _check_om_meta,
 }
 

--- a/src/weatherbrief/fetch/grib/__init__.py
+++ b/src/weatherbrief/fetch/grib/__init__.py
@@ -3157,8 +3157,10 @@ def _prefetch_icon_eu_data_inner(ctx: _IconEuContext) -> None:
 
     # One leading single-level step so the first window hour has a predecessor
     # to de-accumulate rain_con against (#421). Cloud-diag fetch only — the
-    # model-level sounding list above is untouched.
-    if ctx.forecast_hours:
+    # model-level sounding list above is untouched. Skipped when the variant
+    # doesn't fetch rain_con (ICON-D2, #456/#462) — no accumulated field, no
+    # predecessor needed.
+    if ctx.forecast_hours and "rain_con" in variant.cloud_diag_variables:
         lead = icon_eu_previous_step(min(ctx.forecast_hours), variant)
         if lead is not None and lead not in ctx.forecast_hours:
             lead_ck = cache_key(lead, diag_key)
@@ -3348,7 +3350,7 @@ def _enrich_icon_eu_cloud_diagnostics(
     # _matches_valid_time never matches an out-of-window hourly, so it only
     # seeds the de-accumulation state.
     steps = sorted(set(forecast_hours))
-    if steps:
+    if steps and "rain_con" in variant.cloud_diag_variables:
         lead = icon_eu_previous_step(steps[0], variant)
         if lead is not None and lead not in steps:
             steps.insert(0, lead)

--- a/src/weatherbrief/fetch/grib/__init__.py
+++ b/src/weatherbrief/fetch/grib/__init__.py
@@ -1904,11 +1904,13 @@ def enrich_forecasts(
     progress_callback: Callable[[str, str | None], None] | None = None,
     as_of_time: datetime | None = None,
     priority: int | DecodePriority | None = None,
-) -> tuple[dict[str, int], dict[str, str]]:
+) -> tuple[dict[str, int], dict[str, str], dict[str, str]]:
     """Enrich cross-section forecasts with cloud water from GRIB2 sources.
 
     Enriches GFS cross-sections with CLWMR/ICMR and cloud diagnostics.
-    Enriches ICON cross-sections with QC/QI if route is within ICON-EU domain.
+    Enriches ICON cross-sections with QC/QI when the route is within a DWD ICON
+    domain — from ICON-D2 (2.2 km) when the whole route fits the D2 domain and
+    the flight window is within 48h, otherwise ICON-EU (issue #456).
 
     This modifies PressureLevelData and HourlyForecast objects in-place.
 
@@ -1929,13 +1931,13 @@ def enrich_forecasts(
             level.
 
     Returns:
-        Tuple of (grib_init_times, grib_skip_reasons):
+        Tuple of (grib_init_times, grib_skip_reasons, grib_sources):
         - grib_init_times: model name → GRIB init Unix timestamp.
         - grib_skip_reasons: model name → skip reason string (e.g. "out_of_range").
+        - grib_sources: model name → freshness source key actually used
+          (e.g. ``"icon"`` → ``"icon_eu:dwd"`` or ``"icon_d2:dwd"``). Lets pack
+          building attribute the icon slot to the right variant.
     """
-    grib_init_times: dict[str, int] = {}
-    grib_skip_reasons: dict[str, str] = {}
-
     timer = _GribTimer()
     token = _GRIB_TIMER.set(timer)
     ptoken = _DECODE_PRIORITY.set(_resolve_priority(priority))
@@ -1968,6 +1970,10 @@ def _enrich_forecasts_inner(
     """Inner body of enrich_forecasts; assumes _GRIB_TIMER is set to *timer*."""
     grib_init_times: dict[str, int] = {}
     grib_skip_reasons: dict[str, str] = {}
+    # model → freshness source key actually used for the direct-GRIB run. The
+    # icon slot varies (icon_eu:dwd vs icon_d2:dwd) so it can't be inferred from
+    # the model name alone — pack recording reads this (issue #456).
+    grib_sources: dict[str, str] = {}
 
     timer.rss_mark("enrich_start")
 
@@ -2029,21 +2035,50 @@ def _enrich_forecasts_inner(
 
     if ecmwf_grib_ts is not None:
         grib_init_times["ecmwf"] = ecmwf_grib_ts
+        grib_sources["ecmwf"] = "ecmwf:direct"
 
-    # Phase 2: Decode ICON-EU sequentially (memory-heavy, GFS is done).
+    # Phase 2: Decode ICON sequentially (memory-heavy, GFS is done).
+    active_icon_variant = icon_ctx.variant if icon_ctx is not None else None
     with _grib_time("phase2_icon_decode"):
         if icon_ctx is not None:
             icon_ts, icon_skip = _decode_and_merge_icon_eu(
                 icon_ctx, cross_sections, all_forecasts, route_points,
             )
+            # Fallback robustness (#456): if ICON-D2 was selected but produced
+            # NO enrichment at all (D2 feed hiccup / decode failure), re-run the
+            # whole icon slot on ICON-EU rather than leave it un-enriched — never
+            # a half-D2 pack. A partial D2 success (some hours) keeps D2 and lets
+            # the normal time/spatial fill cover gaps, same as ICON-EU today.
+            if icon_ts is None and active_icon_variant is not None \
+                    and active_icon_variant.slug == "icon-d2":
+                from weatherbrief.fetch.grib.icon_eu_fetch import ICON_EU
+                logger.warning(
+                    "ICON-D2 enrichment produced nothing; falling back to ICON-EU",
+                )
+                eu_ctx, eu_skip = _prepare_icon_eu(
+                    cross_sections, route_points, departure_time,
+                    data_dir=data_dir, flight_duration_hours=flight_duration_hours,
+                    as_of_time=as_of_time, force_variant=ICON_EU,
+                )
+                if eu_ctx is not None:
+                    _prefetch_icon_eu_data(eu_ctx)
+                    icon_ts, icon_skip = _decode_and_merge_icon_eu(
+                        eu_ctx, cross_sections, all_forecasts, route_points,
+                    )
+                    active_icon_variant = eu_ctx.variant
+                elif eu_skip is not None:
+                    icon_skip = eu_skip
         else:
             icon_ts, icon_skip = None, icon_prepare_skip
     timer.rss_mark("after_phase2")
 
     if gfs_ts is not None:
         grib_init_times["gfs"] = gfs_ts
+        grib_sources["gfs"] = "gfs:noaa"
     if icon_ts is not None:
         grib_init_times["icon"] = icon_ts
+        if active_icon_variant is not None:
+            grib_sources["icon"] = active_icon_variant.source_key
     elif icon_skip is not None:
         grib_skip_reasons["icon"] = icon_skip
 
@@ -2064,7 +2099,7 @@ def _enrich_forecasts_inner(
         apply_gfs_rh_condensate_gate(cross_sections, all_forecasts)
 
     timer.rss_mark("enrich_end")
-    return grib_init_times, grib_skip_reasons
+    return grib_init_times, grib_skip_reasons, grib_sources
 
 
 # ---------------------------------------------------------------------------
@@ -2879,18 +2914,18 @@ def _enrich_cloud_diagnostics(
 
 
 class _IconEuContext:
-    """Holds resolved ICON-EU run info for split download/decode phases."""
+    """Holds resolved ICON run info (EU or D2) for split download/decode phases."""
 
     __slots__ = (
         "init_date", "init_hour", "forecast_hours", "run_dir",
-        "levels", "point_lats", "point_lons", "session",
+        "levels", "point_lats", "point_lons", "session", "variant",
     )
 
     def __init__(
         self, init_date: str, init_hour: int, forecast_hours: list[int],
         run_dir: Path, levels: list[int],
         point_lats: list[float], point_lons: list[float],
-        session: requests.Session,
+        session: requests.Session, variant,
     ):
         self.init_date = init_date
         self.init_hour = init_hour
@@ -2900,6 +2935,8 @@ class _IconEuContext:
         self.point_lats = point_lats
         self.point_lons = point_lons
         self.session = session
+        # IconVariant (ICON_EU / ICON_D2) chosen for this briefing's icon slot.
+        self.variant = variant
 
 
 def _prepare_icon_eu(
@@ -2910,24 +2947,33 @@ def _prepare_icon_eu(
     data_dir: Path,
     flight_duration_hours: float = 0.0,
     as_of_time: datetime | None = None,
+    force_variant=None,
 ) -> tuple[_IconEuContext | None, str | None]:
-    """Resolve ICON-EU run info and check eligibility.
+    """Resolve the ICON run (EU or D2) for the icon slot and check eligibility.
+
+    The ``icon`` slot is served by **ICON-D2** (2.2 km, convection-permitting)
+    when the *whole* route fits the D2 domain AND a complete D2 run's 48h
+    horizon reaches the flight-window end (issue #456 all-or-nothing gate);
+    otherwise by **ICON-EU** exactly as before. Never a per-point mix.
+
+    ``force_variant`` pins the variant (used by the total-D2-failure fallback to
+    re-run cleanly on ICON-EU) and skips the D2 gate.
 
     Returns ``(context, skip_reason)``. When the context is None the enrichment
     is skipped; ``skip_reason`` classifies *why* so the fetch stage can emit an
     accurate diagnostic instead of the generic "unavailable for this model"
     warning:
 
-    - ``"out_of_domain"`` — route lies outside the ICON-EU grid (expected for
-      non-European routes).
-    - ``"out_of_range"`` — flight window is beyond ICON-EU's 120h horizon
-      (expected for flights >~5 days out).
+    - ``"out_of_domain"`` — route lies outside the chosen grid (expected for
+      non-European routes on the EU fallback).
+    - ``"out_of_range"`` — flight window is beyond the chosen model's horizon
+      (EU 120h / D2 48h).
     - ``None`` — no ICON sections, or a genuine failure (run-finder raised, or
       a run should exist but couldn't be probed); the generic warning stands.
     """
     from weatherbrief.fetch.grib.icon_eu_fetch import (
-        ICON_EU_MODEL_LEVEL_MAX,
-        ICON_EU_MODEL_LEVEL_MIN,
+        ICON_D2,
+        ICON_EU,
         compute_icon_eu_flight_window_hours,
         find_latest_icon_eu_run,
         icon_eu_window_out_of_range,
@@ -2939,50 +2985,74 @@ def _prepare_icon_eu(
         logger.debug("No ICON cross-sections to enrich")
         return None, None
 
-    if not route_in_icon_eu_domain(route_points):
-        logger.info("Route outside ICON-EU domain, skipping ICON-EU enrichment")
+    session = _grib_session()
+    cover_until = departure_time + timedelta(hours=flight_duration_hours)
+
+    # Variant selection. Prefer ICON-D2 when the whole route fits its domain and
+    # a complete D2 run covers the window; the run is resolved here (not
+    # re-probed) so we never pick D2 without a usable run. Otherwise ICON-EU.
+    variant = force_variant
+    run_info: tuple[str, int] | None = None
+    if variant is None:
+        variant = ICON_EU
+        if route_in_icon_eu_domain(route_points, ICON_D2):
+            try:
+                d2_run = find_latest_icon_eu_run(
+                    departure_time, session=session, as_of_time=as_of_time,
+                    cover_until=cover_until, variant=ICON_D2,
+                )
+            except Exception:
+                logger.warning("Failed to find ICON-D2 run; using ICON-EU", exc_info=True)
+                d2_run = None
+            if d2_run is not None:
+                variant, run_info = ICON_D2, d2_run
+                logger.info(
+                    "ICON slot sourced from ICON-D2 (route in D2 domain, run %s %02dz)",
+                    d2_run[0], d2_run[1],
+                )
+
+    if not route_in_icon_eu_domain(route_points, variant):
+        logger.info("Route outside %s domain, skipping ICON enrichment", variant.slug)
         return None, "out_of_domain"
 
-    session = _grib_session()
-
-    cover_until = departure_time + timedelta(hours=flight_duration_hours)
-    try:
-        run_info = find_latest_icon_eu_run(
-            departure_time, session=session, as_of_time=as_of_time,
-            cover_until=cover_until,
-        )
-    except Exception:
-        logger.warning("Failed to find ICON-EU model run", exc_info=True)
-        return None, None
+    if run_info is None:
+        try:
+            run_info = find_latest_icon_eu_run(
+                departure_time, session=session, as_of_time=as_of_time,
+                cover_until=cover_until, variant=variant,
+            )
+        except Exception:
+            logger.warning("Failed to find %s model run", variant.slug, exc_info=True)
+            return None, None
 
     if run_info is None:
-        # The run-finder returns None both when the window is past ICON-EU's
+        # The run-finder returns None both when the window is past the model's
         # horizon and when a run should exist but the probe failed. Only the
         # former is an expected "out of range" skip — classify deterministically.
         if icon_eu_window_out_of_range(
-            departure_time, flight_duration_hours, as_of_time,
+            departure_time, flight_duration_hours, as_of_time, variant,
         ):
-            logger.info("Flight window beyond ICON-EU horizon, skipping ICON-EU enrichment")
+            logger.info("Flight window beyond %s horizon, skipping ICON enrichment", variant.slug)
             return None, "out_of_range"
-        logger.info("No ICON-EU run found that covers the flight window")
+        logger.info("No %s run found that covers the flight window", variant.slug)
         return None, None
 
     init_date, init_hour = run_info
 
     forecast_hours = compute_icon_eu_flight_window_hours(
-        init_date, init_hour, departure_time, flight_duration_hours,
+        init_date, init_hour, departure_time, flight_duration_hours, variant,
     )
 
-    purge_old_runs(data_dir, model="icon-eu")
-    run_dir = cache_dir_for_run(data_dir, init_date, init_hour, model="icon-eu")
-    levels = list(range(ICON_EU_MODEL_LEVEL_MIN, ICON_EU_MODEL_LEVEL_MAX + 1))
+    purge_old_runs(data_dir, model=variant.slug)
+    run_dir = cache_dir_for_run(data_dir, init_date, init_hour, model=variant.slug)
+    levels = list(range(variant.level_min, variant.level_max + 1))
 
     return _IconEuContext(
         init_date=init_date, init_hour=init_hour,
         forecast_hours=forecast_hours, run_dir=run_dir, levels=levels,
         point_lats=[rp.lat for rp in route_points],
         point_lons=[rp.lon for rp in route_points],
-        session=session,
+        session=session, variant=variant,
     ), None
 
 
@@ -3021,12 +3091,16 @@ def _prefetch_icon_eu_data_inner(ctx: _IconEuContext) -> None:
     completion.
     """
     from weatherbrief.fetch.grib.icon_eu_fetch import (
-        ICON_EU_CLOUD_DIAG_CACHE_KEY,
         ICON_EU_VARIABLES,
         fetch_icon_eu_per_variable,
         fetch_icon_eu_single_level,
+        icon_cloud_diag_cache_key,
         icon_eu_previous_step,
     )
+
+    variant = ctx.variant
+    prefix = variant.cache_prefix
+    diag_key = icon_cloud_diag_cache_key(variant)
 
     outer = _icon_prefetch_workers()
     # Keep outer x inner within the session's connection pool for ALL outer
@@ -3043,12 +3117,13 @@ def _prefetch_icon_eu_data_inner(ctx: _IconEuContext) -> None:
                     variables=[var],
                     session=ctx.session,
                     max_workers=inner,
+                    variant=variant,
                 )
             data = per_var.get(var)
             if data:
                 put_cached(ctx.run_dir, ck, data)
         except Exception:
-            logger.warning("Prefetch ICON-EU f%03d %s failed", fhour, var, exc_info=True)
+            logger.warning("Prefetch %s f%03d %s failed", variant.slug, fhour, var, exc_info=True)
 
     def _fetch_diag(fhour: int, ck: str) -> None:
         try:
@@ -3057,25 +3132,26 @@ def _prefetch_icon_eu_data_inner(ctx: _IconEuContext) -> None:
                     ctx.init_date, ctx.init_hour, [fhour],
                     session=ctx.session,
                     max_workers=inner,
+                    variant=variant,
                 )
             grib_bytes = fetched.get(fhour)
             if grib_bytes:
                 put_cached(ctx.run_dir, ck, grib_bytes)
         except Exception:
-            logger.warning("Prefetch ICON-EU cloud diag f%03d failed", fhour, exc_info=True)
+            logger.warning("Prefetch %s cloud diag f%03d failed", variant.slug, fhour, exc_info=True)
 
     jobs: list[tuple] = []
     for fhour in ctx.forecast_hours:
         # Model-level data (P, QC, QI) — per variable
-        legacy_ck = cache_key(fhour, "ICON_EU_QC_QI_P")
+        legacy_ck = cache_key(fhour, f"{prefix}_QC_QI_P")
         if not is_cached(ctx.run_dir, legacy_ck):  # legacy cache hit skips per-var download
             for var in ICON_EU_VARIABLES:
-                ck = cache_key(fhour, f"ICON_EU_{var.upper()}")
+                ck = cache_key(fhour, f"{prefix}_{var.upper()}")
                 if not is_cached(ctx.run_dir, ck):
                     jobs.append((_fetch_var, fhour, var, ck))
 
         # Single-level cloud diagnostics
-        diag_ck = cache_key(fhour, ICON_EU_CLOUD_DIAG_CACHE_KEY)
+        diag_ck = cache_key(fhour, diag_key)
         if not is_cached(ctx.run_dir, diag_ck):
             jobs.append((_fetch_diag, fhour, diag_ck))
 
@@ -3083,9 +3159,9 @@ def _prefetch_icon_eu_data_inner(ctx: _IconEuContext) -> None:
     # to de-accumulate rain_con against (#421). Cloud-diag fetch only — the
     # model-level sounding list above is untouched.
     if ctx.forecast_hours:
-        lead = icon_eu_previous_step(min(ctx.forecast_hours))
+        lead = icon_eu_previous_step(min(ctx.forecast_hours), variant)
         if lead is not None and lead not in ctx.forecast_hours:
-            lead_ck = cache_key(lead, ICON_EU_CLOUD_DIAG_CACHE_KEY)
+            lead_ck = cache_key(lead, diag_key)
             if not is_cached(ctx.run_dir, lead_ck):
                 jobs.append((_fetch_diag, lead, lead_ck))
 
@@ -3114,6 +3190,8 @@ def _decode_and_merge_icon_eu(
     """
     from weatherbrief.fetch.grib.icon_eu_fetch import ICON_EU_VARIABLES
 
+    variant = ctx.variant
+    prefix = variant.cache_prefix
     icon_sections = [cs for cs in cross_sections if cs.model == ModelSource.ICON]
 
     # CLC-derived cloud layers are a time-VARYING forecast field, so keep each
@@ -3129,7 +3207,7 @@ def _decode_and_merge_icon_eu(
     # skipped. The decode bytes are read inside the worker.
     fhour_jobs: dict[int, tuple[str, tuple]] = {}
     for fhour in ctx.forecast_hours:
-        legacy_ck = cache_key(fhour, "ICON_EU_QC_QI_P")
+        legacy_ck = cache_key(fhour, f"{prefix}_QC_QI_P")
         if is_cached(ctx.run_dir, legacy_ck):
             fhour_jobs[fhour] = (
                 "decode_icon_legacy",
@@ -3139,7 +3217,7 @@ def _decode_and_merge_icon_eu(
 
         var_paths: dict[str, str] = {}
         for var in ICON_EU_VARIABLES:
-            ck = cache_key(fhour, f"ICON_EU_{var.upper()}")
+            ck = cache_key(fhour, f"{prefix}_{var.upper()}")
             if is_cached(ctx.run_dir, ck):
                 var_paths[var] = str(ctx.run_dir / ck)
         if var_paths:
@@ -3206,12 +3284,12 @@ def _decode_and_merge_icon_eu(
     _grib_rss_mark("icon_fhour_post_gc")
 
     if not total_enriched:
-        logger.warning("No ICON-EU GRIB2 data retrieved for enrichment")
+        logger.warning("No %s GRIB2 data retrieved for enrichment", variant.slug)
         return None, None
 
     logger.info(
-        "GRIB2 ICON full sounding replacement: %d hourly entries replaced",
-        total_enriched,
+        "GRIB2 ICON full sounding replacement (%s): %d hourly entries replaced",
+        variant.slug, total_enriched,
     )
 
     # Cloud diagnostics (ceiling, convective base/top) from single-level files.
@@ -3220,7 +3298,7 @@ def _decode_and_merge_icon_eu(
         icon_sections, all_forecasts, route_points,
         ctx.init_date, ctx.init_hour, ctx.forecast_hours,
         ctx.run_dir, ctx.point_lats, ctx.point_lons, ctx.session,
-        clc_layers_by_fhour=clc_layers_by_fhour,
+        clc_layers_by_fhour=clc_layers_by_fhour, variant=variant,
     )
 
     return _run_info_to_timestamp(ctx.init_date, ctx.init_hour), None
@@ -3239,6 +3317,7 @@ def _enrich_icon_eu_cloud_diagnostics(
     session: requests.Session,
     *,
     clc_layers_by_fhour: dict[int, list[dict[str, float]]] | None = None,
+    variant=None,
 ) -> None:
     """Enrich ICON forecasts with single-level cloud diagnostics (ceiling, etc.).
 
@@ -3246,14 +3325,21 @@ def _enrich_icon_eu_cloud_diagnostics(
     from model-level data, keyed by forecast hour), missing ``base_ft``/
     ``top_ft`` on low/mid/high NWPCloudLayerDiag are filled from THAT forecast
     hour's geometry — clouds evolve over time, so each valid time uses its own.
+
+    *variant* selects ICON-EU vs ICON-D2 URL/cache conventions (defaults to EU).
     """
     from weatherbrief.fetch.grib.decode import build_icon_cloud_diagnostics
     from weatherbrief.fetch.grib.icon_eu_fetch import (
-        ICON_EU_CLOUD_DIAG_CACHE_KEY,
+        ICON_EU,
         fetch_icon_eu_single_level,
+        icon_cloud_diag_cache_key,
         icon_eu_conv_rain_rate_mm_h,
         icon_eu_previous_step,
     )
+
+    if variant is None:
+        variant = ICON_EU
+    diag_key = icon_cloud_diag_cache_key(variant)
 
     # Prepend one leading step so the first window hour has a predecessor to
     # de-accumulate rain_con against, then walk steps in sorted order carrying
@@ -3263,7 +3349,7 @@ def _enrich_icon_eu_cloud_diagnostics(
     # seeds the de-accumulation state.
     steps = sorted(set(forecast_hours))
     if steps:
-        lead = icon_eu_previous_step(steps[0])
+        lead = icon_eu_previous_step(steps[0], variant)
         if lead is not None and lead not in steps:
             steps.insert(0, lead)
 
@@ -3275,11 +3361,12 @@ def _enrich_icon_eu_cloud_diagnostics(
 
     total_enriched = 0
     for fhour in steps:
-        ck = cache_key(fhour, ICON_EU_CLOUD_DIAG_CACHE_KEY)
+        ck = cache_key(fhour, diag_key)
         if not is_cached(run_dir, ck):
             try:
                 fetched = fetch_icon_eu_single_level(
                     init_date, init_hour, [fhour], session=session,
+                    variant=variant,
                 )
                 grib_bytes = fetched.get(fhour)
                 if grib_bytes:

--- a/src/weatherbrief/fetch/grib/cache.py
+++ b/src/weatherbrief/fetch/grib/cache.py
@@ -26,6 +26,7 @@ logger = logging.getLogger(__name__)
 MODEL_TTL_SECONDS: dict[str, int] = {
     "gfs": 24 * 3600,       # no precache, small footprint (~0.5 GB/run)
     "icon-eu": 12 * 3600,   # precached each main run; previous run is fallback
+    "icon-d2": 6 * 3600,    # 8 runs/day (every 3h); keep current + prior run
 }
 
 # Fallback TTL for models without an explicit entry. Currently unreachable

--- a/src/weatherbrief/fetch/grib/icon_eu_fetch.py
+++ b/src/weatherbrief/fetch/grib/icon_eu_fetch.py
@@ -66,6 +66,10 @@ class IconVariant:
         horizon_main_h/horizon_short_h: Per-cycle model-level forecast horizon.
         hourly_to_h: Last hourly forecast step; steps above it are ``coarse_step_h``.
         coarse_step_h: Step size in the post-hourly region (EU 3h; D2 has none → 1).
+        cloud_diag_variables: Single-level diagnostic variables published for
+            this variant. NOT identical between variants: ICON-D2 has no deep-
+            convection parameterization, so ``hbas_con``/``htop_con``/``rain_con``
+            don't exist (or are meaningless) on its feed — see the D2 tuple below.
     """
 
     slug: str
@@ -88,6 +92,48 @@ class IconVariant:
     horizon_short_h: int
     hourly_to_h: int
     coarse_step_h: int
+    cloud_diag_variables: tuple[str, ...]
+
+
+# Single-level cloud diagnostic variables (ICON-EU).
+# cape_ml / cin_ml (mixed-layer CAPE/CIN, instantaneous) added for the
+# native convective track (#283 Phase 2). rain_con (convective rain,
+# accumulated since init) added in #421 so the convective firing gate and
+# native corroboration can evaluate ICON towers — the rate is de-accumulated
+# in the enrichment loop, not here.
+# SNOW_CON (convective snow, also accumulated) is intentionally NOT fetched
+# (#421 scope decision): it would double the single-level file count for the
+# rare convective-snow-shower case, and omitting it is safe by construction —
+# the firing gate holds down only on positive dry evidence, so a winter ICON
+# tower with rain_con ~0 but real convective snow simply keeps its tier (no
+# regression, just an unclosed corner). If added, sum the two de-accumulated
+# rates before assigning convective_precip_mm_h.
+ICON_EU_CLOUD_DIAG_VARIABLES = (
+    "ceiling", "hbas_con", "htop_con",
+    "clcl", "clcm", "clch", "clct",
+    "cape_ml", "cin_ml",
+    "rain_con",
+)
+
+# Single-level diagnostics for ICON-D2 — deliberately SMALLER than ICON-EU's
+# list. D2 is convection-permitting: it runs NO deep-convection scheme, so
+# (verified live against opendata.dwd.de, 2026-07-21):
+# - hbas_con / htop_con → 404. Only shallow-convection hbas_sc/htop_sc exist,
+#   and those describe fair-weather cumulus — mapping them into
+#   convective_base/top would show a benign low top during a real storm.
+# - rain_con → exists but is near-zero even in severe storms (the remaining
+#   shallow scheme barely precipitates; explicit-storm rain lands in
+#   rain_gsp/prg_gsp). Feeding it into convective_precip_mm_h would make the
+#   native convective gate read "quiet" exactly when D2 sees a storm.
+# All three therefore stay ABSENT for D2 → downstream fields are None
+# (missing-data semantics, which icon_eu_conv_rain_rate_mm_h and the firing
+# gate already handle). Issue #462 replaces them with D2's convection-
+# permitting diagnostics (dbz_cmax, echotop, lpi, uh_max, prg_gsp).
+ICON_D2_CLOUD_DIAG_VARIABLES = (
+    "ceiling",
+    "clcl", "clcm", "clch", "clct",
+    "cape_ml", "cin_ml",
+)
 
 
 # ICON-EU model-level horizon depends on the run cycle (verified empirically
@@ -118,6 +164,7 @@ ICON_EU = IconVariant(
     horizon_short_h=30,
     hourly_to_h=78,
     coarse_step_h=3,
+    cloud_diag_variables=ICON_EU_CLOUD_DIAG_VARIABLES,
 )
 
 # ICON-D2: 2.2 km convection-permitting, central-Europe domain, 8 runs/day,
@@ -127,13 +174,14 @@ ICON_EU = IconVariant(
 # "icon-d2". Domain corners + 65-level count from DWD's ICON-D2 regular-lat-lon
 # product (1215×746 ≈ 906k points ≈ ICON-EU's ~905k).
 #
-# level_min=25 is a deliberately-conservative top: the log-pressure
-# interpolation clips any target pressure level above the fetched column, so
-# over-fetching a few thin upper levels only costs a little bandwidth while
-# under-fetching would truncate the sounding at cruise. 25–65 (41 levels)
-# comfortably spans surface→~FL300. Validate the exact top against DWD's D2 HHL
-# table once the feed is reachable. Publication delay ~1–2h — 2h with margin;
-# the run-finder HEAD-probes anyway so a small miss just walks back one cycle.
+# level_min=16 validated against DWD's HHL (half-level height) field decoded
+# from the live feed (2026-07-21): D2 level 16 ≈ 9,460 m ≈ FL310, matching
+# ICON-EU's level-35 top (~300 hPa). D2 level numbering is NOT comparable to
+# EU's (65 levels vs 74, both numbered top-down with bottom = surface): level
+# 25 — the original guess — sits at only ~6,300 m ≈ FL207 and would truncate
+# every D2 sounding at ~20,000 ft. 16–65 = 50 levels, surface→~FL310.
+# Publication delay ~1–2h — 2h with margin; the run-finder HEAD-probes anyway
+# so a small miss just walks back one cycle.
 ICON_D2 = IconVariant(
     slug="icon-d2",
     source_key="icon_d2:dwd",
@@ -146,7 +194,7 @@ ICON_D2 = IconVariant(
     lon_max=20.34,
     cycles=(21, 18, 15, 12, 9, 6, 3, 0),
     publish_delay_hours=2.0,
-    level_min=25,
+    level_min=16,
     level_max=65,
     var_suffix_upper=False,
     single_level_2d=True,
@@ -155,6 +203,7 @@ ICON_D2 = IconVariant(
     horizon_short_h=48,
     hourly_to_h=48,
     coarse_step_h=1,
+    cloud_diag_variables=ICON_D2_CLOUD_DIAG_VARIABLES,
 )
 
 # Back-compat module constants (ICON-EU). The variant above is the single
@@ -227,26 +276,6 @@ def icon_eu_window_out_of_range(
 # Geopotential height is instead derived from pressure via the hypsometric equation
 # in the sounding analysis (or omitted — not critical for core analysis).
 ICON_EU_VARIABLES = ("qc", "qi", "clc", "p", "t", "qv", "u", "v", "w")
-
-# Single-level cloud diagnostic variables.
-# cape_ml / cin_ml (mixed-layer CAPE/CIN, instantaneous) added for the
-# native convective track (#283 Phase 2). rain_con (convective rain,
-# accumulated since init) added in #421 so the convective firing gate and
-# native corroboration can evaluate ICON towers — the rate is de-accumulated
-# in the enrichment loop, not here.
-# SNOW_CON (convective snow, also accumulated) is intentionally NOT fetched
-# (#421 scope decision): it would double the single-level file count for the
-# rare convective-snow-shower case, and omitting it is safe by construction —
-# the firing gate holds down only on positive dry evidence, so a winter ICON
-# tower with rain_con ~0 but real convective snow simply keeps its tier (no
-# regression, just an unclosed corner). If added, sum the two de-accumulated
-# rates before assigning convective_precip_mm_h.
-ICON_EU_CLOUD_DIAG_VARIABLES = (
-    "ceiling", "hbas_con", "htop_con",
-    "clcl", "clcm", "clch", "clct",
-    "cape_ml", "cin_ml",
-    "rain_con",
-)
 
 # Cache-key label for the single-level cloud-diagnostic blob. Bumped to V2 in
 # #421 when rain_con was added: the blob is cached under ONE key for all
@@ -361,7 +390,8 @@ def fetch_icon_eu_single_level(
         init_date: YYYYMMDD format.
         init_hour: Cycle hour (0, 3, 6, ..., 21).
         forecast_hours: Forecast hours to download.
-        variables: Variable names (defaults to ICON_EU_CLOUD_DIAG_VARIABLES).
+        variables: Variable names (defaults to the variant's
+            ``cloud_diag_variables`` — NOT the same list for EU and D2).
         session: Optional requests session.
         max_workers: Per-call download thread count. Callers that already
             run several fetches concurrently pass a smaller value so the
@@ -372,7 +402,7 @@ def fetch_icon_eu_single_level(
         Dict of {forecast_hour: concatenated decompressed GRIB2 bytes}.
     """
     if variables is None:
-        variables = list(ICON_EU_CLOUD_DIAG_VARIABLES)
+        variables = list(variant.cloud_diag_variables)
 
     sess = session or requests.Session()
     result: dict[int, bytes] = {}

--- a/src/weatherbrief/fetch/grib/icon_eu_fetch.py
+++ b/src/weatherbrief/fetch/grib/icon_eu_fetch.py
@@ -1,12 +1,27 @@
-"""DWD ICON-EU GRIB2 download from opendata.dwd.de.
+"""DWD ICON GRIB2 download from opendata.dwd.de.
 
-ICON-EU provides cloud liquid water (QC) and ice mixing ratio (QI) on model
-levels, covering Europe at ~6.5 km resolution on a regular lat-lon grid.
+Serves two DWD ICON variants that share this entire download/decode machinery
+(same server layout, same variable names, same regular-lat-lon grid type),
+differing only in a handful of config values captured by :class:`IconVariant`
+(issue #456):
+
+- **ICON-EU** — ~6.5 km, all of Europe, hourly to 78h then 3-hourly to 120h.
+  The default variant; every helper here keeps ``variant=ICON_EU`` so existing
+  callers are unchanged.
+- **ICON-D2** — ~2.2 km convection-permitting, central Europe only, hourly to
+  48h. Selected in place of ICON-EU for the ``icon`` slot when the whole route
+  fits the D2 domain and the flight window is within a D2 run's 48h horizon.
+
+Both provide cloud liquid water (QC) and ice mixing ratio (QI) on model levels.
 
 Data structure differs from GFS:
 - Individual bz2-compressed files per variable/level/timestep
 - Model levels (not pressure levels) — need P field for vertical interpolation
 - Separate files per level (no .idx companion files)
+
+The historical ``icon_eu_*`` names are retained (many callers + tests import
+them) even though they now dispatch on ``variant``; think of the prefix as
+"DWD ICON GRIB", not "ICON-EU specifically".
 """
 
 from __future__ import annotations
@@ -15,89 +30,195 @@ import bz2
 import logging
 import math
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 
 import requests
 
 logger = logging.getLogger(__name__)
 
-# DWD Open Data base URL
+# DWD Open Data base URL (ICON-EU). ICON-D2 lives under a sibling path — see
+# the ``base_url`` field on each :class:`IconVariant` below.
 DWD_BASE_URL = "https://opendata.dwd.de/weather/nwp/icon-eu/grib"
+
+@dataclass(frozen=True)
+class IconVariant:
+    """Config for one DWD ICON GRIB variant (ICON-EU or ICON-D2).
+
+    Pure data, no behaviour — every ``icon_eu_*`` helper below reads these
+    fields so the same download/decode path serves both variants (issue #456).
+
+    Attributes:
+        slug: Cache-dir model key and filename model token ("icon-eu"/"icon-d2").
+        source_key: Freshness ``SOURCE_REGISTRY`` key ("icon_eu:dwd"/"icon_d2:dwd").
+        cache_prefix: Prefix for per-run cache-key variable labels
+            ("ICON_EU"/"ICON_D2") so the two variants never collide in a cache dir.
+        base_url: DWD opendata grib base for this model.
+        grid_label: Filename region token ("europe"/"germany").
+        lat_min/lat_max/lon_min/lon_max: All-or-nothing domain bbox.
+        cycles: UTC run hours, freshest-first (run-finder order).
+        publish_delay_hours: Hours after init before a run is expected published.
+        level_min/level_max: Inclusive model-level slice (aviation altitude band).
+        var_suffix_upper: True → uppercase variable suffix in filenames (EU);
+            False → lowercase (D2). Governs both model- and single-level names.
+        single_level_2d: True → single-level filenames carry a "_2d_" segment (D2).
+        main_cycles: Cycles reaching ``horizon_main_h`` (others reach the short one).
+        horizon_main_h/horizon_short_h: Per-cycle model-level forecast horizon.
+        hourly_to_h: Last hourly forecast step; steps above it are ``coarse_step_h``.
+        coarse_step_h: Step size in the post-hourly region (EU 3h; D2 has none → 1).
+    """
+
+    slug: str
+    source_key: str
+    cache_prefix: str
+    base_url: str
+    grid_label: str
+    lat_min: float
+    lat_max: float
+    lon_min: float
+    lon_max: float
+    cycles: tuple[int, ...]
+    publish_delay_hours: float
+    level_min: int
+    level_max: int
+    var_suffix_upper: bool
+    single_level_2d: bool
+    main_cycles: frozenset[int]
+    horizon_main_h: int
+    horizon_short_h: int
+    hourly_to_h: int
+    coarse_step_h: int
+
 
 # ICON-EU model-level horizon depends on the run cycle (verified empirically
 # against opendata.dwd.de directory listings):
 # - Main runs (00z, 06z, 12z, 18z): hourly to 78h, 3-hourly to 120h
 # - Short runs (03z, 09z, 15z, 21z): hourly to 30h, then 6-hourly to 48h
-#
 # We cap short-run usage at 30h so the run-picker falls back to the prior main
-# run for any flight extending past +30h. This keeps every briefing on a
-# uniform hourly grid (short run hourly 0-30h, OR main run hourly 0-78h) and
-# avoids 404s on f031–f035/f037–f041/f043–f047 which are not published.
-ICON_EU_MAIN_CYCLES = {0, 6, 12, 18}
-ICON_EU_MODEL_LEVEL_MAX_HOUR_MAIN = 120
-ICON_EU_MODEL_LEVEL_MAX_HOUR_SHORT = 30
+# run for any flight extending past +30h — keeps every briefing on a uniform
+# hourly grid and avoids 404s on f031–f047 which are not published.
+ICON_EU = IconVariant(
+    slug="icon-eu",
+    source_key="icon_eu:dwd",
+    cache_prefix="ICON_EU",
+    base_url="https://opendata.dwd.de/weather/nwp/icon-eu/grib",
+    grid_label="europe",
+    lat_min=29.5,
+    lat_max=70.5,
+    lon_min=-23.5,
+    lon_max=62.5,
+    cycles=(21, 18, 15, 12, 9, 6, 3, 0),
+    publish_delay_hours=3.0,
+    level_min=35,  # levels 35-74 ≈ 300-1000 hPa (surface to ~FL280)
+    level_max=74,
+    var_suffix_upper=True,
+    single_level_2d=False,
+    main_cycles=frozenset({0, 6, 12, 18}),
+    horizon_main_h=120,
+    horizon_short_h=30,
+    hourly_to_h=78,
+    coarse_step_h=3,
+)
+
+# ICON-D2: 2.2 km convection-permitting, central-Europe domain, 8 runs/day,
+# hourly to 48h (no coarse tail). Filename quirks vs EU (issue #456): lowercase
+# variable suffix (..._60_t.grib2.bz2), single-level files carry a "_2d_"
+# segment (..._006_2d_ceiling.grib2.bz2), region token "germany", model token
+# "icon-d2". Domain corners + 65-level count from DWD's ICON-D2 regular-lat-lon
+# product (1215×746 ≈ 906k points ≈ ICON-EU's ~905k).
+#
+# level_min=25 is a deliberately-conservative top: the log-pressure
+# interpolation clips any target pressure level above the fetched column, so
+# over-fetching a few thin upper levels only costs a little bandwidth while
+# under-fetching would truncate the sounding at cruise. 25–65 (41 levels)
+# comfortably spans surface→~FL300. Validate the exact top against DWD's D2 HHL
+# table once the feed is reachable. Publication delay ~1–2h — 2h with margin;
+# the run-finder HEAD-probes anyway so a small miss just walks back one cycle.
+ICON_D2 = IconVariant(
+    slug="icon-d2",
+    source_key="icon_d2:dwd",
+    cache_prefix="ICON_D2",
+    base_url="https://opendata.dwd.de/weather/nwp/icon-d2/grib",
+    grid_label="germany",
+    lat_min=43.18,
+    lat_max=58.08,
+    lon_min=-3.94,
+    lon_max=20.34,
+    cycles=(21, 18, 15, 12, 9, 6, 3, 0),
+    publish_delay_hours=2.0,
+    level_min=25,
+    level_max=65,
+    var_suffix_upper=False,
+    single_level_2d=True,
+    main_cycles=frozenset({0, 3, 6, 9, 12, 15, 18, 21}),
+    horizon_main_h=48,
+    horizon_short_h=48,
+    hourly_to_h=48,
+    coarse_step_h=1,
+)
+
+# Back-compat module constants (ICON-EU). The variant above is the single
+# source of truth; these aliases keep existing imports/tests working.
+ICON_EU_MAIN_CYCLES = set(ICON_EU.main_cycles)
+ICON_EU_MODEL_LEVEL_MAX_HOUR_MAIN = ICON_EU.horizon_main_h
+ICON_EU_MODEL_LEVEL_MAX_HOUR_SHORT = ICON_EU.horizon_short_h
+ICON_EU_LAT_MIN = ICON_EU.lat_min
+ICON_EU_LAT_MAX = ICON_EU.lat_max
+ICON_EU_LON_MIN = ICON_EU.lon_min
+ICON_EU_LON_MAX = ICON_EU.lon_max
+ICON_EU_CYCLES = list(ICON_EU.cycles)
+ICON_EU_PUBLISH_DELAY_HOURS = ICON_EU.publish_delay_hours
+ICON_EU_MODEL_LEVEL_MIN = ICON_EU.level_min
+ICON_EU_MODEL_LEVEL_MAX = ICON_EU.level_max
 
 
-def icon_eu_model_level_max_hour(init_hour: int) -> int:
-    """Return the model-level forecast horizon for the given ICON-EU cycle."""
-    if init_hour in ICON_EU_MAIN_CYCLES:
-        return ICON_EU_MODEL_LEVEL_MAX_HOUR_MAIN
-    return ICON_EU_MODEL_LEVEL_MAX_HOUR_SHORT
+def icon_eu_model_level_max_hour(
+    init_hour: int, variant: IconVariant = ICON_EU,
+) -> int:
+    """Return the model-level forecast horizon for the given cycle + variant."""
+    if init_hour in variant.main_cycles:
+        return variant.horizon_main_h
+    return variant.horizon_short_h
 
 
 def icon_eu_window_out_of_range(
     target_time: datetime,
     flight_duration_hours: float = 0.0,
     as_of_time: datetime | None = None,
+    variant: IconVariant = ICON_EU,
 ) -> bool:
-    """True when no publishable ICON-EU run has enough horizon for the flight.
+    """True when no publishable run of *variant* has enough horizon for the flight.
 
     Deterministic (no network): walks the same cycles and publication-delay
     logic as :func:`find_latest_icon_eu_run_with_response` and checks whether
     any run available as-of *as_of_time* reaches ``target_time +
     flight_duration_hours``. ICON-EU's model-level horizon is only 120h (5
-    days), so any flight departing >~5 days out is beyond it.
+    days) and ICON-D2's only 48h, so a flight beyond that is out of range.
 
-    Used to distinguish the *expected* "flight beyond ICON-EU horizon" skip
-    (an info-level condition, common for flights 5–9 days out) from a genuine
-    upstream/probe failure — the run-finder returns ``None`` for both.
+    Used to distinguish the *expected* "flight beyond horizon" skip (an
+    info-level condition) from a genuine upstream/probe failure — the
+    run-finder returns ``None`` for both.
     """
     reference_time = as_of_time or datetime.now(timezone.utc)
     need_until = target_time + timedelta(hours=flight_duration_hours)
     for days_back in range(2):
         check_date = reference_time - timedelta(days=days_back)
-        for cycle in ICON_EU_CYCLES:
+        for cycle in variant.cycles:
             init_time = check_date.replace(
                 hour=cycle, minute=0, second=0, microsecond=0,
             )
             if init_time > reference_time:
                 continue
             hours_since_init = (reference_time - init_time).total_seconds() / 3600
-            if hours_since_init < ICON_EU_PUBLISH_DELAY_HOURS:
+            if hours_since_init < variant.publish_delay_hours:
                 continue
-            horizon = init_time + timedelta(hours=icon_eu_model_level_max_hour(cycle))
+            horizon = init_time + timedelta(
+                hours=icon_eu_model_level_max_hour(cycle, variant),
+            )
             if horizon >= need_until:
                 # At least one publishable run reaches the flight window.
                 return False
     return True
-
-# ICON-EU domain bounds (regular lat-lon grid)
-ICON_EU_LAT_MIN = 29.5
-ICON_EU_LAT_MAX = 70.5
-ICON_EU_LON_MIN = -23.5
-ICON_EU_LON_MAX = 62.5
-
-# ICON-EU cycles: every 3 hours
-ICON_EU_CYCLES = [21, 18, 15, 12, 9, 6, 3, 0]
-
-# Publication delay: ICON-EU is typically available ~3h after init
-ICON_EU_PUBLISH_DELAY_HOURS = 3
-
-# Model levels covering surface (~74) to ~FL280 (~level 35).
-# Level 74 is near surface, level 1 is top of atmosphere.
-# Levels 35-74 cover approximately 300-1000 hPa.
-ICON_EU_MODEL_LEVEL_MIN = 35
-ICON_EU_MODEL_LEVEL_MAX = 74
 
 # Variables to fetch: sounding + cloud microphysics + pressure for vertical interpolation.
 # Note: "qv" (specific humidity) is used instead of "relhum" because relhum is only
@@ -136,22 +257,39 @@ ICON_EU_CLOUD_DIAG_VARIABLES = (
 # standalone verification) so the four call sites can never drift apart.
 ICON_EU_CLOUD_DIAG_CACHE_KEY = "ICON_EU_CLOUD_DIAG_V2"
 
+
+def icon_cloud_diag_cache_key(variant: IconVariant = ICON_EU) -> str:
+    """Cache-key label for a variant's single-level cloud-diagnostic blob.
+
+    ``{cache_prefix}_CLOUD_DIAG_V2`` — the ``_V2`` suffix matches the ICON-EU
+    constant so the two share the same rain_con-inclusive schema; only the
+    prefix differs so ICON-D2 blobs never masquerade as ICON-EU in a cache dir.
+    """
+    return f"{variant.cache_prefix}_CLOUD_DIAG_V2"
+
 # Parallel download settings
 MAX_DOWNLOAD_WORKERS = 8
 REQUEST_TIMEOUT = 30  # seconds per file
 
 
-def route_in_icon_eu_domain(route_points: list) -> bool:
-    """Check if all route points fall within the ICON-EU domain.
+def route_in_icon_eu_domain(
+    route_points: list, variant: IconVariant = ICON_EU,
+) -> bool:
+    """Check if all route points fall within *variant*'s domain.
 
     All-or-nothing: returns False if any point is outside.
     """
     for rp in route_points:
-        if not (ICON_EU_LAT_MIN <= rp.lat <= ICON_EU_LAT_MAX):
+        if not (variant.lat_min <= rp.lat <= variant.lat_max):
             return False
-        if not (ICON_EU_LON_MIN <= rp.lon <= ICON_EU_LON_MAX):
+        if not (variant.lon_min <= rp.lon <= variant.lon_max):
             return False
     return True
+
+
+def _icon_var_suffix(variable: str, variant: IconVariant) -> str:
+    """Filename variable suffix, cased per variant (EU upper, D2 lower)."""
+    return variable.upper() if variant.var_suffix_upper else variable.lower()
 
 
 def icon_eu_file_url(
@@ -160,20 +298,21 @@ def icon_eu_file_url(
     forecast_hour: int,
     level: int,
     variable: str,
+    variant: IconVariant = ICON_EU,
 ) -> str:
-    """Build URL for a single ICON-EU GRIB2 bz2 file.
+    """Build URL for a single DWD ICON model-level GRIB2 bz2 file.
 
-    Example:
-        https://opendata.dwd.de/weather/nwp/icon-eu/grib/00/qc/
-        icon-eu_europe_regular-lat-lon_model-level_2026022100_000_35_QC.grib2.bz2
+    Examples:
+        ICON-EU: .../icon-eu/grib/00/qc/
+          icon-eu_europe_regular-lat-lon_model-level_2026022100_000_35_QC.grib2.bz2
+        ICON-D2: .../icon-d2/grib/00/t/
+          icon-d2_germany_regular-lat-lon_model-level_2026072000_006_60_t.grib2.bz2
     """
-    var_lower = variable.lower()
-    var_upper = variable.upper()
     return (
-        f"{DWD_BASE_URL}/{init_hour:02d}/{var_lower}/"
-        f"icon-eu_europe_regular-lat-lon_model-level_"
-        f"{init_date}{init_hour:02d}_{forecast_hour:03d}_{level:02d}_{var_upper}"
-        f".grib2.bz2"
+        f"{variant.base_url}/{init_hour:02d}/{variable.lower()}/"
+        f"{variant.slug}_{variant.grid_label}_regular-lat-lon_model-level_"
+        f"{init_date}{init_hour:02d}_{forecast_hour:03d}_{level:02d}_"
+        f"{_icon_var_suffix(variable, variant)}.grib2.bz2"
     )
 
 
@@ -182,20 +321,25 @@ def icon_eu_single_level_url(
     init_hour: int,
     forecast_hour: int,
     variable: str,
+    variant: IconVariant = ICON_EU,
 ) -> str:
-    """Build URL for a single ICON-EU GRIB2 bz2 file (no level number).
+    """Build URL for a single DWD ICON single-level GRIB2 bz2 file (no level).
 
-    Example:
-        https://opendata.dwd.de/weather/nwp/icon-eu/grib/00/ceiling/
-        icon-eu_europe_regular-lat-lon_single-level_2026022100_006_CEILING.grib2.bz2
+    ICON-D2 single-level files carry a ``_2d_`` segment between the forecast
+    hour and the variable; ICON-EU does not.
+
+    Examples:
+        ICON-EU: .../icon-eu/grib/00/ceiling/
+          icon-eu_europe_regular-lat-lon_single-level_2026022100_006_CEILING.grib2.bz2
+        ICON-D2: .../icon-d2/grib/00/ceiling/
+          icon-d2_germany_regular-lat-lon_single-level_2026072000_006_2d_ceiling.grib2.bz2
     """
-    var_lower = variable.lower()
-    var_upper = variable.upper()
+    segment = "_2d_" if variant.single_level_2d else "_"
     return (
-        f"{DWD_BASE_URL}/{init_hour:02d}/{var_lower}/"
-        f"icon-eu_europe_regular-lat-lon_single-level_"
-        f"{init_date}{init_hour:02d}_{forecast_hour:03d}_{var_upper}"
-        f".grib2.bz2"
+        f"{variant.base_url}/{init_hour:02d}/{variable.lower()}/"
+        f"{variant.slug}_{variant.grid_label}_regular-lat-lon_single-level_"
+        f"{init_date}{init_hour:02d}_{forecast_hour:03d}{segment}"
+        f"{_icon_var_suffix(variable, variant)}.grib2.bz2"
     )
 
 
@@ -206,8 +350,9 @@ def fetch_icon_eu_single_level(
     variables: list[str] | None = None,
     session: requests.Session | None = None,
     max_workers: int = MAX_DOWNLOAD_WORKERS,
+    variant: IconVariant = ICON_EU,
 ) -> dict[int, bytes]:
-    """Download ICON-EU single-level GRIB2 fields and return concatenated bytes per fhour.
+    """Download ICON single-level GRIB2 fields and return concatenated bytes per fhour.
 
     Downloads single-level cloud diagnostic files (no level dimension)
     using the same parallel pattern as model-level fetch.
@@ -221,6 +366,7 @@ def fetch_icon_eu_single_level(
         max_workers: Per-call download thread count. Callers that already
             run several fetches concurrently pass a smaller value so the
             total connection count stays bounded.
+        variant: ICON variant (EU/D2) whose URL conventions to use.
 
     Returns:
         Dict of {forecast_hour: concatenated decompressed GRIB2 bytes}.
@@ -233,7 +379,7 @@ def fetch_icon_eu_single_level(
 
     for fhour in forecast_hours:
         urls = [
-            icon_eu_single_level_url(init_date, init_hour, fhour, var)
+            icon_eu_single_level_url(init_date, init_hour, fhour, var, variant)
             for var in variables
         ]
 
@@ -258,14 +404,14 @@ def fetch_icon_eu_single_level(
         if buf:
             result[fhour] = bytes(buf)
             logger.info(
-                "ICON-EU single-level f%03d: downloaded %d/%d files (%.1f KB)%s",
-                fhour, downloaded, downloaded + total_failed, len(buf) / 1024,
-                _format_failure_summary(failures),
+                "%s single-level f%03d: downloaded %d/%d files (%.1f KB)%s",
+                variant.slug, fhour, downloaded, downloaded + total_failed,
+                len(buf) / 1024, _format_failure_summary(failures),
             )
         elif total_failed:
             logger.warning(
-                "ICON-EU single-level f%03d: all %d files failed%s",
-                fhour, total_failed, _format_failure_summary(failures),
+                "%s single-level f%03d: all %d files failed%s",
+                variant.slug, fhour, total_failed, _format_failure_summary(failures),
             )
 
     return result
@@ -276,14 +422,15 @@ def find_latest_icon_eu_run(
     session: requests.Session | None = None,
     as_of_time: datetime | None = None,
     cover_until: datetime | None = None,
+    variant: IconVariant = ICON_EU,
 ) -> tuple[str, int] | None:
-    """Find the latest available ICON-EU model run whose horizon covers the flight.
+    """Find the latest available ICON model run whose horizon covers the flight.
 
     Thin wrapper around :func:`find_latest_icon_eu_run_with_response` for
     callers that don't need the HEAD response.
     """
     found = find_latest_icon_eu_run_with_response(
-        target_time, session, as_of_time, cover_until,
+        target_time, session, as_of_time, cover_until, variant,
     )
     return (found[0], found[1]) if found is not None else None
 
@@ -293,8 +440,9 @@ def find_latest_icon_eu_run_with_response(
     session: requests.Session | None = None,
     as_of_time: datetime | None = None,
     cover_until: datetime | None = None,
+    variant: IconVariant = ICON_EU,
 ) -> tuple[str, int, requests.Response] | None:
-    """Find the latest ICON-EU run + return the matching probe HEAD response.
+    """Find the latest ICON run + return the matching probe HEAD response.
 
     Tries cycles in reverse chronological order, checking that enough time
     has passed for publication and that the run's model-level horizon
@@ -323,32 +471,37 @@ def find_latest_icon_eu_run_with_response(
     for days_back in range(2):
         check_date = reference_time - timedelta(days=days_back)
         date_str = check_date.strftime("%Y%m%d")
-        for cycle in ICON_EU_CYCLES:
+        for cycle in variant.cycles:
             init_time = check_date.replace(
                 hour=cycle, minute=0, second=0, microsecond=0,
             )
             if init_time > reference_time:
                 continue
             hours_since_init = (reference_time - init_time).total_seconds() / 3600
-            if hours_since_init < ICON_EU_PUBLISH_DELAY_HOURS:
+            if hours_since_init < variant.publish_delay_hours:
                 continue
 
             # Check if this run's horizon covers the flight
-            max_hour = icon_eu_model_level_max_hour(cycle)
+            max_hour = icon_eu_model_level_max_hour(cycle, variant)
             horizon = init_time + timedelta(hours=max_hour)
             if horizon < need_until:
                 logger.debug(
-                    "ICON-EU %s %02dz: horizon %dh doesn't reach flight end, skipping",
-                    date_str, cycle, max_hour,
+                    "%s %s %02dz: horizon %dh doesn't reach flight end, skipping",
+                    variant.slug, date_str, cycle, max_hour,
                 )
                 continue
 
-            # Probe: check if a level-74 P file for forecast hour 000 exists
-            probe_url = icon_eu_file_url(date_str, cycle, 0, 74, "p")
+            # Probe: check if the bottom-level P file for forecast hour 000 exists
+            probe_url = icon_eu_file_url(
+                date_str, cycle, 0, variant.level_max, "p", variant,
+            )
             try:
                 resp = sess.head(probe_url, timeout=10)
                 if resp.status_code == 200:
-                    logger.info("Found ICON-EU run: %s %02dz (horizon %dh)", date_str, cycle, max_hour)
+                    logger.info(
+                        "Found %s run: %s %02dz (horizon %dh)",
+                        variant.slug, date_str, cycle, max_hour,
+                    )
                     return date_str, cycle, resp
             except requests.RequestException:
                 continue
@@ -360,10 +513,11 @@ def bracket_icon_eu_forecast_hours(
     init_date: str,
     init_hour: int,
     target_time: datetime,
+    variant: IconVariant = ICON_EU,
 ) -> tuple[int, int]:
     """Find the two forecast hours that bracket the target time.
 
-    ICON-EU has hourly forecasts for 0-78h, 3-hourly for 78-120h.
+    ICON-EU is hourly for 0–78h then 3-hourly to 120h; ICON-D2 is hourly to 48h.
 
     Returns:
         (f_prev, f_next) bracketing the target.
@@ -374,52 +528,53 @@ def bracket_icon_eu_forecast_hours(
     delta_hours = (target_time - init_dt).total_seconds() / 3600
     delta_hours = max(0, delta_hours)
 
-    if delta_hours <= 78:
+    if delta_hours <= variant.hourly_to_h:
         # Hourly region
         f_prev = int(delta_hours)
         f_next = f_prev + 1
     else:
-        # 3-hourly region
-        base = int((delta_hours - 78) / 3)
-        f_prev = 78 + base * 3
-        f_next = f_prev + 3
+        # Coarse (post-hourly) region
+        step = variant.coarse_step_h
+        base = int((delta_hours - variant.hourly_to_h) / step)
+        f_prev = variant.hourly_to_h + base * step
+        f_next = f_prev + step
 
     # Clamp to max forecast hour
-    f_prev = min(f_prev, 120)
-    f_next = min(f_next, 120)
+    f_prev = min(f_prev, variant.horizon_main_h)
+    f_next = min(f_next, variant.horizon_main_h)
 
     return f_prev, f_next
 
 
-def _snap_to_icon_eu_grid(fhour: float) -> int:
-    """Snap a fractional forecast hour to the nearest ICON-EU grid point.
+def _snap_to_icon_eu_grid(fhour: float, variant: IconVariant = ICON_EU) -> int:
+    """Snap a fractional forecast hour to the nearest grid point for *variant*.
 
-    ICON-EU: 1-hourly for 0–78h, 3-hourly for 78–120h.
+    ICON-EU: 1-hourly for 0–78h, 3-hourly for 78–120h. ICON-D2: 1-hourly to 48h.
     """
-    if fhour <= 78:
+    if fhour <= variant.hourly_to_h:
         return round(fhour)
-    base = 78 + round((fhour - 78) / 3) * 3
-    return min(base, 120)
+    step = variant.coarse_step_h
+    base = variant.hourly_to_h + round((fhour - variant.hourly_to_h) / step) * step
+    return min(base, variant.horizon_main_h)
 
 
-def _snap_to_icon_eu_grid_floor(fhour: float) -> int:
-    """Snap DOWN to nearest ICON-EU grid point (floor, not round).
-
-    ICON-EU: 1-hourly for 0–78h, 3-hourly for 78–120h.
-    """
-    if fhour <= 78:
+def _snap_to_icon_eu_grid_floor(fhour: float, variant: IconVariant = ICON_EU) -> int:
+    """Snap DOWN to nearest grid point (floor, not round) for *variant*."""
+    if fhour <= variant.hourly_to_h:
         return int(fhour)
-    base = 78 + int((fhour - 78) / 3) * 3
-    return min(base, 120)
+    step = variant.coarse_step_h
+    base = variant.hourly_to_h + int((fhour - variant.hourly_to_h) / step) * step
+    return min(base, variant.horizon_main_h)
 
 
-def icon_eu_previous_step(fhour: int) -> int | None:
-    """Return the ICON-EU forecast hour immediately preceding *fhour*.
+def icon_eu_previous_step(fhour: int, variant: IconVariant = ICON_EU) -> int | None:
+    """Return the forecast hour immediately preceding *fhour* for *variant*.
 
-    Respects the temporal grid — 1-hourly at or below 78h (step −1), 3-hourly
-    above it (step −3) — mirroring :func:`_snap_to_icon_eu_grid`. Returns
-    ``None`` for ``fhour == 0``: accumulation is 0 at init by definition, so
-    there is no earlier step to difference an accumulated field against.
+    Respects the temporal grid — 1-hourly at or below ``hourly_to_h`` (step −1),
+    coarse above it (step −``coarse_step_h``) — mirroring
+    :func:`_snap_to_icon_eu_grid`. Returns ``None`` for ``fhour == 0``:
+    accumulation is 0 at init by definition, so there is no earlier step to
+    difference an accumulated field against.
 
     Used to prepend one leading single-level step to the on-demand cloud-diag
     fetch so the first flight-window hour has a predecessor to de-accumulate
@@ -429,9 +584,9 @@ def icon_eu_previous_step(fhour: int) -> int | None:
     """
     if fhour <= 0:
         return None
-    if fhour <= 78:
+    if fhour <= variant.hourly_to_h:
         return fhour - 1
-    return fhour - 3
+    return fhour - variant.coarse_step_h
 
 
 def icon_eu_conv_rain_rate_mm_h(
@@ -461,10 +616,11 @@ def compute_icon_eu_flight_window_hours(
     init_hour: int,
     departure_time: datetime,
     flight_duration_hours: float,
+    variant: IconVariant = ICON_EU,
 ) -> list[int]:
-    """Compute ICON-EU forecast hours covering a flight window.
+    """Compute ICON forecast hours covering a flight window.
 
-    Same logic as GFS but snapped to the ICON-EU temporal grid.
+    Same logic as GFS but snapped to the variant's temporal grid.
     """
     init_dt = datetime.strptime(f"{init_date}{init_hour:02d}", "%Y%m%d%H").replace(
         tzinfo=timezone.utc,
@@ -478,21 +634,21 @@ def compute_icon_eu_flight_window_hours(
         utc = dep_dt + timedelta(hours=h)
         delta = (utc - init_dt).total_seconds() / 3600
         delta = max(0.0, delta)
-        fhours.add(_snap_to_icon_eu_grid(delta))
+        fhours.add(_snap_to_icon_eu_grid(delta, variant))
 
     # Include the floor hour so non-round departure times get coverage
     if dep_dt.minute > 0:
         floor_utc = dep_dt.replace(minute=0, second=0, microsecond=0)
         floor_delta = (floor_utc - init_dt).total_seconds() / 3600
         if floor_delta >= 0:
-            fhours.add(_snap_to_icon_eu_grid(floor_delta))
+            fhours.add(_snap_to_icon_eu_grid(floor_delta, variant))
 
     # Include the floor native hour before departure for forward-fill coverage.
-    # In the 3-hourly region (>78h), rounding may skip the preceding native
+    # In a coarse (post-hourly) region, rounding may skip the preceding native
     # hour, leaving interpolated hours without GRIB diagnostics.
     dep_delta = (dep_dt - init_dt).total_seconds() / 3600
     if dep_delta > 0:
-        fhours.add(_snap_to_icon_eu_grid_floor(dep_delta))
+        fhours.add(_snap_to_icon_eu_grid_floor(dep_delta, variant))
 
     return sorted(fhours)
 
@@ -535,8 +691,9 @@ def fetch_icon_eu_fields(
     levels: list[int],
     variables: list[str],
     session: requests.Session | None = None,
+    variant: IconVariant = ICON_EU,
 ) -> bytes:
-    """Download ICON-EU GRIB2 fields in parallel and return concatenated bytes.
+    """Download ICON model-level GRIB2 fields in parallel and concat bytes.
 
     Downloads individual bz2-compressed files for each variable/level
     combination using a thread pool, decompresses, and concatenates into
@@ -549,6 +706,7 @@ def fetch_icon_eu_fields(
         levels: Model level numbers to download.
         variables: Variable names (e.g. ["qc", "qi", "p"]).
         session: Optional requests session.
+        variant: ICON variant (EU/D2) whose URL conventions to use.
 
     Returns:
         Concatenated decompressed GRIB2 bytes.
@@ -557,7 +715,9 @@ def fetch_icon_eu_fields(
     urls: list[str] = []
     for var in variables:
         for level in levels:
-            urls.append(icon_eu_file_url(init_date, init_hour, forecast_hour, level, var))
+            urls.append(
+                icon_eu_file_url(init_date, init_hour, forecast_hour, level, var, variant),
+            )
 
     result = bytearray()
     downloaded = 0
@@ -578,9 +738,9 @@ def fetch_icon_eu_fields(
 
     total_failed = sum(failures.values())
     logger.info(
-        "ICON-EU f%03d: downloaded %d/%d files (%.1f KB)%s",
-        forecast_hour, downloaded, downloaded + total_failed, len(result) / 1024,
-        _format_failure_summary(failures),
+        "%s f%03d: downloaded %d/%d files (%.1f KB)%s",
+        variant.slug, forecast_hour, downloaded, downloaded + total_failed,
+        len(result) / 1024, _format_failure_summary(failures),
     )
     return bytes(result)
 
@@ -593,8 +753,9 @@ def fetch_icon_eu_per_variable(
     variables: list[str],
     session: requests.Session | None = None,
     max_workers: int = MAX_DOWNLOAD_WORKERS,
+    variant: IconVariant = ICON_EU,
 ) -> dict[str, bytes]:
-    """Download ICON-EU GRIB2 fields per variable for memory-efficient decoding.
+    """Download ICON model-level GRIB2 fields per variable for chunked decode.
 
     Same as fetch_icon_eu_fields but returns separate bytes per variable,
     so callers can decode one variable at a time and free memory between.
@@ -611,7 +772,7 @@ def fetch_icon_eu_per_variable(
 
     for var in variables:
         urls = [
-            icon_eu_file_url(init_date, init_hour, forecast_hour, level, var)
+            icon_eu_file_url(init_date, init_hour, forecast_hour, level, var, variant)
             for level in levels
         ]
 
@@ -636,14 +797,16 @@ def fetch_icon_eu_per_variable(
         if buf:
             result[var] = bytes(buf)
             logger.info(
-                "ICON-EU f%03d %s: downloaded %d/%d levels (%.1f KB)%s",
-                forecast_hour, var, downloaded, downloaded + total_failed,
-                len(buf) / 1024, _format_failure_summary(failures),
+                "%s f%03d %s: downloaded %d/%d levels (%.1f KB)%s",
+                variant.slug, forecast_hour, var, downloaded,
+                downloaded + total_failed, len(buf) / 1024,
+                _format_failure_summary(failures),
             )
         else:
             logger.warning(
-                "ICON-EU f%03d %s: all %d files failed%s",
-                forecast_hour, var, total_failed, _format_failure_summary(failures),
+                "%s f%03d %s: all %d files failed%s",
+                variant.slug, forecast_hour, var, total_failed,
+                _format_failure_summary(failures),
             )
 
     return result

--- a/src/weatherbrief/pipeline.py
+++ b/src/weatherbrief/pipeline.py
@@ -156,6 +156,9 @@ class BriefingResult:
     digest_trace_id: str | None = None
     text_digest: str | None = None
     grib_init_times: dict[str, int] = field(default_factory=dict)
+    # model → freshness source key used for the direct-GRIB run (icon slot may
+    # be icon_eu:dwd or icon_d2:dwd, #456). Consumed by pack building.
+    grib_sources: dict[str, str] = field(default_factory=dict)
     models_fetched: list[str] = field(default_factory=list)
     models_skipped_region: list[str] = field(default_factory=list)
     diagnostics: list[Diagnostic] = field(default_factory=list)
@@ -643,6 +646,7 @@ def execute_briefing(
     result = BriefingResult(snapshot=snapshot, snapshot_path=snapshot_path)
     result.llm_digest_requested = options.generate_llm_digest
     result.grib_init_times = fetch_result.grib_init_times
+    result.grib_sources = fetch_result.grib_sources
     result.models_fetched = fetch_result.models_fetched
     result.models_skipped_region = fetch_result.models_skipped_region
     result.diagnostics = fetch_result.diagnostics

--- a/src/weatherbrief/tasks/fetch.py
+++ b/src/weatherbrief/tasks/fetch.py
@@ -134,6 +134,9 @@ class FetchResult:
     grib_enriched: bool = False
     grib_enrichment_failed: bool = False
     grib_init_times: dict[str, int] = field(default_factory=dict)
+    # model → freshness source key actually used for the direct-GRIB run.
+    # Distinguishes the icon slot's variant (icon_eu:dwd vs icon_d2:dwd, #456).
+    grib_sources: dict[str, str] = field(default_factory=dict)
     diagnostics: list[Diagnostic] = field(default_factory=list)
     open_meteo_api_calls: int = 0
 
@@ -447,12 +450,13 @@ def run_fetch(
     grib_enrichment_failed = False
     grib_init_times: dict[str, int] = {}
     grib_skip_reasons: dict[str, str] = {}
+    grib_sources: dict[str, str] = {}
     if enrich_grib and cross_sections:
         _notify("grib_enrichment")
         try:
             from weatherbrief.fetch.grib import enrich_forecasts
 
-            grib_init_times, grib_skip_reasons = enrich_forecasts(
+            grib_init_times, grib_skip_reasons, grib_sources = enrich_forecasts(
                 cross_sections, all_forecasts, route_points,
                 departure_time, data_dir=data_dir,
                 flight_duration_hours=route.flight_duration_hours,
@@ -515,6 +519,7 @@ def run_fetch(
         grib_enriched=grib_enriched,
         grib_enrichment_failed=grib_enrichment_failed,
         grib_init_times=grib_init_times,
+        grib_sources=grib_sources,
         diagnostics=diagnostics,
         open_meteo_api_calls=client.call_count,
     )

--- a/tests/test_freshness_registry.py
+++ b/tests/test_freshness_registry.py
@@ -152,6 +152,7 @@ def test_all_expected_sources_registered():
         "ecmwf:direct",
         "gfs:noaa",
         "icon_eu:dwd",
+        "icon_d2:dwd",
         "gfs:openmeteo",
         "ecmwf:openmeteo",
         "icon:openmeteo",

--- a/tests/test_icon_d2.py
+++ b/tests/test_icon_d2.py
@@ -1,0 +1,290 @@
+"""Tests for the ICON-D2 in-place upgrade of the icon slot (issue #456).
+
+ICON-D2 (2.2 km, convection-permitting) serves the ``icon`` model slot in place
+of ICON-EU when the whole route fits the D2 domain AND the flight window is
+within a D2 run's 48h horizon; otherwise ICON-EU exactly as before. The two
+variants share the entire download/decode path via :class:`IconVariant`.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+import pytest
+
+from weatherbrief.fetch.grib.icon_eu_fetch import (
+    ICON_D2,
+    ICON_EU,
+    compute_icon_eu_flight_window_hours,
+    icon_cloud_diag_cache_key,
+    icon_eu_file_url,
+    icon_eu_model_level_max_hour,
+    icon_eu_previous_step,
+    icon_eu_single_level_url,
+    icon_eu_window_out_of_range,
+    route_in_icon_eu_domain,
+)
+from weatherbrief.models import RoutePoint
+
+
+def _rp(lat: float, lon: float, nm: float = 0.0) -> RoutePoint:
+    return RoutePoint(lat=lat, lon=lon, distance_from_origin_nm=nm)
+
+
+# ---------------------------------------------------------------------------
+# URL builders — D2 filename quirks vs ICON-EU
+# ---------------------------------------------------------------------------
+
+
+class TestD2UrlBuilders:
+    def test_model_level_lowercase_var_and_germany_grid(self):
+        url = icon_eu_file_url("20260720", 0, 6, 60, "t", ICON_D2)
+        assert url == (
+            "https://opendata.dwd.de/weather/nwp/icon-d2/grib/00/t/"
+            "icon-d2_germany_regular-lat-lon_model-level_"
+            "2026072000_006_60_t.grib2.bz2"
+        )
+
+    def test_single_level_carries_2d_segment_and_lowercase_var(self):
+        url = icon_eu_single_level_url("20260720", 0, 6, "ceiling", ICON_D2)
+        assert url == (
+            "https://opendata.dwd.de/weather/nwp/icon-d2/grib/00/ceiling/"
+            "icon-d2_germany_regular-lat-lon_single-level_"
+            "2026072000_006_2d_ceiling.grib2.bz2"
+        )
+
+    def test_eu_urls_unchanged_by_default(self):
+        # Back-compat: no variant arg → ICON-EU exactly as before.
+        assert icon_eu_file_url("20260221", 0, 6, 74, "t") == (
+            "https://opendata.dwd.de/weather/nwp/icon-eu/grib/00/t/"
+            "icon-eu_europe_regular-lat-lon_model-level_"
+            "2026022100_006_74_T.grib2.bz2"
+        )
+        assert icon_eu_single_level_url("20260221", 0, 6, "ceiling") == (
+            "https://opendata.dwd.de/weather/nwp/icon-eu/grib/00/ceiling/"
+            "icon-eu_europe_regular-lat-lon_single-level_"
+            "2026022100_006_CEILING.grib2.bz2"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Domain gate — all-or-nothing over the central-European D2 box
+# ---------------------------------------------------------------------------
+
+
+class TestD2Domain:
+    def test_germany_internal_route_inside(self):
+        # EDDM (Munich) → EDDH (Hamburg), both well inside the D2 box.
+        points = [_rp(48.35, 11.79), _rp(51.0, 12.5, 150), _rp(53.63, 9.99, 300)]
+        assert route_in_icon_eu_domain(points, ICON_D2) is True
+
+    def test_one_point_outside_fails_all_or_nothing(self):
+        # A single Spanish endpoint drops the whole route out of D2.
+        points = [_rp(48.35, 11.79), _rp(41.3, 2.08, 400)]  # ...→ Barcelona
+        assert route_in_icon_eu_domain(points, ICON_D2) is False
+        # Same route is still inside the wider ICON-EU domain.
+        assert route_in_icon_eu_domain(points, ICON_EU) is True
+
+    def test_scotland_outside_d2_but_inside_eu(self):
+        # Glasgow (4.25°W) is west of the D2 edge (-3.94°E); note that eastern
+        # Scotland (e.g. Edinburgh, 3.19°W) does sit inside the box.
+        points = [_rp(52.0, 0.0), _rp(55.86, -4.25, 300)]  # ...→ Glasgow
+        assert route_in_icon_eu_domain(points, ICON_D2) is False
+        assert route_in_icon_eu_domain(points, ICON_EU) is True
+
+    def test_brittany_edge_west_outside_d2(self):
+        # Brittany sits west of the D2 western edge (-3.94°E).
+        points = [_rp(48.35, 11.79), _rp(48.45, -4.42, 400)]  # ...→ Brest
+        assert route_in_icon_eu_domain(points, ICON_D2) is False
+
+
+# ---------------------------------------------------------------------------
+# Horizon / temporal grid — D2 is hourly to 48h, all cycles
+# ---------------------------------------------------------------------------
+
+
+class TestD2HorizonAndGrid:
+    @pytest.mark.parametrize("cycle", [0, 3, 6, 9, 12, 15, 18, 21])
+    def test_all_cycles_reach_48h(self, cycle):
+        assert icon_eu_model_level_max_hour(cycle, ICON_D2) == 48
+
+    def test_eu_horizon_unchanged(self):
+        assert icon_eu_model_level_max_hour(0, ICON_EU) == 120
+        assert icon_eu_model_level_max_hour(3, ICON_EU) == 30
+
+    def test_previous_step_is_hourly(self):
+        assert icon_eu_previous_step(1, ICON_D2) == 0
+        assert icon_eu_previous_step(48, ICON_D2) == 47
+        assert icon_eu_previous_step(0, ICON_D2) is None
+
+    def test_window_hours_hourly(self):
+        # init 12z, dep 14z, 2h flight → hourly f2..f4.
+        dep = datetime(2026, 7, 20, 14, 0, tzinfo=timezone.utc)
+        hours = compute_icon_eu_flight_window_hours("20260720", 12, dep, 2.0, ICON_D2)
+        assert hours == [2, 3, 4]
+
+    def test_level_slice_and_variant_config(self):
+        assert (ICON_D2.level_min, ICON_D2.level_max) == (25, 65)
+        assert ICON_D2.slug == "icon-d2"
+        assert ICON_D2.source_key == "icon_d2:dwd"
+        assert icon_cloud_diag_cache_key(ICON_D2) == "ICON_D2_CLOUD_DIAG_V2"
+        assert icon_cloud_diag_cache_key(ICON_EU) == "ICON_EU_CLOUD_DIAG_V2"
+
+
+# ---------------------------------------------------------------------------
+# Out-of-range classification against the selected model's horizon
+# ---------------------------------------------------------------------------
+
+
+class TestD2OutOfRange:
+    def test_flight_beyond_48h_is_out_of_range_for_d2(self):
+        ref = datetime(2026, 7, 20, 12, 0, tzinfo=timezone.utc)
+        dep = datetime(2026, 7, 23, 6, 0, tzinfo=timezone.utc)  # ~66h out
+        assert icon_eu_window_out_of_range(dep, 1.0, ref, ICON_D2) is True
+
+    def test_flight_within_48h_in_range_for_d2(self):
+        ref = datetime(2026, 7, 20, 12, 0, tzinfo=timezone.utc)
+        dep = datetime(2026, 7, 21, 12, 0, tzinfo=timezone.utc)  # 24h out
+        assert icon_eu_window_out_of_range(dep, 1.0, ref, ICON_D2) is False
+
+    def test_same_far_flight_still_in_range_for_eu(self):
+        ref = datetime(2026, 7, 20, 12, 0, tzinfo=timezone.utc)
+        dep = datetime(2026, 7, 23, 6, 0, tzinfo=timezone.utc)  # ~66h out < 120h
+        assert icon_eu_window_out_of_range(dep, 1.0, ref, ICON_EU) is False
+
+
+# ---------------------------------------------------------------------------
+# Variant selection in _prepare_icon_eu (the gate + run interaction)
+# ---------------------------------------------------------------------------
+
+
+class TestPrepareIconVariantSelection:
+    """`_prepare_icon_eu` should pick D2 only when the domain + run gate passes."""
+
+    def _icon_cross_sections(self):
+        from weatherbrief.models import ModelSource, RouteCrossSection
+
+        cs = RouteCrossSection(
+            model=ModelSource.ICON,
+            route_points=[],
+            fetched_at=datetime(2026, 7, 20, tzinfo=timezone.utc),
+            point_forecasts=[],
+        )
+        return [cs]
+
+    def _run_finder(self, d2_run, eu_run):
+        """Return a fake find_latest_icon_eu_run keyed on the variant kwarg."""
+        from weatherbrief.fetch.grib.icon_eu_fetch import ICON_D2 as _D2
+
+        def _fake(target_time, session=None, as_of_time=None,
+                  cover_until=None, variant=None):
+            return d2_run if variant is _D2 else eu_run
+
+        return _fake
+
+    def test_picks_d2_when_domain_and_run_ok(self, tmp_path):
+        from weatherbrief.fetch.grib import _prepare_icon_eu
+
+        route = [_rp(48.35, 11.79), _rp(52.52, 13.4, 300)]  # Munich→Berlin
+        dep = datetime(2026, 7, 20, 12, 0, tzinfo=timezone.utc)
+        with patch(
+            "weatherbrief.fetch.grib.icon_eu_fetch.find_latest_icon_eu_run",
+            self._run_finder(d2_run=("20260720", 12), eu_run=("20260720", 12)),
+        ):
+            ctx, skip = _prepare_icon_eu(
+                self._icon_cross_sections(), route, dep,
+                data_dir=tmp_path, flight_duration_hours=2.0,
+            )
+        assert skip is None
+        assert ctx is not None
+        assert ctx.variant is ICON_D2
+        assert ctx.levels == list(range(25, 66))
+
+    def test_falls_back_to_eu_when_route_outside_d2(self, tmp_path):
+        from weatherbrief.fetch.grib import _prepare_icon_eu
+
+        route = [_rp(48.35, 11.79), _rp(41.3, 2.08, 400)]  # ...→ Barcelona
+        dep = datetime(2026, 7, 20, 12, 0, tzinfo=timezone.utc)
+        with patch(
+            "weatherbrief.fetch.grib.icon_eu_fetch.find_latest_icon_eu_run",
+            self._run_finder(d2_run=("20260720", 12), eu_run=("20260720", 12)),
+        ):
+            ctx, skip = _prepare_icon_eu(
+                self._icon_cross_sections(), route, dep,
+                data_dir=tmp_path, flight_duration_hours=2.0,
+            )
+        assert skip is None
+        assert ctx is not None
+        assert ctx.variant is ICON_EU
+
+    def test_falls_back_to_eu_when_d2_run_uncovered(self, tmp_path):
+        from weatherbrief.fetch.grib import _prepare_icon_eu
+
+        # Route fits the D2 box but the D2 run-finder returns None (window past
+        # 48h); ICON-EU still covers it → variant must be EU.
+        route = [_rp(48.35, 11.79), _rp(52.52, 13.4, 300)]
+        dep = datetime(2026, 7, 20, 12, 0, tzinfo=timezone.utc)
+        with patch(
+            "weatherbrief.fetch.grib.icon_eu_fetch.find_latest_icon_eu_run",
+            self._run_finder(d2_run=None, eu_run=("20260720", 12)),
+        ):
+            ctx, skip = _prepare_icon_eu(
+                self._icon_cross_sections(), route, dep,
+                data_dir=tmp_path, flight_duration_hours=2.0,
+            )
+        assert skip is None
+        assert ctx is not None
+        assert ctx.variant is ICON_EU
+
+    def test_force_variant_skips_d2_gate(self, tmp_path):
+        from weatherbrief.fetch.grib import _prepare_icon_eu
+
+        route = [_rp(48.35, 11.79), _rp(52.52, 13.4, 300)]  # inside D2
+        dep = datetime(2026, 7, 20, 12, 0, tzinfo=timezone.utc)
+        with patch(
+            "weatherbrief.fetch.grib.icon_eu_fetch.find_latest_icon_eu_run",
+            self._run_finder(d2_run=("20260720", 12), eu_run=("20260720", 12)),
+        ):
+            ctx, skip = _prepare_icon_eu(
+                self._icon_cross_sections(), route, dep,
+                data_dir=tmp_path, flight_duration_hours=2.0,
+                force_variant=ICON_EU,
+            )
+        assert ctx is not None
+        assert ctx.variant is ICON_EU
+
+
+# ---------------------------------------------------------------------------
+# Cache TTL + freshness registry wiring
+# ---------------------------------------------------------------------------
+
+
+def test_icon_d2_cache_ttl_registered():
+    from weatherbrief.fetch.grib.cache import MODEL_TTL_SECONDS
+
+    assert MODEL_TTL_SECONDS["icon-d2"] == 6 * 3600
+
+
+def test_icon_d2_source_registry_entry():
+    from weatherbrief.fetch.freshness import registry
+
+    cfg = registry.SOURCE_REGISTRY["icon_d2:dwd"]
+    assert cfg.readiness_check == "icon_d2_dwd"
+    assert cfg.model_label == "ICON-D2"
+    assert cfg.provider_label == "DWD"
+    assert cfg.role == "primary-sounding"
+    assert cfg.cycles == (0, 3, 6, 9, 12, 15, 18, 21)
+    # Uniform 48h horizon on every cycle.
+    for h in cfg.cycles:
+        assert registry.run_horizon("icon_d2:dwd", _utc(2026, 7, 20, h)) == timedelta(hours=48)
+
+
+def test_icon_d2_readiness_dispatch_registered():
+    from weatherbrief.fetch.freshness.sources import _DISPATCH, _check_icon_d2_dwd
+
+    assert _DISPATCH["icon_d2_dwd"] is _check_icon_d2_dwd
+
+
+def _utc(y, mo, d, h=0):
+    return datetime(y, mo, d, h, tzinfo=timezone.utc)

--- a/tests/test_icon_d2.py
+++ b/tests/test_icon_d2.py
@@ -125,11 +125,28 @@ class TestD2HorizonAndGrid:
         assert hours == [2, 3, 4]
 
     def test_level_slice_and_variant_config(self):
-        assert (ICON_D2.level_min, ICON_D2.level_max) == (25, 65)
+        # Level slice validated against DWD's HHL field (2026-07-21): D2 level
+        # 16 ≈ 9,460 m ≈ FL310 (≈ ICON-EU's level-35 300 hPa top); level 65 =
+        # surface. D2 level numbers are NOT comparable to EU's.
+        assert (ICON_D2.level_min, ICON_D2.level_max) == (16, 65)
         assert ICON_D2.slug == "icon-d2"
         assert ICON_D2.source_key == "icon_d2:dwd"
         assert icon_cloud_diag_cache_key(ICON_D2) == "ICON_D2_CLOUD_DIAG_V2"
         assert icon_cloud_diag_cache_key(ICON_EU) == "ICON_EU_CLOUD_DIAG_V2"
+
+    def test_d2_diag_list_drops_parameterized_convection_fields(self):
+        # D2 has no deep-convection scheme: hbas_con/htop_con 404 on the feed
+        # and rain_con is near-zero in explicit storms (verified live
+        # 2026-07-21). They must be absent so downstream fields stay None
+        # (missing-data semantics) rather than misleadingly quiet. #462 adds
+        # the convection-permitting replacements.
+        for var in ("hbas_con", "htop_con", "rain_con"):
+            assert var not in ICON_D2.cloud_diag_variables
+            assert var in ICON_EU.cloud_diag_variables
+        # The shared non-convective diagnostics stay identical.
+        for var in ("ceiling", "clcl", "clcm", "clch", "clct", "cape_ml", "cin_ml"):
+            assert var in ICON_D2.cloud_diag_variables
+            assert var in ICON_EU.cloud_diag_variables
 
 
 # ---------------------------------------------------------------------------
@@ -199,7 +216,7 @@ class TestPrepareIconVariantSelection:
         assert skip is None
         assert ctx is not None
         assert ctx.variant is ICON_D2
-        assert ctx.levels == list(range(25, 66))
+        assert ctx.levels == list(range(16, 66))
 
     def test_falls_back_to_eu_when_route_outside_d2(self, tmp_path):
         from weatherbrief.fetch.grib import _prepare_icon_eu

--- a/web/ts/managers/briefing-ui.ts
+++ b/web/ts/managers/briefing-ui.ts
@@ -463,7 +463,13 @@ function buildBasisFromSources(
   for (const [model, rows] of byModel) {
     const primary = rows.find(r => r.role === 'primary') || rows[0];
     const base = rows.find(r => r !== primary);
-    const label = modelLabel(model);
+    // The icon slot can be sourced from ICON-D2 (2.2km) instead of ICON-EU on
+    // short central-European routes (issue #456). modelLabel() keys off the
+    // model name ("icon") and can't tell them apart, so tag the D2 variant
+    // explicitly from the primary source key.
+    const label = primary.source === 'icon_d2:dwd'
+      ? `${modelLabel(model)} (D2)`
+      : modelLabel(model);
     // Drop the provider tag when it's already a token in the model label
     // (e.g. "DWD ICON 12Z DWD" → "DWD ICON 12Z", "ECMWF IFS 12Z ECMWF" →
     // "ECMWF IFS 12Z").  Avoids visible duplication for ICON/ECMWF where


### PR DESCRIPTION
## What & why

In-place upgrade of the existing `icon` model slot (issue #456). When a route fits **entirely** inside the ICON-D2 domain **and** the flight window is within a D2 run's 48h horizon, the ICON GRIB enrichment (full sounding replacement + cloud diagnostics) is sourced from **ICON-D2** (2.2 km, convection-permitting) instead of **ICON-EU** (6.5 km). Otherwise ICON-EU is used exactly as before. This is a source-variant of the same slot — **not** a 7th model, and **never** a per-point mix of D2 and EU within one briefing.

Since ICON-D2 is a config-level clone of the ICON-EU decode path (same server layout, same variable names, same regular-lat-lon grid type), the work is a parametrization rather than a copy:

- **`IconVariant` config object** (`ICON_EU` / `ICON_D2`) captures everything that differs — domain bbox, cycles, publication delay, model-level slice, filename conventions, cache slug, and freshness source key. Every `icon_eu_*` helper (URL builders, domain gate, run finder, window/level/horizon math) now takes `variant=ICON_EU`, so all existing callers and tests are unchanged.
- **D2 filename quirks** handled: model token `icon-d2`, region token `germany`, **lowercase** variable suffix (`…_60_t`), and a `_2d_` segment on single-level files (`…_006_2d_ceiling`).
- **All-or-nothing gate** in `_prepare_icon_eu`: every route point inside the D2 domain AND `flight_window_end ≤ selected_run_init + 48h`. It resolves the D2 run inline while gating, so it never picks D2 without a usable run; if the freshest complete D2 run doesn't cover the window it falls back to ICON-EU rather than a stale D2 run.
- **Fallback robustness**: on a total D2 failure (feed hiccup / decode error) the icon slot re-runs cleanly on ICON-EU — never a half-D2 pack.
- **Source attribution**: `enrich_forecasts` now returns `grib_sources` (model → source key used) so the pack records `model_sources["icon"]` = `icon_eu:dwd` or `icon_d2:dwd`; the freshness bar badges **`ICON (D2)`** when D2 supplied the run.
- **Wiring**: cache TTL (`icon-d2`, 6h), freshness registry entry (`icon_d2:dwd`) + readiness check (`icon_d2_dwd`), design-doc updates (`weather-engine-specs.md` §C.2, `fetch.md`).

**Note on two values that need live validation** (the sandbox has no route to `opendata.dwd.de`): the D2 domain corners and the model-level slice `25–65` are taken from the documented ICON-D2 `germany` regular-lat-lon product (1215×746 ≈ 906k points, matching the issue). `level_min=25` is a deliberately conservative top — the log-p interpolation clips any target level above the fetched column, so over-fetching a few thin upper levels is cheap insurance against truncating the sounding. Both are single well-commented constants; worth confirming against DWD's D2 HHL table once the feed is reachable.

## Issue linkage

Closes #456

## Testing / verification

- New `tests/test_icon_d2.py`: D2 URL builders (model-level lowercase + `_2d_` single-level), all-or-nothing domain gate (Germany-internal inside; Barcelona / Glasgow / Brest one-point-outside → EU), 48h horizon on every cycle, hourly temporal grid, out-of-range classification, `_prepare_icon_eu` variant selection (picks D2 on domain+run fit; falls back to EU when route outside D2 or D2 run uncovered; `force_variant` bypass), cache-TTL + registry + readiness-dispatch wiring.
- Updated `tests/test_freshness_registry.py` for the new `icon_d2:dwd` source.
- ICON-EU back-compat preserved: existing helpers keep `variant=ICON_EU` defaults; existing EU URL/domain/window tests are untouched.
- Verified the pure-logic modules (URL builders, domain/horizon/window math, registry config) standalone in-sandbox; frontend `briefing-ui.ts` typechecks and bundles. **The full pytest suite could not run in-sandbox** (the private `euro-aip` dep requires Python ≥3.12; sandbox is 3.11) — the integration-level tests are written to run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EmbDUYzFjU7jtVbEoNsrqo)_