### PR TITLE
iOS: route SIGMET section (D-0 area hazards) with responsive Move column

### DIFF
--- a/app/flyfun-weather/flyfun-weather/Models/API/SnapshotResponse.swift
+++ b/app/flyfun-weather/flyfun-weather/Models/API/SnapshotResponse.swift
@@ -9,6 +9,9 @@ struct SnapshotResponse: Codable, Sendable {
     let departureTime: String?
     let analyses: [WaypointAnalysis]?
     let routeObservations: RouteObservations?
+    /// D-0 area hazards (SIGMETs) intersecting the route corridor — the sibling
+    /// of `routeObservations` on the same fetch/refresh seam. Nil on D-1+ packs.
+    let routeSigmets: RouteSigmets?
     /// Weather-based divert candidates (D-2 inward, `compute_alternates` pref).
     /// Present only on marginal D-0/D-1/D-2 packs; nil otherwise. Mirrors
     /// `models/alternates.py` / `designs/future/alternates.md`.
@@ -205,4 +208,145 @@ struct ObservationComparison: Codable, Sendable {
     let modelCrosswindKt: Double?
     let windAdvisoryMatch: String?
     let detail: String?
+}
+
+/// D-0 **area hazards** along the route (#493) — the sibling of
+/// `RouteObservations` on the same fetch/refresh seam, but polygon-keyed rather
+/// than airport-keyed and with no model comparison (SIGMETs are presented, not
+/// reconciled).
+///
+/// Mirrors `models/observations.py::RouteSigmets` (source of truth) and the
+/// web's `renderRouteSigmets`.
+///
+/// SYNC: `web/ts/managers/briefing-ui.ts` (`renderRouteSigmets`);
+/// `src/weatherbrief/models/observations.py` defines the shape.
+struct RouteSigmets: Codable, Sendable {
+    let corridorNm: Double?
+    let fetchTime: String?
+    /// The band the fetch filtered on: surface to cruise + 5,000 ft.
+    let altitudeLowFt: Int?
+    let altitudeHighFt: Int?
+    let timeWindowFrom: String?
+    let timeWindowTo: String?
+    /// Every FIR the route crosses — context for "no SIGMETs" as much as for hits.
+    let routeFirs: [String]?
+    let sigmets: [SigmetAlongRoute]?
+
+    // Server-computed fields (pydantic `computed_field`). Optional, and each has
+    // a local fallback below: a pack written before they existed — or any future
+    // producer that omits them — must still render rather than showing "0
+    // SIGMETs" above a populated table.
+    let count: Int?
+    let hazards: [String]?
+    let hasSevere: Bool?
+
+    var matched: [SigmetAlongRoute] { sigmets ?? [] }
+
+    var sigmetCount: Int { count ?? matched.count }
+
+    /// Sorted union of hazard types, matching the server's `hazards`.
+    var hazardTypes: [String] {
+        if let hazards, !hazards.isEmpty { return hazards }
+        return Array(Set(matched.compactMap(\.hazard))).sorted()
+    }
+
+    /// Whether any matched SIGMET is qualified SEV — the summary-bar signal, the
+    /// counterpart of `worst_metar_category` on the observations block.
+    var severe: Bool { hasSevere ?? matched.contains(where: \.isSevere) }
+}
+
+/// One SIGMET intersecting the route corridor.
+/// Mirrors `models/observations.py::SigmetAlongRoute`.
+///
+/// `coords` (the polygon outline, `(lon, lat)` vertices), the enroute span and
+/// the vertical band are deliberately retained by the server so a later map /
+/// cross-section overlay can be drawn without re-fetching — the table itself
+/// doesn't use the polygon.
+struct SigmetAlongRoute: Codable, Identifiable, Sendable {
+    let firId: String
+    let firName: String?
+    /// TURB / ICE / TS / MTW / VA …
+    let hazard: String?
+    /// SEV / EMBD / FRQ / ISOL …
+    let qualifier: String?
+    let baseFt: Int?
+    let topFt: Int?
+    let validFrom: String?
+    let validTo: String?
+    /// Movement direction, e.g. "NE". Absent when the area is stationary.
+    let direction: String?
+    let speedKt: Int?
+    let rawText: String?
+    let matchedFirs: [String]?
+    let minDistanceNm: Double?
+    let enrouteDistanceFromNm: Double?
+    let enrouteDistanceToNm: Double?
+    /// Polygon outline as `[lon, lat]` pairs — decoded from Python tuples, kept
+    /// for the future map/cross-section overlay.
+    let coords: [[Double]]?
+
+    /// Nothing in the payload is a stable id (a FIR can hold several SIGMETs at
+    /// once), so identity is the raw bulletin plus the FIR — the same pair the
+    /// server's delta uses to tell a re-issue from a new hazard.
+    var id: String { "\(firId)|\(rawText ?? "")" }
+
+    /// "SEV TURB" — the row's leading label, matching the web's header cell.
+    /// Falls back to a bare "SIGMET" when the source gave neither field.
+    var headline: String {
+        let parts = [qualifier, hazard].compactMap { $0 }.filter { !$0.isEmpty }
+        return parts.isEmpty ? "SIGMET" : parts.joined(separator: " ")
+    }
+
+    var isSevere: Bool { qualifier?.uppercased() == "SEV" }
+
+    /// "SFC–FL380". Mirrors the web's `sigmetBand` exactly, including the "?" for
+    /// an unknown bound — an omitted base is genuinely unknown, not surface, and
+    /// rendering it as SFC would overstate what the bulletin said.
+    var levelBand: String {
+        if baseFt == nil && topFt == nil { return "—" }
+        return "\(Self.level(baseFt))–\(Self.level(topFt))"
+    }
+
+    static func level(_ ft: Int?) -> String {
+        guard let ft else { return "?" }
+        if ft <= 0 { return "SFC" }
+        // Floor to match the Python/web helper so the same SIGMET reads as the
+        // same flight level on every surface.
+        return String(format: "FL%03d", ft / 100)
+    }
+
+    /// Where the route meets the area: the along-track span if the corridor is
+    /// crossed, otherwise how far off-track the nearest edge sits.
+    var enrouteLabel: String {
+        if let from = enrouteDistanceFromNm, let to = enrouteDistanceToNm {
+            return "\(Int(from.rounded()))–\(Int(to.rounded()))nm"
+        }
+        if let min = minDistanceNm { return "\(Int(min.rounded()))nm off" }
+        return "—"
+    }
+
+    /// "NE 30kt", or nil when the bulletin reports no movement (stationary).
+    var movementLabel: String? {
+        guard let direction, !direction.isEmpty, let speedKt else { return nil }
+        return "\(direction) \(speedKt)kt"
+    }
+
+    /// "170450Z → 170600Z" in aviation DDHHMM form. Nil when neither bound
+    /// parses, so the detail sheet can drop the row instead of showing "? → ?".
+    var validityLabel: String? {
+        let from = validFrom.flatMap(Self.dayZulu)
+        let to = validTo.flatMap(Self.dayZulu)
+        if from == nil && to == nil { return nil }
+        return "\(from ?? "?") → \(to ?? "?")"
+    }
+
+    /// "170450Z" (DDHHMMZ) from an ISO timestamp, always in UTC.
+    static func dayZulu(_ iso: String) -> String? {
+        guard let date = Date.parseISO8601(iso) else { return nil }
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = TimeZone(identifier: "UTC")!
+        let c = cal.dateComponents([.day, .hour, .minute], from: date)
+        guard let d = c.day, let h = c.hour, let m = c.minute else { return nil }
+        return String(format: "%02d%02d%02dZ", d, h, m)
+    }
 }

--- a/app/flyfun-weather/flyfun-weather/Services/FixtureBriefingData.swift
+++ b/app/flyfun-weather/flyfun-weather/Services/FixtureBriefingData.swift
@@ -454,6 +454,42 @@ enum FixtureBriefingData {
             "detail": "Model shows VFR but the METAR reports OVC008 in mist — the model is missing a shallow coastal stratus/fog layer."
           }
         ]
