### PR TITLE
ICON-D2 explicit-convection track for convective advisories (#462)

### DIFF
--- a/designs/meteorology-decisions.md
+++ b/designs/meteorology-decisions.md
@@ -1958,3 +1958,46 @@ follow-up:
 - Watch for any all-quiet-NWP sounding that *did* produce observed convection
   (lightning/METAR-TS) — that is the case the removed floor was protecting, and
   the one that would argue for a narrower cap.
+
+---
+
+## 19. ICON-D2 explicit convection: storm-process vs environment corroborators (#462)
+
+**Date:** 2026-07-21
+**Status:** Implemented (#462).
+**Context:** After #461 sourced the `icon` slot from convection-permitting
+ICON-D2 (dropping parameterized `hbas_con`/`htop_con`/`rain_con`), #462 builds
+the replacement track from explicit storm fields (`dbz_ctmax`, `lpi_max`,
+`w_ctmax`, `grau_gsp`, constructed hourly `echotop`). The issue's v1 decision
+table counted LPI, updraft, graupel, **and** ML-CAPE as independent
+corroborators. Two meteorology problems:
+
+1. **LPI already embeds updraft² × graupel** (Lynn & Yair / DWD LPI). Counting
+   `lpi_max`, `w_ctmax`, and `grau_gsp` as three votes triple-counts one
+   mixed-phase updraft.
+2. **CAPE is environment, not storm process.** A 35–44 dBZ bright band over a
+   primed sounding would upgrade to MARGINAL on CAPE alone — exactly the
+   stratiform false-alarm the quiet-control matrix is meant to catch.
+
+### The decision
+
+- **Firing core:** corridor-max `dbz_ctmax` over `(valid_hour−1, valid_hour]`.
+- **Storm-process corroborators (|C|):** LPI is primary (≥1 → 1, ≥5 → 2). When
+  LPI is missing/below floor, `w_ctmax ≥ 10` and `graupel ≥ 0.5 mm` may each
+  *substitute* (count 1). When LPI is present, w/graupel are narrative detail
+  only — not additive.
+- **CAPE / UH:** narrative only after (or beside) a fire — never upgrade the
+  35–44 band alone. Wording: "graupel / mixed-phase core", never "hail".
+- **Echo top:** `echo_top_18dbz_ft` is character only; `top_ft=None` on
+  `method="nwp_explicit"` so overfly clearance cannot treat it as a cloud top.
+- **Incomplete detection:** assessment with `native_data_complete=False` stays
+  in the NWP slot (not CAPE fallback, not "scheme quiet" for #178/#442
+  cross-check).
+
+Rejected alternatives: (a) issue draft's four-way |C| including CAPE; (b)
+mapping `echotop` into `htop_con` consumers; (c) centreline bilinear sampling
+of 2.2 km extrema (cells between route points vanish).
+
+Aggregation when a lone D2 cell faces quiet coarse models remains an open
+#442 decision — do not silently majority-vote it away; make the per-model D2
+RED visible in details regardless.

--- a/src/weatherbrief/analysis/advisories/convective_character.py
+++ b/src/weatherbrief/analysis/advisories/convective_character.py
@@ -381,6 +381,11 @@ class ConvectiveCharacterEvaluator:
                         (showers is not None and showers >= showers_mm)
                         or (cover is not None and cover >= CHAR_COVER_REALIZED_PCT)
                         or has_geom
+                        or (
+                            nwp is not None
+                            and nwp.method == "nwp_explicit"
+                            and nwp.risk_level != ConvectiveRisk.NONE
+                        )
                     )
                     embedded = _point_embedded(sounding, cruise_ft)
                     # Below-base avoidability geometry (#298): is the layer from

--- a/src/weatherbrief/analysis/sounding/__init__.py
+++ b/src/weatherbrief/analysis/sounding/__init__.py
@@ -234,6 +234,7 @@ def analyze_sounding_lite(
         detect_cloud_layers,
     )
     from weatherbrief.analysis.sounding.convective import (
+        assess_convective_explicit,
         assess_convective_nwp,
         assess_convective_thermo,
     )
@@ -311,9 +312,16 @@ def analyze_sounding_lite(
     convective = assess_convective_thermo(
         indices, omega_700_pa_s=_omega_near_700(derived_levels)
     )
-    convective_nwp = assess_convective_nwp(
-        indices, hourly.nwp_cloud_diagnostics if hourly else None,
-    )
+    if hourly and hourly.explicit_convective_diagnostics is not None:
+        convective_nwp = assess_convective_explicit(
+            indices,
+            hourly.explicit_convective_diagnostics,
+            hourly.nwp_cloud_diagnostics,
+        )
+    else:
+        convective_nwp = assess_convective_nwp(
+            indices, hourly.nwp_cloud_diagnostics if hourly else None,
+        )
 
     # Compute ceiling from NWP-reclassified cloud layers
     sounding_ceiling_ft = compute_sounding_ceiling_ft(

--- a/src/weatherbrief/analysis/sounding/convective.py
+++ b/src/weatherbrief/analysis/sounding/convective.py
@@ -15,6 +15,7 @@ from weatherbrief.models import (
     ConvectiveRegime,
     ConvectiveRisk,
     NWPCloudDiagnostics,
+    NWPExplicitConvectiveDiagnostics,
     ThermodynamicIndices,
 )
 
@@ -891,6 +892,167 @@ def assess_convective_nwp(
     )
 
 
+def _explicit_storm_corroboration(
+    diagnostics: NWPExplicitConvectiveDiagnostics,
+    nwp_diagnostics: NWPCloudDiagnostics | None,
+) -> tuple[int, list[str], list[str]]:
+    """Count storm-process corroborators for the D2 decision table (#462).
+
+    LPI already embeds updraft² weighted by graupel in the charging zone, so
+    LPI and (w_ctmax, grau_gsp) are one physical family — not three independent
+    votes. When LPI is usable it is the primary corroborator (weight 2 at
+    ≥5 J/kg); w/graupel become narrative detail only. When LPI is missing or
+    below floor, w and graupel may each substitute as one count.
+
+    CAPE is environment only — never counted toward |C|. Counting it would let
+    a bright-band 35–44 dBZ echo + unstable sounding narrate as a thunderstorm.
+    """
+    corroborators: list[str] = []
+    narrative: list[str] = []
+    count = 0
+
+    lpi = diagnostics.lightning_potential_hour_max_jkg
+    updraft = diagnostics.updraft_hour_max_ms
+    graupel = diagnostics.graupel_hour_mm
+
+    if lpi is not None and lpi >= 1.0:
+        count += 2 if lpi >= 5.0 else 1
+        corroborators.append(f"LPI {lpi:.1f} J/kg")
+        if updraft is not None and updraft >= 10.0:
+            narrative.append(f"updraft {updraft:.1f} m/s")
+        if graupel is not None and graupel >= 0.5:
+            narrative.append(f"graupel / mixed-phase core {graupel:.1f} mm/h")
+    else:
+        if updraft is not None and updraft >= 10.0:
+            count += 1
+            corroborators.append(f"updraft {updraft:.1f} m/s")
+        if graupel is not None and graupel >= 0.5:
+            count += 1
+            corroborators.append(f"graupel / mixed-phase core {graupel:.1f} mm/h")
+
+    model_ml_cape = nwp_diagnostics.ml_cape_jkg if nwp_diagnostics else None
+    if model_ml_cape is not None and model_ml_cape >= 500.0:
+        narrative.append(f"ML-CAPE {model_ml_cape:.0f} J/kg (environment)")
+
+    uh = diagnostics.updraft_helicity_2_8km_hour_max_m2s2
+    if uh is not None and abs(uh) >= 25.0:
+        narrative.append(f"updraft helicity {uh:.0f} m²/s² (rotation character)")
+
+    return count, corroborators, narrative
+
+
+def assess_convective_explicit(
+    indices: ThermodynamicIndices,
+    diagnostics: NWPExplicitConvectiveDiagnostics,
+    nwp_diagnostics: NWPCloudDiagnostics | None = None,
+) -> ConvectiveAssessment:
+    """Map ICON-D2 explicit-storm evidence onto the shared risk vocabulary.
+
+    This is intentionally separate from :func:`assess_convective_nwp`: D2's
+    reflectivity/updraft fields describe explicitly resolved convection, not a
+    deep-convection parameterization.
+
+    Incomplete detection (``detection_complete=False``) returns an assessment
+    with ``native_data_complete=False`` and risk NONE — never a quiet-scheme
+    claim, never a CAPE fallback presented as D2's explicit verdict. Callers
+    must keep this object in the NWP slot so resolution does not silently swap
+    to thermo. Cross-check treats incomplete as neither quiet nor active.
+    """
+    cape = _effective_cape(indices)
+    lpi = diagnostics.lightning_potential_hour_max_jkg
+    updraft = diagnostics.updraft_hour_max_ms
+    graupel = diagnostics.graupel_hour_mm
+    uh = diagnostics.updraft_helicity_2_8km_hour_max_m2s2
+    dbz = diagnostics.reflectivity_hour_max_dbz
+
+    base_kwargs = dict(
+        cape_jkg=cape,
+        cin_jkg=indices.cin_surface_jkg,
+        lcl_altitude_ft=indices.lcl_altitude_ft,
+        lfc_altitude_ft=indices.lfc_altitude_ft,
+        el_altitude_ft=indices.el_altitude_ft,
+        bulk_shear_0_6km_kt=indices.bulk_shear_0_6km_kt,
+        lifted_index=indices.lifted_index,
+        k_index=indices.k_index,
+        total_totals=indices.total_totals,
+        severe_modifiers=_severity_modifiers(indices, cape),
+        base_ft=None,
+        top_ft=None,
+        cover_pct=None,
+        method="nwp_explicit",
+        source=diagnostics.source,
+        reflectivity_hour_max_dbz=dbz,
+        echo_top_18dbz_ft=diagnostics.echo_top_18dbz_ft,
+        lightning_potential_hour_max_jkg=lpi,
+        updraft_hour_max_ms=updraft,
+        updraft_helicity_2_8km_hour_max_m2s2=uh,
+        graupel_hour_mm=graupel,
+    )
+
+    if not diagnostics.detection_complete:
+        return ConvectiveAssessment(
+            risk_level=ConvectiveRisk.NONE,
+            drivers=[],
+            suppressors=[
+                "ICON-D2 explicit-convection assessment unavailable "
+                "(detection channel incomplete over the corridor)"
+            ],
+            native_data_complete=False,
+            **base_kwargs,
+        )
+
+    dbz_for_table = dbz if dbz is not None else float("-inf")
+    corroborator_count, corroborators, narrative = _explicit_storm_corroboration(
+        diagnostics, nwp_diagnostics,
+    )
+
+    if dbz_for_table < 35.0:
+        risk = ConvectiveRisk.NONE
+    elif dbz_for_table < 45.0:
+        # 35–44 requires a storm-process corroborator (not CAPE alone).
+        if corroborator_count == 0:
+            risk = ConvectiveRisk.NONE
+        elif corroborator_count == 1:
+            risk = ConvectiveRisk.MARGINAL
+        else:
+            risk = ConvectiveRisk.MODERATE
+    elif dbz_for_table < 50.0:
+        risk = (
+            ConvectiveRisk.HIGH
+            if corroborator_count >= 2
+            else ConvectiveRisk.MODERATE
+        )
+    else:
+        risk = ConvectiveRisk.HIGH
+
+    drivers: list[str] = []
+    suppressors: list[str] = []
+    if dbz is not None:
+        drivers.append(f"ICON-D2 hourly corridor reflectivity {dbz:.0f} dBZ")
+    if corroborators:
+        drivers.append("Explicit-storm corroboration: " + ", ".join(corroborators))
+    if narrative:
+        drivers.append("Explicit-storm detail: " + ", ".join(narrative))
+    if 35.0 <= dbz_for_table < 45.0 and corroborator_count == 0:
+        suppressors.append(
+            "35–44 dBZ echo without storm-process corroboration; "
+            "likely stratiform or melting-band enhancement"
+        )
+    if diagnostics.echo_top_18dbz_ft is not None and diagnostics.echo_top_complete:
+        drivers.append(
+            f"18 dBZ echo top ~{diagnostics.echo_top_18dbz_ft:.0f} ft "
+            "(character only — not a cloud top for clearance)"
+        )
+
+    return ConvectiveAssessment(
+        risk_level=risk,
+        drivers=drivers,
+        suppressors=suppressors,
+        native_data_complete=True,
+        **base_kwargs,
+    )
+
+
 # Convective DD-vs-model cross-check thresholds (tunable module constants).
 # These gate the "does the model's own convective scheme corroborate the DD
 # (CAPE-derived) risk" signal surfaced in the advisory popup and LLM digest.
@@ -947,6 +1109,44 @@ def convective_cross_check(
         # itself. Skip it — same reasoning the dd_nwp_agreement convective block
         # used before it was removed. (#283 review) Reachable when a diagnostic
         # carries only stability indices (ml_cape/kx/...) and no cloud content.
+        return None
+
+    if nwp.method == "nwp_explicit":
+        explicit_active = nwp.risk_level != ConvectiveRisk.NONE
+        explicit_quiet = (
+            nwp.native_data_complete is True
+            and nwp.risk_level == ConvectiveRisk.NONE
+        )
+        thermo_high = _RISK_LEVELS.index(thermo.risk_level) >= _RISK_LEVELS.index(
+            ConvectiveRisk.MODERATE
+        )
+        thermo_low = thermo.risk_level in (
+            ConvectiveRisk.NONE, ConvectiveRisk.MARGINAL,
+        )
+        if thermo_high and explicit_quiet:
+            cape_txt = (
+                f" (CAPE {thermo.cape_jkg:.0f})"
+                if thermo.cape_jkg is not None else ""
+            )
+            return ConvectiveCrossCheck(
+                direction="dd_not_corroborated",
+                note=(
+                    f"Thermo Convective shows {thermo.risk_level.value.upper()} instability"
+                    f"{cape_txt}, but ICON-D2 explicit-convection diagnostics are quiet"
+                ),
+            )
+        if thermo_low and explicit_active:
+            dbz_txt = (
+                f" ({nwp.reflectivity_hour_max_dbz:.0f} dBZ corridor maximum)"
+                if nwp.reflectivity_hour_max_dbz is not None else ""
+            )
+            return ConvectiveCrossCheck(
+                direction="model_active_dd_quiet",
+                note=(
+                    f"ICON-D2 explicit convection is active{dbz_txt}, but Thermo "
+                    "Convective shows little instability"
+                ),
+            )
         return None
 
     precip = nwp.convective_precip_mm_h

--- a/src/weatherbrief/fetch/grib/__init__.py
+++ b/src/weatherbrief/fetch/grib/__init__.py
@@ -50,6 +50,7 @@ from weatherbrief.models import (
     HourlyForecast,
     ModelSource,
     NWPCloudDiagnostics,
+    NWPExplicitConvectiveDiagnostics,
     RouteCrossSection,
     RoutePoint,
     WaypointForecast,
@@ -3073,6 +3074,7 @@ def _prepare_icon_eu(
         compute_icon_eu_flight_window_hours,
         find_latest_icon_eu_run,
         icon_eu_window_out_of_range,
+        route_in_icon_d2_product_mask,
         route_in_icon_eu_domain,
     )
 
@@ -3101,11 +3103,18 @@ def _prepare_icon_eu(
                 logger.warning("Failed to find ICON-D2 run; using ICON-EU", exc_info=True)
                 d2_run = None
             if d2_run is not None:
-                variant, run_info = ICON_D2, d2_run
-                logger.info(
-                    "ICON slot sourced from ICON-D2 (route in D2 domain, run %s %02dz)",
-                    d2_run[0], d2_run[1],
-                )
+                if route_in_icon_d2_product_mask(
+                    route_points, d2_run[0], d2_run[1], session=session,
+                ):
+                    variant, run_info = ICON_D2, d2_run
+                    logger.info(
+                        "ICON slot sourced from ICON-D2 (route corridor in delivered mask, run %s %02dz)",
+                        d2_run[0], d2_run[1],
+                    )
+                else:
+                    logger.info(
+                        "Route corridor clips ICON-D2 delivered mask; using ICON-EU"
+                    )
 
     if not route_in_icon_eu_domain(route_points, variant):
         logger.info("Route outside %s domain, skipping ICON enrichment", variant.slug)
@@ -3251,12 +3260,10 @@ def _prefetch_icon_eu_data_inner(ctx: _IconEuContext) -> None:
         if not is_cached(ctx.run_dir, diag_ck):
             jobs.append((_fetch_diag, fhour, diag_ck))
 
-    # One leading single-level step so the first window hour has a predecessor
-    # to de-accumulate rain_con against (#421). Cloud-diag fetch only — the
-    # model-level sounding list above is untouched. Skipped when the variant
-    # doesn't fetch rain_con (ICON-D2, #456/#462) — no accumulated field, no
-    # predecessor needed.
-    if ctx.forecast_hours and "rain_con" in variant.cloud_diag_variables:
+    # One leading single-level step for cross-file interval products. ICON-EU
+    # needs it for rain_con de-accumulation; ICON-D2 needs it both for graupel
+    # de-accumulation and the three pre-hour ECHOTOP quarters (#462).
+    if ctx.forecast_hours and variant.cloud_diag_needs_predecessor:
         lead = icon_eu_previous_step(min(ctx.forecast_hours), variant)
         if lead is not None and lead not in ctx.forecast_hours:
             lead_ck = cache_key(lead, diag_key)
@@ -3446,7 +3453,7 @@ def _enrich_icon_eu_cloud_diagnostics(
     # _matches_valid_time never matches an out-of-window hourly, so it only
     # seeds the de-accumulation state.
     steps = sorted(set(forecast_hours))
-    if steps and "rain_con" in variant.cloud_diag_variables:
+    if steps and variant.cloud_diag_needs_predecessor:
         lead = icon_eu_previous_step(steps[0], variant)
         if lead is not None and lead not in steps:
             steps.insert(0, lead)
@@ -3487,6 +3494,64 @@ def _enrich_icon_eu_cloud_diagnostics(
         diagnostics_per_point = [build_icon_cloud_diagnostics(raw) for raw in decoded_points]
 
         valid_utc = _forecast_hour_to_utc(init_date, init_hour, fhour)
+
+        explicit_per_point: list[NWPExplicitConvectiveDiagnostics] | None = None
+        if variant.slug == "icon-d2" and fhour in forecast_hours:
+            previous_fhour = icon_eu_previous_step(fhour, variant)
+            previous_path: str | None = None
+            if previous_fhour is not None:
+                previous_ck = cache_key(previous_fhour, diag_key)
+                if is_cached(run_dir, previous_ck):
+                    previous_path = str(run_dir / previous_ck)
+            with _grib_time("icon_d2_explicit_decode"):
+                explicit_raw = _dispatch_decode(
+                    "decode_icon_d2_explicit",
+                    str(cache_path), previous_path, fhour,
+                    point_lats, point_lons, 10.0,
+                )
+            from weatherbrief.models import pressure_pa_to_altitude_ft
+
+            explicit_per_point = []
+            for raw in explicit_raw:
+                dbz_hour = raw.get("reflectivity_hour_max_dbz")
+                dbz_instant = raw.get("reflectivity_instant_dbz")
+                echo_pa = raw.get("echo_top_18dbz_pressure_pa")
+                explicit_per_point.append(NWPExplicitConvectiveDiagnostics(
+                    reflectivity_hour_max_dbz=(
+                        float(dbz_hour)
+                        if isinstance(dbz_hour, (int, float)) and dbz_hour > -100.0
+                        else None
+                    ),
+                    reflectivity_instant_dbz=(
+                        float(dbz_instant)
+                        if isinstance(dbz_instant, (int, float)) and dbz_instant > -100.0
+                        else None
+                    ),
+                    echo_top_18dbz_ft=(
+                        pressure_pa_to_altitude_ft(float(echo_pa))
+                        if isinstance(echo_pa, (int, float)) and echo_pa > 0.0
+                        else None
+                    ),
+                    lightning_potential_hour_max_jkg=(
+                        float(raw["lightning_potential_hour_max_jkg"])
+                        if "lightning_potential_hour_max_jkg" in raw else None
+                    ),
+                    updraft_hour_max_ms=(
+                        float(raw["updraft_hour_max_ms"])
+                        if "updraft_hour_max_ms" in raw else None
+                    ),
+                    updraft_helicity_2_8km_hour_max_m2s2=(
+                        float(raw["updraft_helicity_2_8km_hour_max_m2s2"])
+                        if "updraft_helicity_2_8km_hour_max_m2s2" in raw else None
+                    ),
+                    graupel_hour_mm=(
+                        float(raw["graupel_hour_mm"])
+                        if "graupel_hour_mm" in raw else None
+                    ),
+                    detection_complete=bool(raw.get("detection_complete", False)),
+                    strength_complete=bool(raw.get("strength_complete", False)),
+                    echo_top_complete=bool(raw.get("echo_top_complete", False)),
+                ))
 
         # Convective precip rate (#421): rain_con is accumulated since init
         # (kg/m² ≡ mm), so difference it against the previous step and inject the
@@ -3549,37 +3614,81 @@ def _enrich_icon_eu_cloud_diagnostics(
                 if point_idx >= len(diagnostics_per_point):
                     break
                 diag = diagnostics_per_point[point_idx]
-                if diag is None:
-                    continue
                 for hourly in wf.hourly:
                     if not _matches_valid_time(hourly.time, valid_utc):
                         continue
-                    if hourly.nwp_cloud_diagnostics is None:
+                    if diag is not None and hourly.nwp_cloud_diagnostics is None:
                         _apply_cloud_diagnostics(hourly, diag)
                         total_enriched += 1
+                    if explicit_per_point is not None:
+                        hourly.explicit_convective_diagnostics = explicit_per_point[point_idx]
 
         # Also enrich waypoint-only forecasts
         wp_diag_lookup: dict[str, NWPCloudDiagnostics] = {}
-        for rp, diag in zip(route_points, diagnostics_per_point):
+        wp_explicit_lookup: dict[str, NWPExplicitConvectiveDiagnostics] = {}
+        for point_idx, (rp, diag) in enumerate(zip(route_points, diagnostics_per_point)):
             if rp.waypoint_icao and diag is not None:
                 wp_diag_lookup[rp.waypoint_icao] = diag
+            if (
+                rp.waypoint_icao
+                and explicit_per_point is not None
+                and point_idx < len(explicit_per_point)
+            ):
+                wp_explicit_lookup[rp.waypoint_icao] = explicit_per_point[point_idx]
 
         for wf in all_forecasts:
             if wf.model.value != "icon":
                 continue
             diag = wp_diag_lookup.get(wf.waypoint.icao)
-            if diag is None:
+            explicit = wp_explicit_lookup.get(wf.waypoint.icao)
+            if diag is None and explicit is None:
                 continue
             for hourly in wf.hourly:
                 if not _matches_valid_time(hourly.time, valid_utc):
                     continue
-                if hourly.nwp_cloud_diagnostics is None:
+                if diag is not None and hourly.nwp_cloud_diagnostics is None:
                     _apply_cloud_diagnostics(hourly, diag)
+                if explicit is not None:
+                    hourly.explicit_convective_diagnostics = explicit
 
         del decoded_points
         del diagnostics_per_point
+        if explicit_per_point is not None:
+            del explicit_per_point
         del wp_diag_lookup
+        del wp_explicit_lookup
         _grib_gc()
+
+    # Preserve explicit-mode provenance even when the D2 diagnostic blob for a
+    # particular hour failed completely. Without this marker, a forward-filled
+    # cloud-cover object could be misread as a quiet parameterized-convection
+    # assessment even though D2 has no deep-convection scheme.
+    if variant.slug == "icon-d2":
+        requested_valid_times = {
+            _forecast_hour_to_utc(init_date, init_hour, fh)
+            for fh in forecast_hours
+        }
+        for cs in icon_sections:
+            for wf in cs.point_forecasts:
+                for hourly in wf.hourly:
+                    if (
+                        any(_matches_valid_time(hourly.time, vt) for vt in requested_valid_times)
+                        and hourly.explicit_convective_diagnostics is None
+                    ):
+                        hourly.explicit_convective_diagnostics = (
+                            NWPExplicitConvectiveDiagnostics()
+                        )
+        for wf in all_forecasts:
+            if wf.model.value != "icon":
+                continue
+            for hourly in wf.hourly:
+                if (
+                    any(_matches_valid_time(hourly.time, vt) for vt in requested_valid_times)
+                    and hourly.explicit_convective_diagnostics is None
+                ):
+                    hourly.explicit_convective_diagnostics = (
+                        NWPExplicitConvectiveDiagnostics()
+                    )
 
     if total_enriched:
         logger.info(

--- a/src/weatherbrief/fetch/grib/decode.py
+++ b/src/weatherbrief/fetch/grib/decode.py
@@ -11,6 +11,7 @@ Handles two categories of GFS variables:
 from __future__ import annotations
 
 import logging
+import math
 import tempfile
 import warnings
 from pathlib import Path
@@ -1388,6 +1389,304 @@ def decode_icon_eu_cloud_diag_per_point(
         return [{} for _ in range(n_points)]
     finally:
         tmp_path.unlink(missing_ok=True)
+
+
+def _icon_d2_step_hours(xr_var) -> list[float]:
+    """Return forecast-step coordinates as hours for a cfgrib variable."""
+    import numpy as np
+
+    if "step" not in xr_var.coords:
+        return []
+    raw = np.atleast_1d(xr_var.coords["step"].values)
+    return [float(v / np.timedelta64(1, "h")) for v in raw]
+
+
+def _icon_d2_step_grid(xr_var, target_hour: float):
+    """Select one exact D2 message by forecast-step hour."""
+    import numpy as np
+
+    steps = _icon_d2_step_hours(xr_var)
+    if "step" in xr_var.dims:
+        for idx, step_h in enumerate(steps):
+            if abs(step_h - target_hour) < 1e-6:
+                return np.asarray(xr_var.isel(step=idx).values, dtype=np.float64)
+        return None
+    if steps and abs(steps[0] - target_hour) >= 1e-6:
+        return None
+    return np.asarray(xr_var.values, dtype=np.float64)
+
+
+def _corridor_extrema(
+    grid,
+    grid_lats,
+    grid_lons,
+    target_lats: list[float],
+    target_lons: list[float],
+    *,
+    radius_nm: float,
+    mode: str,
+    require_complete: bool = True,
+) -> tuple[list[float | None], list[bool]]:
+    """Reduce a 2-D regular lat/lon grid over circular route corridors.
+
+    Completeness requires every delivered grid cell in the kernel to be
+    finite.  This keeps a partially masked domain edge distinct from a valid
+    quiet value. ``abs_signed_max`` selects by magnitude but retains UH sign.
+    """
+    import numpy as np
+
+    arr = np.asarray(grid, dtype=np.float64)
+    lats = np.asarray(grid_lats, dtype=np.float64)
+    lons = np.asarray(grid_lons, dtype=np.float64)
+    values: list[float | None] = []
+    complete: list[bool] = []
+    for lat, lon in zip(target_lats, target_lons):
+        lat_delta = radius_nm / 60.0
+        lon_delta = radius_nm / max(1e-6, 60.0 * math.cos(math.radians(lat)))
+        ii = np.flatnonzero((lats >= lat - lat_delta) & (lats <= lat + lat_delta))
+        jj = np.flatnonzero((lons >= lon - lon_delta) & (lons <= lon + lon_delta))
+        if ii.size == 0 or jj.size == 0:
+            values.append(None)
+            complete.append(False)
+            continue
+        lat_nm = (lats[ii] - lat) * 60.0
+        lon_nm = (lons[jj] - lon) * 60.0 * math.cos(math.radians(lat))
+        kernel = lat_nm[:, None] ** 2 + lon_nm[None, :] ** 2 <= radius_nm ** 2
+        subset = arr[np.ix_(ii, jj)][kernel]
+        finite = np.isfinite(subset)
+        is_complete = bool(subset.size and finite.all())
+        complete.append(is_complete)
+        if require_complete and not is_complete:
+            values.append(None)
+            continue
+        subset = subset[finite]
+        if subset.size == 0:
+            values.append(None)
+            continue
+        if mode == "max":
+            values.append(float(subset.max()))
+        elif mode == "min":
+            values.append(float(subset.min()))
+        elif mode == "abs_signed_max":
+            values.append(float(subset[np.argmax(np.abs(subset))]))
+        else:  # pragma: no cover - internal programming error
+            raise ValueError(f"Unknown corridor reduction mode: {mode}")
+    return values, complete
+
+
+def _deaccumulate_nonnegative_grid(current, previous):
+    """Cell-wise accumulated-field difference; missing remains missing."""
+    import numpy as np
+
+    current_arr = np.asarray(current, dtype=np.float64)
+    previous_arr = np.asarray(previous, dtype=np.float64)
+    finite = np.isfinite(current_arr) & np.isfinite(previous_arr)
+    return np.where(
+        finite,
+        np.maximum(0.0, current_arr - previous_arr),
+        np.nan,
+    )
+
+
+def _hourly_echo_min_pressure_grid(quarters: list):
+    """Highest 18-dBZ echo over four quarters as minimum positive pressure."""
+    import numpy as np
+
+    if len(quarters) != 4:
+        return None
+    result = np.full_like(quarters[0], np.nan, dtype=np.float64)
+    for quarter in quarters:
+        physical = np.where(np.asarray(quarter) > 0.0, quarter, np.nan)
+        result = np.fmin(result, physical)
+    return result
+
+
+def decode_icon_d2_explicit_per_point(
+    current_grib_bytes: bytes,
+    previous_grib_bytes: bytes | None,
+    forecast_hour: int,
+    latitudes: list[float],
+    longitudes: list[float],
+    corridor_radius_nm: float = 10.0,
+) -> list[dict[str, float | bool]]:
+    """Decode ICON-D2 explicit convection with correct space/time semantics.
+
+    Hourly graupel is differenced on the grid *before* corridor maximisation;
+    differencing two corridor maxima is invalid when their maximizing cells
+    differ.  Hourly ECHOTOP is the minimum pressure across exactly four
+    15-minute windows ending in ``(H-1, H]``.
+    """
+    import cfgrib
+    import numpy as np
+
+    n_points = len(latitudes)
+    empty: list[dict[str, float | bool]] = [{} for _ in range(n_points)]
+    if not current_grib_bytes:
+        return empty
+
+    paths: list[Path] = []
+    datasets: list[list] = []
+
+    def _open(raw: bytes | None) -> list:
+        if not raw:
+            return []
+        with tempfile.NamedTemporaryFile(suffix=".grib2", delete=False) as tmp:
+            tmp.write(raw)
+            path = Path(tmp.name)
+        paths.append(path)
+        opened = cfgrib.open_datasets(str(path), backend_kwargs={"indexpath": ""})
+        datasets.append(opened)
+        return opened
+
+    def _find(dss: list, names: set[str]):
+        for ds in dss:
+            for name, var in ds.data_vars.items():
+                short = str(var.attrs.get("GRIB_shortName", name)).lower()
+                if str(name).lower() in names or short in names:
+                    return var
+        return None
+
+    try:
+        current = _open(current_grib_bytes)
+        previous = _open(previous_grib_bytes)
+        reference = next((ds for ds in current if "latitude" in ds.coords), None)
+        if reference is None:
+            return empty
+        grid_lats = np.asarray(reference.coords["latitude"].values, dtype=np.float64)
+        grid_lons = np.asarray(reference.coords["longitude"].values, dtype=np.float64)
+
+        results: list[dict[str, float | bool]] = [{} for _ in range(n_points)]
+
+        def _put_field(names: set[str], key: str, mode: str = "max") -> list[bool]:
+            var = _find(current, names)
+            grid = _icon_d2_step_grid(var, float(forecast_hour)) if var is not None else None
+            if grid is None:
+                return [False] * n_points
+            vals, flags = _corridor_extrema(
+                grid, grid_lats, grid_lons, latitudes, longitudes,
+                radius_nm=corridor_radius_nm, mode=mode,
+            )
+            for out, val in zip(results, vals):
+                if val is not None:
+                    out[key] = val
+            return flags
+
+        detection = _put_field({"dbz_ctmax"}, "reflectivity_hour_max_dbz")
+        _put_field({"dbz_cmax"}, "reflectivity_instant_dbz")
+        lpi_ok = _put_field({"lpi_max"}, "lightning_potential_hour_max_jkg")
+        w_ok = _put_field({"w_ctmax"}, "updraft_hour_max_ms")
+        _put_field(
+            {"uh_max"}, "updraft_helicity_2_8km_hour_max_m2s2",
+            mode="abs_signed_max",
+        )
+
+        # De-accumulate since-init graupel at each grid cell first.
+        grau_now_var = _find(current, {"tgrp", "grau_gsp"})
+        grau_prev_var = _find(previous, {"tgrp", "grau_gsp"})
+        grau_now = (
+            _icon_d2_step_grid(grau_now_var, float(forecast_hour))
+            if grau_now_var is not None else None
+        )
+        grau_prev = (
+            _icon_d2_step_grid(grau_prev_var, float(forecast_hour - 1))
+            if grau_prev_var is not None else None
+        )
+        grau_ok = [False] * n_points
+        if grau_now is not None and grau_prev is not None:
+            increment = _deaccumulate_nonnegative_grid(grau_now, grau_prev)
+            vals, grau_ok = _corridor_extrema(
+                increment, grid_lats, grid_lons, latitudes, longitudes,
+                radius_nm=corridor_radius_nm, mode="max",
+            )
+            for out, val in zip(results, vals):
+                if val is not None:
+                    out["graupel_hour_mm"] = val
+
+        # Four ECHOTOP quarter windows: previous file's :15/:30/:45 plus
+        # current file's on-the-hour message.  Build the hourly minimum-pressure
+        # field, but judge completeness from the raw finite grids before the
+        # -999 no-echo sentinel is removed.
+        echo_vars = [_find(previous, {"min_pres", "echotop"}),
+                     _find(current, {"min_pres", "echotop"})]
+        wanted = [forecast_hour - 0.75, forecast_hour - 0.5,
+                  forecast_hour - 0.25, float(forecast_hour)]
+        quarters: list = []
+        for wanted_h in wanted:
+            source = echo_vars[0] if wanted_h < forecast_hour else echo_vars[1]
+            grid = _icon_d2_step_grid(source, wanted_h) if source is not None else None
+            if grid is not None:
+                quarters.append(grid)
+        echo_complete = [False] * n_points
+        if len(quarters) == 4:
+            raw_complete = []
+            for quarter in quarters:
+                _, flags = _corridor_extrema(
+                    quarter, grid_lats, grid_lons, latitudes, longitudes,
+                    radius_nm=corridor_radius_nm, mode="min",
+                )
+                raw_complete.append(flags)
+            echo_complete = [all(flags[i] for flags in raw_complete) for i in range(n_points)]
+            hourly_echo = _hourly_echo_min_pressure_grid(quarters)
+            echo_vals, _ = _corridor_extrema(
+                hourly_echo, grid_lats, grid_lons, latitudes, longitudes,
+                radius_nm=corridor_radius_nm, mode="min", require_complete=False,
+            )
+            for i, (out, val) in enumerate(zip(results, echo_vals)):
+                if echo_complete[i] and val is not None:
+                    out["echo_top_18dbz_pressure_pa"] = val
+
+        for i, out in enumerate(results):
+            out["detection_complete"] = detection[i]
+            out["strength_complete"] = lpi_ok[i] and w_ok[i] and grau_ok[i]
+            out["echo_top_complete"] = echo_complete[i]
+        return results
+    except Exception:
+        logger.warning("cfgrib failed to decode ICON-D2 explicit diagnostics", exc_info=True)
+        return empty
+    finally:
+        for group in datasets:
+            for ds in group:
+                ds.close()
+        for path in paths:
+            path.unlink(missing_ok=True)
+
+
+def decode_icon_d2_domain_coverage(
+    grib_bytes: bytes,
+    latitudes: list[float],
+    longitudes: list[float],
+    corridor_radius_nm: float = 10.0,
+) -> bool:
+    """True when every route corridor kernel lies inside the delivered mask."""
+    import cfgrib
+
+    if not grib_bytes:
+        return False
+    with tempfile.NamedTemporaryFile(suffix=".grib2", delete=False) as tmp:
+        tmp.write(grib_bytes)
+        path = Path(tmp.name)
+    datasets = []
+    try:
+        datasets = cfgrib.open_datasets(str(path), backend_kwargs={"indexpath": ""})
+        for ds in datasets:
+            if "latitude" not in ds.coords or "longitude" not in ds.coords:
+                continue
+            for var in ds.data_vars.values():
+                _, complete = _corridor_extrema(
+                    var.values,
+                    ds.coords["latitude"].values,
+                    ds.coords["longitude"].values,
+                    latitudes,
+                    longitudes,
+                    radius_nm=corridor_radius_nm,
+                    mode="max",
+                )
+                return bool(complete) and all(complete)
+        return False
+    finally:
+        for ds in datasets:
+            ds.close()
+        path.unlink(missing_ok=True)
 
 
 _M_TO_FT = 3.28084

--- a/src/weatherbrief/fetch/grib/decode_worker.py
+++ b/src/weatherbrief/fetch/grib/decode_worker.py
@@ -241,6 +241,24 @@ def decode_icon_cloud_diag(
         return decode_icon_eu_cloud_diag_per_point(grib_bytes, latitudes, longitudes)
 
 
+def decode_icon_d2_explicit(
+    current_path: str,
+    previous_path: str | None,
+    forecast_hour: int,
+    latitudes: list[float],
+    longitudes: list[float],
+    corridor_radius_nm: float = 10.0,
+) -> list[dict[str, float | bool]]:
+    with _log_decode("decode_icon_d2_explicit", current_path):
+        from weatherbrief.fetch.grib.decode import decode_icon_d2_explicit_per_point
+        current = Path(current_path).read_bytes()
+        previous = Path(previous_path).read_bytes() if previous_path else None
+        return decode_icon_d2_explicit_per_point(
+            current, previous, forecast_hour, latitudes, longitudes,
+            corridor_radius_nm,
+        )
+
+
 def analyze_sounding_batch(items: list[dict]) -> list[dict]:
     """Lite sounding analysis for a batch of serialised profiles (#448 PR B).
 

--- a/src/weatherbrief/fetch/grib/fill.py
+++ b/src/weatherbrief/fetch/grib/fill.py
@@ -143,14 +143,28 @@ def _fill_diag_hourly(hourly_list: list[HourlyForecast]) -> int:
     """Forward-fill: each gap hour gets a shallow copy of the preceding
     anchor's diag, so a downstream in-place mutation (e.g. icing analysis
     setting a flag) on one hour cannot leak across other hours that share
-    the same anchor."""
+    the same anchor.
+
+    Also hold-fills ``explicit_convective_diagnostics`` (#462): interval-max
+    fields attach to ``(valid_hour−1, valid_hour]`` and persist until the next
+    native hour. Corridor extrema are already reduced at decode — this is
+    temporal hold only, not spatial lerp.
+    """
+    from weatherbrief.models import NWPExplicitConvectiveDiagnostics
+
     filled = 0
     last_diag: NWPCloudDiagnostics | None = None
+    last_explicit: NWPExplicitConvectiveDiagnostics | None = None
     for h in sorted(hourly_list, key=lambda h: h.time):
         if h.nwp_cloud_diagnostics is not None:
             last_diag = h.nwp_cloud_diagnostics
         elif last_diag is not None:
             h.nwp_cloud_diagnostics = last_diag.model_copy()
+            filled += 1
+        if h.explicit_convective_diagnostics is not None:
+            last_explicit = h.explicit_convective_diagnostics
+        elif last_explicit is not None:
+            h.explicit_convective_diagnostics = last_explicit.model_copy()
             filled += 1
     return filled
 

--- a/src/weatherbrief/fetch/grib/icon_eu_fetch.py
+++ b/src/weatherbrief/fetch/grib/icon_eu_fetch.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 import bz2
 import logging
 import math
+import threading
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
@@ -36,6 +37,9 @@ from datetime import datetime, timedelta, timezone
 import requests
 
 logger = logging.getLogger(__name__)
+
+_D2_DOMAIN_MASK_BYTES: dict[tuple[str, int], bytes] = {}
+_D2_DOMAIN_MASK_LOCK = threading.Lock()
 
 # DWD Open Data base URL (ICON-EU). ICON-D2 lives under a sibling path — see
 # the ``base_url`` field on each :class:`IconVariant` below.
@@ -70,6 +74,9 @@ class IconVariant:
             this variant. NOT identical between variants: ICON-D2 has no deep-
             convection parameterization, so ``hbas_con``/``htop_con``/``rain_con``
             don't exist (or are meaningless) on its feed — see the D2 tuple below.
+        cloud_diag_cache_version: Blob schema version for this variant.
+        cloud_diag_needs_predecessor: Fetch one leading single-level step for
+            accumulated or cross-file interval diagnostics.
     """
 
     slug: str
@@ -93,6 +100,8 @@ class IconVariant:
     hourly_to_h: int
     coarse_step_h: int
     cloud_diag_variables: tuple[str, ...]
+    cloud_diag_cache_version: int
+    cloud_diag_needs_predecessor: bool
 
 
 # Single-level cloud diagnostic variables (ICON-EU).
@@ -128,11 +137,15 @@ ICON_EU_CLOUD_DIAG_VARIABLES = (
 # All three therefore stay ABSENT for D2 → downstream fields are None
 # (missing-data semantics, which icon_eu_conv_rain_rate_mm_h and the firing
 # gate already handle). Issue #462 replaces them with D2's convection-
-# permitting diagnostics (dbz_cmax, echotop, lpi, uh_max, prg_gsp).
+# permitting diagnostics.  These remain in the same downloaded blob for I/O
+# efficiency, but decode into NWPExplicitConvectiveDiagnostics, never into the
+# parameterized fields on NWPCloudDiagnostics (#462).
 ICON_D2_CLOUD_DIAG_VARIABLES = (
     "ceiling",
     "clcl", "clcm", "clch", "clct",
     "cape_ml", "cin_ml",
+    "dbz_ctmax", "dbz_cmax", "echotop", "lpi_max", "w_ctmax",
+    "uh_max", "grau_gsp",
 )
 
 
@@ -165,6 +178,8 @@ ICON_EU = IconVariant(
     hourly_to_h=78,
     coarse_step_h=3,
     cloud_diag_variables=ICON_EU_CLOUD_DIAG_VARIABLES,
+    cloud_diag_cache_version=2,
+    cloud_diag_needs_predecessor=True,
 )
 
 # ICON-D2: 2.2 km convection-permitting, central-Europe domain, 8 runs/day,
@@ -204,6 +219,8 @@ ICON_D2 = IconVariant(
     hourly_to_h=48,
     coarse_step_h=1,
     cloud_diag_variables=ICON_D2_CLOUD_DIAG_VARIABLES,
+    cloud_diag_cache_version=3,
+    cloud_diag_needs_predecessor=True,
 )
 
 # Back-compat module constants (ICON-EU). The variant above is the single
@@ -290,11 +307,13 @@ ICON_EU_CLOUD_DIAG_CACHE_KEY = "ICON_EU_CLOUD_DIAG_V2"
 def icon_cloud_diag_cache_key(variant: IconVariant = ICON_EU) -> str:
     """Cache-key label for a variant's single-level cloud-diagnostic blob.
 
-    ``{cache_prefix}_CLOUD_DIAG_V2`` — the ``_V2`` suffix matches the ICON-EU
-    constant so the two share the same rain_con-inclusive schema; only the
-    prefix differs so ICON-D2 blobs never masquerade as ICON-EU in a cache dir.
+    Versioning is per variant: ICON-EU remains V2; ICON-D2 is V3 after adding
+    the explicit-convection message set in #462.
     """
-    return f"{variant.cache_prefix}_CLOUD_DIAG_V2"
+    return (
+        f"{variant.cache_prefix}_CLOUD_DIAG_V"
+        f"{variant.cloud_diag_cache_version}"
+    )
 
 # Parallel download settings
 MAX_DOWNLOAD_WORKERS = 8
@@ -369,6 +388,53 @@ def icon_eu_single_level_url(
         f"{variant.slug}_{variant.grid_label}_regular-lat-lon_single-level_"
         f"{init_date}{init_hour:02d}_{forecast_hour:03d}{segment}"
         f"{_icon_var_suffix(variable, variant)}.grib2.bz2"
+    )
+
+
+def icon_d2_domain_mask_url(init_date: str, init_hour: int) -> str:
+    """URL for the small invariant regular-grid surface-height coverage mask."""
+    return (
+        f"{ICON_D2.base_url}/{init_hour:02d}/hsurf/"
+        f"icon-d2_germany_regular-lat-lon_time-invariant_"
+        f"{init_date}{init_hour:02d}_000_0_hsurf.grib2.bz2"
+    )
+
+
+def route_in_icon_d2_product_mask(
+    route_points: list,
+    init_date: str,
+    init_hour: int,
+    *,
+    session: requests.Session | None = None,
+    corridor_radius_nm: float = 10.0,
+) -> bool:
+    """Gate D2 on its delivered bitmap, including the extraction corridor.
+
+    The regular-lat/lon product is a rectangular container with masked corners;
+    its GRIB template carries no rotated-pole metadata. HSurf is invariant and
+    small, so its bitmap is the authoritative coverage mask for the actual
+    delivered product rather than an inferred native-grid polygon.
+    """
+    from weatherbrief.fetch.grib.decode import decode_icon_d2_domain_coverage
+
+    key = (init_date, init_hour)
+    with _D2_DOMAIN_MASK_LOCK:
+        raw = _D2_DOMAIN_MASK_BYTES.get(key)
+    if raw is None:
+        downloaded, _status = _download_one_file(
+            icon_d2_domain_mask_url(init_date, init_hour),
+            session or requests.Session(),
+        )
+        if downloaded is None:
+            return False
+        raw = downloaded
+        with _D2_DOMAIN_MASK_LOCK:
+            _D2_DOMAIN_MASK_BYTES[key] = raw
+    return decode_icon_d2_domain_coverage(
+        raw,
+        [rp.lat for rp in route_points],
+        [rp.lon for rp in route_points],
+        corridor_radius_nm,
     )
 
 

--- a/src/weatherbrief/models/__init__.py
+++ b/src/weatherbrief/models/__init__.py
@@ -31,6 +31,7 @@ from weatherbrief.models.analysis import (  # noqa: F401
     ParcelPathPoint,
     NWPCloudDiagnostics,
     NWPCloudLayerDiag,
+    NWPExplicitConvectiveDiagnostics,
     PrecipIntensity,
     PrecipPhase,
     PrecipitationAssessment,

--- a/src/weatherbrief/models/analysis.py
+++ b/src/weatherbrief/models/analysis.py
@@ -172,6 +172,29 @@ class NWPCloudDiagnostics(BaseModel):
     freezing_level_ft: Optional[float] = None
 
 
+class NWPExplicitConvectiveDiagnostics(BaseModel):
+    """Convection-permitting model evidence kept separate from scheme output.
+
+    Values are extrema over a route-centred corridor, not interpolated
+    centreline samples.  Completeness describes the delivered data, separately
+    from the meteorological value: a complete quiet reflectivity field has
+    ``reflectivity_hour_max_dbz=None`` and ``detection_complete=True``.
+    """
+
+    source: Literal["icon_d2"] = "icon_d2"
+    corridor_radius_nm: float = 10.0
+    reflectivity_hour_max_dbz: Optional[float] = None
+    reflectivity_instant_dbz: Optional[float] = None
+    echo_top_18dbz_ft: Optional[float] = None
+    lightning_potential_hour_max_jkg: Optional[float] = None
+    updraft_hour_max_ms: Optional[float] = None
+    updraft_helicity_2_8km_hour_max_m2s2: Optional[float] = None
+    graupel_hour_mm: Optional[float] = None
+    detection_complete: bool = False
+    strength_complete: bool = False
+    echo_top_complete: bool = False
+
+
 class RouteConfig(BaseModel):
     """A flight route definition loaded from config."""
 
@@ -309,6 +332,7 @@ class HourlyForecast(BaseModel):
 
     # GFS cloud layer diagnostics from GRIB2 enrichment
     nwp_cloud_diagnostics: Optional[NWPCloudDiagnostics] = None
+    explicit_convective_diagnostics: Optional[NWPExplicitConvectiveDiagnostics] = None
 
     # Pressure level data
     pressure_levels: list[PressureLevelData] = Field(default_factory=list)
@@ -693,7 +717,18 @@ class ConvectiveAssessment(BaseModel):
     top_ft: Optional[float] = None  # thermo: el_altitude_ft; NWP: convective_top_ft
     cover_pct: Optional[float] = None  # NWP only; thermo: None
     convective_precip_mm_h: Optional[float] = None  # NWP native firing signal (#283); thermo: None
-    method: str = "thermo"  # "thermo", "nwp", "nwp_hybrid", "nwp_lcl_top", "nwp_precip", "nwp_cape_fallback"
+    # Explicit-convection detail is deliberately not geometry: echo_top is the
+    # 18-dBZ radar-echo top, below the physical/anvil top, so ``top_ft`` remains
+    # None for this method and the overflight-clearance filter cannot consume it.
+    source: Optional[str] = None
+    native_data_complete: Optional[bool] = None
+    reflectivity_hour_max_dbz: Optional[float] = None
+    echo_top_18dbz_ft: Optional[float] = None
+    lightning_potential_hour_max_jkg: Optional[float] = None
+    updraft_hour_max_ms: Optional[float] = None
+    updraft_helicity_2_8km_hour_max_m2s2: Optional[float] = None
+    graupel_hour_mm: Optional[float] = None
+    method: str = "thermo"  # includes "nwp_explicit" for convection-permitting evidence
 
 
 class CATRiskLayer(BaseModel):

--- a/tests/test_icon_d2.py
+++ b/tests/test_icon_d2.py
@@ -131,7 +131,7 @@ class TestD2HorizonAndGrid:
         assert (ICON_D2.level_min, ICON_D2.level_max) == (16, 65)
         assert ICON_D2.slug == "icon-d2"
         assert ICON_D2.source_key == "icon_d2:dwd"
-        assert icon_cloud_diag_cache_key(ICON_D2) == "ICON_D2_CLOUD_DIAG_V2"
+        assert icon_cloud_diag_cache_key(ICON_D2) == "ICON_D2_CLOUD_DIAG_V3"
         assert icon_cloud_diag_cache_key(ICON_EU) == "ICON_EU_CLOUD_DIAG_V2"
 
     def test_d2_diag_list_drops_parameterized_convection_fields(self):
@@ -147,6 +147,12 @@ class TestD2HorizonAndGrid:
         for var in ("ceiling", "clcl", "clcm", "clch", "clct", "cape_ml", "cin_ml"):
             assert var in ICON_D2.cloud_diag_variables
             assert var in ICON_EU.cloud_diag_variables
+        for var in (
+            "dbz_ctmax", "dbz_cmax", "echotop", "lpi_max", "w_ctmax",
+            "uh_max", "grau_gsp",
+        ):
+            assert var in ICON_D2.cloud_diag_variables
+            assert var not in ICON_EU.cloud_diag_variables
 
 
 # ---------------------------------------------------------------------------
@@ -208,6 +214,9 @@ class TestPrepareIconVariantSelection:
         with patch(
             "weatherbrief.fetch.grib.icon_eu_fetch.find_latest_icon_eu_run",
             self._run_finder(d2_run=("20260720", 12), eu_run=("20260720", 12)),
+        ), patch(
+            "weatherbrief.fetch.grib.icon_eu_fetch.route_in_icon_d2_product_mask",
+            return_value=True,
         ):
             ctx, skip = _prepare_icon_eu(
                 self._icon_cross_sections(), route, dep,
@@ -226,6 +235,9 @@ class TestPrepareIconVariantSelection:
         with patch(
             "weatherbrief.fetch.grib.icon_eu_fetch.find_latest_icon_eu_run",
             self._run_finder(d2_run=("20260720", 12), eu_run=("20260720", 12)),
+        ), patch(
+            "weatherbrief.fetch.grib.icon_eu_fetch.route_in_icon_d2_product_mask",
+            return_value=True,
         ):
             ctx, skip = _prepare_icon_eu(
                 self._icon_cross_sections(), route, dep,
@@ -245,6 +257,29 @@ class TestPrepareIconVariantSelection:
         with patch(
             "weatherbrief.fetch.grib.icon_eu_fetch.find_latest_icon_eu_run",
             self._run_finder(d2_run=None, eu_run=("20260720", 12)),
+        ), patch(
+            "weatherbrief.fetch.grib.icon_eu_fetch.route_in_icon_d2_product_mask",
+            return_value=True,
+        ):
+            ctx, skip = _prepare_icon_eu(
+                self._icon_cross_sections(), route, dep,
+                data_dir=tmp_path, flight_duration_hours=2.0,
+            )
+        assert skip is None
+        assert ctx is not None
+        assert ctx.variant is ICON_EU
+
+    def test_falls_back_to_eu_when_corridor_clips_delivered_mask(self, tmp_path):
+        from weatherbrief.fetch.grib import _prepare_icon_eu
+
+        route = [_rp(48.35, 11.79), _rp(52.52, 13.4, 300)]
+        dep = datetime(2026, 7, 20, 12, 0, tzinfo=timezone.utc)
+        with patch(
+            "weatherbrief.fetch.grib.icon_eu_fetch.find_latest_icon_eu_run",
+            self._run_finder(d2_run=("20260720", 12), eu_run=("20260720", 12)),
+        ), patch(
+            "weatherbrief.fetch.grib.icon_eu_fetch.route_in_icon_d2_product_mask",
+            return_value=False,
         ):
             ctx, skip = _prepare_icon_eu(
                 self._icon_cross_sections(), route, dep,
@@ -262,6 +297,9 @@ class TestPrepareIconVariantSelection:
         with patch(
             "weatherbrief.fetch.grib.icon_eu_fetch.find_latest_icon_eu_run",
             self._run_finder(d2_run=("20260720", 12), eu_run=("20260720", 12)),
+        ), patch(
+            "weatherbrief.fetch.grib.icon_eu_fetch.route_in_icon_d2_product_mask",
+            return_value=True,
         ):
             ctx, skip = _prepare_icon_eu(
                 self._icon_cross_sections(), route, dep,
@@ -301,6 +339,47 @@ def test_icon_d2_readiness_dispatch_registered():
     from weatherbrief.fetch.freshness.sources import _DISPATCH, _check_icon_d2_dwd
 
     assert _DISPATCH["icon_d2_dwd"] is _check_icon_d2_dwd
+
+
+def test_total_d2_failure_reruns_cleanly_on_icon_eu(monkeypatch, tmp_path):
+    """Deferred #461 review case: no D2 enrichment triggers a full EU retry."""
+    from types import SimpleNamespace
+
+    import weatherbrief.fetch.grib as grib_mod
+
+    d2_ctx = SimpleNamespace(variant=ICON_D2)
+    eu_ctx = SimpleNamespace(variant=ICON_EU)
+    prepared: list[object | None] = []
+    prefetched: list[str] = []
+    decoded: list[str] = []
+
+    def fake_prepare(*args, force_variant=None, **kwargs):
+        prepared.append(force_variant)
+        return (eu_ctx, None) if force_variant is ICON_EU else (d2_ctx, None)
+
+    def fake_decode(ctx, *args):
+        decoded.append(ctx.variant.slug)
+        return (None, None) if ctx.variant is ICON_D2 else (1234567890, None)
+
+    monkeypatch.setattr(grib_mod, "_prepare_icon_eu", fake_prepare)
+    monkeypatch.setattr(
+        grib_mod, "_prefetch_icon_eu_data",
+        lambda ctx: prefetched.append(ctx.variant.slug),
+    )
+    monkeypatch.setattr(grib_mod, "_decode_and_merge_icon_eu", fake_decode)
+    monkeypatch.setattr(grib_mod, "_enrich_gfs", lambda *a, **k: None)
+    monkeypatch.setattr(grib_mod, "_enrich_ecmwf", lambda *a, **k: None)
+
+    _, _, sources = grib_mod._enrich_forecasts_inner(
+        grib_mod._GribTimer(), [], [], [],
+        datetime(2026, 7, 20, 12, tzinfo=timezone.utc),
+        data_dir=tmp_path,
+    )
+
+    assert prepared == [None, ICON_EU]
+    assert prefetched == ["icon-d2", "icon-eu"]
+    assert decoded == ["icon-d2", "icon-eu"]
+    assert sources["icon"] == "icon_eu:dwd"
 
 
 def _utc(y, mo, d, h=0):

--- a/tests/test_icon_d2_explicit.py
+++ b/tests/test_icon_d2_explicit.py
@@ -1,0 +1,192 @@
+"""ICON-D2 explicit-convection meteorology and decode semantics (#462)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from weatherbrief.analysis.sounding.convective import (
+    assess_convective_explicit,
+    convective_cross_check,
+)
+from weatherbrief.fetch.grib.decode import (
+    _corridor_extrema,
+    _deaccumulate_nonnegative_grid,
+    _hourly_echo_min_pressure_grid,
+)
+from weatherbrief.models import (
+    ConvectiveAssessment,
+    ConvectiveRisk,
+    NWPCloudDiagnostics,
+    NWPExplicitConvectiveDiagnostics,
+    ThermodynamicIndices,
+)
+
+
+def _diag(dbz: float | None, **updates) -> NWPExplicitConvectiveDiagnostics:
+    values = {
+        "reflectivity_hour_max_dbz": dbz,
+        "detection_complete": True,
+    }
+    values.update(updates)
+    return NWPExplicitConvectiveDiagnostics(**values)
+
+
+@pytest.mark.parametrize(
+    ("dbz", "lpi", "updraft", "graupel", "cape", "expected"),
+    [
+        # Below firing band
+        (34.9, None, None, None, None, ConvectiveRisk.NONE),
+        # 35–44 needs storm-process corroboration (not CAPE alone)
+        (40.0, None, None, None, None, ConvectiveRisk.NONE),
+        (40.0, None, None, None, 500.0, ConvectiveRisk.NONE),
+        (40.0, 1.0, None, None, None, ConvectiveRisk.MARGINAL),
+        # LPI present → w/graupel are narrative only, not additive |C|
+        (40.0, 1.0, 10.0, 0.5, None, ConvectiveRisk.MARGINAL),
+        # No LPI → w + graupel may substitute as two counts
+        (40.0, None, 10.0, 0.5, None, ConvectiveRisk.MODERATE),
+        # Strong LPI alone (≥5) counts as 2
+        (40.0, 5.0, None, None, None, ConvectiveRisk.MODERATE),
+        # 45–49
+        (47.0, None, None, None, None, ConvectiveRisk.MODERATE),
+        (47.0, 5.0, None, None, None, ConvectiveRisk.HIGH),
+        # ≥50 always HIGH on dbz alone
+        (50.0, None, None, None, None, ConvectiveRisk.HIGH),
+    ],
+)
+def test_v1_decision_table(dbz, lpi, updraft, graupel, cape, expected):
+    result = assess_convective_explicit(
+        ThermodynamicIndices(),
+        _diag(
+            dbz,
+            lightning_potential_hour_max_jkg=lpi,
+            updraft_hour_max_ms=updraft,
+            graupel_hour_mm=graupel,
+        ),
+        NWPCloudDiagnostics(ml_cape_jkg=cape) if cape is not None else None,
+    )
+    assert result.risk_level is expected
+    assert result.method == "nwp_explicit"
+    assert result.native_data_complete is True
+    assert result.top_ft is None
+
+
+def test_incomplete_detection_is_unavailable_not_quiet():
+    result = assess_convective_explicit(
+        ThermodynamicIndices(cape_surface_jkg=1500.0),
+        NWPExplicitConvectiveDiagnostics(
+            reflectivity_hour_max_dbz=55.0,
+            detection_complete=False,
+        ),
+    )
+    assert result.method == "nwp_explicit"
+    assert result.native_data_complete is False
+    assert result.risk_level is ConvectiveRisk.NONE
+    # Must not look like a quiet scheme to the DD cross-check.
+    thermo_loaded = ConvectiveAssessment(
+        risk_level=ConvectiveRisk.MODERATE, cape_jkg=800.0, method="thermo",
+    )
+    assert convective_cross_check(thermo_loaded, result) is None
+
+
+def test_echo_top_is_detail_never_clearance_geometry():
+    result = assess_convective_explicit(
+        ThermodynamicIndices(),
+        _diag(50.0, echo_top_18dbz_ft=28000.0, echo_top_complete=True),
+    )
+    assert result.echo_top_18dbz_ft == 28000.0
+    assert result.top_ft is None
+    assert result.base_ft is None
+    assert any("not a cloud top" in d for d in result.drivers)
+
+
+def test_cape_is_narrative_not_firing_corroborator():
+    result = assess_convective_explicit(
+        ThermodynamicIndices(),
+        _diag(40.0),
+        NWPCloudDiagnostics(ml_cape_jkg=1200.0),
+    )
+    assert result.risk_level is ConvectiveRisk.NONE
+    assert any("ML-CAPE" in d for d in result.drivers) or not result.drivers
+    # Environment CAPE still surfaces as detail when a storm does fire.
+    firing = assess_convective_explicit(
+        ThermodynamicIndices(),
+        _diag(50.0),
+        NWPCloudDiagnostics(ml_cape_jkg=1200.0),
+    )
+    assert firing.risk_level is ConvectiveRisk.HIGH
+    assert any("ML-CAPE" in d for d in firing.drivers)
+
+
+def test_cross_check_understands_explicit_active_and_quiet():
+    thermo_quiet = ConvectiveAssessment(
+        risk_level=ConvectiveRisk.NONE, method="thermo",
+    )
+    explicit_active = assess_convective_explicit(
+        ThermodynamicIndices(), _diag(50.0),
+    )
+    xc = convective_cross_check(thermo_quiet, explicit_active)
+    assert xc is not None
+    assert xc.direction == "model_active_dd_quiet"
+
+    thermo_loaded = ConvectiveAssessment(
+        risk_level=ConvectiveRisk.MODERATE, cape_jkg=800.0, method="thermo",
+    )
+    explicit_quiet = assess_convective_explicit(
+        ThermodynamicIndices(), _diag(None),
+    )
+    xc = convective_cross_check(thermo_loaded, explicit_quiet)
+    assert xc is not None
+    assert xc.direction == "dd_not_corroborated"
+
+
+def test_corridor_max_catches_off_centre_cell_and_retains_uh_sign():
+    lats = np.array([49.98, 50.00, 50.02])
+    lons = np.array([7.98, 8.00, 8.02])
+    field = np.zeros((3, 3))
+    field[2, 2] = 48.0
+    values, complete = _corridor_extrema(
+        field, lats, lons, [50.0], [8.0], radius_nm=2.0, mode="max",
+    )
+    assert complete == [True]
+    assert values == [48.0]
+
+    uh = np.array([[10.0, -35.0], [20.0, 30.0]])
+    values, _ = _corridor_extrema(
+        uh, lats[:2], lons[:2], [49.99], [7.99],
+        radius_nm=2.0, mode="abs_signed_max",
+    )
+    assert values == [-35.0]
+
+
+def test_masked_corridor_is_incomplete_not_a_partial_maximum():
+    grid = np.array([[20.0, np.nan], [45.0, 30.0]])
+    values, complete = _corridor_extrema(
+        grid, np.array([50.0, 50.02]), np.array([8.0, 8.02]),
+        [50.01], [8.01], radius_nm=2.0, mode="max",
+    )
+    assert complete == [False]
+    assert values == [None]
+
+
+def test_graupel_is_deaccumulated_before_corridor_maximum():
+    previous = np.array([[10.0, 0.0]])
+    current = np.array([[10.0, 5.0]])
+    increment = _deaccumulate_nonnegative_grid(current, previous)
+    assert increment.tolist() == [[0.0, 5.0]]
+    # Differencing the two corridor maxima would incorrectly yield zero.
+    assert float(current.max() - previous.max()) == 0.0
+    assert float(increment.max()) == 5.0
+
+
+def test_hourly_echo_top_uses_four_quarters_and_ignores_no_echo_sentinel():
+    quarters = [
+        np.array([[-999.0, 70000.0]]),
+        np.array([[65000.0, -999.0]]),
+        np.array([[60000.0, 68000.0]]),
+        np.array([[62000.0, 66000.0]]),
+    ]
+    hourly = _hourly_echo_min_pressure_grid(quarters)
+    assert hourly is not None
+    assert hourly.tolist() == [[60000.0, 66000.0]]
+    assert _hourly_echo_min_pressure_grid(quarters[:3]) is None

--- a/tests/test_icon_prefetch.py
+++ b/tests/test_icon_prefetch.py
@@ -21,6 +21,7 @@ import weatherbrief.fetch.grib.icon_eu_fetch as icon_fetch_mod
 from weatherbrief.fetch.grib import _IconEuContext, _prefetch_icon_eu_data_inner
 from weatherbrief.fetch.grib.cache import cache_key, get_cached, put_cached
 from weatherbrief.fetch.grib.icon_eu_fetch import (
+    ICON_EU,
     ICON_EU_CLOUD_DIAG_CACHE_KEY,
     ICON_EU_VARIABLES,
 )
@@ -36,6 +37,7 @@ def _make_ctx(tmp_path: Path, forecast_hours: list[int]) -> _IconEuContext:
         point_lats=[48.0],
         point_lons=[2.0],
         session=None,
+        variant=ICON_EU,
     )
 
 
@@ -63,8 +65,16 @@ def tracker(monkeypatch):
         with state["lock"]:
             state["active"] -= 1
 
-    def fake_per_variable(init_date, init_hour, fhour, levels, variables,
-                          session=None, max_workers=8):
+    def fake_per_variable(
+        init_date,
+        init_hour,
+        fhour,
+        levels,
+        variables,
+        session=None,
+        max_workers=8,
+        variant=ICON_EU,
+    ):
         _enter()
         try:
             (var,) = variables
@@ -76,7 +86,14 @@ def tracker(monkeypatch):
         finally:
             _exit()
 
-    def fake_single_level(init_date, init_hour, fhours, session=None, max_workers=8):
+    def fake_single_level(
+        init_date,
+        init_hour,
+        fhours,
+        session=None,
+        max_workers=8,
+        variant=ICON_EU,
+    ):
         _enter()
         try:
             (fhour,) = fhours

--- a/web/ts/visualization/cross-section/layers/nwp-convective-bg.ts
+++ b/web/ts/visualization/cross-section/layers/nwp-convective-bg.ts
@@ -2,7 +2,8 @@
  *
  * Renders resolved tower columns from model convective base/top (GFS), plus a
  * depth-unresolved "ghost" column for convective points that fire without a
- * drawable tower — ECMWF `nwp_precip` on `cp`, or a GFS cover-only point with
+ * drawable tower — ECMWF `nwp_precip` on `cp`, ICON-D2 `nwp_explicit` (echo top
+ * is character-only, never clearance geometry), or a GFS cover-only point with
  * no top. Uses NWP model-computed convective cloud bounds directly — no
  * estimateTowerTop needed since these are model parameterization outputs, not
  * thermodynamic estimates. Same color palette as thermo layer for visual

--- a/web/ts/visualization/types.ts
+++ b/web/ts/visualization/types.ts
@@ -311,7 +311,7 @@ export interface VizPoint {
   /** Native convective precip rate (mm/h) — the firing evidence on the
    *  "nwp_precip" path, where base/top are unresolved. Null otherwise. */
   nwpConvectivePrecipMmH: number | null;
-  /** Method tag: "nwp", "nwp_lcl_top", "nwp_hybrid", "nwp_precip", etc. */
+  /** Method tag: "nwp", "nwp_lcl_top", "nwp_hybrid", "nwp_precip", "nwp_explicit", etc. */
   nwpConvectiveMethod: string | null;
   /**
    * True when the model produced a convective_nwp assessment (regardless


### PR DESCRIPTION
## Summary
- Adds an ICON-D2 **explicit-convection** path (`dbz_ctmax`, LPI, updraft, graupel, constructed hourly echo top) with corridor-max sampling, so D2 storms are no longer invisible after #461 dropped parameterized `hbas_con`/`htop_con`/`rain_con`.
- Keeps echo top as character only (`top_ft=None` on `nwp_explicit`) so overfly clearance cannot treat 18 dBZ echo tops as cloud tops.
- Corroboration treats LPI as the primary storm-process signal (w/graupel substitute only when LPI is absent); CAPE is environment/narrative only so 35–44 dBZ bright-band + CAPE cannot fake a thunderstorm. Incomplete detection stays unavailable (not quiet, not CAPE-as-D2).

## Test plan
- [x] `pytest tests/test_icon_d2_explicit.py tests/test_icon_d2.py tests/test_grib_fill.py tests/test_convective.py`
- [ ] Replay in-domain convective hit (e.g. EGTF→LFAT→LFQA 2026-06-27) and confirm D2 fires with unresolved vertical geometry / ghost column
- [ ] Quiet control: stratiform 30–40 dBZ day does not narrate thunderstorms
- [ ] Domain-edge route falls back to ICON-EU via delivered mask / total-failure path
- [ ] Confirm aggregation of a lone D2 cell vs quiet coarse models is still intentional (#442 open)

Closes #462


Made with [Cursor](https://cursor.com)