### PR TITLE
Add wind gust verification scoring and analytics (#491)

### DIFF
--- a/alembic/versions/082_verification_gust.py
+++ b/alembic/versions/082_verification_gust.py
@@ -1,0 +1,155 @@
+"""Persist wind gust in verification scoring (#491).
+
+Only wind *speed* was scored. Gust was never persisted anywhere permanent:
+the model gust lives on ``airport_forecast_snapshots.wind_gusts_10m_kt``,
+which is pruned at >10 days, so the "does the model over-call gusts?"
+question could only ever be asked about the last week and a half.
+
+Raw scores
+----------
+``verification_scores`` gains the forecast gust itself, not just a delta.
+The observed gust is NULL on ~90% of hours (a METAR only carries a gust
+group when the peak exceeds the mean by ~10 kt), so a delta alone would
+drop exactly the rows that answer the question — "the model called a gust
+and the airport wasn't gusting". ``model_gust_flag`` stores that same
+~10 kt criterion applied to the forecast so rollups can SUM it without
+carrying model wind speed.
+
+``taf_verification_scores`` gains the delta only: the TAF gust already
+lives permanently on ``verification_observations.taf_wind_gust_kt``.
+
+Rollups
+-------
+Daily gets additive SUM/count columns for the two conditionings that must
+never be blended (forecast-flagged vs obs-flagged — see
+``tasks/verification_gust``); monthly gets the MAE/bias equivalents.
+Existing rollup rows keep 0/NULL in the new columns until their day/month
+is re-rolled (``verify rollup-daily-stats --rebuild``).
+
+Revision ID: 082
+Revises: 081
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "082"
+down_revision: Union[str, None] = "081"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("verification_scores") as batch_op:
+        batch_op.add_column(
+            sa.Column("model_wind_gust_kt", sa.Float(), nullable=True)
+        )
+        batch_op.add_column(
+            sa.Column("wind_gust_delta_kt", sa.Float(), nullable=True)
+        )
+        batch_op.add_column(
+            sa.Column("model_gust_flag", sa.Boolean(), nullable=True)
+        )
+
+    with op.batch_alter_table("taf_verification_scores") as batch_op:
+        batch_op.add_column(
+            sa.Column("wind_gust_delta_kt", sa.Float(), nullable=True)
+        )
+
+    with op.batch_alter_table("verification_daily_stats") as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "n_gust", sa.Integer(), nullable=False, server_default="0",
+            )
+        )
+        batch_op.add_column(
+            sa.Column("sum_abs_gust_delta_kt", sa.Float(), nullable=True)
+        )
+        batch_op.add_column(
+            sa.Column("sum_gust_delta_kt", sa.Float(), nullable=True)
+        )
+        batch_op.add_column(
+            sa.Column(
+                "n_gust_flagged_peak", sa.Integer(), nullable=False,
+                server_default="0",
+            )
+        )
+        batch_op.add_column(
+            sa.Column("sum_gust_flagged_over_peak_kt", sa.Float(), nullable=True)
+        )
+        batch_op.add_column(
+            sa.Column(
+                "n_model_gust_flag", sa.Integer(), nullable=False,
+                server_default="0",
+            )
+        )
+        batch_op.add_column(
+            sa.Column(
+                "n_obs_gust", sa.Integer(), nullable=False, server_default="0",
+            )
+        )
+        batch_op.add_column(
+            sa.Column(
+                "n_gust_flag_hit", sa.Integer(), nullable=False,
+                server_default="0",
+            )
+        )
+
+    with op.batch_alter_table("verification_monthly_stats") as batch_op:
+        batch_op.add_column(
+            sa.Column("wind_gust_mae_kt", sa.Float(), nullable=True)
+        )
+        batch_op.add_column(
+            sa.Column("wind_gust_bias_kt", sa.Float(), nullable=True)
+        )
+        batch_op.add_column(sa.Column("n_gust", sa.Integer(), nullable=True))
+        batch_op.add_column(
+            sa.Column("gust_over_peak_bias_kt", sa.Float(), nullable=True)
+        )
+        batch_op.add_column(
+            sa.Column("n_gust_flagged_peak", sa.Integer(), nullable=True)
+        )
+        batch_op.add_column(
+            sa.Column("n_model_gust_flag", sa.Integer(), nullable=True)
+        )
+        batch_op.add_column(sa.Column("n_obs_gust", sa.Integer(), nullable=True))
+        batch_op.add_column(
+            sa.Column("n_gust_flag_hit", sa.Integer(), nullable=True)
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("verification_monthly_stats") as batch_op:
+        for col in (
+            "n_gust_flag_hit",
+            "n_obs_gust",
+            "n_model_gust_flag",
+            "n_gust_flagged_peak",
+            "gust_over_peak_bias_kt",
+            "n_gust",
+            "wind_gust_bias_kt",
+            "wind_gust_mae_kt",
+        ):
+            batch_op.drop_column(col)
+
+    with op.batch_alter_table("verification_daily_stats") as batch_op:
+        for col in (
+            "n_gust_flag_hit",
+            "n_obs_gust",
+            "n_model_gust_flag",
+            "sum_gust_flagged_over_peak_kt",
+            "n_gust_flagged_peak",
+            "sum_gust_delta_kt",
+            "sum_abs_gust_delta_kt",
+            "n_gust",
+        ):
+            batch_op.drop_column(col)
+
+    with op.batch_alter_table("taf_verification_scores") as batch_op:
+        batch_op.drop_column("wind_gust_delta_kt")
+
+    with op.batch_alter_table("verification_scores") as batch_op:
+        for col in ("model_gust_flag", "wind_gust_delta_kt", "model_wind_gust_kt"):
+            batch_op.drop_column(col)

--- a/alembic/versions/083_verification_gust.py
+++ b/alembic/versions/083_verification_gust.py
@@ -35,8 +35,8 @@ from typing import Sequence, Union
 import sqlalchemy as sa
 from alembic import op
 
-revision: str = "082"
-down_revision: Union[str, None] = "081"
+revision: str = "083"
+down_revision: Union[str, None] = "082"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/designs/metar-taf-accuracy.md
+++ b/designs/metar-taf-accuracy.md
@@ -65,8 +65,17 @@ tasks/verification_stats.py             ← shared queries for digest + dashboar
 ├── get_notable_misses()                ← raw (needs individual rows)
 ├── get_category_bias_stats()           ← from verification_daily_stats (2 buckets)
 ├── get_wind_advisory_accuracy()        ← from verification_daily_stats
+├── get_gust_accuracy()                 ← from verification_daily_stats; TAF raw (#491)
 ├── get_optimistic_bias_leaderboard()   ← from verification_daily_stats (#154)
 └── get_digest_data()                   ← orchestrator → VerificationDigestData
+
+tasks/verification_gust.py              ← gust definitions + aggregates + backfill (#491)
+├── GUST_FLAG_THRESHOLD_KT              ← 10 kt — the METAR gust-group criterion
+├── forecast_shows_gust()               ← used by scoring to set model_gust_flag
+├── realised_peak_kt()                  ← obs gust if reported, else obs mean wind
+├── gust_aggregate_columns()            ← shared SQL aggregates (daily + monthly)
+├── backfill_taf_gust_deltas()          ← all history (obs row holds both gusts)
+└── backfill_model_gust()               ← un-pruned snapshot window only
 
 tasks/verification_daily_rollup.py      ← daily pre-aggregation (#154)
 ├── rollup_day()                        ← pure SQL INSERT-SELECT, idempotent
@@ -131,8 +140,12 @@ METAR + active-TAF fields as fetched. Natural key `UNIQUE(icao, observation_time
 ### `verification_scores` — model vs reality
 One row per `(icao, observation_time, model, model_init_time, source)`. The `source` column distinguishes flight-based from standalone scores — **all queries filter by source** to prevent mixing. Only two stored values: `'flight'` and `'standalone'` (the `standalone_full`/`standalone_light`/`standalone_forecast` distinction lives only on `verification_cycles.source`, for per-cycle metrics, never on the scores themselves). Migration 055 adds a composite `(source, days_out, observation_time)` index to keep dashboard queries off full table scans.
 
+Gust is stored as a **raw value plus a delta plus a flag** (`model_wind_gust_kt`, `wind_gust_delta_kt`, `model_gust_flag`), unlike every other scored field which keeps only a delta (#491). Two reasons the delta alone doesn't work: the observed gust is NULL on ~90% of hours (a METAR only carries a gust group when the peak exceeds the mean by ~10 kt), so a delta-only column would silently drop exactly the "model called a gust, the airport wasn't gusting" rows; and the forecast gust is **not** recoverable after the fact the way `wind_speed` is, because the snapshot holding it (`airport_forecast_snapshots`) is pruned at >10 days.
+
 ### `taf_verification_scores` — TAF vs METAR
 TAFs are forecasts too, scored per METAR (one TAF scored against multiple METARs across its validity period — shows accuracy over time). Separate table because the key shape differs: `UNIQUE(icao, observation_time, taf_issue_time, source)`.
+
+TAF gust is only a delta (`wind_gust_delta_kt`): the TAF gust itself already lives permanently on `verification_observations.taf_wind_gust_kt`, reachable via `observation_id`. The delta exists for query symmetry and the rollups, and is fully backfillable for all history.
 
 ### `verification_cycles` — per-cycle performance metrics
 Timing (`phase_*_ms`) and counts for each collection/scoring cycle, plus nullable `peak_rss_mb`/`peak_cgroup_mb` (migration 051 / #137; legacy rows predate sampling). `source` distinguishes `flight` / `metar_ingest` / `standalone_*`. The `error` column stores the last 500 chars of a failure traceback so post-mortems don't need log access.
@@ -147,6 +160,7 @@ One row per `(period, source, model, days_out, icao)`, NWP scores only (TAF out 
 - **2 category-direction buckets, not 3** — matches the monthly table's shape; the rare 3-step case (VFR↔LIFR) folds into `_2`. The bias-leaderboard formula `(n_cat_opt_1 + 2 * n_cat_opt_2) / n` weights `_2` accordingly.
 - **No observation_id** — counts of *distinct observations* can't be recovered from per-group counts (one obs → N scores), so `get_activity_summary` keeps its `COUNT(DISTINCT observation_id)` on the raw `verification_scores` instead.
 - **`category_direction(obs, fcst)`** classifies each score as match / optimistic_1/2 (forecast better than reality — dangerous) / pessimistic_1/2 (too conservative). TAF scores use the same classification via `lead_hours // 24 → days_out` bucketing.
+- **Gust columns join the observation row** (#491). The daily rollup's SELECT joins `verification_observations` on the score's FK so it can carry both gust conditionings: magnitude sums (`n_gust`, `sum_abs_gust_delta_kt`, `sum_gust_delta_kt`), the forecast-flagged over-peak sums (`n_gust_flagged_peak`, `sum_gust_flagged_over_peak_kt`), and the occurrence contingency (`n_model_gust_flag`, `n_obs_gust`, `n_gust_flag_hit` — false alarms and misses are derived from those three). The join is inner and can't drop rows: the FK is NOT NULL and retention prunes observations and scores in the same window. Monthly stores the MAE/bias equivalents; its TAF rows leave the occurrence columns NULL (the TAF group key is a `lead_hours` bucket with no SQL expression that truncates identically on SQLite and MySQL — TAF gust occurrence is served at query time by `get_gust_accuracy` instead).
 
 ### `verification_cache` — pre-computed API responses
 Serialized JSON for expensive dashboard/map queries, keyed by `cache_key` (`stats:{source}:{period}`, `bias_leaderboard:{model}:{days_out}:{period}`, `forecast_map:{day}:{hour}`; the `verif_map:*` family was removed in #154). `is_stale()` compares the cached `source_max_time` against live `MAX(observation_time)`/`MAX(fetched_at)` — live > cached means stale, and missing entries are always stale. `rebuild_all()` runs after each standalone cycle, after the daily-rollup refresh.
@@ -276,11 +290,11 @@ Mechanics worth knowing:
 
 ### Digest Data Model
 
-`VerificationDigestData` contains: `period_label`, `activity` (ActivitySummary), `category_accuracy_today` / `category_accuracy_7d` (CategoryAccuracyRow lists), `notable_misses` (with directional severity — optimistic vs pessimistic), `category_bias` (CategoryBiasStats per model), `wind_advisory` (WindAdvisoryStats), `missed_warnings` (MissedWarning list).
+`VerificationDigestData` contains: `period_label`, `activity` (ActivitySummary), `category_accuracy_today` / `category_accuracy_7d` (CategoryAccuracyRow lists), `notable_misses` (with directional severity — optimistic vs pessimistic), `category_bias` (CategoryBiasStats per model), `wind_advisory` (WindAdvisoryStats), `gust_accuracy` (GustAccuracyStats per model/days_out — the email renders D-0 only, the dashboard every lead time), `missed_warnings` (MissedWarning list).
 
 ### Admin Dashboard
 
-`GET /api/admin/verification` (in `api/admin.py`) serves JSON for the web dashboard (`web/verification.html`). Source-filtered: flight and standalone stats are queried independently, never mixed. Dashboard shows category accuracy by model/days_out, notable misses, MAE trends.
+`GET /api/admin/verification` (in `api/admin.py`) serves JSON for the web dashboard (`web/verification.html`). Source-filtered: flight and standalone stats are queried independently, never mixed. Dashboard shows category accuracy by model/days_out, notable misses, MAE trends, and the gust tile (both conditionings side by side — `gust_accuracy` is absent from cache entries written before #491, so the client treats it as empty until the next rebuild).
 
 **Cache layer**: Unfiltered requests (no country/airport filter) use `verification_cache` for fast responses. If the cache is stale or missing, falls back to live query. Filtered requests always run live (small result sets). Cache is rebuilt after each standalone verification cycle via `rebuild_all()` in `cache_builder.py`.
 
@@ -313,6 +327,7 @@ NWP queries (post-#154) read from `verification_daily_stats`:
 - `get_category_accuracy()` — category match rate per model/days_out; TAF added at query time from raw
 - `get_category_bias_stats()` — match + 4 directional buckets (`_2` = "2 or more levels off")
 - `get_wind_advisory_accuracy()` — advisory match rate; TAF added at query time
+- `get_gust_accuracy()` — per model/days_out, both gust conditionings plus the over-warn ratio and hit count (#491). NWP from the rollup's additive sums; TAF joined to the observation at query time
 - `get_optimistic_bias_leaderboard()` — `(n_cat_opt_1 + 2 * n_cat_opt_2) / n` per airport, descending. Drives the leaderboard view that replaced the bias map.
 
 Still on raw `verification_scores` (need individual rows or count-distinct):
@@ -456,6 +471,7 @@ Every derived value must use **the same function the advisory pipeline uses**. T
 | Model visibility | `hourly.visibility_m / 1609.34` (→ statute miles) | `analysis/airport_conditions.py` | Direct from model, converted to SM like advisories do |
 | Model flight category | `classify_flight_category(ceiling_ft, visibility_sm)` | `analysis/airport_conditions.py` | Standard VFR/MVFR/IFR/LIFR thresholds |
 | Model wind advisory | `compute_wind_advisory(dir, speed, gust, runway_ends)` | `tasks/route_weather.py` | Same thresholds: xw ≥15kt amber, ≥25kt red; gust ≥25/35kt |
+| Model gust | `hourly.wind_gusts_10m_kt` (stored raw + delta + flag) | `tasks/verification_gust.py` | `forecast_shows_gust()` applies the METAR ~10 kt criterion to the forecast |
 | Model precipitation | `hourly.precipitation_mm > 0 or hourly.snowfall_cm > 0` | `analysis/sounding/precipitation.py` (`assess_precipitation`) | Same check as `assess_precipitation()` |
 | Model convection | `sounding.convective.risk_level` from `assess_convective_thermo()` | `analysis/sounding/convective.py` | CAPE thresholds: 50/300/1000/2000 J/kg, CIN suppression |
 
@@ -577,6 +593,20 @@ def compute_taf_verification(
     )
 ```
 
+### Gust: Two Conditionings, Never Blended (#491)
+
+Gust accuracy is the one metric where a single averaged number is actively misleading, so `tasks/verification_gust.py` owns the definitions and everything downstream (scoring, both rollups, `get_gust_accuracy`, the dashboard tile) derives from them:
+
+- **Sign** — `delta = forecast − observed`, like every other delta.
+- **Realised peak** — `obs_gust` if the METAR reports a gust group, else `obs_wind`. No gust group means the peak *is* the mean, not that the peak is unknown.
+- **"The forecast shows a gust"** — `forecast_gust − forecast_wind ≥ 10 kt`, the same criterion that puts a gust group on a METAR. Persisted per model score as `model_gust_flag`; the TAF equivalent is "the applicable trend carries a gust group".
+- **Report both conditionings side by side:**
+  - *forecast-flagged* hours — on the hours a model calls a gust, it sits **~+7 kt above** the realised peak, and ~80% of those hours the airport wasn't gusting at all. (This is the "why does the gust layer sit above the TAFs?" view.)
+  - *obs-flagged* hours — on the hours a METAR does report a gust, the model gust lands **4–13 kt below** the true peak. (The extreme-day view.)
+  - TAF over-flags gust *frequency* ~4× but gets the *size* right (±1 kt).
+
+The two select different, mostly non-overlapping samples. Collapsing them into one average is what made the first ad-hoc pass (EGLL/LFPG/EDDF, Apr–Jul 2026) look self-contradictory.
+
 ### Observation Frequency: One Per Airport Per Hour
 
 METARs are issued every 30-60 minutes, and SPECIs can be more frequent. To avoid inflating the dataset with near-duplicate observations, **keep at most one observation per airport per clock hour**. If multiple METARs exist for the same (icao, hour), keep the one closest to the top of the hour (e.g., for 14:00-14:59, prefer the METAR at 14:20 over 14:50). The UNIQUE(icao, observation_time) constraint handles exact dedup; the hourly filtering is applied during collection before insertion.
@@ -626,9 +656,17 @@ python -m weatherbrief.verify score
 # Backfill: re-run scoring after code changes (--flight-id optional)
 python -m weatherbrief.verify backfill --flight-id "LFPG-EDDF-2026-04-01-abc123"
 
-# Export accuracy data
+# Backfill the gust columns from migration 082 (#491). TAF reaches all history;
+# model gust only the un-pruned snapshot window (--days, default 10).
+python -m weatherbrief.verify backfill-gust
+python -m weatherbrief.verify backfill-gust --taf-only
+
+# Export accuracy data (--table observations | scores | taf-scores; the score
+# tables are exported joined to their observation, so forecast gust and
+# observed gust land in the same record)
 python -m weatherbrief.verify export --format csv --output accuracy.csv
-python -m weatherbrief.verify export --format json --output accuracy.json
+python -m weatherbrief.verify export --table scores --source standalone \
+    --model ecmwf --format csv --output scores.csv
 
 # Summary statistics (--source flight|standalone, --model, --icao)
 python -m weatherbrief.verify stats --source standalone
@@ -692,6 +730,8 @@ Dashboard and digest breakdowns — per-model accuracy at lead time, TAF-vs-mode
 | Category direction classification | Distinguishes optimistic (forecast too good — dangerous) from pessimistic (too conservative) with 1-step vs 2-step severity |
 | Dashboard cache with staleness | Expensive queries cached as JSON; staleness checked via MAX(observation_time) comparison; falls back to live on stale |
 | Composite index on (source, days_out, observation_time) | Migration 055 — prevents full table scans on dashboard queries that filter by source + days_out + time range |
+| Store the raw model gust, not just its delta | The observed gust is NULL ~90% of hours and the snapshot holding the forecast gust is pruned at 10 days — a delta-only column would lose the over-warn signal permanently (#491) |
+| Gust reported under two conditionings | Forecast-flagged and obs-flagged hours are nearly disjoint samples pointing opposite ways (over-warns on average, runs low on the gusty days); one blended number reads as self-contradictory |
 
 ## Implementation Status
 

--- a/designs/metar-taf-accuracy.md
+++ b/designs/metar-taf-accuracy.md
@@ -656,7 +656,7 @@ python -m weatherbrief.verify score
 # Backfill: re-run scoring after code changes (--flight-id optional)
 python -m weatherbrief.verify backfill --flight-id "LFPG-EDDF-2026-04-01-abc123"
 
-# Backfill the gust columns from migration 082 (#491). TAF reaches all history;
+# Backfill the gust columns from migration 083 (#491). TAF reaches all history;
 # model gust only the un-pruned snapshot window (--days, default 10).
 python -m weatherbrief.verify backfill-gust
 python -m weatherbrief.verify backfill-gust --taf-only

--- a/src/weatherbrief/db/models.py
+++ b/src/weatherbrief/db/models.py
@@ -676,6 +676,19 @@ class VerificationScoreRow(Base):
     wind_dir_delta_deg: Mapped[float | None] = mapped_column(Float, nullable=True)
     temperature_delta_c: Mapped[float | None] = mapped_column(Float, nullable=True)
 
+    # Gust (#491). The raw forecast gust is stored, not just its delta: the
+    # observed gust is NULL on ~90% of hours (a METAR only carries a gust
+    # group when the peak exceeds the mean by ~10 kt), so a delta alone would
+    # drop exactly the "model called a gust, the airport wasn't gusting" rows.
+    # It is also unrecoverable after the fact — the snapshot that carries it
+    # (airport_forecast_snapshots) is pruned at >10 days.
+    model_wind_gust_kt: Mapped[float | None] = mapped_column(Float, nullable=True)
+    wind_gust_delta_kt: Mapped[float | None] = mapped_column(Float, nullable=True)
+    # "The forecast shows a gust" by the METAR ~10 kt criterion — stored so
+    # rollups can SUM it without carrying model wind speed. See
+    # tasks/verification_gust.forecast_shows_gust.
+    model_gust_flag: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+
     # Wind advisory comparison
     obs_wind_advisory: Mapped[str | None] = mapped_column(String(10), nullable=True)
     model_wind_advisory: Mapped[str | None] = mapped_column(String(10), nullable=True)
@@ -733,6 +746,11 @@ class TafVerificationScoreRow(Base):
     visibility_delta_m: Mapped[float | None] = mapped_column(Float, nullable=True)
     wind_speed_delta_kt: Mapped[float | None] = mapped_column(Float, nullable=True)
     wind_dir_delta_deg: Mapped[float | None] = mapped_column(Float, nullable=True)
+    # Gust delta only (#491) — the TAF gust itself already lives permanently on
+    # verification_observations.taf_wind_gust_kt, reachable via observation_id,
+    # so there is no raw-value column here. This is for query symmetry with
+    # verification_scores and for the rollups.
+    wind_gust_delta_kt: Mapped[float | None] = mapped_column(Float, nullable=True)
 
     # Wind advisory comparison
     obs_wind_advisory: Mapped[str | None] = mapped_column(String(10), nullable=True)
@@ -989,6 +1007,22 @@ class VerificationMonthlyStatsRow(Base):
     wind_speed_mae_kt: Mapped[float | None] = mapped_column(Float, nullable=True)
     temperature_mae_c: Mapped[float | None] = mapped_column(Float, nullable=True)
 
+    # Gust (#491). Two conditionings, never blended — see
+    # tasks/verification_gust for the definitions.
+    #   obs-flagged magnitude: the hours the airport actually gusted
+    wind_gust_mae_kt: Mapped[float | None] = mapped_column(Float, nullable=True)
+    wind_gust_bias_kt: Mapped[float | None] = mapped_column(Float, nullable=True)
+    n_gust: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    #   forecast-flagged magnitude: the hours the forecast called a gust
+    gust_over_peak_bias_kt: Mapped[float | None] = mapped_column(Float, nullable=True)
+    n_gust_flagged_peak: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    #   occurrence contingency (NULL on TAF rows — the obs-side join is only
+    #   run for the model rollup; the daily table carries TAF-free occurrence
+    #   counts and is what the dashboard reads)
+    n_model_gust_flag: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    n_obs_gust: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    n_gust_flag_hit: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
     # Precipitation / convection hit rates (model scores only, NULL for TAF)
     n_precip_hit: Mapped[int | None] = mapped_column(Integer, nullable=True)
     n_precip_miss: Mapped[int | None] = mapped_column(Integer, nullable=True)
@@ -1056,6 +1090,35 @@ class VerificationDailyStatsRow(Base):
     sum_abs_wind_delta_kt: Mapped[float | None] = mapped_column(Float, nullable=True)
     sum_abs_temp_delta_c: Mapped[float | None] = mapped_column(Float, nullable=True)
     sum_abs_vis_delta_m: Mapped[float | None] = mapped_column(Float, nullable=True)
+
+    # Gust (#491). Both conditionings are kept separate on purpose — see
+    # tasks/verification_gust for the definitions. Rows rolled up before
+    # migration 082 carry 0/NULL here until the day is re-rolled.
+    #   obs-flagged magnitude: hours the airport actually gusted
+    n_gust: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default="0",
+    )
+    sum_abs_gust_delta_kt: Mapped[float | None] = mapped_column(Float, nullable=True)
+    sum_gust_delta_kt: Mapped[float | None] = mapped_column(Float, nullable=True)
+    #   forecast-flagged magnitude: hours the forecast called a gust, measured
+    #   against the realised peak (obs gust if reported, else obs mean wind)
+    n_gust_flagged_peak: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default="0",
+    )
+    sum_gust_flagged_over_peak_kt: Mapped[float | None] = mapped_column(
+        Float, nullable=True,
+    )
+    #   occurrence contingency: hit = flagged & observed, false alarm =
+    #   n_model_gust_flag - n_gust_flag_hit, miss = n_obs_gust - n_gust_flag_hit
+    n_model_gust_flag: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default="0",
+    )
+    n_obs_gust: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default="0",
+    )
+    n_gust_flag_hit: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default="0",
+    )
 
     # Advisory direction counts
     n_advisory_match: Mapped[int] = mapped_column(Integer, nullable=False, default=0)

--- a/src/weatherbrief/db/models.py
+++ b/src/weatherbrief/db/models.py
@@ -327,7 +327,7 @@ class BriefingRefreshJobRow(Base):
         Index("ix_refresh_jobs_status", "status"),
         Index("ix_refresh_jobs_flight", "flight_id", "created_at"),
         # Account deletion sweeps by user_id; named here rather than via
-        # ``index=True`` so dev's create_all and migration 082 agree on the name.
+        # ``index=True`` so dev's create_all and migration 083 agree on the name.
         Index("ix_refresh_jobs_user", "user_id"),
     )
 
@@ -1093,7 +1093,7 @@ class VerificationDailyStatsRow(Base):
 
     # Gust (#491). Both conditionings are kept separate on purpose — see
     # tasks/verification_gust for the definitions. Rows rolled up before
-    # migration 082 carry 0/NULL here until the day is re-rolled.
+    # migration 083 carry 0/NULL here until the day is re-rolled.
     #   obs-flagged magnitude: hours the airport actually gusted
     n_gust: Mapped[int] = mapped_column(
         Integer, nullable=False, default=0, server_default="0",

--- a/src/weatherbrief/models/verification.py
+++ b/src/weatherbrief/models/verification.py
@@ -150,6 +150,40 @@ class WindAdvisoryStats(BaseModel):
     sample_count: int = 0
 
 
+class GustAccuracyStats(BaseModel):
+    """Per-model gust accuracy, reported under both conditionings (#491).
+
+    The two halves select different, mostly non-overlapping samples and must
+    never be blended into one number — see ``tasks/verification_gust`` for the
+    definitions.
+
+    *Forecast-flagged* (the "why does the gust layer sit above the TAFs?"
+    view): ``n_flagged`` hours where the forecast called a gust,
+    ``flagged_over_peak_kt`` = mean(forecast gust − realised peak) on those
+    hours, ``over_warn_ratio`` = flagged hours ÷ hours the airport gusted,
+    ``n_flag_hit`` = flagged hours that did gust.
+
+    *Obs-flagged* (the extreme-day view): ``n_gust`` hours where the airport
+    gusted and the forecast had a gust value, with ``gust_mae_kt`` /
+    ``gust_bias_kt`` over those hours.
+    """
+
+    model: str
+    days_out: int = 0
+    n: int = 0
+    # Obs-flagged conditioning
+    n_gust: int = 0
+    gust_mae_kt: float | None = None
+    gust_bias_kt: float | None = None
+    # Forecast-flagged conditioning
+    n_flagged: int = 0
+    flagged_over_peak_kt: float | None = None
+    # Occurrence
+    n_obs_gust: int = 0
+    n_flag_hit: int = 0
+    over_warn_ratio: float | None = None
+
+
 class MissedWarning(BaseModel):
     """An observed ``red`` wind advisory that a model called something milder."""
 
@@ -171,6 +205,7 @@ class VerificationDigestData(BaseModel):
     notable_misses: list[NotableMiss] = Field(default_factory=list)
     category_bias: list[CategoryBiasStats] = Field(default_factory=list)
     wind_advisory: list[WindAdvisoryStats] = Field(default_factory=list)
+    gust_accuracy: list[GustAccuracyStats] = Field(default_factory=list)
     missed_warnings: list[MissedWarning] = Field(default_factory=list)
 
 

--- a/src/weatherbrief/notify/verification_email.py
+++ b/src/weatherbrief/notify/verification_email.py
@@ -122,6 +122,9 @@ def _build_digest_html(data: VerificationDigestData) -> str:
     # --- Wind advisory ---
     parts.append(_render_wind_section(data))
 
+    # --- Gust ---
+    parts.append(_render_gust_section(data))
+
     # Footer
     parts.append(
         '<p style="font-size:11px; color:#999; margin-top:24px;">'
@@ -308,6 +311,51 @@ def _render_wind_section(data: VerificationDigestData) -> str:
     return "".join(parts)
 
 
+def _render_gust_section(data: VerificationDigestData) -> str:
+    """Render gust accuracy under both conditionings (#491).
+
+    Scoped to D-0 — the digest is a daily health check, and the gust table
+    gets wide fast. The dashboard shows every lead time.
+    """
+    rows = [g for g in data.gust_accuracy if g.days_out == 0]
+    if not rows:
+        return ""
+
+    parts: list[str] = [
+        '<h3 style="font-size:15px; margin:20px 0 8px;">Gust Accuracy (D-0)</h3>',
+        '<p style="color:#666; font-size:12px; margin:0 0 8px;">'
+        "Left: hours the forecast called a gust (gust minus own mean wind "
+        "&ge;10 kt) measured against the realised peak. Right: hours the "
+        "airport actually gusted. Different samples — not averaged.</p>",
+        f'<table style="{_STYLE_TABLE}">',
+        "<tr>",
+    ]
+    for h in ("Model", "Flagged", "vs peak", "Over-warn", "Gust hrs", "MAE", "Bias"):
+        parts.append(f'<th style="{_STYLE_TH}">{h}</th>')
+    parts.append("</tr>")
+
+    for g in rows:
+        cells = [
+            f"{g.n_flagged}",
+            f"{g.flagged_over_peak_kt:+.1f} kt" if g.flagged_over_peak_kt is not None else "—",
+            f"{g.over_warn_ratio:.1f}×" if g.over_warn_ratio is not None else "—",
+            f"{g.n_gust}",
+            f"{g.gust_mae_kt:.1f} kt" if g.gust_mae_kt is not None else "—",
+            f"{g.gust_bias_kt:+.1f} kt" if g.gust_bias_kt is not None else "—",
+        ]
+        parts.append("<tr>")
+        parts.append(
+            f'<td style="{_STYLE_TD} font-weight:600;">'
+            f"{html.escape(g.model.upper())}</td>"
+        )
+        for c in cells:
+            parts.append(f'<td style="{_STYLE_TD} text-align:center;">{c}</td>')
+        parts.append("</tr>")
+    parts.append("</table>")
+
+    return "".join(parts)
+
+
 # ---------------------------------------------------------------------------
 # Plain text builder
 # ---------------------------------------------------------------------------
@@ -382,6 +430,27 @@ def _build_digest_plain(data: VerificationDigestData) -> str:
         for w in data.wind_advisory:
             pct = f"{w.accuracy_pct:.0f}%" if w.accuracy_pct is not None else "—"
             lines.append(f"  {w.model.upper():<10} {pct:>6}  (n={w.sample_count})")
+        lines.append("")
+
+    # Gust — both conditionings, D-0 only (see _render_gust_section)
+    gust_rows = [g for g in data.gust_accuracy if g.days_out == 0]
+    if gust_rows:
+        lines.append("GUST ACCURACY (D-0)")
+        lines.append(
+            "  forecast called a gust | airport actually gusted"
+        )
+        for g in gust_rows:
+            peak = (
+                f"{g.flagged_over_peak_kt:+.1f}kt"
+                if g.flagged_over_peak_kt is not None else "—"
+            )
+            warn = f"{g.over_warn_ratio:.1f}x" if g.over_warn_ratio is not None else "—"
+            mae = f"{g.gust_mae_kt:.1f}kt" if g.gust_mae_kt is not None else "—"
+            bias = f"{g.gust_bias_kt:+.1f}kt" if g.gust_bias_kt is not None else "—"
+            lines.append(
+                f"  {g.model.upper():<10} n={g.n_flagged:<5} vs peak {peak:>7} "
+                f"over-warn {warn:>5} | n={g.n_gust:<5} MAE {mae:>7} bias {bias:>7}"
+            )
         lines.append("")
 
     if data.missed_warnings:

--- a/src/weatherbrief/tasks/scoring.py
+++ b/src/weatherbrief/tasks/scoring.py
@@ -162,6 +162,7 @@ def _score_model_vs_metar(
     )
     from weatherbrief.models.analysis import ConvectiveRisk
     from weatherbrief.tasks.route_weather import compute_wind_advisory
+    from weatherbrief.tasks.verification_gust import forecast_shows_gust
 
     if hourly is None:
         return None
@@ -251,6 +252,17 @@ def _score_model_vs_metar(
         wind_dir_delta_deg=_circular_delta(
             hourly.wind_direction_10m_deg, float(obs_row.wind_dir)
         ) if obs_row.wind_dir is not None and hourly.wind_direction_10m_deg is not None else None,
+        # Gust (#491): the raw forecast gust is stored, not just its delta —
+        # the observed gust is NULL on ~90% of hours, so a delta alone would
+        # lose every "model called a gust, airport wasn't gusting" row.
+        model_wind_gust_kt=hourly.wind_gusts_10m_kt,
+        wind_gust_delta_kt=_delta(
+            hourly.wind_gusts_10m_kt,
+            float(obs_row.wind_gust_kt) if obs_row.wind_gust_kt is not None else None,
+        ),
+        model_gust_flag=forecast_shows_gust(
+            hourly.wind_speed_10m_kt, hourly.wind_gusts_10m_kt,
+        ),
         temperature_delta_c=_delta(
             hourly.temperature_2m_c, float(obs_row.temperature_c)
         ) if obs_row.temperature_c is not None and hourly.temperature_2m_c is not None else None,
@@ -323,6 +335,12 @@ def _score_taf_vs_metar(
         wind_dir_delta_deg=_circular_delta(
             float(obs_row.taf_wind_dir) if obs_row.taf_wind_dir is not None else None,
             float(obs_row.wind_dir) if obs_row.wind_dir is not None else None,
+        ),
+        # Gust delta only (#491) — the TAF gust itself is already permanent on
+        # the observation row, reachable via observation_id.
+        wind_gust_delta_kt=_delta(
+            float(obs_row.taf_wind_gust_kt) if obs_row.taf_wind_gust_kt is not None else None,
+            float(obs_row.wind_gust_kt) if obs_row.wind_gust_kt is not None else None,
         ),
         obs_wind_advisory=obs_adv,
         taf_wind_advisory=taf_adv,

--- a/src/weatherbrief/tasks/verification_daily_rollup.py
+++ b/src/weatherbrief/tasks/verification_daily_rollup.py
@@ -22,6 +22,13 @@ Direction encoding mirrors ``tasks/verification_rollup.py`` exactly:
 NULL handling: ``NULL - X = NULL``, and ``NULL = anything`` is FALSE in
 the CASE WHEN comparisons below, so rows with missing categories/advisories
 don't contribute to any direction bucket.
+
+The SELECT joins ``verification_observations`` (inner, on the score's
+``observation_id`` FK) purely for the gust aggregates (#491): the observed
+gust and the realised peak live there, and both are needed to keep the
+forecast-flagged and obs-flagged conditionings separate. The join can't drop
+rows — the FK is NOT NULL and retention prunes observations and scores in the
+same window.
 """
 
 from __future__ import annotations
@@ -41,8 +48,10 @@ from sqlalchemy.orm import Session
 
 from weatherbrief.db.models import (
     VerificationDailyStatsRow,
+    VerificationObservationRow,
     VerificationScoreRow,
 )
+from weatherbrief.tasks.verification_gust import gust_aggregate_columns
 
 logger = logging.getLogger(__name__)
 
@@ -145,6 +154,13 @@ def _build_rollup_select(day_start: datetime, day_end: datetime, day: date_t):
             _sum_when((obs_c.is_(False)) & (mod_c.is_(True))).label(
                 "n_convection_false_alarm"
             ),
+            # Gust (#491) — needs the observation row for the observed gust
+            # and the realised peak, hence the join below.
+            *gust_aggregate_columns(),
+        )
+        .join(
+            VerificationObservationRow,
+            VerificationScoreRow.observation_id == VerificationObservationRow.id,
         )
         .where(
             VerificationScoreRow.observation_time >= day_start,

--- a/src/weatherbrief/tasks/verification_gust.py
+++ b/src/weatherbrief/tasks/verification_gust.py
@@ -1,0 +1,346 @@
+"""Gust verification: standardised definitions, rollup aggregates, backfill.
+
+Wind *gust* is scored alongside steady wind since #491. Every gust number the
+scoring path, the rollups, the dashboard and any ad-hoc analysis produce comes
+from the definitions below, so the two conditionings never get silently
+averaged into one self-contradictory figure.
+
+Definitions
+-----------
+
+- **Sign** — ``delta = forecast - observed``. Negative means the forecast sits
+  below reality.
+- **Realised peak** — the observed gust when the METAR reports a gust group,
+  else the observed mean wind. A METAR only carries a gust group when the peak
+  exceeds the mean by ~10 kt, so "no gust group" means the peak *is* the mean;
+  it does not mean the peak is unknown.
+- **"The forecast shows a gust"** — ``forecast_gust - forecast_wind >=
+  GUST_FLAG_THRESHOLD_KT``, i.e. the same ~10 kt criterion that puts a gust
+  group on a METAR. Persisted per model score as ``model_gust_flag``. The TAF
+  equivalent is "the applicable TAF trend carries a gust group"
+  (``verification_observations.taf_wind_gust_kt`` is non-NULL).
+- **Report both conditionings, never a single blended number:**
+
+  * *forecast-flagged* hours — on the hours a forecast calls a gust, how far
+    above the realised peak does it sit? (the "why does Windy's gust layer sit
+    above the TAFs?" view — models run ~+7 kt high here, and ~80% of those
+    hours the airport wasn't gusting at all.)
+  * *obs-flagged* hours — on the hours the airport actually gusted, how far
+    below the true peak does the forecast sit? (the extreme-day view — models
+    run 4–13 kt *low* here.)
+
+  The two select different, mostly non-overlapping samples. Collapsing them is
+  what made the first ad-hoc pass look self-contradictory.
+
+Occurrence is a 2×2 contingency built from three stored counts:
+``n_model_gust_flag`` (forecast called a gust), ``n_obs_gust`` (airport
+gusted), ``n_gust_flag_hit`` (both). False alarms are ``flag - hit``, misses
+are ``obs - hit``, and the over-warn ratio is ``flag / obs``.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import case, exists, func, select, update
+from sqlalchemy.orm import Session
+
+from weatherbrief.db.models import (
+    AirportForecastSnapshotRow,
+    TafVerificationScoreRow,
+    VerificationObservationRow,
+    VerificationScoreRow,
+)
+
+logger = logging.getLogger(__name__)
+
+# A METAR reports a gust group when the peak exceeds the mean by ~10 kt. The
+# same threshold is applied to forecasts so "the forecast shows a gust" and
+# "the airport was gusting" mean the same thing.
+GUST_FLAG_THRESHOLD_KT = 10.0
+
+
+# ---------------------------------------------------------------------------
+# Scalar definitions (scoring path)
+# ---------------------------------------------------------------------------
+
+
+def forecast_shows_gust(
+    wind_kt: float | None, gust_kt: float | None,
+) -> bool | None:
+    """Whether a forecast's gust is a *gust* by the METAR ~10 kt criterion.
+
+    Returns None when either component is missing — absence of data, not a
+    negative.
+    """
+    if wind_kt is None or gust_kt is None:
+        return None
+    return (float(gust_kt) - float(wind_kt)) >= GUST_FLAG_THRESHOLD_KT
+
+
+def realised_peak_kt(
+    obs_wind_kt: float | None, obs_gust_kt: float | None,
+) -> float | None:
+    """The observed peak wind: the gust if reported, else the mean wind."""
+    if obs_gust_kt is not None:
+        return float(obs_gust_kt)
+    if obs_wind_kt is not None:
+        return float(obs_wind_kt)
+    return None
+
+
+# ---------------------------------------------------------------------------
+# SQL aggregates (shared by the daily and monthly rollups)
+# ---------------------------------------------------------------------------
+
+
+def _sum_when(condition):
+    """SUM of 1 when ``condition`` is TRUE (NULL/FALSE both excluded)."""
+    return func.coalesce(func.sum(case((condition, 1), else_=0)), 0)
+
+
+def realised_peak_expr():
+    """SQL ``realised_peak_kt`` over a joined ``verification_observations``."""
+    return func.coalesce(
+        VerificationObservationRow.wind_gust_kt,
+        VerificationObservationRow.wind_speed_kt,
+    )
+
+
+def gust_aggregate_columns() -> list:
+    """Labelled gust aggregates for a GROUP BY over scores joined to obs.
+
+    The caller must join :class:`VerificationScoreRow` to
+    :class:`VerificationObservationRow` on ``observation_id``. Column names
+    match ``verification_daily_stats``; the monthly rollup consumes a subset
+    by label.
+    """
+    delta = VerificationScoreRow.wind_gust_delta_kt
+    flag = VerificationScoreRow.model_gust_flag.is_(True)
+    obs_gusting = VerificationObservationRow.wind_gust_kt.isnot(None)
+    peak = realised_peak_expr()
+    over_peak = VerificationScoreRow.model_wind_gust_kt - peak
+
+    return [
+        # obs-flagged magnitude — a non-NULL delta means both gusts exist,
+        # i.e. the airport gusted and the forecast had a gust value.
+        func.count(delta).label("n_gust"),
+        func.sum(func.abs(delta)).label("sum_abs_gust_delta_kt"),
+        func.sum(delta).label("sum_gust_delta_kt"),
+        # forecast-flagged magnitude — measured against the realised peak, so
+        # the ~80% of flagged hours with no observed gust still contribute.
+        _sum_when(
+            flag
+            & VerificationScoreRow.model_wind_gust_kt.isnot(None)
+            & peak.isnot(None)
+        ).label("n_gust_flagged_peak"),
+        func.sum(
+            case(
+                (
+                    flag
+                    & VerificationScoreRow.model_wind_gust_kt.isnot(None)
+                    & peak.isnot(None),
+                    over_peak,
+                ),
+                else_=None,
+            )
+        ).label("sum_gust_flagged_over_peak_kt"),
+        # occurrence contingency
+        _sum_when(flag).label("n_model_gust_flag"),
+        _sum_when(obs_gusting).label("n_obs_gust"),
+        _sum_when(flag & obs_gusting).label("n_gust_flag_hit"),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Backfill
+# ---------------------------------------------------------------------------
+
+
+def backfill_taf_gust_deltas(
+    db: Session, *, batch_size: int = 50_000,
+) -> int:
+    """Fill ``taf_verification_scores.wind_gust_delta_kt`` from stored obs.
+
+    Fully backfillable for all history: both the TAF gust
+    (``taf_wind_gust_kt``) and the observed gust live permanently on
+    ``verification_observations``, reachable via ``observation_id``.
+
+    Idempotent — only rows whose observation carries both gusts and whose
+    delta is still NULL are touched. Commits per id batch so a long backfill
+    doesn't hold one transaction open.
+    """
+    max_id = db.execute(
+        select(func.max(TafVerificationScoreRow.id))
+    ).scalar() or 0
+
+    obs_delta = (
+        select(
+            VerificationObservationRow.taf_wind_gust_kt
+            - VerificationObservationRow.wind_gust_kt
+        )
+        .where(
+            VerificationObservationRow.id
+            == TafVerificationScoreRow.observation_id
+        )
+        .scalar_subquery()
+    )
+    has_both = exists(
+        select(1).where(
+            VerificationObservationRow.id
+            == TafVerificationScoreRow.observation_id,
+            VerificationObservationRow.taf_wind_gust_kt.isnot(None),
+            VerificationObservationRow.wind_gust_kt.isnot(None),
+        )
+    )
+
+    updated = 0
+    lo = 0
+    while lo <= max_id:
+        result = db.execute(
+            update(TafVerificationScoreRow)
+            .where(
+                TafVerificationScoreRow.id >= lo,
+                TafVerificationScoreRow.id < lo + batch_size,
+                TafVerificationScoreRow.wind_gust_delta_kt.is_(None),
+                has_both,
+            )
+            .values(wind_gust_delta_kt=obs_delta)
+            .execution_options(synchronize_session=False)
+        )
+        updated += result.rowcount or 0
+        db.commit()
+        lo += batch_size
+
+    logger.info("TAF gust backfill: updated %d scores", updated)
+    return updated
+
+
+def _naive_utc(dt: datetime | None) -> datetime | None:
+    """Normalise to naive UTC so SQLite and MySQL rows key identically."""
+    if dt is None:
+        return None
+    if dt.tzinfo is None:
+        return dt
+    return dt.astimezone(timezone.utc).replace(tzinfo=None)
+
+
+def backfill_model_gust(db: Session, *, days: int = 10) -> int:
+    """Fill model gust fields on ``verification_scores`` from snapshots.
+
+    Only the un-pruned ``airport_forecast_snapshots`` window is recoverable
+    (retention is 10 days) — beyond that, gust history simply accumulates
+    going forward from the permanent score row.
+
+    Works one UTC day at a time to bound memory: for each day it loads the
+    day's un-backfilled scores, the observations they point at, and the
+    snapshots that could match, then matches on
+    ``(icao, model, model_init_time)`` with the forecast hour nearest the
+    observation time. Inside the ±90 min window ``_score_cycle`` pairs on,
+    that is the snapshot the score was written from. Commits per day, and
+    only ever touches rows whose ``model_wind_gust_kt`` is still NULL.
+    """
+    now = datetime.now(timezone.utc)
+    start_day = (now - timedelta(days=days)).date()
+    end_day = now.date()
+
+    updated = 0
+    day = start_day
+    while day <= end_day:
+        day_start = datetime(day.year, day.month, day.day, tzinfo=timezone.utc)
+        day_end = day_start + timedelta(days=1)
+        updated += _backfill_model_gust_day(db, day_start, day_end)
+        db.commit()
+        day += timedelta(days=1)
+
+    logger.info(
+        "Model gust backfill: updated %d scores over %d days", updated, days,
+    )
+    return updated
+
+
+def _backfill_model_gust_day(
+    db: Session, day_start: datetime, day_end: datetime,
+) -> int:
+    """Backfill one UTC day's model gust fields. Caller commits."""
+    scores = db.execute(
+        select(
+            VerificationScoreRow.id,
+            VerificationScoreRow.observation_id,
+            VerificationScoreRow.icao,
+            VerificationScoreRow.model,
+            VerificationScoreRow.model_init_time,
+            VerificationScoreRow.observation_time,
+        ).where(
+            VerificationScoreRow.observation_time >= day_start,
+            VerificationScoreRow.observation_time < day_end,
+            VerificationScoreRow.model_wind_gust_kt.is_(None),
+        )
+    ).all()
+    if not scores:
+        return 0
+
+    # Snapshots are matched within the same ±90 min window _score_cycle uses.
+    snap_rows = db.execute(
+        select(
+            AirportForecastSnapshotRow.icao,
+            AirportForecastSnapshotRow.model,
+            AirportForecastSnapshotRow.model_init_time,
+            AirportForecastSnapshotRow.forecast_hour,
+            AirportForecastSnapshotRow.wind_speed_10m_kt,
+            AirportForecastSnapshotRow.wind_gusts_10m_kt,
+        ).where(
+            AirportForecastSnapshotRow.forecast_hour
+            >= day_start - timedelta(minutes=90),
+            AirportForecastSnapshotRow.forecast_hour
+            < day_end + timedelta(minutes=90),
+            AirportForecastSnapshotRow.wind_gusts_10m_kt.isnot(None),
+        )
+    ).all()
+    if not snap_rows:
+        return 0
+
+    by_key: dict[tuple, list[tuple]] = {}
+    for icao, model, init_time, fhour, wind, gust in snap_rows:
+        key = (icao, model, _naive_utc(init_time))
+        by_key.setdefault(key, []).append((_naive_utc(fhour), wind, gust))
+
+    obs_ids = sorted({s.observation_id for s in scores})
+    obs_gusts: dict[int, float | None] = {}
+    for chunk_start in range(0, len(obs_ids), 5000):
+        chunk = obs_ids[chunk_start : chunk_start + 5000]
+        for oid, gust in db.execute(
+            select(
+                VerificationObservationRow.id,
+                VerificationObservationRow.wind_gust_kt,
+            ).where(VerificationObservationRow.id.in_(chunk))
+        ).all():
+            obs_gusts[oid] = gust
+
+    mappings: list[dict] = []
+    for s in scores:
+        candidates = by_key.get((s.icao, s.model, _naive_utc(s.model_init_time)))
+        if not candidates:
+            continue
+        obs_time = _naive_utc(s.observation_time)
+        fhour, wind, gust = min(
+            candidates, key=lambda c: abs((c[0] - obs_time).total_seconds()),
+        )
+        obs_gust = obs_gusts.get(s.observation_id)
+        mappings.append({
+            "id": s.id,
+            "model_wind_gust_kt": gust,
+            "wind_gust_delta_kt": (
+                float(gust) - float(obs_gust) if obs_gust is not None else None
+            ),
+            "model_gust_flag": forecast_shows_gust(wind, gust),
+        })
+
+    if not mappings:
+        return 0
+
+    # ORM bulk UPDATE by primary key — one executemany, no per-row SELECT.
+    db.execute(update(VerificationScoreRow), mappings)
+    db.flush()
+    return len(mappings)

--- a/src/weatherbrief/tasks/verification_gust.py
+++ b/src/weatherbrief/tasks/verification_gust.py
@@ -60,6 +60,10 @@ logger = logging.getLogger(__name__)
 # "the airport was gusting" mean the same thing.
 GUST_FLAG_THRESHOLD_KT = 10.0
 
+# Backfill pairs a score with a snapshot only inside the same window
+# `_score_cycle` uses live, so a backfilled row never says more than a live one.
+_MATCH_WINDOW = timedelta(minutes=90)
+
 
 # ---------------------------------------------------------------------------
 # Scalar definitions (scoring path)
@@ -291,10 +295,8 @@ def _backfill_model_gust_day(
             AirportForecastSnapshotRow.wind_speed_10m_kt,
             AirportForecastSnapshotRow.wind_gusts_10m_kt,
         ).where(
-            AirportForecastSnapshotRow.forecast_hour
-            >= day_start - timedelta(minutes=90),
-            AirportForecastSnapshotRow.forecast_hour
-            < day_end + timedelta(minutes=90),
+            AirportForecastSnapshotRow.forecast_hour >= day_start - _MATCH_WINDOW,
+            AirportForecastSnapshotRow.forecast_hour < day_end + _MATCH_WINDOW,
             AirportForecastSnapshotRow.wind_gusts_10m_kt.isnot(None),
         )
     ).all()
@@ -327,6 +329,10 @@ def _backfill_model_gust_day(
         fhour, wind, gust = min(
             candidates, key=lambda c: abs((c[0] - obs_time).total_seconds()),
         )
+        # A gap in the snapshot series must leave the row NULL rather than pair
+        # it with a distant forecast hour — same ±90 min reach _score_cycle uses.
+        if abs(fhour - obs_time) > _MATCH_WINDOW:
+            continue
         obs_gust = obs_gusts.get(s.observation_id)
         mappings.append({
             "id": s.id,

--- a/src/weatherbrief/tasks/verification_rollup.py
+++ b/src/weatherbrief/tasks/verification_rollup.py
@@ -17,8 +17,10 @@ from sqlalchemy.orm import Session
 from weatherbrief.db.models import (
     TafVerificationScoreRow,
     VerificationMonthlyStatsRow,
+    VerificationObservationRow,
     VerificationScoreRow,
 )
+from weatherbrief.tasks.verification_gust import gust_aggregate_columns
 
 logger = logging.getLogger(__name__)
 
@@ -169,6 +171,61 @@ def rollup_month(db: Session, month_start: datetime) -> int:
     return rows_created
 
 
+def _obs_conditioned_gust_stats(
+    db: Session, month_start: datetime, month_end: datetime,
+) -> dict[tuple[str, str, int, str], dict]:
+    """Per-group gust aggregates that need the observation row (#491).
+
+    The observed gust and the realised peak live on
+    ``verification_observations``, so the occurrence contingency and the
+    forecast-flagged magnitude can't be derived from a score row alone. One
+    grouped SQL query per month keeps that off the Python path — loading a
+    month of observations into memory is not an option at watchlist scale.
+
+    Keyed like ``_rollup_model_scores``'s groups: (source, model, days_out,
+    icao). TAF rows have no entry — see ``_compute_taf_stats``.
+    """
+    rows = db.execute(
+        select(
+            VerificationScoreRow.source,
+            VerificationScoreRow.model,
+            VerificationScoreRow.days_out,
+            VerificationScoreRow.icao,
+            *gust_aggregate_columns(),
+        )
+        .join(
+            VerificationObservationRow,
+            VerificationScoreRow.observation_id == VerificationObservationRow.id,
+        )
+        .where(
+            VerificationScoreRow.observation_time >= month_start,
+            VerificationScoreRow.observation_time < month_end,
+        )
+        .group_by(
+            VerificationScoreRow.source,
+            VerificationScoreRow.model,
+            VerificationScoreRow.days_out,
+            VerificationScoreRow.icao,
+        )
+    ).all()
+
+    out: dict[tuple[str, str, int, str], dict] = {}
+    for r in rows:
+        n_flagged_peak = int(r.n_gust_flagged_peak or 0)
+        out[(r.source, r.model, r.days_out, r.icao)] = {
+            "n_model_gust_flag": int(r.n_model_gust_flag or 0),
+            "n_obs_gust": int(r.n_obs_gust or 0),
+            "n_gust_flag_hit": int(r.n_gust_flag_hit or 0),
+            "n_gust_flagged_peak": n_flagged_peak,
+            "gust_over_peak_bias_kt": (
+                float(r.sum_gust_flagged_over_peak_kt) / n_flagged_peak
+                if n_flagged_peak and r.sum_gust_flagged_over_peak_kt is not None
+                else None
+            ),
+        }
+    return out
+
+
 def _rollup_model_scores(
     db: Session, month_start: datetime, month_end: datetime,
 ) -> int:
@@ -182,6 +239,8 @@ def _rollup_model_scores(
     )
     scores = db.execute(stmt).scalars().all()
 
+    obs_gust_stats = _obs_conditioned_gust_stats(db, month_start, month_end)
+
     # Group by (source, model, days_out, icao)
     groups: dict[tuple[str, str, int, str], list[VerificationScoreRow]] = {}
     for s in scores:
@@ -189,8 +248,10 @@ def _rollup_model_scores(
         groups.setdefault(key, []).append(s)
 
     rows_created = 0
-    for (source, model, days_out, icao), group in groups.items():
+    for key, group in groups.items():
+        source, model, days_out, icao = key
         stats = _compute_model_stats(group)
+        stats.update(obs_gust_stats.get(key, {}))
         row = VerificationMonthlyStatsRow(
             month=month_start,
             source=source,
@@ -296,8 +357,15 @@ def _hit_miss_counts(
 
 def _base_stats(cat: dict[str, int], adv: dict[str, int], n: int,
                 ceiling_deltas: list[float], visibility_deltas: list[float],
-                wind_deltas: list[float]) -> dict:
-    """Build the stats dict shared by model and TAF rollups."""
+                wind_deltas: list[float], gust_deltas: list[float]) -> dict:
+    """Build the stats dict shared by model and TAF rollups.
+
+    ``gust_deltas`` is the obs-flagged conditioning only: a non-NULL gust
+    delta requires an observed gust, so this is "on the hours the airport
+    actually gusted, how far off was the forecast?" (#491). The
+    forecast-flagged conditioning needs the observation row and is merged in
+    by ``_obs_conditioned_gust_stats``.
+    """
     return {
         "n_scores": n,
         "n_cat_match": cat["match"],
@@ -312,6 +380,9 @@ def _base_stats(cat: dict[str, int], adv: dict[str, int], n: int,
         "ceiling_bias_ft": _mean(ceiling_deltas),
         "visibility_mae_m": _mae(visibility_deltas),
         "wind_speed_mae_kt": _mae(wind_deltas),
+        "wind_gust_mae_kt": _mae(gust_deltas),
+        "wind_gust_bias_kt": _mean(gust_deltas),
+        "n_gust": len(gust_deltas),
     }
 
 
@@ -325,6 +396,7 @@ def _compute_model_stats(scores: Sequence[VerificationScoreRow]) -> dict:
     ceiling_deltas = _collect_deltas(scores, "ceiling_delta_ft")
     visibility_deltas = _collect_deltas(scores, "visibility_delta_m")
     wind_deltas = _collect_deltas(scores, "wind_speed_delta_kt")
+    gust_deltas = _collect_deltas(scores, "wind_gust_delta_kt")
     temp_deltas = _collect_deltas(scores, "temperature_delta_c")
 
     p_hit, p_miss, p_fa, has_precip = _hit_miss_counts(
@@ -334,7 +406,10 @@ def _compute_model_stats(scores: Sequence[VerificationScoreRow]) -> dict:
         scores, "obs_has_convection", "model_has_convection",
     )
 
-    stats = _base_stats(cat, adv, len(scores), ceiling_deltas, visibility_deltas, wind_deltas)
+    stats = _base_stats(
+        cat, adv, len(scores), ceiling_deltas, visibility_deltas,
+        wind_deltas, gust_deltas,
+    )
     stats.update({
         "temperature_mae_c": _mae(temp_deltas),
         "n_precip_hit": p_hit if has_precip else None,
@@ -357,10 +432,25 @@ def _compute_taf_stats(scores: Sequence[TafVerificationScoreRow]) -> dict:
     ceiling_deltas = _collect_deltas(scores, "ceiling_delta_ft")
     visibility_deltas = _collect_deltas(scores, "visibility_delta_m")
     wind_deltas = _collect_deltas(scores, "wind_speed_delta_kt")
+    gust_deltas = _collect_deltas(scores, "wind_gust_delta_kt")
 
-    stats = _base_stats(cat, adv, len(scores), ceiling_deltas, visibility_deltas, wind_deltas)
+    stats = _base_stats(
+        cat, adv, len(scores), ceiling_deltas, visibility_deltas,
+        wind_deltas, gust_deltas,
+    )
     stats.update({
         "temperature_mae_c": None,
+        # Occurrence + forecast-flagged magnitude need the observation row,
+        # and the TAF group key (a lead_hours bucket) has no SQL expression
+        # that truncates identically on SQLite and MySQL. TAF gust occurrence
+        # is served by ``verification_stats.get_gust_accuracy``, which reads
+        # taf_verification_scores joined to observations at query time — the
+        # same treatment every other TAF stat gets (#154).
+        "n_model_gust_flag": None,
+        "n_obs_gust": None,
+        "n_gust_flag_hit": None,
+        "n_gust_flagged_peak": None,
+        "gust_over_peak_bias_kt": None,
         "n_precip_hit": None,
         "n_precip_miss": None,
         "n_precip_false_alarm": None,

--- a/src/weatherbrief/tasks/verification_stats.py
+++ b/src/weatherbrief/tasks/verification_stats.py
@@ -41,6 +41,7 @@ from weatherbrief.models.verification import (
     ActivitySummary,
     CategoryAccuracyRow,
     CategoryBiasStats,
+    GustAccuracyStats,
     MissedWarning,
     NotableMiss,
     OptimisticBiasLeaderboardRow,
@@ -498,6 +499,180 @@ def get_wind_advisory_accuracy(
 
 
 # ---------------------------------------------------------------------------
+# Gust accuracy (#491)
+# ---------------------------------------------------------------------------
+
+
+def _gust_stats(
+    model: str,
+    days_out: int,
+    *,
+    n: int,
+    n_gust: int,
+    sum_abs_gust: float | None,
+    sum_gust: float | None,
+    n_flagged: int,
+    n_flagged_peak: int,
+    sum_over_peak: float | None,
+    n_obs_gust: int,
+    n_flag_hit: int,
+) -> GustAccuracyStats:
+    """Turn additive gust counters into the reported ratios.
+
+    Same ``sum / n`` shape as every other rollup-backed metric — the sums are
+    additive across days, the ratios are not, so they're derived here.
+
+    ``n_flagged`` counts every hour the forecast called a gust;
+    ``n_flagged_peak`` counts the subset that also has a realised peak to
+    measure against (a METAR with neither a gust nor a mean wind has none).
+    They are kept apart so the over-warn ratio and the over-peak mean are each
+    divided by their own denominator.
+    """
+    return GustAccuracyStats(
+        model=model,
+        days_out=days_out,
+        n=n,
+        n_gust=n_gust,
+        gust_mae_kt=(
+            round(float(sum_abs_gust) / n_gust, 1)
+            if n_gust and sum_abs_gust is not None else None
+        ),
+        gust_bias_kt=(
+            round(float(sum_gust) / n_gust, 1)
+            if n_gust and sum_gust is not None else None
+        ),
+        n_flagged=n_flagged,
+        flagged_over_peak_kt=(
+            round(float(sum_over_peak) / n_flagged_peak, 1)
+            if n_flagged_peak and sum_over_peak is not None else None
+        ),
+        n_obs_gust=n_obs_gust,
+        n_flag_hit=n_flag_hit,
+        over_warn_ratio=(
+            round(n_flagged / n_obs_gust, 2) if n_obs_gust else None
+        ),
+    )
+
+
+def get_gust_accuracy(
+    db: Session, since: datetime, until: datetime,
+    source: str = "flight",
+    icao_filter: list[str] | None = None,
+) -> list[GustAccuracyStats]:
+    """Per-model gust accuracy under both conditionings (#491).
+
+    NWP reads the daily rollup (one row per model/days_out); TAF is
+    aggregated at query time from ``taf_verification_scores`` joined to
+    ``verification_observations``, like every other TAF stat — the TAF gust
+    and the observed gust both live on the observation row.
+
+    See ``tasks/verification_gust`` for what "flagged" and "realised peak"
+    mean, and why the forecast-flagged and obs-flagged numbers are reported
+    side by side rather than averaged.
+    """
+    since_d, until_d = _date_range(since, until)
+    v = VerificationDailyStatsRow
+    rows = db.execute(
+        select(
+            v.model,
+            v.days_out,
+            func.sum(v.n).label("n"),
+            func.sum(v.n_gust).label("n_gust"),
+            func.sum(v.sum_abs_gust_delta_kt).label("sum_abs_gust"),
+            func.sum(v.sum_gust_delta_kt).label("sum_gust"),
+            func.sum(v.n_gust_flagged_peak).label("n_flagged_peak"),
+            func.sum(v.sum_gust_flagged_over_peak_kt).label("sum_over_peak"),
+            func.sum(v.n_model_gust_flag).label("n_model_gust_flag"),
+            func.sum(v.n_obs_gust).label("n_obs_gust"),
+            func.sum(v.n_gust_flag_hit).label("n_flag_hit"),
+        )
+        .where(
+            v.date.between(since_d, until_d),
+            v.source == source,
+            v.days_out.in_(_DAYS_OUT_COLS),
+            _icao_clause(v.icao, icao_filter),
+        )
+        .group_by(v.model, v.days_out)
+    ).all()
+
+    results: list[GustAccuracyStats] = []
+    for r in rows:
+        stats = _gust_stats(
+            r.model, r.days_out,
+            n=int(r.n or 0),
+            n_gust=int(r.n_gust or 0),
+            sum_abs_gust=r.sum_abs_gust,
+            sum_gust=r.sum_gust,
+            n_flagged=int(r.n_model_gust_flag or 0),
+            n_flagged_peak=int(r.n_flagged_peak or 0),
+            sum_over_peak=r.sum_over_peak,
+            n_obs_gust=int(r.n_obs_gust or 0),
+            n_flag_hit=int(r.n_flag_hit or 0),
+        )
+        if stats.n_gust or stats.n_flagged or stats.n_obs_gust:
+            results.append(stats)
+
+    results.sort(key=lambda s: (s.model, s.days_out))
+
+    # TAF — raw, joined to the observation for the gust group and peak.
+    t = TafVerificationScoreRow
+    o = VerificationObservationRow
+    peak = func.coalesce(o.wind_gust_kt, o.wind_speed_kt)
+    taf_flagged = o.taf_wind_gust_kt.isnot(None)
+    obs_gusting = o.wind_gust_kt.isnot(None)
+    taf_row = db.execute(
+        select(
+            func.count(t.id).label("n"),
+            func.count(t.wind_gust_delta_kt).label("n_gust"),
+            func.sum(func.abs(t.wind_gust_delta_kt)).label("sum_abs_gust"),
+            func.sum(t.wind_gust_delta_kt).label("sum_gust"),
+            func.coalesce(
+                func.sum(case((taf_flagged, 1), else_=0)), 0,
+            ).label("n_flagged"),
+            func.coalesce(
+                func.sum(case((taf_flagged & peak.isnot(None), 1), else_=0)), 0,
+            ).label("n_flagged_peak"),
+            func.sum(
+                case(
+                    (taf_flagged & peak.isnot(None), o.taf_wind_gust_kt - peak),
+                    else_=None,
+                )
+            ).label("sum_over_peak"),
+            func.coalesce(
+                func.sum(case((obs_gusting, 1), else_=0)), 0,
+            ).label("n_obs_gust"),
+            func.coalesce(
+                func.sum(case((taf_flagged & obs_gusting, 1), else_=0)), 0,
+            ).label("n_flag_hit"),
+        )
+        .join(o, t.observation_id == o.id)
+        .where(
+            t.observation_time.between(since, until),
+            t.source == source,
+            _icao_clause(t.icao, icao_filter),
+        )
+    ).one()
+
+    if taf_row.n:
+        taf_stats = _gust_stats(
+            "TAF", 0,
+            n=int(taf_row.n or 0),
+            n_gust=int(taf_row.n_gust or 0),
+            sum_abs_gust=taf_row.sum_abs_gust,
+            sum_gust=taf_row.sum_gust,
+            n_flagged=int(taf_row.n_flagged or 0),
+            n_flagged_peak=int(taf_row.n_flagged_peak or 0),
+            sum_over_peak=taf_row.sum_over_peak,
+            n_obs_gust=int(taf_row.n_obs_gust or 0),
+            n_flag_hit=int(taf_row.n_flag_hit or 0),
+        )
+        if taf_stats.n_gust or taf_stats.n_flagged or taf_stats.n_obs_gust:
+            results.append(taf_stats)
+
+    return results
+
+
+# ---------------------------------------------------------------------------
 # Missed warnings — still raw (needs individual rows)
 # ---------------------------------------------------------------------------
 
@@ -657,6 +832,7 @@ def get_digest_data(
     notable = _timed("notable", get_notable_misses, db, since, until, source, icao_filter)
     bias = _timed("bias", get_category_bias_stats, db, since, until, source, icao_filter)
     wind = _timed("wind", get_wind_advisory_accuracy, db, since, until, source, icao_filter)
+    gust = _timed("gust", get_gust_accuracy, db, since, until, source, icao_filter)
     missed = _timed("missed", get_missed_warnings, db, since, until, source, icao_filter)
 
     category_7d: list[CategoryAccuracyRow] = []
@@ -685,5 +861,6 @@ def get_digest_data(
         notable_misses=notable,
         category_bias=bias,
         wind_advisory=wind,
+        gust_accuracy=gust,
         missed_warnings=missed,
     )

--- a/src/weatherbrief/verify/__main__.py
+++ b/src/weatherbrief/verify/__main__.py
@@ -91,49 +91,172 @@ def cmd_collect(args):
         db.close()
 
 
+def _export_observations(db, args) -> list[dict]:
+    """Rows for ``export --table observations`` (the default)."""
+    from sqlalchemy import select
+    from weatherbrief.db.models import VerificationObservationRow
+
+    stmt = select(VerificationObservationRow).order_by(
+        VerificationObservationRow.observation_time.desc()
+    )
+    if args.icao:
+        stmt = stmt.where(VerificationObservationRow.icao == args.icao.upper())
+    if args.limit:
+        stmt = stmt.limit(args.limit)
+
+    return [
+        {
+            "id": r.id,
+            "icao": r.icao,
+            "observation_time": r.observation_time.isoformat() if r.observation_time else None,
+            "collected_at": r.collected_at.isoformat() if r.collected_at else None,
+            "flight_category": r.flight_category,
+            "ceiling_ft": r.ceiling_ft,
+            "visibility_m": r.visibility_m,
+            "wind_dir": r.wind_dir,
+            "wind_speed_kt": r.wind_speed_kt,
+            "wind_gust_kt": r.wind_gust_kt,
+            "temperature_c": r.temperature_c,
+            "dewpoint_c": r.dewpoint_c,
+            "qnh": r.qnh,
+            "weather": r.weather,
+            "taf_flight_category": r.taf_flight_category,
+            "metar_raw": r.metar_raw,
+        }
+        for r in db.execute(stmt).scalars().all()
+    ]
+
+
+def _export_scores(db, args) -> list[dict]:
+    """Rows for ``export --table scores`` — model scores joined to the obs.
+
+    The join is the one every gust analysis does by hand: the forecast gust
+    and its flag live on the score, the observed gust and mean wind on the
+    observation. Exporting them together means the two conditionings (#491)
+    can be computed straight from the CSV.
+    """
+    from sqlalchemy import select
+    from weatherbrief.db.models import (
+        VerificationObservationRow,
+        VerificationScoreRow,
+    )
+
+    s, o = VerificationScoreRow, VerificationObservationRow
+    stmt = (
+        select(s, o.wind_speed_kt, o.wind_gust_kt, o.wind_dir)
+        .join(o, s.observation_id == o.id)
+        .order_by(s.observation_time.desc())
+    )
+    if args.icao:
+        stmt = stmt.where(s.icao == args.icao.upper())
+    if args.source:
+        stmt = stmt.where(s.source == args.source)
+    if args.model:
+        stmt = stmt.where(s.model == args.model)
+    if args.limit:
+        stmt = stmt.limit(args.limit)
+
+    return [
+        {
+            "id": r[0].id,
+            "observation_id": r[0].observation_id,
+            "icao": r[0].icao,
+            "observation_time": r[0].observation_time.isoformat() if r[0].observation_time else None,
+            "model": r[0].model,
+            "model_init_time": r[0].model_init_time.isoformat() if r[0].model_init_time else None,
+            "lead_hours": r[0].lead_hours,
+            "days_out": r[0].days_out,
+            "source": r[0].source,
+            "obs_flight_category": r[0].obs_flight_category,
+            "model_flight_category": r[0].model_flight_category,
+            "category_match": r[0].category_match,
+            "ceiling_delta_ft": r[0].ceiling_delta_ft,
+            "visibility_delta_m": r[0].visibility_delta_m,
+            "wind_speed_delta_kt": r[0].wind_speed_delta_kt,
+            "wind_dir_delta_deg": r[0].wind_dir_delta_deg,
+            "model_wind_gust_kt": r[0].model_wind_gust_kt,
+            "wind_gust_delta_kt": r[0].wind_gust_delta_kt,
+            "model_gust_flag": r[0].model_gust_flag,
+            "temperature_delta_c": r[0].temperature_delta_c,
+            "obs_wind_advisory": r[0].obs_wind_advisory,
+            "model_wind_advisory": r[0].model_wind_advisory,
+            "advisory_match": r[0].advisory_match,
+            "obs_wind_speed_kt": r[1],
+            "obs_wind_gust_kt": r[2],
+            "obs_wind_dir": r[3],
+        }
+        for r in db.execute(stmt).all()
+    ]
+
+
+def _export_taf_scores(db, args) -> list[dict]:
+    """Rows for ``export --table taf-scores`` — TAF scores joined to the obs."""
+    from sqlalchemy import select
+    from weatherbrief.db.models import (
+        TafVerificationScoreRow,
+        VerificationObservationRow,
+    )
+
+    t, o = TafVerificationScoreRow, VerificationObservationRow
+    stmt = (
+        select(t, o.wind_speed_kt, o.wind_gust_kt, o.taf_wind_speed_kt, o.taf_wind_gust_kt)
+        .join(o, t.observation_id == o.id)
+        .order_by(t.observation_time.desc())
+    )
+    if args.icao:
+        stmt = stmt.where(t.icao == args.icao.upper())
+    if args.source:
+        stmt = stmt.where(t.source == args.source)
+    if args.limit:
+        stmt = stmt.limit(args.limit)
+
+    return [
+        {
+            "id": r[0].id,
+            "observation_id": r[0].observation_id,
+            "icao": r[0].icao,
+            "observation_time": r[0].observation_time.isoformat() if r[0].observation_time else None,
+            "taf_issue_time": r[0].taf_issue_time.isoformat() if r[0].taf_issue_time else None,
+            "lead_hours": r[0].lead_hours,
+            "source": r[0].source,
+            "obs_flight_category": r[0].obs_flight_category,
+            "taf_flight_category": r[0].taf_flight_category,
+            "category_match": r[0].category_match,
+            "ceiling_delta_ft": r[0].ceiling_delta_ft,
+            "visibility_delta_m": r[0].visibility_delta_m,
+            "wind_speed_delta_kt": r[0].wind_speed_delta_kt,
+            "wind_dir_delta_deg": r[0].wind_dir_delta_deg,
+            "wind_gust_delta_kt": r[0].wind_gust_delta_kt,
+            "obs_wind_advisory": r[0].obs_wind_advisory,
+            "taf_wind_advisory": r[0].taf_wind_advisory,
+            "advisory_match": r[0].advisory_match,
+            "obs_wind_speed_kt": r[1],
+            "obs_wind_gust_kt": r[2],
+            "taf_wind_speed_kt": r[3],
+            "taf_wind_gust_kt": r[4],
+        }
+        for r in db.execute(stmt).all()
+    ]
+
+
 def cmd_export(args):
     """Export verification data."""
     SessionLocal = _init_db()
     db = SessionLocal()
 
+    table = getattr(args, "table", "observations")
+    builders = {
+        "observations": _export_observations,
+        "scores": _export_scores,
+        "taf-scores": _export_taf_scores,
+    }
+
     try:
-        from sqlalchemy import select
-        from weatherbrief.db.models import VerificationObservationRow
+        records = builders[table](db, args)
 
-        stmt = select(VerificationObservationRow).order_by(
-            VerificationObservationRow.observation_time.desc()
-        )
-        if args.icao:
-            stmt = stmt.where(VerificationObservationRow.icao == args.icao.upper())
-        if args.limit:
-            stmt = stmt.limit(args.limit)
-
-        rows = db.execute(stmt).scalars().all()
-
-        if not rows:
-            print("No observations found.")
+        if not records:
+            print(f"No {table} found.")
             return
-
-        records = []
-        for r in rows:
-            records.append({
-                "id": r.id,
-                "icao": r.icao,
-                "observation_time": r.observation_time.isoformat() if r.observation_time else None,
-                "collected_at": r.collected_at.isoformat() if r.collected_at else None,
-                "flight_category": r.flight_category,
-                "ceiling_ft": r.ceiling_ft,
-                "visibility_m": r.visibility_m,
-                "wind_dir": r.wind_dir,
-                "wind_speed_kt": r.wind_speed_kt,
-                "wind_gust_kt": r.wind_gust_kt,
-                "temperature_c": r.temperature_c,
-                "dewpoint_c": r.dewpoint_c,
-                "qnh": r.qnh,
-                "weather": r.weather,
-                "taf_flight_category": r.taf_flight_category,
-                "metar_raw": r.metar_raw,
-            })
 
         output = args.output or sys.stdout
 
@@ -142,7 +265,7 @@ def cmd_export(args):
             if isinstance(output, str):
                 with open(output, "w") as f:
                     f.write(content)
-                print(f"Exported {len(records)} observations to {output}")
+                print(f"Exported {len(records)} {table} to {output}")
             else:
                 output.write(content + "\n")
         else:  # csv
@@ -156,7 +279,7 @@ def cmd_export(args):
             writer.writerows(records)
             if isinstance(output, str):
                 f.close()
-                print(f"Exported {len(records)} observations to {output}")
+                print(f"Exported {len(records)} {table} to {output}")
             else:
                 output.write(buf.getvalue())
     finally:
@@ -205,6 +328,41 @@ def cmd_backfill(args):
         print(f"Flights scored: {result['flights_scored']}")
         print(f"Model scores:   {result['model_scores']}")
         print(f"TAF scores:     {result['taf_scores']}")
+    finally:
+        db.close()
+
+
+def cmd_backfill_gust(args):
+    """Backfill the gust columns added by migration 082 (#491).
+
+    Two independent halves with very different reach: the TAF gust delta is
+    recoverable for all history (both gusts live on the permanent observation
+    row), the model gust only for the un-pruned snapshot window. Neither
+    rewrites any other scored field.
+    """
+    SessionLocal = _init_db()
+    db = SessionLocal()
+
+    try:
+        from weatherbrief.tasks.verification_gust import (
+            backfill_model_gust,
+            backfill_taf_gust_deltas,
+        )
+
+        do_taf = not args.model_only
+        do_model = not args.taf_only
+
+        if do_taf:
+            n = backfill_taf_gust_deltas(db)
+            print(f"TAF gust deltas:  {n}")
+        if do_model:
+            n = backfill_model_gust(db, days=args.days)
+            print(f"Model gust fields: {n} (last {args.days} days)")
+
+        print(
+            "Re-roll the affected days to pick the new columns up in the "
+            "rollup: python -m weatherbrief.verify rollup-daily-stats --rebuild"
+        )
     finally:
         db.close()
 
@@ -677,6 +835,20 @@ def main():
     p_export.add_argument("--output", "-o", help="Output file (default: stdout)")
     p_export.add_argument("--icao", help="Filter by ICAO code")
     p_export.add_argument("--limit", type=int, help="Limit number of records")
+    p_export.add_argument(
+        "--table", choices=["observations", "scores", "taf-scores"],
+        default="observations",
+        help="What to export (default: observations). 'scores' and "
+             "'taf-scores' join the observation row, so forecast gust and "
+             "observed gust land in the same record.",
+    )
+    p_export.add_argument(
+        "--source", choices=["flight", "standalone"],
+        help="Filter scores by source (scores / taf-scores only)",
+    )
+    p_export.add_argument(
+        "--model", help="Filter scores by model, e.g. gfs (scores only)",
+    )
 
     # score
     p_score = subparsers.add_parser("score", help="Score completed flights")
@@ -684,6 +856,28 @@ def main():
     # backfill
     p_backfill = subparsers.add_parser("backfill", help="Re-run scoring (backfill)")
     p_backfill.add_argument("--flight-id", help="Backfill a specific flight")
+
+    # backfill-gust
+    p_backfill_gust = subparsers.add_parser(
+        "backfill-gust",
+        help="Backfill gust columns on existing scores (#491)",
+    )
+    gust_scope = p_backfill_gust.add_mutually_exclusive_group()
+    gust_scope.add_argument(
+        "--taf-only", action="store_true",
+        help="Only the TAF gust delta (fully backfillable from stored obs)",
+    )
+    gust_scope.add_argument(
+        "--model-only", action="store_true",
+        help="Only the model gust fields (limited to the un-pruned snapshot "
+             "window — see --days)",
+    )
+    p_backfill_gust.add_argument(
+        "--days", type=int, default=10,
+        help="How far back to look for model gust, in days (default: 10 — "
+             "airport_forecast_snapshots are pruned beyond that, so older "
+             "scores have no recoverable forecast gust)",
+    )
 
     # stats
     p_stats = subparsers.add_parser("stats", help="Show verification statistics")
@@ -832,6 +1026,8 @@ def main():
         cmd_score(args)
     elif args.command == "backfill":
         cmd_backfill(args)
+    elif args.command == "backfill-gust":
+        cmd_backfill_gust(args)
     elif args.command == "stats":
         cmd_stats(args)
     elif args.command == "discover":

--- a/src/weatherbrief/verify/__main__.py
+++ b/src/weatherbrief/verify/__main__.py
@@ -333,7 +333,7 @@ def cmd_backfill(args):
 
 
 def cmd_backfill_gust(args):
-    """Backfill the gust columns added by migration 082 (#491).
+    """Backfill the gust columns added by migration 083 (#491).
 
     Two independent halves with very different reach: the TAF gust delta is
     recoverable for all history (both gusts live on the permanent observation

--- a/tests/test_verification_gust.py
+++ b/tests/test_verification_gust.py
@@ -1,0 +1,544 @@
+"""Tests for gust verification (#491).
+
+Covers the standardised definitions, the scoring path that persists them,
+the daily/monthly rollup aggregates, the dashboard query, and the two
+backfills.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.orm import sessionmaker
+
+from conftest import make_app_engine
+from weatherbrief.db.models import (
+    AirportForecastSnapshotRow,
+    TafVerificationScoreRow,
+    VerificationDailyStatsRow,
+    VerificationMonthlyStatsRow,
+    VerificationObservationRow,
+    VerificationScoreRow,
+)
+from weatherbrief.tasks.scoring import _score_model_vs_metar, _score_taf_vs_metar
+from weatherbrief.tasks.verification_daily_rollup import rollup_day
+from weatherbrief.tasks.verification_gust import (
+    GUST_FLAG_THRESHOLD_KT,
+    backfill_model_gust,
+    backfill_taf_gust_deltas,
+    forecast_shows_gust,
+    realised_peak_kt,
+)
+from weatherbrief.tasks.verification_rollup import rollup_month
+from weatherbrief.tasks.verification_stats import get_gust_accuracy
+
+
+def _utc(*args) -> datetime:
+    return datetime(*args, tzinfo=timezone.utc)
+
+
+NOW = _utc(2026, 4, 1, 12, 0)
+
+
+# ---------------------------------------------------------------------------
+# Standardised definitions
+# ---------------------------------------------------------------------------
+
+
+class TestForecastShowsGust:
+
+    def test_at_threshold_counts(self):
+        assert forecast_shows_gust(15.0, 15.0 + GUST_FLAG_THRESHOLD_KT) is True
+
+    def test_below_threshold_does_not(self):
+        assert forecast_shows_gust(15.0, 24.0) is False
+
+    def test_missing_component_is_unknown_not_false(self):
+        assert forecast_shows_gust(None, 30.0) is None
+        assert forecast_shows_gust(15.0, None) is None
+
+
+class TestRealisedPeak:
+
+    def test_reported_gust_wins(self):
+        assert realised_peak_kt(12.0, 25.0) == 25.0
+
+    def test_no_gust_group_means_peak_is_the_mean(self):
+        assert realised_peak_kt(12.0, None) == 12.0
+
+    def test_nothing_observed(self):
+        assert realised_peak_kt(None, None) is None
+
+
+# ---------------------------------------------------------------------------
+# Scoring
+# ---------------------------------------------------------------------------
+
+
+class TestScoringPersistsGust:
+
+    def _obs_row(self, **overrides):
+        defaults = dict(
+            id=1, icao="EGTK", observation_time=NOW, flight_category="VFR",
+            ceiling_ft=4000, visibility_m=9999, wind_dir=270, wind_speed_kt=20,
+            wind_gust_kt=28, temperature_c=12,
+            taf_issue_time=NOW - timedelta(hours=4), taf_flight_category="VFR",
+            taf_ceiling_ft=4000, taf_visibility_m=9999, taf_wind_dir=270,
+            taf_wind_speed_kt=18, taf_wind_gust_kt=30,
+        )
+        defaults.update(overrides)
+        return SimpleNamespace(**defaults)
+
+    def _hourly(self, **overrides):
+        defaults = dict(
+            visibility_m=10000, wind_direction_10m_deg=260,
+            wind_speed_10m_kt=18.0, wind_gusts_10m_kt=30.0,
+            precipitation_mm=0.0, snowfall_cm=0.0, temperature_2m_c=11.5,
+        )
+        defaults.update(overrides)
+        return SimpleNamespace(**defaults)
+
+    def _score(self, obs_row, hourly):
+        with patch(
+            "weatherbrief.analysis.airport_conditions.reconcile_ceiling",
+            return_value=3800.0,
+        ), patch(
+            "weatherbrief.analysis.airport_conditions.classify_flight_category",
+            return_value=SimpleNamespace(value="VFR"),
+        ), patch(
+            "weatherbrief.tasks.route_weather.compute_wind_advisory",
+            side_effect=[("green", "R27", 2.0, 12.0), ("green", "R27", 1.5, 10.0)],
+        ):
+            return _score_model_vs_metar(
+                obs_row=obs_row, obs_weather=[], sounding=None, hourly=hourly,
+                runway_ends=[], model="gfs",
+                model_init_time=NOW - timedelta(hours=6), days_out=0,
+            )
+
+    def test_model_gust_fields(self):
+        result = self._score(self._obs_row(), self._hourly())
+        assert result.model_wind_gust_kt == 30.0
+        assert result.wind_gust_delta_kt == pytest.approx(2.0)  # 30 - 28
+        assert result.model_gust_flag is True  # 30 - 18 >= 10
+
+    def test_raw_gust_survives_when_the_airport_was_not_gusting(self):
+        """The row the whole issue exists for: model called a gust, METAR
+        reported none. The delta is NULL but the forecast gust is kept."""
+        result = self._score(self._obs_row(wind_gust_kt=None), self._hourly())
+        assert result.model_wind_gust_kt == 30.0
+        assert result.wind_gust_delta_kt is None
+        assert result.model_gust_flag is True
+
+    def test_forecast_without_a_gust_is_flagged_false(self):
+        result = self._score(
+            self._obs_row(), self._hourly(wind_speed_10m_kt=18.0, wind_gusts_10m_kt=24.0),
+        )
+        assert result.model_gust_flag is False
+        assert result.model_wind_gust_kt == 24.0
+
+    def test_no_model_gust_at_all(self):
+        result = self._score(self._obs_row(), self._hourly(wind_gusts_10m_kt=None))
+        assert result.model_wind_gust_kt is None
+        assert result.wind_gust_delta_kt is None
+        assert result.model_gust_flag is None
+
+    def test_taf_gust_delta(self):
+        with patch(
+            "weatherbrief.tasks.route_weather.compute_wind_advisory",
+            side_effect=[("green", "R27", 2.0, 12.0), ("green", "R27", 1.5, 10.0)],
+        ):
+            result = _score_taf_vs_metar(self._obs_row(), [], [], source="standalone")
+        assert result.wind_gust_delta_kt == pytest.approx(2.0)  # 30 - 28
+
+    def test_taf_gust_delta_null_without_observed_gust(self):
+        with patch(
+            "weatherbrief.tasks.route_weather.compute_wind_advisory",
+            side_effect=[("green", "R27", 2.0, 12.0), ("green", "R27", 1.5, 10.0)],
+        ):
+            result = _score_taf_vs_metar(
+                self._obs_row(wind_gust_kt=None), [], [], source="standalone",
+            )
+        assert result.wind_gust_delta_kt is None
+
+
+# ---------------------------------------------------------------------------
+# Rollups
+# ---------------------------------------------------------------------------
+
+
+def _add_obs(db, icao, when, *, wind=None, gust=None, taf_gust=None) -> int:
+    o = VerificationObservationRow(
+        icao=icao, observation_time=when, collected_at=when,
+        wind_speed_kt=wind, wind_gust_kt=gust, taf_wind_gust_kt=taf_gust,
+    )
+    db.add(o)
+    db.flush()
+    return o.id
+
+
+def _add_score(db, obs_id, icao, when, **kwargs):
+    row = VerificationScoreRow(
+        observation_id=obs_id, icao=icao, observation_time=when,
+        model=kwargs.pop("model", "gfs"),
+        model_init_time=kwargs.pop("init_time", when),
+        lead_hours=0, days_out=kwargs.pop("days_out", 0),
+        source=kwargs.pop("source", "standalone"),
+        **kwargs,
+    )
+    db.add(row)
+    db.flush()
+    return row
+
+
+class TestDailyRollupGust:
+
+    def test_both_conditionings_are_aggregated_separately(self, db_session):
+        day = _utc(2026, 5, 4, 12, 0)
+        # Hour 1: model flags a gust, airport not gusting (mean wind 12 kt).
+        oid1 = _add_obs(db_session, "LFPG", day, wind=12, gust=None)
+        _add_score(
+            db_session, oid1, "LFPG", day,
+            model_wind_gust_kt=25.0, wind_gust_delta_kt=None, model_gust_flag=True,
+        )
+        # Hour 2: model flags a gust and the airport gusted to 30 (model 26).
+        oid2 = _add_obs(db_session, "LFPG", day + timedelta(hours=3), wind=20, gust=30)
+        _add_score(
+            db_session, oid2, "LFPG", day + timedelta(hours=3),
+            model_wind_gust_kt=26.0, wind_gust_delta_kt=-4.0, model_gust_flag=True,
+        )
+        # Hour 3: no gust either side.
+        oid3 = _add_obs(db_session, "LFPG", day + timedelta(hours=6), wind=8, gust=None)
+        _add_score(
+            db_session, oid3, "LFPG", day + timedelta(hours=6),
+            model_wind_gust_kt=12.0, wind_gust_delta_kt=None, model_gust_flag=False,
+        )
+
+        rollup_day(db_session, date(2026, 5, 4))
+        row = db_session.execute(select(VerificationDailyStatsRow)).scalars().one()
+
+        # obs-flagged magnitude: only hour 2 has both gusts
+        assert row.n_gust == 1
+        assert row.sum_gust_delta_kt == pytest.approx(-4.0)
+        assert row.sum_abs_gust_delta_kt == pytest.approx(4.0)
+        # forecast-flagged magnitude: hours 1 and 2, each vs its realised peak
+        # (12 kt mean, then the 30 kt gust) → (25-12) + (26-30) = 9
+        assert row.n_gust_flagged_peak == 2
+        assert row.sum_gust_flagged_over_peak_kt == pytest.approx(9.0)
+        # occurrence
+        assert row.n_model_gust_flag == 2
+        assert row.n_obs_gust == 1
+        assert row.n_gust_flag_hit == 1
+
+    def test_rows_without_gust_data_contribute_nothing(self, db_session):
+        day = _utc(2026, 5, 6, 12, 0)
+        oid = _add_obs(db_session, "EDDF", day, wind=None, gust=None)
+        _add_score(db_session, oid, "EDDF", day)
+
+        rollup_day(db_session, date(2026, 5, 6))
+        row = db_session.execute(select(VerificationDailyStatsRow)).scalars().one()
+        assert row.n == 1
+        assert row.n_gust == 0
+        assert row.n_model_gust_flag == 0
+        assert row.n_obs_gust == 0
+        assert row.n_gust_flagged_peak == 0
+        assert row.sum_gust_delta_kt is None
+        assert row.sum_gust_flagged_over_peak_kt is None
+
+    def test_join_does_not_drop_scores(self, db_session):
+        """The gust join is inner — every score must still be counted."""
+        day = _utc(2026, 5, 7, 12, 0)
+        for i in range(3):
+            oid = _add_obs(db_session, "LSZH", day + timedelta(hours=i), wind=10)
+            _add_score(db_session, oid, "LSZH", day + timedelta(hours=i))
+
+        rollup_day(db_session, date(2026, 5, 7))
+        row = db_session.execute(select(VerificationDailyStatsRow)).scalars().one()
+        assert row.n == 3
+
+
+class TestMonthlyRollupGust:
+
+    def test_model_row_carries_both_conditionings(self, db_session):
+        when = _utc(2026, 3, 10, 12, 0)
+        oid1 = _add_obs(db_session, "LFPG", when, wind=12, gust=None)
+        _add_score(
+            db_session, oid1, "LFPG", when,
+            model_wind_gust_kt=25.0, model_gust_flag=True,
+        )
+        oid2 = _add_obs(db_session, "LFPG", when + timedelta(hours=3), wind=20, gust=30)
+        _add_score(
+            db_session, oid2, "LFPG", when + timedelta(hours=3),
+            model_wind_gust_kt=26.0, wind_gust_delta_kt=-4.0, model_gust_flag=True,
+        )
+
+        rollup_month(db_session, _utc(2026, 3, 1))
+        row = db_session.execute(
+            select(VerificationMonthlyStatsRow).where(
+                VerificationMonthlyStatsRow.model == "gfs"
+            )
+        ).scalars().one()
+
+        assert row.n_gust == 1
+        assert row.wind_gust_mae_kt == pytest.approx(4.0)
+        assert row.wind_gust_bias_kt == pytest.approx(-4.0)
+        assert row.n_model_gust_flag == 2
+        assert row.n_obs_gust == 1
+        assert row.n_gust_flag_hit == 1
+        assert row.n_gust_flagged_peak == 2
+        assert row.gust_over_peak_bias_kt == pytest.approx(4.5)  # (13 + -4) / 2
+
+
+# ---------------------------------------------------------------------------
+# Dashboard query
+# ---------------------------------------------------------------------------
+
+
+class TestGetGustAccuracy:
+
+    def _daily(self, db, **overrides):
+        defaults = dict(
+            date=date(2026, 5, 4), source="standalone", model="gfs", days_out=0,
+            icao="LFPG", n=100, n_gust=10, sum_abs_gust_delta_kt=60.0,
+            sum_gust_delta_kt=-60.0, n_gust_flagged_peak=40,
+            sum_gust_flagged_over_peak_kt=280.0, n_model_gust_flag=40,
+            n_obs_gust=10, n_gust_flag_hit=8,
+        )
+        defaults.update(overrides)
+        row = VerificationDailyStatsRow(**defaults)
+        db.add(row)
+        db.flush()
+        return row
+
+    def test_nwp_reports_both_views(self, db_session):
+        self._daily(db_session)
+        stats = get_gust_accuracy(
+            db_session, _utc(2026, 5, 4), _utc(2026, 5, 5), source="standalone",
+        )
+        assert len(stats) == 1
+        s = stats[0]
+        assert s.model == "gfs"
+        # obs-flagged: model runs low on the hours the airport gusted
+        assert s.n_gust == 10
+        assert s.gust_mae_kt == pytest.approx(6.0)
+        assert s.gust_bias_kt == pytest.approx(-6.0)
+        # forecast-flagged: model sits above the realised peak, and over-warns
+        assert s.n_flagged == 40
+        assert s.flagged_over_peak_kt == pytest.approx(7.0)
+        assert s.over_warn_ratio == pytest.approx(4.0)
+        assert s.n_flag_hit == 8
+
+    def test_sums_are_additive_across_days(self, db_session):
+        self._daily(db_session)
+        self._daily(db_session, date=date(2026, 5, 5))
+        stats = get_gust_accuracy(
+            db_session, _utc(2026, 5, 4), _utc(2026, 5, 6), source="standalone",
+        )
+        assert len(stats) == 1
+        assert stats[0].n_flagged == 80
+        # Ratios stay ratios — they are derived after summing.
+        assert stats[0].flagged_over_peak_kt == pytest.approx(7.0)
+        assert stats[0].over_warn_ratio == pytest.approx(4.0)
+
+    def test_groups_with_no_gust_activity_are_dropped(self, db_session):
+        self._daily(
+            db_session, n_gust=0, sum_abs_gust_delta_kt=None,
+            sum_gust_delta_kt=None, n_gust_flagged_peak=0,
+            sum_gust_flagged_over_peak_kt=None, n_model_gust_flag=0,
+            n_obs_gust=0, n_gust_flag_hit=0,
+        )
+        assert get_gust_accuracy(
+            db_session, _utc(2026, 5, 4), _utc(2026, 5, 5), source="standalone",
+        ) == []
+
+    def test_taf_comes_from_raw_scores(self, db_session):
+        when = _utc(2026, 5, 4, 12, 0)
+        # TAF carries a gust group, airport isn't gusting (mean 12 kt).
+        oid1 = _add_obs(db_session, "LFPG", when, wind=12, gust=None, taf_gust=25)
+        # TAF carries a gust group and the airport gusted to 30.
+        oid2 = _add_obs(
+            db_session, "LFPG", when + timedelta(hours=3),
+            wind=20, gust=30, taf_gust=29,
+        )
+        for oid, obs_time, delta in (
+            (oid1, when, None), (oid2, when + timedelta(hours=3), -1.0),
+        ):
+            db_session.add(TafVerificationScoreRow(
+                observation_id=oid, icao="LFPG", observation_time=obs_time,
+                taf_issue_time=when - timedelta(hours=4), lead_hours=4,
+                source="standalone", wind_gust_delta_kt=delta,
+            ))
+        db_session.flush()
+
+        stats = get_gust_accuracy(
+            db_session, _utc(2026, 5, 4), _utc(2026, 5, 5), source="standalone",
+        )
+        taf = [s for s in stats if s.model == "TAF"]
+        assert len(taf) == 1
+        assert taf[0].n_flagged == 2
+        assert taf[0].n_obs_gust == 1
+        assert taf[0].over_warn_ratio == pytest.approx(2.0)
+        # (25 - 12) + (29 - 30) = 12 over 2 flagged hours
+        assert taf[0].flagged_over_peak_kt == pytest.approx(6.0)
+        assert taf[0].n_gust == 1
+        assert taf[0].gust_bias_kt == pytest.approx(-1.0)
+
+
+# ---------------------------------------------------------------------------
+# Digest rendering
+# ---------------------------------------------------------------------------
+
+
+class TestDigestGustSection:
+
+    def _data(self, **overrides):
+        from weatherbrief.models.verification import (
+            GustAccuracyStats,
+            VerificationDigestData,
+        )
+        defaults = dict(
+            model="ecmwf", days_out=0, n=1000, n_gust=40, gust_mae_kt=6.2,
+            gust_bias_kt=-5.1, n_flagged=160, flagged_over_peak_kt=7.1,
+            n_obs_gust=40, n_flag_hit=32, over_warn_ratio=4.0,
+        )
+        defaults.update(overrides)
+        return VerificationDigestData(
+            period_label="24h", gust_accuracy=[GustAccuracyStats(**defaults)],
+        )
+
+    def test_html_reports_both_conditionings(self):
+        from weatherbrief.notify.verification_email import _render_gust_section
+
+        html = _render_gust_section(self._data())
+        assert "+7.1 kt" in html   # forecast-flagged, above the realised peak
+        assert "4.0×" in html      # over-warn ratio
+        assert "-5.1 kt" in html   # obs-flagged, running low
+
+    def test_html_scoped_to_d0(self):
+        from weatherbrief.notify.verification_email import _render_gust_section
+
+        assert _render_gust_section(self._data(days_out=2)) == ""
+
+    def test_plaintext_includes_gust(self):
+        from weatherbrief.notify.verification_email import _build_digest_plain
+
+        text = _build_digest_plain(self._data())
+        assert "GUST ACCURACY (D-0)" in text
+        assert "over-warn  4.0x" in text
+
+
+# ---------------------------------------------------------------------------
+# Backfill
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def committing_db():
+    """A session with its own engine — the backfills commit per batch."""
+    engine = make_app_engine()
+    session = sessionmaker(bind=engine)()
+    yield session
+    session.close()
+    engine.dispose()
+
+
+class TestTafGustBackfill:
+
+    def test_fills_delta_from_stored_observations(self, committing_db):
+        db = committing_db
+        when = _utc(2026, 4, 20, 12, 0)
+        oid = _add_obs(db, "LFPG", when, wind=20, gust=30, taf_gust=26)
+        db.add(TafVerificationScoreRow(
+            observation_id=oid, icao="LFPG", observation_time=when,
+            taf_issue_time=when - timedelta(hours=5), lead_hours=5,
+            source="standalone",
+        ))
+        db.flush()
+
+        assert backfill_taf_gust_deltas(db) == 1
+        row = db.execute(select(TafVerificationScoreRow)).scalars().one()
+        assert row.wind_gust_delta_kt == pytest.approx(-4.0)
+
+    def test_skips_rows_without_both_gusts_and_is_idempotent(self, committing_db):
+        db = committing_db
+        when = _utc(2026, 4, 21, 12, 0)
+        oid = _add_obs(db, "EDDF", when, wind=20, gust=None, taf_gust=26)
+        db.add(TafVerificationScoreRow(
+            observation_id=oid, icao="EDDF", observation_time=when,
+            taf_issue_time=when - timedelta(hours=5), lead_hours=5,
+            source="standalone",
+        ))
+        db.flush()
+
+        assert backfill_taf_gust_deltas(db) == 0
+        assert backfill_taf_gust_deltas(db) == 0
+        row = db.execute(select(TafVerificationScoreRow)).scalars().one()
+        assert row.wind_gust_delta_kt is None
+
+
+class TestModelGustBackfill:
+
+    def test_fills_from_the_unpruned_snapshot_window(self, committing_db):
+        db = committing_db
+        when = datetime.now(timezone.utc).replace(
+            minute=0, second=0, microsecond=0,
+        ) - timedelta(hours=3)
+        init = when - timedelta(hours=6)
+
+        oid = _add_obs(db, "LFPG", when, wind=20, gust=28)
+        score = _add_score(
+            db, oid, "LFPG", when, init_time=init, model="icon",
+        )
+        db.add(AirportForecastSnapshotRow(
+            icao="LFPG", model="icon", model_init_time=init, forecast_hour=when,
+            wind_speed_10m_kt=18.0, wind_gusts_10m_kt=32.0,
+        ))
+        # A decoy an hour away — the nearest forecast hour must win.
+        db.add(AirportForecastSnapshotRow(
+            icao="LFPG", model="icon", model_init_time=init,
+            forecast_hour=when + timedelta(hours=1),
+            wind_speed_10m_kt=19.0, wind_gusts_10m_kt=40.0,
+        ))
+        db.flush()
+
+        assert backfill_model_gust(db, days=2) == 1
+        db.refresh(score)
+        assert score.model_wind_gust_kt == pytest.approx(32.0)
+        assert score.wind_gust_delta_kt == pytest.approx(4.0)  # 32 - 28
+        assert score.model_gust_flag is True
+
+    def test_leaves_already_populated_scores_alone(self, committing_db):
+        db = committing_db
+        when = datetime.now(timezone.utc).replace(
+            minute=0, second=0, microsecond=0,
+        ) - timedelta(hours=3)
+        init = when - timedelta(hours=6)
+
+        oid = _add_obs(db, "EGLL", when, wind=20, gust=28)
+        _add_score(
+            db, oid, "EGLL", when, init_time=init, model="gfs",
+            model_wind_gust_kt=99.0,
+        )
+        db.add(AirportForecastSnapshotRow(
+            icao="EGLL", model="gfs", model_init_time=init, forecast_hour=when,
+            wind_speed_10m_kt=18.0, wind_gusts_10m_kt=32.0,
+        ))
+        db.flush()
+
+        assert backfill_model_gust(db, days=2) == 0
+        row = db.execute(select(VerificationScoreRow)).scalars().one()
+        assert row.model_wind_gust_kt == pytest.approx(99.0)
+
+    def test_no_snapshot_leaves_the_score_untouched(self, committing_db):
+        db = committing_db
+        when = datetime.now(timezone.utc) - timedelta(hours=3)
+        oid = _add_obs(db, "LSZH", when, wind=20, gust=28)
+        _add_score(db, oid, "LSZH", when, init_time=when - timedelta(hours=6))
+        db.flush()
+
+        assert backfill_model_gust(db, days=2) == 0
+        row = db.execute(select(VerificationScoreRow)).scalars().one()
+        assert row.model_wind_gust_kt is None

--- a/tests/test_verification_gust.py
+++ b/tests/test_verification_gust.py
@@ -532,6 +532,30 @@ class TestModelGustBackfill:
         row = db.execute(select(VerificationScoreRow)).scalars().one()
         assert row.model_wind_gust_kt == pytest.approx(99.0)
 
+    def test_a_snapshot_gap_leaves_the_score_untouched(self, committing_db):
+        """Nearest-wins must not reach past the window live scoring uses."""
+        db = committing_db
+        when = datetime.now(timezone.utc).replace(
+            minute=0, second=0, microsecond=0,
+        ) - timedelta(hours=4)
+        init = when - timedelta(hours=6)
+
+        oid = _add_obs(db, "EHAM", when, wind=20, gust=28)
+        _add_score(db, oid, "EHAM", when, init_time=init, model="icon")
+        # The only snapshot for this key sits 3 h away — a gap, not a match.
+        db.add(AirportForecastSnapshotRow(
+            icao="EHAM", model="icon", model_init_time=init,
+            forecast_hour=when + timedelta(hours=3),
+            wind_speed_10m_kt=19.0, wind_gusts_10m_kt=40.0,
+        ))
+        db.flush()
+
+        assert backfill_model_gust(db, days=2) == 0
+        row = db.execute(select(VerificationScoreRow)).scalars().one()
+        assert row.model_wind_gust_kt is None
+        assert row.wind_gust_delta_kt is None
+        assert row.model_gust_flag is None
+
     def test_no_snapshot_leaves_the_score_untouched(self, committing_db):
         db = committing_db
         when = datetime.now(timezone.utc) - timedelta(hours=3)

--- a/web/ts/adapters/admin-adapter.ts
+++ b/web/ts/adapters/admin-adapter.ts
@@ -430,6 +430,27 @@ export interface WindAdvisoryStats {
   sample_count: number;
 }
 
+/** Gust accuracy under both conditionings — they are never blended (#491).
+ *
+ * Forecast-flagged: `n_flagged` hours the forecast called a gust,
+ * `flagged_over_peak_kt` = mean(forecast gust − realised peak) on those hours,
+ * `over_warn_ratio` = flagged ÷ hours the airport actually gusted.
+ * Obs-flagged: `n_gust` hours the airport gusted, with MAE and signed bias.
+ */
+export interface GustAccuracyStats {
+  model: string;
+  days_out: number;
+  n: number;
+  n_gust: number;
+  gust_mae_kt: number | null;
+  gust_bias_kt: number | null;
+  n_flagged: number;
+  flagged_over_peak_kt: number | null;
+  n_obs_gust: number;
+  n_flag_hit: number;
+  over_warn_ratio: number | null;
+}
+
 export interface MissedWarning {
   icao: string;
   observation_time: string;
@@ -447,6 +468,8 @@ export interface VerificationDigest {
   notable_misses: NotableMiss[];
   category_bias: CategoryBiasStats[];
   wind_advisory: WindAdvisoryStats[];
+  /** Absent on cache entries written before #491 — treat as empty. */
+  gust_accuracy?: GustAccuracyStats[];
   missed_warnings: MissedWarning[];
 }
 

--- a/web/ts/verification-main.ts
+++ b/web/ts/verification-main.ts
@@ -171,6 +171,7 @@ async function loadData(): Promise<void> {
     renderBias(data);
     renderMisses(data);
     renderWind(data);
+    renderGust(data);
     renderHealth(data);
   } catch (err) {
     console.error('Failed to load verification stats', err);
@@ -237,6 +238,23 @@ const SECTION_INFO: Record<string, string> = {
     </div>
     <div class="popup-section"><h4>Missed Wind Warnings</h4>
       <p>Cases where actual conditions triggered a WARNING but the model failed to predict it \u2014 the most safety-critical wind misses.</p>
+    </div>`,
+
+  gust: `
+    <div class="popup-header"><h3>Gust Accuracy</h3></div>
+    <p class="popup-vibe">Two different questions about gust, deliberately never averaged together.</p>
+    <div class="popup-section"><h4>When the forecast calls a gust</h4>
+      <p>A forecast "shows a gust" when its gust exceeds its own mean wind by 10 kt or more — the same criterion that puts a gust group on a METAR.</p>
+      <p><strong>vs peak</strong> — how far the forecast gust sits above the <em>realised peak</em> (the observed gust if the METAR reported one, otherwise the observed mean wind). Models typically run several knots high here.</p>
+      <p><strong>Over-warn</strong> — flagged hours divided by hours the airport actually gusted. 4× means the forecast called four gusty hours for every one that happened.</p>
+      <p><strong>Hit</strong> — share of flagged hours where the airport did gust.</p>
+    </div>
+    <div class="popup-section"><h4>When the airport actually gusted</h4>
+      <p>The opposite conditioning: on the hours a METAR reported a gust, how far off was the forecast gust? Models typically run <em>low</em> here — the extreme days are under-forecast even though the average day is over-warned.</p>
+      <p><strong>MAE</strong> = mean absolute error, <strong>Bias</strong> = signed mean (forecast − observed; negative means the forecast was too low).</p>
+    </div>
+    <div class="popup-section"><h4>Why both</h4>
+      <p>The two select different, mostly non-overlapping sets of hours. A single blended gust number mixes them and reads as self-contradictory.</p>
     </div>`,
 
   health: `
@@ -489,6 +507,62 @@ function renderWind(data: VerificationDigest): void {
     html += '</tbody></table>';
   }
 
+  el.innerHTML = html;
+}
+
+function fmtKt(v: number | null): string {
+  if (v == null) return '—';
+  return `${v > 0 ? '+' : ''}${v.toFixed(1)} kt`;
+}
+
+function renderGust(data: VerificationDigest): void {
+  const el = document.getElementById('gust-section');
+  if (!el) return;
+  // Cache entries written before #491 have no gust_accuracy key.
+  const rows = (data.gust_accuracy ?? []).filter(
+    (g) => g.n_flagged > 0 || g.n_obs_gust > 0 || g.n_gust > 0,
+  );
+
+  let html = `<h2>Gust Accuracy ${infoBtn('gust')}</h2>`;
+  if (rows.length === 0) {
+    el.innerHTML = `${html}<p class="empty-state">No gust data for this period.</p>`;
+    return;
+  }
+
+  html += '<table class="admin-table"><thead>';
+  html += '<tr><th></th><th></th>';
+  html += '<th class="num" colspan="4" style="text-align:center">Forecast called a gust</th>';
+  html += '<th class="num" colspan="3" style="text-align:center">Airport actually gusted</th>';
+  html += '</tr><tr><th>Model</th><th class="num">D-out</th>';
+  html += '<th class="num" title="Hours the forecast gust exceeded its own mean wind by 10 kt or more">Hours</th>';
+  html += '<th class="num" title="Mean forecast gust minus the realised peak (observed gust, else observed mean wind)">vs peak</th>';
+  html += '<th class="num" title="Flagged hours divided by hours the airport actually gusted">Over-warn</th>';
+  html += '<th class="num" title="Share of flagged hours where the airport did gust">Hit</th>';
+  html += '<th class="num" title="Hours with an observed gust and a forecast gust to compare">Hours</th>';
+  html += '<th class="num" title="Mean absolute gust error on those hours">MAE</th>';
+  html += '<th class="num" title="Signed mean error (forecast - observed); negative means the forecast ran low">Bias</th>';
+  html += '</tr></thead><tbody>';
+
+  for (const g of rows) {
+    const hitPct = g.n_flagged > 0 ? (g.n_flag_hit / g.n_flagged) * 100 : null;
+    const overWarn = g.over_warn_ratio != null ? `${g.over_warn_ratio.toFixed(1)}×` : '—';
+    html += '<tr>';
+    html += `<td style="font-weight:600">${escapeHtml(g.model.toUpperCase())}</td>`;
+    html += `<td class="num">D-${g.days_out}</td>`;
+    html += `<td class="num">${g.n_flagged}</td>`;
+    html += `<td class="num">${fmtKt(g.flagged_over_peak_kt)}</td>`;
+    html += `<td class="num">${overWarn}</td>`;
+    html += `<td class="num">${fmtPct(hitPct)}</td>`;
+    html += `<td class="num">${g.n_gust}</td>`;
+    html += `<td class="num">${g.gust_mae_kt != null ? `${g.gust_mae_kt.toFixed(1)} kt` : '—'}</td>`;
+    html += `<td class="num">${fmtKt(g.gust_bias_kt)}</td>`;
+    html += '</tr>';
+  }
+
+  html += '</tbody></table>';
+  html += '<p style="font-size:0.75rem;color:var(--text-muted);margin-top:0.25rem">';
+  html += 'The two halves cover different hours and are never averaged together — forecasts over-warn on the average day and run low on the gusty ones.';
+  html += '</p>';
   el.innerHTML = html;
 }
 

--- a/web/verification.html
+++ b/web/verification.html
@@ -139,6 +139,7 @@
     <div id="bias-section" class="section"></div>
     <div id="misses-section" class="section"></div>
     <div id="wind-section" class="section"></div>
+    <div id="gust-section" class="section"></div>
     <div id="health-section" class="section"></div>
   </div>
 


### PR DESCRIPTION
## What & why

Wind gust was never persisted in verification scoring — only wind speed. This made it impossible to answer "does the model over-call gusts?" beyond the last ~10 days (when snapshot data is pruned). 

This PR adds comprehensive gust verification:

1. **Scoring** — `verification_scores` now captures the forecast gust itself (`model_wind_gust_kt`), its delta vs observed (`wind_gust_delta_kt`), and a boolean flag (`model_gust_flag`) indicating whether the forecast meets the METAR ~10 kt gust criterion. TAF scores get the delta only (the TAF gust already lives on `verification_observations`).

2. **Standardised definitions** — All gust numbers across scoring, rollups, and dashboards come from `tasks/verification_gust`:
   - **Realised peak** = observed gust if reported, else observed mean wind (a METAR only carries a gust group when peak exceeds mean by ~10 kt)
   - **"Forecast shows a gust"** = forecast gust − forecast wind ≥ 10 kt (same criterion as METAR)
   - **Two non-overlapping conditionings** (never blended):
     - *Forecast-flagged*: on hours the forecast called a gust, how far above the realised peak? (models run ~+7 kt high; ~80% of those hours the airport wasn't gusting)
     - *Obs-flagged*: on hours the airport actually gusted, how far below the true peak? (models run 4–13 kt *low* on extreme days)

3. **Rollups** — Daily and monthly stats aggregate both conditionings separately with additive SUM/count columns, plus occurrence contingency (2×2 table: forecast flag, observed gust, both).

4. **Dashboard & email** — New gust accuracy section shows both views side by side with MAE, bias, over-warn ratio, and hit rate.

5. **Backfill** — Two backfill functions recover historical gust data: TAF deltas from permanent observation rows (all history), model gusts from snapshots (last ~10 days only).

## Issue linkage

Closes #491

## Testing / verification

- 544 lines of comprehensive unit tests covering definitions, scoring persistence, daily/monthly rollups, dashboard queries, and both backfills
- Tests verify both conditionings are aggregated separately and never blended
- Existing verification tests pass; new gust fields are optional (NULL-safe) so old rows continue to work
- Database migration uses `batch_alter_table` for SQLite/MySQL compatibility

https://claude.ai/code/session_015YW1hCbPM3HB85TbBAZBrf