### PR TITLE
fix(icing): phantom icing from risk=none zones, and invisible single-level SFIP bands

### DIFF
--- a/src/weatherbrief/analysis/advisories/_helpers.py
+++ b/src/weatherbrief/analysis/advisories/_helpers.py
@@ -13,6 +13,7 @@ from weatherbrief.models import (
     ElevationProfile,
     HighlightRegion,
     HighlightSeverity,
+    IcingRisk,
     IcingZone,
     MitigationProfile,
     MitigationSegment,
@@ -370,12 +371,38 @@ def ribbon_peak(segments: list[RibbonSegment]) -> float | None:
     return None
 
 
+def hazardous_icing_zones(zones: list[IcingZone]) -> list[IcingZone]:
+    """Return only the zones that represent icing a pilot would meet.
+
+    Zone *existence* is not a hazard predicate. The Ogimet methods emit a zone
+    wherever cloud sits in the icing temperature band and stamp it with the
+    computed index, so ``risk == NONE`` there means "assessed here, index below
+    the LIGHT threshold" — the method's way of saying *no icing*, not a hazard.
+    (SFIP is the opposite: it only ever emits zones at LIGHT or worse, which is
+    why grading on bare existence looked correct for as long as DD/SFIP were the
+    only sources.) Grading on existence turns every assessed-but-clean Ogimet
+    point into an icing hit, and the cross-section — which filters ``none`` out
+    of every icing layer — then draws nothing where the advisory claims icing.
+
+    ``sld_risk`` survives a NONE risk: supercooled large droplets are a hazard in
+    their own right regardless of the index. That is the same predicate
+    ``icing_escape._icing_cell_cost`` has always applied to price its cost field
+    (``risk == NONE and not sld_risk`` → skip); this helper shares it with the
+    grading paths, which had drifted from it.
+    """
+    return [z for z in zones if z.risk != IcingRisk.NONE or z.sld_risk]
+
+
 def icing_zones_in_altitude_range(
     zones: list[IcingZone],
     floor_ft: float,
     ceiling_ft: float,
 ) -> list[IcingZone]:
-    """Return icing zones that overlap the altitude range [floor_ft, ceiling_ft]."""
+    """Return icing zones that overlap the altitude range [floor_ft, ceiling_ft].
+
+    Altitude-only: pass the zones through :func:`hazardous_icing_zones` first
+    when the result drives a grade.
+    """
     return [z for z in zones if z.top_ft > floor_ft and z.base_ft < ceiling_ft]
 
 

--- a/src/weatherbrief/analysis/advisories/fiki_icing.py
+++ b/src/weatherbrief/analysis/advisories/fiki_icing.py
@@ -13,6 +13,7 @@ from weatherbrief.analysis.advisories._helpers import (
     EvidenceSample,
     FlaggedCell,
     driving_method_id,
+    hazardous_icing_zones,
     icing_zones_in_altitude_range,
     min_icing_clearance,
     summarize_evidence,
@@ -222,7 +223,9 @@ class FIKIIcingEvaluator:
                     continue
                 total += 1
 
-                zones = sounding.icing_zones
+                # Ogimet zones at risk NONE mean "assessed, no icing" — they must
+                # not add to the transit thickness a FIKI grade is built from.
+                zones = hazardous_icing_zones(sounding.icing_zones)
                 t, sev, sld = _transit_icing(zones, cruise_alt)
 
                 # --- departure / arrival transit icing ---

--- a/src/weatherbrief/analysis/advisories/icing_escape.py
+++ b/src/weatherbrief/analysis/advisories/icing_escape.py
@@ -9,6 +9,7 @@ from weatherbrief.analysis.advisories._helpers import (
     build_cost_model,
     driving_method_id,
     format_extent,
+    hazardous_icing_zones,
     icing_zones_in_altitude_range,
     max_terrain_near_point,
     pct_above_threshold,
@@ -288,8 +289,11 @@ class IcingEscapeEvaluator:
 
                 # Icing above cruise + buffer is deliberately GREEN on the
                 # ribbon too ("not relevant to your flight here" reads as clear).
+                # ``hazardous_icing_zones`` first: an Ogimet zone at risk NONE is
+                # "assessed, no icing", and grading it as a hit is what made this
+                # advisory claim icing the cross-section could not draw.
                 relevant_zones = icing_zones_in_altitude_range(
-                    sounding.icing_zones,
+                    hazardous_icing_zones(sounding.icing_zones),
                     0,
                     ctx.cruise_altitude_ft + icing_altitude_buffer_ft,
                 )

--- a/src/weatherbrief/analysis/advisories/ifr_feasibility.py
+++ b/src/weatherbrief/analysis/advisories/ifr_feasibility.py
@@ -15,6 +15,7 @@ from weatherbrief.analysis.advisories._helpers import (
     build_ribbon,
     driving_method_id,
     format_extent,
+    hazardous_icing_zones,
     min_icing_clearance,
     ribbon_peak,
     worst_severity,
@@ -180,10 +181,14 @@ def _check_enroute_hazards(
         icing_available = sounding.active_icing_available
         if icing_available:
             icing_total += 1
+        # Only zones the pilot would actually meet: an Ogimet zone at risk NONE
+        # is the method reporting "assessed, no icing", and counting it made this
+        # composite flag — and go RED on — icing that does not exist.
+        icing_zones = hazardous_icing_zones(sounding.icing_zones)
         has_icing = (
             icing_available
-            and bool(sounding.icing_zones)
-            and min_icing_clearance(sounding.icing_zones, cruise_altitude_ft)
+            and bool(icing_zones)
+            and min_icing_clearance(icing_zones, cruise_altitude_ft)
             < icing_altitude_buffer_ft
         )
         has_convective = False
@@ -206,7 +211,7 @@ def _check_enroute_hazards(
             icing_count += 1
             # The triggering zones: those within the buffer of cruise.
             band = [
-                z for z in sounding.icing_zones
+                z for z in icing_zones
                 if z.base_ft < cruise_altitude_ft + icing_altitude_buffer_ft
                 and z.top_ft > cruise_altitude_ft - icing_altitude_buffer_ft
             ]

--- a/src/weatherbrief/analysis/sounding/sfip.py
+++ b/src/weatherbrief/analysis/sounding/sfip.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import math
 
 from weatherbrief.analysis.sounding.icing_common import (
+    MIN_ZONE_HALF_THICKNESS_FT,
     group_icing_levels,
     is_in_cloud_layer,
     nwp_cloud_cover_at_altitude,
@@ -403,6 +404,20 @@ def _build_sfip_zone(
     base = levels_in_zone[0]
     top = levels_in_zone[-1]
 
+    base_ft = round(base.altitude_ft)
+    top_ft = round(top.altitude_ft)
+
+    # Expand thin zones (single pressure level) to minimum thickness — the same
+    # treatment ``icing._build_zone_simple`` gives Ogimet zones. A zone spanning
+    # one level would otherwise carry base_ft == top_ft, and a zero-height band
+    # is invisible: the cross-section fills its polygon and nothing appears, so a
+    # genuine MODERATE/SEVERE SFIP signal renders as blank sky. Single-level
+    # zones are the common case, not the edge case, at ECMWF/GFS level spacing.
+    if top_ft - base_ft < MIN_ZONE_HALF_THICKNESS_FT * 2:
+        mid_ft = (base_ft + top_ft) / 2
+        base_ft = round(mid_ft - MIN_ZONE_HALF_THICKNESS_FT)
+        top_ft = round(mid_ft + MIN_ZONE_HALF_THICKNESS_FT)
+
     # Worst risk in zone
     risk_order = [IcingRisk.NONE, IcingRisk.LIGHT, IcingRisk.MODERATE, IcingRisk.SEVERE]
     worst_risk = max(risks, key=lambda r: risk_order.index(r))
@@ -421,8 +436,8 @@ def _build_sfip_zone(
     variant = levels_in_zone[0].sfip_variant or "full"
 
     return SfipZone(
-        base_ft=round(base.altitude_ft),  # type: ignore[arg-type]
-        top_ft=round(top.altitude_ft),  # type: ignore[arg-type]
+        base_ft=base_ft,
+        top_ft=top_ft,
         base_pressure_hpa=base.pressure_hpa,
         top_pressure_hpa=top.pressure_hpa,
         risk=worst_risk,

--- a/tests/analysis/advisories/test_icing_risk_none_zones.py
+++ b/tests/analysis/advisories/test_icing_risk_none_zones.py
@@ -1,0 +1,141 @@
+"""Regression tests: an Ogimet zone at risk NONE is not icing.
+
+The Ogimet methods emit a zone wherever cloud sits in the icing temperature
+band and stamp it with the computed index, so ``risk == NONE`` means "assessed
+here, index below the LIGHT threshold" — the method saying *no icing*. The
+grading paths tested a zone's *existence* instead of its risk, so those
+assessed-but-clean points counted as icing hits.
+
+Reported from a real briefing (EDDC→EDDE→EDGS→EDKV, 2026-07-27): ECMWF graded
+AMBER icing escape and contributed to a RED IFR feasibility on three points
+whose only zones carried ``risk=none`` and an Ogimet index of 0.4–1.9, while the
+cross-section — which filters ``none`` out of every icing layer — correctly drew
+nothing. SFIP never showed the bug because it only ever emits zones at LIGHT or
+worse; the fault surfaced once Ogimet became the graded method.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+
+from weatherbrief.analysis.advisories import RouteContext
+from weatherbrief.analysis.advisories._helpers import hazardous_icing_zones
+from weatherbrief.analysis.advisories.fiki_icing import FIKIIcingEvaluator
+from weatherbrief.analysis.advisories.icing_escape import IcingEscapeEvaluator
+from weatherbrief.analysis.advisories.ifr_feasibility import IFRFeasibilityEvaluator
+from weatherbrief.models import (
+    AdvisoryStatus,
+    IcingRisk,
+    IcingType,
+    IcingZone,
+    RoutePointAnalysis,
+    SoundingAnalysis,
+    ThermodynamicIndices,
+)
+
+
+def _defaults(evaluator) -> dict:
+    return {p.key: p.default for p in evaluator.catalog_entry().parameters}
+
+
+def _ctx(soundings: list[SoundingAnalysis]) -> RouteContext:
+    """RouteContext over one model, zones already resolved into ``icing_zones``."""
+    analyses = [
+        RoutePointAnalysis(
+            point_index=i, lat=48.0, lon=2.0, distance_from_origin_nm=i * 20.0,
+            interpolated_time=datetime(2026, 3, 1, 10, 0),
+            forecast_hour=datetime(2026, 3, 1, 9, 0), track_deg=135.0,
+            sounding={"gfs": s},
+        )
+        for i, s in enumerate(soundings)
+    ]
+    return RouteContext(
+        analyses=analyses, cross_sections=[], elevation=None, models=["gfs"],
+        cruise_altitude_ft=8000, flight_ceiling_ft=18000, total_distance_nm=200,
+    )
+
+
+def _zone(risk: IcingRisk, *, sld: bool = False, index: float = 0.8) -> IcingZone:
+    """A zone straddling cruise+buffer, so only its risk decides the grade.
+
+    Geometry mirrors the reported briefing: a single 700 hPa level padded to
+    1000 ft, sitting just above an 8,000 ft cruise and inside the 2,000 ft
+    relevance buffer.
+    """
+    return IcingZone(
+        base_ft=9623, top_ft=10623, base_pressure_hpa=700, top_pressure_hpa=700,
+        risk=risk, icing_type=IcingType.CLEAR, sld_risk=sld,
+        mean_temperature_c=-0.8, mean_icing_index=index, mean_rh_pct=77.0,
+    )
+
+
+def _sounding(zones: list[IcingZone]) -> SoundingAnalysis:
+    return SoundingAnalysis(
+        indices=ThermodynamicIndices(freezing_level_ft=9000),
+        icing_zones=zones,
+    )
+
+
+# ── the predicate itself ─────────────────────────────────────────────
+
+
+def test_hazardous_filter_drops_none_risk():
+    assert hazardous_icing_zones([_zone(IcingRisk.NONE)]) == []
+
+
+def test_hazardous_filter_keeps_real_icing():
+    for risk in (IcingRisk.LIGHT, IcingRisk.MODERATE, IcingRisk.SEVERE):
+        assert len(hazardous_icing_zones([_zone(risk)])) == 1
+
+
+def test_hazardous_filter_keeps_sld_despite_none_risk():
+    """SLD is a hazard regardless of the index — the same carve-out the escape
+    cost model has always made (``risk == NONE and not sld_risk`` → skip)."""
+    assert len(hazardous_icing_zones([_zone(IcingRisk.NONE, sld=True)])) == 1
+
+
+# ── the grading paths ────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "evaluator", [IcingEscapeEvaluator, FIKIIcingEvaluator, IFRFeasibilityEvaluator]
+)
+def test_none_risk_zones_do_not_flag_icing(evaluator):
+    """A route where every point carries only risk=NONE zones grades GREEN."""
+    ctx = _ctx([_sounding([_zone(IcingRisk.NONE)]) for _ in range(10)])
+    result = evaluator.evaluate(ctx, _defaults(evaluator))
+    assert result.aggregate_status == AdvisoryStatus.GREEN
+    assert result.per_model[0].affected_points == 0
+
+
+@pytest.mark.parametrize(
+    "evaluator", [IcingEscapeEvaluator, FIKIIcingEvaluator, IFRFeasibilityEvaluator]
+)
+def test_real_icing_still_flags(evaluator):
+    """No over-correction: MODERATE zones on the same geometry still flag."""
+    ctx = _ctx([_sounding([_zone(IcingRisk.MODERATE)]) for _ in range(10)])
+    result = evaluator.evaluate(ctx, _defaults(evaluator))
+    assert result.aggregate_status != AdvisoryStatus.GREEN
+    assert result.per_model[0].affected_points > 0
+
+
+def test_none_risk_points_do_not_inflate_the_affected_extent():
+    """The reported symptom: extent counted assessed-but-clean points.
+
+    Half the route carries real LIGHT icing, half carries risk=NONE zones. Only
+    the former may reach the extent — before the fix both did, and the headline
+    read double the true coverage.
+    """
+    soundings = [_sounding([_zone(IcingRisk.LIGHT)]) for _ in range(5)]
+    soundings += [_sounding([_zone(IcingRisk.NONE)]) for _ in range(5)]
+    result = IcingEscapeEvaluator.evaluate(_ctx(soundings), _defaults(IcingEscapeEvaluator))
+    assert result.per_model[0].affected_points == 5
+
+
+def test_sld_at_none_risk_still_flags():
+    """A NONE-risk zone carrying SLD is a hazard and must survive the filter."""
+    ctx = _ctx([_sounding([_zone(IcingRisk.NONE, sld=True)]) for _ in range(10)])
+    result = IcingEscapeEvaluator.evaluate(ctx, _defaults(IcingEscapeEvaluator))
+    assert result.aggregate_status != AdvisoryStatus.GREEN

--- a/tests/test_sfip.py
+++ b/tests/test_sfip.py
@@ -595,3 +595,48 @@ def test_mixed_full_proxy_clw_zero_clear_air():
     zones = assess_sfip_zones(levels)
     # CLW=0 means full variant but gated → no zones despite perfect T/RH
     assert len(zones) == 0
+
+
+# ── Single-level zone thickness ──────────────────────────────────────
+
+
+def test_single_level_zone_has_minimum_thickness():
+    """A zone spanning one pressure level is expanded, not left zero-height.
+
+    ``_build_sfip_zone`` used to take base/top straight from the group's first
+    and last level, so a single-level group produced ``base_ft == top_ft``. The
+    cross-section fills a band polygon with no minimum-height guard, so those
+    zones rendered as nothing — a MODERATE/SEVERE SFIP signal drawn as blank
+    sky. Ogimet's ``_build_zone_simple`` has always expanded them; this pins the
+    same behaviour for SFIP.
+    """
+    # Only the 700 hPa level is in cloud and cold enough to score — its
+    # neighbours are gated out, so the zone spans exactly one level.
+    levels = [
+        _level(800, 6500, 4.0, 3.0, 90.0, 1.0, clw=0.0),
+        _level(700, 10000, -6.0, -6.5, 96.0, 0.5, clw=0.20),
+        _level(600, 13500, -30.0, -31.0, 60.0, 1.0, clw=0.0),
+    ]
+    zones = assess_sfip_zones(levels, nwp_cloud_layers=[_nwp_cloud(9000, 11000)])
+    assert len(zones) == 1
+    zone = zones[0]
+    assert zone.top_ft > zone.base_ft, "single-level zone must not be zero-height"
+    assert zone.top_ft - zone.base_ft == 1000
+    # Expanded symmetrically about the level it came from.
+    assert (zone.base_ft + zone.top_ft) / 2 == pytest.approx(10000)
+    # Pressure bounds still describe the level itself, as Ogimet does.
+    assert zone.base_pressure_hpa == 700
+    assert zone.top_pressure_hpa == 700
+
+
+def test_multi_level_zone_keeps_its_own_bounds():
+    """A zone already thicker than the minimum is left alone."""
+    levels = [
+        _level(850, 5000, -3.0, -4.0, 92.0, 1.0, clw=0.08),
+        _level(800, 6500, -6.0, -7.0, 95.0, 1.0, clw=0.15),
+        _level(750, 8000, -9.0, -10.0, 96.0, 1.0, clw=0.20),
+    ]
+    zones = assess_sfip_zones(levels, nwp_cloud_layers=[_nwp_cloud(4000, 9000)])
+    assert len(zones) == 1
+    assert zones[0].base_ft == 5000
+    assert zones[0].top_ft == 8000


### PR DESCRIPTION
Two independent icing defects found while investigating a user report on flight `eddc_edde_edgs_edkv-2026-07-27-847b`. The user's complaint — *"I don't see on the cross-section the icing it's reporting"* — was the visible symptom of both.

They viewed ECMWF with all three icing layers on (Ogimet-DD, Ogimet-NWP, SFIP-NWP) and got a blank chart, while the advisories reported AMBER icing escape and RED IFR feasibility.

## Bug 1 — advisories counted `risk=none` Ogimet zones as icing

The profile grades icing on Ogimet-NWP. `_resolve_analyses` swaps `icing_ogimet_nwp_zones` into `icing_zones`, and the grading paths then tested a zone's **existence** rather than its risk:

- `_helpers.icing_zones_in_altitude_range` — altitude overlap only, no risk filter
- `ifr_feasibility` — `bool(sounding.icing_zones)`
- `fiki_icing._transit_icing` — sums every zone's thickness regardless of risk

But Ogimet emits a zone wherever cloud sits in the icing temperature band and stamps it with the computed index, so `risk == NONE` means *"assessed here, no icing"*. SFIP is the opposite — it only ever emits zones at LIGHT or worse — which is why grading on bare existence looked correct for as long as DD/SFIP were the only sources.

The correct predicate already existed one function away: `icing_escape._icing_cell_cost` skips `risk == NONE and not sld_risk` when pricing its cost field. So one half of `icing_escape.py` priced these zones at zero while the other half graded them as a hazard. This extracts that predicate as `hazardous_icing_zones` and shares it with the three grading paths.

**On the reported flight**, ECMWF's entire icing signal was three points carrying only `risk=none` zones with an Ogimet index of 0.4–1.9 — while the cross-section, which filters `none` out of every icing layer, correctly drew nothing.

| | before | after |
|---|---|---|
| ECMWF icing_escape | AMBER (3/17) | **GREEN (0/17)** |
| ECMWF ifr_feasibility | AMBER (3/30) | **GREEN (0/30)** |
| ICON icing_escape / ifr | AMBER / RED, 33% (10/30) | AMBER / RED, 27% (8/30) |
| aggregate ifr_feasibility | RED "icing over 93nm (33%)" | RED "icing over 74nm (27%)" |

ICON's real light/moderate icing is untouched apart from dropping its two `risk=none` points. SLD survives a NONE risk, matching the existing cost-model carve-out.

## Bug 2 — single-level SFIP zones render as nothing

`_build_sfip_zone` took base/top straight from the group's first and last level, so a zone spanning exactly one pressure level came out with `base_ft == top_ft`. The cross-section fills a band polygon with no minimum-height guard, so those zones draw as blank sky — even at MODERATE or SEVERE.

This is the common case, not an edge case: **15 of 21 SFIP zones in the reported pack were zero-thickness** (5/5 ECMWF, 3/4 GFS, 7/12 ICON), including ICON's SEVERE zone at EDDE (10,943 ft) and every ECMWF moderate.

Ogimet's `_build_zone_simple` has always expanded thin zones by `MIN_ZONE_HALF_THICKNESS_FT` either side of the level. This applies the same treatment to SFIP so the two methods describe the same geometry. Re-running analysis on the reported pack: 48 SFIP zones, 0 zero-thickness.

Fixed in Python rather than the renderer so web and iOS both get it.

**Behaviour note for SFIP-method users:** zones now have physical extent, so clearance-based checks see them. On this flight that raised affected point counts (ECMWF 1→5, GFS 0→1, ICON 9→10) without changing any aggregate status. Intended — a zone at a level does occupy airspace — but it does shift SFIP-graded icing slightly toward more coverage.

## Testing

- New `tests/analysis/advisories/test_icing_risk_none_zones.py` (11 tests): the predicate itself, all three evaluators GREEN on `risk=none`-only routes, real icing still flagging, extent not inflated, SLD carve-out. Verified these genuinely fail without the fix — all three evaluators go RED with 10/10 affected.
- New SFIP geometry tests: single-level zone expanded symmetrically to 1,000 ft with pressure bounds preserved; multi-level zone left alone.
- Full suite: **4353 passed, 9 skipped, 0 failures**. No existing test pinned the old behaviour.
- Both fixes verified end-to-end by replaying the reported pack with the user's own saved thresholds; the pre-fix replay reproduced the shipped `route_advisories.json` exactly.

## Deliberately out of scope

`analysis/sounding/advisories.py` (the per-waypoint altitude advisories / escape-altitude block, lines ~553, 665–677) has the same `len(icing_zones) > 0` predicate bug. It is a different surface fed by `tasks/analyze.py` before `_resolve_analyses`, on DD zones, and fixing it would move the altitude-table output — left out to keep this PR to the two reported defects. Worth a follow-up.

Advisory grades move here, so the eval corpus will want re-baselining.

🤖 Generated with [Claude Code](https://claude.com/claude-code)