### PR TITLE
feat(advisories): approach feasibility — is the IAP aligned with the wind runway?

### DIFF
--- a/designs/INDEX.md
+++ b/designs/INDEX.md
@@ -54,7 +54,7 @@ Comprehensive catalog of all ~85 weather metrics across 7 models: Open-Meteo API
 → Full doc: analysis-metrics.md
 
 ### advisories
-Route advisory system: 21 deterministic evaluators across 11 categories (icing incl. freezing precipitation, cloud, precipitation/en-route visibility, turbulence incl. wave-corroborated mountain wind, convective incl. convective-character, winds-aloft trip impact, airport conditions incl. density altitude, LLWS and terminal convective, feasibility, model-quality, fronts, sun) with per-model severity grading, user-tunable params, registry auto-discovery, worst/majority aggregation, and recalculation without re-fetching.
+Route advisory system: 22 deterministic evaluators across 11 categories (icing incl. freezing precipitation, cloud, precipitation/en-route visibility, turbulence incl. wave-corroborated mountain wind, convective incl. convective-character, winds-aloft trip impact, airport conditions incl. density altitude, LLWS and terminal convective, feasibility incl. approach feasibility, model-quality, fronts, sun) with per-model severity grading, user-tunable params, registry auto-discovery, worst/majority aggregation, and recalculation without re-fetching.
 Key exports: `evaluate_all`, `get_catalog`, `RouteContext`, `RouteAdvisoriesManifest`
 → Full doc: advisories.md
 

