### PR TITLE
iOS: Current Observations section (METAR/TAF/model comparison) with responsive axis toggle + phone row cap

### DIFF
--- a/app/flyfun-weather/flyfun-weather/Models/API/SnapshotResponse.swift
+++ b/app/flyfun-weather/flyfun-weather/Models/API/SnapshotResponse.swift
@@ -86,8 +86,14 @@ struct RouteObservations: Codable, Sendable {
 
     /// Comparisons keyed by ICAO — the table joins each airport row to its
     /// model reconciliation.
+    ///
+    /// `uniquingKeysWith` rather than `uniqueKeysWithValues`: this is
+    /// server-derived JSON, and the trapping initializer would `fatalError` on a
+    /// duplicate ICAO — crashing the briefing screen over a malformed payload
+    /// instead of degrading. First entry wins, matching `HelpCatalogResponse`,
+    /// `SkewTVariableCatalog` and `TimingScenariosView`.
     var comparisonsByIcao: [String: ObservationComparison] {
-        Dictionary(uniqueKeysWithValues: (comparisons ?? []).map { ($0.icao, $0) })
+        Dictionary((comparisons ?? []).map { ($0.icao, $0) }, uniquingKeysWith: { first, _ in first })
     }
 
     /// Airports that actually reported something. The web filters the table the

--- a/app/flyfun-weather/flyfun-weather/Models/API/SnapshotResponse.swift
+++ b/app/flyfun-weather/flyfun-weather/Models/API/SnapshotResponse.swift
@@ -93,8 +93,39 @@ struct RouteObservations: Codable, Sendable {
     /// Airports that actually reported something. The web filters the table the
     /// same way (`apt.has_metar || apt.has_taf`) — a spatial query can return
     /// small GA fields with no data at all.
+    ///
+    /// Server order is along-route (by enroute distance), which is the useful
+    /// reading order; everything downstream preserves it.
     var reportingAirports: [AirportObservation] {
         (airports ?? []).filter { $0.hasMetar == true || $0.hasTaf == true }
+    }
+
+    /// The subset a phone-width table shows before "Show all": the `limit`
+    /// airports nearest the route, **plus** any airport whose model comparison
+    /// is CONFLICTING — the conflict banner must never point at a row the cap
+    /// hid. Returned in route order, not distance order, so the table still
+    /// reads departure→destination.
+    ///
+    /// A 30 nm corridor on a long route routinely reports 30+ fields, which is a
+    /// reasonable table in a browser window but a very long scroll inside the
+    /// iOS Advisory tab.
+    func nearestReportingAirports(limit: Int) -> [AirportObservation] {
+        let reporting = reportingAirports
+        guard limit > 0, reporting.count > limit else { return reporting }
+
+        // Missing distance sorts last rather than winning the "nearest" race.
+        let byDistance = reporting.sorted {
+            ($0.distanceFromRouteNm ?? .greatestFiniteMagnitude)
+                < ($1.distanceFromRouteNm ?? .greatestFiniteMagnitude)
+        }
+        var keep = Set(byDistance.prefix(limit).map(\.icao))
+
+        let conflicting = comparisonsByIcao
+            .filter { $0.value.categoryMatch == "CONFLICTING" || $0.value.windAdvisoryMatch == "CONFLICTING" }
+            .keys
+        keep.formUnion(conflicting)
+
+        return reporting.filter { keep.contains($0.icao) }
     }
 }
 

--- a/app/flyfun-weather/flyfun-weather/Models/API/SnapshotResponse.swift
+++ b/app/flyfun-weather/flyfun-weather/Models/API/SnapshotResponse.swift
@@ -62,28 +62,110 @@ struct ThermodynamicIndicesSummary: Codable, Sendable {
     let nwpCeilingFt: Double?
 }
 
+/// D-0 METAR/TAF observations along the route, plus the obs-vs-model
+/// reconciliation. Mirrors `models/observations.py::RouteObservations`
+/// (source of truth) and the web's `renderRouteObservations`.
+///
+/// Only populated when `days_out == 0` — European TAFs rarely cover the next
+/// day, so the pipeline skips the fetch entirely on D-1+.
+///
+/// SYNC: `web/ts/managers/briefing-ui.ts` (`renderRouteObservations`) renders
+/// the same shape; `src/weatherbrief/models/observations.py` defines it.
 struct RouteObservations: Codable, Sendable {
     let corridorNm: Double?
     let fetchTime: String?
+    let airportsFound: Int?
+    let airportsWithMetar: Int?
+    let airportsWithTaf: Int?
     let airports: [AirportObservation]?
+    let comparisons: [ObservationComparison]?
     let worstMetarCategory: String?
     let worstTafCategory: String?
+    let hasConflicts: Bool?
+    let phenomenaAlongRoute: [String]?
+
+    /// Comparisons keyed by ICAO — the table joins each airport row to its
+    /// model reconciliation.
+    var comparisonsByIcao: [String: ObservationComparison] {
+        Dictionary(uniqueKeysWithValues: (comparisons ?? []).map { ($0.icao, $0) })
+    }
+
+    /// Airports that actually reported something. The web filters the table the
+    /// same way (`apt.has_metar || apt.has_taf`) — a spatial query can return
+    /// small GA fields with no data at all.
+    var reportingAirports: [AirportObservation] {
+        (airports ?? []).filter { $0.hasMetar == true || $0.hasTaf == true }
+    }
 }
 
 struct AirportObservation: Codable, Identifiable, Sendable {
     let icao: String
     let name: String?
     let distanceFromRouteNm: Double?
+    let enrouteDistanceNm: Double?
+    let nearestWaypointIcao: String?
+
+    // METAR
     let metarRaw: String?
+    let metarTime: String?
     let metarFlightCategory: String?
     let metarCeilingFt: Int?
+    let metarVisibilityM: Int?
+    let metarWindDir: Int?
     let metarWindSpeedKt: Int?
     let metarWindGustKt: Int?
     let metarWeather: [String]?
     let metarTemperatureC: Int?
     let metarDewpointC: Int?
+    let metarQnh: Double?
+
+    // TAF
     let tafRaw: String?
     let tafFlightCategoryAtEta: String?
+    let tafTrendType: String?
+    let tafWindDir: Int?
+    let tafWindSpeedKt: Int?
+    let tafWindGustKt: Int?
+    let tafApplicableText: String?
+    /// Line indices of the base forecast + the BECMG/TEMPO groups active at the
+    /// ETA — used to highlight the applicable lines in the raw TAF.
+    let tafApplicableLines: [Int]?
+
+    // Runway wind advisories — lowercase "green"/"amber"/"red"
+    let metarWindAdvisory: String?
+    let metarBestRunwayId: String?
+    let metarCrosswindKt: Double?
+    let metarHeadwindKt: Double?
+    let tafWindAdvisory: String?
+    let tafBestRunwayId: String?
+    let tafCrosswindKt: Double?
+    let tafHeadwindKt: Double?
+
+    let hasMetar: Bool?
+    let hasTaf: Bool?
+    /// Rounded hours after departure that the flight passes this airport.
+    let etaHourOffset: Int?
 
     var id: String { icao }
+}
+
+/// One airport's observation-vs-model reconciliation.
+/// Mirrors `models/observations.py::ObservationComparison`.
+struct ObservationComparison: Codable, Sendable {
+    let icao: String
+    let obsCategory: String?
+    let modelCategory: String?
+    /// "CONFIRMING" / "SIGNIFICANT" / "CONFLICTING".
+    let categoryMatch: String?
+    let ceilingDeltaFt: Int?
+    let visibilityDeltaM: Double?
+    let windSpeedDeltaKt: Double?
+    let modelWindDir: Double?
+    let modelWindSpeedKt: Double?
+    let modelWindGustKt: Double?
+    let modelWindAdvisory: String?
+    let modelBestRunwayId: String?
+    let modelCrosswindKt: Double?
+    let windAdvisoryMatch: String?
+    let detail: String?
 }

--- a/app/flyfun-weather/flyfun-weather/Services/FixtureBriefingData.swift
+++ b/app/flyfun-weather/flyfun-weather/Services/FixtureBriefingData.swift
@@ -359,24 +359,99 @@ enum FixtureBriefingData {
       "route_observations": {
         "corridor_nm": 15.0,
         "fetch_time": "2099-06-30T05:50:00Z",
-        "worst_metar_category": "VFR",
-        "worst_taf_category": "MVFR",
+        "airports_found": 3,
+        "airports_with_metar": 3,
+        "airports_with_taf": 3,
+        "worst_metar_category": "IFR",
+        "worst_taf_category": "IFR",
+        "has_conflicts": true,
+        "phenomena_along_route": ["TSRA", "BR"],
         "airports": [
           {
             "icao": "LFMD", "name": "Cannes-Mandelieu", "distance_from_route_nm": 0.0,
+            "enroute_distance_nm": 0.0, "nearest_waypoint_icao": "LFMD",
             "metar_raw": "LFMD 300550Z 20008KT 9999 FEW045 SCT090 21/15 Q1016",
-            "metar_flight_category": "VFR", "metar_ceiling_ft": 9000, "metar_wind_speed_kt": 8,
+            "metar_time": "2099-06-30T05:50:00Z",
+            "metar_flight_category": "VFR", "metar_ceiling_ft": 9000, "metar_visibility_m": 9999,
+            "metar_wind_dir": 200, "metar_wind_speed_kt": 8,
             "metar_wind_gust_kt": null, "metar_weather": [], "metar_temperature_c": 21, "metar_dewpoint_c": 15,
-            "taf_raw": "LFMD 300500Z 3006/3018 20010KT 9999 SCT040 TEMPO 3012/3016 VRB15G25KT 4000 TSRA BKN030CB",
-            "taf_flight_category_at_eta": "MVFR"
+            "metar_qnh": 1016.0,
+            "taf_raw": "LFMD 300500Z 3006/3018 20010KT 9999 SCT040\\nTEMPO 3012/3016 VRB15G25KT 4000 TSRA BKN030CB",
+            "taf_flight_category_at_eta": "MVFR", "taf_trend_type": "TEMPO",
+            "taf_wind_dir": 200, "taf_wind_speed_kt": 10, "taf_wind_gust_kt": null,
+            "taf_applicable_lines": [0, 1],
+            "metar_wind_advisory": "green", "metar_best_runway_id": "17", "metar_crosswind_kt": 3.0,
+            "metar_headwind_kt": 7.4,
+            "taf_wind_advisory": "green", "taf_best_runway_id": "17", "taf_crosswind_kt": 4.0,
+            "taf_headwind_kt": 9.2,
+            "has_metar": true, "has_taf": true, "eta_hour_offset": 0
           },
           {
             "icao": "LFML", "name": "Marseille Provence", "distance_from_route_nm": 2.0,
+            "enroute_distance_nm": 78.0, "nearest_waypoint_icao": "LFML",
             "metar_raw": "LFML 300600Z 30012G18KT 9999 BKN038 20/13 Q1017",
-            "metar_flight_category": "VFR", "metar_ceiling_ft": 3800, "metar_wind_speed_kt": 12,
+            "metar_time": "2099-06-30T06:00:00Z",
+            "metar_flight_category": "VFR", "metar_ceiling_ft": 3800, "metar_visibility_m": 9999,
+            "metar_wind_dir": 300, "metar_wind_speed_kt": 12,
             "metar_wind_gust_kt": 18, "metar_weather": [], "metar_temperature_c": 20, "metar_dewpoint_c": 13,
+            "metar_qnh": 1017.0,
             "taf_raw": "LFML 300500Z 3006/3018 30012KT 9999 BKN035",
-            "taf_flight_category_at_eta": "VFR"
+            "taf_flight_category_at_eta": "VFR", "taf_trend_type": null,
+            "taf_wind_dir": 300, "taf_wind_speed_kt": 12, "taf_wind_gust_kt": null,
+            "taf_applicable_lines": [0],
+            "metar_wind_advisory": "amber", "metar_best_runway_id": "31L", "metar_crosswind_kt": 11.0,
+            "metar_headwind_kt": 4.8,
+            "taf_wind_advisory": "green", "taf_best_runway_id": "31L", "taf_crosswind_kt": 6.0,
+            "taf_headwind_kt": 10.4,
+            "has_metar": true, "has_taf": true, "eta_hour_offset": 1
+          },
+          {
+            "icao": "LFTH", "name": "Toulon-Hyeres", "distance_from_route_nm": 11.0,
+            "enroute_distance_nm": 41.0, "nearest_waypoint_icao": "LFTH",
+            "metar_raw": "LFTH 300600Z 09018G28KT 2500 BR OVC008 17/16 Q1015",
+            "metar_time": "2099-06-30T06:00:00Z",
+            "metar_flight_category": "IFR", "metar_ceiling_ft": 800, "metar_visibility_m": 2500,
+            "metar_wind_dir": 90, "metar_wind_speed_kt": 18,
+            "metar_wind_gust_kt": 28, "metar_weather": ["BR"], "metar_temperature_c": 17, "metar_dewpoint_c": 16,
+            "metar_qnh": 1015.0,
+            "taf_raw": "LFTH 300500Z 3006/3018 09018G28KT 3000 BR OVC010\\nBECMG 3009/3011 09012KT 9999 SCT025",
+            "taf_flight_category_at_eta": "IFR", "taf_trend_type": "BECMG",
+            "taf_wind_dir": 90, "taf_wind_speed_kt": 18, "taf_wind_gust_kt": 28,
+            "taf_applicable_lines": [0],
+            "metar_wind_advisory": "red", "metar_best_runway_id": "05", "metar_crosswind_kt": 17.0,
+            "metar_headwind_kt": 6.1,
+            "taf_wind_advisory": "red", "taf_best_runway_id": "05", "taf_crosswind_kt": 17.0,
+            "taf_headwind_kt": 6.1,
+            "has_metar": true, "has_taf": true, "eta_hour_offset": 1
+          }
+        ],
+        "comparisons": [
+          {
+            "icao": "LFMD", "obs_category": "VFR", "model_category": "VFR",
+            "category_match": "CONFIRMING",
+            "ceiling_delta_ft": -400, "visibility_delta_m": 0.0, "wind_speed_delta_kt": 1.0,
+            "model_wind_dir": 205.0, "model_wind_speed_kt": 9.0, "model_wind_gust_kt": null,
+            "model_wind_advisory": "green", "model_best_runway_id": "17", "model_crosswind_kt": 4.0,
+            "wind_advisory_match": "CONFIRMING",
+            "detail": "Model agrees with the observation."
+          },
+          {
+            "icao": "LFML", "obs_category": "VFR", "model_category": "MVFR",
+            "category_match": "SIGNIFICANT",
+            "ceiling_delta_ft": 900, "visibility_delta_m": -1500.0, "wind_speed_delta_kt": -2.0,
+            "model_wind_dir": 295.0, "model_wind_speed_kt": 10.0, "model_wind_gust_kt": null,
+            "model_wind_advisory": "green", "model_best_runway_id": "31L", "model_crosswind_kt": 5.0,
+            "wind_advisory_match": "SIGNIFICANT",
+            "detail": "Model is one category more pessimistic than the METAR (ceiling 2900ft vs 3800ft observed)."
+          },
+          {
+            "icao": "LFTH", "obs_category": "IFR", "model_category": "VFR",
+            "category_match": "CONFLICTING",
+            "ceiling_delta_ft": 3200, "visibility_delta_m": 7499.0, "wind_speed_delta_kt": -8.0,
+            "model_wind_dir": 100.0, "model_wind_speed_kt": 10.0, "model_wind_gust_kt": null,
+            "model_wind_advisory": "amber", "model_best_runway_id": "05", "model_crosswind_kt": 9.0,
+            "wind_advisory_match": "CONFLICTING",
+            "detail": "Model shows VFR but the METAR reports OVC008 in mist — the model is missing a shallow coastal stratus/fog layer."
           }
         ]
       }

--- a/app/flyfun-weather/flyfun-weather/Views/Briefing/AdvisoryTabView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Briefing/AdvisoryTabView.swift
@@ -3,8 +3,9 @@ import SwiftUI
 /// The **Advisory** tab (#310): the read-me-first surface. A prominent accented
 /// hero (traffic-light + assessment reason) pinned at the top, then watch chips,
 /// a responsive advisory grid (AMBER/RED as cards, GREEN collapsed into one
-/// all-clear strip), current airport conditions, and — on marginal D-0/D-2
-/// packs — weather alternates. A sticky scroll-spy bar jumps between sections.
+/// all-clear strip), current airport conditions, — on D-0 — the METAR/TAF
+/// observations comparison, and — on marginal D-0/D-2 packs — weather
+/// alternates. A sticky scroll-spy bar jumps between sections.
 struct AdvisoryTabView: View {
     let viewModel: BriefingViewModel
     @Environment(AppState.self) private var appState
@@ -25,6 +26,10 @@ struct AdvisoryTabView: View {
                     .spyAnchor("advisories")
                 AirportConditionsView(viewModel: viewModel)
                     .spyAnchor("conditions")
+                if hasObservations {
+                    RouteObservationsView(viewModel: viewModel)
+                        .spyAnchor("observations")
+                }
                 if hasAlternates {
                     AlternatesView(viewModel: viewModel)
                         .spyAnchor("alternates")
@@ -128,6 +133,17 @@ struct AdvisoryTabView: View {
         return false
     }
 
+    /// D-0 METAR/TAF observations (#492). Gated on an airport actually having
+    /// reported — the same filter the section's table applies — so the scroll-spy
+    /// never offers an anchor that renders empty.
+    private var hasObservations: Bool {
+        if case .loaded(let snapshot) = viewModel.snapshotState,
+           let obs = snapshot.routeObservations {
+            return !obs.reportingAirports.isEmpty
+        }
+        return false
+    }
+
     private var hasWatchItems: Bool {
         if case .loaded(let digest) = viewModel.digestState { return !digest.watchItemsList.isEmpty }
         return false
@@ -144,6 +160,7 @@ struct AdvisoryTabView: View {
         var sections = [SpySection("hero", "Summary")]
         sections.append(SpySection("advisories", "Advisories"))
         sections.append(SpySection("conditions", "Conditions"))
+        if hasObservations { sections.append(SpySection("observations", "Observations")) }
         if hasAlternates { sections.append(SpySection("alternates", "Alternates")) }
         if hasTimingScenarios { sections.append(SpySection("timing", "Timing")) }
         if hasWatchItems { sections.append(SpySection("watch", "Watch")) }

--- a/app/flyfun-weather/flyfun-weather/Views/Briefing/RouteObservationsView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Briefing/RouteObservationsView.swift
@@ -20,10 +20,19 @@ struct RouteObservationsView: View {
     @Environment(\.horizontalSizeClass) private var sizeClass
     @State private var axis: ObservationAxis = .condition
     @State private var detail: AirportObservation?
+    @State private var showsAllAirports = false
+
+    /// How many airports a phone shows before "Show all".
+    private static let compactRowCap = 10
+
+    /// iPad-class width. Drives two decisions that are independent but happen to
+    /// share the same trigger: rendering both comparison groups side-by-side, and
+    /// listing every reporting airport instead of the nearest few.
+    private var isRegularWidth: Bool { sizeClass == .regular }
 
     /// iPad-class width shows both comparison groups at once, so the axis
     /// switcher would have nothing to do and is hidden.
-    private var showsBothAxes: Bool { sizeClass == .regular }
+    private var showsBothAxes: Bool { isRegularWidth }
 
     private var observations: RouteObservations? {
         if case .loaded(let snapshot) = viewModel.snapshotState { return snapshot.routeObservations }
@@ -166,7 +175,7 @@ struct RouteObservationsView: View {
                         }
                     }
                     Divider().gridCellUnsizedAxes(.horizontal).gridCellColumns(gridColumnCount)
-                    ForEach(obs.reportingAirports) { apt in
+                    ForEach(displayedAirports(obs)) { apt in
                         row(apt, comparison: obs.comparisonsByIcao[apt.icao])
                     }
                 }
@@ -174,7 +183,41 @@ struct RouteObservationsView: View {
             }
             .scrollBounceBehavior(.basedOnSize, axes: .horizontal)
 
+            showAllToggle(obs)
             legend
+        }
+    }
+
+    /// Rows to render: every reporting airport on iPad or once expanded, else the
+    /// nearest few (see `nearestReportingAirports`).
+    private func displayedAirports(_ obs: RouteObservations) -> [AirportObservation] {
+        guard !isRegularWidth, !showsAllAirports else { return obs.reportingAirports }
+        return obs.nearestReportingAirports(limit: Self.compactRowCap)
+    }
+
+    /// Expand/collapse control, shown only when the cap is actually hiding rows.
+    @ViewBuilder
+    private func showAllToggle(_ obs: RouteObservations) -> some View {
+        let total = obs.reportingAirports.count
+        let shown = displayedAirports(obs).count
+        if !isRegularWidth, total > shown || showsAllAirports {
+            Button {
+                withAnimation { showsAllAirports.toggle() }
+            } label: {
+                HStack(spacing: Theme.spacingXS) {
+                    Image(systemName: showsAllAirports ? "chevron.up" : "chevron.down")
+                        .font(.caption2)
+                    // "Show fewer" rather than "Show nearest 10": a pinned
+                    // CONFLICTING airport can push the collapsed count above the
+                    // cap, so naming the number here would sometimes lie.
+                    Text(showsAllAirports ? "Show fewer" : "Show all \(total) airports")
+                }
+                .font(.caption.weight(.medium))
+                .foregroundStyle(Theme.primary)
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityIdentifier("observationsShowAll")
         }
     }
 
@@ -252,9 +295,9 @@ struct RouteObservationsView: View {
             ForEach(visibleAxes) { a in
                 switch a {
                 case .condition:
-                    FlightCategoryBadge(category: apt.metarFlightCategory ?? "—").cell(highlighted: conflicting)
-                    FlightCategoryBadge(category: apt.tafFlightCategoryAtEta ?? "—").cell(highlighted: conflicting)
-                    FlightCategoryBadge(category: comparison?.modelCategory ?? "—").cell(highlighted: conflicting)
+                    categoryCell(apt.metarFlightCategory, highlighted: conflicting)
+                    categoryCell(apt.tafFlightCategoryAtEta, highlighted: conflicting)
+                    categoryCell(comparison?.modelCategory, highlighted: conflicting)
                     AgreementIcon(match: comparison?.categoryMatch).cell(highlighted: conflicting)
                 case .wind:
                     WindAdvisoryBadge(status: apt.metarWindAdvisory, crosswindKt: apt.metarCrosswindKt)
@@ -266,6 +309,22 @@ struct RouteObservationsView: View {
                     AgreementIcon(match: comparison?.windAdvisoryMatch).cell(highlighted: conflicting)
                 }
             }
+        }
+    }
+
+    /// A flight-category cell. Absent data renders as plain muted text, not a
+    /// filled badge — a grey capsule carries the same visual weight as a real
+    /// category and reads as if "—" were itself a rating. Matches how
+    /// `WindAdvisoryBadge` treats a missing advisory.
+    @ViewBuilder
+    private func categoryCell(_ category: String?, highlighted: Bool) -> some View {
+        if let category, !category.isEmpty {
+            FlightCategoryBadge(category: category).cell(highlighted: highlighted)
+        } else {
+            Text("—")
+                .font(.caption2)
+                .foregroundStyle(Theme.textMuted)
+                .cell(highlighted: highlighted)
         }
     }
 

--- a/app/flyfun-weather/flyfun-weather/Views/Briefing/RouteObservationsView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Briefing/RouteObservationsView.swift
@@ -147,6 +147,10 @@ struct RouteObservationsView: View {
     /// the row already fits, which is the common case.
     @ViewBuilder
     private func table(_ obs: RouteObservations) -> some View {
+        // Build the ICAO lookup once per render. `comparisonsByIcao` is a computed
+        // property, so reading it inside the row `ForEach` rebuilt the whole
+        // dictionary for every row — 29 builds per pass on a real corridor.
+        let comparisons = obs.comparisonsByIcao
         VStack(alignment: .leading, spacing: Theme.spacingXS) {
             ScrollView(.horizontal) {
                 // `horizontalSpacing: 0` with per-cell padding instead of grid
@@ -176,7 +180,7 @@ struct RouteObservationsView: View {
                     }
                     Divider().gridCellUnsizedAxes(.horizontal).gridCellColumns(gridColumnCount)
                     ForEach(displayedAirports(obs)) { apt in
-                        row(apt, comparison: obs.comparisonsByIcao[apt.icao])
+                        row(apt, comparison: comparisons[apt.icao])
                     }
                 }
                 .padding(.vertical, Theme.spacingXS)

--- a/app/flyfun-weather/flyfun-weather/Views/Briefing/RouteObservationsView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Briefing/RouteObservationsView.swift
@@ -1,0 +1,586 @@
+import SwiftUI
+
+/// **Current Observations** (#492) — D-0 METAR/TAF along the route reconciled
+/// against the model, sitting between Conditions and Alternates. Mirrors the
+/// web's `renderRouteObservations` (`web/ts/managers/briefing-ui.ts`).
+///
+/// The web table is 11 columns: ICAO/Dist/ETA plus a 4-column **Condition**
+/// group and a 4-column **Wind** group. That is too wide for a phone, so the
+/// two groups become a switchable axis in compact width and render side-by-side
+/// in regular width — the same size-class split `RouteMapView` uses for its
+/// dual-metric layout.
+///
+/// Rendered only when `route_observations` is present, which the pipeline
+/// populates on D-0 only.
+///
+/// SYNC: `web/ts/managers/briefing-ui.ts::renderRouteObservations`.
+struct RouteObservationsView: View {
+    let viewModel: BriefingViewModel
+
+    @Environment(\.horizontalSizeClass) private var sizeClass
+    @State private var axis: ObservationAxis = .condition
+    @State private var detail: AirportObservation?
+
+    /// iPad-class width shows both comparison groups at once, so the axis
+    /// switcher would have nothing to do and is hidden.
+    private var showsBothAxes: Bool { sizeClass == .regular }
+
+    private var observations: RouteObservations? {
+        if case .loaded(let snapshot) = viewModel.snapshotState { return snapshot.routeObservations }
+        return nil
+    }
+
+    var body: some View {
+        if let obs = observations, !obs.reportingAirports.isEmpty {
+            VStack(alignment: .leading, spacing: Theme.spacingM) {
+                header(obs)
+                summary(obs)
+                if obs.hasConflicts == true {
+                    conflictBanner
+                }
+                if !showsBothAxes {
+                    axisPicker
+                }
+                table(obs)
+            }
+            .padding(.horizontal, Theme.cardPadding)
+            .accessibilityIdentifier("observationsSection")
+            .sheet(item: $detail) { apt in
+                ObservationDetailSheet(
+                    airport: apt,
+                    comparison: obs.comparisonsByIcao[apt.icao]
+                )
+            }
+        }
+    }
+
+    // MARK: Header + summary
+
+    @ViewBuilder
+    private func header(_ obs: RouteObservations) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: Theme.spacingS) {
+            Text("Current Observations")
+                .font(.headline)
+                .foregroundStyle(Theme.text)
+            Spacer(minLength: 0)
+            if let fetched = obs.fetchTime, let label = Self.zuluTime(fetched) {
+                Text("Fetched \(label)")
+                    .font(.caption2)
+                    .foregroundStyle(Theme.textMuted)
+            }
+        }
+    }
+
+    /// Coverage line: how many airports reported, the corridor width, the worst
+    /// observed category, and any phenomena seen along the route.
+    @ViewBuilder
+    private func summary(_ obs: RouteObservations) -> some View {
+        VStack(alignment: .leading, spacing: Theme.spacingXS) {
+            HStack(spacing: Theme.spacingS) {
+                Text(coverageText(obs))
+                    .font(.caption)
+                    .foregroundStyle(Theme.textMuted)
+                if let worst = obs.worstMetarCategory {
+                    Text("Worst")
+                        .font(.caption2)
+                        .foregroundStyle(Theme.textMuted)
+                    FlightCategoryBadge(category: worst)
+                }
+                Spacer(minLength: 0)
+            }
+            if let phenomena = obs.phenomenaAlongRoute, !phenomena.isEmpty {
+                Label(phenomena.joined(separator: ", "), systemImage: "cloud.bolt.rain")
+                    .font(.caption)
+                    .foregroundStyle(Theme.amber)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+
+    private func coverageText(_ obs: RouteObservations) -> String {
+        var parts: [String] = []
+        if let m = obs.airportsWithMetar { parts.append("\(m) METAR") }
+        if let t = obs.airportsWithTaf { parts.append("\(t) TAF") }
+        if let c = obs.corridorNm { parts.append("\(Int(c.rounded()))nm corridor") }
+        return parts.joined(separator: " · ")
+    }
+
+    private var conflictBanner: some View {
+        Label(
+            "Observations conflict with the model at one or more airports — the model may be misreading current conditions.",
+            systemImage: "exclamationmark.triangle.fill"
+        )
+        .font(.caption)
+        .foregroundStyle(Theme.amber)
+        .fixedSize(horizontal: false, vertical: true)
+        .padding(Theme.spacingS)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Theme.amber.opacity(0.12), in: RoundedRectangle(cornerRadius: 10))
+    }
+
+    // MARK: Axis switcher (compact width only)
+
+    private var axisPicker: some View {
+        Picker("Compare", selection: $axis) {
+            ForEach(ObservationAxis.allCases) { a in
+                Text(a.label).tag(a)
+            }
+        }
+        .pickerStyle(.segmented)
+        .frame(maxWidth: 260)
+        .accessibilityIdentifier("observationsAxisPicker")
+    }
+
+    // MARK: Table
+
+    /// Horizontally scrollable so a large Dynamic Type size degrades into a pan
+    /// rather than truncating badges. `.basedOnSize` suppresses the bounce when
+    /// the row already fits, which is the common case.
+    @ViewBuilder
+    private func table(_ obs: RouteObservations) -> some View {
+        VStack(alignment: .leading, spacing: Theme.spacingXS) {
+            ScrollView(.horizontal) {
+                // `horizontalSpacing: 0` with per-cell padding instead of grid
+                // spacing: a conflicting row is highlighted by shading its cells,
+                // and Grid applies a row background per cell — with spacing > 0
+                // that tiles into visible gaps rather than one continuous band.
+                Grid(alignment: .leading, horizontalSpacing: 0, verticalSpacing: Theme.spacingS) {
+                    if showsBothAxes {
+                        GridRow {
+                            Color.clear.frame(height: 0).gridCellColumns(3)
+                            groupHeader(ObservationAxis.condition.label).gridCellColumns(4)
+                            groupHeader(ObservationAxis.wind.label).gridCellColumns(4)
+                        }
+                    }
+                    GridRow {
+                        columnHeader("Airport")
+                        columnHeader("Dist")
+                        columnHeader("ETA")
+                        ForEach(visibleAxes) { _ in
+                            columnHeader("METAR")
+                            columnHeader("TAF")
+                            columnHeader("Model")
+                            // Agreement column — the icon is self-explanatory and
+                            // a header would only widen the row.
+                            Color.clear.frame(width: 1, height: 0)
+                        }
+                    }
+                    Divider().gridCellUnsizedAxes(.horizontal).gridCellColumns(gridColumnCount)
+                    ForEach(obs.reportingAirports) { apt in
+                        row(apt, comparison: obs.comparisonsByIcao[apt.icao])
+                    }
+                }
+                .padding(.vertical, Theme.spacingXS)
+            }
+            .scrollBounceBehavior(.basedOnSize, axes: .horizontal)
+
+            legend
+        }
+    }
+
+    /// What the cells mean. The Wind axis especially needs it: the cell is a bare
+    /// crosswind number, so without a unit and a colour key it reads as an
+    /// unlabelled score.
+    @ViewBuilder
+    private var legend: some View {
+        Text(legendText)
+            .font(.caption2)
+            .foregroundStyle(Theme.textMuted)
+            .fixedSize(horizontal: false, vertical: true)
+    }
+
+    private var legendText: String {
+        let condition = "Condition: flight category from the METAR, the TAF at ETA, and the model."
+        let wind = "Wind: crosswind (kt) on the best runway, coloured by wind advisory."
+        let agreement = "✓ agrees · ⚠ one category apart · ✗ conflicts."
+        if showsBothAxes { return "\(condition) \(wind) \(agreement)" }
+        return "\(axis == .condition ? condition : wind) \(agreement)"
+    }
+
+    /// Which comparison groups are drawn — both on iPad, the selected one on
+    /// iPhone.
+    private var visibleAxes: [ObservationAxis] {
+        showsBothAxes ? ObservationAxis.allCases : [axis]
+    }
+
+    private var gridColumnCount: Int { 3 + visibleAxes.count * 4 }
+
+    private func groupHeader(_ text: String) -> some View {
+        Text(text)
+            .font(.caption2.weight(.semibold))
+            .foregroundStyle(Theme.textMuted)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .cell()
+    }
+
+    private func columnHeader(_ text: String) -> some View {
+        Text(text)
+            .font(.caption2)
+            .foregroundStyle(Theme.textMuted)
+            .cell()
+    }
+
+    @ViewBuilder
+    private func row(_ apt: AirportObservation, comparison: ObservationComparison?) -> some View {
+        let conflicting = comparison?.categoryMatch == "CONFLICTING"
+        GridRow {
+            Button { detail = apt } label: {
+                HStack(spacing: Theme.spacingXS) {
+                    Text(apt.icao)
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(Theme.text)
+                    Image(systemName: "info.circle")
+                        .font(.caption2)
+                        .foregroundStyle(Theme.primary)
+                }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("\(apt.icao) details")
+            .cell(highlighted: conflicting)
+
+            Text(apt.distanceFromRouteNm.map { "\(Int($0.rounded()))nm" } ?? "—")
+                .font(.caption)
+                .foregroundStyle(Theme.textMuted)
+                .cell(highlighted: conflicting)
+
+            Text(apt.etaHourOffset.map { "+\($0)h" } ?? "—")
+                .font(.caption)
+                .foregroundStyle(Theme.textMuted)
+                .cell(highlighted: conflicting)
+
+            ForEach(visibleAxes) { a in
+                switch a {
+                case .condition:
+                    FlightCategoryBadge(category: apt.metarFlightCategory ?? "—").cell(highlighted: conflicting)
+                    FlightCategoryBadge(category: apt.tafFlightCategoryAtEta ?? "—").cell(highlighted: conflicting)
+                    FlightCategoryBadge(category: comparison?.modelCategory ?? "—").cell(highlighted: conflicting)
+                    AgreementIcon(match: comparison?.categoryMatch).cell(highlighted: conflicting)
+                case .wind:
+                    WindAdvisoryBadge(status: apt.metarWindAdvisory, crosswindKt: apt.metarCrosswindKt)
+                        .cell(highlighted: conflicting)
+                    WindAdvisoryBadge(status: apt.tafWindAdvisory, crosswindKt: apt.tafCrosswindKt)
+                        .cell(highlighted: conflicting)
+                    WindAdvisoryBadge(status: comparison?.modelWindAdvisory, crosswindKt: comparison?.modelCrosswindKt)
+                        .cell(highlighted: conflicting)
+                    AgreementIcon(match: comparison?.windAdvisoryMatch).cell(highlighted: conflicting)
+                }
+            }
+        }
+    }
+
+    /// "0550Z" from an ISO timestamp.
+    static func zuluTime(_ iso: String) -> String? {
+        guard let date = Date.parseISO8601(iso) else { return nil }
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = TimeZone(identifier: "UTC")!
+        let c = cal.dateComponents([.hour, .minute], from: date)
+        guard let h = c.hour, let m = c.minute else { return nil }
+        return String(format: "%02d%02dZ", h, m)
+    }
+}
+
+private extension View {
+    /// One table cell. The Grid runs at `horizontalSpacing: 0` so the gutter
+    /// lives *inside* the cell — that way a highlighted row's per-cell shading
+    /// tiles into one continuous band instead of a dashed line of blocks.
+    func cell(highlighted: Bool = false) -> some View {
+        self
+            .padding(.horizontal, Theme.spacingXS)
+            .padding(.vertical, 3)
+            // Fill the column the Grid assigns (not just the content width) so a
+            // highlighted row shades as one band; `gridColumnAlignment(.leading)`
+            // on the Grid keeps the content itself left-aligned.
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
+            .background(highlighted ? Theme.amber.opacity(0.12) : .clear)
+    }
+}
+
+/// The two comparison groups the web renders side-by-side.
+enum ObservationAxis: String, CaseIterable, Identifiable, Sendable {
+    case condition
+    case wind
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .condition: "Condition"
+        case .wind: "Wind"
+        }
+    }
+}
+
+// MARK: - Cell components
+
+/// CONFIRMING / SIGNIFICANT / CONFLICTING as a glyph, matching the web's
+/// ✓ / ⚠ / ✗ agreement column.
+struct AgreementIcon: View {
+    let match: String?
+
+    var body: some View {
+        switch match {
+        case "CONFIRMING":
+            Image(systemName: "checkmark").font(.caption2.bold()).foregroundStyle(Theme.green)
+                .accessibilityLabel("Model agrees")
+        case "SIGNIFICANT":
+            Image(systemName: "exclamationmark.triangle.fill").font(.caption2).foregroundStyle(Theme.amber)
+                .accessibilityLabel("One category apart")
+        case "CONFLICTING":
+            Image(systemName: "xmark").font(.caption2.bold()).foregroundStyle(Theme.red)
+                .accessibilityLabel("Model conflicts")
+        default:
+            Text("—").font(.caption2).foregroundStyle(Theme.textMuted)
+        }
+    }
+}
+
+/// Runway wind advisory as a status-coloured capsule. The web shows a bare
+/// G/A/R letter with the crosswind in a hover tooltip; touch has no hover, so
+/// the crosswind value *is* the label and the colour carries the status.
+struct WindAdvisoryBadge: View {
+    let status: String?
+    let crosswindKt: Double?
+
+    private var color: Color {
+        switch status?.lowercased() {
+        case "green": Theme.green
+        case "amber": Theme.amber
+        case "red": Theme.red
+        default: Theme.textMuted
+        }
+    }
+
+    var body: some View {
+        if status == nil {
+            Text("—").font(.caption2).foregroundStyle(Theme.textMuted)
+        } else {
+            Text(crosswindKt.map { "\(Int($0.rounded()))" } ?? "•")
+                .font(.caption2.weight(.semibold))
+                .foregroundStyle(.white)
+                .padding(.horizontal, 6)
+                .padding(.vertical, 2)
+                .background(color, in: Capsule())
+                .accessibilityLabel(accessibilityText)
+        }
+    }
+
+    private var accessibilityText: String {
+        let s = status?.lowercased() ?? "unknown"
+        guard let xw = crosswindKt else { return "Wind \(s)" }
+        return "Wind \(s), \(Int(xw.rounded())) knot crosswind"
+    }
+}
+
+// MARK: - Per-airport detail
+
+/// The web's ⓘ popup: raw METAR, raw TAF with the applicable lines highlighted,
+/// and the per-source wind breakdown.
+private struct ObservationDetailSheet: View {
+    let airport: AirportObservation
+    let comparison: ObservationComparison?
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: Theme.spacingM) {
+                    if let name = airport.name, !name.isEmpty {
+                        Text(name)
+                            .font(.subheadline)
+                            .foregroundStyle(Theme.textMuted)
+                    }
+
+                    metarBlock
+                    tafBlock
+                    windBlock
+
+                    if let detail = comparison?.detail, !detail.isEmpty {
+                        section("Model comparison") {
+                            Text(detail)
+                                .font(.caption)
+                                .foregroundStyle(Theme.text)
+                                .fixedSize(horizontal: false, vertical: true)
+                        }
+                    }
+                }
+                .padding(Theme.cardPadding)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .background(Theme.bg)
+            .navigationTitle(airport.icao)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") { dismiss() }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var metarBlock: some View {
+        section("METAR") {
+            if let raw = airport.metarRaw, !raw.isEmpty {
+                VStack(alignment: .leading, spacing: Theme.spacingXS) {
+                    Text(raw)
+                        .font(.system(.caption, design: .monospaced))
+                        .foregroundStyle(Theme.text)
+                        .textSelection(.enabled)
+                        .fixedSize(horizontal: false, vertical: true)
+                    if let cat = airport.metarFlightCategory {
+                        FlightCategoryBadge(category: cat)
+                    }
+                }
+            } else {
+                unavailable
+            }
+        }
+    }
+
+    /// TAF with the base line + the BECMG/TEMPO groups active at the ETA
+    /// emphasised, the same highlight the web applies from
+    /// `taf_applicable_lines`.
+    @ViewBuilder
+    private var tafBlock: some View {
+        section("TAF") {
+            if let raw = airport.tafRaw, !raw.isEmpty {
+                let applicable = Set(airport.tafApplicableLines ?? [])
+                let lines = raw.components(separatedBy: .newlines)
+                VStack(alignment: .leading, spacing: 2) {
+                    ForEach(Array(lines.enumerated()), id: \.offset) { index, line in
+                        Text(line)
+                            .font(.system(.caption, design: .monospaced))
+                            .foregroundStyle(applicable.contains(index) ? Theme.text : Theme.textMuted)
+                            .fontWeight(applicable.contains(index) ? .semibold : .regular)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(.horizontal, 4)
+                            .background(
+                                applicable.contains(index) ? Theme.primary.opacity(0.10) : .clear,
+                                in: RoundedRectangle(cornerRadius: 4)
+                            )
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                    if let cat = airport.tafFlightCategoryAtEta {
+                        HStack(spacing: Theme.spacingXS) {
+                            Text("At ETA")
+                                .font(.caption2)
+                                .foregroundStyle(Theme.textMuted)
+                            FlightCategoryBadge(category: cat)
+                            if let trend = airport.tafTrendType {
+                                Text(trend)
+                                    .font(.caption2)
+                                    .foregroundStyle(Theme.textMuted)
+                            }
+                        }
+                        .padding(.top, Theme.spacingXS)
+                    }
+                }
+            } else {
+                unavailable
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var windBlock: some View {
+        let rows = windRows
+        if !rows.isEmpty {
+            section("Runway wind") {
+                VStack(alignment: .leading, spacing: Theme.spacingXS) {
+                    ForEach(rows, id: \.source) { r in
+                        HStack(spacing: Theme.spacingS) {
+                            Text(r.source)
+                                .font(.caption2.weight(.semibold))
+                                .foregroundStyle(Theme.textMuted)
+                                .frame(width: 52, alignment: .leading)
+                            WindAdvisoryBadge(status: r.status, crosswindKt: r.crosswind)
+                            if let wind = r.wind {
+                                Text("\(wind)kt")
+                                    .font(.caption)
+                                    .foregroundStyle(Theme.text)
+                            }
+                            if let rwy = r.runway {
+                                Text("Rwy \(rwy)")
+                                    .font(.caption)
+                                    .foregroundStyle(Theme.textMuted)
+                            }
+                            if let xw = r.crosswind {
+                                Text("\(Int(xw.rounded()))kt xwind")
+                                    .font(.caption2)
+                                    .foregroundStyle(Theme.textMuted)
+                            }
+                            Spacer(minLength: 0)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private struct WindRow {
+        let source: String
+        let status: String?
+        let wind: String?
+        let runway: String?
+        let crosswind: Double?
+    }
+
+    private var windRows: [WindRow] {
+        var rows: [WindRow] = []
+        if airport.metarWindAdvisory != nil || airport.metarWindSpeedKt != nil {
+            rows.append(WindRow(
+                source: "METAR",
+                status: airport.metarWindAdvisory,
+                wind: WindFormat.wind(speed: airport.metarWindSpeedKt.map(Double.init),
+                                     dir: airport.metarWindDir.map(Double.init),
+                                     gust: airport.metarWindGustKt.map(Double.init)),
+                runway: airport.metarBestRunwayId,
+                crosswind: airport.metarCrosswindKt
+            ))
+        }
+        if airport.tafWindAdvisory != nil || airport.tafWindSpeedKt != nil {
+            rows.append(WindRow(
+                source: "TAF",
+                status: airport.tafWindAdvisory,
+                wind: WindFormat.wind(speed: airport.tafWindSpeedKt.map(Double.init),
+                                     dir: airport.tafWindDir.map(Double.init),
+                                     gust: airport.tafWindGustKt.map(Double.init)),
+                runway: airport.tafBestRunwayId,
+                crosswind: airport.tafCrosswindKt
+            ))
+        }
+        if let comparison, comparison.modelWindAdvisory != nil || comparison.modelWindSpeedKt != nil {
+            rows.append(WindRow(
+                source: "Model",
+                status: comparison.modelWindAdvisory,
+                wind: WindFormat.wind(speed: comparison.modelWindSpeedKt,
+                                     dir: comparison.modelWindDir,
+                                     gust: comparison.modelWindGustKt),
+                runway: comparison.modelBestRunwayId,
+                crosswind: comparison.modelCrosswindKt
+            ))
+        }
+        return rows
+    }
+
+    private var unavailable: some View {
+        Text("Not available")
+            .font(.caption)
+            .foregroundStyle(Theme.textMuted)
+    }
+
+    @ViewBuilder
+    private func section(_ title: String, @ViewBuilder content: () -> some View) -> some View {
+        VStack(alignment: .leading, spacing: Theme.spacingXS) {
+            Text(title)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(Theme.textMuted)
+            content()
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(Theme.spacingS)
+        .background(Theme.surface, in: RoundedRectangle(cornerRadius: 10))
+        .overlay(RoundedRectangle(cornerRadius: 10).stroke(Theme.border, lineWidth: 0.5))
+    }
+}

--- a/app/flyfun-weather/flyfun-weatherTests/RouteObservationsTests.swift
+++ b/app/flyfun-weather/flyfun-weatherTests/RouteObservationsTests.swift
@@ -209,6 +209,107 @@ import Foundation
     }
 }
 
+// MARK: - Phone row cap (nearest-N + "Show all")
+
+@Suite struct RouteObservationsCapTests {
+
+    /// Build observations from `(icao, distanceNm)` pairs in route order, with an
+    /// optional set of CONFLICTING comparisons.
+    private func observations(
+        _ airports: [(String, Double?)],
+        conflicting: Set<String> = [],
+        silent: Set<String> = []
+    ) throws -> RouteObservations {
+        let aptJSON = airports.map { icao, dist -> String in
+            let d = dist.map { "\($0)" } ?? "null"
+            let reports = silent.contains(icao) ? "false" : "true"
+            return """
+            { "icao": "\(icao)", "distance_from_route_nm": \(d),
+              "metar_weather": [], "has_metar": \(reports), "has_taf": false }
+            """
+        }.joined(separator: ",")
+        let compJSON = airports.map { icao, _ -> String in
+            let match = conflicting.contains(icao) ? "CONFLICTING" : "CONFIRMING"
+            return #"{ "icao": "\#(icao)", "category_match": "\#(match)" }"#
+        }.joined(separator: ",")
+        let json = """
+        { "corridor_nm": 30.0, "fetch_time": "2026-07-25T05:50:00Z",
+          "airports": [\(aptJSON)], "comparisons": [\(compJSON)] }
+        """
+        return try JSONDecoder.weatherBrief.decode(RouteObservations.self, from: Data(json.utf8))
+    }
+
+    @Test func returnsAllWhenUnderTheLimit() throws {
+        let o = try observations([("AAAA", 1), ("BBBB", 2), ("CCCC", 3)])
+        #expect(o.nearestReportingAirports(limit: 10).map(\.icao) == ["AAAA", "BBBB", "CCCC"])
+    }
+
+    @Test func returnsAllWhenExactlyAtTheLimit() throws {
+        let o = try observations([("AAAA", 1), ("BBBB", 2), ("CCCC", 3)])
+        #expect(o.nearestReportingAirports(limit: 3).count == 3)
+    }
+
+    /// Picks by distance but renders in route order — a table that jumped around
+    /// the route would be unreadable.
+    @Test func picksNearestButPreservesRouteOrder() throws {
+        let o = try observations([
+            ("AAAA", 30), ("BBBB", 2), ("CCCC", 40), ("DDDD", 1), ("EEEE", 3),
+        ])
+        let got = o.nearestReportingAirports(limit: 3)
+        // Nearest three are DDDD(1), BBBB(2), EEEE(3) — emitted in route order.
+        #expect(got.map(\.icao) == ["BBBB", "DDDD", "EEEE"])
+    }
+
+    /// A conflicting airport outside the nearest-N must still surface, otherwise
+    /// the conflict banner refers to a row the cap hid.
+    @Test func pinsConflictingAirportBeyondTheCap() throws {
+        let o = try observations([
+            ("AAAA", 1), ("BBBB", 2), ("CCCC", 3), ("ZZZZ", 99),
+        ], conflicting: ["ZZZZ"])
+        let got = o.nearestReportingAirports(limit: 3).map(\.icao)
+        #expect(got.contains("ZZZZ"))
+        #expect(got == ["AAAA", "BBBB", "CCCC", "ZZZZ"])
+    }
+
+    /// A wind-only conflict pins too — `wind_advisory_match` is the other half of
+    /// the banner's trigger.
+    @Test func pinsWindOnlyConflict() throws {
+        let json = """
+        { "corridor_nm": 30.0, "fetch_time": "2026-07-25T05:50:00Z",
+          "airports": [
+            { "icao": "AAAA", "distance_from_route_nm": 1, "metar_weather": [], "has_metar": true },
+            { "icao": "BBBB", "distance_from_route_nm": 2, "metar_weather": [], "has_metar": true },
+            { "icao": "ZZZZ", "distance_from_route_nm": 99, "metar_weather": [], "has_metar": true }
+          ],
+          "comparisons": [
+            { "icao": "ZZZZ", "category_match": "CONFIRMING", "wind_advisory_match": "CONFLICTING" }
+          ] }
+        """
+        let o = try JSONDecoder.weatherBrief.decode(RouteObservations.self, from: Data(json.utf8))
+        #expect(o.nearestReportingAirports(limit: 2).map(\.icao).contains("ZZZZ"))
+    }
+
+    /// Missing distance must not win the "nearest" race — it sorts last.
+    @Test func missingDistanceSortsLast() throws {
+        let o = try observations([("AAAA", nil), ("BBBB", 5), ("CCCC", 6)])
+        #expect(o.nearestReportingAirports(limit: 2).map(\.icao) == ["BBBB", "CCCC"])
+    }
+
+    /// Non-reporting fields are already excluded, so they never consume a slot.
+    @Test func silentAirportsDoNotConsumeSlots() throws {
+        let o = try observations([
+            ("SSS1", 0.1), ("SSS2", 0.2), ("AAAA", 5), ("BBBB", 6),
+        ], silent: ["SSS1", "SSS2"])
+        #expect(o.nearestReportingAirports(limit: 2).map(\.icao) == ["AAAA", "BBBB"])
+    }
+
+    @Test func nonPositiveLimitReturnsEverything() throws {
+        let o = try observations([("AAAA", 1), ("BBBB", 2)])
+        #expect(o.nearestReportingAirports(limit: 0).count == 2)
+        #expect(o.nearestReportingAirports(limit: -1).count == 2)
+    }
+}
+
 // MARK: - Layout model
 
 @Suite struct ObservationAxisTests {

--- a/app/flyfun-weather/flyfun-weatherTests/RouteObservationsTests.swift
+++ b/app/flyfun-weather/flyfun-weatherTests/RouteObservationsTests.swift
@@ -1,0 +1,256 @@
+//
+//  RouteObservationsTests.swift
+//  flyfun-weatherTests
+//
+//  Current Observations section (#492) — the iOS port of the web's
+//  METAR/TAF/model comparison table. Covers the decode contract against the
+//  Python source of truth (`models/observations.py`), the reporting-airport
+//  filter, the comparison join, and the axis model that drives the
+//  compact-vs-regular layout split.
+//
+
+import Testing
+import Foundation
+@testable import flyfun_weather
+
+// MARK: - Decode contract
+
+@Suite struct RouteObservationsDecodeTests {
+
+    /// A full-shape payload as the server actually emits it (snake_case, the
+    /// fields `models/observations.py` declares). Guards against the original
+    /// bug: the DTO decoded a handful of fields and silently dropped
+    /// `comparisons`, the wind advisories, and the ETA.
+    private let json = """
+    {
+      "corridor_nm": 30.0,
+      "fetch_time": "2026-07-25T05:50:00+00:00",
+      "airports_found": 4,
+      "airports_with_metar": 2,
+      "airports_with_taf": 1,
+      "worst_metar_category": "IFR",
+      "worst_taf_category": "MVFR",
+      "has_conflicts": true,
+      "phenomena_along_route": ["TSRA", "BR"],
+      "airports": [
+        {
+          "icao": "EGTF", "name": "Fairoaks", "distance_from_route_nm": 1.5,
+          "enroute_distance_nm": 12.0, "nearest_waypoint_icao": "EGTF",
+          "metar_raw": "EGTF 250550Z 09018G28KT 2500 BR OVC008 17/16 Q1015",
+          "metar_time": "2026-07-25T05:50:00+00:00",
+          "metar_flight_category": "IFR", "metar_ceiling_ft": 800,
+          "metar_visibility_m": 2500, "metar_wind_dir": 90,
+          "metar_wind_speed_kt": 18, "metar_wind_gust_kt": 28,
+          "metar_weather": ["BR"], "metar_temperature_c": 17,
+          "metar_dewpoint_c": 16, "metar_qnh": 1015.0,
+          "taf_raw": "EGTF 250500Z 2506/2518 09018G28KT 3000 BR OVC010\\nBECMG 2509/2511 09012KT 9999 SCT025",
+          "taf_flight_category_at_eta": "MVFR", "taf_trend_type": "BECMG",
+          "taf_wind_dir": 90, "taf_wind_speed_kt": 12, "taf_wind_gust_kt": null,
+          "taf_applicable_text": "BECMG 2509/2511 09012KT 9999 SCT025",
+          "taf_applicable_lines": [0, 1],
+          "metar_wind_advisory": "red", "metar_best_runway_id": "06",
+          "metar_crosswind_kt": 17.4, "metar_headwind_kt": 6.1,
+          "taf_wind_advisory": "amber", "taf_best_runway_id": "06",
+          "taf_crosswind_kt": 11.6, "taf_headwind_kt": 4.1,
+          "has_metar": true, "has_taf": true, "eta_hour_offset": 2
+        },
+        {
+          "icao": "EGLL", "name": "Heathrow", "distance_from_route_nm": 8.0,
+          "enroute_distance_nm": 20.0, "nearest_waypoint_icao": "EGLL",
+          "metar_raw": "EGLL 250550Z 27010KT 9999 FEW030 19/12 Q1016",
+          "metar_flight_category": "VFR", "metar_ceiling_ft": 3000,
+          "metar_wind_dir": 270, "metar_wind_speed_kt": 10,
+          "metar_weather": [], "metar_qnh": 1016.0,
+          "metar_wind_advisory": "green", "metar_best_runway_id": "27R",
+          "metar_crosswind_kt": 2.0,
+          "has_metar": true, "has_taf": false, "eta_hour_offset": 3
+        },
+        {
+          "icao": "EGKB", "name": "Biggin Hill", "distance_from_route_nm": 22.0,
+          "nearest_waypoint_icao": "EGLL",
+          "metar_weather": [],
+          "has_metar": false, "has_taf": false
+        }
+      ],
+      "comparisons": [
+        {
+          "icao": "EGTF", "obs_category": "IFR", "model_category": "VFR",
+          "category_match": "CONFLICTING",
+          "ceiling_delta_ft": 3200, "visibility_delta_m": 7499.0,
+          "wind_speed_delta_kt": -8.0,
+          "model_wind_dir": 100.0, "model_wind_speed_kt": 10.0,
+          "model_wind_gust_kt": null,
+          "model_wind_advisory": "amber", "model_best_runway_id": "06",
+          "model_crosswind_kt": 9.7,
+          "wind_advisory_match": "CONFLICTING",
+          "detail": "Model shows VFR but METAR reports OVC008 in mist."
+        },
+        {
+          "icao": "EGLL", "obs_category": "VFR", "model_category": "VFR",
+          "category_match": "CONFIRMING",
+          "model_wind_advisory": "green", "model_crosswind_kt": 3.0,
+          "wind_advisory_match": "CONFIRMING",
+          "detail": ""
+        }
+      ]
+    }
+    """
+
+    private func decoded() throws -> RouteObservations {
+        try JSONDecoder.weatherBrief.decode(RouteObservations.self, from: Data(json.utf8))
+    }
+
+    @Test func decodesSummaryFields() throws {
+        let obs = try decoded()
+        #expect(obs.corridorNm == 30.0)
+        #expect(obs.airportsFound == 4)
+        #expect(obs.airportsWithMetar == 2)
+        #expect(obs.airportsWithTaf == 1)
+        #expect(obs.worstMetarCategory == "IFR")
+        #expect(obs.worstTafCategory == "MVFR")
+        #expect(obs.hasConflicts == true)
+        #expect(obs.phenomenaAlongRoute == ["TSRA", "BR"])
+        #expect(obs.airports?.count == 3)
+        #expect(obs.comparisons?.count == 2)
+    }
+
+    /// The wind-advisory block and ETA are what make the Wind axis renderable —
+    /// they were entirely absent from the pre-#492 DTO.
+    @Test func decodesWindAdvisoryAndEta() throws {
+        let obs = try decoded()
+        let egtf = try #require(obs.airports?.first { $0.icao == "EGTF" })
+        #expect(egtf.metarWindAdvisory == "red")
+        #expect(egtf.metarBestRunwayId == "06")
+        #expect(egtf.metarCrosswindKt == 17.4)
+        #expect(egtf.metarHeadwindKt == 6.1)
+        #expect(egtf.tafWindAdvisory == "amber")
+        #expect(egtf.tafCrosswindKt == 11.6)
+        #expect(egtf.etaHourOffset == 2)
+        #expect(egtf.metarWindDir == 90)
+        #expect(egtf.metarWindGustKt == 28)
+        #expect(egtf.metarQnh == 1015.0)
+        #expect(egtf.metarVisibilityM == 2500)
+    }
+
+    /// `taf_applicable_lines` drives the highlight in the detail sheet.
+    @Test func decodesTafApplicableLines() throws {
+        let obs = try decoded()
+        let egtf = try #require(obs.airports?.first { $0.icao == "EGTF" })
+        #expect(egtf.tafApplicableLines == [0, 1])
+        #expect(egtf.tafTrendType == "BECMG")
+        // The raw TAF is multi-line, which is what makes the highlight visible.
+        #expect(egtf.tafRaw?.components(separatedBy: .newlines).count == 2)
+    }
+
+    @Test func decodesComparison() throws {
+        let obs = try decoded()
+        let comp = try #require(obs.comparisonsByIcao["EGTF"])
+        #expect(comp.categoryMatch == "CONFLICTING")
+        #expect(comp.modelCategory == "VFR")
+        #expect(comp.obsCategory == "IFR")
+        #expect(comp.ceilingDeltaFt == 3200)
+        #expect(comp.modelWindAdvisory == "amber")
+        #expect(comp.modelCrosswindKt == 9.7)
+        #expect(comp.windAdvisoryMatch == "CONFLICTING")
+        #expect(comp.detail?.isEmpty == false)
+    }
+
+    /// Missing optionals must decode to nil rather than throwing — a small GA
+    /// field with no report at all still arrives in the airports array.
+    @Test func airportWithNoReportDecodes() throws {
+        let obs = try decoded()
+        let egkb = try #require(obs.airports?.first { $0.icao == "EGKB" })
+        #expect(egkb.hasMetar == false)
+        #expect(egkb.metarRaw == nil)
+        #expect(egkb.metarFlightCategory == nil)
+        #expect(egkb.etaHourOffset == nil)
+        #expect(egkb.metarWindAdvisory == nil)
+    }
+
+    /// The table (and the scroll-spy gate) show only airports that reported —
+    /// matching the web's `apt.has_metar || apt.has_taf` filter.
+    @Test func reportingAirportsFiltersSilentFields() throws {
+        let obs = try decoded()
+        #expect(obs.reportingAirports.map(\.icao) == ["EGTF", "EGLL"])
+    }
+
+    @Test func comparisonJoinIsKeyedByIcao() throws {
+        let obs = try decoded()
+        let byIcao = obs.comparisonsByIcao
+        #expect(byIcao.count == 2)
+        #expect(byIcao["EGLL"]?.categoryMatch == "CONFIRMING")
+        // No comparison for the silent field — the row renders an em dash.
+        #expect(byIcao["EGKB"] == nil)
+    }
+
+    /// A D-1+ pack has no observations block at all; the section must simply
+    /// not render rather than decoding into an empty shell.
+    @Test func absentBlockDecodesToNilOnSnapshot() throws {
+        let snapshotJSON = """
+        {
+          "route": { "name": "EGTF EGLL", "waypoints": [], "cruise_altitude_ft": 5000,
+                     "flight_ceiling_ft": 10000, "flight_duration_hours": 1.0 },
+          "target_date": "2026-07-27", "days_out": 2
+        }
+        """
+        let snap = try JSONDecoder.weatherBrief.decode(SnapshotResponse.self, from: Data(snapshotJSON.utf8))
+        #expect(snap.routeObservations == nil)
+    }
+
+    /// An empty airports array must read as "nothing to show" so the section and
+    /// its scroll-spy anchor stay hidden.
+    @Test func emptyAirportsYieldsNoReportingAirports() throws {
+        let empty = """
+        { "corridor_nm": 30.0, "fetch_time": "2026-07-25T05:50:00+00:00", "airports": [] }
+        """
+        let obs = try JSONDecoder.weatherBrief.decode(RouteObservations.self, from: Data(empty.utf8))
+        #expect(obs.reportingAirports.isEmpty)
+        #expect(obs.comparisonsByIcao.isEmpty)
+    }
+}
+
+// MARK: - Layout model
+
+@Suite struct ObservationAxisTests {
+
+    /// Compact width renders one group at a time; regular renders both. The
+    /// table's column count follows (3 fixed + 4 per visible group), which is
+    /// what the grouped header spans must agree with.
+    @Test func axisCasesCoverBothWebGroups() {
+        #expect(ObservationAxis.allCases.count == 2)
+        #expect(ObservationAxis.allCases.map(\.label) == ["Condition", "Wind"])
+    }
+
+    @Test func axisIsStableForPickerSelection() {
+        // The Picker tags on identity, so these must round-trip.
+        #expect(ObservationAxis.condition.id == "condition")
+        #expect(ObservationAxis.wind.id == "wind")
+        #expect(ObservationAxis(rawValue: "wind") == .wind)
+    }
+}
+
+// MARK: - Zulu fetch-time label
+
+@Suite struct ObservationFetchTimeTests {
+
+    /// The server sends `datetime.isoformat()` with microseconds; the plain
+    /// ISO8601 parser rejects those, so the shared fractional-then-plain
+    /// fallback is required.
+    @Test func parsesFractionalSecondsTimestamp() {
+        #expect(RouteObservationsView.zuluTime("2026-07-25T05:50:00.123456+00:00") == "0550Z")
+    }
+
+    @Test func parsesPlainTimestamp() {
+        #expect(RouteObservationsView.zuluTime("2026-07-25T05:50:00Z") == "0550Z")
+    }
+
+    /// Always rendered in UTC regardless of the device locale — an offset
+    /// timestamp must convert, not display its local wall clock.
+    @Test func rendersInUtcNotLocalTime() {
+        #expect(RouteObservationsView.zuluTime("2026-07-25T07:50:00+02:00") == "0550Z")
+    }
+
+    @Test func garbageTimestampYieldsNil() {
+        #expect(RouteObservationsView.zuluTime("not a date") == nil)
+    }
+}

--- a/app/flyfun-weather/flyfun-weatherTests/RouteObservationsTests.swift
+++ b/app/flyfun-weather/flyfun-weatherTests/RouteObservationsTests.swift
@@ -174,6 +174,29 @@ import Foundation
         #expect(obs.reportingAirports.map(\.icao) == ["EGTF", "EGLL"])
     }
 
+    /// A duplicate ICAO in `comparisons` must not crash. This is server-derived
+    /// JSON, and the trapping `Dictionary(uniqueKeysWithValues:)` would
+    /// `fatalError` here — taking down the briefing screen (and this test
+    /// process) over a malformed payload. First entry wins.
+    @Test func duplicateIcaoInComparisonsDoesNotTrap() throws {
+        let json = """
+        { "corridor_nm": 30.0, "fetch_time": "2026-07-25T05:50:00Z",
+          "airports": [
+            { "icao": "EGTF", "distance_from_route_nm": 1, "metar_weather": [], "has_metar": true }
+          ],
+          "comparisons": [
+            { "icao": "EGTF", "category_match": "CONFIRMING", "detail": "first" },
+            { "icao": "EGTF", "category_match": "CONFLICTING", "detail": "second" }
+          ] }
+        """
+        let obs = try JSONDecoder.weatherBrief.decode(RouteObservations.self, from: Data(json.utf8))
+        let byIcao = obs.comparisonsByIcao
+        #expect(byIcao.count == 1)
+        #expect(byIcao["EGTF"]?.detail == "first")
+        // The cap path also reads the lookup, so it must survive the duplicate too.
+        #expect(obs.nearestReportingAirports(limit: 1).map(\.icao) == ["EGTF"])
+    }
+
     @Test func comparisonJoinIsKeyedByIcao() throws {
         let obs = try decoded()
         let byIcao = obs.comparisonsByIcao

--- a/app/flyfun-weather/flyfun-weatherUITests/flyfun_weatherUITests.swift
+++ b/app/flyfun-weather/flyfun-weatherUITests/flyfun_weatherUITests.swift
@@ -9,6 +9,7 @@
 //
 
 import XCTest
+import UIKit
 
 final class flyfun_weatherUITests: XCTestCase {
 
@@ -204,6 +205,98 @@ final class flyfun_weatherUITests: XCTestCase {
         XCTAssertTrue(card.waitForExistence(timeout: 10), "cached flight should be listed offline")
         card.tap()
         waitForBriefingLoaded(app)   // the cached flight's briefing opens offline
+    }
+
+    /// Journey 6 (#492) — Current Observations section. Open fixture-1, jump to
+    /// the Observations scroll-spy section, and confirm the METAR/TAF/model
+    /// comparison table renders. Also pins the responsive contract: the
+    /// Condition/Wind axis picker exists only in compact width (iPhone), because
+    /// regular width (iPad) shows both groups at once.
+    @MainActor
+    func testRouteObservationsSectionRenders() throws {
+        let app = launchMockApp()
+        openFixture1Briefing(app)
+
+        // Advisory is the default tab; the spy pill for the D-0 observations
+        // section only exists when an airport actually reported, so finding it
+        // also confirms the `hasObservations` gate and the spy wiring.
+        let pill = app.buttons["Observations"].firstMatch
+        XCTAssertTrue(pill.waitForExistence(timeout: 15),
+                      "the Observations spy pill should be present for the D-0 fixture")
+        pill.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).tap()
+
+        XCTAssertTrue(app.descendants(matching: .any)["observationsSection"].waitForExistence(timeout: 10),
+                      "observations section should render")
+
+        // Fixture airports appear as rows (the ⓘ button carries the label).
+        XCTAssertTrue(app.buttons["LFMD details"].firstMatch.waitForExistence(timeout: 5),
+                      "LFMD row should render")
+        XCTAssertTrue(app.buttons["LFTH details"].firstMatch.exists,
+                      "LFTH row (the CONFLICTING case) should render")
+
+        // Responsive contract: an axis *picker* on iPhone, both groups at once on
+        // iPad. Keyed off the segment buttons rather than the picker's
+        // accessibilityIdentifier — SwiftUI doesn't surface that identifier on a
+        // `.segmented` Picker. This is also the sharper assertion: in regular
+        // width "Condition"/"Wind" appear as group *headers* (static text), so
+        // their presence as buttons is exactly what distinguishes the two layouts.
+        let conditionSegment = app.buttons["Condition"].firstMatch
+        if UIDevice.current.userInterfaceIdiom == .pad {
+            XCTAssertFalse(conditionSegment.exists,
+                           "regular width shows both axes, so there should be no axis picker")
+            XCTAssertTrue(app.staticTexts["Condition"].firstMatch.exists,
+                          "regular width should render the Condition group header")
+            XCTAssertTrue(app.staticTexts["Wind"].firstMatch.exists,
+                          "regular width should render the Wind group header")
+        } else {
+            XCTAssertTrue(conditionSegment.exists,
+                          "compact width should offer the Condition/Wind axis picker")
+        }
+
+        let shot = XCTAttachment(screenshot: app.screenshot())
+        shot.name = "Observations-Condition"
+        shot.lifetime = .keepAlways
+        add(shot)
+
+        // Switch to the Wind axis (compact only) and capture that too, so the
+        // crosswind capsules are covered by a visual record.
+        if UIDevice.current.userInterfaceIdiom != .pad {
+            let wind = app.buttons["Wind"].firstMatch
+            if wind.waitForExistence(timeout: 5) {
+                wind.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).tap()
+                let windShot = XCTAttachment(screenshot: app.screenshot())
+                windShot.name = "Observations-Wind"
+                windShot.lifetime = .keepAlways
+                add(windShot)
+            }
+        }
+    }
+
+    /// Journey 6b (#492) — the per-airport ⓘ drill-down opens and shows the raw
+    /// METAR/TAF plus the runway-wind breakdown (the web's obs popup).
+    @MainActor
+    func testRouteObservationsDetailSheet() throws {
+        let app = launchMockApp()
+        openFixture1Briefing(app)
+
+        let pill = app.buttons["Observations"].firstMatch
+        XCTAssertTrue(pill.waitForExistence(timeout: 15), "Observations spy pill should be present")
+        pill.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).tap()
+
+        let info = app.buttons["LFTH details"].firstMatch
+        XCTAssertTrue(info.waitForExistence(timeout: 10), "LFTH row should render")
+        info.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).tap()
+
+        // The sheet is titled with the ICAO and shows the raw METAR text.
+        XCTAssertTrue(app.staticTexts["METAR"].firstMatch.waitForExistence(timeout: 10),
+                      "detail sheet should show a METAR block")
+        XCTAssertTrue(app.staticTexts["Runway wind"].firstMatch.exists,
+                      "detail sheet should show the runway-wind breakdown")
+
+        let shot = XCTAttachment(screenshot: app.screenshot())
+        shot.name = "Observations-DetailSheet"
+        shot.lifetime = .keepAlways
+        add(shot)
     }
 
     @MainActor

--- a/designs/metar-taf-route-weather.md
+++ b/designs/metar-taf-route-weather.md
@@ -142,6 +142,25 @@ phone. The two comparison groups therefore become a switchable axis:
 
 Keyed off `horizontalSizeClass`, matching `RouteMapView`'s dual-metric split.
 
+**Phone row cap (deliberate divergence from web).** A 30 nm corridor on a long
+route routinely reports 30+ fields — the EDDC→EGTF verification run returned 29
+with a METAR. Web renders them all, which is fine in a browser window but a very
+long scroll inside the iOS Advisory tab. In **compact** width the table therefore
+shows the **10 nearest** airports (by `distance_from_route_nm`) with a
+"Show all N airports" toggle; regular width always shows everything.
+
+Two details that matter:
+- Selection is by distance but **rendering stays in route order**, so the table
+  still reads departure→destination rather than jumping around the route.
+- Any airport whose comparison is `CONFLICTING` (category **or** wind) is
+  **pinned into the capped set** regardless of distance — otherwise the
+  conflict banner could point at a row the cap had hidden. This means the
+  collapsed view can exceed 10 rows, which is why the collapse affordance reads
+  "Show fewer" rather than naming a number.
+
+Logic lives on the DTO (`RouteObservations.nearestReportingAirports(limit:)`) so
+it is unit-testable rather than buried in the view.
+
 Other parity notes:
 - **Wind cells** show the *crosswind in kt* coloured by advisory status, rather
   than the web's bare G/A/R letter — touch has no hover tooltip, so the value

--- a/designs/metar-taf-route-weather.md
+++ b/designs/metar-taf-route-weather.md
@@ -60,7 +60,7 @@ Gated by `days_out == 0 and options.airports_db_path`. Wrapped in try/except so 
 `AirportObservation` stores flat, serializable METAR/TAF fields (no euro_aip `WeatherReport` objects):
 - METAR: raw text, flight category, ceiling, visibility, wind (dir/speed/gust), weather phenomena, temp, dewpoint, QNH
 - TAF: raw text, flight category at ETA, applicable trend type, wind (dir/speed/gust)
-- Wind advisories: `metar_wind_advisory`, `taf_wind_advisory` (OK/CAUTION/WARNING) with best runway and crosswind values
+- Wind advisories: `metar_wind_advisory`, `taf_wind_advisory` — lowercase `green`/`amber`/`red` (from `_wind_advisory_status()`) — with best runway and crosswind values
 - TAF highlighting: `taf_applicable_lines: list[int]` — line indices for base + applicable BECMG/TEMPO groups
 - ETA: `eta_hour_offset: int | None` — rounded hours after departure (from enroute distance interpolation)
 - Metadata: ICAO, distance from route, enroute distance, nearest waypoint
@@ -120,9 +120,49 @@ Observations section on the briefing page with:
 - **Two-row grouped table headers**: ICAO, Dist, ETA (+0h/+1h/etc.), Conditions group (METAR/TAF/Model categories + agreement) and Wind group (METAR/TAF/Model wind + advisory match)
 - **Info button**: ⓘ in ICAO cell opens detailed airport popup
 - **TAF highlighting**: `taf_applicable_lines` indices highlight the base forecast + applicable BECMG/TEMPO lines in the TAF raw text
-- **Wind advisory icons**: OK/CAUTION/WARNING badges with crosswind values per source
+- **Wind advisory icons**: `green`/`amber`/`red` badges (rendered G/A/R) with crosswind values per source
 - **Agreement column**: CONFIRMING/SIGNIFICANT/CONFLICTING badges for both conditions and wind
 - **Refresh button**: re-fetches METAR/TAF via `POST .../observations/refresh` endpoint, updates snapshot in place
+
+### iOS UI (`Views/Briefing/RouteObservationsView.swift`)
+
+The iOS port (#492) sits in the Advisory tab between Conditions and Alternates —
+the same slot as on web — with a scroll-spy anchor (`observations`). It reads
+`snapshot.route_observations` from the standard snapshot endpoint (no iOS-specific
+endpoint; `GET .../snapshot` returns raw `briefing.json`, so the full shape
+including `comparisons` is already on the wire).
+
+**Responsive two-axis table.** The web table is 11 columns, which does not fit a
+phone. The two comparison groups therefore become a switchable axis:
+
+| Width | Behaviour |
+|---|---|
+| Compact (iPhone) | A segmented Condition / Wind picker above the table; one 7-column group at a time (default Condition) |
+| Regular (iPad) | Both groups side-by-side with the web's two-row grouped header; picker hidden |
+
+Keyed off `horizontalSizeClass`, matching `RouteMapView`'s dual-metric split.
+
+Other parity notes:
+- **Wind cells** show the *crosswind in kt* coloured by advisory status, rather
+  than the web's bare G/A/R letter — touch has no hover tooltip, so the value
+  itself has to be the label. A legend under the table states the unit, the
+  colour meaning, and the ✓/⚠/✗ agreement key.
+- **Detail sheet** replaces the web's ⓘ popup: raw METAR, raw TAF with
+  `taf_applicable_lines` emphasised, and the per-source runway-wind breakdown.
+- **Table cells** run at `Grid(horizontalSpacing: 0)` with the gutter inside each
+  cell, so a CONFLICTING row's per-cell shading tiles into one continuous band
+  (Grid applies a row background per cell, not across the row).
+- **No in-section refresh button.** Web has one; on iOS the toolbar Refresh
+  already routes through the tiered `decide_refresh` gate, which at D-0 performs
+  exactly this cheap realtime refresh.
+- **Route SIGMETs are not ported** — iOS has no `route_sigmets` DTO or view at
+  all, so the block is dropped at decode. Tracked in #493.
+
+Fixture-backed (`FixtureBriefingData.route_observations` carries comparisons +
+wind advisories), so mock mode renders it; covered by
+`RouteObservationsTests.swift` (decode/join/filter) and the XCUI journeys
+`testRouteObservationsSectionRenders` / `testRouteObservationsDetailSheet`, which
+assert the compact-vs-regular contract.
 
 ### HTML Report
 
@@ -137,7 +177,7 @@ Table after airport conditions with columns: ICAO, Distance, ETA, METAR Cat, TAF
 | Category-based comparison (not raw values) | Flight category is the operationally meaningful unit; raw value comparison is noisy |
 | Three-tier classification (no MINOR_DELTA) | Implemented as CONFIRMING/SIGNIFICANT/CONFLICTING; MINOR_DELTA was dropped for simplicity |
 | Sounding ceiling for model category | Uses `sounding_ceiling_ft` from route analyses when available, falling back to visibility-only |
-| Runway crosswind advisory | `compute_wind_advisory()` evaluates all runway ends, picks best runway; OK/CAUTION/WARNING thresholds |
+| Runway crosswind advisory | `compute_wind_advisory()` evaluates all runway ends, picks best runway; `green`/`amber`/`red` thresholds |
 | TAF line highlighting | `_applicable_taf_lines()` identifies base + BECMG/TEMPO groups active at target time for UI highlighting |
 | Per-airport time interpolation | TAF matching and model comparison use `enroute_distance / total_distance * flight_duration` to estimate when the flight passes each airport; falls back to departure time when `flight_duration_hours == 0` |
 | Graceful failure (try/except in pipeline) | Network failures shouldn't block the NWP-based briefing |


### PR DESCRIPTION
Ports the web briefing's **Current Observations** section (METAR/TAF/model
comparison) to iOS, where it was missing entirely.

Closes #492

## The gap

`SnapshotResponse.routeObservations` **was already decoded** but referenced by no
view — a dead field. Worse, the DTO silently dropped the part that carries the
point of the section: `comparisons`, every runway wind advisory, and the ETA.

Judging this an oversight rather than a deliberate omission: it isn't recorded
anywhere as a decision. (I originally cited `designs/future/ios-web-known-gaps.md`
here — the review bot correctly points out that file isn't in the repo. It exists
only as an uncommitted file in my working tree, from separate in-flight work, so
it's invisible to the repo and to this PR. Not committed here because it isn't
mine to commit.)

**No backend change.** `GET .../snapshot` returns raw `briefing.json`, so the
full shape was already on the wire.

## Design

Sits between Conditions and Alternates with a scroll-spy anchor, matching web.
Gated on an airport having actually reported, so the anchor never renders empty.

**Responsive axis.** The web table is 11 columns (ICAO/Dist/ETA + a 4-column
Condition group + a 4-column Wind group), which doesn't fit a phone:

| Width | Behaviour |
|---|---|
| Compact (iPhone) | Segmented Condition / Wind picker; one 7-column group at a time |
| Regular (iPad) | Both groups side-by-side with the web's grouped header; no picker |

Keyed off `horizontalSizeClass`, matching `RouteMapView`'s existing dual-metric split.

**Phone row cap.** Verified against real data: a 30 nm corridor on EDDC→EGTF
returned **29 airports with a METAR**. Web renders all of them — fine in a
browser window, a very long scroll in the Advisory tab. Compact width shows the
**10 nearest** with a "Show all 29 airports" toggle.

Two decisions there worth a reviewer's eye:
- Selection is by distance but **rendering stays in route order**, so the table
  still reads departure→destination instead of jumping around the route.
- Any `CONFLICTING` comparison (category **or** wind) is **pinned into the capped
  set** regardless of distance — otherwise the "observations conflict with the
  model" banner could point at a row the cap had hidden. Consequence: the
  collapsed view can exceed 10 rows, which is why the collapse label reads
  "Show fewer" rather than naming a count that would sometimes be wrong.

## Deliberate divergences from web

- **Wind cells show the crosswind in kt** coloured by advisory status, not web's
  bare `G`/`A`/`R` letter. Web puts the value in a hover tooltip; touch has no
  hover, so the value has to *be* the label. A legend states the unit, the colour
  meaning, and the ✓/⚠/✗ agreement key.
- **No in-section refresh button.** Web has one, but on iOS the toolbar Refresh
  already routes through the tiered `decide_refresh` gate, which at D-0 performs
  exactly this cheap realtime refresh — so it'd be near-redundant.
- **Row cap** (above).

## Two rendering bugs the screenshots caught

Both invisible to passing assertions:

1. `Grid` applies a row background **per cell**, so a CONFLICTING row's amber
   highlight tiled into a dashed line of blocks. Fixed with
   `Grid(horizontalSpacing: 0)` + the gutter inside each cell.
2. A missing flight category rendered as a **grey filled badge** containing "—",
   carrying the same visual weight as a real rating — it read as though "—" were
   itself a category. Now plain muted text, matching `WindAdvisoryBadge`.

## Verification

- **24 unit tests** — decode contract against the Python source of truth, the
  comparison join, the reporting filter, and 8 covering the cap (under/at/over
  limit, route-order preservation, conflict pinning incl. wind-only, nil distance
  sorting last, silent fields not consuming slots, non-positive limits).
- **2 XCUI journeys** asserting the compact-vs-regular contract and the detail sheet.
- **Visually confirmed on iPhone 17 Pro and iPad Pro 11"** — including against the
  real 29-airport dataset (temporarily spliced into the fixture, not committed),
  which exercised cases the fixture doesn't: airports with no runway wind data at
  all, and non-contiguous `taf_applicable_lines` like `[0, 2]`.
- Full suite green.

Fixture extended with comparisons + wind advisories + a CONFLICTING case, so mock
mode renders the section (real data today was benign — all VFR/green/CONFIRMING —
so the fixture is what covers the amber/red/conflict paths).

## Incidental doc fix

`designs/metar-taf-route-weather.md` documented the wind advisory values as
`OK/CAUTION/WARNING`. `_wind_advisory_status()` actually emits lowercase
`green`/`amber`/`red`. Web reads them correctly; the doc was stale.

## Follow-ups filed, not folded in

- **#493** — route SIGMETs are missing from iOS entirely (no DTO, no view). Same
  D-0 sibling surface; deliberately separate.
- **#494** — pre-existing iPad bug: airport condition cards compress to
  per-character text wrapping. Confirmed pre-existing by unwiring this section
  and re-screenshotting, so it isn't caused by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

