### PR TITLE
Add durable refresh tracking and resume after container restart

### DIFF
--- a/alembic/versions/082_briefing_refresh_jobs.py
+++ b/alembic/versions/082_briefing_refresh_jobs.py
@@ -1,0 +1,77 @@
+"""Durable briefing-refresh job tracking (issue #499).
+
+Refresh state used to live only in the in-memory ``_RefreshRegistry``. When the
+container died mid-refresh (OOM, deploy, crash) nothing recorded that a refresh
+had ever been in flight: the pack row is written at the *end*, and the pack
+directory created up front is an orphan with no row pointing at it. This table
+is the write-through mirror of the registry, so an interrupted refresh leaves a
+durable record that boot-time reconciliation can resume — and that a
+post-mortem can read.
+
+``flight_id`` is deliberately **not** a foreign key: the row must outlive the
+flight so reconciliation can distinguish "flight was deleted, don't resume"
+from "no record at all". ``user_id`` does cascade so account deletion takes the
+job history with it (the explicit sweep in ``app._on_delete_user`` covers the
+bulk-delete path, which doesn't emit ORM cascades).
+
+``create_table`` / ``create_index`` work on SQLite (dev) and MySQL (prod)
+without batch mode.
+
+Revision ID: 082
+Revises: 081
+Create Date: 2026-07-26
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "082"
+down_revision: Union[str, None] = "081"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "briefing_refresh_jobs",
+        sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),
+        sa.Column("flight_id", sa.String(256), nullable=False),
+        sa.Column(
+            "user_id",
+            sa.String(64),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=True,
+        ),
+        # "user" | "scheduler" | "resume" — the registry's queue-cap class.
+        sa.Column("triggered_by", sa.String(16), nullable=False, server_default="user"),
+        # Client-declared attribution ("user" | "siri" | "mcp"), carried so a
+        # resumed refresh keeps the original surface in usage accounting.
+        sa.Column("source", sa.String(16), nullable=True),
+        sa.Column("as_of_date", sa.Date, nullable=True),
+        # queued | running | succeeded | failed | abandoned
+        sa.Column("status", sa.String(16), nullable=False, server_default="queued"),
+        sa.Column("attempt", sa.Integer, nullable=False, server_default="1"),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("finished_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("heartbeat_at", sa.DateTime(timezone=True), nullable=True),
+        # Last pipeline stage seen — the "where did it die" half of a post-mortem.
+        sa.Column("stage", sa.String(64), nullable=True),
+        sa.Column("pack_path", sa.String(512), nullable=True),
+        sa.Column("last_error", sa.Text, nullable=True),
+    )
+    # Boot-time reconciliation scans by status (non-terminal rows only).
+    op.create_index("ix_refresh_jobs_status", "briefing_refresh_jobs", ["status"])
+    # /refresh/status falls back to the newest row for a flight.
+    op.create_index(
+        "ix_refresh_jobs_flight", "briefing_refresh_jobs", ["flight_id", "created_at"]
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_refresh_jobs_flight", table_name="briefing_refresh_jobs")
+    op.drop_index("ix_refresh_jobs_status", table_name="briefing_refresh_jobs")
+    op.drop_table("briefing_refresh_jobs")

--- a/alembic/versions/082_briefing_refresh_jobs.py
+++ b/alembic/versions/082_briefing_refresh_jobs.py
@@ -51,7 +51,7 @@ def upgrade() -> None:
         # resumed refresh keeps the original surface in usage accounting.
         sa.Column("source", sa.String(16), nullable=True),
         sa.Column("as_of_date", sa.Date, nullable=True),
-        # queued | running | succeeded | failed | abandoned
+        # queued | running | succeeded | skipped | failed | abandoned
         sa.Column("status", sa.String(16), nullable=False, server_default="queued"),
         sa.Column("attempt", sa.Integer, nullable=False, server_default="1"),
         sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
@@ -69,9 +69,13 @@ def upgrade() -> None:
     op.create_index(
         "ix_refresh_jobs_flight", "briefing_refresh_jobs", ["flight_id", "created_at"]
     )
+    # Account deletion sweeps this table by user_id (app._on_delete_user), and
+    # it only grows — matches the indexed FK-to-users pattern used elsewhere.
+    op.create_index("ix_refresh_jobs_user", "briefing_refresh_jobs", ["user_id"])
 
 
 def downgrade() -> None:
+    op.drop_index("ix_refresh_jobs_user", table_name="briefing_refresh_jobs")
     op.drop_index("ix_refresh_jobs_flight", table_name="briefing_refresh_jobs")
     op.drop_index("ix_refresh_jobs_status", table_name="briefing_refresh_jobs")
     op.drop_table("briefing_refresh_jobs")

--- a/designs/INDEX.md
+++ b/designs/INDEX.md
@@ -191,6 +191,11 @@ Priority-aware, fault-tolerant admission layer in front of the GRIB decode proce
 Key exports: `DecodePriority`, `PriorityDecodeDispatcher`, `set_decode_priority`, `enrich_forecasts(priority=...)`, `_dispatch_decode`, `_dispatch_decode_parallel`, `decode_dead_letter_counts`
 → Full doc: grib-decode-dispatcher.md
 
+### refresh-durability
+Durable briefing-refresh tracking (`briefing_refresh_jobs`, migration 082) as a best-effort write-through mirror of the in-memory `_RefreshRegistry`, plus a one-shot boot-time pass that abandons or resumes refreshes interrupted by a container restart (OOM/deploy/crash). Single uvicorn worker ⇒ any non-terminal row at boot is an orphan; `WB_REFRESH_MAX_ATTEMPTS` (default 2) caps retries; `/refresh/status` falls back to the row so a reload reports "interrupted"/"gave up" instead of nothing.
+Key exports: `BriefingRefreshJobRow`, `record_queued`, `record_running`, `record_heartbeat`, `record_finished`, `list_orphans`, `latest_job_for_flight`, `_RefreshRegistry(durable=True)`, `mark_outcome`, `note_pack_path`, `decide_resume`, `run_refresh_resume`, `resume_max_attempts`
+→ Full doc: refresh-durability.md
+
 ### multi-user-deployment
 Deployment architecture for weather.flyfun.aero: Docker on DigitalOcean, auth via flyfun-common (OAuth, JWT, cross-subdomain SSO), MySQL/SQLite DB schema, rate limiting, encrypted credentials, account deletion + GDPR data export, admin hub, Resend email, deploy commands, env vars.
 → Full doc: multi-user-deployment.md

--- a/designs/multi-user-deployment.md
+++ b/designs/multi-user-deployment.md
@@ -286,6 +286,8 @@ git pull && docker compose up -d --build
 | `RESEND_FROM` | No | — | Resend sender address |
 | `RESEND_REPLY_TO` | No | — | Resend reply-to address |
 | `HMAC_SECRET` | Prod only | derived from JWT_SECRET | HMAC key for pack integrity + admin approval links |
+| `WB_REFRESH_MAX_ATTEMPTS` | No | `2` | Total attempts per briefing refresh, counting the original run. `1` disables resume-after-restart; see [refresh-durability.md](./refresh-durability.md) |
+| `DISABLE_REFRESH_RESUME` | No | — | `1` skips the boot-time reconciliation pass entirely (rows are still written) |
 
 ## References
 

--- a/designs/refresh-durability.md
+++ b/designs/refresh-durability.md
@@ -1,0 +1,179 @@
+# Refresh Durability
+
+> Durable briefing-refresh tracking, and resuming a refresh interrupted by a container restart.
+
+Issue #499. Code: `db/models.py::BriefingRefreshJobRow`, `storage/refresh_jobs.py`,
+`api/packs.py::_RefreshRegistry`, `tasks/refresh_resume.py`, migration `082`.
+
+## The problem
+
+Refresh state used to be **in-memory only**. `_RefreshRegistry` holds a
+`dict[flight_id, RefreshEntry]` and the pipeline runs on a module-level
+`ThreadPoolExecutor(max_workers=2)`. If the container died mid-refresh (OOM
+kill, deploy, crash) that state evaporated and *nothing in the DB or on disk
+recorded that a refresh had ever been in flight*:
+
+- the pack row is written at the end (`_persist_pack_finalize`), or at the
+  `briefing_ready` milestone on the SSE path only (`_persist_pack_provisional`);
+- `_prepare_refresh` mkdirs the pack dir up front, so a killed refresh leaves an
+  orphan directory of partial artifacts with no row pointing at it;
+- web SSE just errored out; iOS polling `/refresh/status` got
+  `{"active": false}` — indistinguishable from "never asked";
+- recovery was accidental: the scheduler picked the flight up at its *next*
+  auto-refresh slot, if one happened to be due. Manual / Siri / MCP refreshes
+  were simply lost.
+
+The 2026-07-23 05:09Z OOM (#490) is the motivating case: a user briefing was
+killed, with no record, no retry, and nothing to post-mortem.
+
+## What makes it cheap
+
+1. **The registry is already the single choke point.** All three refresh paths
+   (sync `POST /refresh`, SSE `/refresh/stream`, scheduler
+   `process_auto_refreshes`) go through `try_register` → `set_refreshing` →
+   `update_progress` → `unregister`. Durability is a write-through mirror at
+   those call sites, not a rewrite.
+2. **Single uvicorn worker** (`Dockerfile`, no `--workers`). So no leases, no
+   instance ids, no distributed locking: *any* non-terminal row present at
+   process boot is by definition an orphan.
+
+## The job row
+
+`briefing_refresh_jobs` (migration 082) — one row per attempt:
+
+| Column | Notes |
+|---|---|
+| `flight_id` | **Not** a foreign key — see below |
+| `user_id` | FK to `users`, `ON DELETE CASCADE` |
+| `triggered_by` | `user` \| `scheduler` \| `resume` — the registry's queue-cap class |
+| `source` | Client-declared attribution (`user` \| `siri` \| `mcp` \| `scheduler`) |
+| `as_of_date` | Set when the refresh pinned a backtest date |
+| `status` | `queued` \| `running` \| `succeeded` \| `failed` \| `abandoned` |
+| `attempt` | 1 for the original run, +1 per resume |
+| `created_at` / `started_at` / `finished_at` / `heartbeat_at` | |
+| `stage` | Last pipeline stage the registry saw — "where did it die" |
+| `pack_path` | Recorded as soon as the pack dir is created |
+| `last_error` | |
+
+`flight_id` is deliberately **not** an FK: the row has to outlive the flight so
+reconciliation can distinguish "the flight was deleted, don't resume" from "no
+record at all". Because of that, `app._on_delete_user` sweeps the table
+explicitly on account deletion (the `FlightRow` bulk delete emits no ORM
+cascades anyway).
+
+A separate table rather than two columns on `flights`: the registry is keyed by
+`flight_id` so at most one refresh per flight is live, but when the container
+OOMs, the record of what was in flight is exactly the post-mortem that wasn't
+possible for #490.
+
+## Write-through
+
+`_RefreshRegistry(durable=True)` — the process-wide `refresh_registry`
+singleton. A bare `_RefreshRegistry()` stays a pure in-memory object, so unit
+tests and ad-hoc use never touch the DB.
+
+| Registry call | Row effect |
+|---|---|
+| `try_register` | insert `queued` (carries `source`, `as_of_date`, `attempt`) |
+| `set_refreshing` | → `running`, stamp `started_at` |
+| `note_pack_path` | record `pack_path` (called from `_prepare_refresh` — the one place every path creates the dir) |
+| `update_progress` | bump `heartbeat_at` + `stage`, throttled to `HEARTBEAT_MIN_INTERVAL` (15s) |
+| `mark_outcome` + `unregister` | terminal status |
+
+Two invariants make this work:
+
+- **Best-effort.** Every write goes through `storage/refresh_jobs.py`'s
+  `record_*` helpers, which open their own short-lived session and swallow all
+  exceptions. A DB hiccup must never fail a refresh; durability here is a
+  diagnostic and a resume hint, not a correctness invariant. DB I/O also happens
+  strictly *outside* the registry lock — the GRIB warm loop polls that lock.
+- **`mark_outcome` is separate from `unregister`.** Callers close the entry in a
+  `finally`, which is exactly what does *not* run when the process is killed. An
+  entry closed without a marked outcome records `failed`; an entry never closed
+  at all stays non-terminal — the orphan. The crash case is the mechanism, not
+  a bug.
+
+## Boot-time reconciliation + resume
+
+`tasks/refresh_resume.py::run_refresh_resume`, wired into `lifespan` like the
+other loops (disable with `DISABLE_REFRESH_RESUME=1`). It is **one-shot, not a
+loop**: orphan-hood is a property of process boot.
+
+Orphan ids are snapshotted *immediately*, then the pass sleeps
+`STARTUP_DELAY_SECONDS` (90s, past the scheduler's own 30s delay). Snapshotting
+first means a refresh started by *this* process can never be mistaken for an
+orphan of the previous one.
+
+`decide_resume` then picks per row, cheapest check first:
+
+| Condition | Outcome |
+|---|---|
+| `attempt >= WB_REFRESH_MAX_ATTEMPTS` | `abandoned` — retry budget spent |
+| Pinned `as_of_date` | `abandoned` — a backtest re-run live answers a different question |
+| Flight deleted | `abandoned` |
+| Flight already departed | `abandoned` |
+| Beyond the forecast horizon | `abandoned` |
+| `decide_refresh` no longer says `full` | `abandoned` — the scheduler already re-briefed it, or no model moved. The gate is a free correctness check |
+| otherwise | **resume** |
+
+Two consequences of the gate check worth knowing:
+
+- An SSE refresh killed *after* the `briefing_ready` milestone already wrote a
+  provisional pack row from the current runs, so the gate says `none` and the
+  resume is skipped. That is the intended outcome: the pilot has a briefing off
+  those runs, and only the LLM digest is missing — which the pack's Generate
+  button covers far more cheaply than a whole pipeline.
+- `heartbeat_at` is only populated on the SSE path, the one that passes a
+  `progress_callback`. The sync and scheduler paths have `started_at` and
+  nothing further until they finish. Reconciliation never reads the heartbeat —
+  non-terminal-at-boot is the whole signal — so this only affects how much a
+  post-mortem can see.
+
+A resume closes the interrupted row as `failed` (`last_error` records the
+interruption) and re-queues through the registry with `triggered_by="resume"`
+and `attempt + 1` — one row per attempt, so the post-mortem reads as a history
+rather than a mutating counter. Execution reuses `scheduler._auto_refresh_one`
+(gate → prepare → pipeline → persist → notify), which grew a `triggered_by`
+parameter purely for usage attribution.
+
+Registering also drives `idle_seconds()` to zero, so the discretionary GRIB warm
+loop yields to a resume exactly as it does for an interactive briefing — the
+#490 machinery falls out for free. `"resume"` joins `"scheduler"` in
+`UNCAPPED_TRIGGERS`: a resume is finishing work the user already asked for and
+must not be turned away by a busy queue.
+
+### Retry cap
+
+`WB_REFRESH_MAX_ATTEMPTS`, **default 2** = the original run plus one resume. Set
+it to 3 for two resumes, 1 to disable resume entirely. Sized so a briefing that
+genuinely does take the container down can only do it twice, while a single OOM
+or deploy never silently loses a user's refresh.
+
+**No crash attribution**: we do not try to tell "this briefing caused the OOM"
+from "something else did" (the GRIB precache and standalone cycle are the
+likelier culprits, and no briefing has been observed crashing the container).
+Any interruption burns an attempt regardless of cause. Likewise no
+SIGTERM-vs-SIGKILL distinction — a deploy mid-briefing burns an attempt and
+still gets its one resume.
+
+## Client-visible terminal state
+
+`GET /flights/{id}/packs/refresh/status` falls back to the job row when there is
+no in-memory entry (`_interrupted_refresh_status`), so a reload after a restart
+reports something instead of silence:
+
+- non-terminal row → `{"active": true, "status": "interrupted", "attempt", "max_attempts", "will_retry"}` plus the last `stage`/`label`/`progress`;
+- `abandoned` row → `{"active": false, "status": "abandoned", "last_error", ...}`.
+
+Bounded by the same `_RefreshRegistry.STALE_ENTRY_SECONDS` (30 min) the warm
+loop uses, so a leaked row can never pin a flight as permanently active. Rows
+belonging to another user are never disclosed. Fields are additive — existing
+web/iOS clients keep working; the UI copy for these states ships separately.
+
+## Out of scope / follow-ons
+
+- Web + iOS UI copy for the "retrying after restart" / "gave up" states.
+- Sweeping orphan pack directories left by killed refreshes (retention loop) —
+  `pack_path` on the abandoned row is the hook.
+- Notifying the user on `abandoned` via the existing notify sink.
+- Pruning old job rows (one small row per refresh; unbounded but slow-growing).

--- a/designs/refresh-durability.md
+++ b/designs/refresh-durability.md
@@ -48,7 +48,7 @@ killed, with no record, no retry, and nothing to post-mortem.
 | `triggered_by` | `user` \| `scheduler` \| `resume` — the registry's queue-cap class |
 | `source` | Client-declared attribution (`user` \| `siri` \| `mcp` \| `scheduler`) |
 | `as_of_date` | Set when the refresh pinned a backtest date |
-| `status` | `queued` \| `running` \| `succeeded` \| `failed` \| `abandoned` |
+| `status` | `queued` \| `running` \| `succeeded` \| `skipped` \| `failed` \| `abandoned` |
 | `attempt` | 1 for the original run, +1 per resume |
 | `created_at` / `started_at` / `finished_at` / `heartbeat_at` | |
 | `stage` | Last pipeline stage the registry saw — "where did it die" |
@@ -79,6 +79,18 @@ tests and ad-hoc use never touch the DB.
 | `note_pack_path` | record `pack_path` (called from `_prepare_refresh` — the one place every path creates the dir) |
 | `update_progress` | bump `heartbeat_at` + `stage`, throttled to `HEARTBEAT_MIN_INTERVAL` (15s) |
 | `mark_outcome` + `unregister` | terminal status |
+
+`succeeded` vs `skipped` is a real distinction, not bookkeeping.
+`scheduler._auto_refresh_one` returns a **bool** — `False` when it
+short-circuits on its own refresh gate (or a missing `AIRPORTS_DB`) rather than
+running the pipeline — and both callers (the auto-refresh cycle and the resume
+pass) use it to close the row honestly. A gated skip is the *routine* outcome
+for a flight that already has a recent pack, so folding it into `succeeded`
+would have the table claim briefings that were never produced — exactly the
+record this feature exists to make trustworthy. Practically, `skipped` rows
+will dominate the table (bounded at roughly one per flight per day, since
+`last_auto_refresh_at` is bumped either way), which sharpens the pruning
+follow-on below.
 
 Two invariants make this work:
 
@@ -129,10 +141,16 @@ Two consequences of the gate check worth knowing:
   non-terminal-at-boot is the whole signal — so this only affects how much a
   post-mortem can see.
 
-A resume closes the interrupted row as `failed` (`last_error` records the
-interruption) and re-queues through the registry with `triggered_by="resume"`
-and `attempt + 1` — one row per attempt, so the post-mortem reads as a history
-rather than a mutating counter. Execution reuses `scheduler._auto_refresh_one`
+A resume re-queues through the registry with `triggered_by="resume"` and
+`attempt + 1`, **then** closes the interrupted row as `failed` — one row per
+attempt, so the post-mortem reads as a history rather than a mutating counter.
+The ordering matters: registering first means the closed row can never claim a
+resume that didn't happen (another refresh may already own the flight by the
+time the pass fires, in which case the row closes `abandoned` with *resume
+skipped, flight already active*). It costs a narrow window where both rows are
+non-terminal — if the process dies inside it, the next boot resumes the old row
+and abandons the new one at the attempt cap, i.e. one extra run rather than a
+lost one. Execution reuses `scheduler._auto_refresh_one`
 (gate → prepare → pipeline → persist → notify), which grew a `triggered_by`
 parameter purely for usage attribution.
 

--- a/src/weatherbrief/api/agent.py
+++ b/src/weatherbrief/api/agent.py
@@ -102,7 +102,11 @@ def _resolve_latest_pack(db: Session, user_id: str, flight_id: str):
     # leaking pack existence / refresh state for a flight the user can't see.
     flights_api._load_flight_or_404(db, flight_id, viewer_id=user_id)
 
-    refresh = packs_api.get_refresh_status(flight_id=flight_id, user_id=user_id)
+    # ``db`` must be passed explicitly: get_refresh_status is a route handler,
+    # so its Depends(get_db) default is only resolved by FastAPI.
+    refresh = packs_api.get_refresh_status(
+        flight_id=flight_id, user_id=user_id, db=db,
+    )
     if refresh.get("active"):
         return None, None, _processing(flight_id)
 

--- a/src/weatherbrief/api/app.py
+++ b/src/weatherbrief/api/app.py
@@ -76,8 +76,9 @@ def _on_delete_user(user_id: str, db):
     """Callback for account deletion: clean up all weatherbrief-specific data."""
     from pathlib import Path
     from weatherbrief.db.models import (
-        BriefingUsageRow, DeviceTokenRow, FeedbackRow, FlightBriefingSeenRow,
-        FlightProfileRow, FlightRow, PirepRow, UserAircraftRow,
+        BriefingRefreshJobRow, BriefingUsageRow, DeviceTokenRow, FeedbackRow,
+        FlightBriefingSeenRow, FlightProfileRow, FlightRow, PirepRow,
+        UserAircraftRow,
     )
     from weatherbrief.storage.flights import _data_dir, _rmtree, safe_path_component
 
@@ -119,6 +120,12 @@ def _on_delete_user(user_id: str, db):
     # delete above doesn't emit per-row ORM cascades).
     db.query(FlightBriefingSeenRow).filter(
         FlightBriefingSeenRow.user_id == user_id
+    ).delete(synchronize_session=False)
+    # Refresh job history — deliberately not FK'd to flights (the row outlives
+    # the flight so a resume can tell "deleted" from "no record"), so the
+    # FlightRow bulk delete above doesn't take it with it.
+    db.query(BriefingRefreshJobRow).filter(
+        BriefingRefreshJobRow.user_id == user_id
     ).delete(synchronize_session=False)
     db.flush()
 
@@ -172,6 +179,16 @@ async def lifespan(app: FastAPI):
         from weatherbrief.scheduler import run_scheduler_loop
 
         scheduler_task = asyncio.create_task(run_scheduler_loop(app.state))
+
+    # Reconcile refreshes that were in flight when the previous process died
+    # (issue #499). One-shot, not a loop: any non-terminal job row at boot is
+    # by definition an orphan (single uvicorn worker), and rows created after
+    # boot belong to this process.
+    refresh_resume_task = None
+    if os.environ.get("DISABLE_REFRESH_RESUME") != "1":
+        from weatherbrief.tasks.refresh_resume import run_refresh_resume
+
+        refresh_resume_task = asyncio.create_task(run_refresh_resume(app.state))
 
     retention_task = None
     if os.environ.get("DISABLE_RETENTION") != "1":
@@ -273,7 +290,8 @@ async def lifespan(app: FastAPI):
 
     yield
 
-    for task in (scheduler_task, retention_task, verification_task,
+    for task in (scheduler_task, refresh_resume_task, retention_task,
+                 verification_task,
                  digest_task, metar_ingest_task, forecast_fetch_task,
                  standalone_task, ecmwf_watcher_task,
                  hewson_precompute_task, freshness_task,

--- a/src/weatherbrief/api/packs.py
+++ b/src/weatherbrief/api/packs.py
@@ -118,10 +118,29 @@ class UserQueueLimitError(Exception):
 
 
 class _RefreshRegistry:
-    """Thread-safe in-memory registry of active refreshes."""
+    """Thread-safe in-memory registry of active refreshes.
+
+    When ``durable`` is set, every state transition is mirrored into the
+    ``briefing_refresh_jobs`` table (issue #499) so a refresh killed mid-flight
+    leaves a record that boot-time reconciliation can resume. The mirror is
+    strictly best-effort — see :mod:`weatherbrief.storage.refresh_jobs`. It
+    defaults off so a bare ``_RefreshRegistry()`` (tests, ad-hoc use) stays a
+    pure in-memory object; the process-wide :data:`refresh_registry` singleton
+    is the durable one.
+    """
 
     MAX_QUEUE_DEPTH = 5
     MAX_PER_USER = 2
+
+    #: Trigger classes that bypass the queue-depth and per-user caps. The
+    #: scheduler is a system actor, and a resume is finishing work the user
+    #: already asked for — neither should be turned away by a busy queue.
+    UNCAPPED_TRIGGERS = frozenset({"scheduler", "resume"})
+
+    #: Minimum spacing between durable heartbeat writes. Progress callbacks
+    #: fire per pipeline stage; the heartbeat only needs to be fresh enough to
+    #: tell a live refresh from a dead one.
+    HEARTBEAT_MIN_INTERVAL = 15.0
 
     #: How long after the last "watch-contact" (SSE keepalive or per-flight
     #: status poll) a flight still counts as actively watched. Must exceed the
@@ -130,9 +149,16 @@ class _RefreshRegistry:
     #: before completion still notifies. Poll cadence is 3s, keepalive 15s.
     WATCH_PRESENCE_TTL = 30.0
 
-    def __init__(self) -> None:
+    def __init__(self, durable: bool = False) -> None:
         self._lock = threading.Lock()
+        self._durable = durable
         self._entries: dict[str, RefreshEntry] = {}
+        # flight_id -> briefing_refresh_jobs.id for the live refresh, and the
+        # outcome recorded for it (set by mark_outcome, consumed by unregister).
+        self._job_ids: dict[str, int] = {}
+        self._outcomes: dict[str, tuple[str, str | None]] = {}
+        # flight_id -> monotonic ts of the last durable heartbeat write.
+        self._heartbeats: dict[str, float] = {}
         # flight_id -> monotonic ts of the last UI watch-contact for that flight
         # (SSE keepalive or /packs/refresh/status poll). Drives notification
         # presence: "was the user watching THIS refresh finish?" — the same
@@ -162,19 +188,27 @@ class _RefreshRegistry:
     def try_register(
         self, flight_id: str, triggered_by: str = "user",
         user_id: str | None = None,
+        *,
+        source: str | None = None,
+        as_of_date: date | None = None,
+        attempt: int = 1,
     ) -> RefreshEntry | None:
         """Atomically register a refresh.
 
         Returns the entry on success, or None if the flight is already active.
         Raises ``QueueFullError`` when the queue depth exceeds the cap
-        (scheduler bypasses the cap).
+        (``UNCAPPED_TRIGGERS`` bypass it).
         Raises ``UserQueueLimitError`` when a user already has
         ``MAX_PER_USER`` active refreshes.
+
+        ``source``, ``as_of_date`` and ``attempt`` are recorded on the durable
+        job row only — they carry the attribution and retry count a resume
+        after a container restart needs, and don't affect in-memory behaviour.
         """
         with self._lock:
             if flight_id in self._entries:
                 return None
-            if triggered_by != "scheduler":
+            if triggered_by not in self.UNCAPPED_TRIGGERS:
                 if len(self._entries) >= self.MAX_QUEUE_DEPTH:
                     raise QueueFullError(len(self._entries))
                 if user_id is not None:
@@ -193,13 +227,35 @@ class _RefreshRegistry:
                 queued_at_mono=now_mono,
             )
             self._entries[flight_id] = entry
-            return entry
+
+        # Durable mirror outside the lock — the registry lock is polled by the
+        # GRIB warm loop and must never be held across DB I/O.
+        if self._durable:
+            from weatherbrief.storage import refresh_jobs
+
+            job_id = refresh_jobs.record_queued(
+                flight_id,
+                user_id=user_id,
+                triggered_by=triggered_by,
+                source=source,
+                as_of_date=as_of_date,
+                attempt=attempt,
+            )
+            if job_id is not None:
+                with self._lock:
+                    self._job_ids[flight_id] = job_id
+        return entry
 
     def set_refreshing(self, flight_id: str) -> None:
         with self._lock:
             if flight_id in self._entries:
                 self._entries[flight_id].status = "refreshing"
                 self._entries[flight_id].refreshing_at_mono = time.monotonic()
+            job_id = self._job_ids.get(flight_id)
+        if self._durable and job_id is not None:
+            from weatherbrief.storage import refresh_jobs
+
+            refresh_jobs.record_running(job_id)
 
     def get_timing(self, flight_id: str) -> tuple[float, float]:
         """Return (queue_wait_seconds, total_elapsed_seconds) for a flight.
@@ -224,13 +280,62 @@ class _RefreshRegistry:
             if flight_id in self._entries:
                 self._entries[flight_id].stage = stage
                 self._entries[flight_id].detail = detail
+            job_id = self._job_ids.get(flight_id)
+            due = False
+            if job_id is not None:
+                last = self._heartbeats.get(flight_id)
+                now_mono = time.monotonic()
+                due = last is None or (now_mono - last) >= self.HEARTBEAT_MIN_INTERVAL
+                if due:
+                    self._heartbeats[flight_id] = now_mono
+        if self._durable and due:
+            from weatherbrief.storage import refresh_jobs
+
+            refresh_jobs.record_heartbeat(job_id, stage)
+
+    def note_pack_path(self, flight_id: str, pack_path) -> None:
+        """Record the pack directory a live refresh is writing into.
+
+        Called from ``_prepare_refresh``, the one place every refresh path
+        creates its pack dir — so a refresh killed before it writes its row
+        still leaves a durable pointer at the orphan artifacts.
+        """
+        with self._lock:
+            job_id = self._job_ids.get(flight_id)
+        if self._durable and job_id is not None:
+            from weatherbrief.storage import refresh_jobs
+
+            refresh_jobs.record_pack_path(job_id, str(pack_path))
+
+    def mark_outcome(self, flight_id: str, status: str, error: str | None = None) -> None:
+        """Record how a refresh ended; ``unregister`` closes the row with it.
+
+        Split from ``unregister`` on purpose: callers close the registry entry
+        in a ``finally``, which is exactly what does *not* run when the process
+        is killed. An unmarked entry therefore closes as ``failed``, and an
+        entry never closed at all stays non-terminal — the orphan the resume
+        pass looks for.
+        """
+        with self._lock:
+            if flight_id in self._job_ids:
+                self._outcomes[flight_id] = (status, error)
 
     def unregister(self, flight_id: str) -> None:
         with self._lock:
             removed = self._entries.pop(flight_id, None)
             self._watched.pop(flight_id, None)
+            self._heartbeats.pop(flight_id, None)
+            job_id = self._job_ids.pop(flight_id, None)
+            outcome = self._outcomes.pop(flight_id, None)
             if removed is not None and not self._entries:
                 self._idle_since = time.monotonic()
+        if self._durable and job_id is not None:
+            from weatherbrief.storage import refresh_jobs
+
+            status, error = outcome or (
+                "failed", "refresh ended without recording an outcome",
+            )
+            refresh_jobs.record_finished(job_id, status, error)
 
     # An entry older than this no longer counts as "active" for idle_seconds:
     # real refreshes finish in ~3-5 min and even a deep queue drains well
@@ -297,7 +402,9 @@ class QueueFullError(Exception):
         super().__init__(f"Refresh queue full ({current_depth} active)")
 
 
-refresh_registry = _RefreshRegistry()
+#: The process-wide registry. Durable: every transition is mirrored into
+#: ``briefing_refresh_jobs`` so an interrupted refresh can be resumed at boot.
+refresh_registry = _RefreshRegistry(durable=True)
 
 router = APIRouter(prefix="/flights/{flight_id}/packs", tags=["packs"])
 
@@ -1121,6 +1228,9 @@ def _prepare_refresh(flight, db_path, user_id, flight_id, db=None, *, is_privile
     fetch_ts = datetime.now(tz=timezone.utc)
     pack_path = pack_dir_for(user_id, flight_id, fetch_ts)
     pack_path.mkdir(parents=True, exist_ok=True)
+    # Every refresh path funnels through here, so this is the one place that
+    # can tell the durable job row where its artifacts are going (issue #499).
+    refresh_registry.note_pack_path(flight_id, pack_path)
 
     # Load settings from the flight's profile (falls back to user default profile)
     autorouter_creds = None
@@ -1913,7 +2023,11 @@ async def refresh_briefing(
 
     # Duplicate / queue-depth check
     try:
-        entry = refresh_registry.try_register(flight_id, triggered_by="user", user_id=user_id)
+        entry = refresh_registry.try_register(
+            flight_id, triggered_by="user", user_id=user_id,
+            source=_normalize_source(source),
+            as_of_date=as_of_time.date() if as_of_time else None,
+        )
     except QueueFullError:
         raise HTTPException(status_code=503, detail="Server busy, too many queued refreshes")
     except UserQueueLimitError as exc:
@@ -1932,7 +2046,8 @@ async def refresh_briefing(
             is_privileged=is_privileged,
             as_of_time=as_of_time,
         )
-    except Exception:
+    except Exception as exc:
+        refresh_registry.mark_outcome(flight_id, "failed", f"refresh setup failed: {exc}")
         refresh_registry.unregister(flight_id)
         raise
 
@@ -1974,8 +2089,10 @@ async def refresh_briefing(
                 )
             finally:
                 thread_db.close()
+            refresh_registry.mark_outcome(flight_id, "succeeded")
             logger.info("Background refresh complete for %s", flight_id)
         except Exception as exc:
+            refresh_registry.mark_outcome(flight_id, "failed", str(exc))
             logger.error("Background refresh failed for %s: %s", flight_id, exc, exc_info=True)
         finally:
             refresh_registry.unregister(flight_id)
@@ -2148,7 +2265,11 @@ async def refresh_briefing_stream(
         # Duplicate / queue-depth check — return SSE error so clients
         # that already opened the stream can handle it gracefully.
         try:
-            entry = refresh_registry.try_register(flight_id, triggered_by="user", user_id=user_id)
+            entry = refresh_registry.try_register(
+                flight_id, triggered_by="user", user_id=user_id,
+                source=_normalize_source(source),
+                as_of_date=as_of_time.date() if as_of_time else None,
+            )
         except QueueFullError:
             async def busy_generator() -> AsyncGenerator[str, None]:
                 event = {"type": "error", "message": "Server busy, too many queued refreshes"}
@@ -2182,8 +2303,11 @@ async def refresh_briefing_stream(
             is_privileged=_can_force_refresh(request, db),
             as_of_time=as_of_time,
         )
-    except Exception:
+    except Exception as exc:
         if registered:
+            refresh_registry.mark_outcome(
+                flight_id, "failed", f"refresh setup failed: {exc}",
+            )
             refresh_registry.unregister(flight_id)
         raise
     finally:
@@ -2298,8 +2422,10 @@ async def refresh_briefing_stream(
                 ).model_dump(mode="json"),
                 "elapsed_seconds": total_elapsed,
             }
+            refresh_registry.mark_outcome(flight_id, "succeeded")
             asyncio.run_coroutine_threadsafe(queue.put(complete_event), loop)
         except Exception as exc:
+            refresh_registry.mark_outcome(flight_id, "failed", str(exc))
             logger.error("Streaming refresh failed: %s", exc, exc_info=True)
             error_event = {"type": "error", "message": str(exc)}
             asyncio.run_coroutine_threadsafe(queue.put(error_event), loop)
@@ -2342,15 +2468,78 @@ async def refresh_briefing_stream(
     )
 
 
+def _interrupted_refresh_status(
+    db: Session, flight_id: str, user_id: str,
+) -> dict | None:
+    """Client-visible fallback when there's no in-memory entry (issue #499).
+
+    After a container restart the in-memory registry is empty, so a poll would
+    otherwise report ``{"active": false}`` — indistinguishable from "you never
+    asked". The durable job row still knows a refresh was in flight, so report
+    ``interrupted`` (a resume is coming) or ``abandoned`` (we gave up) instead.
+
+    Bounded by the same ``STALE_ENTRY_SECONDS`` the warm loop uses, so a leaked
+    row can never pin a flight as permanently active. Returns None when there's
+    nothing meaningful to say.
+    """
+    try:
+        from weatherbrief.storage.refresh_jobs import (
+            TERMINAL_STATUSES,
+            latest_job_for_flight,
+        )
+        from weatherbrief.tasks.refresh_resume import resume_max_attempts
+
+        job = latest_job_for_flight(db, flight_id)
+        if job is None or job.user_id != user_id:
+            return None
+
+        now = datetime.now(timezone.utc)
+        marker = job.finished_at or job.heartbeat_at or job.started_at or job.created_at
+        if marker.tzinfo is None:
+            marker = marker.replace(tzinfo=timezone.utc)
+        if (now - marker).total_seconds() > _RefreshRegistry.STALE_ENTRY_SECONDS:
+            return None
+
+        max_attempts = resume_max_attempts()
+        if job.status not in TERMINAL_STATUSES:
+            # Non-terminal with no live entry: the process that owned it died.
+            return {
+                "active": True,
+                "status": "interrupted",
+                "stage": job.stage,
+                "label": _STAGE_LABELS.get(job.stage, job.stage) if job.stage else None,
+                "detail": None,
+                "progress": _STAGE_PROGRESS.get(job.stage, 0.0) if job.stage else 0.0,
+                "triggered_by": job.triggered_by,
+                "queued_at": job.created_at.isoformat(),
+                "attempt": job.attempt,
+                "max_attempts": max_attempts,
+                "will_retry": job.attempt < max_attempts,
+            }
+        if job.status == "abandoned":
+            return {
+                "active": False,
+                "status": "abandoned",
+                "attempt": job.attempt,
+                "max_attempts": max_attempts,
+                "will_retry": False,
+                "last_error": job.last_error,
+            }
+    except Exception:
+        logger.debug("refresh-status job fallback failed", exc_info=True)
+    return None
+
+
 @router.get("/refresh/status")
 def get_refresh_status(
     flight_id: str,
     user_id: str = Depends(current_user_id),
+    db: Session = Depends(get_db),
 ):
     """Get the refresh status for a specific flight."""
     entry = refresh_registry.get(flight_id)
     if entry is None:
-        return {"active": False}
+        return _interrupted_refresh_status(db, flight_id, user_id) or {"active": False}
     # Polling this per-flight endpoint means the user is on THIS briefing
     # watching the refresh — record a watch-contact for notification presence.
     # (The list poll, /refresh/active, deliberately does not.)

--- a/src/weatherbrief/db/models.py
+++ b/src/weatherbrief/db/models.py
@@ -326,11 +326,18 @@ class BriefingRefreshJobRow(Base):
     __table_args__ = (
         Index("ix_refresh_jobs_status", "status"),
         Index("ix_refresh_jobs_flight", "flight_id", "created_at"),
+        # Account deletion sweeps by user_id; named here rather than via
+        # ``index=True`` so dev's create_all and migration 082 agree on the name.
+        Index("ix_refresh_jobs_user", "user_id"),
     )
 
     #: Statuses a job can end in. Anything else means "still in flight" and, at
-    #: process boot, means "interrupted".
-    TERMINAL = ("succeeded", "failed", "abandoned")
+    #: process boot, means "interrupted". ``skipped`` is distinct from
+    #: ``succeeded`` on purpose: the refresh gate declining a full run is the
+    #: routine outcome for a flight that already has a recent pack, and folding
+    #: it into ``succeeded`` would make the record claim briefings that were
+    #: never produced.
+    TERMINAL = ("succeeded", "skipped", "failed", "abandoned")
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     flight_id: Mapped[str] = mapped_column(String(256), nullable=False)
@@ -343,7 +350,7 @@ class BriefingRefreshJobRow(Base):
     # resumed refresh is still accounted to the surface that asked for it.
     source: Mapped[str | None] = mapped_column(String(16), nullable=True)
     as_of_date: Mapped[date_t | None] = mapped_column(Date, nullable=True)
-    # queued | running | succeeded | failed | abandoned
+    # queued | running | succeeded | skipped | failed | abandoned
     status: Mapped[str] = mapped_column(String(16), default="queued")
     attempt: Mapped[int] = mapped_column(Integer, default=1)
     created_at: Mapped[datetime] = mapped_column(

--- a/src/weatherbrief/db/models.py
+++ b/src/weatherbrief/db/models.py
@@ -307,6 +307,64 @@ class BriefingUsageRow(Base):
     user: Mapped[UserRow] = relationship(UserRow)
 
 
+class BriefingRefreshJobRow(Base):
+    """Durable mirror of an in-flight briefing refresh (issue #499).
+
+    The in-memory ``_RefreshRegistry`` is the single choke point every refresh
+    path goes through; this table is its write-through mirror, so a refresh
+    that is killed mid-flight (OOM, deploy, crash) leaves a record instead of
+    evaporating. A non-terminal row present at process boot is by definition an
+    orphan — the deployment runs a single uvicorn worker, so there is no other
+    instance that could still own it, and no lease is needed.
+
+    ``flight_id`` is intentionally not a foreign key: the row must outlive the
+    flight so reconciliation can tell "flight deleted, don't resume" apart from
+    "no record". See ``weatherbrief.tasks.refresh_resume``.
+    """
+
+    __tablename__ = "briefing_refresh_jobs"
+    __table_args__ = (
+        Index("ix_refresh_jobs_status", "status"),
+        Index("ix_refresh_jobs_flight", "flight_id", "created_at"),
+    )
+
+    #: Statuses a job can end in. Anything else means "still in flight" and, at
+    #: process boot, means "interrupted".
+    TERMINAL = ("succeeded", "failed", "abandoned")
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    flight_id: Mapped[str] = mapped_column(String(256), nullable=False)
+    user_id: Mapped[str | None] = mapped_column(
+        String(64), ForeignKey("users.id", ondelete="CASCADE"), nullable=True
+    )
+    # Registry queue-cap class: "user" | "scheduler" | "resume".
+    triggered_by: Mapped[str] = mapped_column(String(16), default="user")
+    # Client-declared attribution ("user" | "siri" | "mcp"), preserved so a
+    # resumed refresh is still accounted to the surface that asked for it.
+    source: Mapped[str | None] = mapped_column(String(16), nullable=True)
+    as_of_date: Mapped[date_t | None] = mapped_column(Date, nullable=True)
+    # queued | running | succeeded | failed | abandoned
+    status: Mapped[str] = mapped_column(String(16), default="queued")
+    attempt: Mapped[int] = mapped_column(Integer, default=1)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
+    started_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    finished_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    heartbeat_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    # Last pipeline stage the registry saw — the "where did it die" half of a
+    # post-mortem for an interrupted refresh.
+    stage: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    pack_path: Mapped[str | None] = mapped_column(String(512), nullable=True)
+    last_error: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+
 class FeedbackRow(Base):
     __tablename__ = "feedback"
 

--- a/src/weatherbrief/scheduler.py
+++ b/src/weatherbrief/scheduler.py
@@ -154,7 +154,7 @@ async def process_auto_refreshes(app_state) -> None:
 
             try:
                 refresh_registry.set_refreshing(row.id)
-                await asyncio.to_thread(
+                ran = await asyncio.to_thread(
                     _auto_refresh_one, row, app_state, row.user_id
                 )
                 # Record the refresh timestamp
@@ -166,8 +166,16 @@ async def process_auto_refreshes(app_state) -> None:
                         mark_db.commit()
                 finally:
                     mark_db.close()
-                refresh_registry.mark_outcome(row.id, "succeeded")
-                logger.info("Auto-refresh completed: %s", row.id)
+                # "skipped" and "succeeded" are both terminal, but only one of
+                # them means a briefing was produced — the durable record has
+                # to tell them apart to be worth anything (#499).
+                refresh_registry.mark_outcome(
+                    row.id, "succeeded" if ran else "skipped",
+                    None if ran else "refresh gate declined a full run",
+                )
+                logger.info(
+                    "Auto-refresh %s: %s", "completed" if ran else "skipped", row.id,
+                )
             except Exception as exc:
                 refresh_registry.mark_outcome(row.id, "failed", str(exc))
                 logger.error("Auto-refresh failed for %s", row.id, exc_info=True)
@@ -394,13 +402,20 @@ def _auto_refresh_one(
     user_id: str,
     *,
     triggered_by: str = "scheduler",
-) -> None:
+) -> bool:
     """Run the briefing pipeline for a single flight (called in a thread).
 
     ``triggered_by`` is the usage attribution recorded on the briefing —
     ``"scheduler"`` for the auto-refresh loop, ``"resume"`` when the boot-time
     reconciliation pass re-runs a refresh interrupted by a container restart
     (issue #499). Both share the same gate-then-run body.
+
+    Returns **True** when the pipeline actually ran and persisted a pack, and
+    **False** when the call short-circuited (the refresh gate no longer wants a
+    full run, or ``AIRPORTS_DB`` isn't configured). Callers need the difference
+    to close the durable job row honestly — a gated skip is the routine case
+    for a flight that already has a recent pack, and recording it as
+    ``succeeded`` would make the post-mortem record lie (issue #499).
     """
     from weatherbrief.api.packs import (
         _build_data_status, _days_out_now, _finalize_refresh,
@@ -426,12 +441,12 @@ def _auto_refresh_one(
                     "Auto-refresh: gate=%s for %s (%s), skipping",
                     decision.mode, flight_row.id, decision.reason,
                 )
-                return
+                return False
 
         db_path = getattr(app_state, "db_path", "")
         if not db_path:
             logger.warning("Auto-refresh: AIRPORTS_DB not configured, skipping %s", flight_row.id)
-            return
+            return False
 
         route, fetch_ts, pack_path, options, model_metadata, resolved_as_of = _prepare_refresh(
             flight, db_path, user_id, flight_row.id, db=db, is_privileged=True,
@@ -475,6 +490,7 @@ def _auto_refresh_one(
         _notify_refresh_complete(
             db, flight, meta, pack_path, user_id=user_id,
         )
+        return True
 
     finally:
         db.close()

--- a/src/weatherbrief/scheduler.py
+++ b/src/weatherbrief/scheduler.py
@@ -144,7 +144,10 @@ async def process_auto_refreshes(app_state) -> None:
         for row in due:
             from weatherbrief.api.packs import refresh_registry
 
-            entry = refresh_registry.try_register(row.id, triggered_by="scheduler")
+            entry = refresh_registry.try_register(
+                row.id, triggered_by="scheduler", user_id=row.user_id,
+                source="scheduler",
+            )
             if entry is None:
                 logger.info("Auto-refresh: skipping %s (refresh already in progress)", row.id)
                 continue
@@ -163,8 +166,10 @@ async def process_auto_refreshes(app_state) -> None:
                         mark_db.commit()
                 finally:
                     mark_db.close()
+                refresh_registry.mark_outcome(row.id, "succeeded")
                 logger.info("Auto-refresh completed: %s", row.id)
-            except Exception:
+            except Exception as exc:
+                refresh_registry.mark_outcome(row.id, "failed", str(exc))
                 logger.error("Auto-refresh failed for %s", row.id, exc_info=True)
             finally:
                 refresh_registry.unregister(row.id)
@@ -383,8 +388,20 @@ def _flight_start_dt(row: FlightRow) -> datetime | None:
 # ---------------------------------------------------------------------------
 
 
-def _auto_refresh_one(flight_row: FlightRow, app_state, user_id: str) -> None:
-    """Run the briefing pipeline for a single flight (called in a thread)."""
+def _auto_refresh_one(
+    flight_row: FlightRow,
+    app_state,
+    user_id: str,
+    *,
+    triggered_by: str = "scheduler",
+) -> None:
+    """Run the briefing pipeline for a single flight (called in a thread).
+
+    ``triggered_by`` is the usage attribution recorded on the briefing —
+    ``"scheduler"`` for the auto-refresh loop, ``"resume"`` when the boot-time
+    reconciliation pass re-runs a refresh interrupted by a container restart
+    (issue #499). Both share the same gate-then-run body.
+    """
     from weatherbrief.api.packs import (
         _build_data_status, _days_out_now, _finalize_refresh,
         _notify_refresh_complete, _prepare_refresh,
@@ -439,7 +456,7 @@ def _auto_refresh_one(flight_row: FlightRow, app_state, user_id: str) -> None:
         queue_wait, total_elapsed = refresh_registry.get_timing(flight_row.id)
         result.usage.elapsed_seconds = total_elapsed
         result.usage.queue_wait_seconds = queue_wait
-        result.usage.triggered_by = "scheduler"
+        result.usage.triggered_by = triggered_by
 
         meta = _finalize_refresh(
             flight_row.id, flight, fetch_ts, pack_path, result, db,

--- a/src/weatherbrief/storage/refresh_jobs.py
+++ b/src/weatherbrief/storage/refresh_jobs.py
@@ -1,0 +1,213 @@
+"""Durable briefing-refresh job rows — CRUD plus best-effort write-through.
+
+Two layers, deliberately separated:
+
+* the ``*_job`` functions take a caller-supplied :class:`~sqlalchemy.orm.Session`
+  and behave like any other storage module (flush, let the caller commit);
+* the ``record_*`` helpers open their own short-lived session, commit, and
+  **swallow every exception**. They are called from the in-memory refresh
+  registry, which runs on pipeline worker threads with no session in hand. A DB
+  hiccup must never fail a refresh — durability here is a diagnostic and a
+  resume hint, not a correctness invariant.
+
+See ``designs/refresh-durability.md`` and issue #499.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import date as date_t, datetime, timezone
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from flyfun_common.db import SessionLocal
+from weatherbrief.db.models import BriefingRefreshJobRow
+
+logger = logging.getLogger(__name__)
+
+#: Statuses that mean the job is done. A row in any other status at process
+#: boot was interrupted (single uvicorn worker — nothing else can own it).
+TERMINAL_STATUSES = frozenset(BriefingRefreshJobRow.TERMINAL)
+
+
+# ---------------------------------------------------------------------------
+# Session-taking CRUD
+# ---------------------------------------------------------------------------
+
+
+def create_job(
+    db: Session,
+    *,
+    flight_id: str,
+    user_id: str | None = None,
+    triggered_by: str = "user",
+    source: str | None = None,
+    as_of_date: date_t | None = None,
+    attempt: int = 1,
+) -> BriefingRefreshJobRow:
+    """Insert a ``queued`` job row and return it (flushed, not committed)."""
+    row = BriefingRefreshJobRow(
+        flight_id=flight_id,
+        user_id=user_id,
+        triggered_by=triggered_by,
+        source=source,
+        as_of_date=as_of_date,
+        status="queued",
+        attempt=attempt,
+        created_at=datetime.now(timezone.utc),
+    )
+    db.add(row)
+    db.flush()
+    return row
+
+
+def mark_running(db: Session, job_id: int) -> None:
+    """Move a job to ``running`` and stamp ``started_at``."""
+    row = db.get(BriefingRefreshJobRow, job_id)
+    if row is None or row.status in TERMINAL_STATUSES:
+        return
+    row.status = "running"
+    now = datetime.now(timezone.utc)
+    row.started_at = now
+    row.heartbeat_at = now
+    db.flush()
+
+
+def touch_heartbeat(db: Session, job_id: int, stage: str | None = None) -> None:
+    """Bump ``heartbeat_at`` (and the last-seen pipeline stage)."""
+    row = db.get(BriefingRefreshJobRow, job_id)
+    if row is None or row.status in TERMINAL_STATUSES:
+        return
+    row.heartbeat_at = datetime.now(timezone.utc)
+    if stage:
+        row.stage = stage
+    db.flush()
+
+
+def set_pack_path(db: Session, job_id: int, pack_path: str) -> None:
+    """Record the pack directory this job is writing into.
+
+    Set as soon as the directory is created, so a killed refresh leaves a row
+    pointing at its orphan artifacts instead of an untraceable directory.
+    """
+    row = db.get(BriefingRefreshJobRow, job_id)
+    if row is None:
+        return
+    row.pack_path = pack_path[:512]
+    db.flush()
+
+
+def finish_job(
+    db: Session,
+    job_id: int,
+    status: str,
+    *,
+    error: str | None = None,
+) -> None:
+    """Close a job with a terminal ``status`` (idempotent)."""
+    row = db.get(BriefingRefreshJobRow, job_id)
+    if row is None or row.status in TERMINAL_STATUSES:
+        return
+    row.status = status
+    row.finished_at = datetime.now(timezone.utc)
+    if error:
+        row.last_error = error[:2000]
+    db.flush()
+
+
+def list_orphans(db: Session) -> list[BriefingRefreshJobRow]:
+    """Every non-terminal job row, oldest first.
+
+    At process boot these are exactly the refreshes that were in flight when
+    the previous process died.
+    """
+    stmt = (
+        select(BriefingRefreshJobRow)
+        .where(BriefingRefreshJobRow.status.notin_(sorted(TERMINAL_STATUSES)))
+        .order_by(BriefingRefreshJobRow.created_at)
+    )
+    return list(db.execute(stmt).scalars().all())
+
+
+def latest_job_for_flight(db: Session, flight_id: str) -> BriefingRefreshJobRow | None:
+    """Newest job row for a flight, or None."""
+    stmt = (
+        select(BriefingRefreshJobRow)
+        .where(BriefingRefreshJobRow.flight_id == flight_id)
+        .order_by(BriefingRefreshJobRow.created_at.desc(), BriefingRefreshJobRow.id.desc())
+        .limit(1)
+    )
+    return db.execute(stmt).scalars().first()
+
+
+# ---------------------------------------------------------------------------
+# Best-effort write-through (own session, never raises)
+# ---------------------------------------------------------------------------
+
+
+def _best_effort(what: str, fn):
+    """Run ``fn(db)`` in its own committed session, swallowing all failures."""
+    db = None
+    try:
+        db = SessionLocal()
+        result = fn(db)
+        db.commit()
+        return result
+    except Exception:
+        # Deliberately broad and non-fatal: refresh durability is diagnostic.
+        logger.debug("refresh-job write-through (%s) failed", what, exc_info=True)
+        if db is not None:
+            try:
+                db.rollback()
+            except Exception:
+                pass
+        return None
+    finally:
+        if db is not None:
+            try:
+                db.close()
+            except Exception:
+                pass
+
+
+def record_queued(
+    flight_id: str,
+    *,
+    user_id: str | None = None,
+    triggered_by: str = "user",
+    source: str | None = None,
+    as_of_date: date_t | None = None,
+    attempt: int = 1,
+) -> int | None:
+    """Insert a queued job row; return its id (None if the write failed)."""
+
+    def _do(db: Session) -> int:
+        row = create_job(
+            db,
+            flight_id=flight_id,
+            user_id=user_id,
+            triggered_by=triggered_by,
+            source=source,
+            as_of_date=as_of_date,
+            attempt=attempt,
+        )
+        return row.id
+
+    return _best_effort("queued", _do)
+
+
+def record_running(job_id: int) -> None:
+    _best_effort("running", lambda db: mark_running(db, job_id))
+
+
+def record_heartbeat(job_id: int, stage: str | None = None) -> None:
+    _best_effort("heartbeat", lambda db: touch_heartbeat(db, job_id, stage))
+
+
+def record_pack_path(job_id: int, pack_path: str) -> None:
+    _best_effort("pack_path", lambda db: set_pack_path(db, job_id, pack_path))
+
+
+def record_finished(job_id: int, status: str, error: str | None = None) -> None:
+    _best_effort("finished", lambda db: finish_job(db, job_id, status, error=error))

--- a/src/weatherbrief/tasks/refresh_resume.py
+++ b/src/weatherbrief/tasks/refresh_resume.py
@@ -1,0 +1,272 @@
+"""Resume briefing refreshes interrupted by a container restart (issue #499).
+
+Refresh state is mirrored into ``briefing_refresh_jobs`` as it runs (see
+``weatherbrief.storage.refresh_jobs``). The terminal write happens in the
+refresh path's ``finally`` — which is exactly what does *not* run when the
+process is killed (OOM, deploy, crash). So a non-terminal row at process boot
+means "this refresh was interrupted".
+
+The deployment runs a **single uvicorn worker**, so there is no second instance
+that could still legitimately own such a row: no leases, no instance ids, no
+distributed locking. Any non-terminal row present at boot is an orphan, full
+stop.
+
+For each orphan this pass decides between:
+
+* **abandon** — the retry budget is spent, the flight is gone/departed/beyond
+  coverage, the job was a pinned ``as_of_date`` backtest, or the refresh gate
+  no longer wants a full run (the scheduler already re-briefed it, or no model
+  has moved). Closing the row is the whole outcome; no compute is burned.
+* **resume** — re-queue the refresh through the registry with
+  ``triggered_by="resume"`` and ``attempt + 1``. Registering also makes
+  ``idle_seconds()`` go to zero, so the discretionary GRIB warm loop yields to
+  it exactly as it does for an interactive briefing (#490).
+
+Interruptions burn an attempt regardless of cause: we deliberately do not try
+to attribute the crash to the briefing. ``WB_REFRESH_MAX_ATTEMPTS`` (default 2
+= the original run plus one resume) bounds how often a briefing that genuinely
+does take the container down can do it again. Set it to 1 to disable resume.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Literal
+
+from sqlalchemy.orm import Session
+
+from flyfun_common.db import SessionLocal
+from weatherbrief.db.models import BriefingRefreshJobRow, FlightRow
+from weatherbrief.storage.refresh_jobs import (
+    TERMINAL_STATUSES,
+    finish_job,
+    list_orphans,
+)
+
+logger = logging.getLogger(__name__)
+
+#: Original run + one resume. Sized so a briefing that genuinely does take the
+#: container down can only do it twice, while a single OOM or deploy never
+#: silently loses a user's refresh.
+DEFAULT_MAX_ATTEMPTS = 2
+
+#: Past the scheduler's own 30s startup delay, so a flight the scheduler is
+#: about to re-brief anyway has already been picked up and the gate check below
+#: closes the orphan for free.
+STARTUP_DELAY_SECONDS = 90
+
+
+def resume_max_attempts() -> int:
+    """``WB_REFRESH_MAX_ATTEMPTS`` — total attempts allowed per refresh."""
+    raw = os.environ.get("WB_REFRESH_MAX_ATTEMPTS", "").strip()
+    if not raw:
+        return DEFAULT_MAX_ATTEMPTS
+    try:
+        value = int(raw)
+    except ValueError:
+        logger.warning(
+            "Invalid WB_REFRESH_MAX_ATTEMPTS=%r — using %d", raw, DEFAULT_MAX_ATTEMPTS,
+        )
+        return DEFAULT_MAX_ATTEMPTS
+    return max(1, value)
+
+
+@dataclass(frozen=True)
+class ResumeDecision:
+    """What to do with one interrupted refresh."""
+
+    action: Literal["resume", "abandon"]
+    reason: str
+
+
+def decide_resume(
+    db: Session,
+    job: BriefingRefreshJobRow,
+    *,
+    max_attempts: int | None = None,
+    now: datetime | None = None,
+) -> ResumeDecision:
+    """Decide whether an interrupted refresh is worth re-running.
+
+    Ordered cheapest-check-first; every abandon carries the reason that goes
+    into ``last_error`` and the log line.
+    """
+    from weatherbrief.api.packs import (
+        _build_data_status,
+        _days_out_now,
+        decide_refresh,
+        pending_coverage_date,
+    )
+    from weatherbrief.storage.flights import _row_to_flight, list_packs
+
+    limit = resume_max_attempts() if max_attempts is None else max_attempts
+
+    # The interruption itself consumed this attempt.
+    if job.attempt >= limit:
+        return ResumeDecision(
+            "abandon", f"attempt {job.attempt} of {limit} — retry budget spent",
+        )
+
+    # A pinned as_of_date is an admin backtest of the forecast as it stood on a
+    # given day. Re-running it live would answer a different question, so it is
+    # never resumed automatically.
+    if job.as_of_date is not None:
+        return ResumeDecision(
+            "abandon", f"pinned as_of_date={job.as_of_date.isoformat()} backtest",
+        )
+
+    flight_row = db.get(FlightRow, job.flight_id)
+    if flight_row is None:
+        return ResumeDecision("abandon", "flight no longer exists")
+
+    flight = _row_to_flight(flight_row)
+    now = now or datetime.now(timezone.utc)
+    if flight.departure_time <= now:
+        return ResumeDecision("abandon", "flight has already departed")
+
+    coverage_date = pending_coverage_date(flight, as_of=now)
+    if coverage_date is not None:
+        return ResumeDecision(
+            "abandon", f"beyond the forecast horizon (coverage from {coverage_date})",
+        )
+
+    # The refresh gate is a free correctness check: if a full run is no longer
+    # warranted — the scheduler already re-briefed this flight, or no model has
+    # moved since — there is nothing to resume.
+    packs = list_packs(db, job.flight_id)
+    if packs:
+        status = _build_data_status(packs[0], flight)
+        decision = decide_refresh(status, _days_out_now(flight))
+        if decision.mode != "full":
+            return ResumeDecision(
+                "abandon", f"refresh gate now says {decision.mode}: {decision.reason}",
+            )
+
+    return ResumeDecision("resume", f"attempt {job.attempt + 1} of {limit}")
+
+
+def snapshot_orphans() -> list[int]:
+    """Ids of every non-terminal job row, read once at process boot.
+
+    Taken before the startup delay so refreshes started by *this* process can
+    never be mistaken for orphans of the previous one.
+    """
+    db = SessionLocal()
+    try:
+        return [row.id for row in list_orphans(db)]
+    finally:
+        db.close()
+
+
+async def reconcile_one(job_id: int, app_state) -> None:
+    """Abandon or resume a single interrupted refresh."""
+    from weatherbrief.api.packs import refresh_registry
+    from weatherbrief.scheduler import _auto_refresh_one
+
+    db = SessionLocal()
+    try:
+        job = db.get(BriefingRefreshJobRow, job_id)
+        if job is None or job.status in TERMINAL_STATUSES:
+            return
+        flight_id = job.flight_id
+        attempt = job.attempt
+        source = job.source
+        user_id = job.user_id
+        decision = decide_resume(db, job)
+
+        if decision.action == "abandon":
+            logger.warning(
+                "Refresh resume: abandoning interrupted refresh for flight %s "
+                "(attempt %d, pack=%s) — %s",
+                flight_id, attempt, job.pack_path, decision.reason,
+            )
+            finish_job(
+                db, job_id, "abandoned",
+                error=f"interrupted by process restart; {decision.reason}",
+            )
+            db.commit()
+            return
+
+        # Close the interrupted row before re-queuing so the post-mortem keeps
+        # one row per attempt rather than a mutating counter.
+        finish_job(
+            db, job_id, "failed",
+            error=f"interrupted by process restart; resumed as {decision.reason}",
+        )
+        db.commit()
+        if user_id is None:
+            flight_row = db.get(FlightRow, flight_id)
+            user_id = flight_row.user_id if flight_row else None
+    finally:
+        db.close()
+
+    if user_id is None:
+        logger.warning("Refresh resume: no user for flight %s — skipping", flight_id)
+        return
+
+    logger.warning(
+        "Refresh resume: re-running interrupted refresh for flight %s (%s)",
+        flight_id, decision.reason,
+    )
+    entry = refresh_registry.try_register(
+        flight_id, triggered_by="resume", user_id=user_id,
+        source=source, attempt=attempt + 1,
+    )
+    if entry is None:
+        logger.info(
+            "Refresh resume: %s already has a live refresh — nothing to resume",
+            flight_id,
+        )
+        return
+
+    # Own session for the duration: _auto_refresh_one reads attributes off the
+    # FlightRow while it runs, so the row must stay attached to a live session
+    # (same shape as the scheduler's auto-refresh cycle).
+    run_db = SessionLocal()
+    try:
+        flight_row = run_db.get(FlightRow, flight_id)
+        if flight_row is None:
+            refresh_registry.mark_outcome(flight_id, "abandoned", "flight disappeared")
+            return
+        refresh_registry.set_refreshing(flight_id)
+        await asyncio.to_thread(
+            _auto_refresh_one, flight_row, app_state, user_id, triggered_by="resume",
+        )
+        refresh_registry.mark_outcome(flight_id, "succeeded")
+        logger.info("Refresh resume: completed for flight %s", flight_id)
+    except Exception as exc:
+        refresh_registry.mark_outcome(flight_id, "failed", str(exc))
+        logger.error("Refresh resume failed for flight %s", flight_id, exc_info=True)
+    finally:
+        refresh_registry.unregister(flight_id)
+        run_db.close()
+
+
+async def run_refresh_resume(app_state) -> None:
+    """One-shot boot-time reconciliation task, started from the app lifespan."""
+    try:
+        orphans = await asyncio.to_thread(snapshot_orphans)
+    except Exception:
+        logger.error("Refresh resume: could not read interrupted refreshes", exc_info=True)
+        return
+
+    if not orphans:
+        logger.info("Refresh resume: no interrupted refreshes at boot")
+        return
+
+    logger.warning(
+        "Refresh resume: %d refresh(es) were in flight when the previous "
+        "process died — reconciling in %ds",
+        len(orphans), STARTUP_DELAY_SECONDS,
+    )
+    await asyncio.sleep(STARTUP_DELAY_SECONDS)
+
+    for job_id in orphans:
+        try:
+            await reconcile_one(job_id, app_state)
+        except Exception:
+            logger.error("Refresh resume: reconciling job %d failed", job_id, exc_info=True)

--- a/src/weatherbrief/tasks/refresh_resume.py
+++ b/src/weatherbrief/tasks/refresh_resume.py
@@ -162,6 +162,16 @@ def snapshot_orphans() -> list[int]:
         db.close()
 
 
+def _close_orphan(job_id: int, status: str, error: str) -> None:
+    """Terminalize an interrupted job row in its own committed session."""
+    db = SessionLocal()
+    try:
+        finish_job(db, job_id, status, error=error)
+        db.commit()
+    finally:
+        db.close()
+
+
 async def reconcile_one(job_id: int, app_state) -> None:
     """Abandon or resume a single interrupted refresh."""
     from weatherbrief.api.packs import refresh_registry
@@ -191,13 +201,7 @@ async def reconcile_one(job_id: int, app_state) -> None:
             db.commit()
             return
 
-        # Close the interrupted row before re-queuing so the post-mortem keeps
-        # one row per attempt rather than a mutating counter.
-        finish_job(
-            db, job_id, "failed",
-            error=f"interrupted by process restart; resumed as {decision.reason}",
-        )
-        db.commit()
+
         if user_id is None:
             flight_row = db.get(FlightRow, flight_id)
             user_id = flight_row.user_id if flight_row else None
@@ -206,12 +210,18 @@ async def reconcile_one(job_id: int, app_state) -> None:
 
     if user_id is None:
         logger.warning("Refresh resume: no user for flight %s — skipping", flight_id)
+        _close_orphan(job_id, "abandoned", "interrupted by process restart; no owning user")
         return
 
     logger.warning(
         "Refresh resume: re-running interrupted refresh for flight %s (%s)",
         flight_id, decision.reason,
     )
+    # Register BEFORE closing the interrupted row, so the row never claims a
+    # resume that didn't happen. The cost is a narrow window where both rows are
+    # non-terminal: if the process dies in it, the next boot resumes the old row
+    # again and abandons the new one at the attempt cap — an extra run rather
+    # than a lost one, which is the right way round for this failure.
     entry = refresh_registry.try_register(
         flight_id, triggered_by="resume", user_id=user_id,
         source=source, attempt=attempt + 1,
@@ -221,7 +231,18 @@ async def reconcile_one(job_id: int, app_state) -> None:
             "Refresh resume: %s already has a live refresh — nothing to resume",
             flight_id,
         )
+        _close_orphan(
+            job_id, "abandoned",
+            "interrupted by process restart; resume skipped, flight already active",
+        )
         return
+
+    # One row per attempt: this one records the interruption, the row just
+    # registered records the resume.
+    _close_orphan(
+        job_id, "failed",
+        f"interrupted by process restart; resumed as {decision.reason}",
+    )
 
     # Own session for the duration: _auto_refresh_one reads attributes off the
     # FlightRow while it runs, so the row must stay attached to a live session
@@ -233,11 +254,20 @@ async def reconcile_one(job_id: int, app_state) -> None:
             refresh_registry.mark_outcome(flight_id, "abandoned", "flight disappeared")
             return
         refresh_registry.set_refreshing(flight_id)
-        await asyncio.to_thread(
+        ran = await asyncio.to_thread(
             _auto_refresh_one, flight_row, app_state, user_id, triggered_by="resume",
         )
-        refresh_registry.mark_outcome(flight_id, "succeeded")
-        logger.info("Refresh resume: completed for flight %s", flight_id)
+        # decide_resume already checked the gate, so a skip here means it moved
+        # underneath us (the scheduler got there first). Record it as such
+        # rather than as a briefing that never happened.
+        refresh_registry.mark_outcome(
+            flight_id, "succeeded" if ran else "skipped",
+            None if ran else "refresh gate declined a full run",
+        )
+        logger.info(
+            "Refresh resume: %s for flight %s",
+            "completed" if ran else "skipped by the gate", flight_id,
+        )
     except Exception as exc:
         refresh_registry.mark_outcome(flight_id, "failed", str(exc))
         logger.error("Refresh resume failed for flight %s", flight_id, exc_info=True)

--- a/tests/test_refresh_durability.py
+++ b/tests/test_refresh_durability.py
@@ -1,0 +1,588 @@
+"""Durable refresh tracking + resume after a container restart (issue #499).
+
+Three layers under test:
+
+* the write-through mirror in ``_RefreshRegistry`` (queued → running →
+  heartbeat → terminal, and the crash case where the terminal write never
+  happens);
+* ``decide_resume`` — abandon vs re-run for an orphan row at boot;
+* the ``/refresh/status`` fallback that reports "interrupted" / "abandoned"
+  instead of silently nothing after a restart.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta, timezone
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import sessionmaker
+
+from flyfun_common.db import DEV_USER_ID, current_user_id, get_db
+from flyfun_common.db.models import UserPreferencesRow, UserRow
+
+from weatherbrief.api.app import create_app
+from weatherbrief.api.packs import _RefreshRegistry
+from weatherbrief.db.models import BriefingRefreshJobRow, FlightRow
+from weatherbrief.storage import refresh_jobs
+from weatherbrief.tasks import refresh_resume
+
+FLIGHT_ID = "f1"
+OTHER_USER = "someone-else"
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+@pytest.fixture
+def app_db(monkeypatch):
+    """In-memory DB with a dev user + one future flight, wired as SessionLocal.
+
+    The registry's write-through opens its own session (it runs on pipeline
+    worker threads), so the storage module's ``SessionLocal`` is what has to
+    point at the test engine.
+    """
+    from conftest import make_app_engine
+
+    engine = make_app_engine()
+    TestSession = sessionmaker(bind=engine)
+    s = TestSession()
+    for uid in (DEV_USER_ID, OTHER_USER):
+        s.add(UserRow(id=uid, provider="google", provider_sub=uid,
+                      email=f"{uid}@localhost", display_name=uid, approved=True))
+    s.flush()
+    s.add(UserPreferencesRow(user_id=DEV_USER_ID))
+    s.add(FlightRow(id=FLIGHT_ID, user_id=DEV_USER_ID, route_name="EGTF-LFAT",
+                    waypoints_json='["EGTF", "LFAT"]',
+                    departure_time=_now() + timedelta(days=3),
+                    created_at=_now()))
+    s.commit()
+    s.close()
+
+    monkeypatch.setattr(refresh_jobs, "SessionLocal", TestSession)
+    monkeypatch.setattr(refresh_resume, "SessionLocal", TestSession)
+    yield TestSession
+    engine.dispose()
+
+
+def _jobs(app_db) -> list[BriefingRefreshJobRow]:
+    s = app_db()
+    try:
+        return s.query(BriefingRefreshJobRow).order_by(BriefingRefreshJobRow.id).all()
+    finally:
+        s.close()
+
+
+def _only_job(app_db) -> BriefingRefreshJobRow:
+    rows = _jobs(app_db)
+    assert len(rows) == 1
+    return rows[0]
+
+
+# ---------------------------------------------------------------------------
+# Registry write-through
+# ---------------------------------------------------------------------------
+
+
+class TestWriteThrough:
+    def test_try_register_inserts_queued_row(self, app_db):
+        reg = _RefreshRegistry(durable=True)
+        reg.try_register(FLIGHT_ID, user_id=DEV_USER_ID, source="siri")
+
+        row = _only_job(app_db)
+        assert row.flight_id == FLIGHT_ID
+        assert row.user_id == DEV_USER_ID
+        assert row.status == "queued"
+        assert row.triggered_by == "user"
+        assert row.source == "siri"
+        assert row.attempt == 1
+        assert row.started_at is None
+
+    def test_set_refreshing_marks_running(self, app_db):
+        reg = _RefreshRegistry(durable=True)
+        reg.try_register(FLIGHT_ID, user_id=DEV_USER_ID)
+        reg.set_refreshing(FLIGHT_ID)
+
+        row = _only_job(app_db)
+        assert row.status == "running"
+        assert row.started_at is not None
+
+    def test_pack_path_is_recorded(self, app_db):
+        reg = _RefreshRegistry(durable=True)
+        reg.try_register(FLIGHT_ID, user_id=DEV_USER_ID)
+        reg.note_pack_path(FLIGHT_ID, "/data/packs/dev/f1/2026-07-26T10-00-00p00-00")
+
+        assert _only_job(app_db).pack_path.endswith("2026-07-26T10-00-00p00-00")
+
+    def test_progress_heartbeat_is_throttled(self, app_db):
+        """One durable write per HEARTBEAT_MIN_INTERVAL, not one per stage."""
+        reg = _RefreshRegistry(durable=True)
+        reg.try_register(FLIGHT_ID, user_id=DEV_USER_ID)
+        reg.set_refreshing(FLIGHT_ID)
+
+        reg.update_progress(FLIGHT_ID, "fetch")
+        reg.update_progress(FLIGHT_ID, "analyze")
+
+        # In-memory state always tracks the latest stage...
+        assert reg.get(FLIGHT_ID).stage == "analyze"
+        # ...the durable row only took the first (throttled) write.
+        assert _only_job(app_db).stage == "fetch"
+
+    def test_success_closes_the_row(self, app_db):
+        reg = _RefreshRegistry(durable=True)
+        reg.try_register(FLIGHT_ID, user_id=DEV_USER_ID)
+        reg.set_refreshing(FLIGHT_ID)
+        reg.mark_outcome(FLIGHT_ID, "succeeded")
+        reg.unregister(FLIGHT_ID)
+
+        row = _only_job(app_db)
+        assert row.status == "succeeded"
+        assert row.finished_at is not None
+        assert row.last_error is None
+
+    def test_failure_records_the_error(self, app_db):
+        reg = _RefreshRegistry(durable=True)
+        reg.try_register(FLIGHT_ID, user_id=DEV_USER_ID)
+        reg.mark_outcome(FLIGHT_ID, "failed", "open-meteo timed out")
+        reg.unregister(FLIGHT_ID)
+
+        row = _only_job(app_db)
+        assert row.status == "failed"
+        assert "open-meteo" in row.last_error
+
+    def test_unregister_without_an_outcome_is_a_failure(self, app_db):
+        """An unmarked close is a bug elsewhere, not a success."""
+        reg = _RefreshRegistry(durable=True)
+        reg.try_register(FLIGHT_ID, user_id=DEV_USER_ID)
+        reg.unregister(FLIGHT_ID)
+
+        assert _only_job(app_db).status == "failed"
+
+    def test_crash_leaves_a_non_terminal_orphan(self, app_db):
+        """The killed-process case: no unregister ever runs."""
+        reg = _RefreshRegistry(durable=True)
+        reg.try_register(FLIGHT_ID, user_id=DEV_USER_ID)
+        reg.set_refreshing(FLIGHT_ID)
+        # ...container dies here. Nothing else happens.
+
+        s = app_db()
+        try:
+            orphans = refresh_jobs.list_orphans(s)
+        finally:
+            s.close()
+        assert [o.flight_id for o in orphans] == [FLIGHT_ID]
+
+    def test_finished_jobs_are_not_orphans(self, app_db):
+        reg = _RefreshRegistry(durable=True)
+        reg.try_register(FLIGHT_ID, user_id=DEV_USER_ID)
+        reg.mark_outcome(FLIGHT_ID, "succeeded")
+        reg.unregister(FLIGHT_ID)
+
+        s = app_db()
+        try:
+            assert refresh_jobs.list_orphans(s) == []
+        finally:
+            s.close()
+
+    def test_non_durable_registry_writes_nothing(self, app_db):
+        reg = _RefreshRegistry()
+        reg.try_register(FLIGHT_ID, user_id=DEV_USER_ID)
+        reg.set_refreshing(FLIGHT_ID)
+        reg.mark_outcome(FLIGHT_ID, "succeeded")
+        reg.unregister(FLIGHT_ID)
+
+        assert _jobs(app_db) == []
+
+    def test_resume_bypasses_the_queue_cap(self):
+        """A resume is finishing work the user already asked for."""
+        reg = _RefreshRegistry()
+        for i in range(reg.MAX_QUEUE_DEPTH):
+            reg.try_register(f"other-{i}", user_id=f"u{i}")
+        assert reg.try_register(FLIGHT_ID, triggered_by="resume", user_id="u0") is not None
+
+
+# ---------------------------------------------------------------------------
+# WB_REFRESH_MAX_ATTEMPTS
+# ---------------------------------------------------------------------------
+
+
+class TestMaxAttempts:
+    def test_default_is_original_plus_one_resume(self, monkeypatch):
+        monkeypatch.delenv("WB_REFRESH_MAX_ATTEMPTS", raising=False)
+        assert refresh_resume.resume_max_attempts() == 2
+
+    def test_env_override(self, monkeypatch):
+        monkeypatch.setenv("WB_REFRESH_MAX_ATTEMPTS", "3")
+        assert refresh_resume.resume_max_attempts() == 3
+
+    def test_one_disables_resume(self, monkeypatch):
+        monkeypatch.setenv("WB_REFRESH_MAX_ATTEMPTS", "1")
+        assert refresh_resume.resume_max_attempts() == 1
+
+    def test_zero_clamps_to_one(self, monkeypatch):
+        monkeypatch.setenv("WB_REFRESH_MAX_ATTEMPTS", "0")
+        assert refresh_resume.resume_max_attempts() == 1
+
+    def test_garbage_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv("WB_REFRESH_MAX_ATTEMPTS", "lots")
+        assert refresh_resume.resume_max_attempts() == 2
+
+
+# ---------------------------------------------------------------------------
+# decide_resume
+# ---------------------------------------------------------------------------
+
+
+def _make_job(session, **overrides) -> BriefingRefreshJobRow:
+    kwargs = dict(
+        flight_id=FLIGHT_ID,
+        user_id=DEV_USER_ID,
+        triggered_by="user",
+        source="user",
+        status="running",
+        attempt=1,
+        created_at=_now(),
+        started_at=_now(),
+    )
+    kwargs.update(overrides)
+    row = BriefingRefreshJobRow(**kwargs)
+    session.add(row)
+    session.flush()
+    return row
+
+
+class TestDecideResume:
+    @pytest.fixture(autouse=True)
+    def _no_packs(self, monkeypatch):
+        """Default: the flight has no packs, so the gate never runs."""
+        from weatherbrief.storage import flights as flights_mod
+
+        monkeypatch.setattr(flights_mod, "list_packs", lambda db, fid: [])
+
+    def test_resumes_a_fresh_interruption(self, app_db):
+        s = app_db()
+        try:
+            job = _make_job(s)
+            decision = refresh_resume.decide_resume(s, job, max_attempts=2)
+        finally:
+            s.close()
+        assert decision.action == "resume"
+        assert "attempt 2 of 2" in decision.reason
+
+    def test_abandons_when_the_retry_budget_is_spent(self, app_db):
+        s = app_db()
+        try:
+            job = _make_job(s, attempt=2, triggered_by="resume")
+            decision = refresh_resume.decide_resume(s, job, max_attempts=2)
+        finally:
+            s.close()
+        assert decision.action == "abandon"
+        assert "retry budget" in decision.reason
+
+    def test_max_attempts_one_never_resumes(self, app_db):
+        s = app_db()
+        try:
+            job = _make_job(s)
+            decision = refresh_resume.decide_resume(s, job, max_attempts=1)
+        finally:
+            s.close()
+        assert decision.action == "abandon"
+
+    def test_abandons_a_pinned_backtest(self, app_db):
+        s = app_db()
+        try:
+            job = _make_job(s, as_of_date=date(2026, 7, 1))
+            decision = refresh_resume.decide_resume(s, job, max_attempts=2)
+        finally:
+            s.close()
+        assert decision.action == "abandon"
+        assert "as_of_date" in decision.reason
+
+    def test_abandons_when_the_flight_is_gone(self, app_db):
+        s = app_db()
+        try:
+            job = _make_job(s, flight_id="deleted-flight")
+            decision = refresh_resume.decide_resume(s, job, max_attempts=2)
+        finally:
+            s.close()
+        assert decision.action == "abandon"
+        assert "no longer exists" in decision.reason
+
+    def test_abandons_a_departed_flight(self, app_db):
+        s = app_db()
+        try:
+            s.get(FlightRow, FLIGHT_ID).departure_time = _now() - timedelta(hours=1)
+            s.flush()
+            job = _make_job(s)
+            decision = refresh_resume.decide_resume(s, job, max_attempts=2)
+        finally:
+            s.close()
+        assert decision.action == "abandon"
+        assert "already departed" in decision.reason
+
+    def test_abandons_beyond_the_forecast_horizon(self, app_db):
+        s = app_db()
+        try:
+            s.get(FlightRow, FLIGHT_ID).departure_time = _now() + timedelta(days=60)
+            s.flush()
+            job = _make_job(s)
+            decision = refresh_resume.decide_resume(s, job, max_attempts=2)
+        finally:
+            s.close()
+        assert decision.action == "abandon"
+        assert "forecast horizon" in decision.reason
+
+    def test_abandons_when_the_gate_no_longer_wants_a_full_run(
+        self, app_db, monkeypatch,
+    ):
+        """The scheduler already re-briefed it — don't burn the compute twice."""
+        self._patch_gate(monkeypatch, mode="none")
+        s = app_db()
+        try:
+            job = _make_job(s)
+            decision = refresh_resume.decide_resume(s, job, max_attempts=2)
+        finally:
+            s.close()
+        assert decision.action == "abandon"
+        assert "gate now says none" in decision.reason
+
+    def test_resumes_when_the_gate_still_wants_a_full_run(self, app_db, monkeypatch):
+        self._patch_gate(monkeypatch, mode="full")
+        s = app_db()
+        try:
+            job = _make_job(s)
+            decision = refresh_resume.decide_resume(s, job, max_attempts=2)
+        finally:
+            s.close()
+        assert decision.action == "resume"
+
+    @staticmethod
+    def _patch_gate(monkeypatch, *, mode: str) -> None:
+        from types import SimpleNamespace
+
+        from weatherbrief.api import packs as packs_mod
+        from weatherbrief.storage import flights as flights_mod
+
+        monkeypatch.setattr(flights_mod, "list_packs", lambda db, fid: ["pack"])
+        monkeypatch.setattr(packs_mod, "_build_data_status", lambda pack, flight: "status")
+        monkeypatch.setattr(
+            packs_mod, "decide_refresh",
+            lambda status, days_out: SimpleNamespace(mode=mode, reason="because"),
+        )
+
+
+# ---------------------------------------------------------------------------
+# reconcile_one — the boot-time pass end to end
+# ---------------------------------------------------------------------------
+
+
+class TestReconcileOne:
+    @pytest.fixture(autouse=True)
+    def _no_packs(self, monkeypatch):
+        from weatherbrief.storage import flights as flights_mod
+
+        monkeypatch.setattr(flights_mod, "list_packs", lambda db, fid: [])
+
+    @pytest.fixture
+    def ran(self, monkeypatch):
+        """Capture calls to the shared pipeline runner instead of running it."""
+        calls: list[dict] = []
+
+        def _fake(flight_row, app_state, user_id, *, triggered_by="scheduler"):
+            calls.append({
+                "flight_id": flight_row.id,
+                "user_id": user_id,
+                "triggered_by": triggered_by,
+            })
+
+        from weatherbrief import scheduler as scheduler_mod
+
+        monkeypatch.setattr(scheduler_mod, "_auto_refresh_one", _fake)
+        return calls
+
+    def _insert_orphan(self, app_db, **overrides) -> int:
+        s = app_db()
+        try:
+            job = _make_job(s, **overrides)
+            s.commit()
+            return job.id
+        finally:
+            s.close()
+
+    @pytest.mark.asyncio
+    async def test_resume_reruns_and_opens_a_second_attempt(
+        self, app_db, ran, monkeypatch,
+    ):
+        monkeypatch.setenv("WB_REFRESH_MAX_ATTEMPTS", "2")
+        job_id = self._insert_orphan(app_db, stage="fetch")
+
+        await refresh_resume.reconcile_one(job_id, object())
+
+        assert ran == [{
+            "flight_id": FLIGHT_ID, "user_id": DEV_USER_ID, "triggered_by": "resume",
+        }]
+        first, second = _jobs(app_db)
+        assert first.id == job_id
+        assert first.status == "failed"
+        assert "interrupted by process restart" in first.last_error
+        # The resume is its own row, so the post-mortem keeps one row per attempt.
+        assert second.attempt == 2
+        assert second.triggered_by == "resume"
+        assert second.status == "succeeded"
+
+    @pytest.mark.asyncio
+    async def test_abandon_closes_the_row_without_running_anything(
+        self, app_db, ran, monkeypatch,
+    ):
+        monkeypatch.setenv("WB_REFRESH_MAX_ATTEMPTS", "2")
+        job_id = self._insert_orphan(app_db, attempt=2, triggered_by="resume")
+
+        await refresh_resume.reconcile_one(job_id, object())
+
+        assert ran == []
+        row = _only_job(app_db)
+        assert row.id == job_id
+        assert row.status == "abandoned"
+        assert "retry budget" in row.last_error
+
+    @pytest.mark.asyncio
+    async def test_a_failing_resume_still_closes_its_row(
+        self, app_db, ran, monkeypatch,
+    ):
+        monkeypatch.setenv("WB_REFRESH_MAX_ATTEMPTS", "3")
+
+        def _boom(*a, **kw):
+            raise RuntimeError("open-meteo exploded")
+
+        from weatherbrief import scheduler as scheduler_mod
+
+        monkeypatch.setattr(scheduler_mod, "_auto_refresh_one", _boom)
+        job_id = self._insert_orphan(app_db)
+
+        await refresh_resume.reconcile_one(job_id, object())
+
+        _first, second = _jobs(app_db)
+        assert second.status == "failed"
+        assert "exploded" in second.last_error
+
+    @pytest.mark.asyncio
+    async def test_already_terminal_row_is_left_alone(self, app_db, ran):
+        job_id = self._insert_orphan(app_db, status="succeeded", finished_at=_now())
+
+        await refresh_resume.reconcile_one(job_id, object())
+
+        assert ran == []
+        assert _only_job(app_db).status == "succeeded"
+
+    def test_snapshot_orphans_lists_only_non_terminal_rows(self, app_db):
+        live = self._insert_orphan(app_db, status="running")
+        self._insert_orphan(app_db, status="succeeded", finished_at=_now())
+        self._insert_orphan(app_db, status="abandoned", finished_at=_now())
+
+        assert refresh_resume.snapshot_orphans() == [live]
+
+
+# ---------------------------------------------------------------------------
+# /refresh/status fallback
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def client(app_db, tmp_path, monkeypatch):
+    monkeypatch.setenv("DATA_DIR", str(tmp_path / "data"))
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.setenv("JWT_SECRET", "test")
+    app = create_app()
+
+    def _override_get_db():
+        s = app_db()
+        try:
+            yield s
+            s.commit()
+        finally:
+            s.close()
+
+    app.dependency_overrides[get_db] = _override_get_db
+    app.dependency_overrides[current_user_id] = lambda: DEV_USER_ID
+    return TestClient(app, raise_server_exceptions=False)
+
+
+STATUS_URL = f"/api/flights/{FLIGHT_ID}/packs/refresh/status"
+
+
+class TestStatusFallback:
+    def _insert(self, app_db, **overrides):
+        s = app_db()
+        try:
+            _make_job(s, **overrides)
+            s.commit()
+        finally:
+            s.close()
+
+    def test_no_job_reports_inactive(self, client):
+        assert client.get(STATUS_URL).json() == {"active": False}
+
+    def test_interrupted_row_reports_retrying(self, client, app_db, monkeypatch):
+        monkeypatch.setenv("WB_REFRESH_MAX_ATTEMPTS", "2")
+        self._insert(app_db, status="running", stage="fetch", heartbeat_at=_now())
+
+        body = client.get(STATUS_URL).json()
+        assert body["active"] is True
+        assert body["status"] == "interrupted"
+        assert body["stage"] == "fetch"
+        assert body["attempt"] == 1
+        assert body["max_attempts"] == 2
+        assert body["will_retry"] is True
+
+    def test_last_attempt_reports_no_retry(self, client, app_db, monkeypatch):
+        monkeypatch.setenv("WB_REFRESH_MAX_ATTEMPTS", "2")
+        self._insert(app_db, status="running", attempt=2, heartbeat_at=_now())
+
+        body = client.get(STATUS_URL).json()
+        assert body["status"] == "interrupted"
+        assert body["will_retry"] is False
+
+    def test_abandoned_row_reports_gave_up(self, client, app_db):
+        self._insert(
+            app_db, status="abandoned", finished_at=_now(),
+            last_error="interrupted by process restart; retry budget spent",
+        )
+
+        body = client.get(STATUS_URL).json()
+        assert body["active"] is False
+        assert body["status"] == "abandoned"
+        assert "retry budget" in body["last_error"]
+
+    def test_succeeded_row_is_not_surfaced(self, client, app_db):
+        self._insert(app_db, status="succeeded", finished_at=_now())
+        assert client.get(STATUS_URL).json() == {"active": False}
+
+    def test_a_leaked_row_cannot_pin_a_flight_active(self, client, app_db):
+        """Same staleness bound the warm loop uses (STALE_ENTRY_SECONDS)."""
+        stale = _now() - timedelta(
+            seconds=_RefreshRegistry.STALE_ENTRY_SECONDS + 600,
+        )
+        self._insert(app_db, status="running", created_at=stale, started_at=stale)
+
+        assert client.get(STATUS_URL).json() == {"active": False}
+
+    def test_another_users_job_is_not_disclosed(self, client, app_db):
+        self._insert(app_db, status="running", user_id=OTHER_USER)
+        assert client.get(STATUS_URL).json() == {"active": False}
+
+    def test_live_entry_still_wins(self, client, app_db):
+        """A registered refresh reports live progress, not the durable row."""
+        from weatherbrief.api.packs import refresh_registry
+
+        self._insert(app_db, status="running")
+        entry = refresh_registry.try_register(FLIGHT_ID, user_id=DEV_USER_ID)
+        assert entry is not None
+        try:
+            refresh_registry.set_refreshing(FLIGHT_ID)
+            body = client.get(STATUS_URL).json()
+            assert body["active"] is True
+            assert body["status"] == "refreshing"
+        finally:
+            refresh_registry.mark_outcome(FLIGHT_ID, "succeeded")
+            refresh_registry.unregister(FLIGHT_ID)

--- a/tests/test_refresh_durability.py
+++ b/tests/test_refresh_durability.py
@@ -395,6 +395,7 @@ class TestReconcileOne:
                 "user_id": user_id,
                 "triggered_by": triggered_by,
             })
+            return True  # the real one returns "did the pipeline run?"
 
         from weatherbrief import scheduler as scheduler_mod
 
@@ -465,6 +466,47 @@ class TestReconcileOne:
         _first, second = _jobs(app_db)
         assert second.status == "failed"
         assert "exploded" in second.last_error
+
+    @pytest.mark.asyncio
+    async def test_a_gate_skip_is_not_recorded_as_a_briefing(
+        self, app_db, monkeypatch,
+    ):
+        """`_auto_refresh_one` returning False must not close the row as success."""
+        from weatherbrief import scheduler as scheduler_mod
+
+        monkeypatch.setenv("WB_REFRESH_MAX_ATTEMPTS", "3")
+        monkeypatch.setattr(
+            scheduler_mod, "_auto_refresh_one", lambda *a, **kw: False,
+        )
+        job_id = self._insert_orphan(app_db)
+
+        await refresh_resume.reconcile_one(job_id, object())
+
+        _first, second = _jobs(app_db)
+        assert second.status == "skipped"
+        assert "gate declined" in second.last_error
+
+    @pytest.mark.asyncio
+    async def test_a_flight_already_refreshing_is_not_claimed_as_resumed(
+        self, app_db, ran,
+    ):
+        """The interrupted row must not claim a resume that never happened."""
+        from weatherbrief.api.packs import refresh_registry
+
+        job_id = self._insert_orphan(app_db)
+        # Something else grabbed the flight during the startup delay.
+        assert refresh_registry.try_register(FLIGHT_ID, user_id=DEV_USER_ID) is not None
+        try:
+            await refresh_resume.reconcile_one(job_id, object())
+        finally:
+            refresh_registry.mark_outcome(FLIGHT_ID, "succeeded")
+            refresh_registry.unregister(FLIGHT_ID)
+
+        assert ran == []
+        orphan = next(j for j in _jobs(app_db) if j.id == job_id)
+        assert orphan.status == "abandoned"
+        assert "already active" in orphan.last_error
+        assert "resumed as" not in orphan.last_error
 
     @pytest.mark.asyncio
     async def test_already_terminal_row_is_left_alone(self, app_db, ran):


### PR DESCRIPTION
## What & why

Implements durable briefing-refresh job tracking and boot-time resume logic to handle refreshes interrupted by container restarts (OOM, deploy, crash).

**The problem:** Refresh state lived only in the in-memory `_RefreshRegistry`. When the container died mid-refresh, nothing recorded that a refresh had been in flight — the pack row is written at the end, and the pack directory created up front becomes an orphan with no row pointing at it. Recovery was accidental (scheduler's next auto-refresh slot) or nonexistent (manual/Siri/MCP refreshes were lost).

**The solution:** A write-through mirror of the registry into a new `briefing_refresh_jobs` table. Every state transition (`try_register` → `set_refreshing` → `update_progress` → terminal status) is recorded durably. At process boot, a one-shot reconciliation pass identifies non-terminal rows (orphans), decides whether to resume or abandon each one, and re-queues resumable refreshes.

**Key design choices:**
- Single uvicorn worker means any non-terminal row at boot is by definition an orphan — no leases, no instance IDs, no distributed locking needed.
- Write-through is best-effort (swallows DB errors) so durability is diagnostic, not a correctness invariant.
- `flight_id` is intentionally not a foreign key so the row outlives the flight, letting reconciliation distinguish "flight deleted, don't resume" from "no record".
- Separate table rather than columns on `flights` because the registry is keyed by `flight_id` (one refresh per flight max), and the post-mortem record is the whole point.
- Resume is a separate job row (not a mutating counter) so the post-mortem keeps one row per attempt.

## Changes

**New files:**
- `tests/test_refresh_durability.py` — comprehensive test suite covering the write-through mirror, `decide_resume` logic, and boot-time reconciliation
- `src/weatherbrief/tasks/refresh_resume.py` — orphan snapshot, resume decision logic, and reconciliation loop
- `src/weatherbrief/storage/refresh_jobs.py` — CRUD + best-effort write-through helpers
- `designs/refresh-durability.md` — architecture and design rationale
- `alembic/versions/082_briefing_refresh_jobs.py` — migration creating the `briefing_refresh_jobs` table

**Modified files:**
- `src/weatherbrief/db/models.py` — added `BriefingRefreshJobRow` model
- `src/weatherbrief/api/packs.py` — `_RefreshRegistry` now supports durable mode with write-through at every state transition; added `UNCAPPED_TRIGGERS` to let scheduler and resume bypass queue caps
- `src/weatherbrief/scheduler.py` — pass `user_id` and `source="scheduler"` to `try_register`
- `src/weatherbrief/api/app.py` — explicit sweep of `BriefingRefreshJobRow` on user deletion (bulk delete doesn't emit ORM cascades)
- `src/weatherbrief/api/agent.py` — pass `source` to `try_register` for Siri/MCP attribution
- `designs/INDEX.md` and `designs/multi-user-deployment.md` — documentation updates

## Issue linkage

Closes #499

## Testing / verification

Comprehensive test suite in `tests/test_refresh_durability.py` covers:
- Write-through mirror: queued → running → heartbeat → terminal transitions, crash case
- `decide_resume`: retry budget, pinned backtests, deleted/departed flights, forecast horizon, refresh gate checks
- Boot-time reconciliation: resume vs abandon decisions, error handling, already-terminal rows
- Orphan snapshot and max-attempts configuration

All tests pass; the registry defaults to non-durable mode so existing tests are unaffected.

https://claude.ai/code/session_01TcQxEKw62bAhfSbuX5SaTa