### PR TITLE
v2 convective decision table: LPI-primary corroboration + bright-band gate

### DIFF
--- a/designs/meteorology-decisions.md
+++ b/designs/meteorology-decisions.md
@@ -1977,6 +1977,12 @@ the parameterized concepts.
 
 ### The decision — v1 firing/severity table
 
+**Superseded by the 2026-07-21 amendment at the end of this section (#466/#467):
+the corroborator algebra is now LPI-primary, CAPE/UH are narrative-only, the
+≥ 50 dBZ row no longer bypasses corroboration, and a bright-band gate was added.
+The v1 table is retained below as the historical baseline the amendment argues
+against.**
+
 The firing signal is `dbz_ctmax` (column-max simulated reflectivity, max over
 the previous hour), reduced to a **corridor maximum** over a ~10 NM route
 buffer. The corroborator set C (each channel counts 1 when **complete AND over
@@ -2169,3 +2175,145 @@ the −10 °C isotherm) as the replacement corroborator — it is the column
 mixed-phase quantity #462 wanted and will co-locate with the reflectivity
 cores. It must clear the same three-run corridor test above before being wired
 in, so it is deferred pending calibration.
+
+### Amendment (2026-07-21, #466/#467): LPI-primary corroboration + bright-band gate
+
+**Status:** Implemented. Supersedes the v1 firing/severity table above.
+**Composes with #468 (immediately above), which landed first.** The two were
+developed in parallel and agree: #468 removed `grau_gsp` outright as a provably
+dead input, and this amendment independently demoted it from an independent vote
+to LPI-embedded detail. Net result — the vote set is `lpi_max` (primary) with
+`w_ctmax` as its **only** substitute, so the substitute path tops out at
+|C| = 1 and **|C| ≥ 2 is reachable only via LPI ≥ 5**. The `|C| ≥ 2` column of
+the v2 table is therefore an *electrification* column in practice, which is
+deliberate: LPI is the one channel that actually integrates the mixed-phase
+updraft the tier is trying to name.
+**Context:** The v1 table shipped with #462 as calibration *starting points*
+requiring validation before it could be trusted (its own "revisit against the
+validation cases" caveat). Two independent pressures then landed together:
+
+1. **The corroborator argument from the parallel PR #464 implementation** (the
+   #466 issue body). DWD's LPI (Lynn & Yair) is essentially `∫ ε w² dz` with ε
+   weighted by mixed-phase (graupel/ice) content in the charging zone — it
+   *already integrates* updraft and graupel. Counting `lpi_max`, `w_ctmax` and
+   `grau_gsp` as three independent votes triple-counts one mixed-phase updraft,
+   so a moderately-electrified (or bright-band) cell can reach |C| ≥ 2 on
+   physically one signal. And `cape_ml` is *environment*, not storm process: it
+   duplicates the independent thermo track and let a 35–44 dBZ stratiform band
+   upgrade to MARGINAL on ML-CAPE alone — the exact false alarm the quiet
+   controls exist to catch.
+2. **The #467 forward validation.** The #462 retrospective cases proved
+   unrecoverable (DWD open-data keeps only the current D2 run; saved packs from
+   those dates predate the D2 slot), so validation became *forward*. A live
+   stratiform control (**EDDE→EDQD, 2026-07-21**, widespread non-convective
+   rain) ran the D2-vs-forced-EU A/B and **the v1 table false-alarmed HIGH at 4
+   of 8 route points** — 50–54 dBZ column-max with LPI ≈ 0, updraft ≤ 5.5 m/s
+   and ML-CAPE ≤ 242 J/kg, while every other signal (its own LPI/updraft/CAPE,
+   the thermo track, ICON-EU, GFS) said no convection. The 35–44 band this issue
+   was *originally* about behaved correctly (43 and 36 dBZ, |C| = 0 → none). The
+   hole was the **≥ 50 dBZ row bypassing corroborators entirely.**
+
+### The decision — v2 table
+
+| Corridor `dbz_ctmax` | \|C\| = 0 | \|C\| = 1 | \|C\| ≥ 2 |
+|---|---|---|---|
+| < 35 dBZ | no fire | no fire | no fire |
+| 35–44 dBZ | no fire (stratiform note) | MARGINAL | MODERATE |
+| 45–49 dBZ | MODERATE | MODERATE | HIGH |
+| ≥ 50 dBZ | **MODERATE** | HIGH | HIGH |
+
+Three coupled changes (`analysis/sounding/convective.py`):
+
+**A. LPI-primary corroborator algebra** (`_explicit_corroborators`). |C| now
+counts **storm-process** signal only:
+- **LPI is the primary channel.** When present (complete), it votes alone:
+  `≥ 5` → 2, `≥ 1` → 1. `w_ctmax` is then *narrative detail, not additive* — it
+  is an ingredient LPI already integrates.
+- **`w_ctmax` substitutes only when LPI does not vote** — LPI missing *or*
+  present-but-below-floor. The substitute (`w ≥ 10 m/s` → 1) counts only when
+  its own channel is complete-and-over-threshold. It is the only substitute:
+  `grau_gsp`, the other v1 candidate, was removed in #468.
+- **CAPE and UH are narrative-only, never votes.**
+
+  *Completeness invariant (issue #466 note; rule 5 unchanged).* The substitution
+  is **identical** whether LPI is missing or present-and-quiet, so an incomplete
+  LPI channel can never *silently promote* w into counting beyond what a
+  present-but-quiet LPI would give. A masked substitute channel (None) still
+  contributes nothing.
+
+**B. ≥ 50 dBZ no longer self-certifies.** `dbz_ctmax` is a **column max**, and a
+strong melting-layer bright band in heavy stratiform rain reaches 50+ dBZ with
+no convection in the column. |C| = 0 now caps the row at **MODERATE** (was HIGH);
+|C| ≥ 1 restores HIGH.
+
+**C. Bright-band gate** (`assess_convective_explicit`). When the 18 dBZ echo top
+sits **< 10,000 ft above the freezing level** *and* |C| = 0 (no storm-process
+corroboration), the high reflectivity is treated as melting-layer bright band,
+not convection, and the fire is suppressed to **NONE** at any dBZ. Physically a
+bright band sits *at* the melting layer, so its echo top is only a few kft above
+the 0 °C level, whereas a real convective core carries hydrometeors far higher.
+#467 measured the discriminator cleanly: **6.5–7.8 kft** in the stratiform
+control vs **24–27 kft** in the ESMX real storms — a wide margin around the
+10 kft threshold. This finally gives `echo_top_18dbz_ft` a real job while
+preserving rule 1 (it never becomes `top_ft`, so it still cannot reach the
+overfly-clearance filter). Freezing level is taken from the sounding's own 0 °C
+crossing, falling back to the model-native / NWP-diagnostic freezing level.
+
+Under B+C the EDDE→EDQD ≥ 50 dBZ false-alarm points go HIGH → MODERATE (table) →
+NONE (gate); the 35–44 rows are unchanged; and the ESMX real hit (LPI 89, updraft
+23, Δ ≈ 25 kft) stays HIGH. Both directions are pinned as regression tests in
+`tests/test_convective_explicit.py` (`TestExplicitValidationMatrix`,
+`TestExplicitBrightBandGate`, `TestExplicitLpiPrimaryAlgebra`).
+
+### Rejected alternatives
+
+- **Keep the v1 four-way independent |C|** (`lpi + w + graupel + cape`). Rejected:
+  triple-counts the mixed-phase updraft LPI already integrates, and lets CAPE
+  (environment) upgrade a stratiform band — the mechanism behind the #467 false
+  alarm on the corroborated rows.
+- **A straight swap to LPI-primary at #462 implementation time** (what PR #464
+  proposed inline). Rejected then: the v1 table survived two external review
+  rounds, so the firing algebra could not change without running the validation
+  matrix under both schemes. That is why this landed as its own issue with a
+  both-directions acceptance bar, not as a silent edit — the recalibration is
+  now *earned* by the #467 run rather than asserted.
+- **An unconditional bright-band gate** (suppress at Δ < 10 kft regardless of
+  |C|), as the #467 comment framed it ("independent of the corroborator
+  algebra"). Rejected in favour of gating on |C| = 0: a suppressor that can hide
+  a *corroborated* cell is a dangerous false negative, against this codebase's
+  under-warning-is-worse asymmetry and its "never silently hide a storm" bias.
+  A shallow echo top and a firing LPI are physically contradictory (electrification
+  needs ice aloft), so the two rarely conflict; when they do, the positive
+  electrification evidence wins. On the #467 cases the outcome is identical
+  either way (the false-alarm points are all |C| = 0), so no validated behaviour
+  is lost by the safer gating.
+- **A lower / higher Δ threshold than 10 kft.** 10 kft sits in the wide gap
+  between the two observed populations (7.8 vs 24.4 kft). The one residual
+  ambiguous case is the ESMX 45–49 dBZ |C| = 0 points already flagged as
+  suspicious in #467 (Δ ≈ 9.8 / 12.6 kft): the 9.8 kft point is now suppressed,
+  the 12.6 kft one stays MODERATE (the 45–49 |C| = 0 row). That is acceptable —
+  MODERATE, not HIGH, for a 47.8 dBZ echo with LPI 0 and a 3.5 m/s updraft — and
+  the threshold is a calibration knob to revisit as more forward cases land.
+
+### Known interactions / follow-ups
+
+- **Graupel is gone, not merely dead (#468, resolved).** This bullet originally
+  read "`grau_gsp` freezes bitwise from ~f024, so the corroborator is
+  effectively always 0" and treated it as a bug to fix. The #468 investigation
+  landed a different and firmer diagnosis: `grau_gsp` is *surface* graupel
+  precipitation, so it is ~always 0 under warm-season corridor cores by
+  construction — nothing to fix, and it was dropped outright (see the #468
+  section above). The LPI-primary scheme is unaffected either way: LPI carries
+  the storm-process vote when present, and graupel only ever mattered as a
+  substitute when LPI is absent/quiet, where its being 0 simply means `w` must
+  carry it. No v2 grade on the validated cases changes. The consequence that
+  *does* survive is the |C| ≥ 2 ceiling noted at the top of this amendment. If
+  `tcond10_mx` is later wired in as the column replacement (#468 follow-up), it
+  enters as a second substitute and restores a non-LPI route to |C| = 2 — that
+  is a recalibration to validate, not a drop-in.
+- **Aggregation is still not decided here** (unchanged from v1): a lone D2
+  explicit cell against quiet coarse models still aggregates by majority — the
+  "floor the aggregate at AMBER" question belongs in the #442 grade framework.
+- **Still-outstanding #467 controls**: a winter graupel-shower day (needs the
+  season) and a second/third convective hit before the thresholds are treated as
+  fully calibrated rather than validated on one case each way.

--- a/src/weatherbrief/analysis/sounding/convective.py
+++ b/src/weatherbrief/analysis/sounding/convective.py
@@ -900,77 +900,155 @@ def assess_convective_nwp(
 # from assess_convective_nwp's tower-top track, so it gets its own assessment
 # with its own method string ("nwp_explicit") — the two are never blended.
 #
-# v1 decision table (meteorology-decisions §19 — calibration starting points,
-# not physical constants). The firing signal is the corridor-max hour-max
-# reflectivity DBZ_CTMAX; a corroborator set C confirms storm character:
+# v2 decision table (meteorology-decisions §19, 2026-07-21 amendment #466/#467).
+# The firing signal is the corridor-max hour-max reflectivity DBZ_CTMAX; a
+# storm-process corroborator count |C| confirms it is real convection:
 #
 #   corridor dbz_ctmax | |C| = 0                    | |C| = 1  | |C| >= 2
 #   -------------------+----------------------------+----------+---------
 #   < 35 dBZ           | no fire                    | no fire  | no fire
 #   35–44 dBZ          | no fire (stratiform note)  | MARGINAL | MODERATE
 #   45–49 dBZ          | MODERATE                   | MODERATE | HIGH
-#   >= 50 dBZ          | HIGH                       | HIGH     | HIGH
+#   >= 50 dBZ          | MODERATE                   | HIGH     | HIGH
 #
-# Each corroborator counts 1 when its channel is COMPLETE (value non-None —
-# a valid quiet channel decodes to 0.0, #421 None ≠ 0) AND over threshold;
-# lpi >= 5 counts 2. Incomplete channels never downgrade below the dbz-alone
-# row and never upgrade (|C| counts only complete channels); zero on one
-# channel never suppresses positive evidence on another. |uh| is
-# narrative/character only in v1 — HRRR UH thresholds are NOT portable (2–8 km
-# vs 2–5 km layer).
+# Two changes from v1 (both driven by the #467 validation, where the v1 table
+# false-alarmed HIGH at 4 of 8 route points in widespread stratiform rain):
+#   1. The corroborator ALGEBRA is now LPI-primary (see _explicit_corroborators).
+#      DWD's LPI ≈ ∫ ε w² dz weighted by mixed-phase (graupel/ice) content, so it
+#      already embeds updraft × graupel — counting lpi_max + w_ctmax + grau_gsp
+#      as three independent votes triple-counted one mixed-phase updraft. CAPE
+#      (environment, and it duplicates the independent thermo track) and UH are
+#      narrative-only — neither is ever a vote.
+#   2. The >= 50 row no longer bypasses corroboration. dbz_ctmax is a COLUMN
+#      max, and a strong melting-layer bright band in heavy stratiform rain
+#      reaches 50+ dBZ with no convection in the column. |C| = 0 now caps at
+#      MODERATE (was HIGH), and the bright-band gate suppresses it to no-fire
+#      entirely when the echo is shallow — see assess_convective_explicit.
 #
-# The v1 corroborator set is lpi_max + w_ctmax + ml_cape. grau_gsp (surface
-# graupel precipitation) was dropped (#468): it measures snow pellets reaching
-# the GROUND, ~always 0 under warm-season route-corridor cores, not the column
-# mixed-phase property #462 intended — so it could never realistically fire.
-# Its column replacement (tcond10_mx) is deferred pending calibration (#468).
-_EXPLICIT_DBZ_FIRE = 35.0       # below → no fire (environment tracks unaffected)
+# The v2 vote set is therefore lpi_max (primary) with w_ctmax as its only
+# substitute. grau_gsp was dropped outright in #468 — it measures snow pellets
+# reaching the GROUND, ~always 0 under warm-season route-corridor cores, not the
+# column mixed-phase property #462 intended, so it could never realistically
+# fire. That lands in the same place this amendment does (graupel was never an
+# independent vote to begin with); its column replacement (tcond10_mx) is
+# deferred pending calibration (#468).
+#
+# Completeness (rule 5): |C| counts only COMPLETE channels (value non-None — a
+# valid quiet channel decodes to 0.0, #421 None ≠ 0) AND over threshold.
+# Incomplete channels never move the tier in either direction; a zero on one
+# channel never suppresses positive evidence on another.
+_EXPLICIT_DBZ_FIRE = 35.0        # below → no fire (environment tracks unaffected)
 _EXPLICIT_DBZ_CONVECTIVE = 45.0  # 35–44 band may be stratiform/melting-band
-_EXPLICIT_DBZ_SEVERE = 50.0     # >= → HIGH regardless of corroborators
+_EXPLICIT_DBZ_SEVERE = 50.0      # >= 50 still needs |C| >= 1 for HIGH (bright band)
 _EXPLICIT_LPI_CORROB_JKG = 1.0
-_EXPLICIT_LPI_STRONG_JKG = 5.0  # counts as 2 corroborators
+_EXPLICIT_LPI_STRONG_JKG = 5.0   # LPI (the primary channel) >= 5 counts as 2
 _EXPLICIT_UPDRAFT_CORROB_MS = 10.0
-_EXPLICIT_CAPE_CORROB_JKG = 500.0
-_EXPLICIT_UH_NOTE_M2S2 = 25.0   # rotation NOTE only, never a tier input
+_EXPLICIT_CAPE_CORROB_JKG = 500.0  # narrative-only threshold (never a vote)
+_EXPLICIT_UH_NOTE_M2S2 = 25.0    # rotation NOTE only, never a tier input
+# Bright-band gate (#466/#467): the 18 dBZ echo top of a melting-layer bright
+# band sits only a few kft above the freezing level, whereas a real convective
+# core carries hydrometeors far higher. #467 measured echo_top − freezing_level
+# at 6.5–7.8 kft (stratiform false alarm) vs 24–27 kft (real storms). Below this
+# margin, AND with no storm-process corroboration, high reflectivity is treated
+# as melting-layer bright band, not convection, at any dBZ.
+_EXPLICIT_BRIGHT_BAND_DELTA_FT = 10000.0
+
+
+def _explicit_freezing_level_ft(
+    indices: ThermodynamicIndices,
+    nwp_diagnostics: NWPCloudDiagnostics | None,
+) -> float | None:
+    """First available freezing level for the bright-band gate.
+
+    Prefer the sounding's own (DD/MetPy) 0 °C crossing — the same column the
+    echo top's altitude conversion uses — then the Open-Meteo / model-native
+    freezing level, then the NWP cloud-diagnostics one. Any is a usable datum
+    for the echo-top-vs-melting-layer comparison; the gate needs one, not all.
+    """
+    candidates = [indices.freezing_level_ft, indices.nwp_freezing_level_ft]
+    if nwp_diagnostics is not None:
+        candidates.append(nwp_diagnostics.freezing_level_ft)
+    for value in candidates:
+        if value is not None:
+            return value
+    return None
 
 
 def _explicit_corroborators(
     explicit: NWPExplicitConvectiveDiagnostics,
     nwp_diagnostics: NWPCloudDiagnostics | None,
 ) -> tuple[int, list[str], int]:
-    """Count complete-and-over-threshold corroborator channels.
+    """Count storm-process corroborators, LPI-primary (§19 amendment #466).
 
-    Returns ``(count, descriptions, incomplete_channels)``. Only complete
-    channels (non-None values) can count; incomplete ones are tallied so the
-    caller can say so without letting them downgrade or upgrade the tier.
+    Returns ``(count, descriptions, incomplete_channels)``.
+
+    DWD's LPI ≈ ``∫ ε w² dz`` weighted by mixed-phase content, so it already
+    embeds updraft × graupel. Counting ``lpi_max`` + ``w_ctmax`` + ``grau_gsp``
+    as three independent votes triple-counts one mixed-phase updraft, letting a
+    moderately-electrified (or a stratiform bright-band) cell reach |C| >= 2 on
+    physically one signal. So:
+
+    - **LPI is the primary storm-process channel.** When present (complete) it
+      votes alone: ``>= 5`` counts 2, ``>= 1`` counts 1. ``w_ctmax`` is then
+      narrative detail only — NOT additive (it is an ingredient LPI already
+      integrates).
+    - **w_ctmax substitutes only when LPI does not vote** — i.e. LPI is missing
+      OR present-but-below-floor. The substitution is IDENTICAL in both those
+      cases, so an incomplete LPI channel never silently promotes w beyond what
+      a present-but-quiet LPI would give (issue #466 note). It still counts only
+      when its OWN channel is complete-and-over-threshold (rule 5) — a masked
+      w_ctmax (None) contributes nothing.
+    - **CAPE is environment, not storm process** — it duplicates the independent
+      thermo track and let a bright band upgrade on ML-CAPE alone (#467). It is
+      narrative-only now, never a vote. **UH** stays a rotation NOTE only.
+
+    Note the consequence of #468 dropping ``grau_gsp`` (the other v1 substitute):
+    the substitute path can now contribute at most 1, so **|C| >= 2 is reachable
+    only via LPI >= 5**. The decision table's ``|C| >= 2`` column is therefore an
+    electrification column in practice — deliberate, since LPI is the one channel
+    that actually integrates the mixed-phase updraft the tier is trying to name.
     """
     count = 0
     notes: list[str] = []
     incomplete = 0
 
     lpi = explicit.lightning_potential_hour_max_jkg
+    w = explicit.updraft_hour_max_ms
+
+    lpi_voted = False
     if lpi is None:
         incomplete += 1
     elif lpi >= _EXPLICIT_LPI_STRONG_JKG:
         count += 2
+        lpi_voted = True
         notes.append(f"strong lightning potential (LPI {lpi:.1f} J/kg)")
     elif lpi >= _EXPLICIT_LPI_CORROB_JKG:
         count += 1
+        lpi_voted = True
         notes.append(f"lightning potential (LPI {lpi:.1f} J/kg)")
 
-    w = explicit.updraft_hour_max_ms
-    if w is None:
-        incomplete += 1
-    elif w >= _EXPLICIT_UPDRAFT_CORROB_MS:
-        count += 1
-        notes.append(f"strong updraft ({w:.0f} m/s)")
+    if lpi_voted:
+        # LPI already integrates the mixed-phase updraft — surface w as detail,
+        # but never add it to |C| (the v1 double/triple-count this amendment
+        # kills). grau_gsp, the other v1 vote, no longer exists (#468).
+        if w is not None and w >= _EXPLICIT_UPDRAFT_CORROB_MS:
+            notes.append(f"strong updraft ({w:.0f} m/s) — embedded in LPI, not additive")
+    else:
+        # LPI missing or present-but-quiet: w may substitute (1), only when its
+        # own channel is complete-and-over-threshold.
+        if w is None:
+            incomplete += 1
+        elif w >= _EXPLICIT_UPDRAFT_CORROB_MS:
+            count += 1
+            notes.append(f"strong updraft ({w:.0f} m/s)")
 
+    # CAPE: environment, narrative-only (never a vote) — see the docstring.
     cape_ml = nwp_diagnostics.ml_cape_jkg if nwp_diagnostics is not None else None
-    if cape_ml is None:
-        incomplete += 1
-    elif cape_ml >= _EXPLICIT_CAPE_CORROB_JKG:
-        count += 1
-        notes.append(f"unstable environment (ML-CAPE {cape_ml:.0f} J/kg)")
+    if cape_ml is not None and cape_ml >= _EXPLICIT_CAPE_CORROB_JKG:
+        notes.append(
+            f"unstable environment (ML-CAPE {cape_ml:.0f} J/kg) — environment, "
+            "narrative only"
+        )
 
     return count, notes, incomplete
 
@@ -978,11 +1056,15 @@ def _explicit_corroborators(
 def _explicit_risk_from_table(
     dbz: float | None, corroborators: int
 ) -> ConvectiveRisk:
-    """The v1 dbz × |C| decision table (see the constants block above)."""
+    """The v2 dbz × |C| decision table (see the constants block above)."""
     if dbz is None or dbz < _EXPLICIT_DBZ_FIRE:
         return ConvectiveRisk.NONE
     if dbz >= _EXPLICIT_DBZ_SEVERE:
-        return ConvectiveRisk.HIGH
+        # >= 50 dBZ no longer self-certifies (v1 bypass removed, #466/#467):
+        # dbz_ctmax is a column max and a stratiform melting-layer bright band
+        # reaches 50+ with no convection. Uncorroborated → MODERATE, not HIGH
+        # (and the bright-band gate downstream may drop it further to no-fire).
+        return ConvectiveRisk.HIGH if corroborators >= 1 else ConvectiveRisk.MODERATE
     if dbz >= _EXPLICIT_DBZ_CONVECTIVE:
         return ConvectiveRisk.HIGH if corroborators >= 2 else ConvectiveRisk.MODERATE
     # 35–44 dBZ: echo present but possibly stratiform rain / melting-band
@@ -1021,6 +1103,13 @@ def assess_convective_explicit(
       (same reasoning as the ``nwp_precip`` path).
     - A quiet-but-complete hour returns a real ``NONE`` assessment (not
       ``None``) so DD-vs-model cross-checks can still fire.
+    - Bright-band gate (§19 amendment #466/#467): when the 18 dBZ echo top sits
+      < ``_EXPLICIT_BRIGHT_BAND_DELTA_FT`` above the freezing level AND no
+      storm-process corroborator fired (|C| = 0), the high reflectivity is a
+      melting-layer bright band, not convection — the fire is suppressed to
+      ``NONE``. Gated on |C| = 0 so it can never override positive
+      electrification / updraft evidence (a corroborated cell is never hidden —
+      the codebase's under-warning-is-worse safety asymmetry).
     """
     if not explicit.detection_complete:
         return None
@@ -1042,40 +1131,68 @@ def assess_convective_explicit(
     )
     risk = _explicit_risk_from_table(dbz, corrob_count)
 
+    # Bright-band gate (§19 amendment #466/#467). A shallow 18 dBZ echo top
+    # relative to the freezing level is a melting-layer bright band, not a
+    # convective core. Only with |C| = 0 (no storm-process corroboration) and
+    # only when both the echo top (complete) and a freezing level are available
+    # — an unevaluable gate never downgrades (rule 5, safety asymmetry).
+    freezing_ft = _explicit_freezing_level_ft(indices, nwp_diagnostics)
+    echo_top_ft = explicit.echo_top_18dbz_ft
+    bright_band = (
+        risk is not ConvectiveRisk.NONE
+        and corrob_count == 0
+        and echo_top_ft is not None
+        and explicit.echo_top_complete
+        and freezing_ft is not None
+        and (echo_top_ft - freezing_ft) < _EXPLICIT_BRIGHT_BAND_DELTA_FT
+    )
+    if bright_band:
+        risk = ConvectiveRisk.NONE
+
     drivers: list[str] = []
     suppressors: list[str] = []
 
     if dbz is not None and dbz >= _EXPLICIT_DBZ_FIRE:
-        drivers.append(
-            f"Explicitly simulated storm echo — corridor-max reflectivity "
-            f"{dbz:.0f} dBZ over the past hour (ICON-D2, convection-permitting)"
-        )
-        if dbz < _EXPLICIT_DBZ_CONVECTIVE and corrob_count == 0:
+        if bright_band:
+            # echo_top_ft / freezing_ft are both non-None here (gate condition).
             suppressors.append(
-                "Echo present but uncorroborated at 35–44 dBZ — likely "
-                "stratiform rain / melting-band bright-band, not convection"
+                f"Corridor-max reflectivity {dbz:.0f} dBZ, but the 18 dBZ echo "
+                f"top (~{echo_top_ft:.0f} ft) sits only ~{echo_top_ft - freezing_ft:.0f} ft "
+                f"above the freezing level (~{freezing_ft:.0f} ft) with no "
+                "storm-process corroboration — melting-layer bright band in "
+                "stratiform rain, not convection"
             )
-        drivers.extend(corrob_notes)
-        if incomplete and corrob_count < 2:
+        else:
             drivers.append(
-                f"{incomplete} corroborator channel(s) unavailable — tier from "
-                "the reflectivity row alone (missing data never downgrades)"
+                f"Explicitly simulated storm echo — corridor-max reflectivity "
+                f"{dbz:.0f} dBZ over the past hour (ICON-D2, convection-permitting)"
             )
-        if explicit.echo_top_18dbz_ft is not None:
-            # Depth/character AFTER firing — explicitly NOT a cloud top: the
-            # physical storm top (weakly-reflecting anvil ice) sits higher.
-            drivers.append(
-                f"18 dBZ echo top ~{explicit.echo_top_18dbz_ft:.0f} ft "
-                "(storm depth indicator — the cloud top is higher; not for "
-                "overfly planning)"
-            )
-        uh = explicit.updraft_helicity_2_8km_hour_max_m2s2
-        if uh is not None and abs(uh) >= _EXPLICIT_UH_NOTE_M2S2:
-            sense = "cyclonic" if uh > 0 else "anticyclonic"
-            drivers.append(
-                f"Rotating updraft signature (updraft helicity {uh:.0f} m²/s², "
-                f"{sense}) — organized-storm character"
-            )
+            if dbz < _EXPLICIT_DBZ_CONVECTIVE and corrob_count == 0:
+                suppressors.append(
+                    "Echo present but uncorroborated at 35–44 dBZ — likely "
+                    "stratiform rain / melting-band bright-band, not convection"
+                )
+            drivers.extend(corrob_notes)
+            if incomplete and corrob_count < 2:
+                drivers.append(
+                    f"{incomplete} corroborator channel(s) unavailable — tier from "
+                    "the reflectivity row alone (missing data never downgrades)"
+                )
+            if explicit.echo_top_18dbz_ft is not None:
+                # Depth/character AFTER firing — explicitly NOT a cloud top: the
+                # physical storm top (weakly-reflecting anvil ice) sits higher.
+                drivers.append(
+                    f"18 dBZ echo top ~{explicit.echo_top_18dbz_ft:.0f} ft "
+                    "(storm depth indicator — the cloud top is higher; not for "
+                    "overfly planning)"
+                )
+            uh = explicit.updraft_helicity_2_8km_hour_max_m2s2
+            if uh is not None and abs(uh) >= _EXPLICIT_UH_NOTE_M2S2:
+                sense = "cyclonic" if uh > 0 else "anticyclonic"
+                drivers.append(
+                    f"Rotating updraft signature (updraft helicity {uh:.0f} m²/s², "
+                    f"{sense}) — organized-storm character"
+                )
 
     return ConvectiveAssessment(
         risk_level=risk,

--- a/tests/test_convective_explicit.py
+++ b/tests/test_convective_explicit.py
@@ -1,6 +1,7 @@
 """Tests for the ICON-D2 explicit-convection assessment (issue #462).
 
-Covers the v1 decision table (dbz × corroborators), the completeness
+Covers the v2 decision table (dbz × corroborators — LPI-primary algebra and
+the bright-band gate, §19 amendment #466/#467), the completeness
 semantics (incomplete detection → unavailable, never quiet; incomplete
 corroborator channels never downgrade or upgrade), the structural safety
 properties (top_ft always None so the overfly-clearance filter cannot consume
@@ -86,7 +87,7 @@ class TestExplicitAvailability:
 
 
 # ---------------------------------------------------------------------------
-# v1 decision table — dbz rows × corroborator columns
+# v2 decision table — dbz rows × corroborator columns
 # ---------------------------------------------------------------------------
 
 
@@ -105,7 +106,12 @@ class TestExplicitDecisionTable:
         assert result.risk_level == ConvectiveRisk.MARGINAL
 
     def test_35_44_two_corroborators_moderate(self):
-        result = _assess(_explicit(40.0, lpi=2.0, w=12.0))
+        # |C| = 2 under the LPI-primary algebra (v2, §19 amendment). With
+        # grau_gsp gone (#468) the substitute path tops out at 1, so strong LPI
+        # is the only route to 2 — see test_substitute_updraft_cannot_reach_two.
+        # (Under v1, lpi=2 + w=12 also read 2, but that double-counted: LPI
+        # already embeds the updraft.)
+        result = _assess(_explicit(40.0, lpi=6.0, w=12.0))
         assert result.risk_level == ConvectiveRisk.MODERATE
 
     def test_45_49_uncorroborated_moderate(self):
@@ -113,12 +119,28 @@ class TestExplicitDecisionTable:
         assert result.risk_level == ConvectiveRisk.MODERATE
 
     def test_45_49_two_corroborators_high(self):
-        # LPI (1) + strong updraft (1) → 2 corroborators → HIGH.
-        result = _assess(_explicit(47.0, lpi=2.0, w=12.0))
+        # Strong LPI votes 2 on its own → HIGH at 45–49.
+        result = _assess(_explicit(47.0, lpi=6.0, w=12.0))
         assert result.risk_level == ConvectiveRisk.HIGH
 
-    def test_50_plus_high_even_uncorroborated(self):
+    def test_substitute_updraft_cannot_reach_two(self):
+        # Post-#468 invariant: grau_gsp is gone, so when LPI does not vote the
+        # substitute path can contribute at most 1 (w_ctmax). A quiet-LPI cell
+        # with a strong updraft is therefore |C| = 1 → MODERATE at 45–49, NOT
+        # HIGH. |C| >= 2 is reachable only via LPI >= 5.
+        result = _assess(_explicit(47.0, lpi=0.0, w=12.0))
+        assert result.risk_level == ConvectiveRisk.MODERATE
+
+    def test_50_plus_uncorroborated_capped_at_moderate(self):
+        # v2 (#466/#467): ≥50 dBZ no longer self-certifies to HIGH — dbz_ctmax
+        # is a column max and a stratiform bright band reaches 50+. |C| = 0 caps
+        # at MODERATE (no echo top here, so the bright-band gate can't fire).
         result = _assess(_explicit(55.0, lpi=0.0, w=0.0))
+        assert result.risk_level == ConvectiveRisk.MODERATE
+
+    def test_50_plus_one_corroborator_high(self):
+        # A single storm-process corroborator restores HIGH at ≥50.
+        result = _assess(_explicit(55.0, lpi=2.0, w=0.0))
         assert result.risk_level == ConvectiveRisk.HIGH
 
     def test_strong_lpi_counts_double(self):
@@ -126,11 +148,17 @@ class TestExplicitDecisionTable:
         result = _assess(_explicit(47.0, lpi=6.0, w=0.0))
         assert result.risk_level == ConvectiveRisk.HIGH
 
-    def test_cape_ml_from_parameterized_diag_is_a_corroborator(self):
-        diag = NWPCloudDiagnostics(ml_cape_jkg=800.0)
-        # dbz 40 + ML-CAPE (1) + LPI (1) → 2 corroborators → MODERATE.
+    def test_cape_ml_is_narrative_only_not_a_vote(self):
+        # v2 (#466/#467): CAPE is environment (it duplicates the thermo track),
+        # never a corroborator vote. dbz 40 + LPI (1) + ML-CAPE (narrative) is
+        # still |C| = 1 → MARGINAL, and CAPE alone cannot fire anything.
+        diag = NWPCloudDiagnostics(ml_cape_jkg=2000.0)
         result = _assess(_explicit(40.0, lpi=2.0, w=0.0), diag=diag)
-        assert result.risk_level == ConvectiveRisk.MODERATE
+        assert result.risk_level == ConvectiveRisk.MARGINAL
+        assert any("environment, narrative only" in d for d in result.drivers)
+        # CAPE with no storm-process signal at all → no fire.
+        cape_only = _assess(_explicit(40.0, lpi=0.0, w=0.0), diag=diag)
+        assert cape_only.risk_level == ConvectiveRisk.NONE
 
 
 class TestExplicitCompletenessRules:
@@ -151,6 +179,135 @@ class TestExplicitCompletenessRules:
         assert result.risk_level == ConvectiveRisk.MARGINAL
 
 
+class TestExplicitLpiPrimaryAlgebra:
+    """LPI-primary corroborator algebra (§19 amendment, issue #466).
+
+    DWD's LPI ≈ ∫ ε w² dz weighted by mixed-phase content already embeds
+    updraft × graupel, so counting them as independent votes double-counts one
+    signal. LPI votes alone when present; w_ctmax substitutes only when LPI does
+    not vote (missing or below floor); CAPE/UH are narrative-only. With grau_gsp
+    dropped (#468), w_ctmax is the ONLY substitute, so the substitute path tops
+    out at |C| = 1 and |C| >= 2 requires LPI >= 5.
+    """
+
+    def test_lpi_present_makes_w_narrative_not_additive(self):
+        # LPI = 2 (votes 1). A strong updraft is present but must NOT add —
+        # |C| stays 1 → MARGINAL, not MODERATE (v1 read this 2).
+        result = _assess(_explicit(40.0, lpi=2.0, w=12.0))
+        assert result.risk_level == ConvectiveRisk.MARGINAL
+        assert any("not additive" in d for d in result.drivers)
+
+    def test_w_substitutes_when_lpi_below_floor(self):
+        # LPI present but below floor (0.4 < 1) → does not vote → w substitutes
+        # (1) → |C| = 1 → MARGINAL at 35–44.
+        result = _assess(_explicit(40.0, lpi=0.4, w=12.0))
+        assert result.risk_level == ConvectiveRisk.MARGINAL
+
+    def test_single_substitute_is_one(self):
+        result = _assess(_explicit(40.0, lpi=0.0, w=12.0))
+        assert result.risk_level == ConvectiveRisk.MARGINAL
+
+    def test_missing_lpi_does_not_promote_beyond_present_but_quiet(self):
+        # Issue #466 note: an incomplete LPI channel must not silently promote w
+        # into counting beyond what a present-but-quiet LPI gives. The
+        # substitution is identical whether LPI is missing or present-and-quiet.
+        missing = _assess(_explicit(47.0, lpi=None, w=12.0))
+        quiet = _assess(_explicit(47.0, lpi=0.0, w=12.0))
+        assert missing.risk_level == quiet.risk_level == ConvectiveRisk.MODERATE
+
+    def test_masked_substitute_channel_contributes_nothing(self):
+        # LPI missing → substitution regime, but w is also masked (None): it
+        # cannot count (rule 5), so |C| = 0 → the 35–44 row does not fire.
+        # Contrast with the same case where w is present and over threshold.
+        masked = _assess(_explicit(40.0, lpi=None, w=None))
+        assert masked.risk_level == ConvectiveRisk.NONE
+        present = _assess(_explicit(40.0, lpi=None, w=12.0))
+        assert present.risk_level == ConvectiveRisk.MARGINAL
+
+
+class TestExplicitBrightBandGate:
+    """Bright-band gate: shallow echo top vs freezing level (#466/#467).
+
+    A melting-layer bright band reaches high column-max reflectivity with its
+    18 dBZ echo top only a few kft above the freezing level. With no
+    storm-process corroboration, that is suppressed to no-fire.
+    """
+
+    def _indices(self, freezing_ft=None, nwp_freezing_ft=None):
+        return ThermodynamicIndices(
+            freezing_level_ft=freezing_ft, nwp_freezing_level_ft=nwp_freezing_ft,
+        )
+
+    def test_shallow_uncorroborated_echo_suppressed(self):
+        # dbz 52, |C| = 0, echo top 15000 ft, freezing 8000 → Δ 7000 < 10000.
+        expl = _explicit(52.0, lpi=0.0, w=5.0,
+                         echo_top_ft=15000.0, echo_complete=True)
+        result = _assess(expl, self._indices(freezing_ft=8000.0))
+        assert result.risk_level == ConvectiveRisk.NONE
+        assert any("bright band" in s.lower() for s in result.suppressors)
+
+    def test_deep_echo_top_not_suppressed(self):
+        # Same |C| = 0 but a deep echo (32000 ft, Δ 24000) is real convection.
+        expl = _explicit(52.0, lpi=0.0, w=5.0,
+                         echo_top_ft=32000.0, echo_complete=True)
+        result = _assess(expl, self._indices(freezing_ft=8000.0))
+        assert result.risk_level == ConvectiveRisk.MODERATE
+
+    def test_gate_never_overrides_corroborated_cell(self):
+        # Shallow echo top but LPI fires (|C| = 2): the gate must not hide a
+        # corroborated cell (safety asymmetry).
+        expl = _explicit(52.0, lpi=6.0, echo_top_ft=15000.0, echo_complete=True)
+        result = _assess(expl, self._indices(freezing_ft=8000.0))
+        assert result.risk_level == ConvectiveRisk.HIGH
+
+    def test_incomplete_echo_top_does_not_suppress(self):
+        # echo_top_complete=False → the gate cannot be evaluated → no downgrade.
+        expl = _explicit(52.0, lpi=0.0, w=5.0,
+                         echo_top_ft=15000.0, echo_complete=False)
+        result = _assess(expl, self._indices(freezing_ft=8000.0))
+        assert result.risk_level == ConvectiveRisk.MODERATE
+
+    def test_missing_freezing_level_does_not_suppress(self):
+        # No freezing level anywhere → gate unevaluable → no downgrade.
+        expl = _explicit(52.0, lpi=0.0, w=5.0,
+                         echo_top_ft=15000.0, echo_complete=True)
+        result = _assess(expl, self._indices())
+        assert result.risk_level == ConvectiveRisk.MODERATE
+
+    def test_freezing_level_nwp_fallback(self):
+        # Freezing level only from the model-native field still gates.
+        expl = _explicit(52.0, lpi=0.0, w=5.0,
+                         echo_top_ft=15000.0, echo_complete=True)
+        result = _assess(expl, self._indices(nwp_freezing_ft=8000.0))
+        assert result.risk_level == ConvectiveRisk.NONE
+
+
+class TestExplicitValidationMatrix:
+    """The #467 forward-validation cases, both directions (§19 acceptance).
+
+    The recalibration must (a) stop false-alarming on the stratiform bright-band
+    control and (b) not lose the real convective hit.
+    """
+
+    def test_stratiform_bright_band_control_no_longer_high(self):
+        # #467 EDDE→EDQD, 2026-07-21: v1 graded HIGH at ≥50 dBZ with LPI ≈ 0,
+        # updraft ≤ 5.5 m/s, ML-CAPE ≤ 242, echo_top − freezing ≈ 6.5–7.8 kft.
+        # v2: |C| = 0 (LPI quiet, updraft below floor, graupel dead) caps the
+        # row at MODERATE, then the bright-band gate drops it to no-fire.
+        diag = NWPCloudDiagnostics(ml_cape_jkg=242.0)
+        expl = _explicit(52.0, lpi=0.4, w=5.0,
+                         echo_top_ft=14900.0, echo_complete=True)
+        result = _assess(expl, ThermodynamicIndices(freezing_level_ft=7900.0), diag)
+        assert result.risk_level == ConvectiveRisk.NONE
+
+    def test_real_convective_hit_stays_high(self):
+        # #467 ESMX→EKRK: 57 dBZ, LPI 89, updraft 23, echo_top − freezing ≈ 25 kft.
+        expl = _explicit(56.0, lpi=89.2, w=23.1, uh=-55.9,
+                         echo_top_ft=36000.0, echo_complete=True)
+        result = _assess(expl, ThermodynamicIndices(freezing_level_ft=11000.0))
+        assert result.risk_level == ConvectiveRisk.HIGH
+
+
 class TestExplicitStructuralSafety:
     def test_top_ft_always_none_echo_top_is_detail_only(self):
         # The 18 dBZ echo top must be structurally unreachable by the
@@ -165,9 +322,10 @@ class TestExplicitStructuralSafety:
     def test_no_cin_suppression_of_a_simulated_echo(self):
         # The model already convected — penalising the echo on CIN would be
         # circular (nwp_precip precedent). A strong cap must not pull HIGH down.
+        # (LPI ≥ 5 corroborates so the ≥50 row reaches HIGH under v2.)
         indices = ThermodynamicIndices(cin_surface_jkg=-400.0)
         diag = NWPCloudDiagnostics(ml_cin_jkg=-400.0)
-        result = _assess(_explicit(55.0), indices, diag)
+        result = _assess(_explicit(55.0, lpi=6.0, w=0.0), indices, diag)
         assert result.risk_level == ConvectiveRisk.HIGH
 
     def test_uh_is_narrative_only(self):
@@ -272,7 +430,8 @@ def _make_hourly(explicit=None) -> HourlyForecast:
 
 class TestAnalyzeSoundingWiring:
     def test_payload_presence_selects_explicit_track(self):
-        hourly = _make_hourly(_explicit(50.0))
+        # LPI ≥ 5 corroborates so a real ≥50 cell grades HIGH under v2.
+        hourly = _make_hourly(_explicit(50.0, lpi=6.0))
         result = analyze_sounding_lite(hourly.pressure_levels, hourly, model_key="icon")
         assert result is not None
         assert result.convective_nwp is not None


### PR DESCRIPTION
## What & why

Implements the 2026-07-21 amendment (#466/#467) to the explicit convective firing/severity table. The v1 table shipped as calibration starting points requiring validation; the #467 forward validation revealed two coupled issues:

1. **Corroborator algebra triple-counts the mixed-phase updraft.** DWD's LPI already integrates `∫ ε w² dz` weighted by graupel/ice content, so counting `lpi_max + w_ctmax + grau_gsp` as three independent votes counts one signal three times. This let moderately-electrified (or bright-band) cells reach |C| ≥ 2 on physically one process. Additionally, CAPE is *environment* (duplicates the independent thermo track), not storm process — it let a 35–44 dBZ stratiform band upgrade to MARGINAL on ML-CAPE alone.

2. **The ≥ 50 dBZ row bypasses corroboration entirely.** `dbz_ctmax` is a column max, and a strong melting-layer bright band in heavy stratiform rain reaches 50+ dBZ with no convection in the column. The #467 live validation (EDDE→EDQD, 2026-07-21) false-alarmed HIGH at 4 of 8 route points in widespread stratiform rain — 50–54 dBZ with LPI ≈ 0, updraft ≤ 5.5 m/s, ML-CAPE ≤ 242 J/kg.

### Changes

**A. LPI-primary corroborator algebra** (`_explicit_corroborators`):
- LPI is now the primary channel. When present (complete), it votes alone: `≥ 5` → 2, `≥ 1` → 1.
- `w_ctmax` and `grau_gsp` become *narrative detail, not additive* — they are the ingredients LPI already integrates.
- w / graupel substitute only when LPI does not vote (missing or below floor). Each counts only when its own channel is complete-and-over-threshold.
- CAPE and UH are narrative-only, never votes.

**B. ≥ 50 dBZ no longer self-certifies.** |C| = 0 now caps the row at MODERATE (was HIGH); |C| ≥ 1 restores HIGH.

**C. Bright-band gate** (`assess_convective_explicit`): When the 18 dBZ echo top sits < 10,000 ft above the freezing level *and* |C| = 0, the high reflectivity is treated as melting-layer bright band, not convection, and suppressed to NONE. Physically a bright band sits at the melting layer (echo top only a few kft above 0 °C), whereas a real convective core carries hydrometeors far higher. #467 measured cleanly: 6.5–7.8 kft in the stratiform control vs 24–27 kft in real storms.

The v2 decision table:

| Corridor dbz_ctmax | \|C\| = 0 | \|C\| = 1 | \|C\| ≥ 2 |
|---|---|---|---|
| < 35 dBZ | no fire | no fire | no fire |
| 35–44 dBZ | no fire (stratiform note) | MARGINAL | MODERATE |
| 45–49 dBZ | MODERATE | MODERATE | HIGH |
| ≥ 50 dBZ | **MODERATE** | HIGH | HIGH |

Under B+C the EDDE→EDQD false-alarm points go HIGH → MODERATE (table) → NONE (gate); the ESMX real hit (LPI 89, updraft 23, Δ ≈ 25 kft) stays HIGH.

## Issue linkage

Closes #466
Closes #467

## Testing / verification

Added comprehensive test coverage:
-

https://claude.ai/code/session_01EpLHD1Xv73AZn89PfxHT7b