+      },
+      "route_sigmets": {
+        "corridor_nm": 50.0,
+        "fetch_time": "2099-06-30T05:52:00Z",
+        "altitude_low_ft": 0,
+        "altitude_high_ft": 13000,
+        "time_window_from": "2099-06-30T05:52:00Z",
+        "time_window_to": "2099-06-30T23:59:59Z",
+        "route_firs": ["LFMM", "LFFF"],
+        "count": 2,
+        "hazards": ["TS", "TURB"],
+        "has_severe": true,
+        "sigmets": [
+          {
+            "fir_id": "LFMM", "fir_name": "LFMM MARSEILLE", "hazard": "TS", "qualifier": "EMBD",
+            "base_ft": null, "top_ft": 37000,
+            "valid_from": "2099-06-30T05:00:00Z", "valid_to": "2099-06-30T09:00:00Z",
+            "direction": "NE", "speed_kt": 25,
+            "raw_text": "WSFR31 LFPW 300452\\nLFMM SIGMET T03 VALID 300500/300900 LFPW-\\nLFMM MARSEILLE FIR EMBD TS OBS WI N4330 E00530 - N4345 E00700 - N4300\\nE00715 - N4330 E00530 TOP FL370 MOV NE 25KT NC=",
+            "matched_firs": ["LFMM"],
+            "min_distance_nm": 4.2,
+            "enroute_distance_from_nm": 12.0, "enroute_distance_to_nm": 48.0,
+            "coords": [[5.5, 43.5], [7.0, 43.75], [7.25, 43.0], [5.5, 43.5]]
+          },
+          {
+            "fir_id": "LFMM", "fir_name": "LFMM MARSEILLE", "hazard": "TURB", "qualifier": "SEV",
+            "base_ft": 5000, "top_ft": 18000,
+            "valid_from": "2099-06-30T06:00:00Z", "valid_to": "2099-06-30T12:00:00Z",
+            "direction": null, "speed_kt": null,
+            "raw_text": "WSFR31 LFPW 300551\\nLFMM SIGMET T04 VALID 300600/301200 LFPW-\\nLFMM MARSEILLE FIR SEV TURB FCST WI N4315 E00445 - N4400 E00600 -\\nN4245 E00615 - N4315 E00445 SFC/FL180 STNR NC=",
+            "matched_firs": ["LFMM"],
+            "min_distance_nm": 0.0,
+            "enroute_distance_from_nm": 30.0, "enroute_distance_to_nm": 78.0,
+            "coords": [[4.75, 43.25], [6.0, 44.0], [6.25, 42.75], [4.75, 43.25]]
+          }
+        ]
       }
     }
     """)

--- a/app/flyfun-weather/flyfun-weather/Views/Briefing/AdvisoryTabView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Briefing/AdvisoryTabView.swift
@@ -4,8 +4,9 @@ import SwiftUI
 /// hero (traffic-light + assessment reason) pinned at the top, then watch chips,
 /// a responsive advisory grid (AMBER/RED as cards, GREEN collapsed into one
 /// all-clear strip), current airport conditions, — on D-0 — the METAR/TAF
-/// observations comparison, and — on marginal D-0/D-2 packs — weather
-/// alternates. A sticky scroll-spy bar jumps between sections.
+/// observations comparison and the route SIGMET area hazards, and — on marginal
+/// D-0/D-2 packs — weather alternates. A sticky scroll-spy bar jumps between
+/// sections.
 struct AdvisoryTabView: View {
     let viewModel: BriefingViewModel
     @Environment(AppState.self) private var appState
@@ -29,6 +30,10 @@ struct AdvisoryTabView: View {
                 if hasObservations {
                     RouteObservationsView(viewModel: viewModel)
                         .spyAnchor("observations")
+                }
+                if hasSigmets {
+                    RouteSigmetsView(viewModel: viewModel)
+                        .spyAnchor("sigmets")
                 }
                 if hasAlternates {
                     AlternatesView(viewModel: viewModel)
@@ -144,6 +149,17 @@ struct AdvisoryTabView: View {
         return false
     }
 
+    /// D-0 route SIGMETs (#493). Gated on at least one bulletin actually matching
+    /// the corridor — the same filter the section's table applies — so the
+    /// scroll-spy never offers an anchor that renders empty.
+    private var hasSigmets: Bool {
+        if case .loaded(let snapshot) = viewModel.snapshotState,
+           let block = snapshot.routeSigmets {
+            return !block.matched.isEmpty
+        }
+        return false
+    }
+
     private var hasWatchItems: Bool {
         if case .loaded(let digest) = viewModel.digestState { return !digest.watchItemsList.isEmpty }
         return false
@@ -161,6 +177,7 @@ struct AdvisoryTabView: View {
         sections.append(SpySection("advisories", "Advisories"))
         sections.append(SpySection("conditions", "Conditions"))
         if hasObservations { sections.append(SpySection("observations", "Observations")) }
+        if hasSigmets { sections.append(SpySection("sigmets", "Hazards")) }
         if hasAlternates { sections.append(SpySection("alternates", "Alternates")) }
         if hasTimingScenarios { sections.append(SpySection("timing", "Timing")) }
         if hasWatchItems { sections.append(SpySection("watch", "Watch")) }

--- a/app/flyfun-weather/flyfun-weather/Views/Briefing/RouteSigmetsView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Briefing/RouteSigmetsView.swift
@@ -1,0 +1,321 @@
+import SwiftUI
+
+/// **Area Hazards** (#493) — the D-0 route SIGMET table, sitting between the
+/// Observations section and Alternates. Mirrors the web's `renderRouteSigmets`
+/// (`web/ts/managers/briefing-ui.ts`).
+///
+/// The sibling of `RouteObservationsView` on the same fetch/refresh seam, but
+/// area-keyed rather than airport-keyed and with **no model comparison** —
+/// SIGMETs are presented, not reconciled. That makes this the simpler of the two
+/// tables: one row per bulletin, no agreement column, no axis switcher.
+///
+/// The web row is 6 columns; on a phone the **movement** column folds into the
+/// detail sheet (it is the least decision-relevant of the pair the issue calls
+/// out — the vertical band decides whether a GA route is even in the hazard,
+/// while "MOV NE 30kt" only refines the timing). Regular width shows it inline.
+///
+/// Rendered only when the pack carries at least one matched SIGMET, which the
+/// pipeline populates on D-0 only.
+///
+/// SYNC: `web/ts/managers/briefing-ui.ts::renderRouteSigmets`.
+struct RouteSigmetsView: View {
+    let viewModel: BriefingViewModel
+
+    @Environment(\.horizontalSizeClass) private var sizeClass
+    @State private var detail: SigmetAlongRoute?
+
+    /// iPad-class width has room for the movement column inline; a phone reads it
+    /// in the detail sheet.
+    private var showsMovement: Bool { sizeClass == .regular }
+
+    private var sigmets: RouteSigmets? {
+        if case .loaded(let snapshot) = viewModel.snapshotState { return snapshot.routeSigmets }
+        return nil
+    }
+
+    var body: some View {
+        if let block = sigmets, !block.matched.isEmpty {
+            VStack(alignment: .leading, spacing: Theme.spacingM) {
+                header(block)
+                summary(block)
+                if block.severe {
+                    severeBanner
+                }
+                table(block)
+            }
+            .padding(.horizontal, Theme.cardPadding)
+            .accessibilityIdentifier("sigmetsSection")
+            .sheet(item: $detail) { s in
+                SigmetDetailSheet(sigmet: s)
+            }
+        }
+    }
+
+    // MARK: Header + summary
+
+    @ViewBuilder
+    private func header(_ block: RouteSigmets) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: Theme.spacingS) {
+            Text("Area Hazards")
+                .font(.headline)
+                .foregroundStyle(Theme.text)
+            Spacer(minLength: 0)
+            if let fetched = block.fetchTime, let label = RouteObservationsView.zuluTime(fetched) {
+                Text("Fetched \(label)")
+                    .font(.caption2)
+                    .foregroundStyle(Theme.textMuted)
+            }
+        }
+    }
+
+    /// Coverage line: how many bulletins matched, the corridor width, and the
+    /// union of hazard types — the same three facts the web summary carries.
+    @ViewBuilder
+    private func summary(_ block: RouteSigmets) -> some View {
+        VStack(alignment: .leading, spacing: Theme.spacingXS) {
+            Text(coverageText(block))
+                .font(.caption)
+                .foregroundStyle(Theme.textMuted)
+                .fixedSize(horizontal: false, vertical: true)
+            if !block.hazardTypes.isEmpty {
+                Label(block.hazardTypes.joined(separator: ", "), systemImage: "exclamationmark.triangle")
+                    .font(.caption)
+                    .foregroundStyle(Theme.amber)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+
+    private func coverageText(_ block: RouteSigmets) -> String {
+        var parts: [String] = []
+        let n = block.sigmetCount
+        parts.append(n == 1 ? "1 SIGMET" : "\(n) SIGMETs")
+        if let c = block.corridorNm { parts.append("\(Int(c.rounded()))nm corridor") }
+        // The band the fetch filtered on, so an empty-looking table is readable as
+        // "nothing in *this* band" rather than "nothing anywhere".
+        if let high = block.altitudeHighFt {
+            parts.append("\(SigmetAlongRoute.level(block.altitudeLowFt ?? 0))–\(SigmetAlongRoute.level(high))")
+        }
+        return parts.joined(separator: " · ")
+    }
+
+    private var severeBanner: some View {
+        Label(
+            "A SIGMET along this route is qualified SEV — check the raw bulletin before you go.",
+            systemImage: "exclamationmark.triangle.fill"
+        )
+        .font(.caption)
+        .foregroundStyle(Theme.red)
+        .fixedSize(horizontal: false, vertical: true)
+        .padding(Theme.spacingS)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Theme.red.opacity(0.12), in: RoundedRectangle(cornerRadius: 10))
+    }
+
+    // MARK: Table
+
+    /// Horizontally scrollable so a large Dynamic Type size degrades into a pan
+    /// rather than truncating the level band. `.basedOnSize` suppresses the
+    /// bounce when the row already fits, which is the common case.
+    @ViewBuilder
+    private func table(_ block: RouteSigmets) -> some View {
+        VStack(alignment: .leading, spacing: Theme.spacingXS) {
+            ScrollView(.horizontal) {
+                // `horizontalSpacing: 0` with per-cell padding, for the same reason
+                // as the observations table: a severe row is highlighted by shading
+                // its cells, and Grid applies a row background per cell — with
+                // spacing > 0 that tiles into visible gaps rather than one band.
+                Grid(alignment: .leading, horizontalSpacing: 0, verticalSpacing: Theme.spacingS) {
+                    GridRow {
+                        columnHeader("Hazard")
+                        columnHeader("FIR")
+                        columnHeader("Levels")
+                        columnHeader("Enroute")
+                        if showsMovement { columnHeader("Move") }
+                    }
+                    Divider().gridCellUnsizedAxes(.horizontal).gridCellColumns(showsMovement ? 5 : 4)
+                    ForEach(block.matched) { s in
+                        row(s)
+                    }
+                }
+                .padding(.vertical, Theme.spacingXS)
+            }
+            .scrollBounceBehavior(.basedOnSize, axes: .horizontal)
+
+            legend
+        }
+    }
+
+    private func columnHeader(_ text: String) -> some View {
+        Text(text)
+            .font(.caption2)
+            .foregroundStyle(Theme.textMuted)
+            .cell()
+    }
+
+    @ViewBuilder
+    private func row(_ s: SigmetAlongRoute) -> some View {
+        GridRow {
+            Button { detail = s } label: {
+                HStack(spacing: Theme.spacingXS) {
+                    Text(s.headline)
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(s.isSevere ? Theme.red : Theme.text)
+                    Image(systemName: "info.circle")
+                        .font(.caption2)
+                        .foregroundStyle(Theme.primary)
+                }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("\(s.firId) \(s.headline) details")
+            .cell(highlighted: s.isSevere)
+
+            Text(s.firId)
+                .font(.system(.caption, design: .monospaced))
+                .foregroundStyle(Theme.text)
+                .cell(highlighted: s.isSevere)
+
+            Text(s.levelBand)
+                .font(.caption)
+                .foregroundStyle(Theme.text)
+                .cell(highlighted: s.isSevere)
+
+            Text(s.enrouteLabel)
+                .font(.caption)
+                .foregroundStyle(Theme.textMuted)
+                .cell(highlighted: s.isSevere)
+
+            if showsMovement {
+                Text(s.movementLabel ?? "STNR")
+                    .font(.caption)
+                    .foregroundStyle(Theme.textMuted)
+                    .cell(highlighted: s.isSevere)
+            }
+        }
+    }
+
+    /// What the columns mean. "Enroute" especially needs it: the cell is a bare
+    /// nm span that reads as a distance *from* something without the key.
+    @ViewBuilder
+    private var legend: some View {
+        Text(legendText)
+            .font(.caption2)
+            .foregroundStyle(Theme.textMuted)
+            .fixedSize(horizontal: false, vertical: true)
+    }
+
+    private var legendText: String {
+        let base = "Levels: the hazard's vertical band. Enroute: where your track crosses the area, or how far it passes off-track."
+        let move = showsMovement ? " Move: area movement (STNR = stationary)." : ""
+        return "\(base)\(move) Tap a row for the raw bulletin."
+    }
+}
+
+private extension View {
+    /// One table cell — same construction as the observations table: the Grid
+    /// runs at `horizontalSpacing: 0` so the gutter lives *inside* the cell and a
+    /// highlighted row shades as one continuous band.
+    func cell(highlighted: Bool = false) -> some View {
+        self
+            .padding(.horizontal, Theme.spacingXS)
+            .padding(.vertical, 3)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
+            .background(highlighted ? Theme.red.opacity(0.12) : .clear)
+    }
+}
+
+// MARK: - Per-SIGMET detail
+
+/// The web's ⓘ popup: the vertical band, movement, validity window and route
+/// intersection, then the raw bulletin — which is the authoritative text and the
+/// reason the row is tappable at all.
+private struct SigmetDetailSheet: View {
+    let sigmet: SigmetAlongRoute
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: Theme.spacingM) {
+                    Text(firLine)
+                        .font(.subheadline)
+                        .foregroundStyle(Theme.textMuted)
+
+                    section("Hazard") {
+                        VStack(alignment: .leading, spacing: Theme.spacingXS) {
+                            metaRow("Levels", sigmet.levelBand)
+                            metaRow("Move", sigmet.movementLabel ?? "Stationary")
+                            if let valid = sigmet.validityLabel {
+                                metaRow("Valid", valid)
+                            }
+                            metaRow("Enroute", sigmet.enrouteLabel)
+                            if let min = sigmet.minDistanceNm {
+                                metaRow("Nearest", "\(Int(min.rounded()))nm from track")
+                            }
+                        }
+                    }
+
+                    section("Raw bulletin") {
+                        if let raw = sigmet.rawText, !raw.isEmpty {
+                            Text(raw)
+                                .font(.system(.caption, design: .monospaced))
+                                .foregroundStyle(Theme.text)
+                                .textSelection(.enabled)
+                                .fixedSize(horizontal: false, vertical: true)
+                        } else {
+                            Text("Not available")
+                                .font(.caption)
+                                .foregroundStyle(Theme.textMuted)
+                        }
+                    }
+                }
+                .padding(Theme.cardPadding)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .background(Theme.bg)
+            .navigationTitle(sigmet.headline)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") { dismiss() }
+                }
+            }
+        }
+    }
+
+    /// "LFFF PARIS" when the source names the FIR, else the bare id. `fir_name`
+    /// already embeds the id upstream, so don't print it twice.
+    private var firLine: String {
+        guard let name = sigmet.firName, !name.isEmpty else { return sigmet.firId }
+        return name.hasPrefix(sigmet.firId) ? name : "\(sigmet.firId) \(name)"
+    }
+
+    private func metaRow(_ label: String, _ value: String) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: Theme.spacingS) {
+            Text(label)
+                .font(.caption2.weight(.semibold))
+                .foregroundStyle(Theme.textMuted)
+                .frame(width: 62, alignment: .leading)
+            Text(value)
+                .font(.caption)
+                .foregroundStyle(Theme.text)
+                .fixedSize(horizontal: false, vertical: true)
+            Spacer(minLength: 0)
+        }
+    }
+
+    @ViewBuilder
+    private func section(_ title: String, @ViewBuilder content: () -> some View) -> some View {
+        VStack(alignment: .leading, spacing: Theme.spacingXS) {
+            Text(title)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(Theme.textMuted)
+            content()
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(Theme.spacingS)
+        .background(Theme.surface, in: RoundedRectangle(cornerRadius: 10))
+        .overlay(RoundedRectangle(cornerRadius: 10).stroke(Theme.border, lineWidth: 0.5))
+    }
+}

--- a/app/flyfun-weather/flyfun-weatherTests/RouteSigmetsTests.swift
+++ b/app/flyfun-weather/flyfun-weatherTests/RouteSigmetsTests.swift
@@ -1,0 +1,326 @@
+//
+//  RouteSigmetsTests.swift
+//  flyfun-weatherTests
+//
+//  Area Hazards section (#493) — the iOS port of the web's route SIGMET table.
+//  Covers the decode contract against the Python source of truth
+//  (`models/observations.py::RouteSigmets`), the computed-field fallbacks, and
+//  the row formatters that mirror the web's `sigmetLevel`/`sigmetBand`/
+//  `sigmetEnroute` helpers.
+//
+
+import Testing
+import Foundation
+@testable import flyfun_weather
+
+// MARK: - Decode contract
+
+@Suite struct RouteSigmetsDecodeTests {
+
+    /// A real payload, copied in shape from a dev pack's `briefing.json`
+    /// (`route_sigmets`) — including the server's computed `count` / `hazards` /
+    /// `has_severe` and the `(lon, lat)` polygon tuples.
+    private let json = """
+    {
+      "corridor_nm": 50.0,
+      "fetch_time": "2026-07-17T05:46:41.551875Z",
+      "altitude_low_ft": 0,
+      "altitude_high_ft": 10000,
+      "time_window_from": "2026-07-17T05:46:39.781164Z",
+      "time_window_to": "2026-07-17T23:59:59Z",
+      "route_firs": ["EGTT", "LFFF"],
+      "count": 2,
+      "hazards": ["TS", "TURB"],
+      "has_severe": true,
+      "sigmets": [
+        {
+          "fir_id": "LFFF", "fir_name": "LFFF PARIS", "hazard": "TS", "qualifier": "FRQ",
+          "base_ft": null, "top_ft": 38000,
+          "valid_from": "2026-07-17T04:50:00Z", "valid_to": "2026-07-17T06:00:00Z",
+          "direction": "NE", "speed_kt": 30,
+          "raw_text": "WSFR31 LFPW 170452\\nLFFF SIGMET T07 VALID 170450/170600 LFPW-\\nLFFF PARIS FIR/UIR FRQ TS OBS TOP FL380 MOV NE 30KT NC=",
+          "matched_firs": ["LFFF"],
+          "min_distance_nm": 34.04048689854602,
+          "enroute_distance_from_nm": 206.2817732309028,
+          "enroute_distance_to_nm": 222.1127708985998,
+          "coords": [[2.75, 46.75], [1.75, 47.5], [2.75, 48.25], [2.75, 46.75]]
+        },
+        {
+          "fir_id": "EGTT", "fir_name": "EGTT LONDON", "hazard": "TURB", "qualifier": "SEV",
+          "base_ft": 5000, "top_ft": 18000,
+          "valid_from": null, "valid_to": null,
+          "direction": null, "speed_kt": null,
+          "raw_text": "EGTT SIGMET 02 VALID 170600/171200 EGRR- SEV TURB FCST SFC/FL180 STNR NC=",
+          "matched_firs": ["EGTT"],
+          "min_distance_nm": 2.0,
+          "enroute_distance_from_nm": null,
+          "enroute_distance_to_nm": null,
+          "coords": []
+        }
+      ]
+    }
+    """
+
+    private func decoded() throws -> RouteSigmets {
+        try JSONDecoder.weatherBrief.decode(RouteSigmets.self, from: Data(json.utf8))
+    }
+
+    @Test func decodesSummaryFields() throws {
+        let block = try decoded()
+        #expect(block.corridorNm == 50.0)
+        #expect(block.altitudeLowFt == 0)
+        #expect(block.altitudeHighFt == 10000)
+        #expect(block.routeFirs == ["EGTT", "LFFF"])
+        #expect(block.timeWindowTo == "2026-07-17T23:59:59Z")
+        #expect(block.matched.count == 2)
+    }
+
+    /// The server's `computed_field`s ride along in the JSON and are what the
+    /// summary bar reads.
+    @Test func decodesServerComputedFields() throws {
+        let block = try decoded()
+        #expect(block.sigmetCount == 2)
+        #expect(block.hazardTypes == ["TS", "TURB"])
+        #expect(block.severe == true)
+    }
+
+    @Test func decodesPerSigmetFields() throws {
+        let block = try decoded()
+        let ts = try #require(block.matched.first { $0.hazard == "TS" })
+        #expect(ts.firId == "LFFF")
+        #expect(ts.firName == "LFFF PARIS")
+        #expect(ts.qualifier == "FRQ")
+        #expect(ts.baseFt == nil)
+        #expect(ts.topFt == 38000)
+        #expect(ts.direction == "NE")
+        #expect(ts.speedKt == 30)
+        #expect(ts.matchedFirs == ["LFFF"])
+        #expect(ts.enrouteDistanceFromNm == 206.2817732309028)
+        // Multi-line raw bulletin — what the detail sheet renders verbatim.
+        #expect(ts.rawText?.components(separatedBy: .newlines).count == 3)
+    }
+
+    /// The polygon is retained for a future map/cross-section overlay; the table
+    /// doesn't use it, but dropping it at decode would silently lose it.
+    /// Python emits `(lon, lat)` tuples, which arrive as 2-element JSON arrays.
+    @Test func decodesPolygonCoords() throws {
+        let block = try decoded()
+        let ts = try #require(block.matched.first { $0.hazard == "TS" })
+        #expect(ts.coords?.count == 4)
+        #expect(ts.coords?.first == [2.75, 46.75])
+    }
+
+    /// A stationary SIGMET has null movement fields, and an area the route only
+    /// passes near has no enroute span — neither may throw.
+    @Test func stationaryAndOffTrackSigmetDecodes() throws {
+        let block = try decoded()
+        let turb = try #require(block.matched.first { $0.hazard == "TURB" })
+        #expect(turb.direction == nil)
+        #expect(turb.speedKt == nil)
+        #expect(turb.validFrom == nil)
+        #expect(turb.enrouteDistanceFromNm == nil)
+        #expect(turb.coords?.isEmpty == true)
+    }
+
+    /// A D-1+ pack has no SIGMET block at all; the section must simply not render
+    /// rather than decoding into an empty shell. This is the bug #493 fixes from
+    /// the other side — before it, the block was dropped even when present.
+    @Test func absentBlockDecodesToNilOnSnapshot() throws {
+        let snapshotJSON = """
+        {
+          "route": { "name": "EGTF EGLL", "waypoints": [], "cruise_altitude_ft": 5000,
+                     "flight_ceiling_ft": 10000, "flight_duration_hours": 1.0 },
+          "target_date": "2026-07-27", "days_out": 2
+        }
+        """
+        let snap = try JSONDecoder.weatherBrief.decode(SnapshotResponse.self, from: Data(snapshotJSON.utf8))
+        #expect(snap.routeSigmets == nil)
+    }
+
+    /// The common D-0 case: the fetch ran, nothing matched. The block is present
+    /// but empty, and the section (plus its scroll-spy anchor) must stay hidden.
+    @Test func emptySigmetListReadsAsNothingToShow() throws {
+        let empty = """
+        { "corridor_nm": 50.0, "fetch_time": "2026-07-17T05:46:41Z",
+          "route_firs": ["EGTT"], "sigmets": [], "count": 0, "hazards": [], "has_severe": false }
+        """
+        let block = try JSONDecoder.weatherBrief.decode(RouteSigmets.self, from: Data(empty.utf8))
+        #expect(block.matched.isEmpty)
+        #expect(block.sigmetCount == 0)
+        #expect(block.hazardTypes.isEmpty)
+        #expect(block.severe == false)
+    }
+
+    /// The whole snapshot decodes with the SIGMET block attached — the field has
+    /// to be wired onto `SnapshotResponse`, not just exist as a type.
+    @Test func snapshotCarriesTheSigmetBlock() throws {
+        let snapshotJSON = """
+        {
+          "route": { "name": "EGTF EGLL", "waypoints": [], "cruise_altitude_ft": 5000,
+                     "flight_ceiling_ft": 10000, "flight_duration_hours": 1.0 },
+          "target_date": "2026-07-17", "days_out": 0,
+          "route_sigmets": \(json)
+        }
+        """
+        let snap = try JSONDecoder.weatherBrief.decode(SnapshotResponse.self, from: Data(snapshotJSON.utf8))
+        #expect(snap.routeSigmets?.matched.count == 2)
+        #expect(snap.routeSigmets?.severe == true)
+    }
+
+    /// The shipped fixture must render the section in mock mode — otherwise the
+    /// XCUI journey and any manual mock-mode check silently exercise nothing.
+    @Test func fixtureSnapshotCarriesSigmets() {
+        let block = FixtureBriefingData.snapshot.routeSigmets
+        #expect(block?.matched.isEmpty == false)
+        #expect(block?.severe == true)
+    }
+}
+
+// MARK: - Computed-field fallbacks
+
+@Suite struct RouteSigmetsFallbackTests {
+
+    /// `count` / `hazards` / `has_severe` are pydantic `computed_field`s. They are
+    /// present today, but the table must not contradict itself if a producer ever
+    /// omits them — a "0 SIGMETs" summary above two rows is worse than no summary.
+    private let withoutComputed = """
+    { "corridor_nm": 50.0, "fetch_time": "2026-07-17T05:46:41Z",
+      "sigmets": [
+        { "fir_id": "LFFF", "hazard": "TS", "qualifier": "EMBD", "raw_text": "a" },
+        { "fir_id": "EGTT", "hazard": "TURB", "qualifier": "SEV", "raw_text": "b" },
+        { "fir_id": "EGTT", "hazard": "TS", "qualifier": "ISOL", "raw_text": "c" }
+      ] }
+    """
+
+    private func decoded() throws -> RouteSigmets {
+        try JSONDecoder.weatherBrief.decode(RouteSigmets.self, from: Data(withoutComputed.utf8))
+    }
+
+    @Test func countFallsBackToTheRowCount() throws {
+        #expect(try decoded().sigmetCount == 3)
+    }
+
+    /// Deduplicated and sorted, matching the server's `hazards` union.
+    @Test func hazardsFallBackToTheSortedUnion() throws {
+        #expect(try decoded().hazardTypes == ["TS", "TURB"])
+    }
+
+    @Test func severeFallsBackToScanningQualifiers() throws {
+        #expect(try decoded().severe == true)
+    }
+
+    @Test func noSevereQualifierReadsAsNotSevere() throws {
+        let json = """
+        { "corridor_nm": 50.0, "sigmets": [
+            { "fir_id": "LFFF", "hazard": "TS", "qualifier": "ISOL", "raw_text": "a" } ] }
+        """
+        let block = try JSONDecoder.weatherBrief.decode(RouteSigmets.self, from: Data(json.utf8))
+        #expect(block.severe == false)
+    }
+}
+
+// MARK: - Row formatters (web parity)
+
+@Suite struct SigmetRowFormatterTests {
+
+    private func sigmet(_ fields: String) throws -> SigmetAlongRoute {
+        let json = "{ \"fir_id\": \"LFFF\", \(fields) }"
+        return try JSONDecoder.weatherBrief.decode(SigmetAlongRoute.self, from: Data(json.utf8))
+    }
+
+    /// Mirrors the web's `sigmetLevel`, including the floor division — the same
+    /// SIGMET must read as the same flight level on web, PDF and iOS.
+    @Test func levelMatchesTheWebHelper() {
+        #expect(SigmetAlongRoute.level(nil) == "?")
+        #expect(SigmetAlongRoute.level(0) == "SFC")
+        #expect(SigmetAlongRoute.level(-100) == "SFC")
+        #expect(SigmetAlongRoute.level(38000) == "FL380")
+        #expect(SigmetAlongRoute.level(9500) == "FL095")
+        // Floors rather than rounds: FL097, not FL098.
+        #expect(SigmetAlongRoute.level(9799) == "FL097")
+    }
+
+    @Test func levelBandRendersBothBounds() throws {
+        #expect(try sigmet("\"base_ft\": 5000, \"top_ft\": 18000").levelBand == "FL050–FL180")
+        #expect(try sigmet("\"base_ft\": 0, \"top_ft\": 18000").levelBand == "SFC–FL180")
+    }
+
+    /// An omitted base is genuinely unknown, not surface — so it renders "?" like
+    /// the web, rather than overstating what the bulletin said.
+    @Test func unknownBaseRendersAsQuestionMark() throws {
+        #expect(try sigmet("\"top_ft\": 38000").levelBand == "?–FL380")
+    }
+
+    @Test func noVerticalBandRendersEmDash() throws {
+        #expect(try sigmet("\"hazard\": \"TS\"").levelBand == "—")
+    }
+
+    @Test func enrouteSpanPreferredOverOffTrackDistance() throws {
+        let s = try sigmet("\"enroute_distance_from_nm\": 206.3, \"enroute_distance_to_nm\": 222.1, \"min_distance_nm\": 34.0")
+        #expect(s.enrouteLabel == "206–222nm")
+    }
+
+    @Test func offTrackDistanceUsedWhenThereIsNoSpan() throws {
+        #expect(try sigmet("\"min_distance_nm\": 34.04").enrouteLabel == "34nm off")
+    }
+
+    @Test func noIntersectionDataRendersEmDash() throws {
+        #expect(try sigmet("\"hazard\": \"TS\"").enrouteLabel == "—")
+    }
+
+    @Test func movementNeedsBothDirectionAndSpeed() throws {
+        #expect(try sigmet("\"direction\": \"NE\", \"speed_kt\": 30").movementLabel == "NE 30kt")
+        // Stationary: the view renders "STNR" / "Stationary" for nil.
+        #expect(try sigmet("\"hazard\": \"TS\"").movementLabel == nil)
+        #expect(try sigmet("\"direction\": \"NE\"").movementLabel == nil)
+        #expect(try sigmet("\"speed_kt\": 30").movementLabel == nil)
+    }
+
+    @Test func headlineJoinsQualifierAndHazard() throws {
+        #expect(try sigmet("\"qualifier\": \"SEV\", \"hazard\": \"TURB\"").headline == "SEV TURB")
+        #expect(try sigmet("\"hazard\": \"TS\"").headline == "TS")
+        #expect(try sigmet("\"qualifier\": \"EMBD\"").headline == "EMBD")
+        // Neither field present — still labelled, never blank.
+        #expect(try sigmet("\"raw_text\": \"x\"").headline == "SIGMET")
+    }
+
+    @Test func severeIsQualifierSevOnly() throws {
+        #expect(try sigmet("\"qualifier\": \"SEV\"").isSevere == true)
+        #expect(try sigmet("\"qualifier\": \"sev\"").isSevere == true)
+        #expect(try sigmet("\"qualifier\": \"EMBD\"").isSevere == false)
+        #expect(try sigmet("\"hazard\": \"TS\"").isSevere == false)
+    }
+
+    /// Validity is aviation DDHHMMZ and always UTC, regardless of device locale.
+    @Test func validityRendersDayHourMinuteZulu() throws {
+        let s = try sigmet("\"valid_from\": \"2026-07-17T04:50:00Z\", \"valid_to\": \"2026-07-17T06:00:00Z\"")
+        #expect(s.validityLabel == "170450Z → 170600Z")
+    }
+
+    @Test func validityConvertsAnOffsetToUtc() throws {
+        let s = try sigmet("\"valid_from\": \"2026-07-17T06:50:00+02:00\"")
+        #expect(s.validityLabel == "170450Z → ?")
+    }
+
+    /// The server writes `datetime.isoformat()` with microseconds — the plain
+    /// ISO8601 parser rejects those, so the fractional-first fallback is required.
+    @Test func validityParsesFractionalSeconds() throws {
+        let s = try sigmet("\"valid_to\": \"2026-07-17T06:00:00.551875Z\"")
+        #expect(s.validityLabel == "? → 170600Z")
+    }
+
+    /// Both bounds missing — the detail sheet drops the row rather than printing
+    /// "? → ?".
+    @Test func noValidityYieldsNil() throws {
+        #expect(try sigmet("\"hazard\": \"TS\"").validityLabel == nil)
+        #expect(SigmetAlongRoute.dayZulu("not a date") == nil)
+    }
+
+    /// Identity is FIR + raw bulletin: a FIR routinely has several concurrent
+    /// SIGMETs, so keying on `fir_id` alone would collapse them into one row.
+    @Test func idDistinguishesConcurrentSigmetsInOneFir() throws {
+        let a = try sigmet("\"hazard\": \"TS\", \"raw_text\": \"first\"")
+        let b = try sigmet("\"hazard\": \"TURB\", \"raw_text\": \"second\"")
+        #expect(a.id != b.id)
+    }
+}

--- a/app/flyfun-weather/flyfun-weatherUITests/flyfun_weatherUITests.swift
+++ b/app/flyfun-weather/flyfun-weatherUITests/flyfun_weatherUITests.swift
@@ -299,6 +299,73 @@ final class flyfun_weatherUITests: XCTestCase {
         add(shot)
     }
 
+    /// Journey 7 (#493) — Area Hazards (route SIGMET) section. Open fixture-1,
+    /// jump to the Hazards scroll-spy section, and confirm the table renders with
+    /// the severe row present. Also pins the responsive contract: the movement
+    /// column is inline in regular width (iPad) and folded into the detail sheet
+    /// in compact width (iPhone).
+    @MainActor
+    func testRouteSigmetsSectionRenders() throws {
+        let app = launchMockApp()
+        openFixture1Briefing(app)
+
+        // The spy pill only exists when a SIGMET actually matched the corridor,
+        // so finding it also confirms the `hasSigmets` gate and the spy wiring.
+        let pill = app.buttons["Hazards"].firstMatch
+        XCTAssertTrue(pill.waitForExistence(timeout: 15),
+                      "the Hazards spy pill should be present for the D-0 fixture")
+        pill.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).tap()
+
+        XCTAssertTrue(app.descendants(matching: .any)["sigmetsSection"].waitForExistence(timeout: 10),
+                      "SIGMET section should render")
+
+        // Both fixture bulletins appear as rows (the ⓘ button carries the label).
+        XCTAssertTrue(app.buttons["LFMM EMBD TS details"].firstMatch.waitForExistence(timeout: 5),
+                      "the embedded-TS row should render")
+        XCTAssertTrue(app.buttons["LFMM SEV TURB details"].firstMatch.exists,
+                      "the SEV row (which drives the severe banner) should render")
+
+        // Responsive contract: "Move" is a column header on iPad only.
+        let moveHeader = app.staticTexts["Move"].firstMatch
+        if UIDevice.current.userInterfaceIdiom == .pad {
+            XCTAssertTrue(moveHeader.exists, "regular width should render the Move column")
+        } else {
+            XCTAssertFalse(moveHeader.exists,
+                           "compact width folds movement into the detail sheet")
+        }
+
+        let shot = XCTAttachment(screenshot: app.screenshot())
+        shot.name = "Sigmets-Table"
+        shot.lifetime = .keepAlways
+        add(shot)
+    }
+
+    /// Journey 7b (#493) — the per-SIGMET ⓘ drill-down opens and shows the raw
+    /// bulletin (the web's SIGMET popup), which is the authoritative text.
+    @MainActor
+    func testRouteSigmetDetailSheet() throws {
+        let app = launchMockApp()
+        openFixture1Briefing(app)
+
+        let pill = app.buttons["Hazards"].firstMatch
+        XCTAssertTrue(pill.waitForExistence(timeout: 15), "Hazards spy pill should be present")
+        pill.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).tap()
+
+        let info = app.buttons["LFMM SEV TURB details"].firstMatch
+        XCTAssertTrue(info.waitForExistence(timeout: 10), "SEV TURB row should render")
+        info.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).tap()
+
+        XCTAssertTrue(app.staticTexts["Raw bulletin"].firstMatch.waitForExistence(timeout: 10),
+                      "detail sheet should show the raw bulletin block")
+        XCTAssertTrue(app.staticTexts["Hazard"].firstMatch.exists,
+                      "detail sheet should show the hazard meta block")
+
+        let shot = XCTAttachment(screenshot: app.screenshot())
+        shot.name = "Sigmets-DetailSheet"
+        shot.lifetime = .keepAlways
+        add(shot)
+    }
+
     @MainActor
     func testLaunchPerformance() throws {
         measure(metrics: [XCTApplicationLaunchMetric()]) {

--- a/designs/metar-taf-route-weather.md
+++ b/designs/metar-taf-route-weather.md
@@ -174,8 +174,8 @@ Other parity notes:
 - **No in-section refresh button.** Web has one; on iOS the toolbar Refresh
   already routes through the tiered `decide_refresh` gate, which at D-0 performs
   exactly this cheap realtime refresh.
-- **Route SIGMETs are not ported** — iOS has no `route_sigmets` DTO or view at
-  all, so the block is dropped at decode. Tracked in #493.
+- **Route SIGMETs** are the sibling section, ported in #493 — see
+  [iOS UI](#ios-ui-viewsbriefingroutesigmetsviewswift) below.
 
 Fixture-backed (`FixtureBriefingData.route_observations` carries comparisons +
 wind advisories), so mock mode renders it; covered by
@@ -301,6 +301,55 @@ clears on the next load. The web UI (`briefing-ui.ts:renderRefreshDelta` →
   `sigmets-section` in `briefing.html`. Read-only — the observations Refresh button refreshes
   SIGMETs too (combined seam).
 
+### iOS UI (`Views/Briefing/RouteSigmetsView.swift`)
+
+Ported in #493, one release after the observations section it sits under. Slot:
+the Advisory tab, after Observations and before Alternates, with a scroll-spy
+anchor (`sigmets`, pill label "Hazards"). Reads `snapshot.route_sigmets` from the
+standard snapshot endpoint — no iOS-specific endpoint and no backend change, since
+`GET .../snapshot` already returns raw `briefing.json`. Before the port the block
+was simply dropped at decode: `SnapshotResponse` had no field for it.
+
+Simpler than its sibling: one row per bulletin, no comparison join, no axis
+switcher — SIGMETs are presented, not reconciled.
+
+| Width | Behaviour |
+|---|---|
+| Compact (iPhone) | 4 columns: Hazard, FIR, Levels, Enroute. Movement folds into the detail sheet |
+| Regular (iPad) | The web's 5th column, Move (`STNR` when stationary), renders inline |
+
+Movement is the column that gives way because the vertical band decides whether a
+GA route is in the hazard at all, while "MOV NE 30kt" only refines the timing.
+
+Parity notes:
+- **Formatters mirror the web helpers exactly** (`sigmetLevel`/`sigmetBand`/
+  `sigmetEnroute`), including floor-division flight levels (`FL097`, not `FL098`)
+  and `?` for an unknown bound — an omitted `base_ft` is genuinely unknown, and
+  rendering it as `SFC` would overstate the bulletin. They live on the DTO
+  (`SigmetAlongRoute.levelBand` / `.enrouteLabel` / `.movementLabel` /
+  `.headline`), so they are unit-testable outside SwiftUI.
+- **Severe row highlight** is red rather than the observations table's amber, and
+  `has_severe` raises a banner — the counterpart of the obs conflict banner.
+- **Detail sheet** replaces the web's ⓘ popup: level band, movement, validity
+  (aviation `DDHHMMZ`), route intersection, then the raw bulletin (selectable
+  monospace) — which is the authoritative text.
+- **Server computed fields** (`count`, `hazards`, `has_severe`) are decoded as
+  optionals with local fallbacks, so a payload without them can't render a
+  "0 SIGMETs" summary above a populated table.
+- **Row identity** is `fir_id` + `raw_text`: one FIR routinely carries several
+  concurrent SIGMETs, so keying on the FIR alone would collapse them into one row.
+- **Polygon `coords` is decoded but unused** — kept on the DTO so the future
+  map/cross-section overlay below doesn't need a second wire change.
+
+Fixture-backed (`FixtureBriefingData.snapshot` carries two SIGMETs, one `SEV`), so
+mock mode renders it; covered by `RouteSigmetsTests.swift` (decode/fallbacks/
+formatters) and the XCUI journeys `testRouteSigmetsSectionRenders` /
+`testRouteSigmetDetailSheet`, which assert the compact-vs-regular contract.
+
+**Verification note**: D-0 only, like observations, so on-device verification needs
+a same-day flight with a live SIGMET along the route. Fixture + XCUI coverage is
+the practical check.
+
 ### Future cross-section / map overlay (not yet built)
 
 The model deliberately retains the polygon `coords`, the `enroute_distance_from/to_nm`
@@ -335,5 +384,6 @@ No re-fetch needed — everything required is already serialized on the snapshot
 - Digest: `src/weatherbrief/digest/prompt_builder.py`, `src/weatherbrief/digest/text.py`
 - Report: `src/weatherbrief/report/templates/briefing.html`, `src/weatherbrief/report/render.py`
 - Web UI: `web/ts/managers/briefing-ui.ts` (`renderRouteSigmets`, `renderRefreshDelta`)
+- iOS UI: `app/flyfun-weather/flyfun-weather/Views/Briefing/RouteObservationsView.swift`, `RouteSigmetsView.swift`; DTOs in `Models/API/SnapshotResponse.swift`; tests `flyfun-weatherTests/RouteObservationsTests.swift`, `RouteSigmetsTests.swift`
 - Tests: `tests/test_route_weather.py` (incl. `TestRunRealtimeRefresh`), `tests/test_refresh_delta.py`, `tests/test_packs.py::TestDecideRefresh`
 - euro_aip weather module: [briefing_weather.md](rzflight design doc)


### PR DESCRIPTION
Closes #493.

Route SIGMETs render on web but were entirely absent from iOS — no view, and no DTO, so the block was dropped at decode. Pure client gap: `GET .../snapshot` already returns raw `briefing.json` with `route_sigmets` on it, so there is no backend or endpoint work here.

The sibling of #492's Observations section on the same fetch/refresh seam, but area-keyed rather than airport-keyed and with no model comparison — which makes it the simpler table: one row per bulletin, no agreement column, no axis switcher.

## What's in it

- **DTOs** — `RouteSigmets` + `SigmetAlongRoute` on `SnapshotResponse`. The row formatters (`levelBand`, `enrouteLabel`, `movementLabel`, `headline`, `validityLabel`) live on the DTO so they're unit-testable outside SwiftUI, and they mirror the web helpers exactly: floor-division flight levels (`FL097`, not `FL098`) and `?` for an unknown bound — an omitted `base_ft` is genuinely unknown, and rendering it `SFC` would overstate the bulletin.
- **`RouteSigmetsView`** in the Advisory tab after Observations, before Alternates, with a `sigmets` scroll-spy anchor (pill label "Hazards"), gated on a non-empty list so the spy never offers an empty anchor.
- **Responsive split** — compact width shows Hazard / FIR / Levels / Enroute and folds movement into the detail sheet; regular width renders the web's 5th column (`Move`, `STNR` when stationary). Movement gives way because the vertical band decides whether a GA route is in the hazard at all, while "MOV NE 30kt" only refines the timing.
- **Detail sheet** replaces the web's ⓘ popup: level band, movement, validity in aviation `DDHHMMZ`, route intersection, then the raw bulletin (selectable monospace) — the authoritative text.
- **`has_severe`** raises a red banner and shades the SEV row — the counterpart of the observations conflict banner.
- **Computed-field fallbacks** — the server's `count`/`hazards`/`has_severe` are pydantic `computed_field`s; they decode as optionals with local fallbacks so a payload without them can't render a "0 SIGMETs" summary above a populated table.
- **Polygon `coords` decoded but unused** — kept on the DTO so the future map/cross-section overlay (design doc, "Future cross-section / map overlay") needs no second wire change.

Out of scope, per the issue: the map/cross-section overlay itself.

## Verification

- `flyfun-weatherTests` — full target passes; 30 new tests in `RouteSigmetsTests.swift` cover the decode contract against a payload copied in shape from a real dev pack (including `(lon, lat)` polygon tuples and a null-base SIGMET), the computed-field fallbacks, and every row formatter.
- XCUI `testRouteSigmetsSectionRenders` / `testRouteSigmetDetailSheet` pass on iPhone 17 Pro and iPad Pro 11" — asserting the Move column is inline on iPad and absent on iPhone. Screenshots attached to the result bundles.
- The sibling `testRouteObservations*` journeys re-run green (the new section sits below them).

D-0 only, like observations, so on-device verification needs a same-day flight with a live SIGMET along the route; fixture + XCUI coverage is the practical check. The fixture carries two SIGMETs (one `SEV`, one stationary with a null base) so mock mode renders it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
