### PR TITLE
ICON-D2 explicit-convection track: reflectivity firing, corridor extrema, echo top detail-only (#462)

### DIFF
--- a/designs/meteorology-decisions.md
+++ b/designs/meteorology-decisions.md
@@ -1958,3 +1958,126 @@ follow-up:
 - Watch for any all-quiet-NWP sounding that *did* produce observed convection
   (lightning/METAR-TS) — that is the case the removed floor was protecting, and
   the one that would argue for a narrower cap.
+
+## 19. ICON-D2 explicit-convection track: reflectivity firing, corridor extrema, echo top as detail-only
+
+**Date:** 2026-07-21
+**Status:** Implemented (#462).
+**Context:** Follow-up to the ICON-D2 source upgrade (#456). D2 runs **no
+deep-convection parameterization**, so the parameterized diagnostics consumed
+from ICON-EU (`hbas_con`/`htop_con`/`rain_con`) either don't exist on the D2
+feed or silently change meaning; D2 packs ship those fields as ``None``. Deep
+convection in D2 lives in **explicit storm fields** — a different *kind* of
+signal — so it gets its own payload, its own assessment
+(``method="nwp_explicit"``), and its own cross-check, never blended with the
+parameterized track. All feed semantics below were verified against
+`opendata.dwd.de` (eccodes per-message inspection of live 00z files) and the
+DWD ICON database manual on 2026-07-21.
+
+### The variable set (and what was rejected)
+
+- ``dbz_ctmax`` (column-max simulated reflectivity, hour-max) — the **firing
+  signal**. One full-hour message per file; attaches to ``(H−1, H]``.
+  Caveat accepted: DWD's forward operator is a Rayleigh approximation over
+  QR/QS/QG/T, so absolute dBZ is approximate (bright-band/graupel biases) —
+  handled by the 35–44 dBZ corroboration row, not by lowering the tier.
+- ``lpi_max`` (Lynn & Yair 2010; w² integrated over the graupel-bearing
+  layer), ``w_ctmax`` (max updraft 0–10 km), ``grau_gsp`` (grid-scale graupel,
+  de-accumulated **per cell** from on-the-hour accumulations) — the
+  corroborator set. LPI physically requires the graupel scheme, so LPI and
+  graupel are correlated corroborators — |C| is not "independent
+  confirmations", and is treated as such in calibration.
+- ``uh_max_med`` (updraft helicity 2–5 km) — **chosen over ``uh_max``
+  (2–8 km)** because 2–5 km is the literature/HRRR-calibrated layer, keeping
+  rotation notes comparable to portable thresholds. Narrative-only in v1
+  either way; signed argmax-|uh| keeps the rotation sense.
+- ``echotop`` (delivered as ``min_pres`` in Pa, 4×15-min messages per file) —
+  the hourly product is **constructed** as the min pressure over the four
+  quarter windows ending in ``(H−1, H]`` (three from file f(H−1), one from
+  f(H)). It is a **storm-depth indicator, never a cloud top**: an 18 dBZ echo
+  top sits below the physical storm top (weakly-reflecting anvil ice), so it
+  is structurally barred from ``top_ft`` (the assessment always sets
+  ``top_ft=None``) and from the overfly-clearance filter, where it would err
+  in the dangerous direction.
+- Rejected/deferred: ``dbz_cmax`` (instant; sub-hourly detail not needed in
+  v1), ``tcond10_mx`` (overlaps the dbz signal), ``rain_con`` (≈0 without the
+  deep scheme), ``hbas_con``/``htop_con``/``prr_con``/``echotopinm`` (404),
+  ``uh_max`` (superseded by ``uh_max_med``, above), ICON-D2-EPS (future
+  probabilistic signal class), radar blending (out of scope).
+
+### Sentinel discipline: bitmap is the only "unknown"
+
+The GRIB **bitmap** alone marks missing data (the masked domain corners,
+~16.7% of cells on every field). Encoded quiet values are real data: **−150
+dBZ** is the genuine no-echo floor and participates in the corridor max;
+**−999 Pa** is "no ≥18 dBZ echo this quarter" and counts as a valid cell
+(excluded only from the pressure min). Completeness flags are driven by
+bitmap-valid corridor fractions (≥ 50 %), never by decoded values — so a
+quiet night reads QUIET, never UNAVAILABLE, and a masked corridor reads
+UNAVAILABLE, never QUIET. This is the #421 None ≠ 0 rule applied at grid
+level.
+
+### Firing table (v1 calibration starting points, not physical constants)
+
+| corridor ``dbz_ctmax`` | \|C\| = 0 | \|C\| = 1 | \|C\| ≥ 2 |
+|---|---|---|---|
+| < 35 dBZ | no fire | no fire | no fire |
+| 35–44 dBZ | no fire (stratiform/bright-band note) | MARGINAL | MODERATE |
+| 45–49 dBZ | MODERATE | MODERATE | HIGH |
+| ≥ 50 dBZ | HIGH | HIGH | HIGH |
+
+Corroborators (count only when the channel is **complete**): ``lpi_max`` ≥ 1
+J/kg (≥ 5 counts 2), ``w_ctmax`` ≥ 10 m/s, ``grau_gsp`` ≥ 0.5 mm in the hour,
+``cape_ml`` ≥ 500 J/kg. Incomplete channels never downgrade below the
+dbz-alone row and never upgrade. No CIN suppression: a simulated echo IS
+realized convection (the model already convected), so penalising it on
+surface/ML CIN would be circular. Graupel wording is never "hail".
+
+### Corridor extrema, and the cell-vs-shield discriminator
+
+Per-point bilinear sampling defeats a 2.2 km model: a cell between route
+points vanishes, making D2 *less* likely to fire than coarse models. All
+explicit channels are therefore reduced over a ~10 NM disc per route point
+(values are **corridor maxima**, disclosed as such). Consequences accepted:
+one real cell lights up several adjacent route points (coverage inflation),
+and D2 reads systematically "more alarming" than centreline-sampled models —
+the right asymmetry for aviation. Because the corridor max alone cannot tell
+a discrete cell from a stratiform shield, the payload also carries the
+centreline bilinear reflectivity: point ≈ max ⇒ widespread (stratiform
+wording); max ≫ point ⇒ discrete cell (geometry note). Cheap, and it makes
+the 35–44 dBZ row's "likely stratiform" note geometric rather than guessed.
+
+### Lead-time confidence is a first-order variable
+
+ICON-D2 is **radar-nudged** (latent-heat nudging of 3-D volume reflectivity),
+so its reflectivity is observationally constrained in the first hours and
+increasingly free-running — with the usual convection-permitting placement
+error growth — thereafter. The assessment attaches lead-time wording to every
+fired cell: ≤ 6 h "radar-nudged, positions meaningful"; 6–24 h "presence/
+character reliable, placement approximate"; > 24 h "environment-level
+signal". Wording only, never a tier input: placement uncertainty must not
+downgrade a simulated echo. Rejected: lead-scaled tiers (hides evidence
+instead of framing it).
+
+### Unavailable ≠ quiet, end to end
+
+A payload is attached to **every** D2-enriched hour (all-None with
+completeness flags False when the decode fails), so "no payload" means "not
+D2-sourced" and can never read as model-quiet. ``detection_complete=False``
+yields no assessment (``convective_nwp=None``) plus
+``convective_explicit_unavailable=True``; the convective evaluator renders
+those points **UNAVAILABLE** (excluded from the extent denominator like a
+missing sounding) instead of GREEN. Grading falls back to the thermo track
+badged truthfully (``convective_method_effective="thermo"``); the DD
+cross-check compares against the explicit verdict's own firing semantics and
+stays silent when there is no explicit verdict.
+
+### Aggregation: deliberately deferred to #442
+
+A lone D2 explicit cell against quiet coarse models aggregates GREEN under
+today's majority rules. The proposal on the table — high-confidence D2
+explicit convection floors the aggregate at AMBER ("ICON-D2 explicitly
+develops a cell; coarser models do not resolve it"), possibly lead-scaled —
+changes aggregation semantics and is decided in the #442 grade rework, not
+silently here. What this track does now: the per-model D2 status is fully
+visible in the per-model breakdown regardless.

--- a/src/weatherbrief/analysis/advisories/convective.py
+++ b/src/weatherbrief/analysis/advisories/convective.py
@@ -162,6 +162,19 @@ class ConvectiveEvaluator:
                     ribbon_points.append((dist, HighlightSeverity.UNAVAILABLE))
                     region_cells.append((dist, None))
                     continue
+
+                # Explicit-convection unavailable (#462): this ICON-D2 hour
+                # carried an explicit payload whose detection channel failed
+                # (masked corridor / decode failure). Render UNAVAILABLE and
+                # exclude from the extent denominator exactly like a missing
+                # sounding — unknown must never read as "checked, nothing
+                # firing" (GREEN), and the thermo fallback (badged "thermo"
+                # via convective_method_effective) must not present as D2's
+                # explicit verdict on the ribbon.
+                if sounding.convective_explicit_unavailable:
+                    ribbon_points.append((dist, HighlightSeverity.UNAVAILABLE))
+                    region_cells.append((dist, None))
+                    continue
                 total += 1
 
                 # Independent of the grade filters below: compare the chosen

--- a/src/weatherbrief/analysis/sounding/__init__.py
+++ b/src/weatherbrief/analysis/sounding/__init__.py
@@ -311,9 +311,29 @@ def analyze_sounding_lite(
     convective = assess_convective_thermo(
         indices, omega_700_pa_s=_omega_near_700(derived_levels)
     )
-    convective_nwp = assess_convective_nwp(
-        indices, hourly.nwp_cloud_diagnostics if hourly else None,
-    )
+    # NWP convective track (#283): the model's own convective signal. On
+    # ICON-D2 hours the payload is the EXPLICIT storm-field diagnostics
+    # (#462) — a different kind of signal with its own assessment; presence
+    # of the payload IS the explicit-mode switch (provenance travels via
+    # payload.source). A payload with incomplete detection yields None →
+    # recorded as explicit-unavailable (unknown, never "scheme quiet").
+    convective_explicit_unavailable = False
+    explicit_payload = hourly.explicit_convective_diagnostics if hourly else None
+    if explicit_payload is not None:
+        from weatherbrief.analysis.sounding.convective import (
+            assess_convective_explicit,
+        )
+
+        convective_nwp = assess_convective_explicit(
+            indices,
+            hourly.nwp_cloud_diagnostics if hourly else None,
+            explicit_payload,
+        )
+        convective_explicit_unavailable = convective_nwp is None
+    else:
+        convective_nwp = assess_convective_nwp(
+            indices, hourly.nwp_cloud_diagnostics if hourly else None,
+        )
 
     # Compute ceiling from NWP-reclassified cloud layers
     sounding_ceiling_ft = compute_sounding_ceiling_ft(
@@ -344,6 +364,7 @@ def analyze_sounding_lite(
         convective=convective,
         convective_thermo=convective,
         convective_nwp=convective_nwp,
+        convective_explicit_unavailable=convective_explicit_unavailable,
         precipitation=None,
         vertical_motion=None,
         cloud_cover_low_pct=hourly.cloud_cover_low_pct if hourly else None,

--- a/src/weatherbrief/analysis/sounding/convective.py
+++ b/src/weatherbrief/analysis/sounding/convective.py
@@ -891,6 +891,332 @@ def assess_convective_nwp(
     )
 
 
+# --- Explicit-convection assessment (ICON-D2, issue #462) --------------------
+#
+# D2 is convection-permitting: deep convection lives in explicit storm fields
+# (simulated reflectivity, echo top, LPI, updrafts, graupel), not in a
+# parameterized scheme's diagnosed tower. This is a different KIND of signal
+# from assess_convective_nwp's tower-top track, so it gets its own assessment
+# with its own method string ("nwp_explicit") — the two are never blended.
+#
+# v1 decision table (meteorology-decisions §19 — calibration starting points,
+# not physical constants). The firing signal is the corridor-max hour-max
+# reflectivity DBZ_CTMAX; a corroborator set C confirms storm character:
+#
+#   corridor dbz_ctmax | |C| = 0                    | |C| = 1  | |C| >= 2
+#   -------------------+----------------------------+----------+---------
+#   < 35 dBZ           | no fire                    | no fire  | no fire
+#   35–44 dBZ          | no fire (stratiform note)  | MARGINAL | MODERATE
+#   45–49 dBZ          | MODERATE                   | MODERATE | HIGH
+#   >= 50 dBZ          | HIGH                       | HIGH     | HIGH
+#
+# Each corroborator counts 1 when its channel is COMPLETE (non-None — a valid
+# quiet channel decodes to 0.0, #421 None ≠ 0) AND over threshold; lpi >= 5
+# counts 2. Incomplete channels never downgrade below the dbz-alone row and
+# never upgrade (|C| counts only complete channels); zero on one channel never
+# suppresses positive evidence on another. |uh| is narrative/character only.
+_EXPLICIT_DBZ_FIRE = 35.0       # below → no fire (environment tracks unaffected)
+_EXPLICIT_DBZ_CONVECTIVE = 45.0  # 35–44 band may be stratiform/melting-band
+_EXPLICIT_DBZ_SEVERE = 50.0     # >= → HIGH regardless of corroborators
+_EXPLICIT_LPI_CORROB_JKG = 1.0
+_EXPLICIT_LPI_STRONG_JKG = 5.0  # counts as 2 corroborators
+_EXPLICIT_UPDRAFT_CORROB_MS = 10.0
+_EXPLICIT_GRAUPEL_CORROB_MM = 0.5
+_EXPLICIT_CAPE_CORROB_JKG = 500.0
+_EXPLICIT_UH_NOTE_M2S2 = 25.0   # rotation NOTE only, never a tier input
+# Corridor-vs-centreline discriminator: a corridor max this far above the
+# centreline value marks a discrete cell NEAR the route rather than a
+# widespread shield over it (geometry note, not a tier input).
+_EXPLICIT_CELL_MINUS_SHIELD_DBZ = 10.0
+
+# Lead-time confidence bands (meteorology-decisions §19): ICON-D2 is radar-
+# nudged (latent-heat nudging of 3-D volume reflectivity), so short leads are
+# observationally constrained; cell-placement trust decays with lead while
+# presence/character retains value much longer. Wording only, never a tier
+# input — placement uncertainty must not downgrade a simulated echo.
+_EXPLICIT_LEAD_RADAR_NUDGED_H = 6.0
+_EXPLICIT_LEAD_PLACEMENT_H = 24.0
+
+
+def _explicit_corroborators(
+    explicit: "NWPExplicitConvectiveDiagnostics",
+    nwp_diagnostics: NWPCloudDiagnostics | None,
+) -> tuple[int, list[str], int]:
+    """Count complete-and-over-threshold corroborator channels.
+
+    Returns ``(count, descriptions, incomplete_channels)``. Only complete
+    channels (non-None values) can count; incomplete ones are tallied so the
+    caller can say so without letting them downgrade or upgrade the tier.
+    """
+    count = 0
+    notes: list[str] = []
+    incomplete = 0
+
+    lpi = explicit.lightning_potential_hour_max_jkg
+    if lpi is None:
+        incomplete += 1
+    elif lpi >= _EXPLICIT_LPI_STRONG_JKG:
+        count += 2
+        notes.append(f"strong lightning potential (LPI {lpi:.1f} J/kg)")
+    elif lpi >= _EXPLICIT_LPI_CORROB_JKG:
+        count += 1
+        notes.append(f"lightning potential (LPI {lpi:.1f} J/kg)")
+
+    w = explicit.updraft_hour_max_ms
+    if w is None:
+        incomplete += 1
+    elif w >= _EXPLICIT_UPDRAFT_CORROB_MS:
+        count += 1
+        notes.append(f"strong updraft ({w:.0f} m/s)")
+
+    graupel = explicit.graupel_hour_mm
+    if graupel is None:
+        incomplete += 1
+    elif graupel >= _EXPLICIT_GRAUPEL_CORROB_MM:
+        count += 1
+        # Hard wording rule (#462): graupel / mixed-phase core — never "hail".
+        # An hourly ACCUMULATION in mm — not a rate (the parameterized notes
+        # nearby are genuinely mm/h, so the unit has to differ here).
+        notes.append(f"graupel / strong mixed-phase core ({graupel:.1f} mm this hour)")
+
+    cape_ml = nwp_diagnostics.ml_cape_jkg if nwp_diagnostics is not None else None
+    if cape_ml is None:
+        incomplete += 1
+    elif cape_ml >= _EXPLICIT_CAPE_CORROB_JKG:
+        count += 1
+        notes.append(f"unstable environment (ML-CAPE {cape_ml:.0f} J/kg)")
+
+    return count, notes, incomplete
+
+
+def _explicit_risk_from_table(
+    dbz: float | None, corroborators: int
+) -> ConvectiveRisk:
+    """The v1 dbz × |C| decision table (see the constants block above)."""
+    if dbz is None or dbz < _EXPLICIT_DBZ_FIRE:
+        return ConvectiveRisk.NONE
+    if dbz >= _EXPLICIT_DBZ_SEVERE:
+        return ConvectiveRisk.HIGH
+    if dbz >= _EXPLICIT_DBZ_CONVECTIVE:
+        return ConvectiveRisk.HIGH if corroborators >= 2 else ConvectiveRisk.MODERATE
+    # 35–44 dBZ: echo present but possibly stratiform rain / melting-band
+    # bright-band — only corroborated echoes fire.
+    if corroborators >= 2:
+        return ConvectiveRisk.MODERATE
+    if corroborators == 1:
+        return ConvectiveRisk.MARGINAL
+    return ConvectiveRisk.NONE
+
+
+def _explicit_lead_note(lead_hours: float | None) -> str | None:
+    """Lead-time confidence wording for a fired explicit cell (#462)."""
+    if lead_hours is None:
+        return None
+    if lead_hours <= _EXPLICIT_LEAD_RADAR_NUDGED_H:
+        return (
+            "Short lead — radar-nudged ICON-D2 (latent-heat nudging): cell "
+            "positions are observationally constrained"
+        )
+    if lead_hours <= _EXPLICIT_LEAD_PLACEMENT_H:
+        return (
+            "Cell presence/character reliable at this lead; exact placement "
+            "approximate — plan deviations on area, not on the depicted cell"
+        )
+    return (
+        "Long lead for a convection-permitting model — treat as an "
+        "environment-level signal: exact cell placement at this range is unlikely"
+    )
+
+
+def assess_convective_explicit(
+    indices: ThermodynamicIndices,
+    nwp_diagnostics: NWPCloudDiagnostics | None,
+    explicit: "NWPExplicitConvectiveDiagnostics",
+) -> ConvectiveAssessment | None:
+    """Assess convective risk from a convection-permitting model's storm fields.
+
+    The explicit-convection sibling of :func:`assess_convective_nwp` (#462):
+    consumes the :class:`NWPExplicitConvectiveDiagnostics` payload (corridor
+    extrema — see the payload docstring) and returns the standard convective-
+    assessment contract with ``method="nwp_explicit"``.
+
+    Structural safety properties:
+    - ``top_ft`` is ALWAYS ``None`` — D2 cells have unresolved vertical
+      geometry for clearance purposes, so the overfly-clearance filter
+      structurally cannot consume the 18 dBZ echo top as a cloud top. The echo
+      top travels only as the ``echo_top_18dbz_ft`` character/detail field.
+    - ``detection_complete=False`` returns ``None`` — "explicit assessment
+      unavailable". It must NOT become an NWP ``NONE`` (unknown is not quiet),
+      nor a CAPE-only fallback presented as D2's explicit verdict; the caller
+      records the unavailability (``convective_explicit_unavailable``) and the
+      DD/thermo track remains fully usable.
+    - No CIN suppression: a simulated echo IS realized convection — the model
+      already convected, so penalising it on surface/ML CIN would be circular
+      (same reasoning as the ``nwp_precip`` path).
+    - A quiet-but-complete hour returns a real ``NONE`` assessment (not
+      ``None``) so DD-vs-model cross-checks can still fire.
+    """
+    if not explicit.detection_complete:
+        return None
+
+    dbz = explicit.reflectivity_hour_max_dbz
+    cape = _effective_cape(indices)
+    cin = indices.cin_surface_jkg
+    # Hard wording rule (#462): the explicit track never says "hail" — D2's
+    # mixed-phase signal is graupel, which does not discriminate hail.
+    # _severity_modifiers' freezing-level+CAPE heuristic emits "hail risk", so
+    # rephrase it here to the graupel/mixed-phase framing.
+    modifiers = [
+        m.replace("hail risk", "graupel / strong mixed-phase core potential")
+        for m in _severity_modifiers(indices, cape)
+    ]
+
+    corrob_count, corrob_notes, incomplete = _explicit_corroborators(
+        explicit, nwp_diagnostics,
+    )
+    risk = _explicit_risk_from_table(dbz, corrob_count)
+
+    drivers: list[str] = []
+    suppressors: list[str] = []
+
+    if dbz is not None and dbz >= _EXPLICIT_DBZ_FIRE:
+        drivers.append(
+            f"Explicitly simulated storm echo — corridor-max reflectivity "
+            f"{dbz:.0f} dBZ over the past hour (ICON-D2, convection-permitting)"
+        )
+        point_dbz = explicit.reflectivity_point_dbz
+        if (
+            point_dbz is not None
+            and dbz >= _EXPLICIT_DBZ_CONVECTIVE
+            and dbz - point_dbz >= _EXPLICIT_CELL_MINUS_SHIELD_DBZ
+        ):
+            drivers.append(
+                f"Discrete cell geometry — corridor max {dbz:.0f} dBZ vs "
+                f"{point_dbz:.0f} dBZ at the route point: a compact cell near "
+                "the route, not a shield over it"
+            )
+        if dbz < _EXPLICIT_DBZ_CONVECTIVE and corrob_count == 0:
+            if (
+                point_dbz is not None
+                and point_dbz >= _EXPLICIT_DBZ_FIRE - 5.0
+                and dbz - point_dbz < _EXPLICIT_CELL_MINUS_SHIELD_DBZ
+            ):
+                suppressors.append(
+                    "Echo widespread and uncorroborated at 35–44 dBZ — likely "
+                    "stratiform rain / melting-band bright-band, not convection"
+                )
+            else:
+                suppressors.append(
+                    "Echo present but uncorroborated at 35–44 dBZ — possibly "
+                    "stratiform rain / melting-band bright-band, not convection"
+                )
+        drivers.extend(corrob_notes)
+        if incomplete and corrob_count < 2:
+            drivers.append(
+                f"{incomplete} corroborator channel(s) unavailable — tier from "
+                "the reflectivity row alone (missing data never downgrades)"
+            )
+        if explicit.echo_top_18dbz_ft is not None:
+            # Depth/character AFTER firing — explicitly NOT a cloud top: the
+            # physical storm top (weakly-reflecting anvil ice) sits higher.
+            drivers.append(
+                f"18 dBZ echo top ~{explicit.echo_top_18dbz_ft:.0f} ft "
+                "(storm depth indicator — the cloud top is higher; not for "
+                "overfly planning)"
+            )
+        uh = explicit.updraft_helicity_2_5km_hour_max_m2s2
+        if uh is not None and abs(uh) >= _EXPLICIT_UH_NOTE_M2S2:
+            sense = "cyclonic" if uh > 0 else "anticyclonic"
+            drivers.append(
+                f"Rotating updraft signature (2–5 km updraft helicity "
+                f"{uh:.0f} m²/s², {sense}) — organized-storm character"
+            )
+        lead_note = _explicit_lead_note(explicit.lead_hours)
+        if lead_note is not None:
+            drivers.append(lead_note)
+
+    return ConvectiveAssessment(
+        risk_level=risk,
+        cape_jkg=cape,
+        cin_jkg=cin,
+        lcl_altitude_ft=indices.lcl_altitude_ft,
+        lfc_altitude_ft=indices.lfc_altitude_ft,
+        el_altitude_ft=indices.el_altitude_ft,
+        bulk_shear_0_6km_kt=indices.bulk_shear_0_6km_kt,
+        lifted_index=indices.lifted_index,
+        k_index=indices.k_index,
+        total_totals=indices.total_totals,
+        severe_modifiers=modifiers,
+        drivers=drivers,
+        suppressors=suppressors,
+        base_ft=None,
+        top_ft=None,   # structural: echo top must never reach the clearance filter
+        cover_pct=None,
+        convective_precip_mm_h=None,
+        method="nwp_explicit",
+        explicit_source=explicit.source,
+        reflectivity_hour_max_dbz=dbz,
+        echo_top_18dbz_ft=explicit.echo_top_18dbz_ft,
+    )
+
+
+def _explicit_cross_check(
+    thermo: "ConvectiveAssessment",
+    nwp: "ConvectiveAssessment",
+) -> "ConvectiveCrossCheck | None":
+    """DD-vs-explicit divergence for the ICON-D2 mode (#462).
+
+    Same two material divergences as the parameterized check, keyed on the
+    explicit track's own firing verdict (the decision table already folds in
+    reflectivity + corroborators):
+    - thermo MODERATE+ but the simulated radar is quiet/uncorroborated →
+      ``dd_not_corroborated``;
+    - thermo NONE/MARGINAL but D2 explicitly develops a cell (MODERATE+) →
+      ``model_active_dd_quiet``.
+    MARGINAL explicit (a single-corroborator 35–44 dBZ echo) sits in neither
+    band, mirroring the parameterized gap between quiet and active.
+    """
+    model_active = _RISK_LEVELS.index(nwp.risk_level) >= _RISK_LEVELS.index(
+        ConvectiveRisk.MODERATE
+    )
+    model_quiet = nwp.risk_level == ConvectiveRisk.NONE
+
+    thermo_high = _RISK_LEVELS.index(thermo.risk_level) >= _RISK_LEVELS.index(
+        ConvectiveRisk.MODERATE
+    )
+    thermo_low = thermo.risk_level in (ConvectiveRisk.NONE, ConvectiveRisk.MARGINAL)
+
+    dbz = nwp.reflectivity_hour_max_dbz
+    if thermo_high and model_quiet:
+        cape_txt = f" (CAPE {thermo.cape_jkg:.0f})" if thermo.cape_jkg is not None else ""
+        echo_txt = (
+            f"corridor-max reflectivity {dbz:.0f} dBZ"
+            if dbz is not None else "no simulated echo"
+        )
+        note = (
+            f"Thermo Convective shows {thermo.risk_level.value.upper()} instability"
+            f"{cape_txt}, but ICON-D2's explicit convection is quiet ({echo_txt})"
+        )
+        return ConvectiveCrossCheck(direction="dd_not_corroborated", note=note)
+
+    if thermo_low and model_active:
+        echo_txt = (
+            f"{dbz:.0f} dBZ corridor-max echo" if dbz is not None else "a storm cell"
+        )
+        dd_txt = (
+            "little instability"
+            if thermo.risk_level == ConvectiveRisk.NONE
+            else "only marginal instability"
+        )
+        note = (
+            f"ICON-D2 explicitly develops a cell ({echo_txt}), but Thermo "
+            f"Convective shows {dd_txt}"
+        )
+        return ConvectiveCrossCheck(direction="model_active_dd_quiet", note=note)
+
+    return None
+
+
 # Convective DD-vs-model cross-check thresholds (tunable module constants).
 # These gate the "does the model's own convective scheme corroborate the DD
 # (CAPE-derived) risk" signal surfaced in the advisory popup and LLM digest.
@@ -941,6 +1267,10 @@ def convective_cross_check(
     """
     if nwp is None or thermo is None:
         return None
+    if nwp.method == "nwp_explicit":
+        # ICON-D2 explicit-convection mode (#462): the firing verdict is the
+        # reflectivity decision table, not precip/cover/tower — own check.
+        return _explicit_cross_check(thermo, nwp)
     if nwp.method == "nwp_cape_fallback":
         # Circular: the fallback is CAPE-scored like thermo (no native scheme
         # output), so a quiet/active comparison would re-derive thermo against

--- a/src/weatherbrief/fetch/grib/__init__.py
+++ b/src/weatherbrief/fetch/grib/__init__.py
@@ -3035,6 +3035,91 @@ class _IconEuContext:
         self.variant = variant
 
 
+def _icon_d2_validity_mask(
+    d2_run: tuple[str, int],
+    *,
+    session: requests.Session,
+    data_dir: Path,
+) -> "tuple[object, object, object] | None":
+    """Cached bitmap validity mask for the delivered D2 grid (#462).
+
+    Built once from any regular-grid D2 field (dbz_ctmax; the domain bitmap is
+    identical on every field) and cached under the icon-d2 cache root — the
+    model TTL simply rebuilds it. Tests the ACTUAL delivered product rather
+    than documented domain geometry. Returns ``(lat_vec, lon_vec,
+    valid_mask)`` or None when no probe file decodes.
+    """
+    import numpy as np
+
+    from weatherbrief.fetch.grib.decode import read_icon_d2_grid_mask
+    from weatherbrief.fetch.grib.icon_eu_fetch import (
+        ICON_D2,
+        fetch_icon_eu_single_level,
+    )
+
+    mask_dir = data_dir / ".cache" / "grib" / ICON_D2.slug / "grid-validity"
+    mask_path = mask_dir / "mask.npz"
+    try:
+        if mask_path.exists():
+            with np.load(mask_path) as z:
+                return z["lat_vec"], z["lon_vec"], z["valid_mask"]
+    except Exception:
+        logger.warning("Failed to read cached ICON-D2 validity mask; rebuilding", exc_info=True)
+
+    init_date, init_hour = d2_run
+    for probe_hour in (1, 6, 12, 0):
+        try:
+            fetched = fetch_icon_eu_single_level(
+                init_date, init_hour, [probe_hour], variables=["dbz_ctmax"],
+                session=session, max_workers=1, variant=ICON_D2,
+            )
+        except Exception:
+            logger.debug("ICON-D2 mask probe f%03d failed", probe_hour, exc_info=True)
+            continue
+        blob = fetched.get(probe_hour)
+        if not blob:
+            continue
+        mask = read_icon_d2_grid_mask(blob)
+        if mask is None:
+            continue
+        lat_vec, lon_vec, valid_mask = mask
+        try:
+            mask_dir.mkdir(parents=True, exist_ok=True)
+            np.savez(mask_path, lat_vec=lat_vec, lon_vec=lon_vec, valid_mask=valid_mask)
+        except Exception:
+            logger.debug("Failed to cache ICON-D2 validity mask", exc_info=True)
+        return lat_vec, lon_vec, valid_mask
+    return None
+
+
+def _icon_d2_route_corridors_valid(
+    route_points: list[RoutePoint],
+    d2_run: tuple[str, int],
+    *,
+    session: requests.Session,
+    data_dir: Path,
+) -> bool:
+    """True when every route point's corridor disc lies in valid D2 cells (#462).
+
+    A route can pass the bbox gate yet clip the bitmap-masked corners (~16.7%
+    of delivered cells) or the grid boundary; corridor extrema there would be
+    computed over partial neighbourhoods. When the mask itself is unavailable
+    (transient fetch/decode failure), keep D2 and let decode-time
+    completeness report masked corridors as unavailable rather than bouncing
+    the whole route to the coarser model.
+    """
+    from weatherbrief.fetch.grib.decode import corridor_fully_valid
+
+    mask = _icon_d2_validity_mask(d2_run, session=session, data_dir=data_dir)
+    if mask is None:
+        return True
+    lat_vec, lon_vec, valid_mask = mask
+    return all(
+        corridor_fully_valid(lat_vec, lon_vec, valid_mask, rp.lat, rp.lon)
+        for rp in route_points
+    )
+
+
 def _prepare_icon_eu(
     cross_sections: list[RouteCrossSection],
     route_points: list[RoutePoint],
@@ -3101,11 +3186,24 @@ def _prepare_icon_eu(
                 logger.warning("Failed to find ICON-D2 run; using ICON-EU", exc_info=True)
                 d2_run = None
             if d2_run is not None:
-                variant, run_info = ICON_D2, d2_run
-                logger.info(
-                    "ICON slot sourced from ICON-D2 (route in D2 domain, run %s %02dz)",
-                    d2_run[0], d2_run[1],
-                )
+                # Domain-mask hardening (#462): the bbox gate is not enough —
+                # the delivered D2 grid carries ~16.7% bitmap-masked cells
+                # (the native domain's corners), and corridor extrema need the
+                # FULL corridor unmasked. If any route point's corridor clips
+                # masked cells or the grid edge, fall back to ICON-EU (same
+                # all-or-nothing rule).
+                if _icon_d2_route_corridors_valid(
+                    route_points, d2_run, session=session, data_dir=data_dir,
+                ):
+                    variant, run_info = ICON_D2, d2_run
+                    logger.info(
+                        "ICON slot sourced from ICON-D2 (route in D2 domain, run %s %02dz)",
+                        d2_run[0], d2_run[1],
+                    )
+                else:
+                    logger.info(
+                        "Route corridor clips ICON-D2 masked domain cells; using ICON-EU",
+                    )
 
     if not route_in_icon_eu_domain(route_points, variant):
         logger.info("Route outside %s domain, skipping ICON enrichment", variant.slug)
@@ -3252,11 +3350,10 @@ def _prefetch_icon_eu_data_inner(ctx: _IconEuContext) -> None:
             jobs.append((_fetch_diag, fhour, diag_ck))
 
     # One leading single-level step so the first window hour has a predecessor
-    # to de-accumulate rain_con against (#421). Cloud-diag fetch only — the
-    # model-level sounding list above is untouched. Skipped when the variant
-    # doesn't fetch rain_con (ICON-D2, #456/#462) — no accumulated field, no
-    # predecessor needed.
-    if ctx.forecast_hours and "rain_con" in variant.cloud_diag_variables:
+    # (#421 rain_con; #462 D2 grau_gsp de-accumulation + the three leading
+    # echotop quarter messages — variant-level flag). Cloud-diag fetch only —
+    # the model-level sounding list above is untouched.
+    if ctx.forecast_hours and variant.needs_predecessor_step:
         lead = icon_eu_previous_step(min(ctx.forecast_hours), variant)
         if lead is not None and lead not in ctx.forecast_hours:
             lead_ck = cache_key(lead, diag_key)
@@ -3426,7 +3523,10 @@ def _enrich_icon_eu_cloud_diagnostics(
 
     *variant* selects ICON-EU vs ICON-D2 URL/cache conventions (defaults to EU).
     """
-    from weatherbrief.fetch.grib.decode import build_icon_cloud_diagnostics
+    from weatherbrief.fetch.grib.decode import (
+        build_icon_cloud_diagnostics,
+        build_icon_d2_explicit_diagnostics,
+    )
     from weatherbrief.fetch.grib.icon_eu_fetch import (
         ICON_EU,
         fetch_icon_eu_single_level,
@@ -3439,17 +3539,21 @@ def _enrich_icon_eu_cloud_diagnostics(
         variant = ICON_EU
     diag_key = icon_cloud_diag_cache_key(variant)
 
-    # Prepend one leading step so the first window hour has a predecessor to
-    # de-accumulate rain_con against, then walk steps in sorted order carrying
-    # the previous accumulated value + valid time — a direct port of the ECMWF
-    # a1 loop (#421). The leading step is a harmless no-op for enrichment:
-    # _matches_valid_time never matches an out-of-window hourly, so it only
-    # seeds the de-accumulation state.
+    # Prepend one leading step so the first window hour has a predecessor
+    # (#421 rain_con de-accumulation; #462 D2 grau_gsp de-accumulation + the
+    # three leading echotop quarter messages — variant-level flag), then walk
+    # steps in sorted order carrying the previous accumulated value + valid
+    # time — a direct port of the ECMWF a1 loop (#421). The leading step is a
+    # harmless no-op for enrichment: _matches_valid_time never matches an
+    # out-of-window hourly, so it only seeds the de-accumulation state (and,
+    # on D2, the previous-step blob path for the explicit decode).
     steps = sorted(set(forecast_hours))
-    if steps and "rain_con" in variant.cloud_diag_variables:
+    if steps and variant.needs_predecessor_step:
         lead = icon_eu_previous_step(steps[0], variant)
         if lead is not None and lead not in steps:
             steps.insert(0, lead)
+
+    is_d2 = variant.slug == "icon-d2"
 
     n_points = len(point_lats)
     # None = no prior step for that point (unknown, missing-data-safe for the
@@ -3458,7 +3562,7 @@ def _enrich_icon_eu_cloud_diagnostics(
     prev_valid_utc: datetime | None = None
 
     total_enriched = 0
-    for fhour in steps:
+    for step_pos, fhour in enumerate(steps):
         ck = cache_key(fhour, diag_key)
         if not is_cached(run_dir, ck):
             try:
@@ -3476,11 +3580,38 @@ def _enrich_icon_eu_cloud_diagnostics(
             continue
 
         cache_path = run_dir / ck
-        with _grib_time("icon_cloud_diag_decode"):
-            decoded_points = _dispatch_decode(
-                "decode_icon_cloud_diag",
-                str(cache_path), point_lats, point_lons,
-            )
+        explicit_payloads: list | None = None
+        if is_d2:
+            # D2 (#462): one worker decodes BOTH the standard diagnostics
+            # (non-explicit messages, cfgrib) and the explicit-convection
+            # corridor extrema (eccodes per-message selection, multi-message
+            # storm fields never reach cfgrib's merge). The previous step's
+            # blob supplies the three leading echotop quarters and the
+            # grau_gsp predecessor accumulation.
+            prev_path = ""
+            if step_pos > 0:
+                prev_ck = cache_key(steps[step_pos - 1], diag_key)
+                if is_cached(run_dir, prev_ck):
+                    prev_path = str(run_dir / prev_ck)
+            with _grib_time("icon_cloud_diag_decode"):
+                decoded_points, explicit_raws = _dispatch_decode(
+                    "decode_icon_d2_diag",
+                    str(cache_path), prev_path, fhour, point_lats, point_lons,
+                )
+            # Always-attach: build a payload per point even when the explicit
+            # decode failed (all-None + completeness False) so "no payload"
+            # unambiguously means "not D2-sourced" — a failed detection
+            # channel can never masquerade as model-quiet (#462 handoff).
+            explicit_payloads = [
+                build_icon_d2_explicit_diagnostics(raw, lead_hours=float(fhour))
+                for raw in explicit_raws
+            ]
+        else:
+            with _grib_time("icon_cloud_diag_decode"):
+                decoded_points = _dispatch_decode(
+                    "decode_icon_cloud_diag",
+                    str(cache_path), point_lats, point_lons,
+                )
         if not decoded_points:
             continue
 
@@ -3549,32 +3680,50 @@ def _enrich_icon_eu_cloud_diagnostics(
                 if point_idx >= len(diagnostics_per_point):
                     break
                 diag = diagnostics_per_point[point_idx]
-                if diag is None:
+                payload = (
+                    explicit_payloads[point_idx]
+                    if explicit_payloads is not None else None
+                )
+                if diag is None and payload is None:
                     continue
                 for hourly in wf.hourly:
                     if not _matches_valid_time(hourly.time, valid_utc):
                         continue
-                    if hourly.nwp_cloud_diagnostics is None:
+                    if diag is not None and hourly.nwp_cloud_diagnostics is None:
                         _apply_cloud_diagnostics(hourly, diag)
                         total_enriched += 1
+                    # Always-attach (#462): first writer wins, mirroring the
+                    # cloud-diag guard; the payload goes on even when the
+                    # standard diag is absent for this point.
+                    if payload is not None and hourly.explicit_convective_diagnostics is None:
+                        hourly.explicit_convective_diagnostics = payload
 
         # Also enrich waypoint-only forecasts
         wp_diag_lookup: dict[str, NWPCloudDiagnostics] = {}
-        for rp, diag in zip(route_points, diagnostics_per_point):
+        wp_payload_lookup: dict[str, object] = {}
+        for rp, diag, payload in zip(
+            route_points, diagnostics_per_point,
+            explicit_payloads or [None] * len(diagnostics_per_point),
+        ):
             if rp.waypoint_icao and diag is not None:
                 wp_diag_lookup[rp.waypoint_icao] = diag
+            if rp.waypoint_icao and payload is not None:
+                wp_payload_lookup[rp.waypoint_icao] = payload
 
         for wf in all_forecasts:
             if wf.model.value != "icon":
                 continue
             diag = wp_diag_lookup.get(wf.waypoint.icao)
-            if diag is None:
+            payload = wp_payload_lookup.get(wf.waypoint.icao)
+            if diag is None and payload is None:
                 continue
             for hourly in wf.hourly:
                 if not _matches_valid_time(hourly.time, valid_utc):
                     continue
-                if hourly.nwp_cloud_diagnostics is None:
+                if diag is not None and hourly.nwp_cloud_diagnostics is None:
                     _apply_cloud_diagnostics(hourly, diag)
+                if payload is not None and hourly.explicit_convective_diagnostics is None:
+                    hourly.explicit_convective_diagnostics = payload
 
         del decoded_points
         del diagnostics_per_point

--- a/src/weatherbrief/fetch/grib/decode.py
+++ b/src/weatherbrief/fetch/grib/decode.py
@@ -11,8 +11,10 @@ Handles two categories of GFS variables:
 from __future__ import annotations
 
 import logging
+import math
 import tempfile
 import warnings
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import NamedTuple
 
@@ -1530,6 +1532,542 @@ def build_icon_cloud_diagnostics(
         convective_top_ft=convective_top_ft,
         ml_cape_jkg=ml_cape,
         ml_cin_jkg=ml_cin,
+    )
+
+
+# ---------------------------------------------------------------------------
+# ICON-D2 explicit-convection decode (#462) — eccodes per-message path
+# ---------------------------------------------------------------------------
+#
+# D2's convection-permitting storm fields CANNOT go through the cfgrib path
+# above: several of them pack multiple sub-hourly GRIB messages per file and
+# the hourly products must be selected/constructed by validity — never merged
+# (verified against the live feed 2026-07-21, eccodes inspection of 00z f012):
+#
+# - dbz_ctmax / lpi_max / w_ctmax / uh_max_med: ONE message per file,
+#   stepType=max over the PREVIOUS hour (stepRange "11-12"-style). Interval
+#   maxima attach to (H−1, H].
+# - echotop (shortName min_pres, Pa, stepType=min, −999 Pa = valid "no echo"):
+#   FOUR 15-min messages per file, valid :00/:15/:30/:45. The hourly echo top
+#   for flight hour H is CONSTRUCTED as the min pressure over the four quarter
+#   windows ending at H−45/H−30/H−15/H — three messages from file f(H−1) plus
+#   the first of file f(H) — aligned with dbz_ctmax's (H−1, H] interval.
+# - grau_gsp (shortName tgrp, kg/m², stepType=accum since init): ONE on-the-
+#   hour message (stepUnits=hours) plus three quarter-hour accums we must NOT
+#   use. De-accumulated PER CELL (accum_H − accum_{H−1}, clipped ≥ 0), then
+#   corridor-max — like rain_con but on the grid, before reduction.
+#
+# Sentinel discipline (None ≠ 0, #421): the GRIB BITMAP alone marks missing
+# data (masked domain corners, ~16.7% of cells on every field). Encoded quiet
+# values are real data: −150 dBZ = genuinely quiet reflectivity floor (kept —
+# it participates in the corridor max), −999 Pa = "no 18 dBZ echo this
+# quarter" (excluded from the pressure min, counted as a valid cell).
+# Completeness flags below are driven by bitmap-valid corridor fractions,
+# never by decoded values.
+#
+# Corridor extrema: per-point bilinear sampling defeats a 2.2 km model — a
+# cell between route points vanishes. Each channel is reduced over a disc of
+# D2_CORRIDOR_RADIUS_KM around each route point; values are corridor extrema,
+# not centreline values. dbz_ctmax additionally keeps the centreline bilinear
+# value so a widespread stratiform shield (point ≈ corridor max) is
+# distinguishable from a discrete cell (max ≫ point).
+
+D2_CORRIDOR_RADIUS_NM = 10.0
+D2_CORRIDOR_RADIUS_KM = D2_CORRIDOR_RADIUS_NM * 1.852
+
+_D2_EXPLICIT_SHORTNAMES = frozenset({
+    "dbz_ctmax", "min_pres", "lpi_max", "w_ctmax", "uh_max_med", "tgrp",
+})
+_D2_MISSING_VALUE = 9999.0          # eccodes missingValue on these products
+_D2_ECHOTOP_NO_ECHO_PA = -999.0     # valid "no ≥18 dBZ echo" sentinel
+_D2_CORRIDOR_MIN_VALID_FRAC = 0.5   # corridor coverage required per channel
+_KM_PER_DEG_LAT = 111.195
+
+
+class _D2Message(NamedTuple):
+    """One decoded explicit-convection GRIB message as a 2-D grid."""
+    var: str                # canonical field key (dbz_ctmax / echotop / ...)
+    values: "np.ndarray"    # (n_lat, n_lon) float64, missing → NaN
+    valid_minutes: int      # validity offset from run init, in minutes
+    on_hour_accum: bool     # grau_gsp only: stepUnits=hours since-init accum
+
+
+def _d2_valid_offset_minutes(gid) -> int:
+    """(validityDate/validityTime − dataDate/dataTime) in minutes (eccodes)."""
+    import eccodes
+
+    def _ymdh(date_key: str, time_key: str) -> datetime:
+        d = int(eccodes.codes_get(gid, date_key))
+        t = int(eccodes.codes_get(gid, time_key))  # HHMM (e.g. 1115 = 11:15)
+        return datetime(
+            d // 10000, (d // 100) % 100, d % 100,
+            t // 100, t % 100, tzinfo=timezone.utc,
+        )
+
+    delta = _ymdh("validityDate", "validityTime") - _ymdh("dataDate", "dataTime")
+    return int(delta.total_seconds() // 60)
+
+
+def _read_d2_explicit_messages(
+    grib_bytes: bytes,
+) -> "tuple[list[_D2Message], np.ndarray | None, np.ndarray | None, bytes]":
+    """Split a D2 single-level blob into explicit messages + a standard remainder.
+
+    Returns ``(messages, lat_vec, lon_vec, standard_bytes)``: the decoded
+    explicit-convection messages (values as NaN-masked grids), the shared grid
+    axes (None when no explicit message was found), and the concatenation of
+    every NON-explicit message (ceiling/clc*/cape_ml/cin_ml) for the existing
+    cfgrib path — so multi-message storm fields never reach cfgrib's merge
+    logic. Grid axes come from the first explicit message's eccodes-computed
+    latitudes/longitudes arrays (SIGNED, monotonic: −3.94…20.34 °E), NOT from
+    the raw grid keys (which encode the first longitude as 356.06°).
+    """
+    import eccodes
+    import numpy as np
+
+    messages: list[_D2Message] = []
+    standard = bytearray()
+    lat_vec = lon_vec = None
+    if not grib_bytes:
+        return messages, None, None, b""
+
+    with tempfile.NamedTemporaryFile(suffix=".grib2", delete=False) as tmp:
+        tmp.write(grib_bytes)
+        tmp_path = Path(tmp.name)
+    try:
+        with open(tmp_path, "rb") as f:
+            while True:
+                gid = eccodes.codes_grib_new_from_file(f)
+                if gid is None:
+                    break
+                try:
+                    short = str(eccodes.codes_get(gid, "shortName")).lower()
+                    if short not in _D2_EXPLICIT_SHORTNAMES:
+                        standard.extend(eccodes.codes_get_message(gid))
+                        continue
+                    ni = int(eccodes.codes_get(gid, "Ni"))
+                    nj = int(eccodes.codes_get(gid, "Nj"))
+                    if lat_vec is None:
+                        lats = np.asarray(
+                            eccodes.codes_get_array(gid, "latitudes"), dtype=np.float64,
+                        )
+                        lons = np.asarray(
+                            eccodes.codes_get_array(gid, "longitudes"), dtype=np.float64,
+                        )
+                        lat_vec = lats.reshape(nj, ni)[:, 0]
+                        lon_vec = lons.reshape(nj, ni)[0, :]
+                    values = np.asarray(
+                        eccodes.codes_get_values(gid), dtype=np.float64,
+                    ).reshape(nj, ni)
+                    missing = float(eccodes.codes_get(gid, "missingValue"))
+                    values = np.where(values == missing, np.nan, values)
+
+                    var = {
+                        "dbz_ctmax": "dbz_ctmax",
+                        "min_pres": "echotop",
+                        "lpi_max": "lpi_max",
+                        "w_ctmax": "w_ctmax",
+                        "uh_max_med": "uh_max_med",
+                        "tgrp": "grau_gsp",
+                    }[short]
+                    step_units = int(eccodes.codes_get(gid, "stepUnits"))
+                    step_type = str(eccodes.codes_get(gid, "stepType"))
+                    messages.append(_D2Message(
+                        var=var,
+                        values=values,
+                        valid_minutes=_d2_valid_offset_minutes(gid),
+                        on_hour_accum=(step_type == "accum" and step_units == 1),
+                    ))
+                finally:
+                    eccodes.codes_release(gid)
+    finally:
+        tmp_path.unlink(missing_ok=True)
+    return messages, lat_vec, lon_vec, bytes(standard)
+
+
+def read_icon_d2_grid_mask(
+    grib_bytes: bytes,
+) -> "tuple[np.ndarray, np.ndarray, np.ndarray] | None":
+    """Grid axes + bitmap validity mask from the first message of a D2 blob.
+
+    Used by the domain-gate hardening (#462): the delivered regular-lat-lon
+    grid carries ~16.7% bitmap-masked cells (the native rotated domain's
+    corners), and this mask tests the ACTUAL delivered product. Returns
+    ``(lat_vec, lon_vec, valid_mask)`` with valid_mask True where the cell is
+    a real model cell, or None when undecodable.
+    """
+    import eccodes
+    import numpy as np
+
+    if not grib_bytes:
+        return None
+    with tempfile.NamedTemporaryFile(suffix=".grib2", delete=False) as tmp:
+        tmp.write(grib_bytes)
+        tmp_path = Path(tmp.name)
+    try:
+        with open(tmp_path, "rb") as f:
+            gid = eccodes.codes_grib_new_from_file(f)
+            if gid is None:
+                return None
+            try:
+                ni = int(eccodes.codes_get(gid, "Ni"))
+                nj = int(eccodes.codes_get(gid, "Nj"))
+                lats = np.asarray(eccodes.codes_get_array(gid, "latitudes"))
+                lons = np.asarray(eccodes.codes_get_array(gid, "longitudes"))
+                values = np.asarray(eccodes.codes_get_values(gid), dtype=np.float64)
+                missing = float(eccodes.codes_get(gid, "missingValue"))
+                return (
+                    lats.reshape(nj, ni)[:, 0],
+                    lons.reshape(nj, ni)[0, :],
+                    (values.reshape(nj, ni) != missing),
+                )
+            finally:
+                eccodes.codes_release(gid)
+    finally:
+        tmp_path.unlink(missing_ok=True)
+
+
+def _d2_corridor_cells(
+    lat_vec: "np.ndarray",
+    lon_vec: "np.ndarray",
+    lat: float,
+    lon: float,
+    radius_km: float = D2_CORRIDOR_RADIUS_KM,
+) -> "tuple[np.ndarray, np.ndarray, bool] | None":
+    """Grid cells within *radius_km* of a route point.
+
+    Returns ``(rows, cols, clipped)`` — index arrays of the corridor disc and
+    whether the disc was cut by the grid boundary — or None when the point is
+    outside the grid entirely. A clipped corridor is incomplete by
+    construction: the extremum would be computed over a partial
+    neighbourhood, so callers treat completeness as False.
+    """
+    import numpy as np
+
+    frac_lat, lat_ok = _frac_grid_indices(lat_vec, [lat])
+    frac_lon, lon_ok = _frac_grid_indices(lon_vec, [lon])
+    if not (bool(lat_ok[0]) and bool(lon_ok[0])):
+        return None
+
+    ci = float(frac_lat[0])  # lat axis (rows)
+    cj = float(frac_lon[0])  # lon axis (cols)
+    dlat_km = abs(float(lat_vec[-1] - lat_vec[0])) / max(len(lat_vec) - 1, 1) * _KM_PER_DEG_LAT
+    dlon_km = (
+        abs(float(lon_vec[-1] - lon_vec[0])) / max(len(lon_vec) - 1, 1)
+        * _KM_PER_DEG_LAT * math.cos(math.radians(lat))
+    )
+    if dlat_km <= 0 or dlon_km <= 0:
+        return None
+
+    ri = int(math.ceil(radius_km / dlat_km))
+    rj = int(math.ceil(radius_km / dlon_km))
+    n_rows, n_cols = len(lat_vec), len(lon_vec)
+    i0, i1 = int(math.floor(ci)) - ri, int(math.ceil(ci)) + ri + 1
+    j0, j1 = int(math.floor(cj)) - rj, int(math.ceil(cj)) + rj + 1
+    clipped = i0 < 0 or j0 < 0 or i1 > n_rows or j1 > n_cols
+    i0, j0 = max(i0, 0), max(j0, 0)
+    i1, j1 = min(i1, n_rows), min(j1, n_cols)
+    if i0 >= i1 or j0 >= j1:
+        return None
+
+    ii = np.arange(i0, i1)[:, None]
+    jj = np.arange(j0, j1)[None, :]
+    dist2 = ((ii - ci) * dlat_km) ** 2 + ((jj - cj) * dlon_km) ** 2
+    sel = dist2 <= radius_km ** 2
+    rows = np.broadcast_to(ii, dist2.shape)[sel]
+    cols = np.broadcast_to(jj, dist2.shape)[sel]
+    if rows.size == 0:
+        return None
+    return rows, cols, clipped
+
+
+def _d2_corridor_stats(
+    values: "np.ndarray",
+    rows: "np.ndarray",
+    cols: "np.ndarray",
+) -> "tuple[np.ndarray, float]":
+    """Valid corridor values + valid fraction for one point/channel."""
+    import numpy as np
+
+    cell_values = values[rows, cols]
+    valid = ~np.isnan(cell_values)
+    frac = float(valid.sum()) / float(cell_values.size) if cell_values.size else 0.0
+    return cell_values[valid], frac
+
+
+def corridor_fully_valid(
+    lat_vec: "np.ndarray",
+    lon_vec: "np.ndarray",
+    valid_mask: "np.ndarray",
+    lat: float,
+    lon: float,
+    radius_km: float = D2_CORRIDOR_RADIUS_KM,
+) -> bool:
+    """True when a route point's ENTIRE corridor disc lies in valid grid cells.
+
+    Domain-gate hardening (#462): a route can pass the D2 bbox gate yet clip
+    the delivered grid's bitmap-masked corners (~16.7% of cells) or its outer
+    boundary — corridor extrema there would be computed over partial
+    neighbourhoods. The gate requires the full disc present and unmasked.
+    """
+    cells = _d2_corridor_cells(lat_vec, lon_vec, lat, lon, radius_km)
+    if cells is None:
+        return False
+    rows, cols, clipped = cells
+    if clipped:
+        return False
+    return bool(valid_mask[rows, cols].all())
+
+
+def _d2_centreline_value(
+    values: "np.ndarray",
+    lat_vec: "np.ndarray",
+    lon_vec: "np.ndarray",
+    lat: float,
+    lon: float,
+) -> float | None:
+    """Bilinear value at the exact route point (None on any masked corner)."""
+    import numpy as np
+
+    bw = _bilinear_grid_weights(lat_vec, lon_vec, [lat], [lon])
+    if bw is None or bw.inb_idx.size == 0:
+        return None
+    corners = np.array([
+        values[bw.i0[0], bw.j0[0]], values[bw.i0[0], bw.j1[0]],
+        values[bw.i1[0], bw.j0[0]], values[bw.i1[0], bw.j1[0]],
+    ])
+    if np.isnan(corners).any():
+        return None
+    v = (
+        bw.w00[0] * corners[0] + bw.w01[0] * corners[1]
+        + bw.w10[0] * corners[2] + bw.w11[0] * corners[3]
+    )
+    return float(v)
+
+
+def _isa_pressure_to_ft(pressure_pa: float) -> float:
+    """Pressure → altitude via the ICAO standard atmosphere (single datum).
+
+    The echo top is a corridor extremum — its cell is generally NOT under the
+    route centreline, so converting through the centreline sounding column
+    would borrow a datum from the wrong place; ISA is reproducible and good
+    to ~±1000 ft at storm-top levels, ample for a depth/character indicator
+    that is explicitly never used for overfly clearance (#462).
+    """
+    if pressure_pa <= 0:
+        return 0.0
+    if pressure_pa >= 22632.06:  # troposphere (to 11 km)
+        h_m = 44330.8 * (1.0 - (pressure_pa / 101325.0) ** 0.1902632)
+    else:  # isothermal stratosphere (11–20 km)
+        h_m = 11000.0 + 6341.62 * math.log(22632.06 / pressure_pa)
+    return h_m * _M_TO_FT
+
+
+def decode_icon_d2_explicit(
+    grib_bytes: bytes,
+    prev_grib_bytes: bytes | None,
+    fhour: int,
+    latitudes: list[float],
+    longitudes: list[float],
+) -> "tuple[list[dict[str, float | None]], bytes]":
+    """Decode D2 explicit-convection fields to corridor extrema per route point.
+
+    Args:
+        grib_bytes: This forecast hour's single-level blob (all variables).
+        prev_grib_bytes: The PREVIOUS step's blob — supplies the three leading
+            echotop quarters and the grau_gsp predecessor accumulation. None
+            when no predecessor was fetched (hour 0 or a failed lead file).
+        fhour: This blob's forecast hour H. The decoded products describe the
+            ``(H−1, H]`` interval (interval-max semantics, #462 rule 3).
+        latitudes/longitudes: Route points (signed −180…+180 lons).
+
+    Returns:
+        ``(raws, standard_bytes)`` — one raw dict per route point (corridor
+        extrema + per-channel valid fractions + corridor-clipped flag), and
+        the non-explicit remainder of THIS hour's blob for the cfgrib path.
+        A route point outside the grid gets an all-None dict with
+        ``corridor_clipped=True`` (unknown, never quiet).
+    """
+    import numpy as np
+
+    n_points = len(latitudes)
+    messages, lat_vec, lon_vec, standard = _read_d2_explicit_messages(grib_bytes)
+    prev_messages: list[_D2Message] = []
+    if prev_grib_bytes:
+        prev_messages, _, _, _ = _read_d2_explicit_messages(prev_grib_bytes)
+
+    raws: list[dict[str, float | None]] = [
+        {
+            "reflectivity_hour_max_dbz": None,
+            "reflectivity_point_dbz": None,
+            "dbz_valid_frac": 0.0,
+            "echo_top_18dbz_pa": None,
+            "echo_top_quarters_valid": 0,
+            "lightning_potential_hour_max_jkg": None,
+            "lpi_valid_frac": 0.0,
+            "updraft_hour_max_ms": None,
+            "w_valid_frac": 0.0,
+            "updraft_helicity_2_5km_hour_max_m2s2": None,
+            "uh_valid_frac": 0.0,
+            "graupel_hour_mm": None,
+            "grau_valid_frac": 0.0,
+            "corridor_clipped": True,
+        }
+        for _ in range(n_points)
+    ]
+    if lat_vec is None:
+        return raws, standard
+
+    # Hour-max channels from THIS hour's file (one message each).
+    hour_max: dict[str, np.ndarray] = {}
+    # echotop quarter windows keyed by end-minute offset (both files).
+    echo_quarters: dict[int, np.ndarray] = {}
+    # grau_gsp on-the-hour accumulations keyed by whole-hour offset.
+    grau_accums: dict[int, np.ndarray] = {}
+    for msg in messages:
+        if msg.var in ("dbz_ctmax", "lpi_max", "w_ctmax", "uh_max_med"):
+            hour_max[msg.var] = msg.values
+        elif msg.var == "echotop":
+            echo_quarters[msg.valid_minutes] = msg.values
+        elif msg.var == "grau_gsp" and msg.on_hour_accum:
+            grau_accums[msg.valid_minutes // 60] = msg.values
+    for msg in prev_messages:
+        if msg.var == "echotop":
+            echo_quarters.setdefault(msg.valid_minutes, msg.values)
+        elif msg.var == "grau_gsp" and msg.on_hour_accum:
+            grau_accums.setdefault(msg.valid_minutes // 60, msg.values)
+
+    # dbz_ctmax's interval is (H−1, H]; the four echo-top quarter windows
+    # ENDING in that interval are H−45/H−30/H−15/H (minutes since init).
+    quarter_ends = [fhour * 60 - 45, fhour * 60 - 30, fhour * 60 - 15, fhour * 60]
+
+    # Per-cell graupel de-accumulation (both accums must exist; clip ≥ 0 so a
+    # reset accumulation never yields negative rates — rain_con precedent).
+    grau_hourly: np.ndarray | None = None
+    accum_h = grau_accums.get(fhour)
+    accum_prev = grau_accums.get(fhour - 1)
+    if accum_h is not None and accum_prev is not None:
+        grau_hourly = np.clip(accum_h - accum_prev, 0.0, None)
+
+    for pt in range(n_points):
+        lat, lon = latitudes[pt], longitudes[pt]
+        cells = _d2_corridor_cells(lat_vec, lon_vec, lat, lon)
+        if cells is None:
+            continue  # all-None + corridor_clipped=True (already initialised)
+        rows, cols, clipped = cells
+        raw = raws[pt]
+        raw["corridor_clipped"] = clipped
+
+        grid = hour_max.get("dbz_ctmax")
+        if grid is not None:
+            valid, frac = _d2_corridor_stats(grid, rows, cols)
+            raw["dbz_valid_frac"] = frac
+            if valid.size:
+                # −150 dBZ is a valid quiet floor — it participates in the max.
+                raw["reflectivity_hour_max_dbz"] = float(np.max(valid))
+            raw["reflectivity_point_dbz"] = _d2_centreline_value(
+                grid, lat_vec, lon_vec, lat, lon,
+            )
+
+        grid = hour_max.get("lpi_max")
+        if grid is not None:
+            valid, frac = _d2_corridor_stats(grid, rows, cols)
+            raw["lpi_valid_frac"] = frac
+            if valid.size:
+                raw["lightning_potential_hour_max_jkg"] = float(np.max(valid))
+
+        grid = hour_max.get("w_ctmax")
+        if grid is not None:
+            valid, frac = _d2_corridor_stats(grid, rows, cols)
+            raw["w_valid_frac"] = frac
+            if valid.size:
+                raw["updraft_hour_max_ms"] = float(np.max(valid))
+
+        grid = hour_max.get("uh_max_med")
+        if grid is not None:
+            valid, frac = _d2_corridor_stats(grid, rows, cols)
+            raw["uh_valid_frac"] = frac
+            if valid.size:
+                # argmax |uh| but store the SIGNED value (rotation sense kept).
+                raw["updraft_helicity_2_5km_hour_max_m2s2"] = float(
+                    valid[np.argmax(np.abs(valid))]
+                )
+
+        if grau_hourly is not None:
+            valid, frac = _d2_corridor_stats(grau_hourly, rows, cols)
+            raw["grau_valid_frac"] = frac
+            if valid.size:
+                raw["graupel_hour_mm"] = float(np.max(valid))
+
+        # Hourly echo top: corridor min pressure per quarter (sentinel −999 Pa
+        # excluded — it is "no echo", not a high top), then the min across the
+        # four quarters (highest echo of the hour). Quarters missing from both
+        # files simply don't count — completeness records how many were valid.
+        quarter_mins: list[float] = []
+        quarters_valid = 0
+        for q_end in quarter_ends:
+            q_grid = echo_quarters.get(q_end)
+            if q_grid is None:
+                continue
+            cell_values, frac = _d2_corridor_stats(q_grid, rows, cols)
+            if frac < _D2_CORRIDOR_MIN_VALID_FRAC:
+                continue
+            real = cell_values[cell_values > _D2_ECHOTOP_NO_ECHO_PA]
+            quarters_valid += 1
+            if real.size:
+                quarter_mins.append(float(np.min(real)))
+        raw["echo_top_quarters_valid"] = quarters_valid
+        if quarters_valid == len(quarter_ends) and quarter_mins:
+            # Only a FULL set of quarters yields the hourly value — a partial
+            # min would understate storm depth while looking complete.
+            raw["echo_top_18dbz_pa"] = min(quarter_mins)
+
+    return raws, standard
+
+
+def build_icon_d2_explicit_diagnostics(
+    raw: dict[str, float | None],
+    lead_hours: float | None,
+) -> "NWPExplicitConvectiveDiagnostics":
+    """Convert one corridor-extrema raw dict into the payload model (#462).
+
+    Completeness is bitmap-driven per channel: a corridor needs ≥ 50% valid
+    cells (and no grid-boundary clipping) for its channel to count as
+    complete; quiet floors (−150 dBZ, −999 Pa) are valid data, never missing.
+    """
+    from weatherbrief.models.analysis import NWPExplicitConvectiveDiagnostics
+
+    clipped = bool(raw.get("corridor_clipped"))
+
+    def _enough(frac_key: str) -> bool:
+        return not clipped and (raw.get(frac_key) or 0.0) >= _D2_CORRIDOR_MIN_VALID_FRAC
+
+    detection_complete = _enough("dbz_valid_frac")
+    strength_complete = (
+        _enough("lpi_valid_frac") and _enough("w_valid_frac") and _enough("grau_valid_frac")
+    )
+    echo_top_complete = not clipped and raw.get("echo_top_quarters_valid") == 4
+
+    echo_top_pa = raw.get("echo_top_18dbz_pa")
+    echo_top_ft = (
+        round(_isa_pressure_to_ft(echo_top_pa)) if echo_top_pa is not None else None
+    )
+
+    return NWPExplicitConvectiveDiagnostics(
+        source="icon_d2",
+        reflectivity_hour_max_dbz=raw.get("reflectivity_hour_max_dbz"),
+        reflectivity_point_dbz=raw.get("reflectivity_point_dbz"),
+        echo_top_18dbz_ft=echo_top_ft,
+        lightning_potential_hour_max_jkg=raw.get("lightning_potential_hour_max_jkg"),
+        updraft_hour_max_ms=raw.get("updraft_hour_max_ms"),
+        updraft_helicity_2_5km_hour_max_m2s2=raw.get(
+            "updraft_helicity_2_5km_hour_max_m2s2"
+        ),
+        graupel_hour_mm=raw.get("graupel_hour_mm"),
+        lead_hours=lead_hours,
+        detection_complete=detection_complete,
+        strength_complete=strength_complete,
+        echo_top_complete=echo_top_complete,
     )
 
 

--- a/src/weatherbrief/fetch/grib/decode_worker.py
+++ b/src/weatherbrief/fetch/grib/decode_worker.py
@@ -241,6 +241,37 @@ def decode_icon_cloud_diag(
         return decode_icon_eu_cloud_diag_per_point(grib_bytes, latitudes, longitudes)
 
 
+def decode_icon_d2_diag(
+    file_path: str,
+    prev_file_path: str,
+    fhour: int,
+    latitudes: list[float],
+    longitudes: list[float],
+) -> tuple[list[dict[str, float]], list[dict]]:
+    """ICON-D2 single-level decode: standard diagnostics + explicit convection (#462).
+
+    Returns ``(standard_results, explicit_raws)``: the cfgrib-decoded standard
+    cloud diagnostics (from the blob's non-explicit messages) and the per-point
+    corridor-extrema raw dicts for the explicit-convection payload. Multi-
+    message storm fields are selected/constructed by validity inside
+    decode_icon_d2_explicit — never merged by cfgrib.
+    """
+    with _log_decode("decode_icon_d2_diag", file_path):
+        from weatherbrief.fetch.grib.decode import (
+            decode_icon_d2_explicit,
+            decode_icon_eu_cloud_diag_per_point,
+        )
+        grib_bytes = Path(file_path).read_bytes()
+        prev_bytes = Path(prev_file_path).read_bytes() if prev_file_path else None
+        raws, standard = decode_icon_d2_explicit(
+            grib_bytes, prev_bytes, fhour, latitudes, longitudes,
+        )
+        standard_results = decode_icon_eu_cloud_diag_per_point(
+            standard, latitudes, longitudes,
+        )
+        return standard_results, raws
+
+
 def analyze_sounding_batch(items: list[dict]) -> list[dict]:
     """Lite sounding analysis for a batch of serialised profiles (#448 PR B).
 

--- a/src/weatherbrief/fetch/grib/fill.py
+++ b/src/weatherbrief/fetch/grib/fill.py
@@ -90,6 +90,7 @@ def propagate_all(
     # every hour look like an anchor afterwards.
     _linear_interp_ecmwf_surface(sections, all_forecasts)
     _fill_cloud_diagnostics(sections, all_forecasts, gfs_init=gfs_init)
+    _fill_explicit_diagnostics(sections, all_forecasts)
     _linear_interp_pressure_levels(sections, all_forecasts)
     # CLW/ICMR overlay onto OM pressure_levels (GFS path only — for ECMWF/ICON
     # the pressure-level interp above already populates CLW/ICMR within the
@@ -151,6 +152,64 @@ def _fill_diag_hourly(hourly_list: list[HourlyForecast]) -> int:
             last_diag = h.nwp_cloud_diagnostics
         elif last_diag is not None:
             h.nwp_cloud_diagnostics = last_diag.model_copy()
+            filled += 1
+    return filled
+
+
+def _fill_explicit_diagnostics(
+    sections: list[RouteCrossSection],
+    all_forecasts: list[WaypointForecast],
+) -> None:
+    """Hold ``explicit_convective_diagnostics`` over gap hours (#462).
+
+    Interval-max semantics (rule 3): the payload at anchor hour H describes
+    the ``(H−1, H]`` window, so a gap hour strictly between anchors H and H+1
+    lies in the NEXT anchor's window and inherits THAT payload — the same
+    covering-interval hold as the 10fg gust precedent (#441 #6), never a
+    linear blend of reflectivity (logarithmic quantity) and never a forward
+    smear of last hour's storm. Hours after the last anchor get the last
+    completed interval. No-op for models without explicit payloads.
+    """
+    total = 0
+    for cs in sections:
+        for wf in cs.point_forecasts:
+            total += _fill_explicit_hourly(wf.hourly)
+    for wf in all_forecasts:
+        total += _fill_explicit_hourly(wf.hourly)
+    if total:
+        logger.info(
+            "Explicit-convective diagnostics held over on %d gap hourly entries",
+            total,
+        )
+
+
+def _fill_explicit_hourly(hourly_list: list[HourlyForecast]) -> int:
+    sorted_hours = sorted(hourly_list, key=lambda h: h.time)
+    if not sorted_hours:
+        return 0
+    anchor_indices = [
+        i for i, h in enumerate(sorted_hours)
+        if h.explicit_convective_diagnostics is not None
+    ]
+    if not anchor_indices:
+        return 0
+
+    filled = 0
+    # Between anchors: the NEXT anchor's window contains the gap hour.
+    for k in range(len(anchor_indices) - 1):
+        prev_i, next_i = anchor_indices[k], anchor_indices[k + 1]
+        next_payload = sorted_hours[next_i].explicit_convective_diagnostics
+        for i in range(prev_i + 1, next_i):
+            h = sorted_hours[i]
+            if h.explicit_convective_diagnostics is None:
+                h.explicit_convective_diagnostics = next_payload.model_copy()
+                filled += 1
+    # After the last anchor: the last completed interval (forward hold).
+    last_payload = sorted_hours[anchor_indices[-1]].explicit_convective_diagnostics
+    for i in range(anchor_indices[-1] + 1, len(sorted_hours)):
+        h = sorted_hours[i]
+        if h.explicit_convective_diagnostics is None:
+            h.explicit_convective_diagnostics = last_payload.model_copy()
             filled += 1
     return filled
 

--- a/src/weatherbrief/fetch/grib/icon_eu_fetch.py
+++ b/src/weatherbrief/fetch/grib/icon_eu_fetch.py
@@ -70,6 +70,9 @@ class IconVariant:
             this variant. NOT identical between variants: ICON-D2 has no deep-
             convection parameterization, so ``hbas_con``/``htop_con``/``rain_con``
             don't exist (or are meaningless) on its feed — see the D2 tuple below.
+        cloud_diag_cache_version: Version suffix of the single-level
+            cloud-diagnostic blob cache key. Bump when the variable list (blob
+            content) changes so warm caches re-fetch (#421 precedent).
     """
 
     slug: str
@@ -93,6 +96,21 @@ class IconVariant:
     hourly_to_h: int
     coarse_step_h: int
     cloud_diag_variables: tuple[str, ...]
+    cloud_diag_cache_version: str = "V2"
+
+    @property
+    def needs_predecessor_step(self) -> bool:
+        """True when the single-level fetch needs one leading step prepended.
+
+        Any variable whose hourly value is derived against the previous step
+        requires the lead file: accumulated fields de-accumulated per hour
+        (``rain_con`` on EU, ``grau_gsp`` on D2) and sub-hourly windowed fields
+        whose hourly product spans messages from two adjacent files (D2
+        ``echotop`` quarters — #462).
+        """
+        return bool(
+            {"rain_con", "grau_gsp", "echotop"}.intersection(self.cloud_diag_variables)
+        )
 
 
 # Single-level cloud diagnostic variables (ICON-EU).
@@ -115,9 +133,9 @@ ICON_EU_CLOUD_DIAG_VARIABLES = (
     "rain_con",
 )
 
-# Single-level diagnostics for ICON-D2 — deliberately SMALLER than ICON-EU's
-# list. D2 is convection-permitting: it runs NO deep-convection scheme, so
-# (verified live against opendata.dwd.de, 2026-07-21):
+# Single-level diagnostics for ICON-D2. D2 is convection-permitting: it runs
+# NO deep-convection scheme, so (verified live against opendata.dwd.de,
+# 2026-07-21):
 # - hbas_con / htop_con → 404. Only shallow-convection hbas_sc/htop_sc exist,
 #   and those describe fair-weather cumulus — mapping them into
 #   convective_base/top would show a benign low top during a real storm.
@@ -125,14 +143,36 @@ ICON_EU_CLOUD_DIAG_VARIABLES = (
 #   shallow scheme barely precipitates; explicit-storm rain lands in
 #   rain_gsp/prg_gsp). Feeding it into convective_precip_mm_h would make the
 #   native convective gate read "quiet" exactly when D2 sees a storm.
-# All three therefore stay ABSENT for D2 → downstream fields are None
-# (missing-data semantics, which icon_eu_conv_rain_rate_mm_h and the firing
-# gate already handle). Issue #462 replaces them with D2's convection-
-# permitting diagnostics (dbz_cmax, echotop, lpi, uh_max, prg_gsp).
+# All three therefore stay ABSENT for D2 → downstream parameterized fields are
+# None (missing-data semantics). In their place (#462), D2's convection-
+# permitting storm fields (all verified against the live feed 2026-07-21 —
+# eccodes per-message inspection of 00z f012 files):
+# - dbz_ctmax — column-max simulated reflectivity, dBZ, stepType=max over the
+#   previous hour (single full-hour message per file). The firing signal.
+# - echotop — LOWEST PRESSURE (= highest altitude) with reflectivity ≥ 18 dBZ,
+#   delivered as shortName `min_pres` in Pa, stepType=min, FOUR 15-min
+#   messages per file; −999 Pa = "no echo this quarter" (valid data, not
+#   missing). The hourly product is CONSTRUCTED as the min over the four
+#   quarter windows ending in (H−1, H] — three messages from file f(H−1) plus
+#   the first of file f(H). Depth/character only — NEVER a cloud top.
+# - lpi_max — Lightning Potential Index (Lynn & Yair 2010), J/kg, hour max.
+# - w_ctmax — max updraft in the 0–10 km column, m/s, hour max.
+# - uh_max_med — updraft helicity over the 2–5 km AGL layer, m²/s², hour max
+#   of the SIGNED amplitude. Chosen over uh_max (2–8 km) deliberately: 2–5 km
+#   is the literature/HRRR-calibrated layer, so rotation notes can reference
+#   portable thresholds.
+# - grau_gsp — grid-scale graupel, kg/m² ≡ mm, ACCUMULATED since init; the
+#   file carries one on-the-hour message (stepUnits=hours) plus three quarter-
+#   hour accums — de-accumulation uses the on-the-hour messages only.
+# Deferred: dbz_cmax (instant — optional sub-hourly detail), tcond10_mx
+# (column condensate above −10 °C — overlaps the dbz signal; revisit with
+# calibration). Not usable: hbas_con/htop_con (404), rain_con (≈0), prr_con
+# (404), echotopinm (404 — only the pressure form is delivered).
 ICON_D2_CLOUD_DIAG_VARIABLES = (
     "ceiling",
     "clcl", "clcm", "clch", "clct",
     "cape_ml", "cin_ml",
+    "dbz_ctmax", "echotop", "lpi_max", "w_ctmax", "uh_max_med", "grau_gsp",
 )
 
 
@@ -204,6 +244,10 @@ ICON_D2 = IconVariant(
     hourly_to_h=48,
     coarse_step_h=1,
     cloud_diag_variables=ICON_D2_CLOUD_DIAG_VARIABLES,
+    # V2 → V3 in #462: the explicit-convection storm fields (dbz_ctmax,
+    # echotop, lpi_max, w_ctmax, uh_max_med, grau_gsp) joined the blob, so
+    # pre-#462 cached blobs must re-fetch.
+    cloud_diag_cache_version="V3",
 )
 
 # Back-compat module constants (ICON-EU). The variant above is the single
@@ -290,11 +334,13 @@ ICON_EU_CLOUD_DIAG_CACHE_KEY = "ICON_EU_CLOUD_DIAG_V2"
 def icon_cloud_diag_cache_key(variant: IconVariant = ICON_EU) -> str:
     """Cache-key label for a variant's single-level cloud-diagnostic blob.
 
-    ``{cache_prefix}_CLOUD_DIAG_V2`` — the ``_V2`` suffix matches the ICON-EU
-    constant so the two share the same rain_con-inclusive schema; only the
-    prefix differs so ICON-D2 blobs never masquerade as ICON-EU in a cache dir.
+    ``{cache_prefix}_CLOUD_DIAG_{version}`` — the prefix keeps the two variants
+    from colliding in a cache dir; the version is bumped per variant whenever
+    its variable list (blob content) changes, so warm caches re-fetch (#421
+    precedent). ICON-D2 moved to ``_V3`` in #462 when the explicit-convection
+    storm fields were added to its blob; ICON-EU stays at ``_V2``.
     """
-    return f"{variant.cache_prefix}_CLOUD_DIAG_V2"
+    return f"{variant.cache_prefix}_CLOUD_DIAG_{variant.cloud_diag_cache_version}"
 
 # Parallel download settings
 MAX_DOWNLOAD_WORKERS = 8

--- a/src/weatherbrief/models/__init__.py
+++ b/src/weatherbrief/models/__init__.py
@@ -31,6 +31,7 @@ from weatherbrief.models.analysis import (  # noqa: F401
     ParcelPathPoint,
     NWPCloudDiagnostics,
     NWPCloudLayerDiag,
+    NWPExplicitConvectiveDiagnostics,
     PrecipIntensity,
     PrecipPhase,
     PrecipitationAssessment,

--- a/src/weatherbrief/models/analysis.py
+++ b/src/weatherbrief/models/analysis.py
@@ -172,6 +172,60 @@ class NWPCloudDiagnostics(BaseModel):
     freezing_level_ft: Optional[float] = None
 
 
+class NWPExplicitConvectiveDiagnostics(BaseModel):
+    """Explicit-convection storm diagnostics from a convection-permitting model.
+
+    ICON-D2 runs no deep-convection parameterization (#456/#461), so the
+    parameterized diagnostics on :class:`NWPCloudDiagnostics`
+    (``convective_base/top_ft``, ``convective_precip_mm_h``) are structurally
+    ``None`` on D2-sourced packs. Deep convection in D2 lives in explicit storm
+    fields instead — a different KIND of signal, kept in this separate nested
+    object so the two tracks can never be conflated (#462).
+
+    Semantics (hard rules, all verified against the live DWD feed 2026-07-21):
+    - Every field is a **corridor extremum** over a route buffer (~10 NM), not
+      a centreline point value — per-point bilinear sampling would let a 2.2 km
+      storm cell slip between route points. ``reflectivity_point_dbz`` is the
+      exception: the centreline bilinear value, kept alongside the corridor max
+      so widespread stratiform echo (point ≈ corridor max) is distinguishable
+      from a discrete cell (max ≫ point).
+    - Interval-max fields describe the hour ENDING at the carrying
+      ``HourlyForecast.time`` — the ``(H−1, H]`` window — not the instant.
+    - ``echo_top_18dbz_ft`` is the highest altitude with simulated
+      reflectivity ≥ 18 dBZ. It sits BELOW the physical storm top (anvil ice
+      reflects weakly) and must NEVER be used as a cloud top — in particular
+      never for overfly-clearance decisions. Depth/character only.
+    - ``graupel_hour_mm`` is graupel (a strong mixed-phase core indicator) —
+      wording is never "hail".
+    - ``None`` ≠ 0 (#421): a ``None`` channel is unknown; the completeness
+      flags below say whether ``None`` reflectivity/echo-top means "quiet"
+      (channel complete, no echo) or "unavailable" (channel failed).
+
+    Completeness is per-tier and means "enough valid (unmasked) corridor cells
+    decoded" — NOT merely "file downloaded": an all-masked corridor is
+    UNAVAILABLE; a valid −150 dBZ reflectivity floor is genuinely QUIET. The
+    GRIB bitmap alone decides validity; encoded quiet-floor values (−150 dBZ,
+    −999 Pa echo-top sentinel) are real data and count as valid.
+    """
+
+    source: Literal["icon_d2"]
+    reflectivity_hour_max_dbz: Optional[float] = None   # dbz_ctmax corridor max (raw; ≤ −30 ≈ no echo)
+    reflectivity_point_dbz: Optional[float] = None      # dbz_ctmax centreline bilinear (cell-vs-shield discriminator)
+    echo_top_18dbz_ft: Optional[float] = None           # hourly min pressure over 4 quarter-windows, Pa→ft (ISA); NOT a cloud top
+    lightning_potential_hour_max_jkg: Optional[float] = None  # lpi_max corridor max
+    updraft_hour_max_ms: Optional[float] = None         # w_ctmax corridor max (0–10 km column)
+    updraft_helicity_2_5km_hour_max_m2s2: Optional[float] = None  # uh_max_med corridor argmax |uh|, SIGNED (2–5 km layer)
+    graupel_hour_mm: Optional[float] = None             # grau_gsp per-cell de-accumulated, corridor max
+    # Forecast lead of the carrying hour relative to run init — drives the
+    # explicit track's confidence wording (radar-nudged short leads are far
+    # more placement-trustworthy than 24–48h free-running cells).
+    lead_hours: Optional[float] = None
+
+    detection_complete: bool = False   # dbz_ctmax corridor valid this hour
+    strength_complete: bool = False    # lpi_max + w_ctmax + graupel corridors all valid
+    echo_top_complete: bool = False    # all 4 quarter windows present and corridor-valid
+
+
 class RouteConfig(BaseModel):
     """A flight route definition loaded from config."""
 
@@ -309,6 +363,13 @@ class HourlyForecast(BaseModel):
 
     # GFS cloud layer diagnostics from GRIB2 enrichment
     nwp_cloud_diagnostics: Optional[NWPCloudDiagnostics] = None
+
+    # Explicit-convection storm diagnostics (ICON-D2 GRIB2 enrichment, #462).
+    # Present on every ICON-D2-enriched hour — including failed/incomplete
+    # decode (then all-None with completeness flags False), so "no payload"
+    # unambiguously means "this hour was not D2-sourced" and a failed detection
+    # channel can never masquerade as model-quiet.
+    explicit_convective_diagnostics: Optional[NWPExplicitConvectiveDiagnostics] = None
 
     # Pressure level data
     pressure_levels: list[PressureLevelData] = Field(default_factory=list)
@@ -693,7 +754,15 @@ class ConvectiveAssessment(BaseModel):
     top_ft: Optional[float] = None  # thermo: el_altitude_ft; NWP: convective_top_ft
     cover_pct: Optional[float] = None  # NWP only; thermo: None
     convective_precip_mm_h: Optional[float] = None  # NWP native firing signal (#283); thermo: None
-    method: str = "thermo"  # "thermo", "nwp", "nwp_hybrid", "nwp_lcl_top", "nwp_precip", "nwp_cape_fallback"
+    method: str = "thermo"  # "thermo", "nwp", "nwp_hybrid", "nwp_lcl_top", "nwp_precip", "nwp_cape_fallback", "nwp_explicit"
+    # Explicit-convection provenance + detail fields (#462, method="nwp_explicit"
+    # only). Corridor maxima from the convection-permitting model's storm
+    # fields. echo_top_18dbz_ft is a depth/character detail — deliberately a
+    # separate field from top_ft so the overfly-clearance filter structurally
+    # cannot consume it as a cloud top.
+    explicit_source: Optional[str] = None            # "icon_d2"
+    reflectivity_hour_max_dbz: Optional[float] = None
+    echo_top_18dbz_ft: Optional[float] = None
 
 
 class CATRiskLayer(BaseModel):
@@ -736,6 +805,16 @@ class SoundingAnalysis(BaseModel):
     convective: Optional[ConvectiveAssessment] = None
     convective_thermo: Optional[ConvectiveAssessment] = None
     convective_nwp: Optional[ConvectiveAssessment] = None
+    # Explicit-convection unavailability marker (#462). True when this model's
+    # hour carried an explicit-convection payload (ICON-D2) whose detection
+    # channel was incomplete: the explicit assessment could not run, so
+    # ``convective_nwp`` is None — deliberately NOT a quiet NONE assessment
+    # (unknown must never read as "scheme quiet") and NOT a CAPE fallback
+    # presented as D2's explicit verdict. Grading falls back to the thermo
+    # track (badged truthfully by convective_method_effective); the advisory
+    # evaluator renders the point UNAVAILABLE, not GREEN. Sibling of
+    # ``active_icing_available`` (#391 pattern).
+    convective_explicit_unavailable: bool = False
     precipitation: Optional[PrecipitationAssessment] = None
     vertical_motion: Optional[VerticalMotionAssessment] = None
     # Bulk Open-Meteo 3-level cloud-cover summary. NOT the native NWP cloud

--- a/tests/test_icon_d2.py
+++ b/tests/test_icon_d2.py
@@ -131,7 +131,7 @@ class TestD2HorizonAndGrid:
         assert (ICON_D2.level_min, ICON_D2.level_max) == (16, 65)
         assert ICON_D2.slug == "icon-d2"
         assert ICON_D2.source_key == "icon_d2:dwd"
-        assert icon_cloud_diag_cache_key(ICON_D2) == "ICON_D2_CLOUD_DIAG_V2"
+        assert icon_cloud_diag_cache_key(ICON_D2) == "ICON_D2_CLOUD_DIAG_V3"  # #462 bump
         assert icon_cloud_diag_cache_key(ICON_EU) == "ICON_EU_CLOUD_DIAG_V2"
 
     def test_d2_diag_list_drops_parameterized_convection_fields(self):
@@ -208,6 +208,11 @@ class TestPrepareIconVariantSelection:
         with patch(
             "weatherbrief.fetch.grib.icon_eu_fetch.find_latest_icon_eu_run",
             self._run_finder(d2_run=("20260720", 12), eu_run=("20260720", 12)),
+        ), patch(
+            # #462 domain-mask gate: corridor validity checked in
+            # test_icon_d2_explicit.py; keep this test on the bbox+run path.
+            "weatherbrief.fetch.grib._icon_d2_route_corridors_valid",
+            return_value=True,
         ):
             ctx, skip = _prepare_icon_eu(
                 self._icon_cross_sections(), route, dep,

--- a/tests/test_icon_d2_explicit.py
+++ b/tests/test_icon_d2_explicit.py
@@ -1,0 +1,860 @@
+"""Tests for ICON-D2 explicit-convection diagnostics (issue #462).
+
+D2 is convection-permitting: deep convection lives in explicit storm fields
+(simulated reflectivity, echo top, LPI, updrafts, graupel) rather than a
+parameterized scheme's diagnostics. These tests cover the variant config,
+the corridor-extrema decode (message selection, sentinel rules, sub-hourly
+echo-top construction, graupel de-accumulation), the payload builder, the
+firing decision table + assessment contract, the evaluator's UNAVAILABLE
+handling, the fill hold-over, and the domain-mask gate.
+
+The eccodes plumbing of ``_read_d2_explicit_messages`` was verified against
+the live DWD feed (2026-07-21); here it is replaced by synthetic messages so
+every reduction rule is tested deterministically without GRIB fixtures.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+from weatherbrief.fetch.grib.decode import (
+    D2_CORRIDOR_RADIUS_KM,
+    _D2Message,
+    _d2_corridor_cells,
+    _isa_pressure_to_ft,
+    build_icon_d2_explicit_diagnostics,
+    corridor_fully_valid,
+    decode_icon_d2_explicit,
+)
+from weatherbrief.fetch.grib.icon_eu_fetch import (
+    ICON_D2,
+    ICON_EU,
+    IconVariant,
+    icon_cloud_diag_cache_key,
+)
+
+
+# ---------------------------------------------------------------------------
+# Synthetic grid + message helpers
+# ---------------------------------------------------------------------------
+
+LAT0, LON0, STEP = 45.0, 0.0, 0.1
+N_SIDE = 61
+
+
+def _grid_vecs(n: int = N_SIDE):
+    lat_vec = LAT0 + np.arange(n) * STEP
+    lon_vec = LON0 + np.arange(n) * STEP
+    return lat_vec, lon_vec
+
+
+CENTRE = (LAT0 + 10 * STEP, LON0 + 10 * STEP)  # well inside the grid
+
+
+def _msg(var, values, valid_minutes, on_hour_accum=False):
+    return _D2Message(
+        var=var,
+        values=np.asarray(values, dtype=np.float64),
+        valid_minutes=valid_minutes,
+        on_hour_accum=on_hour_accum,
+    )
+
+
+def _patch_messages(main_msgs, prev_msgs=None):
+    """Patch the eccodes reader with synthetic message lists."""
+    lat_vec, lon_vec = _grid_vecs()
+    main_msgs = list(main_msgs)
+    prev_msgs = list(prev_msgs or [])
+
+    def fake(grib_bytes):
+        if grib_bytes == b"main":
+            return main_msgs, lat_vec, lon_vec, b"std"
+        if grib_bytes == b"prev":
+            return prev_msgs, lat_vec, lon_vec, b""
+        raise AssertionError(f"unexpected blob {grib_bytes!r}")
+
+    return patch(
+        "weatherbrief.fetch.grib.decode._read_d2_explicit_messages",
+        side_effect=fake,
+    )
+
+
+def _field(value: float, n: int = N_SIDE) -> np.ndarray:
+    return np.full((n, n), value, dtype=np.float64)
+
+
+def _cell_idx(lat: float, lon: float) -> tuple[int, int]:
+    return round((lat - LAT0) / STEP), round((lon - LON0) / STEP)
+
+
+# ---------------------------------------------------------------------------
+# Variant config
+# ---------------------------------------------------------------------------
+
+
+class TestVariantConfig:
+    def test_d2_carries_explicit_variables(self):
+        for var in ("dbz_ctmax", "echotop", "lpi_max", "w_ctmax", "uh_max_med", "grau_gsp"):
+            assert var in ICON_D2.cloud_diag_variables
+
+    def test_d2_still_excludes_parameterized_scheme_fields(self):
+        # No deep-convection scheme on D2: these must stay absent (#456).
+        for var in ("hbas_con", "htop_con", "rain_con"):
+            assert var not in ICON_D2.cloud_diag_variables
+
+    def test_eu_list_unchanged(self):
+        assert "uh_max_med" not in ICON_EU.cloud_diag_variables
+        assert "rain_con" in ICON_EU.cloud_diag_variables
+
+    def test_cache_key_bumped_for_d2_only(self):
+        assert icon_cloud_diag_cache_key(ICON_D2) == "ICON_D2_CLOUD_DIAG_V3"
+        assert icon_cloud_diag_cache_key(ICON_EU) == "ICON_EU_CLOUD_DIAG_V2"
+
+    def test_needs_predecessor_step(self):
+        # EU: rain_con de-accumulation; D2: grau_gsp + echotop quarters.
+        assert ICON_EU.needs_predecessor_step is True
+        assert ICON_D2.needs_predecessor_step is True
+        bare = IconVariant(**{**ICON_D2.__dict__, "cloud_diag_variables": ("ceiling",)})
+        assert bare.needs_predecessor_step is False
+
+
+# ---------------------------------------------------------------------------
+# Corridor geometry
+# ---------------------------------------------------------------------------
+
+
+class TestCorridorCells:
+    def test_disc_centred_and_radius_respected(self):
+        lat_vec, lon_vec = _grid_vecs()
+        rows, cols, clipped = _d2_corridor_cells(lat_vec, lon_vec, *CENTRE)
+        assert not clipped
+        assert rows.size > 4  # a real disc, not just the nearest cell
+        dlat_km = STEP * 111.195
+        dlon_km = STEP * 111.195 * np.cos(np.radians(CENTRE[0]))
+        ci, cj = _cell_idx(*CENTRE)
+        dist = np.sqrt(((rows - ci) * dlat_km) ** 2 + ((cols - cj) * dlon_km) ** 2)
+        assert dist.max() <= D2_CORRIDOR_RADIUS_KM + 1e-9
+        # Nearest cell included; a cell clearly outside the radius excluded.
+        assert (rows == ci).any() and (cols == cj).any()
+        assert not ((rows == ci) & (cols == cj + 10)).any()
+
+    def test_point_outside_grid_returns_none(self):
+        lat_vec, lon_vec = _grid_vecs()
+        assert _d2_corridor_cells(lat_vec, lon_vec, 60.0, 1.0) is None
+
+    def test_edge_point_is_clipped(self):
+        lat_vec, lon_vec = _grid_vecs()
+        cells = _d2_corridor_cells(lat_vec, lon_vec, LAT0 + STEP, LON0 + STEP)
+        assert cells is not None
+        assert cells[2] is True  # clipped flag
+
+    def test_corridor_fully_valid(self):
+        lat_vec, lon_vec = _grid_vecs()
+        mask = np.ones((N_SIDE, N_SIDE), dtype=bool)
+        assert corridor_fully_valid(lat_vec, lon_vec, mask, *CENTRE)
+        # One masked cell inside the disc → corridor not fully valid.
+        ci, cj = _cell_idx(*CENTRE)
+        mask[ci + 1, cj] = False
+        assert not corridor_fully_valid(lat_vec, lon_vec, mask, *CENTRE)
+        # Outside the grid / clipped at the boundary → not valid.
+        assert not corridor_fully_valid(lat_vec, lon_vec, mask, 60.0, 1.0)
+        assert not corridor_fully_valid(
+            lat_vec, lon_vec, np.ones((N_SIDE, N_SIDE), dtype=bool),
+            LAT0 + STEP, LON0 + STEP,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Explicit decode — channel reductions
+# ---------------------------------------------------------------------------
+
+
+class TestDecodeChannels:
+    def test_corridor_max_catches_cell_off_centreline(self):
+        lat0, lon0 = CENTRE
+        dbz = _field(-150.0)
+        ci, cj = _cell_idx(lat0, lon0)
+        dbz[ci + 1, cj + 1] = 50.0  # ~9 km away, inside the corridor
+        with _patch_messages([_msg("dbz_ctmax", dbz, 720)]):
+            raws, std = decode_icon_d2_explicit(b"main", None, 12, [lat0], [lon0])
+        raw = raws[0]
+        assert std == b"std"  # standard remainder passes through untouched
+        assert raw["reflectivity_hour_max_dbz"] == 50.0
+        # Centreline stays quiet — the point-vs-corridor discriminator.
+        assert raw["reflectivity_point_dbz"] == -150.0
+        assert raw["dbz_valid_frac"] == 1.0
+
+    def test_quiet_floor_is_valid_data_not_missing(self):
+        # All cells at the −150 dBZ quiet floor + some bitmap-masked (NaN):
+        # max must be the floor (quiet), and only bitmap cells reduce the frac.
+        dbz = _field(-150.0)
+        ci, cj = _cell_idx(*CENTRE)
+        dbz[ci, cj] = np.nan
+        dbz[ci + 1, cj + 1] = np.nan
+        with _patch_messages([_msg("dbz_ctmax", dbz, 720)]):
+            raws, _ = decode_icon_d2_explicit(b"main", None, 12, [CENTRE[0]], [CENTRE[1]])
+        raw = raws[0]
+        assert raw["reflectivity_hour_max_dbz"] == -150.0
+        assert 0.0 < raw["dbz_valid_frac"] < 1.0
+        # Centreline None on a masked corner cell, but not "quiet by value".
+        assert raw["reflectivity_point_dbz"] is None
+
+    def test_uh_signed_argmax(self):
+        uh = _field(0.0)
+        ci, cj = _cell_idx(*CENTRE)
+        uh[ci, cj] = 10.0
+        uh[ci + 1, cj + 1] = -40.0  # larger amplitude, negative sense
+        with _patch_messages([_msg("uh_max_med", uh, 720)]):
+            raws, _ = decode_icon_d2_explicit(b"main", None, 12, [CENTRE[0]], [CENTRE[1]])
+        assert raws[0]["updraft_helicity_2_5km_hour_max_m2s2"] == -40.0
+
+    def test_lpi_and_w_corridor_max(self):
+        lpi = _field(0.0)
+        w = _field(0.0)
+        ci, cj = _cell_idx(*CENTRE)
+        lpi[ci + 1, cj] = 7.5
+        w[ci, cj + 1] = 12.0
+        with _patch_messages([_msg("lpi_max", lpi, 720), _msg("w_ctmax", w, 720)]):
+            raws, _ = decode_icon_d2_explicit(b"main", None, 12, [CENTRE[0]], [CENTRE[1]])
+        assert raws[0]["lightning_potential_hour_max_jkg"] == 7.5
+        assert raws[0]["updraft_hour_max_ms"] == 12.0
+
+    def test_point_outside_grid_all_none_clipped(self):
+        with _patch_messages([_msg("dbz_ctmax", _field(45.0), 720)]):
+            raws, _ = decode_icon_d2_explicit(b"main", None, 12, [60.0], [1.0])
+        raw = raws[0]
+        assert raw["reflectivity_hour_max_dbz"] is None
+        assert raw["corridor_clipped"] is True
+        assert raw["dbz_valid_frac"] == 0.0
+
+
+class TestEchoTopConstruction:
+    def _quarters(self, base_p: float, hot: dict[int, float] | None = None):
+        """Four quarter grids (all sentinel except *hot* cells by end-minute)."""
+        qs = {}
+        for end in (675, 690, 705, 720):
+            grid = _field(-999.0)
+            if hot and end in hot:
+                ci, cj = _cell_idx(*CENTRE)
+                grid[ci, cj] = hot[end]
+            qs[end] = grid
+        return qs
+
+    def test_hourly_min_over_four_quarters(self):
+        # 3 quarters from the previous file + 1 from this file (#462 rule).
+        qs = self._quarters(-999.0, hot={690: 40000.0, 720: 30000.0})
+        main = [_msg("echotop", qs[720], 720)]
+        prev = [_msg("echotop", qs[e], e) for e in (675, 690, 705)]
+        with _patch_messages(main, prev):
+            raws, _ = decode_icon_d2_explicit(b"main", b"prev", 12, [CENTRE[0]], [CENTRE[1]])
+        raw = raws[0]
+        assert raw["echo_top_quarters_valid"] == 4
+        assert raw["echo_top_18dbz_pa"] == 30000.0  # min pressure = highest echo
+
+    def test_all_quiet_quarters_complete_but_none(self):
+        # All four quarters valid but all-sentinel (no echo): complete AND
+        # None — quiet, not unavailable.
+        qs = self._quarters(-999.0)
+        main = [_msg("echotop", qs[720], 720)]
+        prev = [_msg("echotop", qs[e], e) for e in (675, 690, 705)]
+        with _patch_messages(main, prev):
+            raws, _ = decode_icon_d2_explicit(b"main", b"prev", 12, [CENTRE[0]], [CENTRE[1]])
+        raw = raws[0]
+        assert raw["echo_top_quarters_valid"] == 4
+        assert raw["echo_top_18dbz_pa"] is None
+
+    def test_missing_quarter_degrades_no_partial_min(self):
+        qs = self._quarters(-999.0, hot={720: 30000.0})
+        main = [_msg("echotop", qs[720], 720)]
+        prev = [_msg("echotop", qs[e], e) for e in (675, 690)]  # 705 missing
+        with _patch_messages(main, prev):
+            raws, _ = decode_icon_d2_explicit(b"main", b"prev", 12, [CENTRE[0]], [CENTRE[1]])
+        raw = raws[0]
+        assert raw["echo_top_quarters_valid"] == 3
+        # A partial min must NOT be presented as the hourly value.
+        assert raw["echo_top_18dbz_pa"] is None
+
+    def test_no_predecessor_blob(self):
+        qs = self._quarters(-999.0, hot={720: 25000.0})
+        main = [_msg("echotop", qs[720], 720)]
+        with _patch_messages(main):
+            raws, _ = decode_icon_d2_explicit(b"main", None, 12, [CENTRE[0]], [CENTRE[1]])
+        assert raws[0]["echo_top_quarters_valid"] == 1
+        assert raws[0]["echo_top_18dbz_pa"] is None
+
+
+class TestGraupelDeaccum:
+    def test_on_the_hour_per_cell_difference_then_corridor_max(self):
+        ci, cj = _cell_idx(*CENTRE)
+        accum_prev = _field(0.5)
+        accum_h = _field(0.5)
+        accum_h[ci + 1, cj + 1] = 3.0  # +2.5 mm this hour, one cell
+        main = [
+            _msg("grau_gsp", accum_h, 720, on_hour_accum=True),
+            _msg("grau_gsp", _field(99.0), 735, on_hour_accum=False),  # ignored
+        ]
+        prev = [_msg("grau_gsp", accum_prev, 660, on_hour_accum=True)]
+        with _patch_messages(main, prev):
+            raws, _ = decode_icon_d2_explicit(b"main", b"prev", 12, [CENTRE[0]], [CENTRE[1]])
+        raw = raws[0]
+        assert raw["graupel_hour_mm"] == pytest.approx(2.5)
+        assert raw["grau_valid_frac"] == 1.0
+
+    def test_missing_predecessor_means_unknown_not_zero(self):
+        main = [_msg("grau_gsp", _field(3.0), 720, on_hour_accum=True)]
+        with _patch_messages(main):
+            raws, _ = decode_icon_d2_explicit(b"main", None, 12, [CENTRE[0]], [CENTRE[1]])
+        assert raws[0]["graupel_hour_mm"] is None
+        assert raws[0]["grau_valid_frac"] == 0.0
+
+    def test_reset_accumulation_clips_negative(self):
+        accum_prev = _field(4.0)
+        accum_h = _field(1.0)  # would be −3 without the clip
+        main = [_msg("grau_gsp", accum_h, 720, on_hour_accum=True)]
+        prev = [_msg("grau_gsp", accum_prev, 660, on_hour_accum=True)]
+        with _patch_messages(main, prev):
+            raws, _ = decode_icon_d2_explicit(b"main", b"prev", 12, [CENTRE[0]], [CENTRE[1]])
+        assert raws[0]["graupel_hour_mm"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Payload builder (completeness + ISA conversion)
+# ---------------------------------------------------------------------------
+
+
+class TestBuilder:
+    def _raw(self, **over):
+        raw = {
+            "reflectivity_hour_max_dbz": 45.0,
+            "reflectivity_point_dbz": 20.0,
+            "dbz_valid_frac": 1.0,
+            "echo_top_18dbz_pa": 30000.0,
+            "echo_top_quarters_valid": 4,
+            "lightning_potential_hour_max_jkg": 2.0,
+            "lpi_valid_frac": 1.0,
+            "updraft_hour_max_ms": 12.0,
+            "w_valid_frac": 1.0,
+            "updraft_helicity_2_5km_hour_max_m2s2": -30.0,
+            "uh_valid_frac": 1.0,
+            "graupel_hour_mm": 0.8,
+            "grau_valid_frac": 1.0,
+            "corridor_clipped": False,
+        }
+        raw.update(over)
+        return raw
+
+    def test_complete_payload(self):
+        p = build_icon_d2_explicit_diagnostics(self._raw(), lead_hours=9.0)
+        assert p.source == "icon_d2"
+        assert p.detection_complete and p.strength_complete and p.echo_top_complete
+        assert p.lead_hours == 9.0
+        assert p.echo_top_18dbz_ft == pytest.approx(
+            _isa_pressure_to_ft(30000.0), abs=1.0,
+        )
+
+    def test_low_valid_fraction_marks_channels_incomplete(self):
+        p = build_icon_d2_explicit_diagnostics(
+            self._raw(dbz_valid_frac=0.3, grau_valid_frac=0.1), 1.0,
+        )
+        assert not p.detection_complete
+        assert not p.strength_complete
+        assert p.echo_top_complete  # unaffected channel stays complete
+
+    def test_clipped_corridor_marks_everything_incomplete(self):
+        p = build_icon_d2_explicit_diagnostics(
+            self._raw(corridor_clipped=True), 1.0,
+        )
+        assert not p.detection_complete
+        assert not p.strength_complete
+        assert not p.echo_top_complete
+
+    def test_isa_pressure_to_ft(self):
+        assert _isa_pressure_to_ft(101325.0) == pytest.approx(0.0, abs=1.0)
+        # ~11 km tropopause break and stratospheric extension above it.
+        assert _isa_pressure_to_ft(22632.06) == pytest.approx(36089.0, abs=50)
+        assert _isa_pressure_to_ft(20000.0) > _isa_pressure_to_ft(22632.06)
+
+
+# ---------------------------------------------------------------------------
+# Decision table + assessment contract
+# ---------------------------------------------------------------------------
+
+
+class TestDecisionTable:
+    @pytest.mark.parametrize(
+        "dbz,corroborators,expected",
+        [
+            (None, 2, "NONE"),
+            (20.0, 2, "NONE"),
+            (34.9, 2, "NONE"),
+            (36.0, 0, "NONE"),       # uncorroborated 35–44: no fire
+            (36.0, 1, "MARGINAL"),
+            (36.0, 2, "MODERATE"),
+            (45.0, 0, "MODERATE"),
+            (47.0, 1, "MODERATE"),
+            (47.0, 2, "HIGH"),
+            (52.0, 0, "HIGH"),       # ≥50 fires HIGH regardless
+        ],
+    )
+    def test_table_rows(self, dbz, corroborators, expected):
+        from weatherbrief.analysis.sounding.convective import _explicit_risk_from_table
+        from weatherbrief.models import ConvectiveRisk
+
+        assert _explicit_risk_from_table(dbz, corroborators) is ConvectiveRisk[expected]
+
+
+def _payload(**over) -> "object":
+    from weatherbrief.models import NWPExplicitConvectiveDiagnostics
+
+    kw = dict(
+        source="icon_d2",
+        reflectivity_hour_max_dbz=None,
+        detection_complete=True,
+        strength_complete=True,
+        echo_top_complete=True,
+    )
+    kw.update(over)
+    return NWPExplicitConvectiveDiagnostics(**kw)
+
+
+def _indices(**over):
+    from weatherbrief.models import ThermodynamicIndices
+
+    kw = dict(
+        cape_surface_jkg=800.0,
+        cin_surface_jkg=-50.0,
+        freezing_level_ft=9000.0,
+    )
+    kw.update(over)
+    return ThermodynamicIndices(**kw)
+
+
+class TestAssessConvectiveExplicit:
+    def test_incomplete_detection_returns_none(self):
+        from weatherbrief.analysis.sounding.convective import assess_convective_explicit
+
+        assert assess_convective_explicit(
+            _indices(), None, _payload(detection_complete=False),
+        ) is None
+
+    def test_quiet_but_complete_is_real_none_not_none(self):
+        from weatherbrief.analysis.sounding.convective import assess_convective_explicit
+
+        a = assess_convective_explicit(
+            _indices(), None,
+            _payload(reflectivity_hour_max_dbz=-150.0),
+        )
+        assert a is not None
+        assert a.risk_level.value == "none"
+        assert a.method == "nwp_explicit"
+        assert a.explicit_source == "icon_d2"
+
+    def test_top_ft_never_set_even_with_echo_top(self):
+        from weatherbrief.analysis.sounding.convective import assess_convective_explicit
+
+        a = assess_convective_explicit(
+            _indices(), None,
+            _payload(
+                reflectivity_hour_max_dbz=55.0,
+                echo_top_18dbz_ft=38000.0,
+            ),
+        )
+        assert a.top_ft is None  # clearance filter can never consume echo top
+        assert a.echo_top_18dbz_ft == 38000.0  # carried as character detail
+        assert any("not for overfly planning" in d for d in a.drivers)
+
+    def test_fired_cell_with_corroborators(self):
+        from weatherbrief.analysis.sounding.convective import assess_convective_explicit
+        from weatherbrief.models import NWPCloudDiagnostics
+
+        a = assess_convective_explicit(
+            _indices(),
+            NWPCloudDiagnostics(ml_cape_jkg=1200.0),
+            _payload(
+                reflectivity_hour_max_dbz=47.0,
+                lightning_potential_hour_max_jkg=6.0,  # counts as 2
+                updraft_hour_max_ms=15.0,
+                graupel_hour_mm=1.2,
+            ),
+        )
+        assert a.risk_level.value == "high"  # 45–49 row, |C| ≥ 2
+        assert any("47 dBZ" in d for d in a.drivers)
+        assert not any("hail" in d for d in a.drivers)
+        assert any("mm this hour" in d for d in a.drivers)  # accumulation, not rate
+
+    def test_incomplete_channels_never_upgrade(self):
+        from weatherbrief.analysis.sounding.convective import assess_convective_explicit
+
+        # 36 dBZ with ALL corroborator channels None → counts 0 → no fire.
+        a = assess_convective_explicit(
+            _indices(), None, _payload(reflectivity_hour_max_dbz=36.0),
+        )
+        assert a.risk_level.value == "none"
+        assert any("unavailable" in d for d in a.drivers)
+
+    def test_hail_wording_rephrased_to_graupel(self):
+        from weatherbrief.analysis.sounding.convective import assess_convective_explicit
+
+        a = assess_convective_explicit(
+            _indices(freezing_level_ft=13000.0, cape_surface_jkg=1500.0),
+            None,
+            _payload(reflectivity_hour_max_dbz=52.0),
+        )
+        joined = " ".join(a.severe_modifiers + a.drivers)
+        assert "hail" not in joined
+        assert "graupel / strong mixed-phase core potential" in joined
+
+    def test_uh_note_signed_and_narrative_only(self):
+        from weatherbrief.analysis.sounding.convective import assess_convective_explicit
+
+        a = assess_convective_explicit(
+            _indices(), None,
+            _payload(
+                reflectivity_hour_max_dbz=40.0,  # |C|=0 row → stays NONE
+                updraft_helicity_2_5km_hour_max_m2s2=-30.0,
+            ),
+        )
+        assert a.risk_level.value == "none"  # UH never a tier input in v1
+        # …and the note only appears once fired.
+        b = assess_convective_explicit(
+            _indices(), None,
+            _payload(
+                reflectivity_hour_max_dbz=50.0,
+                updraft_helicity_2_5km_hour_max_m2s2=-30.0,
+            ),
+        )
+        assert any("anticyclonic" in d for d in b.drivers)
+
+    @pytest.mark.parametrize(
+        "lead,fragment",
+        [
+            (3.0, "radar-nudged"),
+            (12.0, "placement approximate"),
+            (36.0, "environment-level signal"),
+        ],
+    )
+    def test_lead_time_wording(self, lead, fragment):
+        from weatherbrief.analysis.sounding.convective import assess_convective_explicit
+
+        a = assess_convective_explicit(
+            _indices(), None,
+            _payload(reflectivity_hour_max_dbz=50.0, lead_hours=lead),
+        )
+        assert any(fragment in d for d in a.drivers)
+
+    def test_cell_vs_shield_geometry_notes(self):
+        from weatherbrief.analysis.sounding.convective import assess_convective_explicit
+
+        cell = assess_convective_explicit(
+            _indices(), None,
+            _payload(reflectivity_hour_max_dbz=48.0, reflectivity_point_dbz=20.0),
+        )
+        assert any("Discrete cell geometry" in d for d in cell.drivers)
+
+        shield = assess_convective_explicit(
+            _indices(), None,
+            _payload(reflectivity_hour_max_dbz=38.0, reflectivity_point_dbz=35.0),
+        )
+        assert any("widespread" in s for s in shield.suppressors)
+
+
+class TestExplicitCrossCheck:
+    def _nwp(self, risk, dbz):
+        from weatherbrief.models import ConvectiveAssessment, ConvectiveRisk
+
+        return ConvectiveAssessment(
+            risk_level=ConvectiveRisk[risk],
+            method="nwp_explicit",
+            explicit_source="icon_d2",
+            reflectivity_hour_max_dbz=dbz,
+        )
+
+    def _thermo(self, risk):
+        from weatherbrief.models import ConvectiveAssessment, ConvectiveRisk
+
+        return ConvectiveAssessment(risk_level=ConvectiveRisk[risk], method="thermo")
+
+    def test_dd_not_corroborated(self):
+        from weatherbrief.analysis.sounding.convective import convective_cross_check
+
+        xc = convective_cross_check(self._thermo("MODERATE"), self._nwp("NONE", -150.0))
+        assert xc is not None and xc.direction == "dd_not_corroborated"
+        assert "explicit convection is quiet" in xc.note
+
+    def test_model_active_dd_quiet(self):
+        from weatherbrief.analysis.sounding.convective import convective_cross_check
+
+        xc = convective_cross_check(self._thermo("NONE"), self._nwp("MODERATE", 47.0))
+        assert xc is not None and xc.direction == "model_active_dd_quiet"
+        assert "explicitly develops a cell" in xc.note
+
+    def test_marginal_explicit_is_silent(self):
+        from weatherbrief.analysis.sounding.convective import convective_cross_check
+
+        assert convective_cross_check(self._thermo("NONE"), self._nwp("MARGINAL", 36.0)) is None
+        assert convective_cross_check(self._thermo("MODERATE"), self._nwp("MARGINAL", 36.0)) is None
+
+
+# ---------------------------------------------------------------------------
+# Evaluator: explicit-unavailable renders UNAVAILABLE, never GREEN
+# ---------------------------------------------------------------------------
+
+
+def _make_rpa(point_index: int, distance_nm: float, sounding=None):
+    from weatherbrief.models import RoutePointAnalysis
+
+    return RoutePointAnalysis(
+        point_index=point_index,
+        lat=48.0 + point_index * 0.5,
+        lon=2.0 + point_index * 0.5,
+        distance_from_origin_nm=distance_nm,
+        interpolated_time=datetime(2026, 3, 1, 10, 0),
+        forecast_hour=datetime(2026, 3, 1, 9, 0),
+        track_deg=135.0,
+        sounding=sounding or {},
+        model_divergence=[],
+    )
+
+
+def _make_elevation():
+    from weatherbrief.models import ElevationPoint, ElevationProfile
+
+    points = [
+        ElevationPoint(
+            distance_nm=i * 200 / 19, elevation_ft=500,
+            lat=48.0 + i * 0.1, lon=2.0 + i * 0.1,
+        )
+        for i in range(20)
+    ]
+    return ElevationProfile(
+        route_name="test", points=points,
+        max_elevation_ft=500, total_distance_nm=200,
+    )
+
+
+def _eval_context(soundings: list) -> "object":
+    from weatherbrief.analysis.advisories import RouteContext
+
+    analyses = [
+        _make_rpa(i, i * 20.0, sounding={"icon": s} if s is not None else {})
+        for i, s in enumerate(soundings)
+    ]
+    return RouteContext(
+        analyses=analyses,
+        cross_sections=[],
+        elevation=_make_elevation(),
+        models=["icon"],
+        cruise_altitude_ft=8000,
+        flight_ceiling_ft=18000,
+        total_distance_nm=200,
+    )
+
+
+class TestEvaluatorExplicitUnavailable:
+    def test_unavailable_points_render_unavailable_not_green(self):
+        from weatherbrief.analysis.advisories.convective import ConvectiveEvaluator
+        from weatherbrief.models import (
+            ConvectiveAssessment,
+            HighlightSeverity,
+            SoundingAnalysis,
+            ThermodynamicIndices,
+        )
+
+        unavailable = SoundingAnalysis(
+            indices=ThermodynamicIndices(),
+            convective=None,
+            convective_explicit_unavailable=True,
+        )
+        quiet = SoundingAnalysis(
+            indices=ThermodynamicIndices(),
+            convective=ConvectiveAssessment(method="nwp_explicit"),
+        )
+        ctx = _eval_context([unavailable, unavailable, quiet, quiet, quiet])
+        result = ConvectiveEvaluator.evaluate(ctx, {})
+        per_model = result.per_model[0]
+        assert per_model.status.value == "green"  # quiet points still grade
+        assert per_model.total_points == 3  # unavailable excluded from extent
+        ribbon = per_model.highlights.ribbon  # list[RibbonSegment]
+        assert any(
+            seg.severity == HighlightSeverity.UNAVAILABLE for seg in ribbon
+        )
+
+    def test_all_unavailable_means_advisory_unavailable(self):
+        from weatherbrief.analysis.advisories.convective import ConvectiveEvaluator
+        from weatherbrief.models import SoundingAnalysis, ThermodynamicIndices
+
+        unavailable = SoundingAnalysis(
+            indices=ThermodynamicIndices(),
+            convective_explicit_unavailable=True,
+        )
+        ctx = _eval_context([unavailable, unavailable])
+        result = ConvectiveEvaluator.evaluate(ctx, {})
+        assert result.per_model[0].status.value == "unavailable"
+
+
+# ---------------------------------------------------------------------------
+# Fill hold-over (covering-interval semantics)
+# ---------------------------------------------------------------------------
+
+
+class TestFillHoldOver:
+    def _hourly(self, hour, payload=None):
+        from weatherbrief.models import HourlyForecast
+
+        h = HourlyForecast(time=datetime(2026, 7, 21, hour, 0, tzinfo=timezone.utc))
+        h.explicit_convective_diagnostics = payload
+        return h
+
+    def test_gap_hour_gets_next_anchor_payload_trailing_gets_last(self):
+        from weatherbrief.fetch.grib.fill import _fill_explicit_hourly
+        from weatherbrief.models import NWPExplicitConvectiveDiagnostics
+
+        p12 = NWPExplicitConvectiveDiagnostics(
+            source="icon_d2", reflectivity_hour_max_dbz=40.0,
+        )
+        p13 = NWPExplicitConvectiveDiagnostics(
+            source="icon_d2", reflectivity_hour_max_dbz=50.0,
+        )
+        hours = [
+            self._hourly(12, p12),
+            self._hourly(13, None),  # gap — inside the (12,13] window
+            self._hourly(14, p13),
+            self._hourly(15, None),  # trailing — last completed interval
+        ]
+        # Rename for clarity: hours[1] sits between anchors 12:00 and 14:00.
+        filled = _fill_explicit_hourly(hours)
+        assert filled == 2
+        # Gap hour inherits the NEXT anchor's window, not the previous storm.
+        assert hours[1].explicit_convective_diagnostics.reflectivity_hour_max_dbz == 50.0
+        # Trailing hour holds the last completed interval.
+        assert hours[3].explicit_convective_diagnostics.reflectivity_hour_max_dbz == 50.0
+        # Anchors untouched.
+        assert hours[0].explicit_convective_diagnostics is p12
+
+    def test_no_payloads_is_noop(self):
+        from weatherbrief.fetch.grib.fill import _fill_explicit_hourly
+
+        assert _fill_explicit_hourly([self._hourly(12), self._hourly(13)]) == 0
+
+
+# ---------------------------------------------------------------------------
+# Domain-mask gate in _prepare_icon_eu
+# ---------------------------------------------------------------------------
+
+
+class TestDomainMaskGate:
+    def _icon_cross_sections(self):
+        from weatherbrief.models import ModelSource, RouteCrossSection
+
+        return [RouteCrossSection(
+            model=ModelSource.ICON,
+            route_points=[],
+            fetched_at=datetime(2026, 7, 20, tzinfo=timezone.utc),
+            point_forecasts=[],
+        )]
+
+    def _run_finder(self, d2_run, eu_run):
+        from weatherbrief.fetch.grib.icon_eu_fetch import ICON_D2 as _D2
+
+        def _fake(target_time, session=None, as_of_time=None,
+                  cover_until=None, variant=None):
+            return d2_run if variant is _D2 else eu_run
+
+        return _fake
+
+    def test_masked_corridor_falls_back_to_eu(self, tmp_path):
+        from weatherbrief.fetch.grib import _prepare_icon_eu
+        from weatherbrief.fetch.grib.icon_eu_fetch import ICON_EU
+        from weatherbrief.models import RoutePoint
+
+        route = [
+            RoutePoint(lat=48.35, lon=11.79, distance_from_origin_nm=0),
+            RoutePoint(lat=52.52, lon=13.4, distance_from_origin_nm=300),
+        ]
+        dep = datetime(2026, 7, 20, 12, 0, tzinfo=timezone.utc)
+        with patch(
+            "weatherbrief.fetch.grib.icon_eu_fetch.find_latest_icon_eu_run",
+            self._run_finder(d2_run=("20260720", 12), eu_run=("20260720", 12)),
+        ), patch(
+            "weatherbrief.fetch.grib._icon_d2_route_corridors_valid",
+            return_value=False,
+        ):
+            ctx, skip = _prepare_icon_eu(
+                self._icon_cross_sections(), route, dep,
+                data_dir=tmp_path, flight_duration_hours=2.0,
+            )
+        assert skip is None
+        assert ctx is not None
+        assert ctx.variant is ICON_EU
+
+    def test_valid_corridor_keeps_d2(self, tmp_path):
+        from weatherbrief.fetch.grib import _prepare_icon_eu
+        from weatherbrief.fetch.grib.icon_eu_fetch import ICON_D2
+        from weatherbrief.models import RoutePoint
+
+        route = [RoutePoint(lat=48.35, lon=11.79, distance_from_origin_nm=0)]
+        dep = datetime(2026, 7, 20, 12, 0, tzinfo=timezone.utc)
+        with patch(
+            "weatherbrief.fetch.grib.icon_eu_fetch.find_latest_icon_eu_run",
+            self._run_finder(d2_run=("20260720", 12), eu_run=("20260720", 12)),
+        ), patch(
+            "weatherbrief.fetch.grib._icon_d2_route_corridors_valid",
+            return_value=True,
+        ):
+            ctx, skip = _prepare_icon_eu(
+                self._icon_cross_sections(), route, dep,
+                data_dir=tmp_path, flight_duration_hours=2.0,
+            )
+        assert ctx is not None
+        assert ctx.variant is ICON_D2
+
+
+# ---------------------------------------------------------------------------
+# Total-D2-failure → ICON-EU re-run (carried from PR #461 review)
+# ---------------------------------------------------------------------------
+
+
+class TestTotalD2FailureFallback:
+    def test_decode_failure_reruns_icon_slot_on_eu(self, tmp_path):
+        import contextlib
+        from types import SimpleNamespace
+        from unittest.mock import Mock
+
+        import weatherbrief.fetch.grib as grib
+        from weatherbrief.fetch.grib.icon_eu_fetch import ICON_D2, ICON_EU
+
+        d2_ctx = SimpleNamespace(variant=ICON_D2)
+        eu_ctx = SimpleNamespace(variant=ICON_EU)
+        prepare_calls = []
+        decode_calls = []
+
+        def _prepare(*args, **kwargs):
+            prepare_calls.append(kwargs.get("force_variant"))
+            return (d2_ctx, None) if len(prepare_calls) == 1 else (eu_ctx, None)
+
+        def _decode(ctx, *args):
+            decode_calls.append(ctx.variant.slug)
+            if ctx.variant.slug == "icon-d2":
+                return None, None  # total D2 failure
+            return 2026072012, None
+
+        timer = Mock()
+        with patch.object(grib, "_prepare_icon_eu", side_effect=_prepare), \
+             patch.object(grib, "_decode_and_merge_icon_eu", side_effect=_decode), \
+             patch.object(grib, "_prefetch_icon_eu_data", lambda *a, **k: None), \
+             patch.object(grib, "_enrich_gfs", lambda *a, **k: None), \
+             patch.object(grib, "_enrich_ecmwf", lambda *a, **k: None), \
+             patch.object(grib, "_grib_time", lambda *a, **k: contextlib.nullcontext()):
+            init_times, sources, skips = grib._enrich_forecasts_inner(
+                timer, [], [], [],
+                datetime(2026, 7, 20, 12, 0, tzinfo=timezone.utc),
+                data_dir=tmp_path, flight_duration_hours=2.0,
+            )
+
+        assert decode_calls == ["icon-d2", "icon-eu"]
+        assert prepare_calls[1] is ICON_EU
+        assert init_times.get("icon") == 2026072012


### PR DESCRIPTION
Independent implementation of **#462**, built from the pre-#462 base (`faa66f97`, which includes #461's `IconVariant` groundwork).

**Status note:** #463 has already merged an implementation of this issue, so this branch conflicts with `main` in the same feature area — it is offered as an **independent alternative implementation for review/comparison**, not intended to merge as-is. The Files-changed view (three-dot diff from the merge-base `faa66f97`) shows exactly this implementation and nothing else. It implements the issue's design plus the deltas from an independent meteorological review ([details below](#user-content-review-deltas-vs-the-issue-spec)), every one of them re-verified against the live DWD feed on 2026-07-21.

## What it does

D2 is convection-permitting (no deep-convection scheme), so the parameterized diagnostics consumed from ICON-EU (`hbas_con`/`htop_con`/`rain_con`) don't exist or change meaning on its feed. This builds the replacement: an **explicit-convection track** sourced from D2's storm fields, kept strictly separate from the parameterized track end-to-end.

- **Variables** (all re-verified live against `opendata.dwd.de`, eccodes per-message inspection of 00z files, 2026-07-21, + DWD ICON DB manual): `dbz_ctmax` (firing signal, hour-max), `echotop` (`min_pres` Pa, 4×15-min messages; hourly product constructed over the 4 quarters ending in (H−1, H]), `lpi_max`, `w_ctmax`, `grau_gsp` (per-cell de-accumulation, on-the-hour messages only), and **`uh_max_med`** (2–5 km).
- **New eccodes decode path**: messages selected by validity; multi-message storm fields never reach cfgrib's merge. **Corridor extrema** (~10 NM disc) replace per-point bilinear sampling; `dbz_ctmax` also keeps the centreline value as a cell-vs-shield discriminator.
- **Payload** `NWPExplicitConvectiveDiagnostics` attached to **every** D2 hour (always-attach: decode failure = all-None + flags False, never "quiet").
- **`assess_convective_explicit`**: dbz × corroborator decision table; **`top_ft` always None** so the 18 dBZ echo top structurally cannot reach the overfly-clearance filter; no CIN suppression (a simulated echo IS realized convection); lead-time confidence wording; graupel-never-hail wording; own DD-vs-explicit cross-check.
- **`detection_complete=False`** → `convective_explicit_unavailable`: the advisory renders **UNAVAILABLE** (excluded from extent math), never GREEN; grading falls back to thermo badged truthfully (`convective_method_effective="thermo"`).
- **Domain-gate hardening**: cached bitmap validity mask requires the whole corridor unmasked, else ICON-EU (all-or-nothing, #456 rule).
- **Fill**: interval-max hold-over — gap hours inherit the NEXT anchor's (covering) interval (10fg gust precedent, #441).
- **Cache**: D2 cloud-diag key V2→V3 (#421 precedent); predecessor-step gate generalized to a variant flag (`grau_gsp` + `echotop` now need the lead file).
- **Aggregation floor for a lone D2 cell deliberately left to #442**; the per-model D2 status is visible regardless. Full rationale: `designs/meteorology-decisions.md` §19.

## Review deltas vs the issue spec

1. **Sentinel discipline fix** — the spec's "dbz ≤ −100 → None" contradicts its own "valid −150 dBZ floor is genuinely QUIET": the GRIB **bitmap** alone marks missing (~16.7% of cells); −150 dBZ and −999 Pa are real quiet data. Completeness is bitmap-driven per channel, so quiet nights read QUIET, never UNAVAILABLE.
2. **`uh_max_med` (2–5 km) instead of `uh_max` (2–8 km)** — the 2–5 km layer IS on the feed and is the literature/HRRR-calibrated layer, so the "thresholds not portable" caveat disappears. Still narrative-only in v1.
3. **"Unavailable renders GREEN" gap closed** — the evaluator previously mapped a missing convective assessment to GREEN; explicit-unavailable now renders UNAVAILABLE and is excluded from the extent denominator.
4. **Lead-time confidence bands** — ICON-D2 is radar-nudged (LHN), so wording is stratified: ≤6 h "positions meaningful", 6–24 h "placement approximate", >24 h "environment-level signal". Wording only, never a tier input.
5. **Centreline-vs-corridor discriminator** — widespread shield (point ≈ max) vs discrete cell (max ≫ point) feeds the 35–44 dBZ stratiform note.
6. **Echo-top Pa→ft via ISA** — single reproducible datum for a corridor extremum whose cell is not under the centreline; documented as character-only.

## Verification

- Decode smoke-tested against real downloaded D2 blobs: corridor catches a 45 dBZ cell ~10 km off the centreline near Berlin that bilinear sampling reads as 27 dBZ; masked SW corner yields all-None + incomplete (UNAVAILABLE, not quiet); echo-top hourly min + ISA conversion (63,495 Pa → 12,375 ft) verified.
- **56 new tests** in `tests/test_icon_d2_explicit.py`: corridor math, sentinel rules, quarter construction/degradation, graupel de-accum (incl. reset-clip), builder completeness, decision table, assessment contract (`top_ft` never set), cross-check, evaluator UNAVAILABLE, fill semantics, mask gate, and the total-D2-failure → EU re-run test carried from #461's review.
- Full suite: **no regressions** (6 pre-existing failures on the base in `test_icon_prefetch`/`test_auth`, unrelated; one assertion updated for the intentional V2→V3 cache bump).

🤖 Generated with [Kimi Code](https://www.kimi.com/code) — co-authored on the commit via `Co-authored-by`.