### PR TITLE
feat(ios): delete a flight from the list, plus link/share polish

### DIFF
--- a/app/flyfun-weather/flyfun-weather/Services/BriefingRepository.swift
+++ b/app/flyfun-weather/flyfun-weather/Services/BriefingRepository.swift
@@ -12,8 +12,19 @@ enum RefreshSource: String, Sendable {
 /// Abstraction over briefing data access.
 protocol BriefingRepository: Sendable {
     func flights() async throws -> [FlightResponse]
+    /// Fetch one flight by id, independent of the viewer's list. Backs the
+    /// `briefing.html?flight=<id>` Universal Link fallback for flights that
+    /// aren't in the list (e.g. a feedback email about another pilot's flight):
+    /// the server allows the owner always and any authenticated viewer for a
+    /// non-private flight (role comes back `subscriber`), and 404s otherwise.
+    func flight(id: String) async throws -> FlightResponse
     func createFlight(_ request: CreateFlightRequest) async throws -> FlightResponse
     func updateFlight(flightId: String, request: UpdateFlightRequest) async throws -> UpdateFlightResponse
+    /// Permanently delete one of the viewer's own flights and all of its briefing
+    /// history (server 204, owner-only — a subscriber unsubscribes instead).
+    /// Online-only; the caching layer also drops the flight's local pack cache,
+    /// since a deleted flight can never be refreshed or re-downloaded.
+    func deleteFlight(id: String) async throws
     func aircraft() async throws -> [AircraftResponse]
     func profiles() async throws -> [ProfileResponse]
     /// Account usage summary — the iOS app reads only the durable timing-scan
@@ -117,6 +128,10 @@ final class OnlineBriefingRepository: BriefingRepository {
         try await client.request("/api/flights")
     }
 
+    func flight(id: String) async throws -> FlightResponse {
+        try await client.request("/api/flights/\(id)")
+    }
+
     func createFlight(_ request: CreateFlightRequest) async throws -> FlightResponse {
         let body = try JSONEncoder.weatherBrief.encode(request)
         return try await client.request("/api/flights", method: "POST", body: body)
@@ -127,6 +142,10 @@ final class OnlineBriefingRepository: BriefingRepository {
         // Server returns the updated flight plus an invalidation hint describing
         // how much of the briefing the edit invalidated.
         return try await client.request("/api/flights/\(flightId)", method: "PATCH", body: body)
+    }
+
+    func deleteFlight(id: String) async throws {
+        try await client.requestVoid("/api/flights/\(id)")
     }
 
     func aircraft() async throws -> [AircraftResponse] {

--- a/app/flyfun-weather/flyfun-weather/Services/CachingBriefingRepository.swift
+++ b/app/flyfun-weather/flyfun-weather/Services/CachingBriefingRepository.swift
@@ -74,6 +74,20 @@ final class CachingBriefingRepository: BriefingRepository, CacheStatusReporting 
         try await online.updateFlight(flightId: flightId, request: request)
     }
 
+    /// Delete server-side first — only once the server confirms (204) do we drop
+    /// the local copy, so a failed delete leaves a flight that still exists with
+    /// its downloaded packs intact. After that the packs are unreachable (no
+    /// refresh, no re-download), so evict them: index entries first, then the
+    /// whole flight directory including the sidecars, matching the order the
+    /// eviction sweep in `pruneStalePacks` uses.
+    func deleteFlight(id: String) async throws {
+        try await online.deleteFlight(id: id)
+        for entry in await cache.cachedPacks() where entry.flightId == id {
+            await cache.deletePack(flightId: id, timestamp: entry.timestamp)
+        }
+        await cache.removeFlightDirectory(flightId: id)
+    }
+
     func aircraft() async throws -> [AircraftResponse] {
         try await online.aircraft()
     }
@@ -135,6 +149,21 @@ final class CachingBriefingRepository: BriefingRepository, CacheStatusReporting 
             if !recovered.isEmpty {
                 Self.logger.info("Recovered \(recovered.count) flights from download cache")
                 return recovered
+            }
+            throw error
+        }
+    }
+
+    /// Online-first single-flight fetch (Universal Link fallback for flights not
+    /// in the list). Offline fallback: the cached list, since a flight outside
+    /// the viewer's list is never in the per-flight cache anyway.
+    func flight(id: String) async throws -> FlightResponse {
+        do {
+            return try await online.flight(id: id)
+        } catch {
+            if let cached = await readCachedFlightsFromDisk(),
+               let match = cached.first(where: { $0.id == id }) {
+                return match
             }
             throw error
         }

--- a/app/flyfun-weather/flyfun-weather/Services/FixtureBriefingRepository.swift
+++ b/app/flyfun-weather/flyfun-weather/Services/FixtureBriefingRepository.swift
@@ -78,6 +78,13 @@ final class FixtureBriefingRepository: BriefingRepository, CacheStatusReporting 
 
     func flights() async throws -> [FlightResponse] { flightsFixture + createdFlights }
 
+    func flight(id: String) async throws -> FlightResponse {
+        guard let match = (flightsFixture + createdFlights).first(where: { $0.id == id }) else {
+            throw APIError.notFound
+        }
+        return match
+    }
+
     func createFlight(_ request: CreateFlightRequest) async throws -> FlightResponse {
         let flight = FlightResponse(
             id: "created-\(createdFlights.count + 1)",
@@ -169,6 +176,7 @@ final class FixtureBriefingRepository: BriefingRepository, CacheStatusReporting 
     // MARK: Not yet needed by a journey
 
     func updateFlight(flightId: String, request: UpdateFlightRequest) async throws -> UpdateFlightResponse { throw FixtureError.notProvided("updateFlight") }
+    func deleteFlight(id: String) async throws { throw FixtureError.notProvided("deleteFlight") }
     func createAircraft(_ request: CreateAircraftRequest) async throws -> AircraftResponse { throw FixtureError.notProvided("createAircraft") }
     func parseFpl(_ text: String) async throws -> ParseFplResponse { throw FixtureError.notProvided("parseFpl") }
     /// Echo the typed tokens back as a clean interpretation. The create/edit flow

--- a/app/flyfun-weather/flyfun-weather/ViewModels/FlightListViewModel.swift
+++ b/app/flyfun-weather/flyfun-weather/ViewModels/FlightListViewModel.swift
@@ -151,6 +151,19 @@ final class FlightListViewModel {
         }
     }
 
+    /// Permanently delete one of the user's own flights (and all its briefing
+    /// history), then re-sync the list so the row — and its offline badge and
+    /// Spotlight entry, both derived from the reloaded list — disappears with it.
+    /// Owner-only and online-only, mirroring the web's Delete button.
+    ///
+    /// Rethrows: a failed delete leaves the row in place, which must read as a
+    /// failure to the user rather than a silent no-op.
+    func deleteFlight(_ flight: FlightResponse) async throws {
+        try await repository.deleteFlight(id: flight.id)
+        Self.logger.info("Deleted flight \(flight.id)")
+        await loadFlights()
+    }
+
     // MARK: - Active-refresh polling (live "Updating…" row indicator)
 
     /// Poll `GET /api/refresh/active` every 5s while the list is visible so a row

--- a/app/flyfun-weather/flyfun-weather/Views/Briefing/BriefingContainerView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Briefing/BriefingContainerView.swift
@@ -14,6 +14,7 @@ struct BriefingContainerView: View {
     /// is immutable. Seeded from the flight in `.task`; updated optimistically.
     @State private var notifyOverride: FlightNotifyOverride = .default
     @State private var notifyOverrideBusy = false
+    @State private var showingShareSheet = false
 
     private static let dayTimeUTC: DateFormatter = {
         let fmt = DateFormatter()
@@ -81,8 +82,14 @@ struct BriefingContainerView: View {
                         // URL. Only the owner sees it, and only for a non-private
                         // flight with a minted code (isShareable) — a private link
                         // would 404 for the recipient, matching the web gate.
-                        if flight.isShareable, let code = flight.shareCode {
-                            ShareLink(item: AppState.shareURL(forShareCode: code)) {
+                        // UIActivityViewController instead of `ShareLink` so the
+                        // sheet can carry the custom "Open in Safari" activity
+                        // (iOS offers Chrome via its share extension but never
+                        // Safari — see ShareActivitySheet).
+                        if flight.isShareable, flight.shareCode != nil {
+                            Button {
+                                showingShareSheet = true
+                            } label: {
                                 Label("Share", systemImage: "square.and.arrow.up")
                                     .font(.caption)
                             }
@@ -111,6 +118,14 @@ struct BriefingContainerView: View {
                                             isInFlightWindow: isInFlightWindow, startTracking: startTracking)
                     }
                 }
+            }
+        }
+        .sheet(isPresented: $showingShareSheet) {
+            if let code = flight.shareCode {
+                ShareActivitySheet(items: [AppState.shareURL(forShareCode: code)],
+                                   activities: [OpenInSafariActivity()])
+                    .presentationDetents([.medium, .large])
+                    .ignoresSafeArea()
             }
         }
         .sheet(isPresented: $showingPirepSheet) {

--- a/app/flyfun-weather/flyfun-weather/Views/Briefing/RouteObservationsView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Briefing/RouteObservationsView.swift
@@ -151,6 +151,10 @@ struct RouteObservationsView: View {
         // property, so reading it inside the row `ForEach` rebuilt the whole
         // dictionary for every row — 29 builds per pass on a real corridor.
         let comparisons = obs.comparisonsByIcao
+        // Same reason: `displayedAirports` re-runs the nearest-N sort (and rebuilds
+        // the comparison lookup for the conflict pin) on every call, and both the
+        // rows and the "Show all" toggle need it.
+        let displayed = displayedAirports(obs)
         VStack(alignment: .leading, spacing: Theme.spacingXS) {
             ScrollView(.horizontal) {
                 // `horizontalSpacing: 0` with per-cell padding instead of grid
@@ -179,7 +183,7 @@ struct RouteObservationsView: View {
                         }
                     }
                     Divider().gridCellUnsizedAxes(.horizontal).gridCellColumns(gridColumnCount)
-                    ForEach(displayedAirports(obs)) { apt in
+                    ForEach(displayed) { apt in
                         row(apt, comparison: comparisons[apt.icao])
                     }
                 }
@@ -187,7 +191,7 @@ struct RouteObservationsView: View {
             }
             .scrollBounceBehavior(.basedOnSize, axes: .horizontal)
 
-            showAllToggle(obs)
+            showAllToggle(obs, shown: displayed.count)
             legend
         }
     }
@@ -200,10 +204,11 @@ struct RouteObservationsView: View {
     }
 
     /// Expand/collapse control, shown only when the cap is actually hiding rows.
+    /// Takes `shown` from the caller rather than recomputing `displayedAirports`,
+    /// which would re-run the nearest-N sort a second time per render.
     @ViewBuilder
-    private func showAllToggle(_ obs: RouteObservations) -> some View {
+    private func showAllToggle(_ obs: RouteObservations, shown: Int) -> some View {
         let total = obs.reportingAirports.count
-        let shown = displayedAirports(obs).count
         if !isRegularWidth, total > shown || showsAllAirports {
             Button {
                 withAnimation { showsAllAirports.toggle() }

--- a/app/flyfun-weather/flyfun-weather/Views/Flights/FlightListView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Flights/FlightListView.swift
@@ -41,6 +41,12 @@ struct FlightListView: View {
     /// Error surfaced when a swipe/context-menu unsubscribe fails, so the row
     /// staying put reads as a failure rather than a silent no-op (#446).
     @State private var unsubscribeError: String?
+    /// A flight the user swiped/long-pressed Delete on, held while the destructive
+    /// confirmation is up. Deleting drops all briefing history and can't be undone,
+    /// so — like the web's `confirm()` — it is never a one-tap action.
+    @State private var deleteCandidate: FlightResponse?
+    /// Error surfaced when a delete fails (same reasoning as `unsubscribeError`).
+    @State private var deleteError: String?
     /// Bumped on every `openForecastMap`, used as the map view's `.id` so a *new*
     /// inbound deep link while the map is already open re-creates the view (the
     /// deep link is applied only at `ForecastMapViewModel.init`).
@@ -280,7 +286,7 @@ struct FlightListView: View {
                 }
             }
         }
-        .alert("Shared flight unavailable", isPresented: Binding(
+        .alert("Flight unavailable", isPresented: Binding(
             get: { shareResolveError != nil },
             set: { if !$0 { shareResolveError = nil } }
         )) {
@@ -295,6 +301,34 @@ struct FlightListView: View {
             Button("OK", role: .cancel) {}
         } message: {
             Text(unsubscribeError ?? "")
+        }
+        // Destructive delete confirmation. Attached at the list level (not per row)
+        // so the swipe action can complete and the row close before the dialog
+        // appears; `presenting:` carries the flight so the message names the route.
+        .confirmationDialog(
+            "Delete Flight?",
+            isPresented: Binding(
+                get: { deleteCandidate != nil },
+                set: { if !$0 { deleteCandidate = nil } }
+            ),
+            titleVisibility: .visible,
+            presenting: deleteCandidate
+        ) { flight in
+            Button("Delete Flight", role: .destructive) {
+                if let viewModel { delete(flight, viewModel: viewModel) }
+            }
+            .accessibilityIdentifier("confirmDeleteFlightButton")
+            Button("Cancel", role: .cancel) {}
+        } message: { flight in
+            Text("\(flight.shortTitle) and all of its briefing history will be deleted. This can’t be undone.")
+        }
+        .alert("Couldn’t delete flight", isPresented: Binding(
+            get: { deleteError != nil },
+            set: { if !$0 { deleteError = nil } }
+        )) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(deleteError ?? "")
         }
         .task {
             guard let repo = appState.repository else { return }
@@ -443,9 +477,30 @@ struct FlightListView: View {
                     applyPendingNavigation()
                 }
             } else {
-                // Authoritative reload still lacks it — it's genuinely gone. Drop.
+                // Authoritative reload still lacks it — the link names a flight
+                // outside the viewer's list (a feedback email about another
+                // pilot's flight, a link from a different sign-in account). The
+                // server still serves GET /flights/{id} to any authenticated
+                // viewer for a non-private flight, so fetch it directly instead
+                // of silently landing on the list. A non-owner comes back
+                // role == .subscriber and gets the same preview-before-subscribe
+                // screen as a /s/{code} share link; a 404 (private/unknown)
+                // surfaces an alert so the tap is never a silent no-op.
                 reloadRetryFlightId = nil
                 appState.clearPendingNavigation()
+                guard let repo = appState.repository else { return }
+                Task {
+                    do {
+                        let flight = try await repo.flight(id: flightId)
+                        if flight.role == .subscriber {
+                            sharedPreviewFlight = flight
+                        } else {
+                            selection = .flight(flight)
+                        }
+                    } catch {
+                        shareResolveError = "This briefing isn’t available. The flight may be private, deleted, or on a different account."
+                    }
+                }
             }
         }
     }
@@ -464,6 +519,23 @@ struct FlightListView: View {
                 unsubscribeError = error.errorDescription ?? "Couldn’t unsubscribe from this flight."
             } catch {
                 unsubscribeError = error.localizedDescription
+            }
+        }
+    }
+
+    /// Delete one of the user's own flights (confirmed), then reload the list so
+    /// the row disappears. Same detail-pane hygiene as `unsubscribe`: if the
+    /// deleted flight is the current iPad selection, clear it so the detail pane
+    /// doesn't dangle on a flight the server no longer has.
+    private func delete(_ flight: FlightResponse, viewModel: FlightListViewModel) {
+        Task {
+            do {
+                if selection == .flight(flight) { selection = nil }
+                try await viewModel.deleteFlight(flight)
+            } catch let error as APIError {
+                deleteError = error.errorDescription ?? "Couldn’t delete this flight."
+            } catch {
+                deleteError = error.localizedDescription
             }
         }
     }
@@ -531,6 +603,18 @@ struct FlightListView: View {
                     Label("Unsubscribe", systemImage: "person.badge.minus")
                 }
             }
+            // Delete an owned flight, matching the web's Delete button. Owner-only
+            // (the server 404s a subscriber's delete) and online-only. Never
+            // immediate: it opens the destructive confirmation. `allowsFullSwipe`
+            // is already false on this edge, so a long swipe can't trigger it.
+            if !viewModel.isOffline && flight.isEditable {
+                Button(role: .destructive) {
+                    deleteCandidate = flight
+                } label: {
+                    Label("Delete", systemImage: "trash")
+                }
+                .accessibilityIdentifier("deleteFlightSwipeButton")
+            }
         }
         .contextMenu {
             if !viewModel.isOffline && flight.isEditable {
@@ -572,6 +656,14 @@ struct FlightListView: View {
                 } label: {
                     Label("Unsubscribe", systemImage: "person.badge.minus")
                 }
+            }
+            if !viewModel.isOffline && flight.isEditable {
+                Button(role: .destructive) {
+                    deleteCandidate = flight
+                } label: {
+                    Label("Delete Flight", systemImage: "trash")
+                }
+                .accessibilityIdentifier("deleteFlightMenuItem")
             }
         }
     }

--- a/app/flyfun-weather/flyfun-weather/Views/Shared/ShareActivitySheet.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Shared/ShareActivitySheet.swift
@@ -1,0 +1,60 @@
+import SwiftUI
+import UIKit
+
+/// "Open in Safari" entry for the share sheet. iOS never offers Safari as a
+/// share target on its own (only apps that ship a share extension, like Chrome,
+/// appear), so sharing our briefing URL had "Open in Chrome" but no Safari row.
+/// This custom activity fills the gap. Opening our own Universal Link via
+/// `UIApplication.open` is safe: the system deliberately routes an app's own
+/// universal link to the browser instead of bouncing it back into the app.
+final class OpenInSafariActivity: UIActivity {
+    private var url: URL?
+
+    override class var activityCategory: UIActivity.Category { .action }
+    override var activityType: UIActivity.ActivityType {
+        UIActivity.ActivityType("net.ro-z.flyfun-weather.openInSafari")
+    }
+    override var activityTitle: String? { String(localized: "Open in Safari") }
+    override var activityImage: UIImage? { UIImage(systemName: "safari") }
+
+    override func canPerform(withActivityItems activityItems: [Any]) -> Bool {
+        activityItems.contains { $0 is URL }
+    }
+
+    override func prepare(withActivityItems activityItems: [Any]) {
+        url = activityItems.first { $0 is URL } as? URL
+    }
+
+    override func perform() {
+        guard let url else {
+            activityDidFinish(false)
+            return
+        }
+        UIApplication.shared.open(url) { [weak self] success in
+            self?.activityDidFinish(success)
+        }
+    }
+}
+
+/// `UIActivityViewController` wrapper so a share sheet can carry custom
+/// activities — SwiftUI's `ShareLink` cannot. Present inside a `.sheet`; the
+/// completion handler dismisses the hosting sheet when the user finishes or
+/// cancels, mirroring `ShareLink`'s behaviour.
+struct ShareActivitySheet: UIViewControllerRepresentable {
+    let items: [Any]
+    var activities: [UIActivity] = []
+    @Environment(\.dismiss) private var dismiss
+
+    func makeUIViewController(context: Context) -> UIActivityViewController {
+        let controller = UIActivityViewController(
+            activityItems: items,
+            applicationActivities: activities.isEmpty ? nil : activities
+        )
+        controller.completionWithItemsHandler = { _, _, _, _ in
+            dismiss()
+        }
+        return controller
+    }
+
+    func updateUIViewController(_ uiViewController: UIActivityViewController, context: Context) {}
+}

--- a/app/flyfun-weather/flyfun-weatherTests/ServiceTests.swift
+++ b/app/flyfun-weather/flyfun-weatherTests/ServiceTests.swift
@@ -217,6 +217,61 @@ import Foundation
     }
 }
 
+// MARK: - Deleting a flight evicts its local cache
+
+/// A deleted flight's downloaded packs can never be refreshed or re-downloaded,
+/// so the caching layer drops them (index entries + sidecar directory) once the
+/// server confirms — but only then.
+@Suite struct CachingRepositoryDeleteFlightTests {
+
+    private let all = CachedPackEntry.requiredEndpoints
+
+    /// Seed two flights' packs + sidecars into a temp cache.
+    private func seededCache() async throws -> BriefingCacheStore {
+        let store = BriefingCacheStore(cacheDir: makeTempDir())
+        await store.registerDownload(flightId: "f1", timestamp: "t1", flightTitle: "T",
+                                     assessment: nil, endpoints: all, totalBytes: 1)
+        await store.registerDownload(flightId: "f1", timestamp: "t2", flightTitle: "T",
+                                     assessment: nil, endpoints: all, totalBytes: 1)
+        try await store.writeFlightMetadata(Data("{}".utf8), flightId: "f1", name: "flight")
+        await store.registerDownload(flightId: "f2", timestamp: "t1", flightTitle: "T",
+                                     assessment: nil, endpoints: all, totalBytes: 1)
+        try await store.writeFlightMetadata(Data("{}".utf8), flightId: "f2", name: "flight")
+        return store
+    }
+
+    @Test func successfulDeleteEvictsEveryPackAndTheSidecarDirectory() async throws {
+        let cache = try await seededCache()
+        let online = MockBriefingRepository()
+        let repo = CachingBriefingRepository.makeForTesting(online: online, cache: cache)
+
+        try await repo.deleteFlight(id: "f1")
+
+        #expect(online.deletedFlightIds == ["f1"])
+        #expect(await cache.hasCachedPacks(flightId: "f1") == false)
+        #expect(await cache.readFlightMetadata(flightId: "f1", name: "flight") == nil)
+        // The other flight is untouched.
+        #expect(await cache.hasCachedPacks(flightId: "f2"))
+        #expect(await cache.readFlightMetadata(flightId: "f2", name: "flight") != nil)
+    }
+
+    /// A server-side failure must leave the local copy alone — the flight still
+    /// exists, so throwing away its offline packs would be data loss.
+    @Test func failedDeleteKeepsCachedPacks() async throws {
+        let cache = try await seededCache()
+        let online = MockBriefingRepository()
+        online.deleteFlightResult = .failure(MockError.injected("server down"))
+        let repo = CachingBriefingRepository.makeForTesting(online: online, cache: cache)
+
+        await #expect(throws: MockError.self) {
+            try await repo.deleteFlight(id: "f1")
+        }
+
+        #expect(await cache.hasCachedPacks(flightId: "f1"))
+        #expect(await cache.readFlightMetadata(flightId: "f1", name: "flight") != nil)
+    }
+}
+
 // MARK: - Cache eviction staleness (pure cutoff + legacy fallback)
 
 @Suite struct PackStalenessTests {

--- a/app/flyfun-weather/flyfun-weatherTests/TestSupport.swift
+++ b/app/flyfun-weather/flyfun-weatherTests/TestSupport.swift
@@ -39,6 +39,9 @@ final class MockBriefingRepository: BriefingRepository, @unchecked Sendable {
     var aircraftResult: Result<[AircraftResponse], Error> = .success([])
     var createFlightResult: Result<FlightResponse, Error> = .failure(MockError.notStubbed("createFlight"))
     var updateFlightResult: Result<UpdateFlightResponse, Error> = .failure(MockError.notStubbed("updateFlight"))
+    /// Delete succeeds by default (the common case under test is the happy path);
+    /// set a `.failure` to drive the surfaced-error branch.
+    var deleteFlightResult: Result<Void, Error> = .success(())
     var interpretRouteResult: Result<InterpretRouteResponse, Error> = .failure(MockError.notStubbed("interpretRoute"))
     var submitPirepsBatchResult: Result<[PirepResponse], Error> = .success([PirepResponse.offline])
 
@@ -54,6 +57,7 @@ final class MockBriefingRepository: BriefingRepository, @unchecked Sendable {
     private(set) var submitPirepsBatchCallCount = 0
     private(set) var interpretRouteCallCount = 0
     private(set) var lastUpdateRequest: UpdateFlightRequest?
+    private(set) var deletedFlightIds: [String] = []
     private(set) var lastCreateRequest: CreateFlightRequest?
     private(set) var lastInterpretRawRoute: String?
 
@@ -67,6 +71,12 @@ final class MockBriefingRepository: BriefingRepository, @unchecked Sendable {
         if let hook = beforeFlightsReturn { await hook() }
         return try flightsResult.get()
     }
+    func flight(id: String) async throws -> FlightResponse {
+        guard let match = try flightsResult.get().first(where: { $0.id == id }) else {
+            throw APIError.notFound
+        }
+        return match
+    }
     func createFlight(_ request: CreateFlightRequest) async throws -> FlightResponse {
         lastCreateRequest = request
         return try createFlightResult.get()
@@ -74,6 +84,10 @@ final class MockBriefingRepository: BriefingRepository, @unchecked Sendable {
     func updateFlight(flightId: String, request: UpdateFlightRequest) async throws -> UpdateFlightResponse {
         lastUpdateRequest = request
         return try updateFlightResult.get()
+    }
+    func deleteFlight(id: String) async throws {
+        deletedFlightIds.append(id)
+        try deleteFlightResult.get()
     }
     func aircraft() async throws -> [AircraftResponse] { try aircraftResult.get() }
     func profiles() async throws -> [ProfileResponse] { [] }

--- a/app/flyfun-weather/flyfun-weatherTests/UniversalLinkRoutingTests.swift
+++ b/app/flyfun-weather/flyfun-weatherTests/UniversalLinkRoutingTests.swift
@@ -31,6 +31,15 @@ struct UniversalLinkRoutingTests {
         #expect(target == .briefing(flightId: "123"))
     }
 
+    @Test func routesFeedbackEmailLinkWithPackTimestamp() {
+        // The feedback/admin notification email appends `&t=<pack ISO timestamp>`
+        // (with an unencoded `+00:00` offset) to pin the pack on the web. The app
+        // ignores `t` and must still route to the flight.
+        let target = AppState.navigationTarget(
+            for: url("https://weather.flyfun.aero/briefing.html?flight=eglm_sopit_disit_egbo-2026-07-25-781c&t=2026-07-22T16:07:05.119539+00:00"))
+        #expect(target == .briefing(flightId: "eglm_sopit_disit_egbo-2026-07-25-781c"))
+    }
+
     @Test func picksFlightParamAmongOthers() {
         let target = AppState.navigationTarget(
             for: url("https://weather.flyfun.aero/briefing.html?theme=dark&flight=abc&x=1"))

--- a/app/flyfun-weather/flyfun-weatherTests/ViewModelTests.swift
+++ b/app/flyfun-weather/flyfun-weatherTests/ViewModelTests.swift
@@ -396,6 +396,49 @@ import MapKit
         }
         #expect(flights.first?.latestBriefing?.assessment == "RED")   // fresh reconcile preserved
     }
+
+    // MARK: Delete an owned flight (swipe / context menu)
+
+    /// A confirmed delete calls the repository once and re-syncs the list, so the
+    /// row disappears immediately instead of at the next foreground refresh.
+    @Test func deleteFlightCallsRepositoryThenReloads() async throws {
+        let repo = MockBriefingRepository()
+        repo.flightsResult = .success([makeFlight(id: "a"), makeFlight(id: "b")])
+        let vm = FlightListViewModel(repository: repo)
+        await vm.loadFlights()
+        // Server truth after the delete.
+        repo.flightsResult = .success([makeFlight(id: "b")])
+
+        try await vm.deleteFlight(makeFlight(id: "a"))
+
+        #expect(repo.deletedFlightIds == ["a"])
+        guard case .loaded(let flights) = vm.state else {
+            Issue.record("expected .loaded, got \(vm.state)")
+            return
+        }
+        #expect(flights.map(\.id) == ["b"])
+    }
+
+    /// A failed delete rethrows (the view surfaces it) and leaves the list exactly
+    /// as it was — a row that couldn't be deleted must not vanish as if it had been.
+    @Test func deleteFlightFailureRethrowsAndKeepsRow() async {
+        let repo = MockBriefingRepository()
+        repo.flightsResult = .success([makeFlight(id: "a")])
+        repo.deleteFlightResult = .failure(MockError.injected("not owned"))
+        let vm = FlightListViewModel(repository: repo)
+        await vm.loadFlights()
+
+        await #expect(throws: MockError.self) {
+            try await vm.deleteFlight(makeFlight(id: "a"))
+        }
+
+        guard case .loaded(let flights) = vm.state else {
+            Issue.record("expected .loaded, got \(vm.state)")
+            return
+        }
+        #expect(flights.map(\.id) == ["a"])
+        #expect(repo.flightsCallCount == 1)     // no reload on failure
+    }
 }
 
 // MARK: - FlightCardView content equality (#426)

--- a/designs/future/ios-web-known-gaps.md
+++ b/designs/future/ios-web-known-gaps.md
@@ -1,0 +1,99 @@
+# iOS ↔ Web Known Gaps
+
+Deliberate feature gaps between the web app and the iOS companion app. These are
+**decisions**, not bugs — surfaces we chose not to port (yet) and the reasoning,
+so a future "should we build this on iOS?" starts from context instead of
+rediscovery. When a gap is closed, move it to the bottom under "Closed".
+
+Related: [ios-app-roadmap.md](../ios-app-roadmap.md) (phase plan + open questions),
+[ios-app-overview.md](../ios-app-overview.md).
+
+---
+
+## No advisory recalculate on iOS
+
+**Added:** 2026-07-07
+**Web location:** `web/ts/managers/advisories-ui.ts` (profile selector `:438`,
+altitude-override slider `:578`, `onRecalculate` callback `:354`) →
+`POST /api/flights/{id}/packs/{ts}/advisories/recalculate` (`recalculate_advisories`,
+`api/packs.py:3080`, `tasks/advise.py:run_advisories_from_pack`).
+
+**Context — the Refresh-vs-recalculate decision.** Two distinct operations:
+
+- **Refresh** = *get new data* — new model runs, or on D-0 live METAR/TAF/SIGMET
+  (the tiered `decide_refresh` gate, `api/packs.py:796`). A user pressing Refresh
+  expects the whole briefing, including the AI summary, to reflect the latest
+  *weather*. Shared endpoint, identical on web + iOS.
+- **Recalculate** = *re-grade the same forecast against changed settings*
+  (altitude, profile, icing/cloud/convective method, advisory params,
+  aggregation). No new data came from the sky, so the AI digest is intentionally
+  **not** regenerated — the `digest.profileMismatch` banner flags it as written
+  for the prior settings, with regeneration explicit/opt-in.
+
+We deliberately did **not** fold a recalc mode into the Refresh gate: it would
+overload Refresh's meaning and create the false expectation that the AI summary
+rewrites itself on an altitude nudge. Instead, recalculate lives **inside the
+advisory section**, next to the altitude/profile controls, so its scope is
+self-evident ("this recomputes *these*, not the rest").
+
+**The gap.** That in-section recomputation is **web-only**. On web the profile
+selector and altitude slider re-grade in place. iOS has **no in-briefing
+recalculate control** — it only recomputes advisories via the *edit-flight* flow
+(`AddFlightViewModel.regenerateBriefing(for:invalidation:)`,
+`app/.../ViewModels/AddFlightViewModel.swift:750`), which reacts to the
+`PATCH /api/flights/{id}` `invalidation` hint (`advisories_only` →
+`recalculateAdvisories()`). So an iOS user who wants to try a different
+altitude/profile *on an existing briefing* can't, short of editing the flight.
+
+**Decision.** Accept the gap for now. The backend endpoint already exists and is
+client-agnostic, so this is purely a client-UI gap. Porting it properly is a
+**full feature**, not a button: iOS would need the advisory-section controls
+(altitude-override slider with the altitude-table delta note, owner-only profile
+selector) *and* the recalc/re-render wiring — i.e. the same control suite web
+grew incrementally. A bare "Recalculate" button with nothing to change first
+would be pointless.
+
+**Revisit / to build when we do:**
+- Port the advisory-section controls (altitude slider + profile selector) to the
+  iOS briefing view, reusing `recalculateAdvisories()` (already in
+  `BriefingRepository`).
+- Optional **staleness hint**: a stored `advisory_inputs_hash` on the pack
+  (reuse `_load_advisory_profile`'s assembled inputs) lets the button surface
+  "settings changed since these advisories were computed" — also closes the
+  invisible case where the *profile's contents* were edited elsewhere (touches
+  no flight, fires no `invalidation`). Applies to web too.
+- Keep Refresh data-only on both clients; do **not** add a `recalc` mode to
+  `decide_refresh`.
+
+---
+
+## No profile edit page on iOS
+
+**Added:** 2026-07-07
+**Web location:** profile CRUD via `api/profiles.py` (`FlightProfileRow.settings_json`,
+`ProfileSettings` schema `:31`) + web profile management UI.
+
+**The gap.** iOS can **select** an existing profile when creating/editing a
+flight (`AddFlightViewModel` `selectedProfileId`, applies the profile's
+altitude/ceiling), but there is **no page to create or edit a profile's
+contents** — name, advisory enabled/params, aggregation, icing/cloud/convective
+method, `advisory_models`, `auto_front_detection`. Those settings live in
+`FlightProfileRow.settings_json` and are only editable from the web app.
+
+**Decision.** Accept for now. Profile authoring is a lower-frequency, form-heavy
+task that fits the larger screen; the iOS app's job today is briefing
+consumption + flight setup, and selecting a pre-built profile covers the common
+case. This gap compounds the one above: without profile editing *and* without
+in-briefing recalculate, an iOS-only user is limited to whatever profiles they
+built on web.
+
+**Revisit / to build when we do:**
+- A profile list + editor screen driven by the advisory catalog
+  (`GET /api/.../advisories/catalog` gives parameter defs), mirroring the web
+  form. Naturally pairs with the advisory-recalculate port above.
+
+---
+
+## Closed
+
+_(none yet)_


### PR DESCRIPTION
Two independent iOS improvements that happened to grow in the same files, so they ship together.

## Delete a flight from the list

Parity with the web's Delete button — iOS previously had no way to remove a flight.

- **Trailing-swipe Delete next to Edit**, plus a matching context-menu item.
- Gated exactly like Edit: **owner-only** (the server 404s a subscriber's delete — a subscriber gets Unsubscribe instead) and **online-only**.
- **Never one-tap**: opens a destructive confirmation naming the route ("LFMD → LFML and all of its briefing history will be deleted. This can't be undone."), mirroring the web's `confirm()`. `allowsFullSwipe` is already false on that edge, so a long swipe can't fire it either.
- `deleteFlight(id:)` on `BriefingRepository` → `DELETE /api/flights/{id}` (the endpoint the web already uses).
- **Cache ordering matters**: the caching layer deletes server-side *first*, and only then evicts the flight's packs and sidecar directory. A failed delete leaves a flight that still exists with its offline data intact.
- `FlightListViewModel.deleteFlight` re-syncs the list, so the row, its offline badge, and its Spotlight entry drop together. It rethrows so the view surfaces the failure — a row that stays put must not read as a silent no-op. The iPad detail selection is cleared if it pointed at the deleted flight.

## Universal Link + share polish

- A `briefing.html?flight=<id>` link for a flight **outside the viewer's list** (a feedback email about another pilot's flight, a link from a different sign-in) now fetches it directly instead of silently landing on the list. A non-owner comes back `role == .subscriber` and gets the same preview-before-subscribe screen as a `/s/{code}` share link; a 404 surfaces an alert. Also tolerates the feedback email's unencoded `&t=<pack timestamp>`.
- Share sheet now uses `UIActivityViewController` with a custom **"Open in Safari"** activity — iOS offers Chrome (via its share extension) but never Safari on its own, so the briefing URL had no way back to Safari.
- Observations table: hoist `displayedAirports` out of the row builder so the nearest-N sort runs once per render instead of twice.
- `designs/future/ios-web-known-gaps.md` records the deliberate web-only gaps (advisory recalculate, profile editing) with reasoning, so a future "should we build this on iOS?" starts from context.

## Testing

`xcodebuild build` clean; full `flyfun-weatherTests` suite passes on iPhone 17 Pro (**TEST SUCCEEDED**).

New tests:
- `deleteFlightCallsRepositoryThenReloads` — repository called once, list re-synced.
- `deleteFlightFailureRethrowsAndKeepsRow` — rethrows, list untouched, no reload.
- `successfulDeleteEvictsEveryPackAndTheSidecarDirectory` — all packs + sidecars gone, other flights untouched.
- `failedDeleteKeepsCachedPacks` — server failure leaves the cache intact.
- `routesFeedbackEmailLinkWithPackTimestamp` — `&t=` tolerated.

**Not verified**: the swipe gesture itself on a device/simulator — there are no existing swipe-action UI tests to extend. The swipe and confirm buttons carry `deleteFlightSwipeButton` / `confirmDeleteFlightButton` identifiers if we want one later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)