--- a/designs/advisories.md
+++ b/designs/advisories.md
@@ -263,6 +263,18 @@ non-precision minimum. Merging the two axes made the evaluator announce "wind
 favours RWY 20; approaches serve 02, **20**" — naming the served, wind-favoured
 runway as if it were unserved (caught in review on #511).
 
+**One discriminator drives both the grade and the copy** (`_Softening`, whose
+value doubles as the message-key suffix — `minima_{circling,uncertain,blocked}`
+× `misaligned_{…}`). Choosing them from different tests is a bug generator, and
+it produced two: an AMBER earned by an *unrelated* unresolved approach kept the
+hard "the ceiling will not support circling" claim, and — worse, in the branch
+review didn't flag — the misalignment case advised "plan for circling" at a
+ceiling the same call had just decided was below the circling minimum. Softening
+for uncertainty is correct, but it has to name that reason in its own words
+rather than borrow the circling advice. Note the fix is *not* to grade off
+`circling_supported` alone: that would harden genuine uncertainty into RED,
+which is precisely what rule 2 forbids.
+
 **Circling is flagged, never graded.** `nav.db` carries no circling minima, and
 "circling not authorised" / night / category restrictions are not in the data at
 all. `circling_ceiling_ft` (default 1000) only decides whether a misaligned

--- a/designs/advisories.md
+++ b/designs/advisories.md
@@ -176,6 +176,9 @@ states, and keeping them apart is the point:
 | `circling=True` | ICAO letter-suffixed circling-only procedure (`RNP A`, `NDB C`) |
 | neither | alignment unresolved — treated as *uncertainty*, never as hard misalignment |
 
+The container adds a fourth, airport-level state: `lookup_failed` (see
+UNAVAILABLE below).
+
 Circling detection keys on the single trailing letter, excluding X/Y/Z (those are
 straight-in *variant* designators) and any name carrying a digit. That digit
 guard is what matters: of the 262 ident-less rows in `nav.db`, only **39** are
@@ -201,15 +204,26 @@ no longer be expected to complete the arrival visually.
 | **MVFR** | IAP presence only, capped at AMBER. Any approach → GREEN; none → AMBER. **Never RED.** Alignment/circling/tailwind are not applied: with a 1000–3000 ft ceiling the landing can be completed visually, so a misaligned approach is not a penalty |
 | **IFR / LIFR** | Full logic. GREEN = straight-in to an end whose wind is within limits and a ceiling clear of the estimated minima band. AMBER = a compromise (circling required, ceiling *inside* the band, or a tailwind still within limits). RED = a hard fact only |
 
-**UNAVAILABLE** is reserved for "the evaluator could not run" — `arrival_approaches`
-absent (old pack / no nav.db) or no per-model airport condition. It is *not* used
-for an airport with no approaches: **zero procedure rows is treated as "no
-instrument approach available", full stop.** There is deliberately no third state
-distinguishing "genuinely has none" from "never ingested". Per-country coverage
-in `nav.db` is cleanly bimodal (40–100% or exactly 0.0%), and every 0% country is
-outside the current European scope, so the rule cannot misfire today.
-**Caveat for the US-expansion work:** in a 0%-coverage country this would grade
-every IFR destination RED. Revisit before enabling coverage there.
+**UNAVAILABLE** is reserved for "the evaluator could not run": `arrival_approaches`
+absent (old pack / no nav.db), no per-model airport condition, or
+`AirportApproaches.lookup_failed` — the ICAO was unknown to `nav.db`, or the
+procedure query raised. It is *not* used for an airport with no approaches:
+**zero procedure rows is treated as "no instrument approach available", full
+stop.** There is deliberately no third state distinguishing "genuinely has none"
+from "never ingested". Per-country coverage in `nav.db` is cleanly bimodal
+(40–100% or exactly 0.0%), and every 0% country is outside the current European
+scope, so the rule cannot misfire today. **Caveat for the US-expansion work:** in
+a 0%-coverage country this would grade every IFR destination RED. Revisit before
+enabling coverage there.
+
+`lookup_failed` exists because "this field has no instrument approach" is the
+**most severe input the grade map takes** (RED at IFR/LIFR), and it arrives as
+the same empty approach list a parse failure would produce. Only the flag tells
+them apart, so every path in `get_runway_approaches` that fails to *determine*
+the picture sets it rather than returning an empty list — a data problem must not
+be able to manufacture a RED. (The outer failure — the whole lookup raising —
+already degrades to `arrival_approaches=None` in
+`tasks/advise.py::_collect_arrival_approaches`; this closes the inner one.)
 
 **Two rules keep it honest.**
 

--- a/designs/advisories.md
+++ b/designs/advisories.md
@@ -237,8 +237,10 @@ already degrades to `arrival_approaches=None` in
    light. Emitting GREEN/AMBER/RED from the same data makes a soft claim look
    hard, so: **estimate uncertainty may push toward AMBER, never toward RED.**
    RED needs a hard fact — no IAP at all, a ceiling/visibility below even the
-   *best case* (`min(dh_lo)` / `min(vis_lo)`), or an approach-served end with an
-   out-of-limits tailwind *and* a ceiling that will not support circling. A
+   *best case* (`min(dh_lo)` / `min(vis_lo)`), an approach-served end with an
+   out-of-limits tailwind *and* a ceiling that will not support circling, or the
+   same best-case test applied **per approach** to an end the wind is happy with
+   (below). A
    forecast *inside* the band (`[dh_lo, dh_hi]`, `[vis_lo, vis_hi]`) is AMBER —
    the AMBER middle is exactly the width of our uncertainty about the published
    minima. Neither an approach of unresolved alignment nor a served end the wind
@@ -247,6 +249,19 @@ already degrades to `arrival_approaches=None` in
    absent visibility means the model does not publish one (ECMWF visibility is
    GRIB-only) and the axis is skipped, matching `flight_category`, which also
    does not read an absent visibility as a poor one.
+
+**Two failures reach the "no usable straight-in" fallback, and they are not the
+same story.** Either every approach-served end is out on wind (genuine
+misalignment — "wind favours 24; approaches serve 02"), or an end the wind is
+*happy* with is blocked only by its own approach's minima. The second is not
+misalignment at all, so it gets its own copy naming the runway and its approach
+class. This is why `_GradedPlan` keeps the wind and minima verdicts apart
+instead of merging them: the airport-wide best-case gate uses `min(dh_lo)` over
+*all* approaches, so a ceiling can clear it (via, say, an ILS on the
+wind-unusable end) and still sit below the wind-favoured end's own
+non-precision minimum. Merging the two axes made the evaluator announce "wind
+favours RWY 20; approaches serve 02, **20**" — naming the served, wind-favoured
+runway as if it were unserved (caught in review on #511).
 
 **Circling is flagged, never graded.** `nav.db` carries no circling minima, and
 "circling not authorised" / night / category restrictions are not in the data at

--- a/designs/advisories.md
+++ b/designs/advisories.md
@@ -4,7 +4,7 @@
 
 ## Intent
 
-Provide actionable, severity-graded (GREEN/AMBER/RED) advisories from 21 hazard evaluators (grouped into icing, cloud, precipitation, turbulence, convective, wind, model, airport, feasibility, fronts, and sun categories) along the route. Evaluators analyze existing route analysis data — no additional data fetch. User-tunable parameters allow recalculation without re-running the pipeline. This is a **route-level** system (advisory per route), complementing the per-waypoint `AltitudeAdvisories` in the sounding subpackage.
+Provide actionable, severity-graded (GREEN/AMBER/RED) advisories from 22 hazard evaluators (grouped into icing, cloud, precipitation, turbulence, convective, wind, model, airport, feasibility, fronts, and sun categories) along the route. Evaluators analyze existing route analysis data — no additional data fetch. User-tunable parameters allow recalculation without re-running the pipeline. This is a **route-level** system (advisory per route), complementing the per-waypoint `AltitudeAdvisories` in the sounding subpackage.
 
 ## Architecture
 
@@ -14,6 +14,7 @@ RouteContext (immutable)
   ├── cross_sections: list[RouteCrossSection]  (per-model forecast grids)
   ├── elevation: ElevationProfile | None
   ├── airport_conditions: AirportConditions | None  (dep + arr weather)
+  ├── arrival_approaches: AirportApproaches | None  (destination IAPs, #509)
   ├── sun: RouteSunAnalysis | None  ├── route_fronts: RouteFrontsManifest | None
   ├── cruise_speed_ias_kt, flight_duration_hours  (headwind trip-time inputs)
   ├── models, cruise_altitude_ft, flight_ceiling_ft, total_distance_nm, locale
@@ -38,6 +39,7 @@ Registry → evaluate_all(ctx, enabled_ids?, user_params?, aggregation?)
   ├── @register LLWSEvaluator
   ├── @register VFRFeasibilityEvaluator    # composite go/no-go
   ├── @register IFRFeasibilityEvaluator
+  ├── @register ApproachFeasibilityEvaluator  # arrival: approach vs wind vs ceiling
   ├── @register FrontsEvaluator            # fronts (experimental, gated on artifact)
   └── @register SunEvaluator               # sun (glare + night-proximity + seating note)
       ↓
@@ -85,7 +87,7 @@ Detail text comes from the worst-performing model. Shared classmethods on the mo
 
 `AdvisoryStatus.majority(statuses)` implements the majority logic: count each status (ignoring UNAVAILABLE), find max count, return worst among tied leaders. The registry re-aggregates after each evaluator returns if mode isn't WORST, so evaluator code is unchanged.
 
-## The 21 Evaluators
+## The 22 Evaluators
 
 ### Icing
 
@@ -140,6 +142,7 @@ Detail text comes from the worst-performing model. Shared classmethods on the mo
 |-----------|----------|-------|----------------|
 | `VFRFeasibilityEvaluator` | feasibility | Composite VFR go/no-go combining: airport flight category, en-route cloud clearance (base vs cruise), VMC compliance (BKN/OVC percentage), climb-out/descent corridor decks (BKN/OVC fully below cruise within `terminal_corridor_nm` of either end — OVC→RED, BKN→AMBER, see meteorology-decisions §10), and en-route precipitation (shared `classify_enroute_precip`, capped at AMBER in the composite). Worst of sub-assessments wins | `cloud_clearance_ft`, `imc_pct_amber`, `imc_pct_red`, `terminal_corridor_nm` (5) |
 | `IFRFeasibilityEvaluator` | feasibility | Composite IFR go/no-go combining: airport IFR viability (LIFR→amber, below minimums→red), en-route icing exposure (uses shared `icing_zones_in_altitude_range()` helper over `[0, cruise + icing_altitude_buffer_ft]`, aligned with FIKI advisory), convective risk along route | `min_dep_ceiling_ft`, `min_arr_ceiling_ft`, `icing_pct_amber`, `icing_pct_red`, `icing_altitude_buffer_ft` |
+| `ApproachFeasibilityEvaluator` | flight_rules | **The arrival question no other evaluator owns (#509):** *can I get in, on a runway I can also land on?* Joins the destination's ceiling, the runway the wind favours, and which runways actually have a published approach — a joint function of ceiling **and** wind **and** infrastructure. See the dedicated section below | `tailwind_limit_kt` (10), `crosswind_limit_kt` (20), `circling_ceiling_ft` (1000) |
 
 ### Sun
 
@@ -148,6 +151,115 @@ Detail text comes from the worst-performing model. Shared classmethods on the mo
 | `SunEvaluator` | sun | Informational, never go/no-go. Thin classifier over the precomputed `RouteSunAnalysis` on `ctx.sun` (built by `analysis/sun.py:compute_route_sun`). Model-independent → single `per_model=["all"]` like `ModelAgreementEvaluator`. AMBER when a low sun sits roughly down the wind-best runway on takeoff/landing (glare, recomputed from stored geometry so params honour recalc), and — for day-VFR profiles — when the leg ends near/after sunset or starts near/before sunrise (gated by `warn_near_sunset`; glare AMBER always applies). Detail text always carries the sun-side seating note. UNAVAILABLE (per-model) on old packs / when `ctx.sun is None` | `glare_azimuth_deg` (30), `glare_elev_max_deg` (15), `warn_near_sunset` (true), `sunset_margin_min` (30) |
 
 **Sun pipeline (issue #227):** the heavy/airport-independent parts (night intervals + sun-side summary) are computed once in `tasks/analyze.py` and stored on `RouteAnalysesManifest.sun` (served to the client for cross-section night shading). The advise stage recomputes the full `RouteSunAnalysis` — adding dep/arr glare from the wind-best runway (shared `select_best_runway` helper in `airport_conditions.py`) — onto `RouteContext.sun`, where `run_advisories_from_pack` also rebuilds it so recalculation works. Solar math lives in the `euro_aip` solar primitive (`euro_aip/utils/solar.py`, astral-backed); azimuths and runway headings are both **true** degrees, so glare needs no magnetic conversion.
+
+## Approach feasibility — the arrival intersection (#509)
+
+`enrich_wind` (`analysis/airport_consensus.py`) picks the best runway with
+**zero approach awareness** — `min(crosswind_kt, -headwind_kt)` across all ends.
+So the briefing could say *"destination IFR, ceiling 600 ft, best runway 24"* at
+a field where 24 has no approach and the ILS serves 06. `flight_category` grades
+ceiling/vis, `airport_wind` grades wind, `ifr_feasibility` composites
+airport+icing+convective — **no evaluator owned the intersection**. This one
+does, with its own semantic, its own params and its own detail payload.
+`enrich_wind`'s `best_runway` semantics are deliberately unchanged: the pure-wind
+answer is the correct one for VFR arrivals and for the forecast map.
+
+**Data plumbing.** `airports.py::get_runway_approaches(icaos, db_path)` mirrors
+`get_runway_ends` — the wind side of the same question — and returns
+`AirportApproaches` per ICAO (`models/airport_conditions.py`, sibling of
+`RunwayEnd`). Each `RunwayApproach` resolves into exactly one of **three**
+states, and keeping them apart is the point:
+
+| State | Means |
+|-------|-------|
+| `runway_id` set | straight-in to that runway END; only set when the procedure's ident joins a **live** (non-closed) end that has a true heading, so it can always be paired with that end's wind components |
+| `circling=True` | ICAO letter-suffixed circling-only procedure (`RNP A`, `NDB C`) |
+| neither | alignment unresolved — treated as *uncertainty*, never as hard misalignment |
+
+Circling detection keys on the single trailing letter, excluding X/Y/Z (those are
+straight-in *variant* designators) and any name carrying a digit. That digit
+guard is what matters: of the 262 ident-less rows in `nav.db`, only **39** are
+real circling procedures — a naive "no runway ident ⇒ circling" rule would be
+wrong ~85% of the time (`MIPS: RNP (LNAV) ARINC CODING` and friends).
+
+**Wiring — two points, both required.** `RouteContext.arrival_approaches`
+follows the `route_fronts` / `sun` precedent: `None` ⇒ UNAVAILABLE, so old packs
+degrade cleanly. Both the briefing run and the recalculate/preview re-run build
+it (`tasks/advise.py::_collect_arrival_approaches`), and the API recalc/preview/
+alt endpoints now hand `airports_db_path` down — the recalc path has no resolved
+`RouteConfig`, so `_arrival_icao` falls back to the recomputed airport
+conditions' arrival ICAO. Miss either point and the advisory silently degrades
+to a grey card on recalculate.
+
+**Grade map.** The destination's flight category selects which logic applies —
+the alignment/circling/tailwind reasoning only earns its keep once the pilot can
+no longer be expected to complete the arrival visually.
+
+| Category | Logic |
+|----------|-------|
+| **VFR** | GREEN, always. Visually reachable; approach infrastructure is irrelevant (GREEN not UNAVAILABLE — a benign assessment is a real assessment) |
+| **MVFR** | IAP presence only, capped at AMBER. Any approach → GREEN; none → AMBER. **Never RED.** Alignment/circling/tailwind are not applied: with a 1000–3000 ft ceiling the landing can be completed visually, so a misaligned approach is not a penalty |
+| **IFR / LIFR** | Full logic. GREEN = straight-in to an end whose wind is within limits and a ceiling clear of the estimated minima band. AMBER = a compromise (circling required, ceiling *inside* the band, or a tailwind still within limits). RED = a hard fact only |
+
+**UNAVAILABLE** is reserved for "the evaluator could not run" — `arrival_approaches`
+absent (old pack / no nav.db) or no per-model airport condition. It is *not* used
+for an airport with no approaches: **zero procedure rows is treated as "no
+instrument approach available", full stop.** There is deliberately no third state
+distinguishing "genuinely has none" from "never ingested". Per-country coverage
+in `nav.db` is cleanly bimodal (40–100% or exactly 0.0%), and every 0% country is
+outside the current European scope, so the rule cannot misfire today.
+**Caveat for the US-expansion work:** in a 0%-coverage country this would grade
+every IFR destination RED. Revisit before enabling coverage there.
+
+**Two rules keep it honest.**
+
+1. **One minima table.** Decision heights come from
+   `analysis/alternate_requirement.py::APPROACH_CLASS_PROXY` via
+   `proxy_for_approach` — the same estimates the alternate-requirement card
+   shows. A second table answering the same question on the same page is a drift
+   bug waiting to happen.
+2. **Asymmetric uncertainty.** Those DHs are *estimates*, which is exactly why
+   `alternate_requirement` reports Likely/Marginal/Unlikely instead of a traffic
+   light. Emitting GREEN/AMBER/RED from the same data makes a soft claim look
+   hard, so: **estimate uncertainty may push toward AMBER, never toward RED.**
+   RED needs a hard fact — no IAP at all, a ceiling/visibility below even the
+   *best case* (`min(dh_lo)` / `min(vis_lo)`), or an approach-served end with an
+   out-of-limits tailwind *and* a ceiling that will not support circling. A
+   forecast *inside* the band (`[dh_lo, dh_hi]`, `[vis_lo, vis_hi]`) is AMBER —
+   the AMBER middle is exactly the width of our uncertainty about the published
+   minima. Neither an approach of unresolved alignment nor a served end the wind
+   model did not cover can drive RED: both are our gap, not a fact about the
+   arrival. An absent ceiling means "no BKN/OVC layer" (clears everything); an
+   absent visibility means the model does not publish one (ECMWF visibility is
+   GRIB-only) and the axis is skipped, matching `flight_category`, which also
+   does not read an absent visibility as a poor one.
+
+**Circling is flagged, never graded.** `nav.db` carries no circling minima, and
+"circling not authorised" / night / category restrictions are not in the data at
+all. `circling_ceiling_ft` (default 1000) only decides whether a misaligned
+arrival softens to AMBER — it is never a circling verdict.
+
+**Alignment is brittle**, so the grade is computed **per model** and the
+registry's majority aggregation absorbs the disagreement (wind direction can
+spread 180° across models at D-3, and alignment is discrete). Near the wind
+boundary the verdict degrades to AMBER rather than flipping GREEN↔RED: crossing
+the tailwind limit only removes the straight-in option; RED additionally needs
+the ceiling to fail circling.
+
+**Known gap (deliberate).** At D-0 this should prefer the TAF over the NWP
+consensus so the card cannot contradict the alternates card beside it. Advisories
+run at pipeline step 3 and METAR/TAF are fetched at step 3.5, so `RouteContext`
+has no observation to read; the NWP consensus in `airport_conditions.arrival` is
+what is graded today. Also deferred (from #509): per-candidate approach
+feasibility for *alternates*, an approach-aware "best usable runway" alongside
+`best_runway` in `enrich_wind`, and #510's user-declared unpublished approaches
+(cloud-break procedures) damping the "no IAP → RED" case at UK GA bases.
+
+No highlights are emitted — like every airport advisory this is point-in-space,
+not route geometry (see the "Not emitting" list under Highlights). Web/iOS/MCP/
+digest pick it up from the catalog with no per-advisory registration; it is added
+to `ADVISORY_PRIORITY` (`web/ts/helpers/advisory-order.ts`) so it sorts beside
+the feasibility composites rather than at the bottom of its band.
 
 ## Mitigations (advice only — #328/#330)
 

--- a/designs/advisories.md
+++ b/designs/advisories.md
@@ -263,17 +263,36 @@ non-precision minimum. Merging the two axes made the evaluator announce "wind
 favours RWY 20; approaches serve 02, **20**" — naming the served, wind-favoured
 runway as if it were unserved (caught in review on #511).
 
-**One discriminator drives both the grade and the copy** (`_Softening`, whose
-value doubles as the message-key suffix — `minima_{circling,uncertain,blocked}`
-× `misaligned_{…}`). Choosing them from different tests is a bug generator, and
-it produced two: an AMBER earned by an *unrelated* unresolved approach kept the
-hard "the ceiling will not support circling" claim, and — worse, in the branch
-review didn't flag — the misalignment case advised "plan for circling" at a
-ceiling the same call had just decided was below the circling minimum. Softening
-for uncertainty is correct, but it has to name that reason in its own words
-rather than borrow the circling advice. Note the fix is *not* to grade off
-`circling_supported` alone: that would harden genuine uncertainty into RED,
-which is precisely what rule 2 forbids.
+**The fallback verdict is a CROSS PRODUCT, and is built as one.** Four review
+rounds on #511 each found a different cell of it rendering the wrong sentence,
+because the cells were written out by hand. Two independent axes:
+
+| `_Blocker` — what stops the arrival | `_Softening` — why it is not RED |
+|---|---|
+| `MINIMA` — a wind-acceptable end blocked only by its own approach's minima | `CIRCLING` — ceiling **and** visibility support circling |
+| `MISALIGNED` — every approach-served end is out on wind | `UNRESOLVED` — an approach we could not match to a runway |
+| `NO_STRAIGHT_IN` — no straight-in published at all (circling-only, or unresolvable) | `NO_WIND_DATA` — no wind components for the served end(s) |
+| | `NONE` — nothing softens it (the only RED) |
+
+`_fallback_detail` composes `"{blocked_<blocker>} — {soften_<softening>}"`, so
+every cell has correct text by construction and a new blocker or reason costs
+**one** string rather than a row or column. The bugs this replaced: an AMBER
+earned by an unrelated unresolved approach kept the hard "will not support
+circling" claim; the misalignment branch advised "plan for circling" at a
+ceiling the same call had just ruled out; `NO_WIND_DATA` borrowed the
+`UNRESOLVED` copy and sent the pilot checking plates for an alignment ambiguity
+that did not exist; and a circling-only field rendered "approaches serve **-**".
+A test asserts every cell resolves in all four locales and that no non-circling
+reason recommends circling.
+
+Two rules the axes encode. **Softening is never dropped to fix copy:** grading
+off `circling_supported` alone would harden genuine uncertainty into RED, which
+is exactly what rule 2 forbids — an unresolved approach may serve the
+wind-favoured end with lower minima. And **circling needs visibility, not just a
+ceiling** (`circling_visibility_m`, default 1500 m): a generous or absent
+ceiling in fog that clears the straight-in floor but not the circling one used
+to soften a genuine "no way in" into AMBER *and recommend circling*. Absent
+values stay permissive on both terms, so a data gap never hardens a grade.
 
 **Circling is flagged, never graded.** `nav.db` carries no circling minima, and
 "circling not authorised" / night / category restrictions are not in the data at
@@ -298,9 +317,19 @@ feasibility for *alternates*, an approach-aware "best usable runway" alongside
 
 No highlights are emitted — like every airport advisory this is point-in-space,
 not route geometry (see the "Not emitting" list under Highlights). Web/iOS/MCP/
-digest pick it up from the catalog with no per-advisory registration; it is added
-to `ADVISORY_PRIORITY` (`web/ts/helpers/advisory-order.ts`) so it sorts beside
-the feasibility composites rather than at the bottom of its band.
+digest pick the advisory itself up from the catalog with no per-advisory
+registration, but **three id→category tables are hand-maintained and do need an
+entry** (all three list both feasibility composites, so a new one is easy to
+miss): `ADVISORY_PRIORITY` (`web/ts/helpers/advisory-order.ts`) so it sorts
+beside them rather than at the bottom of its band; `ADVISORY_TAG_MAP`
+(`debriefs/taxonomy.py`, mirrored in `web/ts/components/debrief-taxonomy.ts` —
+iOS reads it from the served catalog) → `IMC`, so a RED/AMBER verdict can be
+graded against the pilot's debrief outcome; and `ADVISORY_SITUATION`
+(`eval_workbench/situations.py`) → the existing `ifr_marginal` cell, so it
+contributes to eval-corpus situation coverage. `ifr_marginal` rather than a new
+`SITUATION_VOCAB` entry: this only grades at an IFR/LIFR destination, and a new
+vocab cell changes the coverage-matrix denominator every fixture is scored
+against.
 
 ## Mitigations (advice only — #328/#330)
 

--- a/designs/advisories.md
+++ b/designs/advisories.md
@@ -297,7 +297,14 @@ values stay permissive on both terms, so a data gap never hardens a grade.
 **Circling is flagged, never graded.** `nav.db` carries no circling minima, and
 "circling not authorised" / night / category restrictions are not in the data at
 all. `circling_ceiling_ft` (default 1000) only decides whether a misaligned
-arrival softens to AMBER — it is never a circling verdict.
+arrival softens to AMBER — it is never a circling verdict. The same rule governs
+the airport-wide best-case gate: **circling-only procedures are excluded from
+`_best_case_minima`**, because `APPROACH_CLASS_PROXY` holds *straight-in* minima
+and real circling minima are categorically higher for the same class — blending
+a circling ILS in would claim a 200 ft best case the field does not offer, an
+optimistic assumption sitting inside a RED gate. A field whose every approach is
+circling-only has no straight-in minimum to test against, so the gate is skipped
+and the fallback speaks.
 
 **Alignment is brittle**, so the grade is computed **per model** and the
 registry's majority aggregation absorbs the disagreement (wind direction can

--- a/designs/alternate-requirement.md
+++ b/designs/alternate-requirement.md
@@ -281,7 +281,14 @@ estimates; planning guidance only.
 - User-entered Field-16 alternate list.
 - Real plate minima from a procedures DB (would replace the proxy ranges and
   shrink Marginal toward exact Yes/No).
-- Route advisory evaluator (GREEN/AMBER/RED), isolated-aerodrome fuel rules.
+- Isolated-aerodrome fuel rules.
+- ~~Route advisory evaluator (GREEN/AMBER/RED)~~ — shipped as a *different*
+  question: `approach_feasibility` (#509, see [advisories.md](./advisories.md))
+  consumes `APPROACH_CLASS_PROXY` / `proxy_for_approach` to ask "can I get in, on
+  a runway I can also land on?", not "is a filed alternate required?". It shares
+  this module's DH estimates deliberately — one minima table, no drift — and
+  inherits the asymmetric-uncertainty rule that keeps a soft claim from reading
+  as a hard one: estimate uncertainty may push it to AMBER, never to RED.
 
 ## References
 

--- a/src/weatherbrief/airports.py
+++ b/src/weatherbrief/airports.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import re
 from dataclasses import dataclass
 from functools import lru_cache
 from typing import TYPE_CHECKING, Literal
@@ -11,7 +12,7 @@ from euro_aip.storage.database_storage import DatabaseStorage
 from timezonefinder import TimezoneFinder
 
 from weatherbrief.fetch.route_walk import walk_route
-from weatherbrief.models import RunwayEnd, Waypoint
+from weatherbrief.models import AirportApproaches, RunwayApproach, RunwayEnd, Waypoint
 
 if TYPE_CHECKING:
     from euro_aip.briefing.models.route import Route
@@ -274,6 +275,137 @@ def get_runway_ends(icao_codes: list[str], db_path: str) -> dict[str, list[Runwa
                 ends.append(RunwayEnd(id=rwy.he_ident, heading_deg=rwy.he_heading_degT))
 
         result[icao] = ends
+
+    return result
+
+
+# ICAO names a circling-only approach with a single trailing letter ("RNP A",
+# "NDB C", "LOC A") instead of a runway number. X/Y/Z are excluded: those are
+# straight-in *variant* designators ("ILS Z RWY 09"), not circling. A name
+# carrying any digit is a runway-numbered procedure, so it is never circling —
+# that guard is what keeps parser artifacts like
+# "MIPS: RNP (LNAV) ARINC CODING" (issue #509: 223 of 262 ident-less rows) from
+# being mislabelled as circling.
+_CIRCLING_SUFFIX_RE = re.compile(r"(?:^|[\s/-])([A-W])$")
+
+
+def _is_circling_name(name: str | None) -> bool:
+    """True when a procedure name reads as an ICAO circling-only approach."""
+    if not name:
+        return False
+    text = name.strip().upper()
+    if any(ch.isdigit() for ch in text):
+        return False
+    return bool(_CIRCLING_SUFFIX_RE.search(text))
+
+
+# A runway identifier is a 1-2 digit number with an optional L/C/R parallel
+# designator. Matching that shape (rather than sifting digits and letters out of
+# the whole string) is what keeps a decorated ident like "RWY 09R" from
+# normalizing to nonsense.
+_RUNWAY_IDENT_RE = re.compile(r"(?<!\d)(\d{1,2})\s*([LCR])?(?![\dA-Z])")
+
+
+def _normalize_runway_ident(ident: str | None) -> str | None:
+    """Canonicalize a runway identifier for joining procedures to runway ends.
+
+    Drops zero padding on the numeric part ("02" -> "2") and any surrounding
+    decoration ("RWY 09R" -> "9R"), so a procedure's runway reference joins a
+    runway end whichever way either side spelled it. Returns ``None`` when the
+    string holds no runway number at all.
+    """
+    if not ident:
+        return None
+    match = _RUNWAY_IDENT_RE.search(ident.upper())
+    if match is None:
+        return None
+    return f"{int(match.group(1))}{match.group(2) or ''}"
+
+
+def get_runway_approaches(
+    icao_codes: list[str], db_path: str,
+) -> dict[str, AirportApproaches]:
+    """Get published instrument approaches per airport, joined to runway ends.
+
+    Mirrors :func:`get_runway_ends`, which supplies the wind side of the same
+    question ("which runway does the wind favour?"). This supplies the
+    infrastructure side ("which runway can I actually shoot an approach to?"),
+    consumed by the ``approach_feasibility`` advisory (issue #509).
+
+    Each :class:`RunwayApproach` resolves into exactly one of three states:
+
+    * ``runway_id`` set — a straight-in approach to that runway END. Only set
+      when the procedure's runway identifier joins a live (non-closed) runway
+      end that has a true heading, so the evaluator can always pair it with the
+      wind components for that end.
+    * ``circling=True`` — an ICAO letter-suffixed circling-only procedure.
+    * neither — an approach whose alignment could not be resolved. Deliberately
+      NOT collapsed into "circling": the consumer treats unresolved alignment as
+      uncertainty (which may only soften a grade), never as a hard misalignment.
+
+    Args:
+        icao_codes: ICAO codes to look up.
+        db_path: Path to the euro_aip SQLite database.
+
+    Returns:
+        Dict mapping ICAO code to :class:`AirportApproaches`. An unknown ICAO
+        yields an empty entry with ``has_procedure_data=False``.
+    """
+    model = _load_airport_model(db_path)
+
+    result: dict[str, AirportApproaches] = {}
+    for icao in icao_codes:
+        airport = model.airports.get(icao)
+        if airport is None:
+            result[icao] = AirportApproaches(icao=icao, has_procedure_data=False)
+            continue
+
+        # Live runway ends with a true heading — the only ends the wind side can
+        # grade, so an approach that joins nothing else is left unresolved.
+        live_ends: dict[str, str] = {}
+        for rwy in getattr(airport, "runways", None) or []:
+            if getattr(rwy, "closed", False):
+                continue
+            for ident, heading in (
+                (rwy.le_ident, rwy.le_heading_degT),
+                (rwy.he_ident, rwy.he_heading_degT),
+            ):
+                key = _normalize_runway_ident(ident)
+                if key is not None and heading is not None:
+                    live_ends[key] = ident.strip().upper()
+
+        try:
+            procedures = list(airport.procedures_query.approaches().all())
+            has_procedure_data = bool(getattr(airport, "procedures", None))
+        except Exception:  # noqa: BLE001 - a bad procedure row must not fail a briefing
+            logger.debug("Approach lookup failed for %s", icao, exc_info=True)
+            result[icao] = AirportApproaches(icao=icao, has_procedure_data=False)
+            continue
+
+        approaches: list[RunwayApproach] = []
+        for proc in procedures:
+            name = str(getattr(proc, "name", "") or "")
+            raw_ident = None
+            try:
+                raw_ident = proc.get_full_runway_ident()
+            except Exception:  # noqa: BLE001 - fall back to the plain column
+                raw_ident = getattr(proc, "runway_ident", None)
+            key = _normalize_runway_ident(raw_ident)
+            runway_id = live_ends.get(key) if key else None
+            approaches.append(RunwayApproach(
+                name=name,
+                approach_type=getattr(proc, "approach_type", None),
+                runway_id=runway_id,
+                circling=runway_id is None and _is_circling_name(
+                    getattr(proc, "raw_name", None) or name,
+                ),
+            ))
+
+        result[icao] = AirportApproaches(
+            icao=icao,
+            has_procedure_data=has_procedure_data,
+            approaches=approaches,
+        )
 
     return result
 

--- a/src/weatherbrief/airports.py
+++ b/src/weatherbrief/airports.py
@@ -343,13 +343,19 @@ def get_runway_approaches(
       NOT collapsed into "circling": the consumer treats unresolved alignment as
       uncertainty (which may only soften a grade), never as a hard misalignment.
 
+    The same principle governs failure: an unknown ICAO or a procedure query
+    that raises yields ``lookup_failed=True``, never an empty approach list. An
+    empty list is a *fact* ("this field has no instrument approach") that the
+    grade map treats as the most severe input there is, so a data gap must not
+    be able to impersonate one.
+
     Args:
         icao_codes: ICAO codes to look up.
         db_path: Path to the euro_aip SQLite database.
 
     Returns:
-        Dict mapping ICAO code to :class:`AirportApproaches`. An unknown ICAO
-        yields an empty entry with ``has_procedure_data=False``.
+        Dict mapping ICAO code to :class:`AirportApproaches`, one entry per
+        requested code.
     """
     model = _load_airport_model(db_path)
 
@@ -357,7 +363,7 @@ def get_runway_approaches(
     for icao in icao_codes:
         airport = model.airports.get(icao)
         if airport is None:
-            result[icao] = AirportApproaches(icao=icao, has_procedure_data=False)
+            result[icao] = AirportApproaches(icao=icao, lookup_failed=True)
             continue
 
         # Live runway ends with a true heading — the only ends the wind side can
@@ -378,8 +384,12 @@ def get_runway_approaches(
             procedures = list(airport.procedures_query.approaches().all())
             has_procedure_data = bool(getattr(airport, "procedures", None))
         except Exception:  # noqa: BLE001 - a bad procedure row must not fail a briefing
+            # ``lookup_failed``, NOT an empty approach list: a malformed row is
+            # our gap, and "no approach at all" is the single most severe input
+            # the grade map takes. Degrading a parse failure into that fact
+            # would manufacture a RED out of a data problem.
             logger.debug("Approach lookup failed for %s", icao, exc_info=True)
-            result[icao] = AirportApproaches(icao=icao, has_procedure_data=False)
+            result[icao] = AirportApproaches(icao=icao, lookup_failed=True)
             continue
 
         approaches: list[RunwayApproach] = []

--- a/src/weatherbrief/analysis/advisories/__init__.py
+++ b/src/weatherbrief/analysis/advisories/__init__.py
@@ -17,6 +17,7 @@ from typing import Protocol, runtime_checkable
 
 from weatherbrief.models import (
     AdvisoryCatalogEntry,
+    AirportApproaches,
     AirportConditions,
     ElevationProfile,
     RouteAdvisoryResult,
@@ -59,6 +60,14 @@ class RouteContext:
     # Precomputed solar analysis (issue #227): night intervals + sun-side note +
     # dep/arr glare. Read by SunEvaluator. None on old packs / when unavailable.
     sun: RouteSunAnalysis | None = None
+    # Published instrument approaches at the DESTINATION (issue #509), joined to
+    # runway ends so the evaluator can pair each approach with the wind on the
+    # end it serves. Read by ApproachFeasibilityEvaluator. ``None`` means the
+    # collection step could not run (old pack, no nav.db) — the evaluator then
+    # returns UNAVAILABLE, the ``route_fronts`` / ``sun`` precedent. It is NOT
+    # the "airport has no approach" signal: that is a present object with an
+    # empty ``approaches`` list.
+    arrival_approaches: AirportApproaches | None = None
 
 
 @runtime_checkable

--- a/src/weatherbrief/analysis/advisories/approach_feasibility.py
+++ b/src/weatherbrief/analysis/advisories/approach_feasibility.py
@@ -88,21 +88,34 @@ class _EndPlan:
         return -self.wind.headwind_kt
 
 
+class _Blocker(str, Enum):
+    """WHAT stops the arrival, once no straight-in candidate is usable."""
+
+    #: An end the wind is happy with exists, blocked only by its own approach's
+    #: minima. Not misalignment at all — naming it as such was the #511 bug.
+    MINIMA = "minima"
+    #: Every approach-served end is out on wind. The genuine misalignment case.
+    MISALIGNED = "misaligned"
+    #: No straight-in approach is published here at all — circling-only
+    #: procedures, or approaches whose runway could not be resolved. Distinct
+    #: from MISALIGNED, which names the served ends; this one has none to name,
+    #: and rendering it through the misaligned copy produced "approaches serve -".
+    NO_STRAIGHT_IN = "no_straight_in"
+
+
 class _Softening(str, Enum):
-    """Why (or whether) a no-usable-straight-in verdict softens off RED.
+    """WHY (or whether) that blocker softens off RED."""
 
-    The value doubles as the message-key suffix, so the grade and the copy
-    cannot be chosen from different tests — the bug this enum replaces.
-    """
-
-    #: The ceiling supports circling — a real option, so say "plan for circling".
+    #: Ceiling AND visibility support circling — a real option.
     CIRCLING = "circling"
-    #: We could not resolve an approach's alignment, or the wind model did not
-    #: cover a served end. Genuine uncertainty (design rule 2), so it softens —
-    #: but the copy must name THAT reason, never borrow the circling advice.
-    UNCERTAIN = "uncertain"
+    #: An approach we could not match to a runway; it may serve the very end the
+    #: wind favours. Genuine uncertainty (design rule 2), so it softens.
+    UNRESOLVED = "unresolved"
+    #: The wind model produced no components for the served end(s). Also our
+    #: gap, and a DIFFERENT gap — it must not borrow the unresolved copy.
+    NO_WIND_DATA = "no_wind_data"
     #: Nothing softens it.
-    NONE = "blocked"
+    NONE = "none"
 
     @property
     def status(self) -> AdvisoryStatus:
@@ -110,6 +123,24 @@ class _Softening(str, Enum):
             AdvisoryStatus.RED if self is _Softening.NONE
             else AdvisoryStatus.AMBER
         )
+
+
+def _fallback_detail(
+    blocker: _Blocker, softening: _Softening, loc: str | None, **fields: object,
+) -> str:
+    """Compose the no-usable-straight-in copy from its two independent axes.
+
+    The verdict here is a cross product — WHAT blocks the arrival x WHY it is
+    not RED — and three review rounds on #511 each found a different cell of it
+    rendering the wrong sentence, because the copy was picked by hand per
+    branch. Composing the two halves means every cell has correct text by
+    construction: a new blocker or a new softening reason adds ONE string, not a
+    row or column of them, and none can silently fall back to another cell's
+    wording.
+    """
+    cause = adv_t(f"approach_feasibility.blocked_{blocker.value}", loc, **fields)
+    clause = adv_t(f"approach_feasibility.soften_{softening.value}", loc)
+    return f"{cause} — {clause}"
 
 
 @dataclass(frozen=True)
@@ -257,6 +288,7 @@ def _grade_full(
     tailwind_limit = float(params.get("tailwind_limit_kt", 10))
     crosswind_limit = float(params.get("crosswind_limit_kt", 20))
     circling_ceiling = float(params.get("circling_ceiling_ft", 1000))
+    circling_vis = float(params.get("circling_visibility_m", 1500))
 
     if not approaches.has_iap:
         key = (
@@ -306,60 +338,65 @@ def _grade_full(
             wind=_wind_note(best.plan, loc),
         )
 
-    # No usable straight-in. Neither an approach we could not align, nor a
-    # straight-in end the wind model did not cover, may drive RED (design
-    # rule 2) — both are our uncertainty, not a fact about the arrival. Ceiling
-    # decides whether circling is even on the table, but we never compute a
-    # circling verdict (design rule 3), only whether to soften to AMBER.
+    # ---- No usable straight-in. Resolve WHAT blocks it and WHY it isn't RED,
+    # then compose the copy from both. Neither an approach we could not align
+    # nor a served end the wind model did not cover may drive RED (design
+    # rule 2) — those are our gaps, not facts about the arrival.
     alignment_unresolved = any(
         not a.runway_id and not a.circling for a in approaches.approaches
     )
     wind_unresolved = bool(approaches.served_runway_ids) and not graded
-    circling_supported = ceiling is None or ceiling >= circling_ceiling
-    # ONE discriminator drives both the grade and the copy. They were split
-    # before — status off `circling_supported or <uncertainty>`, copy off
-    # `circling_supported` alone — which let an unrelated unresolved approach
-    # soften the grade to AMBER while the text still made the hard claim, and
-    # (worse) let the misalignment branch advise "plan for circling" at a
-    # ceiling that will not support it. Softening for uncertainty is correct,
-    # but it has to say so in its own words rather than borrow the circling copy.
+
+    # Circling needs BOTH a ceiling and the visibility to see the runway from
+    # the circuit. A ceiling-only test softened a genuine "no way in" to
+    # "plan for circling" in fog sitting above the straight-in visibility floor.
+    # Absent values stay permissive, so a gap never hardens a grade.
+    circling_supported = (
+        (ceiling is None or ceiling >= circling_ceiling)
+        and (cond.visibility_m is None or cond.visibility_m >= circling_vis)
+    )
+
     if circling_supported:
         softening = _Softening.CIRCLING
-    elif alignment_unresolved or wind_unresolved:
-        softening = _Softening.UNCERTAIN
+    elif alignment_unresolved:
+        softening = _Softening.UNRESOLVED
+    elif wind_unresolved:
+        softening = _Softening.NO_WIND_DATA
     else:
         softening = _Softening.NONE
 
-    # Two different failures land here and they are NOT the same story. If an
-    # end the wind is happy with exists and is blocked only by its own
-    # approach's minima, there is no misalignment at all — saying "wind favours
-    # 20, approaches serve 02, 20 — plan for circling" would name the served,
-    # wind-favoured runway as if it were unserved. This is rule 2 applied per
-    # approach rather than airport-wide: the forecast is below the best case for
-    # *that* end's approach, even though a lower-minima approach exists on an
-    # end the wind has ruled out.
+    # An end the wind is happy with, blocked only by its own approach's minima,
+    # is not misalignment: this is rule 2 applied per approach rather than
+    # airport-wide (the airport-wide gate uses min(dh_lo) over ALL approaches,
+    # so a lower-minima approach on a wind-blocked end can carry the ceiling
+    # past it while the wind-favoured end's own minimum is not met).
     minima_blocked = [
         g for g in graded
         if g.wind != AdvisoryStatus.RED and g.minima == AdvisoryStatus.RED
     ]
+    wind_best = cond.best_runway.runway_id if cond.best_runway else "-"
+
     if minima_blocked:
         closest = min(minima_blocked, key=lambda g: g.plan.proxy.dh_lo)
-        return softening.status, adv_t(
-            f"approach_feasibility.minima_{softening.value}", loc,
+        return softening.status, _fallback_detail(
+            _Blocker.MINIMA, softening, loc,
             runway=closest.plan.wind.runway_id,
             approach=_approach_label(closest.plan.approach),
             dh=int(closest.plan.proxy.dh_lo),
         )
 
-    # Every approach-served end is out on wind (or there is nothing straight-in
-    # to grade) — the genuine misalignment case.
-    wind_best = cond.best_runway.runway_id if cond.best_runway else None
-    served = ", ".join(sorted(approaches.served_runway_ids)) or "-"
+    if not approaches.served_runway_ids:
+        # Nothing straight-in to name — circling-only procedures, or approaches
+        # whose runway would not resolve. Routing this through the misaligned
+        # copy rendered "approaches serve -".
+        return softening.status, _fallback_detail(
+            _Blocker.NO_STRAIGHT_IN, softening, loc, wind_runway=wind_best,
+        )
 
-    return softening.status, adv_t(
-        f"approach_feasibility.misaligned_{softening.value}", loc,
-        served=served, wind_runway=wind_best or "-",
-        ceiling=int(ceiling) if ceiling is not None else 0,
+    return softening.status, _fallback_detail(
+        _Blocker.MISALIGNED, softening, loc,
+        served=", ".join(sorted(approaches.served_runway_ids)),
+        wind_runway=wind_best,
     )
 
 
@@ -455,6 +492,17 @@ class ApproachFeasibilityEvaluator:
                     ),
                     type="altitude", unit="ft",
                     default=1000, min=500, max=2500, step=100,
+                ),
+                AdvisoryParameterDef(
+                    key="circling_visibility_m",
+                    label="Circling visibility",
+                    description=(
+                        "Assumed visibility needed to circle. Circling needs "
+                        "visual reference to the runway, so a generous ceiling "
+                        "in fog is not a way in"
+                    ),
+                    type="number", unit="m",
+                    default=1500, min=800, max=5000, step=100,
                 ),
             ],
         )

--- a/src/weatherbrief/analysis/advisories/approach_feasibility.py
+++ b/src/weatherbrief/analysis/advisories/approach_feasibility.py
@@ -175,14 +175,30 @@ def _proxy(approach: RunwayApproach) -> ApproachProxy:
     return proxy
 
 
-def _best_case_minima(approaches: list[RunwayApproach]) -> tuple[float, float]:
+def _best_case_minima(
+    approaches: list[RunwayApproach],
+) -> tuple[float, float] | None:
     """Lowest plausible (decision height ft, visibility m) across the approaches.
 
     The *best case* deliberately: a forecast below this is below every plate the
     field could hold, which is the only ceiling/visibility fact hard enough to
-    justify RED (design rule 2). Callers must pass a non-empty list.
+    justify RED (design rule 2).
+
+    **Circling-only procedures are excluded.** ``APPROACH_CLASS_PROXY`` holds
+    *straight-in* minima, and real circling minima are categorically higher for
+    the same approach class — so folding a circling ILS in would claim a 200 ft
+    best case the field does not offer, an optimistic assumption sitting inside
+    a RED gate. That is also design rule 3: we have no circling minima, so we
+    flag circling rather than grading it.
+
+    Returns ``None`` when every published approach is circling-only, i.e. there
+    is no straight-in minimum to test the forecast against — the caller skips
+    the gate and lets the fallback speak. (This ``None`` is live, not defensive:
+    a circling-only field is the #509 EGKA-class shape.)
     """
-    proxies = [_proxy(a) for a in approaches]
+    proxies = [_proxy(a) for a in approaches if not a.circling]
+    if not proxies:
+        return None
     return min(p.dh_lo for p in proxies), min(p.vis_lo for p in proxies)
 
 
@@ -302,17 +318,19 @@ def _grade_full(
     # Hard forecast fact — below every plate the field could hold. Checked before
     # the wind so a genuinely un-shootable approach reads as such regardless of
     # which runway the wind favours.
-    best_dh, best_vis = _best_case_minima(approaches.approaches)
-    if ceiling is not None and ceiling < best_dh:
-        return AdvisoryStatus.RED, adv_t(
-            "approach_feasibility.below_minima", loc,
-            ceiling=int(ceiling), dh=int(best_dh),
-        )
-    if cond.visibility_m is not None and cond.visibility_m < best_vis:
-        return AdvisoryStatus.RED, adv_t(
-            "approach_feasibility.below_vis_minima", loc,
-            vis=int(cond.visibility_m), min_vis=int(best_vis),
-        )
+    best_case = _best_case_minima(approaches.approaches)
+    if best_case is not None:
+        best_dh, best_vis = best_case
+        if ceiling is not None and ceiling < best_dh:
+            return AdvisoryStatus.RED, adv_t(
+                "approach_feasibility.below_minima", loc,
+                ceiling=int(ceiling), dh=int(best_dh),
+            )
+        if cond.visibility_m is not None and cond.visibility_m < best_vis:
+            return AdvisoryStatus.RED, adv_t(
+                "approach_feasibility.below_vis_minima", loc,
+                vis=int(cond.visibility_m), min_vis=int(best_vis),
+            )
 
     # Straight-in candidates, best arrival first. Wind and minima are kept
     # apart, not just merged into one verdict: when no candidate is usable, WHY

--- a/src/weatherbrief/analysis/advisories/approach_feasibility.py
+++ b/src/weatherbrief/analysis/advisories/approach_feasibility.py
@@ -87,6 +87,25 @@ class _EndPlan:
         return -self.wind.headwind_kt
 
 
+@dataclass(frozen=True)
+class _GradedPlan:
+    """One candidate arrival with its two failure axes kept separate.
+
+    ``status`` is the verdict for this candidate, but ``wind`` and ``minima``
+    survive alongside it because "no usable straight-in" has two very different
+    causes — the wind ruled the end out, or the end's own approach minima did —
+    and they need different copy.
+    """
+
+    wind: AdvisoryStatus
+    minima: AdvisoryStatus
+    plan: _EndPlan
+
+    @property
+    def status(self) -> AdvisoryStatus:
+        return AdvisoryStatus.worst([self.wind, self.minima])
+
+
 def _proxy(approach: RunwayApproach) -> ApproachProxy:
     """Estimated minima for one approach — never ``None`` for a present IAP.
 
@@ -238,49 +257,76 @@ def _grade_full(
             vis=int(cond.visibility_m), min_vis=int(best_vis),
         )
 
-    # Straight-in candidates, best arrival first.
-    plans = _straight_in_plans(cond, approaches)
+    # Straight-in candidates, best arrival first. Wind and minima are kept
+    # apart, not just merged into one verdict: when no candidate is usable, WHY
+    # it is unusable decides which story the pilot gets (see the fallback).
     graded = sorted(
         (
-            (
-                AdvisoryStatus.worst([
-                    _plan_wind_status(p, tailwind_limit, crosswind_limit),
-                    _minima_status(cond, p.proxy),
-                ]),
-                p,
+            _GradedPlan(
+                wind=_plan_wind_status(p, tailwind_limit, crosswind_limit),
+                minima=_minima_status(cond, p.proxy),
+                plan=p,
             )
-            for p in plans
+            for p in _straight_in_plans(cond, approaches)
         ),
-        key=lambda pair: (_rank(pair[0]), pair[1].tailwind_kt, pair[1].wind.crosswind_kt),
+        key=lambda g: (_rank(g.status), g.plan.tailwind_kt, g.plan.wind.crosswind_kt),
     )
 
     best = graded[0] if graded else None
-    if best is not None and best[0] != AdvisoryStatus.RED:
-        status, plan = best
-        return status, adv_t(
+    if best is not None and best.status != AdvisoryStatus.RED:
+        return best.status, adv_t(
             "approach_feasibility.straight_in", loc,
-            approach=_approach_label(plan.approach),
-            runway=plan.wind.runway_id,
-            wind=_wind_note(plan, loc),
+            approach=_approach_label(best.plan.approach),
+            runway=best.plan.wind.runway_id,
+            wind=_wind_note(best.plan, loc),
         )
 
-    # No usable straight-in: either every aligned end is out on wind, or the
-    # only approaches are circling-only / of unresolved alignment. Ceiling
-    # decides whether circling is even on the table — but we never compute a
+    # No usable straight-in. Neither an approach we could not align, nor a
+    # straight-in end the wind model did not cover, may drive RED (design
+    # rule 2) — both are our uncertainty, not a fact about the arrival. Ceiling
+    # decides whether circling is even on the table, but we never compute a
     # circling verdict (design rule 3), only whether to soften to AMBER.
-    wind_best = cond.best_runway.runway_id if cond.best_runway else None
-    served = ", ".join(sorted(approaches.served_runway_ids)) or "-"
-
-    # Neither an approach we could not align, nor a straight-in end the wind
-    # model did not cover, may drive RED (design rule 2) — both are our
-    # uncertainty, not a fact about the arrival.
     alignment_unresolved = any(
         not a.runway_id and not a.circling for a in approaches.approaches
     )
-    wind_unresolved = bool(approaches.served_runway_ids) and not plans
+    wind_unresolved = bool(approaches.served_runway_ids) and not graded
     circling_supported = ceiling is None or ceiling >= circling_ceiling
+    soften = circling_supported or alignment_unresolved or wind_unresolved
 
-    if circling_supported or alignment_unresolved or wind_unresolved:
+    # Two different failures land here and they are NOT the same story. If an
+    # end the wind is happy with exists and is blocked only by its own
+    # approach's minima, there is no misalignment at all — saying "wind favours
+    # 20, approaches serve 02, 20 — plan for circling" would name the served,
+    # wind-favoured runway as if it were unserved. This is rule 2 applied per
+    # approach rather than airport-wide: the forecast is below the best case for
+    # *that* end's approach, even though a lower-minima approach exists on an
+    # end the wind has ruled out.
+    minima_blocked = [
+        g for g in graded
+        if g.wind != AdvisoryStatus.RED and g.minima == AdvisoryStatus.RED
+    ]
+    if minima_blocked:
+        closest = min(minima_blocked, key=lambda g: g.plan.proxy.dh_lo)
+        key = (
+            "approach_feasibility.minima_circling" if circling_supported
+            else "approach_feasibility.minima_blocked"
+        )
+        return (
+            AdvisoryStatus.AMBER if soften else AdvisoryStatus.RED,
+            adv_t(
+                key, loc,
+                runway=closest.plan.wind.runway_id,
+                approach=_approach_label(closest.plan.approach),
+                dh=int(closest.plan.proxy.dh_lo),
+            ),
+        )
+
+    # Every approach-served end is out on wind (or there is nothing straight-in
+    # to grade) — the genuine misalignment case.
+    wind_best = cond.best_runway.runway_id if cond.best_runway else None
+    served = ", ".join(sorted(approaches.served_runway_ids)) or "-"
+
+    if soften:
         return AdvisoryStatus.AMBER, adv_t(
             "approach_feasibility.circling", loc,
             served=served, wind_runway=wind_best or "-",

--- a/src/weatherbrief/analysis/advisories/approach_feasibility.py
+++ b/src/weatherbrief/analysis/advisories/approach_feasibility.py
@@ -45,6 +45,7 @@ beside it. Advisories run at pipeline step 3 and METAR/TAF are fetched at step
 from __future__ import annotations
 
 from dataclasses import dataclass
+from enum import Enum
 
 from weatherbrief.analysis.advisories import RouteContext
 from weatherbrief.analysis.advisories.registry import register
@@ -85,6 +86,30 @@ class _EndPlan:
     def tailwind_kt(self) -> float:
         """Positive when the wind pushes from behind on this end."""
         return -self.wind.headwind_kt
+
+
+class _Softening(str, Enum):
+    """Why (or whether) a no-usable-straight-in verdict softens off RED.
+
+    The value doubles as the message-key suffix, so the grade and the copy
+    cannot be chosen from different tests — the bug this enum replaces.
+    """
+
+    #: The ceiling supports circling — a real option, so say "plan for circling".
+    CIRCLING = "circling"
+    #: We could not resolve an approach's alignment, or the wind model did not
+    #: cover a served end. Genuine uncertainty (design rule 2), so it softens —
+    #: but the copy must name THAT reason, never borrow the circling advice.
+    UNCERTAIN = "uncertain"
+    #: Nothing softens it.
+    NONE = "blocked"
+
+    @property
+    def status(self) -> AdvisoryStatus:
+        return (
+            AdvisoryStatus.RED if self is _Softening.NONE
+            else AdvisoryStatus.AMBER
+        )
 
 
 @dataclass(frozen=True)
@@ -291,7 +316,19 @@ def _grade_full(
     )
     wind_unresolved = bool(approaches.served_runway_ids) and not graded
     circling_supported = ceiling is None or ceiling >= circling_ceiling
-    soften = circling_supported or alignment_unresolved or wind_unresolved
+    # ONE discriminator drives both the grade and the copy. They were split
+    # before — status off `circling_supported or <uncertainty>`, copy off
+    # `circling_supported` alone — which let an unrelated unresolved approach
+    # soften the grade to AMBER while the text still made the hard claim, and
+    # (worse) let the misalignment branch advise "plan for circling" at a
+    # ceiling that will not support it. Softening for uncertainty is correct,
+    # but it has to say so in its own words rather than borrow the circling copy.
+    if circling_supported:
+        softening = _Softening.CIRCLING
+    elif alignment_unresolved or wind_unresolved:
+        softening = _Softening.UNCERTAIN
+    else:
+        softening = _Softening.NONE
 
     # Two different failures land here and they are NOT the same story. If an
     # end the wind is happy with exists and is blocked only by its own
@@ -307,18 +344,11 @@ def _grade_full(
     ]
     if minima_blocked:
         closest = min(minima_blocked, key=lambda g: g.plan.proxy.dh_lo)
-        key = (
-            "approach_feasibility.minima_circling" if circling_supported
-            else "approach_feasibility.minima_blocked"
-        )
-        return (
-            AdvisoryStatus.AMBER if soften else AdvisoryStatus.RED,
-            adv_t(
-                key, loc,
-                runway=closest.plan.wind.runway_id,
-                approach=_approach_label(closest.plan.approach),
-                dh=int(closest.plan.proxy.dh_lo),
-            ),
+        return softening.status, adv_t(
+            f"approach_feasibility.minima_{softening.value}", loc,
+            runway=closest.plan.wind.runway_id,
+            approach=_approach_label(closest.plan.approach),
+            dh=int(closest.plan.proxy.dh_lo),
         )
 
     # Every approach-served end is out on wind (or there is nothing straight-in
@@ -326,14 +356,8 @@ def _grade_full(
     wind_best = cond.best_runway.runway_id if cond.best_runway else None
     served = ", ".join(sorted(approaches.served_runway_ids)) or "-"
 
-    if soften:
-        return AdvisoryStatus.AMBER, adv_t(
-            "approach_feasibility.circling", loc,
-            served=served, wind_runway=wind_best or "-",
-        )
-
-    return AdvisoryStatus.RED, adv_t(
-        "approach_feasibility.misaligned", loc,
+    return softening.status, adv_t(
+        f"approach_feasibility.misaligned_{softening.value}", loc,
         served=served, wind_runway=wind_best or "-",
         ceiling=int(ceiling) if ceiling is not None else 0,
     )

--- a/src/weatherbrief/analysis/advisories/approach_feasibility.py
+++ b/src/weatherbrief/analysis/advisories/approach_feasibility.py
@@ -1,0 +1,432 @@
+"""Approach feasibility advisory evaluator (issue #509).
+
+Answers the arrival question nothing else in the briefing does: **can I get in,
+on a runway I can also land on?**
+
+``flight_category`` grades the destination's ceiling/visibility, ``airport_wind``
+grades the wind, and ``enrich_wind`` picks the wind-best runway with no approach
+awareness at all — so the briefing can say *"destination IFR, ceiling 600 ft,
+best runway 24"* at a field where 24 has no approach and the ILS serves 06. This
+evaluator owns that intersection: ceiling **and** wind **and** infrastructure.
+
+Design rules that make this correct rather than merely plausible (all from #509):
+
+1. **One minima table.** Decision heights come from
+   ``analysis.alternate_requirement.APPROACH_CLASS_PROXY`` via
+   ``proxy_for_approach`` — the same estimates the alternate-requirement card
+   shows. A second table would drift.
+2. **Asymmetric uncertainty.** Those DHs are *estimates*. Estimate uncertainty
+   may push toward AMBER, never toward RED: RED needs a hard fact (no IAP at
+   all) or a ceiling below even the **best-case** DH.
+3. **Flag circling, don't grade it.** ``nav.db`` carries no circling minima and
+   no "circling not authorised" flag, so a circling-only approach is surfaced as
+   a compromise (AMBER), never given a computed circling verdict.
+4. **Alignment is brittle.** Wind direction spreads across models at range and
+   alignment is discrete, so the grade is computed per model and the registry's
+   majority aggregation absorbs the disagreement. Near the wind boundary the
+   verdict degrades to AMBER rather than flipping GREEN <-> RED.
+
+The destination's flight category selects which logic applies — the alignment /
+circling / tailwind reasoning only earns its keep once the pilot can no longer be
+expected to complete the arrival visually:
+
+* **VFR** -> GREEN, always. Approach infrastructure is irrelevant.
+* **MVFR** -> IAP presence only, capped at AMBER (any approach -> GREEN, none ->
+  AMBER). Never RED.
+* **IFR / LIFR** -> the full logic below.
+
+Known gap (deliberate, #509 design constraint 4): at D-0 this should prefer the
+TAF over the NWP consensus so the card cannot contradict the alternates card
+beside it. Advisories run at pipeline step 3 and METAR/TAF are fetched at step
+3.5, so ``RouteContext`` has no observation to read; the NWP consensus in
+``airport_conditions.arrival`` is what is graded today.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from weatherbrief.analysis.advisories import RouteContext
+from weatherbrief.analysis.advisories.registry import register
+from weatherbrief.analysis.advisories.strings import adv_t
+from weatherbrief.analysis.alternate_requirement import ApproachProxy, proxy_for_approach
+from weatherbrief.models import (
+    AdvisoryCatalogEntry,
+    AdvisoryParameterDef,
+    AdvisoryStatus,
+    ModelAdvisoryResult,
+    RouteAdvisoryResult,
+)
+from weatherbrief.models.airport_conditions import (
+    AirportApproaches,
+    AirportModelCondition,
+    FlightCategory,
+    RunwayApproach,
+    RunwayWind,
+)
+
+ADVISORY_ID = "approach_feasibility"
+
+# Categories at which the alignment / circling / tailwind logic applies. Above
+# these the pilot completes the landing visually, so a misaligned or
+# circling-only approach is not a penalty.
+_FULL_LOGIC_CATEGORIES = (FlightCategory.IFR, FlightCategory.LIFR)
+
+
+@dataclass(frozen=True)
+class _EndPlan:
+    """One candidate arrival: a straight-in approach paired with its wind."""
+
+    approach: RunwayApproach
+    wind: RunwayWind
+    proxy: ApproachProxy | None
+
+    @property
+    def tailwind_kt(self) -> float:
+        """Positive when the wind pushes from behind on this end."""
+        return -self.wind.headwind_kt
+
+
+def _best_case_minima(
+    approaches: list[RunwayApproach],
+) -> tuple[float, float] | None:
+    """Lowest plausible (decision height ft, visibility m) across the approaches.
+
+    The *best case* deliberately: a forecast below this is below every plate the
+    field could hold, which is the only ceiling/visibility fact hard enough to
+    justify RED (design rule 2). Returns ``None`` when no approach has a proxy.
+    """
+    proxies = [
+        p for p in (
+            proxy_for_approach(a.approach_type, has_iap=True) for a in approaches
+        ) if p is not None
+    ]
+    if not proxies:
+        return None
+    return min(p.dh_lo for p in proxies), min(p.vis_lo for p in proxies)
+
+
+def _wind_for_end(cond: AirportModelCondition, runway_id: str) -> RunwayWind | None:
+    """The model's wind components on one runway end, if it computed them."""
+    key = runway_id.strip().upper()
+    return next((r for r in cond.all_runways if r.runway_id.strip().upper() == key), None)
+
+
+def _straight_in_plans(
+    cond: AirportModelCondition, approaches: AirportApproaches,
+) -> list[_EndPlan]:
+    """Every straight-in approach whose served end also has wind components.
+
+    An approach whose end the wind model does not cover is dropped rather than
+    assumed benign — it simply cannot be graded, and the remaining plans (or the
+    absence of any) carry the verdict.
+    """
+    plans: list[_EndPlan] = []
+    for approach in approaches.approaches:
+        if not approach.runway_id:
+            continue
+        wind = _wind_for_end(cond, approach.runway_id)
+        if wind is None:
+            continue
+        plans.append(_EndPlan(
+            approach=approach,
+            wind=wind,
+            proxy=proxy_for_approach(approach.approach_type, has_iap=True),
+        ))
+    return plans
+
+
+def _plan_wind_status(
+    plan: _EndPlan, tailwind_limit_kt: float, crosswind_limit_kt: float,
+) -> AdvisoryStatus:
+    """Grade the wind on one straight-in candidate.
+
+    GREEN needs components genuinely within limits — no tailwind at all and a
+    crosswind inside the limit. A tailwind that is still within the limit is a
+    compromise (AMBER); beyond it the end is not usable straight-in, which is
+    the only wind outcome that can feed the RED path.
+    """
+    tail = plan.tailwind_kt
+    if tail > tailwind_limit_kt:
+        return AdvisoryStatus.RED
+    if tail > 0 or plan.wind.crosswind_kt > crosswind_limit_kt:
+        return AdvisoryStatus.AMBER
+    return AdvisoryStatus.GREEN
+
+
+def _band_status(value: float | None, lo: float, hi: float) -> AdvisoryStatus:
+    """Grade a forecast value against an estimated-minima band ``[lo, hi]``.
+
+    Clear of the band (``>= hi``, the worst-case plate) -> GREEN; inside it ->
+    AMBER, because the plate decides and we do not have it; below even the best
+    case -> RED. This is where design rule 2 lives: the AMBER middle is exactly
+    the width of our uncertainty about the published minima.
+    """
+    if value is None:
+        return AdvisoryStatus.GREEN
+    if value < lo:
+        return AdvisoryStatus.RED
+    if value < hi:
+        return AdvisoryStatus.AMBER
+    return AdvisoryStatus.GREEN
+
+
+def _minima_status(
+    cond: AirportModelCondition, proxy: ApproachProxy | None,
+) -> AdvisoryStatus:
+    """Grade ceiling AND visibility against one approach's estimated minima.
+
+    A ceiling of ``None`` means the model found no BKN/OVC layer, which clears
+    everything. A visibility of ``None`` means the model does not publish one
+    (ECMWF visibility is GRIB-only) — the axis is skipped rather than flagged,
+    matching ``flight_category``, which also does not read an absent visibility
+    as a poor one.
+    """
+    if proxy is None:
+        return AdvisoryStatus.AMBER
+    return AdvisoryStatus.worst([
+        _band_status(cond.ceiling_ft, proxy.dh_lo, proxy.dh_hi),
+        _band_status(cond.visibility_m, proxy.vis_lo, proxy.vis_hi),
+    ])
+
+
+def _rank(status: AdvisoryStatus) -> int:
+    """Order statuses best-first so the most usable arrival plan wins."""
+    return {
+        AdvisoryStatus.GREEN: 0,
+        AdvisoryStatus.AMBER: 1,
+        AdvisoryStatus.UNAVAILABLE: 2,
+        AdvisoryStatus.RED: 3,
+    }[status]
+
+
+def _grade_full(
+    cond: AirportModelCondition,
+    approaches: AirportApproaches,
+    params: dict[str, float],
+    loc: str | None,
+) -> tuple[AdvisoryStatus, str]:
+    """IFR/LIFR logic: alignment, circling and tailwind all apply."""
+    tailwind_limit = float(params.get("tailwind_limit_kt", 10))
+    crosswind_limit = float(params.get("crosswind_limit_kt", 20))
+    circling_ceiling = float(params.get("circling_ceiling_ft", 1000))
+
+    if not approaches.has_iap:
+        key = (
+            "approach_feasibility.no_iap" if approaches.has_procedure_data
+            else "approach_feasibility.no_procedure_data"
+        )
+        return AdvisoryStatus.RED, adv_t(key, loc, icao=approaches.icao)
+
+    ceiling = cond.ceiling_ft
+
+    # Hard forecast fact — below every plate the field could hold. Checked before
+    # the wind so a genuinely un-shootable approach reads as such regardless of
+    # which runway the wind favours.
+    best_case = _best_case_minima(approaches.approaches)
+    if best_case is not None:
+        best_dh, best_vis = best_case
+        if ceiling is not None and ceiling < best_dh:
+            return AdvisoryStatus.RED, adv_t(
+                "approach_feasibility.below_minima", loc,
+                ceiling=int(ceiling), dh=int(best_dh),
+            )
+        if cond.visibility_m is not None and cond.visibility_m < best_vis:
+            return AdvisoryStatus.RED, adv_t(
+                "approach_feasibility.below_vis_minima", loc,
+                vis=int(cond.visibility_m), min_vis=int(best_vis),
+            )
+
+    # Straight-in candidates, best arrival first.
+    plans = _straight_in_plans(cond, approaches)
+    graded = sorted(
+        (
+            (
+                AdvisoryStatus.worst([
+                    _plan_wind_status(p, tailwind_limit, crosswind_limit),
+                    _minima_status(cond, p.proxy),
+                ]),
+                p,
+            )
+            for p in plans
+        ),
+        key=lambda pair: (_rank(pair[0]), pair[1].tailwind_kt, pair[1].wind.crosswind_kt),
+    )
+
+    best = graded[0] if graded else None
+    if best is not None and best[0] != AdvisoryStatus.RED:
+        status, plan = best
+        return status, adv_t(
+            "approach_feasibility.straight_in", loc,
+            approach=_approach_label(plan.approach),
+            runway=plan.wind.runway_id,
+            wind=_wind_note(plan, loc),
+        )
+
+    # No usable straight-in: either every aligned end is out on wind, or the
+    # only approaches are circling-only / of unresolved alignment. Ceiling
+    # decides whether circling is even on the table — but we never compute a
+    # circling verdict (design rule 3), only whether to soften to AMBER.
+    wind_best = cond.best_runway.runway_id if cond.best_runway else None
+    served = ", ".join(sorted(approaches.served_runway_ids)) or "-"
+
+    # Neither an approach we could not align, nor a straight-in end the wind
+    # model did not cover, may drive RED (design rule 2) — both are our
+    # uncertainty, not a fact about the arrival.
+    alignment_unresolved = any(
+        not a.runway_id and not a.circling for a in approaches.approaches
+    )
+    wind_unresolved = bool(approaches.served_runway_ids) and not plans
+    circling_supported = ceiling is None or ceiling >= circling_ceiling
+
+    if circling_supported or alignment_unresolved or wind_unresolved:
+        return AdvisoryStatus.AMBER, adv_t(
+            "approach_feasibility.circling", loc,
+            served=served, wind_runway=wind_best or "-",
+        )
+
+    return AdvisoryStatus.RED, adv_t(
+        "approach_feasibility.misaligned", loc,
+        served=served, wind_runway=wind_best or "-",
+        ceiling=int(ceiling) if ceiling is not None else 0,
+    )
+
+
+def _approach_label(approach: RunwayApproach) -> str:
+    """Short label for one approach: its class, falling back to its name."""
+    return approach.approach_type or approach.name or "IAP"
+
+
+def _wind_note(plan: _EndPlan, loc: str | None) -> str:
+    """Human phrasing of the wind on the chosen end."""
+    tail = plan.tailwind_kt
+    if tail > 0:
+        return adv_t("approach_feasibility.tailwind", loc, kt=round(tail))
+    return adv_t("approach_feasibility.headwind", loc, kt=round(-tail))
+
+
+def _grade_mvfr(
+    approaches: AirportApproaches, loc: str | None,
+) -> tuple[AdvisoryStatus, str]:
+    """MVFR: IAP presence only, capped at AMBER. Never RED."""
+    if approaches.has_iap:
+        return AdvisoryStatus.GREEN, adv_t(
+            "approach_feasibility.mvfr_ok", loc, count=len(approaches.approaches),
+        )
+    return AdvisoryStatus.AMBER, adv_t("approach_feasibility.mvfr_no_iap", loc)
+
+
+@register
+class ApproachFeasibilityEvaluator:
+    """Is the instrument approach aligned with the runway the wind favours?"""
+
+    @staticmethod
+    def catalog_entry() -> AdvisoryCatalogEntry:
+        return AdvisoryCatalogEntry(
+            id=ADVISORY_ID,
+            name="Approach Feasibility",
+            short_description="Can you get in, on a runway you can also land on?",
+            description=(
+                "Joins three facts the briefing otherwise reports separately at "
+                "the destination: the ceiling, the runway the wind favours, and "
+                "which runways actually have a published instrument approach. "
+                "A VFR destination is always green — it is visually reachable. "
+                "At MVFR only the presence of an approach is checked (no "
+                "approach at all is amber; alignment is not a penalty when the "
+                "landing can be completed visually). At IFR/LIFR the full logic "
+                "applies: green for a straight-in approach to a runway whose "
+                "wind components are within limits and a ceiling clear of the "
+                "estimated minima; amber for a compromise (circling required, "
+                "ceiling inside the estimated minima band, or a tailwind still "
+                "within limits); red only for a hard fact — no approach at all, "
+                "a ceiling below even the best-case decision height, or an "
+                "approach-served runway with an out-of-limits tailwind and no "
+                "ceiling for circling. Decision heights are estimates shared "
+                "with the alternate-requirement card, so uncertainty can only "
+                "soften a grade, never harden it."
+            ),
+            category="flight_rules",
+            timing_class="cheap",
+            # Deliberately NOT timing_hint: the ceiling half of this advisory is
+            # the same destination burn-off case ``flight_category`` already
+            # hints on, and the wind half follows ``airport_wind``, which does
+            # not hint either. A second hint on one phenomenon adds no lever.
+            parameters=[
+                AdvisoryParameterDef(
+                    key="tailwind_limit_kt",
+                    label="Tailwind limit",
+                    description=(
+                        "Tailwind on an approach-served runway above this is "
+                        "treated as not usable straight-in"
+                    ),
+                    type="speed", unit="kt",
+                    default=10, min=0, max=20, step=1,
+                    audience="pilot",
+                ),
+                AdvisoryParameterDef(
+                    key="crosswind_limit_kt",
+                    label="Crosswind limit",
+                    description=(
+                        "Crosswind on an approach-served runway above this is a "
+                        "compromise (amber). Crosswind severity itself is graded "
+                        "by the Airport Wind advisory"
+                    ),
+                    type="speed", unit="kt",
+                    default=20, min=5, max=40, step=5,
+                    audience="pilot",
+                ),
+                AdvisoryParameterDef(
+                    key="circling_ceiling_ft",
+                    label="Circling ceiling",
+                    description=(
+                        "Assumed ceiling needed to circle. Below this a "
+                        "misaligned approach can no longer be salvaged visually"
+                    ),
+                    type="altitude", unit="ft",
+                    default=1000, min=500, max=2500, step=100,
+                ),
+            ],
+        )
+
+    @staticmethod
+    def evaluate(ctx: RouteContext, params: dict[str, float]) -> RouteAdvisoryResult:
+        loc = ctx.locale
+
+        # The collection step could not run (old pack / no nav.db). Absent data
+        # is not a clear approach — say so, per the route_fronts/sun precedent.
+        if ctx.arrival_approaches is None or ctx.airport_conditions is None:
+            return RouteAdvisoryResult.from_per_model(ADVISORY_ID, [], params)
+
+        approaches = ctx.arrival_approaches
+        arr = ctx.airport_conditions.arrival
+
+        per_model: list[ModelAdvisoryResult] = []
+        for model in ctx.models:
+            cond = arr.condition_for_model(model)
+            if cond is None:
+                per_model.append(ModelAdvisoryResult.build(
+                    model=model, status=AdvisoryStatus.UNAVAILABLE,
+                    detail=adv_t("no_data", loc), affected=0, total=0,
+                    total_distance_nm=ctx.total_distance_nm,
+                ))
+                continue
+
+            if cond.flight_category == FlightCategory.VFR:
+                status, detail = AdvisoryStatus.GREEN, adv_t(
+                    "approach_feasibility.vfr", loc,
+                )
+            elif cond.flight_category in _FULL_LOGIC_CATEGORIES:
+                status, detail = _grade_full(cond, approaches, params, loc)
+            else:
+                status, detail = _grade_mvfr(approaches, loc)
+
+            label = adv_t("airport.arr", loc)
+            per_model.append(ModelAdvisoryResult.build(
+                model=model, status=status,
+                detail=f"{label} {arr.icao}: {cond.flight_category.value} — {detail}",
+                affected=1 if status != AdvisoryStatus.GREEN else 0,
+                total=1,
+                total_distance_nm=ctx.total_distance_nm,
+            ))
+
+        return RouteAdvisoryResult.from_per_model(ADVISORY_ID, per_model, params)

--- a/src/weatherbrief/analysis/advisories/approach_feasibility.py
+++ b/src/weatherbrief/analysis/advisories/approach_feasibility.py
@@ -79,7 +79,7 @@ class _EndPlan:
 
     approach: RunwayApproach
     wind: RunwayWind
-    proxy: ApproachProxy | None
+    proxy: ApproachProxy
 
     @property
     def tailwind_kt(self) -> float:
@@ -87,22 +87,27 @@ class _EndPlan:
         return -self.wind.headwind_kt
 
 
-def _best_case_minima(
-    approaches: list[RunwayApproach],
-) -> tuple[float, float] | None:
+def _proxy(approach: RunwayApproach) -> ApproachProxy:
+    """Estimated minima for one approach — never ``None`` for a present IAP.
+
+    ``proxy_for_approach`` only returns ``None`` for ``has_iap=False``, and the
+    caller has already established that this approach exists; an unknown or
+    unmapped ``approach_type`` degrades to the most-demanding non-precision
+    range rather than to nothing.
+    """
+    proxy = proxy_for_approach(approach.approach_type, has_iap=True)
+    assert proxy is not None  # noqa: S101 - narrows the type; see docstring
+    return proxy
+
+
+def _best_case_minima(approaches: list[RunwayApproach]) -> tuple[float, float]:
     """Lowest plausible (decision height ft, visibility m) across the approaches.
 
     The *best case* deliberately: a forecast below this is below every plate the
     field could hold, which is the only ceiling/visibility fact hard enough to
-    justify RED (design rule 2). Returns ``None`` when no approach has a proxy.
+    justify RED (design rule 2). Callers must pass a non-empty list.
     """
-    proxies = [
-        p for p in (
-            proxy_for_approach(a.approach_type, has_iap=True) for a in approaches
-        ) if p is not None
-    ]
-    if not proxies:
-        return None
+    proxies = [_proxy(a) for a in approaches]
     return min(p.dh_lo for p in proxies), min(p.vis_lo for p in proxies)
 
 
@@ -131,7 +136,7 @@ def _straight_in_plans(
         plans.append(_EndPlan(
             approach=approach,
             wind=wind,
-            proxy=proxy_for_approach(approach.approach_type, has_iap=True),
+            proxy=_proxy(approach),
         ))
     return plans
 
@@ -172,7 +177,7 @@ def _band_status(value: float | None, lo: float, hi: float) -> AdvisoryStatus:
 
 
 def _minima_status(
-    cond: AirportModelCondition, proxy: ApproachProxy | None,
+    cond: AirportModelCondition, proxy: ApproachProxy,
 ) -> AdvisoryStatus:
     """Grade ceiling AND visibility against one approach's estimated minima.
 
@@ -182,8 +187,6 @@ def _minima_status(
     matching ``flight_category``, which also does not read an absent visibility
     as a poor one.
     """
-    if proxy is None:
-        return AdvisoryStatus.AMBER
     return AdvisoryStatus.worst([
         _band_status(cond.ceiling_ft, proxy.dh_lo, proxy.dh_hi),
         _band_status(cond.visibility_m, proxy.vis_lo, proxy.vis_hi),
@@ -223,19 +226,17 @@ def _grade_full(
     # Hard forecast fact — below every plate the field could hold. Checked before
     # the wind so a genuinely un-shootable approach reads as such regardless of
     # which runway the wind favours.
-    best_case = _best_case_minima(approaches.approaches)
-    if best_case is not None:
-        best_dh, best_vis = best_case
-        if ceiling is not None and ceiling < best_dh:
-            return AdvisoryStatus.RED, adv_t(
-                "approach_feasibility.below_minima", loc,
-                ceiling=int(ceiling), dh=int(best_dh),
-            )
-        if cond.visibility_m is not None and cond.visibility_m < best_vis:
-            return AdvisoryStatus.RED, adv_t(
-                "approach_feasibility.below_vis_minima", loc,
-                vis=int(cond.visibility_m), min_vis=int(best_vis),
-            )
+    best_dh, best_vis = _best_case_minima(approaches.approaches)
+    if ceiling is not None and ceiling < best_dh:
+        return AdvisoryStatus.RED, adv_t(
+            "approach_feasibility.below_minima", loc,
+            ceiling=int(ceiling), dh=int(best_dh),
+        )
+    if cond.visibility_m is not None and cond.visibility_m < best_vis:
+        return AdvisoryStatus.RED, adv_t(
+            "approach_feasibility.below_vis_minima", loc,
+            vis=int(cond.visibility_m), min_vis=int(best_vis),
+        )
 
     # Straight-in candidates, best arrival first.
     plans = _straight_in_plans(cond, approaches)
@@ -392,9 +393,16 @@ class ApproachFeasibilityEvaluator:
     def evaluate(ctx: RouteContext, params: dict[str, float]) -> RouteAdvisoryResult:
         loc = ctx.locale
 
-        # The collection step could not run (old pack / no nav.db). Absent data
-        # is not a clear approach — say so, per the route_fronts/sun precedent.
-        if ctx.arrival_approaches is None or ctx.airport_conditions is None:
+        # The collection step could not run (old pack / no nav.db), or it ran
+        # and could not determine the approach picture (unknown ICAO, procedure
+        # query raised). Absent data is not a clear approach — and, just as
+        # importantly, it is not a *missing* approach either: grading it would
+        # turn a data gap into the grade map's most severe input.
+        if (
+            ctx.arrival_approaches is None
+            or ctx.arrival_approaches.lookup_failed
+            or ctx.airport_conditions is None
+        ):
             return RouteAdvisoryResult.from_per_model(ADVISORY_ID, [], params)
 
         approaches = ctx.arrival_approaches

--- a/src/weatherbrief/analysis/advisories/registry.py
+++ b/src/weatherbrief/analysis/advisories/registry.py
@@ -52,7 +52,7 @@ _DIAGNOSTICS_CATEGORIES: frozenset[str] = frozenset({"model"})
 # registry, not the client.
 ENTRY_ORDER: dict[str, list[str]] = {
     "airport": ["flight_category", "airport_wind", "density_altitude", "llws"],
-    "flight_rules": ["vfr_feasibility", "ifr_feasibility"],
+    "flight_rules": ["vfr_feasibility", "ifr_feasibility", "approach_feasibility"],
     "wind": ["headwind"],
     "icing": ["icing_escape", "fiki_icing", "freezing_precip"],
     "cloud": ["cloud_top", "vmc_cruise"],

--- a/src/weatherbrief/analysis/advisories/strings.py
+++ b/src/weatherbrief/analysis/advisories/strings.py
@@ -763,6 +763,30 @@ _STRINGS: dict[str, dict[str, str]] = {
         "de": "Wind begünstigt RWY {wind_runway}; Anflüge bedienen {served} — Platzrunde einplanen",
         "es": "El viento favorece la RWY {wind_runway}; las aproximaciones sirven {served} — prever circling",
     },
+    "approach_feasibility.minima_circling": {
+        "en": "RWY {runway} is clear on wind, but the forecast is below typical {approach} minima (~{dh}ft) — plan for circling",
+        "fr": "La RWY {runway} est bonne au vent, mais la prévision est sous les minima {approach} typiques (~{dh}ft) — prévoir une MVL",
+        "de": "RWY {runway} ist windseitig frei, aber die Vorhersage liegt unter typischen {approach}-Minima (~{dh}ft) — Platzrunde einplanen",
+        "es": "La RWY {runway} está bien de viento, pero el pronóstico está por debajo de los mínimos {approach} típicos (~{dh}ft) — prever circling",
+    },
+    "approach_feasibility.minima_blocked": {
+        "en": (
+            "RWY {runway} is clear on wind, but the forecast is below typical "
+            "{approach} minima (~{dh}ft), and the ceiling will not support circling"
+        ),
+        "fr": (
+            "La RWY {runway} est bonne au vent, mais la prévision est sous les minima "
+            "{approach} typiques (~{dh}ft), et le plafond ne permet pas la MVL"
+        ),
+        "de": (
+            "RWY {runway} ist windseitig frei, aber die Vorhersage liegt unter typischen "
+            "{approach}-Minima (~{dh}ft), und die Untergrenze trägt keine Platzrunde"
+        ),
+        "es": (
+            "La RWY {runway} está bien de viento, pero el pronóstico está por debajo de los "
+            "mínimos {approach} típicos (~{dh}ft), y el techo no permite circling"
+        ),
+    },
     "approach_feasibility.misaligned": {
         "en": (
             "Wind favours RWY {wind_runway}; approaches serve {served}, "

--- a/src/weatherbrief/analysis/advisories/strings.py
+++ b/src/weatherbrief/analysis/advisories/strings.py
@@ -757,7 +757,7 @@ _STRINGS: dict[str, dict[str, str]] = {
         "de": "{kt}kt Rückenwind auf dieser Bahn",
         "es": "{kt}kt de viento en cola en esa pista",
     },
-    "approach_feasibility.circling": {
+    "approach_feasibility.misaligned_circling": {
         "en": "Wind favours RWY {wind_runway}; approaches serve {served} — plan for circling",
         "fr": "Le vent favorise la RWY {wind_runway} ; les approches desservent {served} — prévoir une MVL",
         "de": "Wind begünstigt RWY {wind_runway}; Anflüge bedienen {served} — Platzrunde einplanen",
@@ -768,6 +768,46 @@ _STRINGS: dict[str, dict[str, str]] = {
         "fr": "La RWY {runway} est bonne au vent, mais la prévision est sous les minima {approach} typiques (~{dh}ft) — prévoir une MVL",
         "de": "RWY {runway} ist windseitig frei, aber die Vorhersage liegt unter typischen {approach}-Minima (~{dh}ft) — Platzrunde einplanen",
         "es": "La RWY {runway} está bien de viento, pero el pronóstico está por debajo de los mínimos {approach} típicos (~{dh}ft) — prever circling",
+    },
+    "approach_feasibility.minima_uncertain": {
+        "en": (
+            "RWY {runway} is clear on wind, but the forecast is below typical "
+            "{approach} minima (~{dh}ft) — and an approach here could not be "
+            "matched to a runway, so check the plates"
+        ),
+        "fr": (
+            "La RWY {runway} est bonne au vent, mais la prévision est sous les minima "
+            "{approach} typiques (~{dh}ft) — et une approche ici n'a pu être rattachée "
+            "à une piste, vérifier les cartes"
+        ),
+        "de": (
+            "RWY {runway} ist windseitig frei, aber die Vorhersage liegt unter typischen "
+            "{approach}-Minima (~{dh}ft) — und ein Anflug hier konnte keiner Bahn "
+            "zugeordnet werden, Karten prüfen"
+        ),
+        "es": (
+            "La RWY {runway} está bien de viento, pero el pronóstico está por debajo de los "
+            "mínimos {approach} típicos (~{dh}ft) — y una aproximación aquí no pudo "
+            "asociarse a una pista, revisar las cartas"
+        ),
+    },
+    "approach_feasibility.misaligned_uncertain": {
+        "en": (
+            "Wind favours RWY {wind_runway}; approaches serve {served}, and an "
+            "approach here could not be matched to a runway — check the plates"
+        ),
+        "fr": (
+            "Le vent favorise la RWY {wind_runway} ; les approches desservent {served}, "
+            "et une approche ici n'a pu être rattachée à une piste — vérifier les cartes"
+        ),
+        "de": (
+            "Wind begünstigt RWY {wind_runway}; Anflüge bedienen {served}, und ein "
+            "Anflug hier konnte keiner Bahn zugeordnet werden — Karten prüfen"
+        ),
+        "es": (
+            "El viento favorece la RWY {wind_runway}; las aproximaciones sirven {served}, "
+            "y una aproximación aquí no pudo asociarse a una pista — revisar las cartas"
+        ),
     },
     "approach_feasibility.minima_blocked": {
         "en": (
@@ -787,7 +827,7 @@ _STRINGS: dict[str, dict[str, str]] = {
             "mínimos {approach} típicos (~{dh}ft), y el techo no permite circling"
         ),
     },
-    "approach_feasibility.misaligned": {
+    "approach_feasibility.misaligned_blocked": {
         "en": (
             "Wind favours RWY {wind_runway}; approaches serve {served}, "
             "and ceiling {ceiling}ft will not support circling"

--- a/src/weatherbrief/analysis/advisories/strings.py
+++ b/src/weatherbrief/analysis/advisories/strings.py
@@ -757,93 +757,54 @@ _STRINGS: dict[str, dict[str, str]] = {
         "de": "{kt}kt Rückenwind auf dieser Bahn",
         "es": "{kt}kt de viento en cola en esa pista",
     },
-    "approach_feasibility.misaligned_circling": {
-        "en": "Wind favours RWY {wind_runway}; approaches serve {served} — plan for circling",
-        "fr": "Le vent favorise la RWY {wind_runway} ; les approches desservent {served} — prévoir une MVL",
-        "de": "Wind begünstigt RWY {wind_runway}; Anflüge bedienen {served} — Platzrunde einplanen",
-        "es": "El viento favorece la RWY {wind_runway}; las aproximaciones sirven {served} — prever circling",
+    # The no-usable-straight-in verdict is a CROSS PRODUCT — what blocks the
+    # arrival ("blocked_*") x why it is not RED ("soften_*") — composed as
+    # "{cause} — {clause}" by ``_fallback_detail``. Three review rounds on #511
+    # each found a different cell of it rendering the wrong sentence while the
+    # cells were written out by hand; composing them means a new blocker or a
+    # new softening reason costs ONE string, not a whole row or column, and no
+    # cell can silently borrow another's wording.
+    "approach_feasibility.blocked_minima": {
+        "en": "RWY {runway} is clear on wind, but the forecast is below typical {approach} minima (~{dh}ft)",
+        "fr": "La RWY {runway} est bonne au vent, mais la prévision est sous les minima {approach} typiques (~{dh}ft)",
+        "de": "RWY {runway} ist windseitig frei, aber die Vorhersage liegt unter typischen {approach}-Minima (~{dh}ft)",
+        "es": "La RWY {runway} está bien de viento, pero el pronóstico está por debajo de los mínimos {approach} típicos (~{dh}ft)",
     },
-    "approach_feasibility.minima_circling": {
-        "en": "RWY {runway} is clear on wind, but the forecast is below typical {approach} minima (~{dh}ft) — plan for circling",
-        "fr": "La RWY {runway} est bonne au vent, mais la prévision est sous les minima {approach} typiques (~{dh}ft) — prévoir une MVL",
-        "de": "RWY {runway} ist windseitig frei, aber die Vorhersage liegt unter typischen {approach}-Minima (~{dh}ft) — Platzrunde einplanen",
-        "es": "La RWY {runway} está bien de viento, pero el pronóstico está por debajo de los mínimos {approach} típicos (~{dh}ft) — prever circling",
+    "approach_feasibility.blocked_misaligned": {
+        "en": "Wind favours RWY {wind_runway}; approaches serve {served}",
+        "fr": "Le vent favorise la RWY {wind_runway} ; les approches desservent {served}",
+        "de": "Wind begünstigt RWY {wind_runway}; Anflüge bedienen {served}",
+        "es": "El viento favorece la RWY {wind_runway}; las aproximaciones sirven {served}",
     },
-    "approach_feasibility.minima_uncertain": {
-        "en": (
-            "RWY {runway} is clear on wind, but the forecast is below typical "
-            "{approach} minima (~{dh}ft) — and an approach here could not be "
-            "matched to a runway, so check the plates"
-        ),
-        "fr": (
-            "La RWY {runway} est bonne au vent, mais la prévision est sous les minima "
-            "{approach} typiques (~{dh}ft) — et une approche ici n'a pu être rattachée "
-            "à une piste, vérifier les cartes"
-        ),
-        "de": (
-            "RWY {runway} ist windseitig frei, aber die Vorhersage liegt unter typischen "
-            "{approach}-Minima (~{dh}ft) — und ein Anflug hier konnte keiner Bahn "
-            "zugeordnet werden, Karten prüfen"
-        ),
-        "es": (
-            "La RWY {runway} está bien de viento, pero el pronóstico está por debajo de los "
-            "mínimos {approach} típicos (~{dh}ft) — y una aproximación aquí no pudo "
-            "asociarse a una pista, revisar las cartas"
-        ),
+    "approach_feasibility.blocked_no_straight_in": {
+        "en": "No straight-in approach is published here; wind favours RWY {wind_runway}",
+        "fr": "Aucune approche directe publiée ici ; le vent favorise la RWY {wind_runway}",
+        "de": "Kein Geradeausanflug hier veröffentlicht; Wind begünstigt RWY {wind_runway}",
+        "es": "No hay aproximación directa publicada aquí; el viento favorece la RWY {wind_runway}",
     },
-    "approach_feasibility.misaligned_uncertain": {
-        "en": (
-            "Wind favours RWY {wind_runway}; approaches serve {served}, and an "
-            "approach here could not be matched to a runway — check the plates"
-        ),
-        "fr": (
-            "Le vent favorise la RWY {wind_runway} ; les approches desservent {served}, "
-            "et une approche ici n'a pu être rattachée à une piste — vérifier les cartes"
-        ),
-        "de": (
-            "Wind begünstigt RWY {wind_runway}; Anflüge bedienen {served}, und ein "
-            "Anflug hier konnte keiner Bahn zugeordnet werden — Karten prüfen"
-        ),
-        "es": (
-            "El viento favorece la RWY {wind_runway}; las aproximaciones sirven {served}, "
-            "y una aproximación aquí no pudo asociarse a una pista — revisar las cartas"
-        ),
+    "approach_feasibility.soften_circling": {
+        "en": "plan for circling",
+        "fr": "prévoir une MVL",
+        "de": "Platzrunde einplanen",
+        "es": "prever circling",
     },
-    "approach_feasibility.minima_blocked": {
-        "en": (
-            "RWY {runway} is clear on wind, but the forecast is below typical "
-            "{approach} minima (~{dh}ft), and the ceiling will not support circling"
-        ),
-        "fr": (
-            "La RWY {runway} est bonne au vent, mais la prévision est sous les minima "
-            "{approach} typiques (~{dh}ft), et le plafond ne permet pas la MVL"
-        ),
-        "de": (
-            "RWY {runway} ist windseitig frei, aber die Vorhersage liegt unter typischen "
-            "{approach}-Minima (~{dh}ft), und die Untergrenze trägt keine Platzrunde"
-        ),
-        "es": (
-            "La RWY {runway} está bien de viento, pero el pronóstico está por debajo de los "
-            "mínimos {approach} típicos (~{dh}ft), y el techo no permite circling"
-        ),
+    "approach_feasibility.soften_unresolved": {
+        "en": "an approach here could not be matched to a runway, so check the plates",
+        "fr": "une approche ici n'a pu être rattachée à une piste, vérifier les cartes",
+        "de": "ein Anflug hier konnte keiner Bahn zugeordnet werden, Karten prüfen",
+        "es": "una aproximación aquí no pudo asociarse a una pista, revisar las cartas",
     },
-    "approach_feasibility.misaligned_blocked": {
-        "en": (
-            "Wind favours RWY {wind_runway}; approaches serve {served}, "
-            "and ceiling {ceiling}ft will not support circling"
-        ),
-        "fr": (
-            "Le vent favorise la RWY {wind_runway} ; les approches desservent {served}, "
-            "et le plafond {ceiling}ft ne permet pas la MVL"
-        ),
-        "de": (
-            "Wind begünstigt RWY {wind_runway}; Anflüge bedienen {served}, "
-            "und Untergrenze {ceiling}ft trägt keine Platzrunde"
-        ),
-        "es": (
-            "El viento favorece la RWY {wind_runway}; las aproximaciones sirven {served}, "
-            "y el techo {ceiling}ft no permite circling"
-        ),
+    "approach_feasibility.soften_no_wind_data": {
+        "en": "no wind components for the approach-served runway, so this could not be checked",
+        "fr": "pas de composantes de vent pour la piste desservie, vérification impossible",
+        "de": "keine Windkomponenten für die angeflogene Bahn, nicht prüfbar",
+        "es": "sin componentes de viento para la pista servida, no se pudo comprobar",
+    },
+    "approach_feasibility.soften_none": {
+        "en": "conditions will not support circling",
+        "fr": "les conditions ne permettent pas la MVL",
+        "de": "die Bedingungen tragen keine Platzrunde",
+        "es": "las condiciones no permiten circling",
     },
 
     # --- shared airport labels ---

--- a/src/weatherbrief/analysis/advisories/strings.py
+++ b/src/weatherbrief/analysis/advisories/strings.py
@@ -692,6 +692,96 @@ _STRINGS: dict[str, dict[str, str]] = {
         "es": "Vientos débiles en altura — impacto insignificante",
     },
 
+    # --- approach_feasibility (#509) ---
+    # Phrasing stays in the "directs attention" register — it names the
+    # geometry ("wind favours 24, the ILS serves 06") and never issues a
+    # usability verdict. Runway designators and approach classes are aviation
+    # abbreviations and stay untranslated.
+    "approach_feasibility.vfr": {
+        "en": "VFR — reachable visually, approach not a factor",
+        "fr": "VFR — accessible à vue, l'approche n'est pas un facteur",
+        "de": "VFR — visuell erreichbar, Anflug nicht entscheidend",
+        "es": "VFR — alcanzable visualmente, la aproximación no es un factor",
+    },
+    "approach_feasibility.mvfr_ok": {
+        "en": "{count} published approach(es) — landing can still be completed visually",
+        "fr": "{count} approche(s) publiée(s) — l'atterrissage reste réalisable à vue",
+        "de": "{count} veröffentlichte Anflüge — Landung noch visuell möglich",
+        "es": "{count} aproximación(es) publicada(s) — el aterrizaje aún puede completarse visualmente",
+    },
+    "approach_feasibility.mvfr_no_iap": {
+        "en": "No published instrument approach — arrival depends on staying visual",
+        "fr": "Aucune approche aux instruments publiée — l'arrivée dépend du maintien du vol à vue",
+        "de": "Kein veröffentlichter Instrumentenanflug — Ankunft hängt vom Sichtflug ab",
+        "es": "Sin aproximación instrumental publicada — la llegada depende de mantener el vuelo visual",
+    },
+    "approach_feasibility.no_iap": {
+        "en": "No published instrument approach at {icao}",
+        "fr": "Aucune approche aux instruments publiée à {icao}",
+        "de": "Kein veröffentlichter Instrumentenanflug in {icao}",
+        "es": "Sin aproximación instrumental publicada en {icao}",
+    },
+    "approach_feasibility.no_procedure_data": {
+        "en": "No approach procedure data for {icao}",
+        "fr": "Aucune donnée de procédure d'approche pour {icao}",
+        "de": "Keine Anflugverfahrensdaten für {icao}",
+        "es": "Sin datos de procedimientos de aproximación para {icao}",
+    },
+    "approach_feasibility.below_minima": {
+        "en": "Ceiling {ceiling}ft is below the best-case decision height (~{dh}ft) for any approach here",
+        "fr": "Plafond {ceiling}ft sous la hauteur de décision la plus favorable (~{dh}ft) de toute approche ici",
+        "de": "Untergrenze {ceiling}ft unter der günstigsten Entscheidungshöhe (~{dh}ft) jedes Anflugs hier",
+        "es": "Techo {ceiling}ft por debajo de la altura de decisión más favorable (~{dh}ft) de cualquier aproximación aquí",
+    },
+    "approach_feasibility.below_vis_minima": {
+        "en": "Visibility {vis}m is below the best-case minimum (~{min_vis}m) for any approach here",
+        "fr": "Visibilité {vis}m sous le minimum le plus favorable (~{min_vis}m) de toute approche ici",
+        "de": "Sicht {vis}m unter dem günstigsten Minimum (~{min_vis}m) jedes Anflugs hier",
+        "es": "Visibilidad {vis}m por debajo del mínimo más favorable (~{min_vis}m) de cualquier aproximación aquí",
+    },
+    "approach_feasibility.straight_in": {
+        "en": "{approach} serves RWY {runway} — {wind}",
+        "fr": "{approach} dessert la RWY {runway} — {wind}",
+        "de": "{approach} bedient RWY {runway} — {wind}",
+        "es": "{approach} sirve la RWY {runway} — {wind}",
+    },
+    "approach_feasibility.headwind": {
+        "en": "{kt}kt headwind on that runway",
+        "fr": "{kt}kt de vent de face sur cette piste",
+        "de": "{kt}kt Gegenwind auf dieser Bahn",
+        "es": "{kt}kt de viento en contra en esa pista",
+    },
+    "approach_feasibility.tailwind": {
+        "en": "{kt}kt tailwind on that runway",
+        "fr": "{kt}kt de vent arrière sur cette piste",
+        "de": "{kt}kt Rückenwind auf dieser Bahn",
+        "es": "{kt}kt de viento en cola en esa pista",
+    },
+    "approach_feasibility.circling": {
+        "en": "Wind favours RWY {wind_runway}; approaches serve {served} — plan for circling",
+        "fr": "Le vent favorise la RWY {wind_runway} ; les approches desservent {served} — prévoir une MVL",
+        "de": "Wind begünstigt RWY {wind_runway}; Anflüge bedienen {served} — Platzrunde einplanen",
+        "es": "El viento favorece la RWY {wind_runway}; las aproximaciones sirven {served} — prever circling",
+    },
+    "approach_feasibility.misaligned": {
+        "en": (
+            "Wind favours RWY {wind_runway}; approaches serve {served}, "
+            "and ceiling {ceiling}ft will not support circling"
+        ),
+        "fr": (
+            "Le vent favorise la RWY {wind_runway} ; les approches desservent {served}, "
+            "et le plafond {ceiling}ft ne permet pas la MVL"
+        ),
+        "de": (
+            "Wind begünstigt RWY {wind_runway}; Anflüge bedienen {served}, "
+            "und Untergrenze {ceiling}ft trägt keine Platzrunde"
+        ),
+        "es": (
+            "El viento favorece la RWY {wind_runway}; las aproximaciones sirven {served}, "
+            "y el techo {ceiling}ft no permite circling"
+        ),
+    },
+
     # --- shared airport labels ---
     "airport.dep": {
         "en": "Dep",

--- a/src/weatherbrief/api/packs.py
+++ b/src/weatherbrief/api/packs.py
@@ -3202,6 +3202,8 @@ def compute_alt_advisories(
         user_params=user_params,
         aggregation=aggregation,
         airport_conditions_recompute=recompute_conds,
+        # Destination approach data for approach_feasibility (#509).
+        airports_db_path=db_path,
         icing_method=icing_method,
         cloud_source=cloud_source,
         convective_method=convective_method,
@@ -3471,6 +3473,11 @@ def recalculate_advisories(
         user_params=user_params,
         aggregation=aggregation,
         airport_conditions_recompute=recompute_conds,
+        # Destination approach data for approach_feasibility (#509). The recalc
+        # path has no resolved RouteConfig, so the evaluator's arrival ICAO comes
+        # from the recomputed airport conditions — but the nav.db path still has
+        # to be handed down, or the advisory silently degrades on recalculate.
+        airports_db_path=getattr(request.app.state, "db_path", ""),
         icing_method=icing_method,
         cloud_source=cloud_source,
         convective_method=convective_method,
@@ -3604,6 +3611,10 @@ def preview_advisories(
         user_params=user_params,
         aggregation=aggregation,
         airport_conditions_recompute=recompute_conds,
+        # Destination approach data for approach_feasibility (#509) — the
+        # evaluator degrades to UNAVAILABLE without it, so the preview would
+        # otherwise show a grey card the real briefing grades.
+        airports_db_path=getattr(request.app.state, "db_path", ""),
         icing_method=icing_method,
         cloud_source=cloud_source,
         convective_method=convective_method,

--- a/src/weatherbrief/debriefs/taxonomy.py
+++ b/src/weatherbrief/debriefs/taxonomy.py
@@ -102,6 +102,10 @@ ADVISORY_TAG_MAP: dict[str, ConditionTag] = {
     "cloud_top": ConditionTag.IMC,
     "vfr_feasibility": ConditionTag.IMC,
     "ifr_feasibility": ConditionTag.IMC,
+    # Only bites at an IFR/LIFR destination (VFR is always green, MVFR caps at
+    # amber on IAP presence), so the pilot-facing outcome to grade it against is
+    # the IMC one, even though a tailwind can be what tips it.
+    "approach_feasibility": ConditionTag.IMC,
     "flight_category": ConditionTag.IMC,
     "turbulence": ConditionTag.TURB,
     "mountain_wind": ConditionTag.TURB,

--- a/src/weatherbrief/eval_workbench/rerun.py
+++ b/src/weatherbrief/eval_workbench/rerun.py
@@ -26,9 +26,20 @@ from pathlib import Path
 
 from weatherbrief.models import AdvisoryAggregation, RouteAdvisoriesManifest
 
-# Advisories whose re-run needs the DB-backed airport-conditions recompute we
-# intentionally skip here; flagged so a diff consumer can discount them.
-_AIRPORT_CONDITION_ADVISORIES = {"airport_conditions", "density_altitude", "llws"}
+# Advisories whose re-run needs a DB-backed recompute we intentionally skip
+# here; flagged so a diff consumer can discount them.
+#
+# ``approach_feasibility`` (#509) belongs here for a second reason: it also
+# needs ``airports_db_path`` (nav.db procedures), which this module never passes
+# to ``run_advisories_from_pack``, so its re-run is always UNAVAILABLE.
+#
+# NB ``airport_conditions`` matches no registered advisory id — the airport
+# category is flight_category / airport_wind / density_altitude / llws — so the
+# first two are currently unflagged. Pre-existing, left alone here rather than
+# silently changing diff output for advisories this change does not touch.
+_AIRPORT_CONDITION_ADVISORIES = {
+    "airport_conditions", "density_altitude", "llws", "approach_feasibility",
+}
 
 
 def load_saved_manifest(pack_dir: Path) -> RouteAdvisoriesManifest | None:

--- a/src/weatherbrief/eval_workbench/situations.py
+++ b/src/weatherbrief/eval_workbench/situations.py
@@ -32,6 +32,11 @@ ADVISORY_SITUATION: dict[str, str] = {
     "airport_wind": "wind",
     "flight_category": "low_category",
     "vfr_feasibility": "vfr_marginal",
+    # Folds into the existing "ifr_marginal" cell rather than opening a new one:
+    # it only grades at an IFR/LIFR destination, and a new vocab entry would
+    # change the coverage-matrix denominator every corpus fixture is scored
+    # against (parent #252 / #254).
+    "approach_feasibility": "ifr_marginal",
     "ifr_feasibility": "ifr_marginal",
 }
 

--- a/src/weatherbrief/models/__init__.py
+++ b/src/weatherbrief/models/__init__.py
@@ -127,10 +127,12 @@ from weatherbrief.models.fronts import (  # noqa: F401
 )
 from weatherbrief.models.airport_conditions import (  # noqa: F401
     FLIGHT_CATEGORY_COLORS,
+    AirportApproaches,
     AirportConditions,
     AirportConditionsSummary,
     AirportModelCondition,
     FlightCategory,
+    RunwayApproach,
     RunwayEnd,
     RunwayWind,
 )

--- a/src/weatherbrief/models/airport_conditions.py
+++ b/src/weatherbrief/models/airport_conditions.py
@@ -46,6 +46,52 @@ class RunwayEnd(BaseModel):
     heading_deg: float  # true heading
 
 
+class RunwayApproach(BaseModel):
+    """One published instrument approach procedure at an airport.
+
+    Sourced from ``nav.db`` ``procedures`` rows (see
+    ``weatherbrief.airports.get_runway_approaches``). ``runway_id`` is the
+    runway END the procedure serves — the join key against
+    :class:`RunwayEnd` / :class:`RunwayWind` — and is ``None`` when the
+    procedure is not runway-aligned (a circling-only procedure, or a row whose
+    runway could not be resolved).
+    """
+
+    name: str  # raw procedure name, e.g. "RWY02 ILS" / "RNP A"
+    approach_type: str | None = None  # "ILS", "RNP", "VOR"… (None = unknown class)
+    runway_id: str | None = None  # runway end served, e.g. "02" — None = not aligned
+    circling: bool = False  # ICAO letter-suffixed circling procedure ("RNP A")
+
+
+class AirportApproaches(BaseModel):
+    """The published approach picture at one airport.
+
+    ``has_procedure_data`` distinguishes "we have procedure rows for this
+    airport, and none of them is an approach" from "this airport has no
+    procedure rows at all". Both mean *no instrument approach* to the grade map
+    (issue #509 decided against a third state), but the detail text says which.
+    """
+
+    icao: str
+    has_procedure_data: bool = False
+    approaches: list[RunwayApproach] = Field(default_factory=list)
+
+    @property
+    def has_iap(self) -> bool:
+        """True when at least one instrument approach is published."""
+        return bool(self.approaches)
+
+    def for_runway(self, runway_id: str) -> list[RunwayApproach]:
+        """Approaches serving a specific runway end (straight-in only)."""
+        key = runway_id.strip().upper()
+        return [a for a in self.approaches if a.runway_id == key]
+
+    @property
+    def served_runway_ids(self) -> set[str]:
+        """Runway ends with at least one straight-in approach."""
+        return {a.runway_id for a in self.approaches if a.runway_id}
+
+
 class RunwayWind(BaseModel):
     """Wind components relative to a runway."""
 

--- a/src/weatherbrief/models/airport_conditions.py
+++ b/src/weatherbrief/models/airport_conditions.py
@@ -66,25 +66,28 @@ class RunwayApproach(BaseModel):
 class AirportApproaches(BaseModel):
     """The published approach picture at one airport.
 
-    ``has_procedure_data`` distinguishes "we have procedure rows for this
-    airport, and none of them is an approach" from "this airport has no
-    procedure rows at all". Both mean *no instrument approach* to the grade map
-    (issue #509 decided against a third state), but the detail text says which.
+    Three states, and keeping the last one apart is what stops a data gap from
+    reading as a confident verdict:
+
+    * approaches present — the normal case.
+    * ``has_procedure_data`` tells the two *genuine* absences apart: "we have
+      procedure rows and none is an approach" vs "no procedure rows at all".
+      Both mean *no instrument approach* to the grade map (issue #509 decided
+      against a third state there), but the detail text says which.
+    * ``lookup_failed`` — we could not determine the picture (unknown ICAO, or
+      the procedure query raised). NOT an absence of approaches: a consumer must
+      report this as "could not assess", never grade on it.
     """
 
     icao: str
     has_procedure_data: bool = False
+    lookup_failed: bool = False
     approaches: list[RunwayApproach] = Field(default_factory=list)
 
     @property
     def has_iap(self) -> bool:
         """True when at least one instrument approach is published."""
         return bool(self.approaches)
-
-    def for_runway(self, runway_id: str) -> list[RunwayApproach]:
-        """Approaches serving a specific runway end (straight-in only)."""
-        key = runway_id.strip().upper()
-        return [a for a in self.approaches if a.runway_id == key]
 
     @property
     def served_runway_ids(self) -> set[str]:

--- a/src/weatherbrief/tasks/advise.py
+++ b/src/weatherbrief/tasks/advise.py
@@ -19,6 +19,7 @@ from weatherbrief.models import (
     AdvisoryChip,
     AdvisoryStatus,
     AdvisorySummary,
+    AirportApproaches,
     AirportConditions,
     AltitudeTableResult,
     ElevationProfile,
@@ -307,6 +308,40 @@ def _compute_airport_conditions(
         return None
 
 
+def _arrival_icao(
+    route: RouteConfig | None,
+    airport_conds: AirportConditions | None,
+) -> str | None:
+    """Destination ICAO from the route, falling back to the airport conditions."""
+    if route is not None:
+        return route.destination.icao
+    if airport_conds is not None:
+        return airport_conds.arrival.icao
+    return None
+
+
+def _collect_arrival_approaches(
+    arr_icao: str | None,
+    airports_db_path: str | None,
+) -> AirportApproaches | None:
+    """Published approaches at the destination, for ``approach_feasibility`` (#509).
+
+    Deliberately keyed on the ICAO rather than a ``RouteConfig`` so the recalc
+    path (which has airport conditions but often no resolved route) can call it
+    with exactly the same code. Returns ``None`` when the lookup could not run at
+    all — the evaluator then reports UNAVAILABLE rather than "no approach".
+    """
+    if not arr_icao or not airports_db_path:
+        return None
+    try:
+        from weatherbrief.airports import get_runway_approaches
+
+        return get_runway_approaches([arr_icao], airports_db_path).get(arr_icao)
+    except Exception:
+        logger.warning("Arrival approach lookup failed for %s", arr_icao, exc_info=True)
+        return None
+
+
 def _compute_route_sun(
     rp_analyses: list[RoutePointAnalysis],
     airport_conds: AirportConditions | None,
@@ -393,6 +428,9 @@ def run_advisories(
             locale=locale,
             route_fronts=route_fronts,
             sun=_compute_route_sun(rp_analyses, airport_conds),
+            arrival_approaches=_collect_arrival_approaches(
+                route.destination.icao, airports_db_path,
+            ),
             cruise_speed_ias_kt=cruise_speed_ias_kt,
             flight_duration_hours=route.flight_duration_hours,
         )
@@ -563,6 +601,13 @@ def run_advisories_from_pack(
             locale=locale,
             route_fronts=route_fronts,
             sun=route_sun,
+            # Recalc has no resolved route on the API path, so the destination
+            # comes from the (re)computed airport conditions — the same ICAO the
+            # advisory grades against, which is what keeps this wiring point from
+            # silently dropping the advisory on recalculate (#509).
+            arrival_approaches=_collect_arrival_approaches(
+                _arrival_icao(route, airport_conds), airports_db_path,
+            ),
             cruise_speed_ias_kt=cruise_speed_ias_kt,
             flight_duration_hours=flight_duration_hours,
         )
@@ -950,6 +995,9 @@ def run_alt_from_pack(
             airport_conditions=airport_conds,
             locale=locale,
             route_fronts=route_fronts,
+            arrival_approaches=_collect_arrival_approaches(
+                _arrival_icao(route, airport_conds), airports_db_path,
+            ),
             cruise_speed_ias_kt=cruise_speed_ias_kt,
             flight_duration_hours=route.flight_duration_hours,
         )

--- a/tests/analysis/advisories/test_approach_feasibility.py
+++ b/tests/analysis/advisories/test_approach_feasibility.py
@@ -125,6 +125,14 @@ _RWY_24 = _runway_wind("24", 240.0, headwind=15.0, crosswind=0.0)  # wind-best
 _ILS_02 = RunwayApproach(name="RWY02 ILS", approach_type="ILS", runway_id="02")
 _ILS_20 = RunwayApproach(name="RWY20 ILS", approach_type="ILS", runway_id="20")
 
+# Two served ends whose approaches sit in DIFFERENT estimated-minima bands —
+# ILS best case 200 ft vs non-precision best case 400 ft. The airport-wide gate
+# uses the lower of the two, so a ceiling between them passes it while still
+# being below one end's own minimum.
+_VOR_20 = RunwayApproach(name="RWY20 VOR", approach_type="VOR", runway_id="20")
+_RWY_02_TAILWIND = _runway_wind("02", 20.0, headwind=-15.0, crosswind=3.0)
+_RWY_20_HEADWIND = _runway_wind("20", 200.0, headwind=15.0, crosswind=3.0)
+
 
 class TestUnavailable:
     def test_no_approach_data_is_unavailable_not_green(self):
@@ -302,6 +310,57 @@ class TestFullLogic:
             _approaches(_ILS_20),
         )
         assert _grade(ctx) == AdvisoryStatus.AMBER
+
+    def test_minima_blocked_served_end_is_not_reported_as_misaligned(self):
+        """Two served ends with *different* minima bands — the #511 review case.
+
+        02 has an ILS (best case 200 ft) but an out-of-limits tailwind; 20 is
+        the wind-favoured end and has only a VOR (best case 400 ft). A 250 ft
+        ceiling clears the airport-wide gate (min 200 ft, from 02's ILS) but is
+        below 20's own best case, so every straight-in candidate grades RED —
+        for two entirely different reasons. The old code fell through to the
+        misalignment copy and announced "wind favours RWY 20; approaches serve
+        02, 20", naming the served, wind-favoured runway as if it were unserved.
+        """
+        ctx = _ctx(
+            _conditions(
+                FlightCategory.IFR, [_RWY_02_TAILWIND, _RWY_20_HEADWIND],
+                ceiling_ft=250, visibility_m=4000,
+            ),
+            _approaches(_ILS_02, _VOR_20),
+        )
+        result = ApproachFeasibilityEvaluator.evaluate(ctx, _defaults())
+        detail = result.aggregate_detail
+        assert result.aggregate_status == AdvisoryStatus.RED
+        assert "RWY 20" in detail and "VOR" in detail
+        # The misalignment story must not be told: there is no misalignment.
+        assert "favours" not in detail
+        assert "serve" not in detail
+
+    def test_minima_blocked_softens_to_amber_with_circling_room(self):
+        """Same shape, but a ceiling that supports circling — visibility blocks 20."""
+        ctx = _ctx(
+            _conditions(
+                FlightCategory.IFR, [_RWY_02_TAILWIND, _RWY_20_HEADWIND],
+                ceiling_ft=1200, visibility_m=1000,
+            ),
+            _approaches(_ILS_02, _VOR_20),
+        )
+        result = ApproachFeasibilityEvaluator.evaluate(ctx, _defaults())
+        assert result.aggregate_status == AdvisoryStatus.AMBER
+        assert "RWY 20" in result.aggregate_detail
+
+    def test_all_ends_out_on_wind_still_reads_as_misalignment(self):
+        """The genuine misalignment case must keep its own copy."""
+        ctx = _ctx(
+            _conditions(FlightCategory.IFR, [_RWY_02, _RWY_24], ceiling_ft=600),
+            _approaches(_ILS_02),
+        )
+        result = ApproachFeasibilityEvaluator.evaluate(
+            ctx, {**_defaults(), "tailwind_limit_kt": 5},
+        )
+        assert result.aggregate_status == AdvisoryStatus.RED
+        assert "24" in result.aggregate_detail  # wind-favoured, unserved
 
     def test_best_usable_end_wins_over_a_worse_served_end(self):
         """Two served ends: the grade comes from the better arrival, not the worse."""

--- a/tests/analysis/advisories/test_approach_feasibility.py
+++ b/tests/analysis/advisories/test_approach_feasibility.py
@@ -143,6 +143,22 @@ class TestUnavailable:
         )
         assert _grade(ctx) == AdvisoryStatus.RED
 
+    def test_failed_lookup_is_unavailable_not_a_red_no_approach(self):
+        """A data gap must never impersonate the grade map's most severe input.
+
+        ``lookup_failed`` and "no approaches" both arrive as an empty approach
+        list; only the flag tells them apart, and grading the gap would
+        manufacture a RED out of a parse failure.
+        """
+        failed = AirportApproaches(icao="EGKA", lookup_failed=True)
+        ctx = _ctx(_conditions(FlightCategory.IFR, [_RWY_02, _RWY_20]), failed)
+        assert _grade(ctx) == AdvisoryStatus.UNAVAILABLE
+
+    def test_failed_lookup_is_unavailable_even_at_mvfr(self):
+        failed = AirportApproaches(icao="EGKA", lookup_failed=True)
+        ctx = _ctx(_conditions(FlightCategory.MVFR, [_RWY_24]), failed)
+        assert _grade(ctx) == AdvisoryStatus.UNAVAILABLE
+
 
 class TestCategoryGating:
     def test_vfr_is_always_green(self):

--- a/tests/analysis/advisories/test_approach_feasibility.py
+++ b/tests/analysis/advisories/test_approach_feasibility.py
@@ -559,6 +559,45 @@ class TestCirclingNeedsVisibilityNotJustCeiling:
         assert result.aggregate_status == AdvisoryStatus.AMBER
 
 
+class TestCirclingMinimaAreNotStraightInMinima:
+    """A circling procedure must not lend its class's straight-in minima.
+
+    ``APPROACH_CLASS_PROXY`` holds straight-in minima; real circling minima are
+    categorically higher for the same class. Folding a circling ILS into the
+    airport-wide best-case gate would claim a 200 ft best case the field does
+    not offer — design rule 3 (flag circling, don't grade it) applied to the gate.
+    """
+
+    def test_a_circling_ils_does_not_lower_the_best_case_gate(self):
+        """Only a VOR is straight-in here, so 300 ft is below the real best case."""
+        circling_ils = RunwayApproach(name="ILS A", approach_type="ILS", circling=True)
+        ctx = _ctx(
+            _conditions(
+                FlightCategory.LIFR, [_RWY_20_HEADWIND],
+                ceiling_ft=300, visibility_m=4000,
+            ),
+            _approaches(circling_ils, _VOR_20),
+        )
+        result = ApproachFeasibilityEvaluator.evaluate(ctx, _defaults())
+        assert result.aggregate_status == AdvisoryStatus.RED
+        # The gate fired on the VOR's 400 ft, not the circling ILS's 200 ft.
+        assert "400" in result.aggregate_detail
+
+    def test_a_circling_only_field_skips_the_gate_rather_than_inventing_one(self):
+        """No straight-in minimum exists to test against — let the fallback speak."""
+        circling = RunwayApproach(name="RNP A", approach_type="RNP", circling=True)
+        ctx = _ctx(
+            _conditions(
+                FlightCategory.IFR, [_RWY_02, _RWY_24],
+                ceiling_ft=1500, visibility_m=4000,
+            ),
+            _approaches(circling),
+        )
+        result = ApproachFeasibilityEvaluator.evaluate(ctx, _defaults())
+        assert result.aggregate_status == AdvisoryStatus.AMBER
+        assert "No straight-in approach is published" in result.aggregate_detail
+
+
 class TestNoStraightInIsItsOwnStory:
     def test_circling_only_field_does_not_render_an_empty_served_list(self):
         """"approaches serve -" — a plausible shape at small European fields."""

--- a/tests/analysis/advisories/test_approach_feasibility.py
+++ b/tests/analysis/advisories/test_approach_feasibility.py
@@ -14,7 +14,10 @@ import pytest
 from weatherbrief.analysis.advisories import RouteContext
 from weatherbrief.analysis.advisories.approach_feasibility import (
     ApproachFeasibilityEvaluator,
+    _Blocker,
+    _Softening,
 )
+from weatherbrief.analysis.advisories.strings import _STRINGS
 from weatherbrief.models import AdvisoryStatus
 from weatherbrief.units import M_PER_SM
 from weatherbrief.models.airport_conditions import (
@@ -338,17 +341,27 @@ class TestFullLogic:
         assert "serve" not in detail
 
     def test_minima_blocked_softens_to_amber_with_circling_room(self):
-        """Same shape, but a ceiling that supports circling — visibility blocks 20."""
+        """Same shape, but circling is on the table, so it softens to AMBER.
+
+        The circling assumption is lowered rather than the ceiling raised: the
+        minima block needs a ceiling *below* 20's 400 ft best case, so no
+        ceiling can both block the straight-in and clear a 1000 ft circling
+        assumption. A pilot with a lower personal circling minimum is exactly
+        the case the param exists for.
+        """
         ctx = _ctx(
             _conditions(
                 FlightCategory.IFR, [_RWY_02_TAILWIND, _RWY_20_HEADWIND],
-                ceiling_ft=1200, visibility_m=1000,
+                ceiling_ft=250, visibility_m=4000,
             ),
             _approaches(_ILS_02, _VOR_20),
         )
-        result = ApproachFeasibilityEvaluator.evaluate(ctx, _defaults())
+        result = ApproachFeasibilityEvaluator.evaluate(
+            ctx, {**_defaults(), "circling_ceiling_ft": 200},
+        )
         assert result.aggregate_status == AdvisoryStatus.AMBER
         assert "RWY 20" in result.aggregate_detail
+        assert "plan for circling" in result.aggregate_detail
 
     def test_uncertainty_softening_never_borrows_the_circling_advice(self):
         """An AMBER earned by uncertainty must say so, not claim circling.
@@ -453,6 +466,120 @@ class TestPerModel:
         result = ApproachFeasibilityEvaluator.evaluate(_ctx(conds, _approaches(_ILS_20)), _defaults())
         statuses = {m.model: m.status for m in result.per_model}
         assert statuses[MODELS[1]] == AdvisoryStatus.UNAVAILABLE
+
+
+class TestFallbackCopyIsComplete:
+    """The no-usable-straight-in verdict is a cross product, so test it as one.
+
+    Three review rounds on #511 each found a different cell of (what blocks the
+    arrival x why it is not RED) rendering the wrong sentence, because the cells
+    were written out by hand. The copy is now composed from the two axes; these
+    tests pin that every cell resolves to real text and that each softening
+    reason says its own thing.
+    """
+
+    def test_every_cell_resolves_to_real_text(self):
+        """No cell may fall through to a raw key (``adv_t``'s silent fallback)."""
+        for blocker in _Blocker:
+            for softening in _Softening:
+                for key in (
+                    f"approach_feasibility.blocked_{blocker.value}",
+                    f"approach_feasibility.soften_{softening.value}",
+                ):
+                    assert key in _STRINGS, f"missing string: {key}"
+                    assert set(_STRINGS[key]) >= {"en", "fr", "de", "es"}
+
+    def test_softening_reasons_do_not_share_wording(self):
+        """Each reason must be distinguishable — the #511 round-3/4 bug class."""
+        english = {
+            s: _STRINGS[f"approach_feasibility.soften_{s.value}"]["en"]
+            for s in _Softening
+        }
+        assert len(set(english.values())) == len(_Softening)
+        # Only the circling cell may recommend circling.
+        for softening, text in english.items():
+            if softening is not _Softening.CIRCLING:
+                assert "plan for circling" not in text
+
+    def test_only_the_unsoftened_cell_is_red(self):
+        assert _Softening.NONE.status == AdvisoryStatus.RED
+        for softening in _Softening:
+            if softening is not _Softening.NONE:
+                assert softening.status == AdvisoryStatus.AMBER
+
+
+class TestCirclingNeedsVisibilityNotJustCeiling:
+    def test_fog_above_the_straight_in_floor_does_not_soften_to_circling(self):
+        """Circling needs visual reference to the runway.
+
+        A generous (or absent) ceiling with visibility that clears the
+        straight-in floor but not the circling one used to soften a genuine
+        "no way in" into AMBER *and recommend circling* — in fog.
+        """
+        ctx = _ctx(
+            _conditions(
+                FlightCategory.IFR, [_RWY_02, _RWY_24],
+                ceiling_ft=None, visibility_m=900,
+            ),
+            _approaches(_ILS_02),
+        )
+        result = ApproachFeasibilityEvaluator.evaluate(
+            ctx, {**_defaults(), "tailwind_limit_kt": 5},
+        )
+        assert result.aggregate_status == AdvisoryStatus.RED
+        assert "circling" not in result.aggregate_detail.replace(
+            "will not support circling", "",
+        )
+
+    def test_good_visibility_still_allows_the_circling_softening(self):
+        ctx = _ctx(
+            _conditions(
+                FlightCategory.IFR, [_RWY_02, _RWY_24],
+                ceiling_ft=1500, visibility_m=4000,
+            ),
+            _approaches(_ILS_02),
+        )
+        result = ApproachFeasibilityEvaluator.evaluate(
+            ctx, {**_defaults(), "tailwind_limit_kt": 5},
+        )
+        assert result.aggregate_status == AdvisoryStatus.AMBER
+        assert "plan for circling" in result.aggregate_detail
+
+    def test_absent_visibility_never_hardens_the_grade(self):
+        """A model that publishes no visibility must not cost the pilot a grade."""
+        conds = _conditions(
+            FlightCategory.IFR, [_RWY_02, _RWY_24], ceiling_ft=1500,
+        )
+        for c in conds.arrival.conditions:
+            c.visibility_m = None
+        result = ApproachFeasibilityEvaluator.evaluate(
+            _ctx(conds, _approaches(_ILS_02)),
+            {**_defaults(), "tailwind_limit_kt": 5},
+        )
+        assert result.aggregate_status == AdvisoryStatus.AMBER
+
+
+class TestNoStraightInIsItsOwnStory:
+    def test_circling_only_field_does_not_render_an_empty_served_list(self):
+        """"approaches serve -" — a plausible shape at small European fields."""
+        circling = RunwayApproach(name="RNP A", approach_type="RNP", circling=True)
+        ctx = _ctx(
+            _conditions(FlightCategory.IFR, [_RWY_02, _RWY_24], ceiling_ft=1500),
+            _approaches(circling),
+        )
+        detail = ApproachFeasibilityEvaluator.evaluate(ctx, _defaults()).aggregate_detail
+        assert "serve -" not in detail
+        assert "No straight-in approach is published" in detail
+
+    def test_missing_wind_components_say_so_rather_than_blame_alignment(self):
+        """The served end IS matched; the gap is wind data. Say which."""
+        conds = _conditions(FlightCategory.IFR, [], ceiling_ft=600)
+        result = ApproachFeasibilityEvaluator.evaluate(
+            _ctx(conds, _approaches(_ILS_20)), _defaults(),
+        )
+        assert result.aggregate_status == AdvisoryStatus.AMBER
+        assert "no wind components" in result.aggregate_detail
+        assert "could not be matched to a runway" not in result.aggregate_detail
 
 
 class TestCatalog:

--- a/tests/analysis/advisories/test_approach_feasibility.py
+++ b/tests/analysis/advisories/test_approach_feasibility.py
@@ -1,0 +1,360 @@
+"""Tests for the approach_feasibility advisory evaluator (issue #509).
+
+The advisory joins three facts nothing else joins: the destination's ceiling,
+the runway the wind favours, and which runways actually have a published
+approach. The cases below pin the grade map, the two rules that keep it honest
+(RED needs a hard fact; estimate uncertainty may only soften), and the
+UNAVAILABLE-vs-no-approach distinction.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from weatherbrief.analysis.advisories import RouteContext
+from weatherbrief.analysis.advisories.approach_feasibility import (
+    ApproachFeasibilityEvaluator,
+)
+from weatherbrief.models import AdvisoryStatus
+from weatherbrief.units import M_PER_SM
+from weatherbrief.models.airport_conditions import (
+    AirportApproaches,
+    AirportConditions,
+    AirportConditionsSummary,
+    AirportModelCondition,
+    FlightCategory,
+    RunwayApproach,
+    RunwayEnd,
+    RunwayWind,
+)
+
+MODELS = ["gfs", "ecmwf"]
+
+# Ceiling/visibility that produce each category (the evaluator branches on the
+# stored ``flight_category``; these keep the fixtures self-consistent).
+_CAT_DEFAULTS: dict[FlightCategory, tuple[int, float]] = {
+    FlightCategory.VFR: (5000, 10.0),
+    FlightCategory.MVFR: (2000, 4.0),
+    FlightCategory.IFR: (800, 2.0),
+    FlightCategory.LIFR: (300, 0.5),
+}
+
+
+def _defaults() -> dict[str, float]:
+    entry = ApproachFeasibilityEvaluator.catalog_entry()
+    return {p.key: p.default for p in entry.parameters}
+
+
+def _runway_wind(runway_id: str, heading: float, headwind: float, crosswind: float = 0.0):
+    return RunwayWind(
+        runway_id=runway_id, heading_deg=heading,
+        crosswind_kt=crosswind, headwind_kt=headwind,
+    )
+
+
+def _conditions(
+    category: FlightCategory,
+    all_runways: list[RunwayWind],
+    *,
+    best_runway: RunwayWind | None = None,
+    ceiling_ft: int | None = None,
+    visibility_m: float | None = None,
+    icao: str = "EGKA",
+) -> AirportConditions:
+    """Airport conditions where every model sees the same arrival picture."""
+    default_ceiling, vis = _CAT_DEFAULTS[category]
+    ceiling = default_ceiling if ceiling_ft is None else ceiling_ft
+    vis_m = vis * M_PER_SM if visibility_m is None else visibility_m
+    # Best runway by pure wind (what enrich_wind / airport_wind pick) — the
+    # approach-blind answer this advisory exists to cross-check.
+    best = best_runway or (
+        min(all_runways, key=lambda r: (r.crosswind_kt, -r.headwind_kt))
+        if all_runways else None
+    )
+    conds = [
+        AirportModelCondition(
+            model=m, flight_category=category, ceiling_ft=ceiling,
+            visibility_sm=vis, visibility_m=vis_m,
+            wind_speed_kt=15.0, wind_direction_deg=240.0,
+            best_runway=best, all_runways=all_runways,
+        )
+        for m in MODELS
+    ]
+    summary = AirportConditionsSummary(
+        icao=icao, name=icao,
+        runway_ends=[RunwayEnd(id=r.runway_id, heading_deg=r.heading_deg) for r in all_runways],
+        conditions=conds,
+    )
+    dep = AirportConditionsSummary(icao="EGTK", name="EGTK", conditions=[
+        AirportModelCondition(model=m, flight_category=FlightCategory.VFR) for m in MODELS
+    ])
+    return AirportConditions(departure=dep, arrival=summary)
+
+
+def _approaches(
+    *approaches: RunwayApproach, has_procedure_data: bool = True, icao: str = "EGKA",
+) -> AirportApproaches:
+    return AirportApproaches(
+        icao=icao,
+        has_procedure_data=has_procedure_data or bool(approaches),
+        approaches=list(approaches),
+    )
+
+
+def _ctx(
+    conditions: AirportConditions | None,
+    approaches: AirportApproaches | None,
+) -> RouteContext:
+    return RouteContext(
+        analyses=[], cross_sections=[], elevation=None, models=MODELS,
+        cruise_altitude_ft=6000, flight_ceiling_ft=12000, total_distance_nm=120,
+        airport_conditions=conditions, arrival_approaches=approaches,
+    )
+
+
+def _grade(ctx: RouteContext, **overrides) -> AdvisoryStatus:
+    params = {**_defaults(), **overrides}
+    return ApproachFeasibilityEvaluator.evaluate(ctx, params).aggregate_status
+
+
+# The EGKA shape from #509: hard runway 02/20 has the approaches, the grass
+# 06/24 does not, so the wind can favour a runway with no way in.
+_RWY_02 = _runway_wind("02", 20.0, headwind=-8.0, crosswind=6.0)   # 8 kt tailwind
+_RWY_20 = _runway_wind("20", 200.0, headwind=8.0, crosswind=6.0)
+_RWY_24 = _runway_wind("24", 240.0, headwind=15.0, crosswind=0.0)  # wind-best
+_ILS_02 = RunwayApproach(name="RWY02 ILS", approach_type="ILS", runway_id="02")
+_ILS_20 = RunwayApproach(name="RWY20 ILS", approach_type="ILS", runway_id="20")
+
+
+class TestUnavailable:
+    def test_no_approach_data_is_unavailable_not_green(self):
+        """A missing collection step is a data gap, never a clear approach."""
+        ctx = _ctx(_conditions(FlightCategory.IFR, [_RWY_02, _RWY_20]), None)
+        assert _grade(ctx) == AdvisoryStatus.UNAVAILABLE
+
+    def test_no_airport_conditions_is_unavailable(self):
+        assert _grade(_ctx(None, _approaches(_ILS_02))) == AdvisoryStatus.UNAVAILABLE
+
+    def test_airport_with_no_approaches_is_graded_not_unavailable(self):
+        """Absence of procedures means "no approach", not "could not assess"."""
+        ctx = _ctx(
+            _conditions(FlightCategory.IFR, [_RWY_02, _RWY_20]),
+            _approaches(has_procedure_data=False),
+        )
+        assert _grade(ctx) == AdvisoryStatus.RED
+
+
+class TestCategoryGating:
+    def test_vfr_is_always_green(self):
+        """Visually reachable — approach infrastructure is irrelevant."""
+        ctx = _ctx(
+            _conditions(FlightCategory.VFR, [_RWY_24]),
+            _approaches(has_procedure_data=False),
+        )
+        assert _grade(ctx) == AdvisoryStatus.GREEN
+
+    def test_mvfr_with_any_approach_is_green(self):
+        """Alignment is not a penalty when the landing can be completed visually."""
+        ctx = _ctx(
+            _conditions(FlightCategory.MVFR, [_RWY_02, _RWY_24]),
+            _approaches(_ILS_02),
+        )
+        assert _grade(ctx) == AdvisoryStatus.GREEN
+
+    def test_mvfr_without_approach_is_amber_never_red(self):
+        ctx = _ctx(
+            _conditions(FlightCategory.MVFR, [_RWY_24]),
+            _approaches(has_procedure_data=False),
+        )
+        assert _grade(ctx) == AdvisoryStatus.AMBER
+
+    def test_mvfr_ignores_a_misaligned_approach(self):
+        """The EGKA shape at MVFR: wind favours 24, ILS serves 02 — still green."""
+        ctx = _ctx(
+            _conditions(FlightCategory.MVFR, [_RWY_02, _RWY_24]),
+            _approaches(_ILS_02),
+        )
+        assert _grade(ctx) == AdvisoryStatus.GREEN
+
+
+class TestFullLogic:
+    def test_aligned_headwind_clear_ceiling_is_green(self):
+        ctx = _ctx(
+            _conditions(FlightCategory.IFR, [_RWY_02, _RWY_20], ceiling_ft=900),
+            _approaches(_ILS_20),
+        )
+        assert _grade(ctx) == AdvisoryStatus.GREEN
+
+    def test_ceiling_inside_the_estimated_minima_band_is_amber(self):
+        """ILS proxy DH band is 200-300 ft: inside it the plate decides, not us.
+
+        Visibility is held clear of its own band so the ceiling alone drives it.
+        """
+        ctx = _ctx(
+            _conditions(
+                FlightCategory.LIFR, [_RWY_02, _RWY_20],
+                ceiling_ft=250, visibility_m=4000,
+            ),
+            _approaches(_ILS_20),
+        )
+        assert _grade(ctx) == AdvisoryStatus.AMBER
+
+    def test_ceiling_below_best_case_dh_is_red(self):
+        ctx = _ctx(
+            _conditions(
+                FlightCategory.LIFR, [_RWY_02, _RWY_20],
+                ceiling_ft=150, visibility_m=4000,
+            ),
+            _approaches(_ILS_20),
+        )
+        assert _grade(ctx) == AdvisoryStatus.RED
+
+    def test_visibility_inside_the_estimated_minima_band_is_amber(self):
+        """ILS proxy visibility band is 550-1500 m."""
+        ctx = _ctx(
+            _conditions(FlightCategory.LIFR, [_RWY_20], ceiling_ft=900, visibility_m=900),
+            _approaches(_ILS_20),
+        )
+        assert _grade(ctx) == AdvisoryStatus.AMBER
+
+    def test_visibility_below_best_case_minimum_is_red(self):
+        ctx = _ctx(
+            _conditions(FlightCategory.LIFR, [_RWY_20], ceiling_ft=900, visibility_m=300),
+            _approaches(_ILS_20),
+        )
+        assert _grade(ctx) == AdvisoryStatus.RED
+
+    def test_absent_visibility_does_not_flag_the_axis(self):
+        """ECMWF publishes no visibility — absence is skipped, not read as poor."""
+        conds = _conditions(FlightCategory.IFR, [_RWY_20], ceiling_ft=900)
+        for c in conds.arrival.conditions:
+            c.visibility_m = None
+        assert _grade(_ctx(conds, _approaches(_ILS_20))) == AdvisoryStatus.GREEN
+
+    def test_wind_components_missing_never_drives_red(self):
+        """A served end the wind model did not cover is our gap, not a fact."""
+        conds = _conditions(FlightCategory.IFR, [], ceiling_ft=600)
+        assert _grade(_ctx(conds, _approaches(_ILS_20))) == AdvisoryStatus.AMBER
+
+    def test_tailwind_within_limit_on_the_served_end_is_amber(self):
+        """A usable-but-compromised arrival: served end has an 8 kt tailwind."""
+        ctx = _ctx(
+            _conditions(FlightCategory.IFR, [_RWY_02, _RWY_24], ceiling_ft=900),
+            _approaches(_ILS_02),
+        )
+        assert _grade(ctx) == AdvisoryStatus.AMBER
+
+    def test_tailwind_over_limit_with_circling_ceiling_is_amber(self):
+        """Straight-in is out on wind, but the ceiling still supports circling."""
+        ctx = _ctx(
+            _conditions(FlightCategory.IFR, [_RWY_02, _RWY_24], ceiling_ft=1200),
+            _approaches(_ILS_02),
+            # 8 kt tailwind on 02 exceeds a tightened 5 kt limit
+        )
+        assert _grade(ctx, tailwind_limit_kt=5) == AdvisoryStatus.AMBER
+
+    def test_tailwind_over_limit_without_circling_ceiling_is_red(self):
+        """The #509 RED case: misaligned + no circling ceiling + tailwind out."""
+        ctx = _ctx(
+            _conditions(FlightCategory.IFR, [_RWY_02, _RWY_24], ceiling_ft=600),
+            _approaches(_ILS_02),
+        )
+        assert _grade(ctx, tailwind_limit_kt=5) == AdvisoryStatus.RED
+
+    def test_circling_only_approach_is_amber_never_graded(self):
+        """No circling minima in the data — flag it, don't compute a verdict."""
+        circling = RunwayApproach(name="RNP A", approach_type="RNP", circling=True)
+        ctx = _ctx(
+            _conditions(FlightCategory.IFR, [_RWY_02, _RWY_24], ceiling_ft=1500),
+            _approaches(circling),
+        )
+        assert _grade(ctx) == AdvisoryStatus.AMBER
+
+    def test_unresolved_alignment_never_drives_red(self):
+        """Estimate/data uncertainty may soften a grade, never harden it."""
+        unresolved = RunwayApproach(name="MIPS: RNP (LNAV) ARINC CODING", approach_type="RNP")
+        ctx = _ctx(
+            _conditions(FlightCategory.IFR, [_RWY_02, _RWY_24], ceiling_ft=600),
+            _approaches(unresolved),
+        )
+        assert _grade(ctx, tailwind_limit_kt=5) == AdvisoryStatus.AMBER
+
+    def test_crosswind_over_limit_on_the_served_end_is_amber(self):
+        gusty = _runway_wind("20", 200.0, headwind=8.0, crosswind=25.0)
+        ctx = _ctx(
+            _conditions(FlightCategory.IFR, [gusty], ceiling_ft=900),
+            _approaches(_ILS_20),
+        )
+        assert _grade(ctx) == AdvisoryStatus.AMBER
+
+    def test_best_usable_end_wins_over_a_worse_served_end(self):
+        """Two served ends: the grade comes from the better arrival, not the worse."""
+        ctx = _ctx(
+            _conditions(FlightCategory.IFR, [_RWY_02, _RWY_20], ceiling_ft=900),
+            _approaches(_ILS_02, _ILS_20),
+        )
+        assert _grade(ctx) == AdvisoryStatus.GREEN
+
+
+class TestDetail:
+    def test_detail_names_the_wind_runway_and_the_served_runway(self):
+        ctx = _ctx(
+            _conditions(FlightCategory.IFR, [_RWY_02, _RWY_24], ceiling_ft=600),
+            _approaches(_ILS_02),
+        )
+        result = ApproachFeasibilityEvaluator.evaluate(
+            ctx, {**_defaults(), "tailwind_limit_kt": 5},
+        )
+        detail = result.aggregate_detail
+        assert "24" in detail and "02" in detail
+
+    def test_detail_reports_the_arrival_category(self):
+        ctx = _ctx(
+            _conditions(FlightCategory.LIFR, [_RWY_20], ceiling_ft=900),
+            _approaches(_ILS_20),
+        )
+        result = ApproachFeasibilityEvaluator.evaluate(ctx, _defaults())
+        assert "LIFR" in result.aggregate_detail
+        assert "EGKA" in result.aggregate_detail
+
+
+class TestPerModel:
+    def test_models_disagreeing_on_the_wind_aggregate_by_majority(self):
+        """Two models see a usable straight-in, one does not — majority wins."""
+        conds = _conditions(FlightCategory.IFR, [_RWY_02, _RWY_20], ceiling_ft=900)
+        # Flip one model onto a heavy tailwind on the only served end.
+        arr = conds.arrival
+        arr.conditions[1] = AirportModelCondition(
+            model=MODELS[1], flight_category=FlightCategory.IFR, ceiling_ft=600,
+            visibility_sm=2.0,
+            all_runways=[_runway_wind("20", 200.0, headwind=-20.0, crosswind=3.0)],
+            best_runway=_runway_wind("02", 20.0, headwind=20.0, crosswind=3.0),
+        )
+        result = ApproachFeasibilityEvaluator.evaluate(_ctx(conds, _approaches(_ILS_20)), _defaults())
+        statuses = {m.model: m.status for m in result.per_model}
+        assert statuses[MODELS[0]] == AdvisoryStatus.GREEN
+        assert statuses[MODELS[1]] == AdvisoryStatus.RED
+
+    def test_model_without_conditions_is_unavailable_for_that_model(self):
+        conds = _conditions(FlightCategory.IFR, [_RWY_20], ceiling_ft=900)
+        conds.arrival.conditions = [conds.arrival.conditions[0]]
+        result = ApproachFeasibilityEvaluator.evaluate(_ctx(conds, _approaches(_ILS_20)), _defaults())
+        statuses = {m.model: m.status for m in result.per_model}
+        assert statuses[MODELS[1]] == AdvisoryStatus.UNAVAILABLE
+
+
+class TestCatalog:
+    def test_registered_in_flight_rules_with_pilot_tier_limits(self):
+        entry = ApproachFeasibilityEvaluator.catalog_entry()
+        assert entry.category == "flight_rules"
+        assert entry.default_enabled is True
+        audiences = {p.key: p.audience for p in entry.parameters}
+        assert audiences["tailwind_limit_kt"] == "pilot"
+        assert audiences["circling_ceiling_ft"] == "advanced"
+
+    @pytest.mark.parametrize("key", ["tailwind_limit_kt", "crosswind_limit_kt", "circling_ceiling_ft"])
+    def test_params_are_honoured_on_recalc(self, key):
+        """Every declared param must actually reach the grading code."""
+        entry = ApproachFeasibilityEvaluator.catalog_entry()
+        param = next(p for p in entry.parameters if p.key == key)
+        assert param.min <= param.default <= param.max

--- a/tests/analysis/advisories/test_approach_feasibility.py
+++ b/tests/analysis/advisories/test_approach_feasibility.py
@@ -350,6 +350,43 @@ class TestFullLogic:
         assert result.aggregate_status == AdvisoryStatus.AMBER
         assert "RWY 20" in result.aggregate_detail
 
+    def test_uncertainty_softening_never_borrows_the_circling_advice(self):
+        """An AMBER earned by uncertainty must say so, not claim circling.
+
+        Softening for an unresolved approach is correct (design rule 2), but
+        the grade and the copy have to come from the same test. When they were
+        chosen separately, the misalignment branch advised "plan for circling"
+        at a 600 ft ceiling — below the 1000 ft the same call had just decided
+        circling needs — and the minima branch paired an AMBER badge with the
+        hard "will not support circling" claim.
+        """
+        unresolved = RunwayApproach(name="MIPS: RNP (LNAV) ARINC CODING", approach_type="RNP")
+
+        misaligned = ApproachFeasibilityEvaluator.evaluate(
+            _ctx(
+                _conditions(FlightCategory.IFR, [_RWY_02, _RWY_24], ceiling_ft=600),
+                _approaches(_ILS_02, unresolved),
+            ),
+            {**_defaults(), "tailwind_limit_kt": 5},
+        )
+        assert misaligned.aggregate_status == AdvisoryStatus.AMBER
+        assert "circling" not in misaligned.aggregate_detail
+        assert "could not be matched" in misaligned.aggregate_detail
+
+        minima = ApproachFeasibilityEvaluator.evaluate(
+            _ctx(
+                _conditions(
+                    FlightCategory.IFR, [_RWY_02_TAILWIND, _RWY_20_HEADWIND],
+                    ceiling_ft=250, visibility_m=4000,
+                ),
+                _approaches(_ILS_02, _VOR_20, unresolved),
+            ),
+            _defaults(),
+        )
+        assert minima.aggregate_status == AdvisoryStatus.AMBER
+        assert "will not support circling" not in minima.aggregate_detail
+        assert "could not be matched" in minima.aggregate_detail
+
     def test_all_ends_out_on_wind_still_reads_as_misalignment(self):
         """The genuine misalignment case must keep its own copy."""
         ctx = _ctx(
@@ -428,8 +465,40 @@ class TestCatalog:
         assert audiences["circling_ceiling_ft"] == "advanced"
 
     @pytest.mark.parametrize("key", ["tailwind_limit_kt", "crosswind_limit_kt", "circling_ceiling_ft"])
-    def test_params_are_honoured_on_recalc(self, key):
-        """Every declared param must actually reach the grading code."""
+    def test_param_defaults_sit_inside_their_declared_bounds(self, key):
+        """Bounds sanity only — the wiring is covered by the test below."""
         entry = ApproachFeasibilityEvaluator.catalog_entry()
         param = next(p for p in entry.parameters if p.key == key)
         assert param.min <= param.default <= param.max
+
+    def test_every_declared_param_actually_reaches_the_grading_code(self):
+        """A param declared in the catalog but dropped in ``_grade_full`` would
+        be silently inert on the settings page. Each one is moved across the
+        threshold it controls and must change the verdict."""
+        # tailwind_limit_kt: an 8 kt tailwind on the only served end.
+        tail = _ctx(
+            _conditions(FlightCategory.IFR, [_RWY_02, _RWY_24], ceiling_ft=1500),
+            _approaches(_ILS_02),
+        )
+        assert _grade(tail, tailwind_limit_kt=10) == AdvisoryStatus.AMBER  # within
+        assert _grade(tail, tailwind_limit_kt=5) == AdvisoryStatus.AMBER   # out → circling
+        assert "circling" in ApproachFeasibilityEvaluator.evaluate(
+            tail, {**_defaults(), "tailwind_limit_kt": 5},
+        ).aggregate_detail
+
+        # crosswind_limit_kt: 10 kt crosswind on a headwind runway.
+        gusty = _runway_wind("20", 200.0, headwind=8.0, crosswind=10.0)
+        cross = _ctx(
+            _conditions(FlightCategory.IFR, [gusty], ceiling_ft=900),
+            _approaches(_ILS_20),
+        )
+        assert _grade(cross, crosswind_limit_kt=20) == AdvisoryStatus.GREEN
+        assert _grade(cross, crosswind_limit_kt=5) == AdvisoryStatus.AMBER
+
+        # circling_ceiling_ft: 600 ft ceiling with the only approach misaligned.
+        circ = _ctx(
+            _conditions(FlightCategory.IFR, [_RWY_02, _RWY_24], ceiling_ft=600),
+            _approaches(_ILS_02),
+        )
+        assert _grade(circ, tailwind_limit_kt=5, circling_ceiling_ft=1000) == AdvisoryStatus.RED
+        assert _grade(circ, tailwind_limit_kt=5, circling_ceiling_ft=500) == AdvisoryStatus.AMBER

--- a/tests/test_advise_arrival_approaches.py
+++ b/tests/test_advise_arrival_approaches.py
@@ -1,0 +1,80 @@
+"""Tests for the destination-approach wiring behind ``approach_feasibility`` (#509).
+
+The advisory reads ``RouteContext.arrival_approaches``. Two wiring points build
+that context — the briefing run and the recalculate/preview re-run — and the
+recalculate one has no resolved ``RouteConfig``, so it resolves the destination
+from the recomputed airport conditions instead. If either point drops the
+lookup, the advisory silently degrades to a grey UNAVAILABLE card; these tests
+pin both.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from weatherbrief.models import AirportApproaches, RunwayApproach
+from weatherbrief.models.airport_conditions import (
+    AirportConditions,
+    AirportConditionsSummary,
+)
+from weatherbrief.tasks import advise
+
+
+class _Route:
+    """Just enough of RouteConfig for the destination lookup."""
+
+    class _Waypoint:
+        def __init__(self, icao):
+            self.icao = icao
+
+    def __init__(self, icao):
+        self.destination = self._Waypoint(icao)
+
+
+def _conditions(arr_icao: str) -> AirportConditions:
+    return AirportConditions(
+        departure=AirportConditionsSummary(icao="EGTK", name="EGTK"),
+        arrival=AirportConditionsSummary(icao=arr_icao, name=arr_icao),
+    )
+
+
+class TestArrivalIcaoResolution:
+    def test_prefers_the_resolved_route(self):
+        assert advise._arrival_icao(_Route("EGKA"), _conditions("EGBJ")) == "EGKA"
+
+    def test_falls_back_to_airport_conditions_on_the_recalc_path(self):
+        """Recalculate has no RouteConfig — the destination comes from the pack."""
+        assert advise._arrival_icao(None, _conditions("EGBJ")) == "EGBJ"
+
+    def test_no_route_and_no_conditions_is_none(self):
+        assert advise._arrival_icao(None, None) is None
+
+
+class TestCollectArrivalApproaches:
+    def test_looks_up_the_destination(self, monkeypatch):
+        expected = AirportApproaches(
+            icao="EGKA", has_procedure_data=True,
+            approaches=[RunwayApproach(name="RWY02 ILS", approach_type="ILS", runway_id="02")],
+        )
+        seen: dict = {}
+
+        def _fake(icaos, db_path):
+            seen["icaos"] = icaos
+            seen["db_path"] = db_path
+            return {"EGKA": expected}
+
+        monkeypatch.setattr("weatherbrief.airports.get_runway_approaches", _fake)
+        assert advise._collect_arrival_approaches("EGKA", "nav.db") is expected
+        assert seen == {"icaos": ["EGKA"], "db_path": "nav.db"}
+
+    @pytest.mark.parametrize("icao,db_path", [(None, "nav.db"), ("EGKA", None), ("EGKA", "")])
+    def test_missing_inputs_degrade_to_none(self, icao, db_path):
+        """None means "could not assess", which the evaluator reports as UNAVAILABLE."""
+        assert advise._collect_arrival_approaches(icao, db_path) is None
+
+    def test_lookup_failure_never_breaks_the_briefing(self, monkeypatch):
+        def _boom(icaos, db_path):
+            raise RuntimeError("nav.db is corrupt")
+
+        monkeypatch.setattr("weatherbrief.airports.get_runway_approaches", _boom)
+        assert advise._collect_arrival_approaches("EGKA", "nav.db") is None

--- a/tests/test_runway_approaches.py
+++ b/tests/test_runway_approaches.py
@@ -1,0 +1,168 @@
+"""Tests for ``get_runway_approaches`` — approaches joined to runway ends (#509).
+
+Uses the real euro_aip ``Airport`` / ``Runway`` / ``Procedure`` classes and mocks
+only the DB layer, so a change to the euro_aip contract (procedure fields, the
+``procedures_query`` collection) fails here rather than silently degrading every
+destination to "no approach".
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from euro_aip.models.airport import Airport
+from euro_aip.models.procedure import Procedure
+from euro_aip.models.runway import Runway
+
+from weatherbrief.airports import (
+    _is_circling_name,
+    _normalize_runway_ident,
+    get_runway_approaches,
+)
+
+
+def _airport(ident: str, runways: list[Runway], procedures: list[Procedure]) -> Airport:
+    airport = Airport(ident=ident)
+    airport.runways = runways
+    airport.procedures = procedures
+    return airport
+
+
+def _runway(le: str, he: str, *, closed: bool = False, headings: bool = True) -> Runway:
+    return Runway(
+        airport_ident="EGKA", closed=closed,
+        le_ident=le, le_heading_degT=20.0 if headings else None,
+        he_ident=he, he_heading_degT=200.0 if headings else None,
+    )
+
+
+def _approach(name: str, approach_type: str | None, runway_ident: str | None) -> Procedure:
+    return Procedure(
+        name=name, procedure_type="approach",
+        approach_type=approach_type, runway_ident=runway_ident,
+    )
+
+
+class _FakeCollection:
+    def __init__(self, airports: dict[str, Airport]):
+        self._airports = airports
+
+    def get(self, icao):
+        return self._airports.get(icao)
+
+
+class _FakeModel:
+    def __init__(self, airports: dict[str, Airport]):
+        self.airports = _FakeCollection(airports)
+
+
+def _lookup(airports: dict[str, Airport], icaos: list[str]):
+    with patch("weatherbrief.airports._load_airport_model", return_value=_FakeModel(airports)):
+        return get_runway_approaches(icaos, "nav.db")
+
+
+class TestNormalizeRunwayIdent:
+    @pytest.mark.parametrize("raw,expected", [
+        ("02", "2"), ("2", "2"), ("13L", "13L"), ("rwy 09r", "9R"),
+        (" 27 ", "27"), (None, None), ("", None), ("A", None),
+    ])
+    def test_canonicalizes_for_joining(self, raw, expected):
+        assert _normalize_runway_ident(raw) == expected
+
+
+class TestCirclingDetection:
+    @pytest.mark.parametrize("name", ["RNP A", "NDB C", "LOC A", "VOR/DME B"])
+    def test_letter_suffix_is_circling(self, name):
+        assert _is_circling_name(name) is True
+
+    @pytest.mark.parametrize("name", [
+        # The #509 finding: 223 of 262 ident-less rows are parser artifacts,
+        # so a naive "no runway ident => circling" rule is wrong ~85% of the time.
+        "MIPS: RNP (LNAV) ARINC CODING",
+        "RWY13 ILS LOC",
+        # X/Y/Z are straight-in variant designators, not circling letters.
+        "ILS Z",
+        "",
+    ])
+    def test_other_names_are_not_circling(self, name):
+        assert _is_circling_name(name) is False
+
+
+class TestGetRunwayApproaches:
+    def test_joins_approach_to_a_live_runway_end(self):
+        airports = {"EGKA": _airport(
+            "EGKA", [_runway("02", "20")], [_approach("RWY02 ILS", "ILS", "02")],
+        )}
+        result = _lookup(airports, ["EGKA"])["EGKA"]
+        assert result.has_procedure_data is True
+        assert result.has_iap is True
+        assert result.served_runway_ids == {"02"}
+        assert result.for_runway("02")[0].approach_type == "ILS"
+
+    def test_zero_padding_does_not_break_the_join(self):
+        airports = {"EGKA": _airport(
+            "EGKA", [_runway("02", "20")], [_approach("RWY2 ILS", "ILS", "2")],
+        )}
+        assert _lookup(airports, ["EGKA"])["EGKA"].served_runway_ids == {"02"}
+
+    def test_approach_on_a_runway_the_field_does_not_have_is_unresolved(self):
+        """Not collapsed into "circling" — unresolved alignment is its own state."""
+        airports = {"EGKA": _airport(
+            "EGKA", [_runway("02", "20")], [_approach("RWY09 RNP", "RNP", "09")],
+        )}
+        result = _lookup(airports, ["EGKA"])["EGKA"]
+        assert result.has_iap is True
+        assert result.served_runway_ids == set()
+        assert result.approaches[0].circling is False
+
+    def test_closed_runway_is_not_a_landing_option(self):
+        airports = {"EGKA": _airport(
+            "EGKA", [_runway("02", "20", closed=True)],
+            [_approach("RWY02 ILS", "ILS", "02")],
+        )}
+        assert _lookup(airports, ["EGKA"])["EGKA"].served_runway_ids == set()
+
+    def test_end_without_a_true_heading_cannot_be_paired_with_wind(self):
+        airports = {"EGKA": _airport(
+            "EGKA", [_runway("02", "20", headings=False)],
+            [_approach("RWY02 ILS", "ILS", "02")],
+        )}
+        assert _lookup(airports, ["EGKA"])["EGKA"].served_runway_ids == set()
+
+    def test_circling_procedure_is_flagged(self):
+        airports = {"EGKA": _airport(
+            "EGKA", [_runway("02", "20")], [_approach("RNP A", "RNP", None)],
+        )}
+        approach = _lookup(airports, ["EGKA"])["EGKA"].approaches[0]
+        assert approach.circling is True
+        assert approach.runway_id is None
+
+    def test_airport_with_no_procedures_reports_no_procedure_data(self):
+        airports = {"EGTF": _airport("EGTF", [_runway("06", "24")], [])}
+        result = _lookup(airports, ["EGTF"])["EGTF"]
+        assert result.has_procedure_data is False
+        assert result.has_iap is False
+
+    def test_departure_procedures_are_not_approaches(self):
+        sid = Procedure(name="RWY02 SID", procedure_type="departure", runway_ident="02")
+        airports = {"EGKA": _airport("EGKA", [_runway("02", "20")], [sid])}
+        result = _lookup(airports, ["EGKA"])["EGKA"]
+        assert result.has_procedure_data is True  # rows exist…
+        assert result.has_iap is False            # …but none is an approach
+
+    def test_unknown_icao_degrades_without_raising(self):
+        result = _lookup({}, ["ZZZZ"])["ZZZZ"]
+        assert result.has_procedure_data is False
+        assert result.approaches == []
+
+    def test_the_egka_shape_from_the_issue(self):
+        """IAPs on 02/20, nothing on 06/24 or 13/31 — the misalignment case."""
+        airports = {"EGKA": _airport(
+            "EGKA",
+            [_runway("02", "20"), _runway("06", "24"), _runway("13", "31")],
+            [_approach("RWY02 RNP", "RNP", "02"), _approach("RWY20 RNP", "RNP", "20")],
+        )}
+        result = _lookup(airports, ["EGKA"])["EGKA"]
+        assert result.served_runway_ids == {"02", "20"}
+        assert result.for_runway("24") == []

--- a/tests/test_runway_approaches.py
+++ b/tests/test_runway_approaches.py
@@ -98,7 +98,7 @@ class TestGetRunwayApproaches:
         assert result.has_procedure_data is True
         assert result.has_iap is True
         assert result.served_runway_ids == {"02"}
-        assert result.for_runway("02")[0].approach_type == "ILS"
+        assert result.approaches[0].approach_type == "ILS"
 
     def test_zero_padding_does_not_break_the_join(self):
         airports = {"EGKA": _airport(
@@ -165,4 +165,39 @@ class TestGetRunwayApproaches:
         )}
         result = _lookup(airports, ["EGKA"])["EGKA"]
         assert result.served_runway_ids == {"02", "20"}
-        assert result.for_runway("24") == []
+        assert "24" not in result.served_runway_ids
+
+
+class TestFailureNeverImpersonatesAbsence:
+    """A data gap must not become "this field has no instrument approach".
+
+    That string is the grade map's most severe input (RED at IFR/LIFR), so
+    every path that fails to determine the picture sets ``lookup_failed``
+    instead of returning an empty approach list.
+    """
+
+    def test_unknown_icao_is_a_failed_lookup_not_an_absence(self):
+        result = _lookup({}, ["ZZZZ"])["ZZZZ"]
+        assert result.lookup_failed is True
+        assert result.has_procedure_data is False
+        assert result.approaches == []
+
+    def test_raising_procedure_query_is_a_failed_lookup(self):
+        class _Exploding(Airport):
+            @property
+            def procedures_query(self):
+                raise ValueError("malformed procedure row")
+
+        airport = _Exploding(ident="EGKA")
+        airport.runways = [_runway("02", "20")]
+        airport.procedures = []
+        result = _lookup({"EGKA": airport}, ["EGKA"])["EGKA"]
+        assert result.lookup_failed is True
+        assert result.approaches == []
+
+    def test_a_genuine_absence_is_not_a_failed_lookup(self):
+        """EGTF Fairoaks really has no approach — that IS a fact to grade on."""
+        airports = {"EGTF": _airport("EGTF", [_runway("06", "24")], [])}
+        result = _lookup(airports, ["EGTF"])["EGTF"]
+        assert result.lookup_failed is False
+        assert result.has_iap is False

--- a/web/ts/components/debrief-taxonomy.ts
+++ b/web/ts/components/debrief-taxonomy.ts
@@ -98,6 +98,7 @@ const ADVISORY_TAG_MAP: Record<string, ConditionTagId> = {
   cloud_top:         'IMC',
   vfr_feasibility:   'IMC',
   ifr_feasibility:   'IMC',
+  approach_feasibility: 'IMC',
   flight_category:   'IMC',
   turbulence:        'TURB',
   mountain_wind:     'TURB',

--- a/web/ts/helpers/advisory-order.ts
+++ b/web/ts/helpers/advisory-order.ts
@@ -29,6 +29,7 @@ const BAND_ORDER: AdvisoryBand[] =
 export const ADVISORY_PRIORITY: string[] = [
   'ifr_feasibility',
   'vfr_feasibility',
+  'approach_feasibility',  // Can you get in, on a runway you can land on?
   'flight_category',     // Airport Weather
   'airport_wind',
   'cloud_top',


### PR DESCRIPTION
## What & why

Adds a dedicated `approach_feasibility` evaluator answering the arrival question no existing evaluator owns: **can I get in, on a runway I can also land on?**

`enrich_wind` (`analysis/airport_consensus.py:122`) picks the best runway with **zero approach awareness** — `min(crosswind_kt, -headwind_kt)` across all ends — so the briefing could say *"destination IFR, ceiling 600 ft, best runway 24"* at a field where 24 has no approach and the ILS serves 06. `flight_category` grades ceiling/vis, `airport_wind` grades wind, `ifr_feasibility` composites airport+icing+convective; nothing joined ceiling **and** wind **and** infrastructure. This does, with its own semantic, its own tunable params and its own drillable detail payload. `enrich_wind`'s `best_runway` semantics are deliberately unchanged — the pure-wind answer is still correct for VFR arrivals and for the forecast map.

**Data plumbing.** `airports.py::get_runway_approaches` mirrors `get_runway_ends` (the wind side of the same question) and returns `AirportApproaches` per ICAO. Each `RunwayApproach` resolves into exactly one of three states, and keeping the third apart is the point:

| State | Means |
|-------|-------|
| `runway_id` set | straight-in to that runway END — only when the procedure's ident joins a **live** (non-closed) end with a true heading, so it can always be paired with that end's wind |
| `circling=True` | ICAO letter-suffixed circling-only procedure (`RNP A`, `NDB C`) |
| neither | alignment unresolved — treated as *uncertainty*, never hard misalignment |

Circling detection keys on the single trailing letter, excluding X/Y/Z (straight-in *variant* designators) and any name carrying a digit. That digit guard is what matters: only **39** of the 262 ident-less rows in `nav.db` are real circling procedures, so a naive "no runway ident ⇒ circling" rule would be wrong ~85% of the time (`MIPS: RNP (LNAV) ARINC CODING` and friends).

The container carries a fourth, airport-level state — `lookup_failed` — see UNAVAILABLE below.

**Grade map**, gated on the destination's flight category — the alignment/circling/tailwind reasoning only earns its keep once the pilot can no longer be expected to complete the arrival visually:

| Category | Logic |
|----------|-------|
| **VFR** | GREEN, always. Visually reachable; infrastructure irrelevant (GREEN not UNAVAILABLE) |
| **MVFR** | IAP presence only, capped at AMBER. Any approach → GREEN, none → AMBER. **Never RED** |
| **IFR / LIFR** | Full logic. GREEN = straight-in to an end whose wind is within limits with ceiling/vis clear of the estimated minima band; AMBER = a compromise; RED = a hard fact only |

**UNAVAILABLE** is reserved for "the evaluator could not run": `arrival_approaches` absent (old pack / no nav.db), no per-model airport condition, or `lookup_failed` — the ICAO was unknown to `nav.db`, or the procedure query raised. Zero procedure rows is graded as *no instrument approach*, full stop — no third state there, per the issue's decision. Documented caveat for the US-expansion work: in a 0%-coverage country that rule would grade every IFR destination RED.

`lookup_failed` exists because "this field has no instrument approach" is the **most severe input the grade map takes** (RED at IFR/LIFR), and it arrives as the same empty approach list a parse failure would produce. Only the flag tells them apart, so every path in `get_runway_approaches` that fails to *determine* the picture sets it rather than returning an empty list — a data problem must not be able to manufacture a RED.

**Two rules keep it honest:**
1. **One minima table** — decision heights come from `analysis/alternate_requirement.py::APPROACH_CLASS_PROXY` via `proxy_for_approach`, the same estimates the alternate-requirement card shows. No second table to drift. Circling-only procedures are **excluded** from the airport-wide best-case gate: that table holds *straight-in* minima, and real circling minima are categorically higher for the same class.
2. **Asymmetric uncertainty** — estimate uncertainty may push toward AMBER, never toward RED. RED needs no IAP at all, a ceiling/visibility below even the *best case*, an approach-served end with an out-of-limits tailwind **and** conditions that will not support circling, or that same best-case test applied per approach to an end the wind is happy with. A forecast *inside* the band is AMBER — the AMBER middle is exactly the width of our uncertainty about the plate. Neither an approach of unresolved alignment, nor a served end the wind model did not cover, nor a failed lookup can drive RED.

**The no-usable-straight-in verdict is a cross product**, and is built as one: `_Blocker` (`MINIMA` / `MISALIGNED` / `NO_STRAIGHT_IN`) × `_Softening` (`CIRCLING` / `UNRESOLVED` / `NO_WIND_DATA` / `NONE`), composed by `_fallback_detail` as `"{cause} — {clause}"`. Every cell has correct text by construction, and a new blocker or reason costs one string rather than a row or column. A matrix test asserts every cell resolves in all four locales and that no non-circling reason recommends circling.

**Circling is flagged, never graded** — `nav.db` has no circling minima. `circling_ceiling_ft` / `circling_visibility_m` only decide whether a blocked arrival softens to AMBER; circling needs *both*, since a generous ceiling in fog is not a way in. **Alignment is graded per model** so the registry's majority aggregation absorbs cross-model wind spread, and crossing the tailwind limit only removes the straight-in option, so the verdict degrades to AMBER near the boundary rather than flipping GREEN↔RED.

**Wiring — both context builders plus the alt path.** `RouteContext.arrival_approaches` follows the `route_fronts` / `sun` precedent (`None` ⇒ UNAVAILABLE, old packs degrade cleanly). The briefing run and the recalculate/preview re-run both build it, and the recalc/preview/alt API endpoints now hand `airports_db_path` down — the recalc path has no resolved `RouteConfig`, so `_arrival_icao` falls back to the recomputed airport conditions' arrival ICAO. Miss either point and the advisory silently degrades to a grey card on recalculate.

Params (`flight_rules` category, `default_enabled=True`, no self-gating on `aircraft.is_ifr` — matching `vfr_feasibility`/`ifr_feasibility`): `tailwind_limit_kt` (10 kt, pilot tier), `crosswind_limit_kt` (20 kt, pilot tier), `circling_ceiling_ft` (1000 ft, advanced), `circling_visibility_m` (1500 m, advanced).

**Surfacing.** The advisory itself needs no per-advisory registration — web/iOS render cards from the served catalog, and MCP `summarize_advisories` / `get_advisory_detail` plus the digest prompt builder are generic. But **four hand-maintained id→category tables do need an entry**, and all four already list both feasibility composites: `ADVISORY_PRIORITY` (`web/ts/helpers/advisory-order.ts`), `ADVISORY_TAG_MAP` (`debriefs/taxonomy.py` + its TS mirror; iOS reads it from the served catalog) → `IMC`, `ADVISORY_SITUATION` (`eval_workbench/situations.py`) → the existing `ifr_marginal` cell, and `_AIRPORT_CONDITION_ADVISORIES` (`eval_workbench/rerun.py`) so corpus re-runs flag it rather than reporting its UNAVAILABLE as an unexplained regression. Detail strings are localized en/fr/de/es. No cross-section highlights or chip — like every airport advisory this is point-in-space, not route geometry. No new API-serialized field, so no iOS DTO change.

### Deferred, and why

- **TAF preference at D-0.** The issue asks this to prefer TAF over NWP so the card cannot contradict the alternates card beside it. Advisories run at pipeline step 3 and METAR/TAF are fetched at step 3.5, so `RouteContext` has no observation to read — closing this means reordering the pipeline, well beyond this change. The NWP consensus in `airport_conditions.arrival` is what is graded today; recorded as a known gap in the evaluator docstring and in `designs/advisories.md`.
- Per-candidate approach feasibility for **alternates**, and an approach-aware "best usable runway" alongside `best_runway` — both listed as out-of-scope / follow-up in the issue.
- #510 (user-declared unpublished approaches) ships after this, as specified.

**Noticed, not fixed here (pre-existing):** `_AIRPORT_CONDITION_ADVISORIES` contains `"airport_conditions"`, which matches no registered advisory id — the airport category is `flight_category` / `airport_wind` / `density_altitude` / `llws` — so those first two are currently unflagged in every workbench diff. Flagged in a code comment; fixing it would silently change diff output for advisories this PR does not touch.

Design docs updated: a dedicated section in `designs/advisories.md` (grade map, resolution states, the honesty rules, the blocker × softening cross product, the wiring points, the known gap), evaluator counts in `designs/INDEX.md`, and the now-shipped follow-up struck from `designs/alternate-requirement.md`.

## Issue linkage

Closes #509

## Testing / verification

83 new tests across three files.

- **`tests/analysis/advisories/test_approach_feasibility.py`** (46) — UNAVAILABLE vs no-approach vs failed lookup; the VFR/MVFR/IFR gating incl. "MVFR ignores a misaligned approach"; ceiling and visibility band edges; the tailwind ladder; circling-only, unresolved-alignment and missing-wind-data never driving RED; the minima-vs-misalignment split (two served ends in *different* minima bands); the full blocker × softening matrix resolving in all four locales; circling needing visibility as well as ceiling; circling minima not lending straight-in minima to the gate; per-model split; and a real param-wiring test that moves each of the four params across the threshold it controls and asserts the verdict changes.
- **`tests/test_runway_approaches.py`** (29) — runs against the **real** euro_aip `Airport`/`Runway`/`Procedure` classes with only the DB layer mocked, so a euro_aip contract change fails here rather than silently degrading every destination to "no approach". Covers ident normalization (`RWY 09R` → `9R`; this caught a real bug in the first implementation), circling-vs-parser-artifact detection, closed runways, ends without a true heading, departures not counting as approaches, the EGKA shape from the issue, and a `TestFailureNeverImpersonatesAbsence` group pinning that an unknown ICAO and a raising procedure query both set `lookup_failed` while a genuine absence (EGTF Fairoaks) still grades.
- **`tests/test_advise_arrival_approaches.py`** (8) — both wiring points, incl. the recalc path's fallback to the airport-conditions arrival ICAO and lookup failure degrading to `None` rather than breaking a briefing.
- **Existing:** full backend suite — 4320 passed, with the failure set matching the pre-change baseline exactly (16 failures + 6 collection errors, all environmental in this sandbox: subprocess launching, thread-pool timing, OAuth redirect, ECMWF file paths). Web: `npm test` 556 passed across 35 files; `tsc --noEmit` shows only two pre-existing errors in `ts/eval/label-panel.ts`, untouched here.

Two limits worth a spot-check after deploy: the sandbox has no `nav.db`, so the euro_aip join is verified against the real model classes with a mocked DB layer rather than against production procedure rows (EGKA / EGBJ are the fields to eyeball); and `euro-aip` requires Python ≥3.12 while this container has 3.11, so it was installed with `--ignore-requires-python` (it is pure Python) — that affects only the local test environment, not the change.