### PR TITLE
feat(advisories): user-declared unpublished approaches (cloud break procedures)

### DIFF
--- a/.claude/skills/check-health/SKILL.md
+++ b/.claude/skills/check-health/SKILL.md
@@ -61,7 +61,16 @@ Read:
 - All containers `(healthy)`. `weatherbrief` and `weatherbrief-mcp` are the two we own; the rest are siblings.
 - `weatherbrief` MEM USAGE / LIMIT — cgroup limit is **6 GiB** (raised from 4 GiB; do not cite the older "3 GiB" / "4 GiB" numbers from memory). Sustained >4.5 GiB warrants a note.
 - `shared-mysql` at **~1.2–1.6 GiB is expected and healthy** since 2026-07-18: `innodb_buffer_pool_size` was raised 128 MB → 1 GiB (flyfun-weather#448). Don't flag the jump from the old ~330 MiB baseline. Do flag if it reads ~330 MiB again — that means the container restarted *without* the compose-file setting (run `docker compose up -d` in `~/digitalocean/shared-infra`, or re-apply `SET GLOBAL innodb_buffer_pool_size`).
-- Host **Swap used** — anything more than a few hundred MB swap in use is a warn. The droplet has 4 GiB swap; production sometimes parks 1–2 GiB of mmap-backed cfgrib pages there under memory pressure (see lesson §L2 before reflexively flagging).
+  - **A low RSS here does not prove the setting was lost.** `docker stats` shows resident memory only, so a buffer pool that got **swapped out** reads low while the config is still correct. Observed 2026-07-28: RSS 542 MiB — below the expected band — but `innodb_buffer_pool_size` was still `1073741824` and `mysqld` held 2.3 GiB in swap. Confirm before concluding:
+    ```bash
+    ssh brice@161.35.35.15 "docker exec shared-mysql mysql -uroot -p\$(grep -h MYSQL_ROOT_PASSWORD ~/digitalocean/shared-infra/.env | cut -d= -f2) -e \"SHOW VARIABLES LIKE 'innodb_buffer_pool_size'\""
+    ```
+    Config right + RSS low + swap high = paged-out pool. Not a config regression, but DB reads are hitting disk; a `docker compose restart shared-mysql` in a quiet window faults it back in.
+- Host **Swap used** — the droplet has **8 GiB** swap (not the 4 GiB this doc claimed until 2026-07-28). Anything more than a few hundred MB is nominally a warn, but read *who holds it* before flagging: production sometimes parks 1–2 GiB of mmap-backed cfgrib pages there under memory pressure (see lesson §L2). Attribute it before judging:
+  ```bash
+  ssh brice@161.35.35.15 "for f in /proc/*/status; do awk '/^Name:/{n=\$2}/^VmSwap:/{if(\$2>50000) print \$2\" kB  \"n}' \$f 2>/dev/null; done | sort -rn | head -12"
+  ```
+  On a long-uptime box (87 days at the 2026-07-28 observation) cold pages accumulate without indicating live pressure — check `free -h` **available** and current load before calling it. Observed 2026-07-28: 3.9 GiB total swap, **2.3 GiB of it `mysqld`**, with available at 3.9 GiB and load 0.53 → note, not issue.
 - Host **free Mem** — single-digit MB free is fine if buff/cache is large; what matters is `available`.
 - `uptime` load triplet — same interpretation as the DO metrics, just current.
 
@@ -142,7 +151,26 @@ ssh brice@161.35.35.15 "docker logs --since <window> weatherbrief 2>&1 \
 
 ## 6. Standalone verification cycle
 
-Schedule: **light** (score-only) cycles at 06:15 / 09:15 / 12:15 / 15:15 / 18:15 UTC; **forecast** (heavy fetch) cycles at **07:15 / 19:15 UTC**; **METAR ingest** every 30 min. Grep the latest cycle's footprint:
+Schedule: **light** (score-only) cycles at 06:15 / 09:15 / 12:15 / 15:15 / 18:15 UTC; **METAR ingest** every 30 min; and at **07:15 / 19:15 UTC** the heavy forecast work — which **no longer runs on the droplet** (see below).
+
+> **⚠️ The droplet does not run the heavy forecast cycle any more.** It is produced off-box by the `mac-mini-m4` compute node (`deploy/compute-nodes.json`), which emits a SQLite artifact into `/mnt/flyfun_data/weather/snapshot_inbox/` and the droplet **imports** it. Verified 2026-07-28: the last local `standalone_forecast` cycle was **2026-07-26 07:15** (~45 min), while `standalone_imported` runs twice daily and takes **~72 s**. The node's runner script still carries a stale "VALIDATION PHASE: prod does NOT ingest yet" comment — ignore it, ingest is live.
+>
+> Ground truth is the DB, not the logs (the import is quiet in `docker logs`):
+> ```bash
+> ssh brice@161.35.35.15 "docker exec weatherbrief python -c \"
+> from weatherbrief.db import get_engine
+> from sqlalchemy import text
+> with get_engine().connect() as c:
+>     for r in c.execute(text('''SELECT source, COUNT(*), MAX(started_at), AVG(duration_ms)/1000
+>         FROM verification_cycles WHERE started_at > UTC_TIMESTAMP() - INTERVAL 3 DAY
+>         GROUP BY source ORDER BY 2 DESC''')): print(r)
+> \""
+> ```
+> Expect `standalone_imported` ~2/day at ~60–90 s. **If `standalone_imported` goes stale, the node stopped delivering** — check it is reachable and that its cycle ran (`~/flyfun-data/logs/`). The local `standalone_forecast` path still exists as a fallback but is a **cold path**: it has not executed since 2026-07-26, and the droplet sets `STANDALONE_ANALYSIS_WORKERS=0`, so if it ever does run it falls back to inline single-core (~68 min, the pre-PR-B figure) rather than the ~25–35 min band below. Treat the bands below as applying to the **node's** cycle.
+>
+> Note the inbox is **append-only in practice** — artifacts are not deleted after import (10 files × ~14 MB on 2026-07-28). Harmless at that rate, but it is not self-pruning.
+
+Grep the latest cycle's footprint:
 
 ```bash
 ssh brice@161.35.35.15 "docker logs --since 24h weatherbrief 2>&1 \
@@ -151,7 +179,7 @@ ssh brice@161.35.35.15 "docker logs --since 24h weatherbrief 2>&1 \
 
 The cycle has **three flavours**, each with its own `Standalone <type> cycle:` summary line. Don't conflate them:
 - **light** — scoring + rollup + stats/leaderboard cache rebuild (no model fetch, no forecast-map rebuild). Runs at the five light hours.
-- **forecast** — heavy model fetch (gfs / icon / ecmwf — no UKMO in standalone), then forecast-map cache rebuild ONLY (rollup + stats/leaderboard are skipped since #448: the cycle creates no scores). Runs at 07:15 / 19:15.
+- **forecast** — heavy model fetch (gfs / icon / ecmwf — no UKMO in standalone), then forecast-map cache rebuild ONLY (rollup + stats/leaderboard are skipped since #448: the cycle creates no scores). Runs at 07:15 / 19:15 **on the compute node**, not the droplet — the droplet sees the result as a `standalone_imported` cycle (~72 s). A local `standalone_forecast` line appearing on the droplet means the fallback fired: worth investigating why the artifact didn't arrive.
 - **metar_ingest** — observation pull, every 30 min, cheap.
 
 Read:
@@ -207,7 +235,7 @@ Three upstreams are routinely flaky; learn the steady-state rates so you only fl
 
 ## 9. Storage & retention
 
-`/mnt/flyfun_data` is the canonical disk gauge (**199 GB volume** — resized up from 149 GB; don't cite the old number). Steady-state usage is **~68–78 %**, re-baselined 2026-07-27 at 71 % (134 GB used, 56 GB free) — see §L9 for the composition breakdown. Only flag when:
+`/mnt/flyfun_data` is the canonical disk gauge (**199 GB volume** — resized up from 149 GB; don't cite the old number). Steady-state usage is **~62–78 %**, re-baselined 2026-07-28 at **66 % (124 GB used, 67 GB free)** — down from 71 %/134 GB the day before, which is ordinary ICON cache churn, not a leak. See §L9 for the composition breakdown. Only flag when:
 - Sustained **>85 %** (real warn — ~169 GB, within ~30 GB of full)
 - Sustained **>90 %** (issue — ~179 GB, briefings will start failing soon)
 
@@ -320,8 +348,10 @@ The 4 vCPU / 7.8 GB droplet was upgraded based on a miscalculation; downgrade re
 ### §L6 — Scan traffic is noise
 Lines like `GET /joomla/.env`, `error_log.php`, `wp-login.php`, `.git/`, `xmlrpc` are random attack scans hitting the front door. Filter them out of any "errors" count; mention only if the rate is unusually high (e.g. ratelimit something).
 
-### §L7 — Forecast cycle hours overlap with user peak
-06:15 / 09:15 / 12:15 / 15:15 / 18:15 UTC are the **light** cycle hours (short since #448); the **heavy forecast** cycles run 07:15 / 19:15 UTC and hold one core for the better part of an hour (pre-PR-B). Load spikes and slower briefings *during* these windows are expected. A briefing taking 2× normal at 07:40 UTC is not the same problem as one taking 2× at 02:00 UTC.
+### §L7 — Cycle hours overlap with user peak
+06:15 / 09:15 / 12:15 / 15:15 / 18:15 UTC are the **light** cycle hours (short since #448). Load spikes and slower briefings *during* these windows are expected — a briefing taking 2× normal at 09:20 UTC is not the same problem as one taking 2× at 02:00 UTC.
+
+**Superseded 2026-07-28:** this lesson used to say the heavy forecast cycle holds a droplet core for the better part of an hour at 07:15 / 19:15. That work moved off-box (see §6) — the droplet now only *imports* the node's artifact (~72 s), so those two hours are no longer a load excuse on the droplet. Load above the 4-vCPU line outside a light-cycle hour is most often concurrent user briefings; check §4b timings before assuming a cycle. Observed 2026-07-28: load 1m peak 5.02 in a window with no cycle at all and 7 briefings in flight.
 
 ### §L8 — `docker compose` v2, not `docker-compose`
 On this droplet the binary is `docker compose` (two words). Don't try `docker-compose`.
@@ -348,6 +378,7 @@ On this droplet the binary is `docker compose` (two words). Don't try `docker-co
 Historical notes:
 - 2026-05-19: `/mnt/flyfun_data` at 79 % of the then-149 GB volume, all components in-band. The "growth" was just ICON-EU cycling 00z→12z runs.
 - 2026-07-27: re-baselined after the volume resize to 199 GB and the arrival of the ICON-D2 cache. 134 GB used (71 %), every component in band.
+- 2026-07-28: 124 GB used (66 %) — 10 GB *lower* than the day before, purely ICON cache phase. Confirms the swing described above and is the reason the band's floor was widened from 68 % to 62 %. A drop is as unremarkable as a rise; neither is a signal on its own.
 
 ```
 verdict: ok            ← or `warn` / `issue`
@@ -361,7 +392,7 @@ standalone: last cycle <time> ago, T min, peak_rss <N> MB            (ok|warn)
 grib pool:  K resets in window                                       (ok|note)
 rss:        no new HWM steps   (or "+N MB step at <ts>")             (ok|note)
 upstream:   M Open-Meteo 502s, K AvWx, L DWD                         (ok|note)
-disk total: /mnt/flyfun_data X% of 199 GB (band ~68–78%)             (ok|warn)
+disk total: /mnt/flyfun_data X% of 199 GB (band ~62–78%)             (ok|warn)
 caches:     icon-d2 N GB, icon-eu N GB, gfs N GB, ecmwf N GB         (ok|warn if out-of-band)
 growing:    packs N GB / F flights, mysql data N GB, binlogs N GB    (ok|note|warn)
 retention:  Retention applied (last <time>); GRIB purge alive        (ok|warn if missing)

--- a/designs/advisories.md
+++ b/designs/advisories.md
@@ -318,9 +318,9 @@ consensus so the card cannot contradict the alternates card beside it. Advisorie
 run at pipeline step 3 and METAR/TAF are fetched at step 3.5, so `RouteContext`
 has no observation to read; the NWP consensus in `airport_conditions.arrival` is
 what is graded today. Also deferred (from #509): per-candidate approach
-feasibility for *alternates*, an approach-aware "best usable runway" alongside
-`best_runway` in `enrich_wind`, and #510's user-declared unpublished approaches
-(cloud-break procedures) damping the "no IAP → RED" case at UK GA bases.
+feasibility for *alternates*, and an approach-aware "best usable runway"
+alongside `best_runway` in `enrich_wind`. #510's user-declared unpublished
+approaches shipped — see the next section.
 
 No highlights are emitted — like every airport advisory this is point-in-space,
 not route geometry (see the "Not emitting" list under Highlights). Web/iOS/MCP/
@@ -337,6 +337,106 @@ contributes to eval-corpus situation coverage. `ifr_marginal` rather than a new
 `SITUATION_VOCAB` entry: this only grades at an IFR/LIFR destination, and a new
 vocab cell changes the coverage-matrix denominator every fixture is scored
 against.
+
+### User-declared unpublished approaches (#510)
+
+`approach_feasibility` grades a field with no published procedure as **RED** at
+IFR/LIFR. That is the right default, and it over-fires in the UK, where a field
+can have no AIP-published procedure while pilots routinely fly a self-briefed
+**cloud break procedure** or a private/unpublished GNSS approach. `EGTF`
+(Fairoaks) has **zero** rows in `procedures`, so for a pilot based there *every*
+IFR arrival at their home field graded RED — enough noise to make the advisory
+worth ignoring, which is worse than not having it. This is **not a data gap**:
+#509 established these absences are genuine. The published data is right and the
+operational reality differs.
+
+**Storage is a user preference, not an advisory param.** `app_prefs_json →
+declared_approach_icaos`, read by `api/preferences.py::load_declared_approaches`
+(the sibling of `load_user_locale`). It is a fact about the pilot and the
+airport ("I'm current on the Fairoaks cloud break"), entered once and applied
+everywhere — not a per-profile judgment. It could not have been an
+`AdvisoryParameterDef` anyway: `default` is typed `float`, and all 83 params in
+use are numeric.
+
+**Resolution happens in the collection step**, not the evaluator:
+`get_runway_approaches(icaos, db_path, declared_icaos)` injects a synthetic
+`RunwayApproach(source="user_declared")`. Every field that could confer credit
+is empty **by construction** — `approach_type` is `None` so no minima class can
+be inferred, `runway_id` is `None` so it can never be paired with a runway end's
+wind. The type is fixed rather than user-selectable precisely so a pilot cannot
+declare "ILS" and be handed a 200 ft decision height on a procedure that has no
+plate. It is *not* injected over `lookup_failed`: that state means "we could not
+determine the picture", and a declaration does not determine it either.
+
+`AirportApproaches.published` is the split that keeps this honest — **everything
+reasoning about minima, alignment or approach class reads it**, never
+`approaches`. Miss that and the declaration (no runway, not circling) silently
+reads as UNRESOLVED alignment, and the best-case minima gate starts testing
+ceilings against a plate that does not exist.
+
+| Destination | Undeclared | Declared |
+|---|---|---|
+| VFR | GREEN | GREEN |
+| MVFR | AMBER (no IAP) | **GREEN** (own copy — never called "published") |
+| IFR | RED (no IAP) | **AMBER** |
+| LIFR | RED | **RED** — hard cap |
+
+**The IFR amber does *not* fall out of the existing rules**, contrary to the
+framing in #510, and this is the one place the issue's stated mechanism was
+wrong. The no-straight-in fallback only softens off RED when the weather
+supports circling (`circling_ceiling_ft` / `circling_visibility_m`, 1000 ft /
+1500 m) — but an IFR ceiling is 500–1000 ft *by definition*, so a declared EGTF
+at 700 ft would still have graded RED, leaving exactly the false REDs the
+declaration exists to damp. Hence an explicit `_Softening.DECLARED` and a
+dedicated no-published branch in `_grade_full`. The issue's **table** is
+implemented as specified; only its rationale is corrected here.
+
+**LIFR stays RED as an explicit cap.** With no published procedure there are no
+published minima, so no DH can be claimed at all — the estimated-band logic must
+not be applied to a procedure that does not exist. The cap gates both the bare
+declared field and the `DECLARED` softening on a published field.
+
+Three rules bound what a declaration can do:
+
+1. **Circling outranks it.** When the weather genuinely supports circling,
+   "plan for circling" is the more actionable line and holds regardless.
+2. **It never softens below the weather** (#510 guardrail 3). A ceiling below
+   the best-case DH of a *real* plate stays RED; the declaration removes the
+   *infrastructure* penalty only. Ceiling, visibility, wind and crosswind
+   grading are untouched.
+3. **The basis is always visible** (guardrail 2). Every declared verdict names
+   it — *"graded against your declared unpublished approach at EGTF, which has
+   no published minima, so check your own"*. **Shared briefings are explicitly
+   not handled, by decision:** a pack stores its computed manifest, so `/s/{code}`
+   renders the owner's baked-in grades. We do **not** re-grade per viewer — that
+   sentence is the only thing that travels with the share.
+
+**Containment is the main hazard, and it is structural.** A self-briefed
+approach cannot make a field qualify as a filed alternate under EASA NCO.OP.143
+nor relieve the NCO.OP.140 trigger, so it must never reach
+`alternate_requirement` or the alternates candidate gate. It cannot today:
+`tasks/alternates.py` answers "does this field qualify?" from its own
+`ap.procedures_query.approaches()` and never calls `get_runway_approaches`, the
+only function that knows about declarations. `tests/test_declared_approach_guardrails.py`
+pins that — including an enumeration of every module referencing
+`has_declared_approach`, so a new consumer has to be a deliberate act rather
+than an accident.
+
+**Wiring — four paths, all required.** `BriefingOptions.declared_approach_icaos`
+covers the briefing run; `api/packs.py::_load_advisory_profile` returns it as a
+12th element, feeding recalculate, the settings preview, the alt-departure re-run
+**and** `tasks/time_scan_runner`. The time-scan is easy to miss and matters: it
+grades the planned departure through the same path and asserts shift=0
+reproduces the briefing, so omitting it would make the scan contradict the card
+beside it. Validation on save is `airports.py::unknown_icaos` against `nav.db`,
+and an unknown code **rejects the whole write** with a 400 naming the codes —
+dropping it silently would leave the pilot believing their home field is
+declared when it is not.
+
+Out of scope, deliberately: declaring approach type, minima or runway alignment;
+per-runway declarations (circling-equivalent confers no alignment credit either
+way); sharing the list between users; viewer-scoped re-grading of shared
+briefings.
 
 ## Mitigations (advice only — #328/#330)
 

--- a/src/weatherbrief/airports.py
+++ b/src/weatherbrief/airports.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import re
+from collections.abc import Iterable
 from dataclasses import dataclass
 from functools import lru_cache
 from typing import TYPE_CHECKING, Literal
@@ -13,6 +14,7 @@ from timezonefinder import TimezoneFinder
 
 from weatherbrief.fetch.route_walk import walk_route
 from weatherbrief.models import AirportApproaches, RunwayApproach, RunwayEnd, Waypoint
+from weatherbrief.models.airport_conditions import SOURCE_USER_DECLARED
 
 if TYPE_CHECKING:
     from euro_aip.briefing.models.route import Route
@@ -322,8 +324,53 @@ def _normalize_runway_ident(ident: str | None) -> str | None:
     return f"{int(match.group(1))}{match.group(2) or ''}"
 
 
+def unknown_icaos(icao_codes: Iterable[str], db_path: str) -> list[str]:
+    """Which of these ICAO codes ``nav.db`` does not know, in input order.
+
+    Used to validate the user's declared-approach list on save (#510): a
+    typo'd ``EGFT`` must be reported back rather than stored, because a
+    declaration that silently matches no airport is indistinguishable from no
+    declaration at all — and the pilot would go on believing their home field
+    is covered.
+
+    Returns an empty list when the model cannot be loaded at all: a missing or
+    unreadable ``AIRPORTS_DB`` is a server-configuration gap, and rejecting the
+    user's input over it would be blaming them for it.
+    """
+    codes = [c.strip().upper() for c in icao_codes if c and c.strip()]
+    if not codes:
+        return []
+    try:
+        model = _load_airport_model(db_path)
+    except Exception:  # noqa: BLE001 - see docstring: don't punish the user
+        logger.warning("Airport model unavailable; skipping ICAO validation", exc_info=True)
+        return []
+    return [c for c in codes if model.airports.get(c) is None]
+
+
+def _declared_approach() -> RunwayApproach:
+    """The synthetic entry standing for a pilot-declared unpublished approach.
+
+    Every field that could confer credit is left empty on purpose:
+    ``approach_type`` stays ``None`` so no minima class can be inferred from it,
+    and ``runway_id`` stays ``None`` so it can never be paired with a runway
+    end's wind. The declaration says an approach *exists*, and nothing more —
+    the type is fixed rather than user-selectable precisely so a pilot cannot
+    declare "ILS" and be handed a 200 ft decision height on a procedure that has
+    no plate (#510).
+    """
+    return RunwayApproach(
+        name="Declared unpublished approach",
+        approach_type=None,
+        runway_id=None,
+        circling=False,
+        source=SOURCE_USER_DECLARED,
+    )
+
+
 def get_runway_approaches(
     icao_codes: list[str], db_path: str,
+    declared_icaos: Iterable[str] | None = None,
 ) -> dict[str, AirportApproaches]:
     """Get published instrument approaches per airport, joined to runway ends.
 
@@ -349,14 +396,31 @@ def get_runway_approaches(
     grade map treats as the most severe input there is, so a data gap must not
     be able to impersonate one.
 
+    ``declared_icaos`` (issue #510) carries the airports where the *pilot* has
+    told us they have an unpublished/self-briefed approach — a cloud break
+    procedure or a private GNSS approach. Resolving it here rather than as an
+    evaluator parameter keeps the evaluator pure: it sees one approach list and
+    only has to recognise the ``user_declared`` source. The injected entry has
+    no runway and no approach class **by construction**, so it can never earn
+    alignment credit or lend an estimated decision height.
+
+    A declaration is deliberately injected even when the lookup found published
+    procedures — the two facts are independent, and grading simply prefers the
+    published ones. It is NOT injected over ``lookup_failed``: that state means
+    "we could not determine the picture", and a declaration does not determine
+    it either.
+
     Args:
         icao_codes: ICAO codes to look up.
         db_path: Path to the euro_aip SQLite database.
+        declared_icaos: Airports where the user declared an unpublished
+            approach. Matched case-insensitively.
 
     Returns:
         Dict mapping ICAO code to :class:`AirportApproaches`, one entry per
         requested code.
     """
+    declared = {c.strip().upper() for c in (declared_icaos or []) if c and c.strip()}
     model = _load_airport_model(db_path)
 
     result: dict[str, AirportApproaches] = {}
@@ -410,6 +474,9 @@ def get_runway_approaches(
                     getattr(proc, "raw_name", None) or name,
                 ),
             ))
+
+        if icao.strip().upper() in declared:
+            approaches.append(_declared_approach())
 
         result[icao] = AirportApproaches(
             icao=icao,

--- a/src/weatherbrief/analysis/advisories/approach_feasibility.py
+++ b/src/weatherbrief/analysis/advisories/approach_feasibility.py
@@ -35,6 +35,27 @@ expected to complete the arrival visually:
   AMBER). Never RED.
 * **IFR / LIFR** -> the full logic below.
 
+**Declared unpublished approaches (#510).** A pilot can declare that they have
+an unpublished/self-briefed approach at a field — a cloud break procedure or a
+private GNSS approach — which is common in the UK, where a field with zero AIP
+rows (EGTF Fairoaks and friends) is routinely arrived at IFR. Without this,
+every IFR arrival at such a home field grades RED, which is enough noise to make
+the advisory worth ignoring. A declaration is treated as *"an approach exists,
+alignment unknown"*: it is RNP-equivalent and circling-equivalent, so it can
+never earn GREEN at IFR, and it is **never credited at LIFR** — with no
+published procedure there are no published minima, so no decision height can be
+claimed at all. It only ever removes the *infrastructure* penalty: ceiling,
+visibility, wind and crosswind grading are untouched, and the airport-wide
+best-case minima gate still reads published plates only.
+
+Note that this AMBER does **not** fall out of the pre-existing rules, contrary
+to the framing in #510. The no-straight-in fallback only softens off RED when
+the weather supports circling (``circling_ceiling_ft`` / ``circling_visibility_m``,
+1000 ft / 1500 m by default) — but an IFR ceiling is 500–1000 ft *by
+definition*, so a declared field at 700 ft would still have graded RED, leaving
+exactly the false REDs the declaration exists to damp. Hence the explicit
+``_Softening.DECLARED`` and the no-published branch in ``_grade_full``.
+
 Known gap (deliberate, #509 design constraint 4): at D-0 this should prefer the
 TAF over the NWP consensus so the card cannot contradict the alternates card
 beside it. Advisories run at pipeline step 3 and METAR/TAF are fetched at step
@@ -114,6 +135,11 @@ class _Softening(str, Enum):
     #: The wind model produced no components for the served end(s). Also our
     #: gap, and a DIFFERENT gap — it must not borrow the unresolved copy.
     NO_WIND_DATA = "no_wind_data"
+    #: The pilot declared an unpublished/self-briefed approach here (#510). Not
+    #: a gap in our data at all — an operational fact we were told — but it
+    #: softens for the same reason the others do: it means the published picture
+    #: is not the whole picture. Never available at LIFR (see ``_grade_full``).
+    DECLARED = "declared"
     #: Nothing softens it.
     NONE = "none"
 
@@ -209,16 +235,20 @@ def _wind_for_end(cond: AirportModelCondition, runway_id: str) -> RunwayWind | N
 
 
 def _straight_in_plans(
-    cond: AirportModelCondition, approaches: AirportApproaches,
+    cond: AirportModelCondition, approaches: list[RunwayApproach],
 ) -> list[_EndPlan]:
     """Every straight-in approach whose served end also has wind components.
 
     An approach whose end the wind model does not cover is dropped rather than
     assumed benign — it simply cannot be graded, and the remaining plans (or the
     absence of any) carry the verdict.
+
+    Takes the *published* list rather than the container: a declared approach
+    carries no runway and would be dropped anyway, but passing it in at all
+    would invite a future caller to grade one.
     """
     plans: list[_EndPlan] = []
-    for approach in approaches.approaches:
+    for approach in approaches:
         if not approach.runway_id:
             continue
         wind = _wind_for_end(cond, approach.runway_id)
@@ -306,7 +336,36 @@ def _grade_full(
     circling_ceiling = float(params.get("circling_ceiling_ft", 1000))
     circling_vis = float(params.get("circling_visibility_m", 1500))
 
-    if not approaches.has_iap:
+    # A declaration is credited at IFR but never at LIFR (#510 hard cap): with no
+    # published procedure there are no published minima, so no decision height
+    # can be claimed at all — and LIFR is where a claimed DH would matter most.
+    # This is the one place the cap is applied, and it gates BOTH the
+    # no-published branch below and the DECLARED softening further down.
+    declared_credited = (
+        approaches.has_declared_approach
+        and cond.flight_category != FlightCategory.LIFR
+    )
+
+    # Everything past this point reasons about minima, alignment or approach
+    # class, so it reads ``published`` — never ``approaches``. A declaration has
+    # no plate and no runway; letting it into these lists would hand a personal
+    # assertion an estimated decision height (and, since it carries neither a
+    # runway nor the circling flag, would silently read as UNRESOLVED alignment).
+    published = approaches.published
+
+    if not published:
+        if approaches.has_declared_approach:
+            # The #510 case: a UK field with a cloud break procedure and zero
+            # AIP rows. Circling-equivalent, so it can never earn GREEN — but at
+            # IFR it is a real consideration rather than a stopper, which is the
+            # whole point of the declaration.
+            if not declared_credited:
+                return AdvisoryStatus.RED, adv_t(
+                    "approach_feasibility.declared_lifr", loc, icao=approaches.icao,
+                )
+            return AdvisoryStatus.AMBER, adv_t(
+                "approach_feasibility.declared_only", loc, icao=approaches.icao,
+            )
         key = (
             "approach_feasibility.no_iap" if approaches.has_procedure_data
             else "approach_feasibility.no_procedure_data"
@@ -318,7 +377,7 @@ def _grade_full(
     # Hard forecast fact — below every plate the field could hold. Checked before
     # the wind so a genuinely un-shootable approach reads as such regardless of
     # which runway the wind favours.
-    best_case = _best_case_minima(approaches.approaches)
+    best_case = _best_case_minima(published)
     if best_case is not None:
         best_dh, best_vis = best_case
         if ceiling is not None and ceiling < best_dh:
@@ -342,7 +401,7 @@ def _grade_full(
                 minima=_minima_status(cond, p.proxy),
                 plan=p,
             )
-            for p in _straight_in_plans(cond, approaches)
+            for p in _straight_in_plans(cond, published)
         ),
         key=lambda g: (_rank(g.status), g.plan.tailwind_kt, g.plan.wind.crosswind_kt),
     )
@@ -361,7 +420,7 @@ def _grade_full(
     # nor a served end the wind model did not cover may drive RED (design
     # rule 2) — those are our gaps, not facts about the arrival.
     alignment_unresolved = any(
-        not a.runway_id and not a.circling for a in approaches.approaches
+        not a.runway_id and not a.circling for a in published
     )
     wind_unresolved = bool(approaches.served_runway_ids) and not graded
 
@@ -374,8 +433,13 @@ def _grade_full(
         and (cond.visibility_m is None or cond.visibility_m >= circling_vis)
     )
 
+    # Circling outranks the declaration: when the weather genuinely supports
+    # circling, "plan for circling" is the more actionable line, and it holds
+    # whether or not the pilot declared anything.
     if circling_supported:
         softening = _Softening.CIRCLING
+    elif declared_credited:
+        softening = _Softening.DECLARED
     elif alignment_unresolved:
         softening = _Softening.UNRESOLVED
     elif wind_unresolved:
@@ -434,10 +498,20 @@ def _wind_note(plan: _EndPlan, loc: str | None) -> str:
 def _grade_mvfr(
     approaches: AirportApproaches, loc: str | None,
 ) -> tuple[AdvisoryStatus, str]:
-    """MVFR: IAP presence only, capped at AMBER. Never RED."""
-    if approaches.has_iap:
+    """MVFR: IAP presence only, capped at AMBER. Never RED.
+
+    A declaration counts as presence here — that is the #510 MVFR row (AMBER ->
+    GREEN) — but it gets its own copy: calling one "published" would be the same
+    false claim in the sentence that the grade map refuses to make in the grade.
+    """
+    published = approaches.published
+    if published:
         return AdvisoryStatus.GREEN, adv_t(
-            "approach_feasibility.mvfr_ok", loc, count=len(approaches.approaches),
+            "approach_feasibility.mvfr_ok", loc, count=len(published),
+        )
+    if approaches.has_declared_approach:
+        return AdvisoryStatus.GREEN, adv_t(
+            "approach_feasibility.mvfr_declared", loc, icao=approaches.icao,
         )
     return AdvisoryStatus.AMBER, adv_t("approach_feasibility.mvfr_no_iap", loc)
 
@@ -469,7 +543,12 @@ class ApproachFeasibilityEvaluator:
                 "approach-served runway with an out-of-limits tailwind and no "
                 "ceiling for circling. Decision heights are estimates shared "
                 "with the alternate-requirement card, so uncertainty can only "
-                "soften a grade, never harden it."
+                "soften a grade, never harden it. If you have declared an "
+                "unpublished approach at the destination in your account "
+                "settings, a field with no published procedure is graded amber "
+                "rather than red at IFR — never green, and never credited at "
+                "LIFR, where there are no published minima to fly to. A "
+                "declaration never affects alternate-minima calculations."
             ),
             category="flight_rules",
             timing_class="cheap",

--- a/src/weatherbrief/analysis/advisories/strings.py
+++ b/src/weatherbrief/analysis/advisories/strings.py
@@ -715,6 +715,35 @@ _STRINGS: dict[str, dict[str, str]] = {
         "de": "Kein veröffentlichter Instrumentenanflug — Ankunft hängt vom Sichtflug ab",
         "es": "Sin aproximación instrumental publicada — la llegada depende de mantener el vuelo visual",
     },
+    # --- user-declared unpublished approaches (#510) ---
+    # Every one of these names the basis in the line itself: the grade is being
+    # softened on the pilot's own assertion, and #510 guardrail 2 makes saying
+    # so mandatory — a shared briefing renders the owner's baked-in grades, so
+    # this sentence is the only thing that travels with it.
+    "approach_feasibility.mvfr_declared": {
+        "en": "Your declared unpublished approach at {icao} — landing can still be completed visually",
+        "fr": "Votre approche non publiée déclarée à {icao} — l'atterrissage reste réalisable à vue",
+        "de": "Ihr angegebener nicht veröffentlichter Anflug in {icao} — Landung noch visuell möglich",
+        "es": "Su aproximación no publicada declarada en {icao} — el aterrizaje aún puede completarse visualmente",
+    },
+    "approach_feasibility.declared_only": {
+        "en": "No published instrument approach — graded against your declared unpublished approach at {icao}, which has no published minima, so check your own",
+        "fr": "Aucune approche aux instruments publiée — évalué d'après votre approche non publiée déclarée à {icao}, sans minima publiés : vérifiez les vôtres",
+        "de": "Kein veröffentlichter Instrumentenanflug — bewertet anhand Ihres angegebenen nicht veröffentlichten Anflugs in {icao}, der keine veröffentlichten Minima hat; prüfen Sie Ihre eigenen",
+        "es": "Sin aproximación instrumental publicada — evaluado con su aproximación no publicada declarada en {icao}, que no tiene mínimos publicados: verifique los suyos",
+    },
+    "approach_feasibility.declared_lifr": {
+        "en": "No published instrument approach — your declared unpublished approach at {icao} cannot be credited at LIFR, as it has no published minima to fly to",
+        "fr": "Aucune approche aux instruments publiée — votre approche non publiée déclarée à {icao} ne peut être créditée en LIFR, faute de minima publiés",
+        "de": "Kein veröffentlichter Instrumentenanflug — Ihr angegebener nicht veröffentlichter Anflug in {icao} kann bei LIFR nicht angerechnet werden, da keine veröffentlichten Minima vorliegen",
+        "es": "Sin aproximación instrumental publicada — su aproximación no publicada declarada en {icao} no puede acreditarse en LIFR, al no tener mínimos publicados",
+    },
+    "approach_feasibility.soften_declared": {
+        "en": "you declared an unpublished approach here, so check your own minima",
+        "fr": "vous avez déclaré une approche non publiée ici, vérifiez vos propres minima",
+        "de": "Sie haben hier einen nicht veröffentlichten Anflug angegeben, prüfen Sie Ihre eigenen Minima",
+        "es": "usted declaró una aproximación no publicada aquí, verifique sus propios mínimos",
+    },
     "approach_feasibility.no_iap": {
         "en": "No published instrument approach at {icao}",
         "fr": "Aucune approche aux instruments publiée à {icao}",

--- a/src/weatherbrief/api/packs.py
+++ b/src/weatherbrief/api/packs.py
@@ -1256,9 +1256,11 @@ def _prepare_refresh(flight, db_path, user_id, flight_id, db=None, *, is_privile
     units_region = "auto"
     profile_name_for_digest = None
     profile_settings: dict = {}
+    declared_approach_icaos: list[str] = []
     if db is not None:
         from weatherbrief.api.preferences import (
             load_autorouter_token,
+            load_declared_approaches,
             load_units_region,
             load_user_locale,
         )
@@ -1267,6 +1269,7 @@ def _prepare_refresh(flight, db_path, user_id, flight_id, db=None, *, is_privile
         autorouter_creds = load_autorouter_token(db, user_id)
         locale = load_user_locale(db, user_id)
         units_region = load_units_region(db, user_id)
+        declared_approach_icaos = load_declared_approaches(db, user_id)
         profile_ctx = load_profile_context(db, flight.profile_id, user_id)
         profile_settings = profile_ctx.settings
         profile_name_for_digest = profile_ctx.name
@@ -1328,6 +1331,7 @@ def _prepare_refresh(flight, db_path, user_id, flight_id, db=None, *, is_privile
         autorouter_token=autorouter_creds,
         user_id=user_id,
         airports_db_path=db_path,
+        declared_approach_icaos=declared_approach_icaos,
         icing_severity_enhance=do_icing_enhance,
         auto_front_detection=auto_front_detection,
         compute_alternates=compute_alternates,
@@ -3189,7 +3193,7 @@ def compute_alt_advisories(
     route = _build_route_config(flight, db_path)
 
     # Load advisory profile
-    enabled_ids, enabled_map, user_params, aggregation, adv_models, icing_method, cloud_source, convective_method, recompute_conds, locale, _auto_front_detection = \
+    enabled_ids, enabled_map, user_params, aggregation, adv_models, icing_method, cloud_source, convective_method, recompute_conds, locale, _auto_front_detection, declared_approaches = \
         _load_advisory_profile(db, flight, user_id, request, pack_dir)
 
     advisory_result = run_alt_from_pack(
@@ -3204,6 +3208,7 @@ def compute_alt_advisories(
         airport_conditions_recompute=recompute_conds,
         # Destination approach data for approach_feasibility (#509).
         airports_db_path=db_path,
+        declared_approach_icaos=declared_approaches,
         icing_method=icing_method,
         cloud_source=cloud_source,
         convective_method=convective_method,
@@ -3344,7 +3349,14 @@ def _load_advisory_profile(
     Shared by recalculate_advisories and altitude_table endpoints.
     Returns (enabled_ids, enabled_map, user_params, aggregation, adv_models,
     icing_method, cloud_source, convective_method, recompute_conds_callback,
-    locale, auto_front_detection).
+    locale, auto_front_detection, declared_approach_icaos).
+
+    Note the last two are *account*-level, not profile-level: ``locale`` and the
+    declared unpublished approaches (#510) are facts about the pilot, not about
+    a flight profile. They ride here because this is the one place every
+    advisory re-run path — recalculate, settings preview, alt departure and the
+    background timing scan — resolves its inputs, and an advisory that reads
+    them has to be fed by all four or it contradicts the briefing beside it.
 
     ``enabled_map`` is the raw ``{id: bool}`` map (``None`` when the profile has
     no advisory customization). It is threaded through to the front advisory so
@@ -3363,7 +3375,7 @@ def _load_advisory_profile(
     ``load_profile_settings`` silently degrades an unowned id to empty settings.
     """
     from weatherbrief.analysis.advisories import resolve_enabled_ids
-    from weatherbrief.api.preferences import load_user_locale
+    from weatherbrief.api.preferences import load_declared_approaches, load_user_locale
     from weatherbrief.api.profiles import load_profile_settings
     from weatherbrief.models import AdvisoryAggregation
 
@@ -3386,6 +3398,7 @@ def _load_advisory_profile(
     if request is not None:
         db_path = getattr(request.app.state, "db_path", "") or db_path
     locale = load_user_locale(db, user_id)
+    declared_approach_icaos = load_declared_approaches(db, user_id)
 
     def recompute_conds(rp_analyses, cross_sections, advisory_model_names):
         from types import SimpleNamespace
@@ -3396,7 +3409,7 @@ def _load_advisory_profile(
             db_path=db_path, models=advisory_model_names,
         )
 
-    return enabled_ids, enabled_map, user_params, aggregation, adv_models, icing_method, cloud_source, convective_method, recompute_conds, locale, auto_front_detection
+    return enabled_ids, enabled_map, user_params, aggregation, adv_models, icing_method, cloud_source, convective_method, recompute_conds, locale, auto_front_detection, declared_approach_icaos
 
 
 class RecalculateAdvisoriesResponse(BaseModel):
@@ -3433,7 +3446,7 @@ def recalculate_advisories(
     # (Mirror of compute_alt_advisories, which is also owner-gated.)
     flight, pack_dir = _owned_flight_pack_with_analyses(db, flight_id, timestamp, user_id)
 
-    enabled_ids, enabled_map, user_params, aggregation, adv_models, icing_method, cloud_source, convective_method, recompute_conds, locale, auto_front_detection = \
+    enabled_ids, enabled_map, user_params, aggregation, adv_models, icing_method, cloud_source, convective_method, recompute_conds, locale, auto_front_detection, declared_approaches = \
         _load_advisory_profile(db, flight, user_id, request, pack_dir)
 
     # Experimental front detection (#196): keep route_fronts.json in sync with
@@ -3478,6 +3491,9 @@ def recalculate_advisories(
         # from the recomputed airport conditions — but the nav.db path still has
         # to be handed down, or the advisory silently degrades on recalculate.
         airports_db_path=getattr(request.app.state, "db_path", ""),
+        # ... and the same for the user's declared unpublished approaches
+        # (#510), or a declared field reverts to RED on every recalculate.
+        declared_approach_icaos=declared_approaches,
         icing_method=icing_method,
         cloud_source=cloud_source,
         convective_method=convective_method,
@@ -3578,7 +3594,7 @@ def preview_advisories(
 
     (_saved_enabled_ids, saved_enabled_map, saved_params, saved_agg, saved_models,
      saved_icing, saved_cloud, saved_convective, recompute_conds, locale,
-     _auto_front) = _load_advisory_profile(
+     _auto_front, declared_approaches) = _load_advisory_profile(
         db, flight, user_id, request, pack_dir, profile_id=body.profile_id,
     )
 
@@ -3615,6 +3631,7 @@ def preview_advisories(
         # evaluator degrades to UNAVAILABLE without it, so the preview would
         # otherwise show a grey card the real briefing grades.
         airports_db_path=getattr(request.app.state, "db_path", ""),
+        declared_approach_icaos=declared_approaches,
         icing_method=icing_method,
         cloud_source=cloud_source,
         convective_method=convective_method,
@@ -3848,7 +3865,10 @@ def altitude_table(
     if not ra_path.exists():
         raise HTTPException(status_code=404, detail="Route analyses not available")
 
-    enabled_ids, _enabled_map, user_params, aggregation, adv_models, icing_method, cloud_source, convective_method, recompute_conds, locale, _auto_front_detection = \
+    # ``_declared_approaches`` unused on purpose: the altitude table sweeps only
+    # the altitude-dependent advisories, and approach_feasibility is not one —
+    # it grades a fixed point in space, the destination.
+    enabled_ids, _enabled_map, user_params, aggregation, adv_models, icing_method, cloud_source, convective_method, recompute_conds, locale, _auto_front_detection, _declared_approaches = \
         _load_advisory_profile(db, flight, user_id, request, pack_dir)
 
     result = run_altitude_table_from_pack(

--- a/src/weatherbrief/api/preferences.py
+++ b/src/weatherbrief/api/preferences.py
@@ -5,11 +5,12 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 from datetime import date
 from typing import Any, Literal
 
-from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel, field_validator
+from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel, Field, field_validator
 from sqlalchemy.orm import Session
 
 from flyfun_common import fx
@@ -105,6 +106,14 @@ class PreferencesResponse(BaseModel):
     pirep_can_view: bool = False
     pirep_can_publish: bool = False
     donations_enabled: bool = False  # global: Stripe configured (gates the donate UI)
+    # Airports where the pilot has an unpublished/self-briefed approach — a
+    # cloud break procedure or a private GNSS approach (#510). A fact about the
+    # pilot and the airport, entered once and applied everywhere, which is why
+    # it lives here rather than in a flight profile's advisory params. Consumed
+    # ONLY by the approach_feasibility advisory: it must never reach the
+    # alternate-minima calculations, where a personal assertion would turn into
+    # a regulatory claim.
+    declared_approach_icaos: list[str] = Field(default_factory=list)
 
 
 class PreferencesUpdate(BaseModel):
@@ -128,12 +137,60 @@ class PreferencesUpdate(BaseModel):
     notify_scope: NotifyScope | None = None
     notify_change_only: bool | None = None
     notify_decay_notice: bool | None = None  # only meaningful as false, to dismiss
+    # Accepts the raw free-form text the settings field holds ("EGTF, EGSX
+    # EGLK") as well as a JSON array, and canonicalizes either on the way in —
+    # normalization lives here rather than in the web client so every writer
+    # (a direct PUT, a future iOS screen) stores the same shape.
+    declared_approach_icaos: list[str] | str | None = None
+
+    @field_validator("declared_approach_icaos")
+    @classmethod
+    def _normalize_declared(cls, v: list[str] | str | None) -> list[str] | None:
+        """Split on commas/whitespace, uppercase, trim, dedupe, keep order."""
+        return None if v is None else _normalize_icao_list(v)
 
     @field_validator("display_currency")
     @classmethod
     def _normalize_display_currency(cls, v: str | None) -> str | None:
         """Normalize to "auto" or a 3-letter code so the contract is explicit."""
         return None if v is None else _normalize_currency(v)
+
+
+def _normalize_icao_list(value: list[str] | str) -> list[str]:
+    """Canonicalize free-form ICAO input to an uppercase, deduped list.
+
+    Accepts either the raw text of the settings field or an already-split list
+    whose elements may themselves hold separators, so a client that does its own
+    (partial) splitting cannot produce a different stored shape than one that
+    posts the text verbatim. Input order is preserved — the user's list is
+    theirs to order.
+    """
+    raw = value if isinstance(value, str) else " ".join(v for v in value if v)
+    seen: dict[str, None] = {}
+    for token in re.split(r"[\s,;]+", raw.upper()):
+        if token:
+            seen.setdefault(token, None)
+    return list(seen)
+
+
+def _parse_declared_approaches(raw: str) -> list[str]:
+    """Extract the declared unpublished-approach airports from ``app_prefs_json``.
+
+    Re-normalizes on read as well as on write: the key is small enough to have
+    been hand-edited in the DB, and a stored ``"egtf"`` that reads back
+    lowercase would silently match no airport in the collection step, which is
+    the exact failure mode #510 exists to prevent.
+    """
+    try:
+        data = json.loads(raw) if raw else {}
+    except json.JSONDecodeError:
+        return []
+    stored = data.get("declared_approach_icaos")
+    if not stored:
+        return []
+    if not isinstance(stored, (list, str)):
+        return []
+    return _normalize_icao_list(stored)
 
 
 def _load_prefs(db: Session, user_id: str) -> UserPreferencesRow:
@@ -269,6 +326,7 @@ def _build_response(row: UserPreferencesRow, db: Session, user_id: str) -> Prefe
         pirep_can_view=prefs_data.get("pirep_can_view", False),
         pirep_can_publish=prefs_data.get("pirep_can_publish", False),
         donations_enabled=stripe_configured(),
+        declared_approach_icaos=_parse_declared_approaches(row.app_prefs_json),
         **toggles,
     )
 
@@ -287,6 +345,7 @@ def get_preferences(
 @router.put("", response_model=PreferencesResponse)
 def update_preferences(
     body: PreferencesUpdate,
+    request: Request,
     user_id: str = Depends(current_user_id),
     db: Session = Depends(get_db),
 ):
@@ -369,6 +428,30 @@ def update_preferences(
     if body.digest_config is not None:
         data["digest_config"] = body.digest_config.model_dump(exclude_none=True)
 
+    if body.declared_approach_icaos is not None:
+        # Validate before storing, and reject the whole write rather than
+        # dropping the bad codes: a typo'd EGFT that vanished on save would
+        # leave the pilot believing their home field is declared when it is not
+        # — silently reinstating the very false REDs the declaration removes
+        # (#510). An empty list is a legitimate write (clearing the list), and
+        # skips straight through.
+        from weatherbrief.airports import unknown_icaos
+
+        db_path = getattr(request.app.state, "db_path", "") or ""
+        bad = unknown_icaos(body.declared_approach_icaos, db_path)
+        if bad:
+            raise HTTPException(
+                status_code=400,
+                detail={
+                    "error": "unknown_airports",
+                    "codes": bad,
+                    "message": (
+                        "Not recognised as airport codes: " + ", ".join(bad)
+                    ),
+                },
+            )
+        data["declared_approach_icaos"] = body.declared_approach_icaos
+
     row.app_prefs_json = json.dumps(data)
 
     if is_dev_mode() and body.autorouter_username and body.autorouter_password:
@@ -435,6 +518,26 @@ def load_user_locale(db: Session, user_id: str) -> str | None:
         return locale if locale and locale != "en" else None
     except json.JSONDecodeError:
         return None
+
+
+def load_declared_approaches(db: Session, user_id: str) -> list[str]:
+    """Airports where this user declared an unpublished approach (#510).
+
+    The single read path for the briefing pipeline, mirroring
+    :func:`load_user_locale` — another account-level preference the advisory
+    stack consumes. Returns ``[]`` for a user with no row or no declaration, so
+    every caller can pass the result straight through without a None check.
+
+    Consumers must be limited to ``approach_feasibility``. This list is a
+    personal operational assertion and carries no regulatory weight: a
+    self-briefed approach cannot make a field qualify as a filed alternate under
+    EASA NCO.OP.143, nor relieve the NCO.OP.140 trigger, so it must never reach
+    ``alternate_requirement`` or the alternates candidate gate.
+    """
+    row = db.get(UserPreferencesRow, user_id)
+    if not row or not row.app_prefs_json:
+        return []
+    return _parse_declared_approaches(row.app_prefs_json)
 
 
 def load_units_region(db: Session, user_id: str) -> str:

--- a/src/weatherbrief/models/airport_conditions.py
+++ b/src/weatherbrief/models/airport_conditions.py
@@ -39,6 +39,13 @@ class FlightCategory(str, Enum):
         return FLIGHT_CATEGORY_COLORS[self.value]
 
 
+# Provenance of a :class:`RunwayApproach`. Kept as constants rather than an Enum
+# so the value serializes as a plain string in the pack manifest, matching every
+# other string field in this module.
+SOURCE_PUBLISHED = "published"
+SOURCE_USER_DECLARED = "user_declared"
+
+
 class RunwayEnd(BaseModel):
     """One end of a runway."""
 
@@ -47,20 +54,33 @@ class RunwayEnd(BaseModel):
 
 
 class RunwayApproach(BaseModel):
-    """One published instrument approach procedure at an airport.
+    """One instrument approach available at an airport.
 
-    Sourced from ``nav.db`` ``procedures`` rows (see
+    Normally sourced from ``nav.db`` ``procedures`` rows (see
     ``weatherbrief.airports.get_runway_approaches``). ``runway_id`` is the
     runway END the procedure serves — the join key against
     :class:`RunwayEnd` / :class:`RunwayWind` — and is ``None`` when the
     procedure is not runway-aligned (a circling-only procedure, or a row whose
     runway could not be resolved).
+
+    ``source`` separates a *published* procedure from a pilot's declaration that
+    they have an unpublished/self-briefed approach at the field (a cloud break
+    procedure — issue #510). The two must never be confused: a declaration is a
+    personal operational assertion with no plate and therefore no minima, so it
+    can soften the infrastructure penalty and nothing else. It carries no
+    alignment (``runway_id`` is always ``None``) and no approach class.
     """
 
     name: str  # raw procedure name, e.g. "RWY02 ILS" / "RNP A"
     approach_type: str | None = None  # "ILS", "RNP", "VOR"… (None = unknown class)
     runway_id: str | None = None  # runway end served, e.g. "02" — None = not aligned
     circling: bool = False  # ICAO letter-suffixed circling procedure ("RNP A")
+    source: str = SOURCE_PUBLISHED  # "published" | "user_declared" (#510)
+
+    @property
+    def is_declared(self) -> bool:
+        """True for a pilot-declared unpublished approach, not a published one."""
+        return self.source == SOURCE_USER_DECLARED
 
 
 class AirportApproaches(BaseModel):
@@ -77,6 +97,11 @@ class AirportApproaches(BaseModel):
     * ``lookup_failed`` — we could not determine the picture (unknown ICAO, or
       the procedure query raised). NOT an absence of approaches: a consumer must
       report this as "could not assess", never grade on it.
+
+    A pilot's declaration of an unpublished approach (#510) rides in the same
+    list with ``source="user_declared"``, so ``has_iap`` covers both — but
+    ``published`` is what any minima or alignment reasoning must read, because a
+    declaration has neither a plate nor a runway.
     """
 
     icao: str
@@ -86,8 +111,28 @@ class AirportApproaches(BaseModel):
 
     @property
     def has_iap(self) -> bool:
-        """True when at least one instrument approach is published."""
+        """True when any approach is available — published or declared."""
         return bool(self.approaches)
+
+    @property
+    def published(self) -> list[RunwayApproach]:
+        """Only the published procedures.
+
+        Everything that reasons about minima, alignment or approach class must
+        start here: a declared approach has no plate, so folding it in would let
+        a personal assertion carry an estimated decision height.
+        """
+        return [a for a in self.approaches if not a.is_declared]
+
+    @property
+    def has_published_iap(self) -> bool:
+        """True when at least one *published* instrument approach exists."""
+        return bool(self.published)
+
+    @property
+    def has_declared_approach(self) -> bool:
+        """True when the pilot declared an unpublished approach here (#510)."""
+        return any(a.is_declared for a in self.approaches)
 
     @property
     def served_runway_ids(self) -> set[str]:

--- a/src/weatherbrief/pipeline.py
+++ b/src/weatherbrief/pipeline.py
@@ -102,6 +102,11 @@ class BriefingOptions:
     profile_id: int | None = None  # flight profile ID for digest tracking
     profile_name: str | None = None  # flight profile name for digest tracking
     guidance_key: str | None = None  # digest guidance preset (conservative/balanced/tolerant)
+    # Airports where the user declared an unpublished/self-briefed approach
+    # (#510). Read only by ``approach_feasibility`` — never by the alternates
+    # or alternate-requirement stages, where a personal declaration would be
+    # making a regulatory claim.
+    declared_approach_icaos: list[str] | None = None
 
 
 @dataclass
@@ -442,6 +447,7 @@ def _execute_briefing_stages(
             cloud_source=options.cloud_source,
             convective_method=options.convective_method,
             locale=options.locale,
+            declared_approach_icaos=options.declared_approach_icaos,
             # Precompute the altitude table now, while cross-sections are still
             # in memory (cleared just below). Feeds the digest's ALTITUDE OPTIONS
             # block and the client-side lever; default 2000ft step (#259).
@@ -500,6 +506,7 @@ def _execute_briefing_stages(
                 convective_method=options.convective_method,
                 locale=options.locale,
                 cruise_speed_ias_kt=options.cruise_speed_ias_kt,
+                declared_approach_icaos=options.declared_approach_icaos,
             )
         except Exception:
             logger.warning("Alt advisory evaluation failed (non-fatal)", exc_info=True)

--- a/src/weatherbrief/tasks/advise.py
+++ b/src/weatherbrief/tasks/advise.py
@@ -323,6 +323,7 @@ def _arrival_icao(
 def _collect_arrival_approaches(
     arr_icao: str | None,
     airports_db_path: str | None,
+    declared_approach_icaos: list[str] | None = None,
 ) -> AirportApproaches | None:
     """Published approaches at the destination, for ``approach_feasibility`` (#509).
 
@@ -330,13 +331,21 @@ def _collect_arrival_approaches(
     path (which has airport conditions but often no resolved route) can call it
     with exactly the same code. Returns ``None`` when the lookup could not run at
     all — the evaluator then reports UNAVAILABLE rather than "no approach".
+
+    ``declared_approach_icaos`` carries the user's unpublished-approach
+    declarations (#510). Every caller of this helper must supply it: the
+    briefing, the recalculate/preview re-run, the alt-departure re-run and the
+    timing scan all render the same advisory, so one that omits it would grade
+    a declared field RED beside a briefing that grades it AMBER.
     """
     if not arr_icao or not airports_db_path:
         return None
     try:
         from weatherbrief.airports import get_runway_approaches
 
-        return get_runway_approaches([arr_icao], airports_db_path).get(arr_icao)
+        return get_runway_approaches(
+            [arr_icao], airports_db_path, declared_approach_icaos,
+        ).get(arr_icao)
     except Exception:
         logger.warning("Arrival approach lookup failed for %s", arr_icao, exc_info=True)
         return None
@@ -383,6 +392,7 @@ def run_advisories(
     locale: str | None = None,
     cruise_speed_ias_kt: float | None = None,
     altitude_table_step_ft: int | None = None,
+    declared_approach_icaos: list[str] | None = None,
 ) -> AdvisoryResult:
     """Evaluate route advisories from analysis results.
 
@@ -429,7 +439,7 @@ def run_advisories(
             route_fronts=route_fronts,
             sun=_compute_route_sun(rp_analyses, airport_conds),
             arrival_approaches=_collect_arrival_approaches(
-                route.destination.icao, airports_db_path,
+                route.destination.icao, airports_db_path, declared_approach_icaos,
             ),
             cruise_speed_ias_kt=cruise_speed_ias_kt,
             flight_duration_hours=route.flight_duration_hours,
@@ -521,6 +531,7 @@ def run_advisories_from_pack(
     cruise_speed_ias_kt: float | None = None,
     flight_duration_hours: float = 0.0,
     persist: bool = True,
+    declared_approach_icaos: list[str] | None = None,
 ) -> AdvisoryResult:
     """Re-evaluate advisories from persisted pack_dir artifacts.
 
@@ -607,6 +618,7 @@ def run_advisories_from_pack(
             # silently dropping the advisory on recalculate (#509).
             arrival_approaches=_collect_arrival_approaches(
                 _arrival_icao(route, airport_conds), airports_db_path,
+                declared_approach_icaos,
             ),
             cruise_speed_ias_kt=cruise_speed_ias_kt,
             flight_duration_hours=flight_duration_hours,
@@ -890,6 +902,7 @@ def run_alt_from_pack(
     cross_sections: list[RouteCrossSection] | None = None,
     persist: bool = True,
     detect_fronts: bool = True,
+    declared_approach_icaos: list[str] | None = None,
 ) -> AdvisoryResult:
     """Re-run analysis + advisories at an alt departure time using existing pack data.
 
@@ -997,6 +1010,7 @@ def run_alt_from_pack(
             route_fronts=route_fronts,
             arrival_approaches=_collect_arrival_approaches(
                 _arrival_icao(route, airport_conds), airports_db_path,
+                declared_approach_icaos,
             ),
             cruise_speed_ias_kt=cruise_speed_ias_kt,
             flight_duration_hours=route.flight_duration_hours,

--- a/src/weatherbrief/tasks/time_scan.py
+++ b/src/weatherbrief/tasks/time_scan.py
@@ -525,6 +525,7 @@ def confirm_candidate(
     convective_method: str | None = None,
     locale: str | None = None,
     cruise_speed_ias_kt: float | None = None,
+    declared_approach_icaos: list[str] | None = None,
 ):
     """Multi-model check of one provisional candidate — the honesty-ladder top.
 
@@ -615,6 +616,7 @@ def confirm_candidate(
             convective_method=convective_method,
             locale=locale,
             cruise_speed_ias_kt=cruise_speed_ias_kt,
+            declared_approach_icaos=declared_approach_icaos,
             cross_sections=cross_sections,
             persist=False,
             detect_fronts=False,
@@ -794,6 +796,7 @@ def run_time_scan(
     convective_method: str | None = None,
     locale: str | None = None,
     cruise_speed_ias_kt: float | None = None,
+    declared_approach_icaos: list[str] | None = None,
 ) -> TimeWindowScan | None:
     """Grade the flight's Flexibility scenarios against the saved pack.
 
@@ -856,6 +859,7 @@ def run_time_scan(
         convective_method=convective_method,
         locale=locale,
         cruise_speed_ias_kt=cruise_speed_ias_kt,
+        declared_approach_icaos=declared_approach_icaos,
         cross_sections=cross_sections,
     )
 

--- a/src/weatherbrief/tasks/time_scan_runner.py
+++ b/src/weatherbrief/tasks/time_scan_runner.py
@@ -136,7 +136,7 @@ def _run_scan_job(flight_id: str, pack_dir: Path, fetch_ts: datetime, db_path: s
             (
                 enabled_ids, enabled_map, user_params, aggregation, adv_models,
                 icing_method, cloud_source, convective_method, recompute_conds,
-                locale, _afd,
+                locale, _afd, declared_approaches,
             ) = _load_advisory_profile(
                 db, flight, flight.user_id, None, pack_dir, db_path=db_path,
             )
@@ -156,6 +156,7 @@ def _run_scan_job(flight_id: str, pack_dir: Path, fetch_ts: datetime, db_path: s
                 cloud_source=cloud_source,
                 convective_method=convective_method,
                 locale=locale,
+                declared_approach_icaos=declared_approaches,
             )
             if scan is None:
                 _write_status(pack_dir, "skipped", flight.flexibility, reason="no_data")
@@ -272,7 +273,7 @@ def _run_confirm_job(
             (
                 enabled_ids, enabled_map, user_params, aggregation, adv_models,
                 icing_method, cloud_source, convective_method, recompute_conds,
-                locale, _afd,
+                locale, _afd, declared_approaches,
             ) = _load_advisory_profile(
                 db, flight, flight.user_id, None, pack_dir, db_path=db_path,
             )
@@ -291,6 +292,7 @@ def _run_confirm_job(
                 cloud_source=cloud_source,
                 convective_method=convective_method,
                 locale=locale,
+                declared_approach_icaos=declared_approaches,
             )
 
             # Re-load before mutating — the artifact may have moved while the

--- a/tests/analysis/advisories/test_approach_feasibility.py
+++ b/tests/analysis/advisories/test_approach_feasibility.py
@@ -21,6 +21,7 @@ from weatherbrief.analysis.advisories.strings import _STRINGS
 from weatherbrief.models import AdvisoryStatus
 from weatherbrief.units import M_PER_SM
 from weatherbrief.models.airport_conditions import (
+    SOURCE_USER_DECLARED,
     AirportApproaches,
     AirportConditions,
     AirportConditionsSummary,
@@ -668,3 +669,230 @@ class TestCatalog:
         )
         assert _grade(circ, tailwind_limit_kt=5, circling_ceiling_ft=1000) == AdvisoryStatus.RED
         assert _grade(circ, tailwind_limit_kt=5, circling_ceiling_ft=500) == AdvisoryStatus.AMBER
+
+
+# ---------------------------------------------------------------------------
+# User-declared unpublished approaches (issue #510)
+# ---------------------------------------------------------------------------
+
+_DECLARED = RunwayApproach(
+    name="Declared unpublished approach", source=SOURCE_USER_DECLARED,
+)
+# A circling-only published procedure, for the "declaration alongside published
+# procedures" cases.
+_RNP_A = RunwayApproach(name="RNP A", approach_type="RNP", circling=True)
+
+
+def _detail(ctx: RouteContext, **overrides) -> str:
+    params = {**_defaults(), **overrides}
+    return ApproachFeasibilityEvaluator.evaluate(ctx, params).aggregate_detail
+
+
+class TestDeclaredApproachGradeMap:
+    """The #510 table: VFR green, MVFR green, IFR amber, LIFR red.
+
+    Note this does NOT fall out of #509's pre-existing rules, contrary to the
+    issue's framing — the no-straight-in fallback only softens off RED when the
+    weather supports circling (1000 ft / 1500 m), and an IFR ceiling is
+    500–1000 ft by definition. Hence the dedicated branch, and hence these
+    tests: they pin the row the issue specified, not the row the old rule gives.
+    """
+
+    def test_ifr_declared_is_amber_not_red(self):
+        ctx = _ctx(
+            _conditions(FlightCategory.IFR, [_RWY_02, _RWY_24], icao="EGTF"),
+            _approaches(_DECLARED, has_procedure_data=False, icao="EGTF"),
+        )
+        assert _grade(ctx) == AdvisoryStatus.AMBER
+
+    def test_ifr_declared_amber_holds_below_circling_minima(self):
+        """The case the declaration exists for — and the one the old rule missed.
+
+        A 600 ft IFR ceiling supports no circling, so the pre-#510 fallback
+        would have graded this RED: exactly the EGTF-class false red that made
+        the advisory worth ignoring for a UK home-field pilot.
+        """
+        ctx = _ctx(
+            _conditions(FlightCategory.IFR, [_RWY_02, _RWY_24], ceiling_ft=600, icao="EGTF"),
+            _approaches(_DECLARED, has_procedure_data=False, icao="EGTF"),
+        )
+        assert _grade(ctx) == AdvisoryStatus.AMBER
+
+    def test_lifr_declared_stays_red(self):
+        """The hard cap: no published procedure means no published minima."""
+        ctx = _ctx(
+            _conditions(FlightCategory.LIFR, [_RWY_02, _RWY_24], icao="EGTF"),
+            _approaches(_DECLARED, has_procedure_data=False, icao="EGTF"),
+        )
+        assert _grade(ctx) == AdvisoryStatus.RED
+
+    def test_mvfr_declared_is_green(self):
+        ctx = _ctx(
+            _conditions(FlightCategory.MVFR, [_RWY_02, _RWY_24], icao="EGTF"),
+            _approaches(_DECLARED, has_procedure_data=False, icao="EGTF"),
+        )
+        assert _grade(ctx) == AdvisoryStatus.GREEN
+
+    def test_vfr_declared_is_green(self):
+        ctx = _ctx(
+            _conditions(FlightCategory.VFR, [_RWY_02, _RWY_24], icao="EGTF"),
+            _approaches(_DECLARED, has_procedure_data=False, icao="EGTF"),
+        )
+        assert _grade(ctx) == AdvisoryStatus.GREEN
+
+    def test_undeclared_field_is_unchanged(self):
+        """The #509 baseline the declaration is measured against."""
+        bare = _approaches(has_procedure_data=False, icao="EGTF")
+        assert _grade(_ctx(_conditions(FlightCategory.IFR, [_RWY_02], icao="EGTF"), bare)) \
+            == AdvisoryStatus.RED
+        assert _grade(_ctx(_conditions(FlightCategory.MVFR, [_RWY_02], icao="EGTF"), bare)) \
+            == AdvisoryStatus.AMBER
+
+    def test_declared_can_never_earn_green_at_ifr(self):
+        """Circling-equivalent: no straight-in alignment credit, ever.
+
+        Even with the wind dead on the nose of every runway and a ceiling well
+        clear of any plausible minima, a declaration tops out at amber.
+        """
+        ctx = _ctx(
+            _conditions(
+                FlightCategory.IFR,
+                [_runway_wind("20", 200.0, headwind=15.0, crosswind=0.0)],
+                ceiling_ft=3000, icao="EGTF",
+            ),
+            _approaches(_DECLARED, has_procedure_data=False, icao="EGTF"),
+        )
+        assert _grade(ctx) == AdvisoryStatus.AMBER
+
+
+class TestDeclaredApproachHonesty:
+    """A declaration may soften the infrastructure penalty, and nothing else."""
+
+    def test_detail_always_names_the_basis(self):
+        """#510 guardrail 2: the grade is softened on the pilot's own assertion.
+
+        A shared briefing renders the owner's baked-in grades, so this sentence
+        is the only thing that travels with it — the viewer has no other way to
+        know the amber rests on a declaration.
+        """
+        for category in (FlightCategory.MVFR, FlightCategory.IFR, FlightCategory.LIFR):
+            detail = _detail(_ctx(
+                _conditions(category, [_RWY_02, _RWY_24], icao="EGTF"),
+                _approaches(_DECLARED, has_procedure_data=False, icao="EGTF"),
+            ))
+            assert "declared" in detail.lower(), (category, detail)
+            assert "EGTF" in detail
+
+    def test_declared_is_never_called_published(self):
+        """The MVFR copy counts *published* approaches; a declaration is not one.
+
+        Asserted against the count phrasing rather than the word "published" —
+        the declared copy legitimately contains it, inside "unpublished".
+        """
+        declared = _detail(_ctx(
+            _conditions(FlightCategory.MVFR, [_RWY_02], icao="EGTF"),
+            _approaches(_DECLARED, has_procedure_data=False, icao="EGTF"),
+        ))
+        published = _detail(_ctx(
+            _conditions(FlightCategory.MVFR, [_RWY_02]),
+            _approaches(_ILS_02),
+        ))
+        assert "approach(es)" in published  # the counted copy exists…
+        assert "approach(es)" not in declared  # …and a declaration never gets it
+        assert "unpublished" in declared
+
+    def test_declared_lends_no_minima(self):
+        """The best-case gate reads published plates only.
+
+        A declared field has no plate, so there is no decision height to test a
+        ceiling against — the airport-wide RED gate must not fire on one, and
+        must not borrow ILS minima from thin air either.
+        """
+        ctx = _ctx(
+            _conditions(FlightCategory.IFR, [_RWY_02, _RWY_24], ceiling_ft=550, icao="EGTF"),
+            _approaches(_DECLARED, has_procedure_data=False, icao="EGTF"),
+        )
+        detail = _detail(ctx)
+        assert _grade(ctx) == AdvisoryStatus.AMBER
+        assert "decision height" not in detail
+
+    def test_declared_does_not_read_as_unresolved_alignment(self):
+        """It has no runway_id and is not circling — the UNRESOLVED shape.
+
+        Reading it as "an approach we could not match to a runway" would blame
+        our data for what is actually the pilot's declaration, and hand them the
+        wrong instruction ("check the plates" for a procedure with no plate).
+        """
+        detail = _detail(_ctx(
+            _conditions(FlightCategory.IFR, [_RWY_02, _RWY_24], icao="EGTF"),
+            _approaches(_DECLARED, has_procedure_data=False, icao="EGTF"),
+        ))
+        assert "could not be matched" not in detail
+
+    def test_declared_never_softens_below_the_weather(self):
+        """#510 guardrail 3, at a field that DOES have a published approach.
+
+        A ceiling below the best-case decision height is a hard weather fact
+        about a real plate. The declaration removes the infrastructure penalty
+        only, so this stays RED.
+        """
+        ctx = _ctx(
+            _conditions(FlightCategory.IFR, [_RWY_02, _RWY_20], ceiling_ft=100),
+            _approaches(_ILS_02, _ILS_20, _DECLARED),
+        )
+        assert _grade(ctx) == AdvisoryStatus.RED
+
+    def test_declaration_softens_a_misaligned_published_field(self):
+        """Published approaches all out on wind, plus a declaration → amber.
+
+        The declaration says the published picture is not the whole picture,
+        which is the same reason the other softenings exist.
+        """
+        args = (
+            _conditions(FlightCategory.IFR, [_RWY_02, _RWY_24], ceiling_ft=600),
+            _ILS_02,
+        )
+        without = _ctx(args[0], _approaches(args[1]))
+        with_decl = _ctx(args[0], _approaches(args[1], _DECLARED))
+        assert _grade(without, tailwind_limit_kt=5) == AdvisoryStatus.RED
+        assert _grade(with_decl, tailwind_limit_kt=5) == AdvisoryStatus.AMBER
+
+    def test_declaration_is_not_credited_at_lifr_on_a_published_field(self):
+        """The hard cap applies to the softening too, not just the bare field."""
+        conds = _conditions(FlightCategory.LIFR, [_RWY_02, _RWY_24], ceiling_ft=400)
+        assert _grade(
+            _ctx(conds, _approaches(_ILS_02, _DECLARED)), tailwind_limit_kt=5,
+        ) == AdvisoryStatus.RED
+
+    def test_circling_outranks_the_declaration(self):
+        """When the weather genuinely supports circling, say so — it is the
+        more actionable line, and it holds regardless of any declaration."""
+        detail = _detail(_ctx(
+            _conditions(FlightCategory.IFR, [_RWY_02, _RWY_24], ceiling_ft=1500),
+            _approaches(_ILS_02, _DECLARED),
+        ), tailwind_limit_kt=5)
+        assert "circling" in detail
+
+    def test_circling_only_published_plus_declaration(self):
+        """A circling-only field (the EGKA shape) with a declaration.
+
+        Neither lends a straight-in minimum, so the verdict must come from the
+        declaration rather than falling through to RED.
+        """
+        ctx = _ctx(
+            _conditions(FlightCategory.IFR, [_RWY_02, _RWY_24], ceiling_ft=600),
+            _approaches(_RNP_A, _DECLARED),
+        )
+        assert _grade(ctx) == AdvisoryStatus.AMBER
+
+    def test_declared_softening_resolves_in_all_locales(self):
+        """Every cell of the blocker x softening product must have real copy."""
+        assert f"approach_feasibility.soften_{_Softening.DECLARED.value}" in _STRINGS
+        for key in (
+            f"approach_feasibility.soften_{_Softening.DECLARED.value}",
+            "approach_feasibility.declared_only",
+            "approach_feasibility.declared_lifr",
+            "approach_feasibility.mvfr_declared",
+        ):
+            for lang in ("en", "fr", "de", "es"):
+                assert _STRINGS[key].get(lang), (key, lang)

--- a/tests/test_advise_arrival_approaches.py
+++ b/tests/test_advise_arrival_approaches.py
@@ -58,14 +58,32 @@ class TestCollectArrivalApproaches:
         )
         seen: dict = {}
 
-        def _fake(icaos, db_path):
+        def _fake(icaos, db_path, declared=None):
             seen["icaos"] = icaos
             seen["db_path"] = db_path
+            seen["declared"] = declared
             return {"EGKA": expected}
 
         monkeypatch.setattr("weatherbrief.airports.get_runway_approaches", _fake)
         assert advise._collect_arrival_approaches("EGKA", "nav.db") is expected
-        assert seen == {"icaos": ["EGKA"], "db_path": "nav.db"}
+        assert seen == {"icaos": ["EGKA"], "db_path": "nav.db", "declared": None}
+
+    def test_passes_the_declared_list_through(self, monkeypatch):
+        """The #510 declarations must reach the collection step from every path.
+
+        Pinned because the helper swallows every exception to protect the
+        briefing: a signature drift here would surface as a silently absent
+        advisory, not as an error.
+        """
+        seen: dict = {}
+
+        def _fake(icaos, db_path, declared=None):
+            seen["declared"] = declared
+            return {"EGTF": AirportApproaches(icao="EGTF")}
+
+        monkeypatch.setattr("weatherbrief.airports.get_runway_approaches", _fake)
+        advise._collect_arrival_approaches("EGTF", "nav.db", ["EGTF", "EGSX"])
+        assert seen["declared"] == ["EGTF", "EGSX"]
 
     @pytest.mark.parametrize("icao,db_path", [(None, "nav.db"), ("EGKA", None), ("EGKA", "")])
     def test_missing_inputs_degrade_to_none(self, icao, db_path):

--- a/tests/test_declared_approach_guardrails.py
+++ b/tests/test_declared_approach_guardrails.py
@@ -1,0 +1,121 @@
+"""The declared-approach containment guardrail (issue #510, guardrail 1).
+
+A pilot's declaration that they have an unpublished/self-briefed approach is a
+personal operational assertion. It carries **no regulatory weight**: a
+self-briefed approach cannot make a field qualify as a filed alternate under
+EASA NCO.OP.143, and cannot relieve the NCO.OP.140 trigger. If it ever set
+``has_instrument_approach`` in the shared airport path, the alternates table and
+the FAA/EASA verdicts would start making regulatory claims out of it.
+
+Containment is structural today: ``tasks/alternates.py`` runs its own
+``procedures_query.approaches()`` against euro_aip and never calls
+``get_runway_approaches``, the one function that knows about declarations. These
+tests pin that structure, because the failure they guard against is silent — a
+wrongly-qualified alternate looks exactly like a correctly-qualified one.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from weatherbrief.airports import get_runway_approaches
+from weatherbrief.models.airport_conditions import AirportApproaches
+
+SRC = Path(__file__).resolve().parents[1] / "src" / "weatherbrief"
+
+# The modules that turn approach availability into a regulatory statement.
+REGULATORY_MODULES = [
+    SRC / "tasks" / "alternates.py",
+    SRC / "tasks" / "alternate_requirement.py",
+    SRC / "analysis" / "alternate_requirement.py",
+]
+
+# Names that only exist to carry a declaration. Any of them appearing in a
+# module above means the declaration has reached the regulatory path.
+DECLARATION_NAMES = (
+    "declared_approach_icaos",
+    "load_declared_approaches",
+    "has_declared_approach",
+    "SOURCE_USER_DECLARED",
+    "user_declared",
+    "get_runway_approaches",
+)
+
+
+@pytest.mark.parametrize("path", REGULATORY_MODULES, ids=lambda p: p.name)
+def test_regulatory_modules_never_see_a_declaration(path):
+    """No alternate-minima module may reference the declaration machinery."""
+    source = path.read_text()
+    for name in DECLARATION_NAMES:
+        assert name not in source, (
+            f"{path.name} references {name!r}. A user-declared unpublished "
+            "approach must never reach the alternates or alternate-requirement "
+            "path — see #510 guardrail 1."
+        )
+
+
+def test_alternates_resolves_approaches_independently():
+    """Alternates ask euro_aip directly, not the declaration-aware collector.
+
+    This is what makes the containment structural rather than a convention: the
+    two questions ("can the pilot get in?" and "does this field qualify as a
+    filed alternate?") are answered from different code, so wiring a
+    declaration into one cannot leak into the other.
+    """
+    source = (SRC / "tasks" / "alternates.py").read_text()
+    assert "procedures_query.approaches()" in source
+
+
+def test_only_the_advisory_evaluator_consumes_the_declaration():
+    """Enumerate the consumers, so a new one has to be a deliberate act."""
+    consumers = {
+        p.relative_to(SRC).as_posix()
+        for p in SRC.rglob("*.py")
+        if "has_declared_approach" in p.read_text()
+    }
+    assert consumers == {
+        "models/airport_conditions.py",              # defines it
+        "analysis/advisories/approach_feasibility.py",  # the sole consumer
+    }, consumers
+
+
+def test_declaration_does_not_survive_into_the_published_view(monkeypatch):
+    """``published`` is the list every minima/alignment reader must use.
+
+    ``AlternateAirport.best_approach_type`` and the qualification proxies are
+    all keyed off an approach *class*; a declaration has none, so its presence
+    must not change what a published-only reader sees.
+    """
+    class _Airport:
+        ident = "EGTF"
+        runways: list = []
+        procedures: list = []
+
+        class procedures_query:  # noqa: N801 - mirrors the euro_aip attribute
+            @staticmethod
+            def approaches():
+                class _Empty:
+                    @staticmethod
+                    def all():
+                        return []
+                return _Empty()
+
+    class _Model:
+        class airports:
+            @staticmethod
+            def get(icao):
+                return _Airport() if icao == "EGTF" else None
+
+    monkeypatch.setattr(
+        "weatherbrief.airports._load_airport_model", lambda _p: _Model(),
+    )
+    declared: AirportApproaches = get_runway_approaches(
+        ["EGTF"], "nav.db", ["EGTF"],
+    )["EGTF"]
+
+    assert declared.has_iap is True            # the advisory sees it…
+    assert declared.has_published_iap is False  # …and nothing else does
+    assert declared.published == []
+    assert declared.served_runway_ids == set()

--- a/tests/test_preferences.py
+++ b/tests/test_preferences.py
@@ -247,3 +247,94 @@ class TestProfilesRouteOrdering:
         resp = client.get("/api/user/profiles/digest-guidance-presets")
         assert resp.status_code == 200
         assert isinstance(resp.json(), list)
+
+
+class TestDeclaredApproaches:
+    """User-declared unpublished approaches (issue #510).
+
+    Storage is a plain ``app_prefs_json`` key rather than an advisory param
+    because it is a fact about the pilot and the airport ("I'm current on the
+    Fairoaks cloud break"), not about a flight profile — entered once, applied
+    everywhere.
+    """
+
+    def test_default_is_empty(self, client):
+        assert client.get("/api/user/preferences").json()["declared_approach_icaos"] == []
+
+    def test_free_form_text_is_canonicalized(self, client):
+        """The field is free-form; the canonical shape is the server's job.
+
+        Normalizing here rather than in the web client means every writer — a
+        direct PUT, a future iOS screen — stores the same thing.
+        """
+        resp = client.put(
+            "/api/user/preferences",
+            json={"declared_approach_icaos": " egtf, EGSX  egtf;eglk "},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["declared_approach_icaos"] == ["EGTF", "EGSX", "EGLK"]
+        # …and survives the round trip
+        assert client.get("/api/user/preferences").json()["declared_approach_icaos"] == [
+            "EGTF", "EGSX", "EGLK",
+        ]
+
+    def test_accepts_a_json_array_too(self, client):
+        resp = client.put(
+            "/api/user/preferences", json={"declared_approach_icaos": ["egtf", "EGSX"]},
+        )
+        assert resp.json()["declared_approach_icaos"] == ["EGTF", "EGSX"]
+
+    def test_can_be_cleared(self, client):
+        client.put("/api/user/preferences", json={"declared_approach_icaos": "EGTF"})
+        resp = client.put("/api/user/preferences", json={"declared_approach_icaos": ""})
+        assert resp.status_code == 200
+        assert resp.json()["declared_approach_icaos"] == []
+
+    def test_preserves_sibling_keys(self, client):
+        """The merge-preserving write — a declaration must not drop settings."""
+        client.put("/api/user/preferences", json={"units_region": "us"})
+        client.put("/api/user/preferences", json={"declared_approach_icaos": "EGTF"})
+        data = client.get("/api/user/preferences").json()
+        assert data["units_region"] == "us"
+        assert data["declared_approach_icaos"] == ["EGTF"]
+
+    def test_unknown_code_is_rejected_and_nothing_is_stored(self, client, monkeypatch):
+        """A typo'd EGFT must come back, never be silently dropped.
+
+        Dropping it would leave the pilot believing their home field is
+        declared when it is not — silently reinstating the very false REDs the
+        declaration removes.
+        """
+        client.put("/api/user/preferences", json={"declared_approach_icaos": "EGTF"})
+        monkeypatch.setattr(
+            "weatherbrief.airports.unknown_icaos", lambda codes, db_path: ["EGFT"],
+        )
+        resp = client.put(
+            "/api/user/preferences", json={"declared_approach_icaos": "EGTF EGFT"},
+        )
+        assert resp.status_code == 400
+        detail = resp.json()["detail"]
+        assert detail["error"] == "unknown_airports"
+        assert detail["codes"] == ["EGFT"]
+        assert "EGFT" in detail["message"]
+        # The whole write is rejected — the previous list is untouched.
+        assert client.get("/api/user/preferences").json()["declared_approach_icaos"] == ["EGTF"]
+
+    def test_validation_is_skipped_when_the_airport_db_is_unavailable(self):
+        """A missing AIRPORTS_DB is a server-config gap, not the user's typo."""
+        from weatherbrief.airports import unknown_icaos
+
+        assert unknown_icaos(["EGTF"], "/nonexistent/nav.db") == []
+        assert unknown_icaos([], "") == []
+
+    def test_load_helper_reads_the_stored_list(self, client, app_db):
+        """The single read path used by every advisory entry point."""
+        from weatherbrief.api.preferences import load_declared_approaches
+
+        client.put("/api/user/preferences", json={"declared_approach_icaos": "egtf EGSX"})
+        session = app_db()
+        try:
+            assert load_declared_approaches(session, DEV_USER_ID) == ["EGTF", "EGSX"]
+            assert load_declared_approaches(session, "nobody") == []
+        finally:
+            session.close()

--- a/tests/test_runway_approaches.py
+++ b/tests/test_runway_approaches.py
@@ -57,9 +57,9 @@ class _FakeModel:
         self.airports = _FakeCollection(airports)
 
 
-def _lookup(airports: dict[str, Airport], icaos: list[str]):
+def _lookup(airports: dict[str, Airport], icaos: list[str], declared=None):
     with patch("weatherbrief.airports._load_airport_model", return_value=_FakeModel(airports)):
-        return get_runway_approaches(icaos, "nav.db")
+        return get_runway_approaches(icaos, "nav.db", declared)
 
 
 class TestNormalizeRunwayIdent:
@@ -200,4 +200,73 @@ class TestFailureNeverImpersonatesAbsence:
         airports = {"EGTF": _airport("EGTF", [_runway("06", "24")], [])}
         result = _lookup(airports, ["EGTF"])["EGTF"]
         assert result.lookup_failed is False
+        assert result.has_iap is False
+
+
+class TestDeclaredUnpublishedApproaches:
+    """Injection of the pilot's declared unpublished approaches (issue #510).
+
+    Resolving the declaration in the collection step is what keeps the
+    evaluator pure — it sees one approach list and only has to recognise the
+    source. These pin that the injected entry can never confer credit it has no
+    basis for.
+    """
+
+    def test_declared_icao_gets_a_synthetic_approach(self):
+        """EGTF Fairoaks: zero procedure rows, but the pilot flies a cloud break."""
+        airports = {"EGTF": _airport("EGTF", [_runway("06", "24")], [])}
+        result = _lookup(airports, ["EGTF"], ["EGTF"])["EGTF"]
+        assert result.has_iap is True
+        assert result.has_declared_approach is True
+        assert result.has_published_iap is False
+        assert result.published == []
+
+    def test_undeclared_icao_is_untouched(self):
+        airports = {"EGTF": _airport("EGTF", [_runway("06", "24")], [])}
+        result = _lookup(airports, ["EGTF"], ["EGSX"])["EGTF"]
+        assert result.has_iap is False
+        assert result.has_declared_approach is False
+
+    def test_declaration_carries_no_alignment_and_no_class(self):
+        """The type is fixed and the runway absent BY CONSTRUCTION.
+
+        Letting a user declare "ILS" would hand them a 200 ft decision height on
+        a procedure with no plate; a runway would earn straight-in alignment
+        credit against the wind. Neither is available to declare, so neither can
+        be claimed.
+        """
+        airports = {"EGTF": _airport("EGTF", [_runway("06", "24")], [])}
+        declared = _lookup(airports, ["EGTF"], ["EGTF"])["EGTF"].approaches[0]
+        assert declared.runway_id is None
+        assert declared.approach_type is None
+        assert declared.is_declared is True
+
+    def test_declaration_does_not_add_a_served_runway(self):
+        """``served_runway_ids`` drives the alignment copy — it must stay published."""
+        airports = {
+            "EGKA": _airport(
+                "EGKA", [_runway("02", "20")],
+                [_approach("RWY02 ILS", "ILS", "02")],
+            ),
+        }
+        result = _lookup(airports, ["EGKA"], ["EGKA"])["EGKA"]
+        assert result.served_runway_ids == {"02"}
+        assert result.has_declared_approach is True
+        assert [a.name for a in result.published] == ["RWY02 ILS"]
+
+    def test_matching_is_case_and_whitespace_insensitive(self):
+        airports = {"EGTF": _airport("EGTF", [_runway("06", "24")], [])}
+        result = _lookup(airports, ["EGTF"], [" egtf ", ""])["EGTF"]
+        assert result.has_declared_approach is True
+
+    def test_declaration_never_overrides_a_failed_lookup(self):
+        """``lookup_failed`` means "we could not determine the picture".
+
+        A declaration does not determine it either — and turning that state
+        into a gradeable one would let a data gap produce a verdict, which is
+        the failure mode ``lookup_failed`` exists to prevent.
+        """
+        result = _lookup({}, ["EGTF"], ["EGTF"])["EGTF"]
+        assert result.lookup_failed is True
+        assert result.has_declared_approach is False
         assert result.has_iap is False

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -2642,6 +2642,13 @@ label {
   font-size: 0.9rem;
 }
 
+/* Inline, per-field validation message. Sits under the input it belongs to,
+   unlike .status-error, which is the form-wide banner. */
+.field-error {
+  color: var(--red);
+  font-weight: 500;
+}
+
 /* --- Settings utility classes --- */
 .settings-actions { gap: 0.75rem; margin-bottom: 1rem; align-items: center; }
 .section-hint { margin-bottom: 0.75rem; }

--- a/web/settings.html
+++ b/web/settings.html
@@ -151,6 +151,29 @@
         </div>
 
         <div class="section">
+          <h3 data-i18n="settings.declaredApproaches.title">Unpublished Approaches</h3>
+          <p class="muted section-hint" data-i18n="settings.declaredApproaches.hint">
+            Airports where you have an approach available to you that is not published in the AIP —
+            a cloud break procedure or a private/unpublished GNSS approach. This is a personal
+            operational declaration about your own currency and procedures, not a published procedure.
+          </p>
+          <div class="form-row">
+            <div class="form-group grow">
+              <label for="input-declared-approaches" data-i18n="settings.declaredApproaches.label">Airports (ICAO)</label>
+              <input type="text" id="input-declared-approaches" placeholder="EGTF, EGSX EGLK" autocomplete="off" autocapitalize="characters" spellcheck="false">
+              <span class="field-hint" data-i18n="settings.declaredApproaches.fieldHint">Separate codes with spaces or commas.</span>
+            </div>
+          </div>
+          <p class="field-hint" id="declared-approaches-error" style="display:none;"></p>
+          <p class="muted section-hint" data-i18n="settings.declaredApproaches.scope">
+            Used only by the Approach Feasibility advisory: at a destination with no published
+            instrument approach, an IFR arrival reads amber rather than red — never green, and never
+            in LIFR, where there are no published minima to fly to. It never affects
+            alternate-minima calculations or whether a field qualifies as a filed alternate.
+          </p>
+        </div>
+
+        <div class="section">
           <h3>Optional Services</h3>
           <p class="muted section-hint">Enable additional features. These are experimental or still being calibrated and are off by default.</p>
           <div class="form-row model-checkboxes">

--- a/web/ts/adapters/preferences-adapter.ts
+++ b/web/ts/adapters/preferences-adapter.ts
@@ -65,6 +65,10 @@ export interface PreferencesResponse {
   pirep_can_view: boolean;
   pirep_can_publish: boolean;
   donations_enabled: boolean; // global: Stripe configured (gates the donate link)
+  // Airports where the pilot declared an unpublished/self-briefed approach
+  // (#510). Always canonical (uppercase, deduped) — the server normalizes on
+  // write, so the field can be rendered by joining without further cleanup.
+  declared_approach_icaos: string[];
 }
 
 export interface PreferencesUpdate {
@@ -86,6 +90,10 @@ export interface PreferencesUpdate {
   notify_scope?: 'auto' | 'all' | 'off';
   notify_change_only?: boolean;
   notify_decay_notice?: boolean; // only meaningful as false, to dismiss the notice
+  // Sent as the raw text of the settings field; the server splits on
+  // commas/whitespace, uppercases and dedupes. Deliberately not normalized here
+  // — one normalizer, server-side, so every client stores the same shape.
+  declared_approach_icaos?: string;
 }
 
 /**

--- a/web/ts/i18n/locales/de.json
+++ b/web/ts/i18n/locales/de.json
@@ -855,5 +855,11 @@
   "flights.form.profileInfoTitle": "Profil",
   "flights.form.profileInfoBody": "Ein Profil ist, was Sie mit dem Flugzeug vorhaben — Ihre Reiseflughöhe, persönliche Wettergrenzen und welche Hinweise für diese Art Flug zählen. Legen Sie mehrere an — ein IFR-Reiseprofil, ein VFR-Lokalprofil, ein strengeres Trainingsprofil — und wechseln Sie pro Flug. Profile erstellen und bearbeiten Sie in den Einstellungen.",
   "flights.form.profileInfoEditThis": "Dieses Profil bearbeiten",
-  "flights.form.profileInfoEditAny": "Profile verwalten"
+  "flights.form.profileInfoEditAny": "Profile verwalten",
+  "settings.declaredApproaches.title": "Nicht veröffentlichte Anflüge",
+  "settings.declaredApproaches.hint": "Flugplätze, an denen Ihnen ein nicht im AIP veröffentlichter Anflug zur Verfügung steht — ein Wolkendurchstoßverfahren (Cloud Break) oder ein privater GNSS-Anflug. Dies ist eine persönliche betriebliche Erklärung über Ihre eigenen Verfahren, kein veröffentlichtes Verfahren.",
+  "settings.declaredApproaches.label": "Flugplätze (ICAO)",
+  "settings.declaredApproaches.fieldHint": "Codes durch Leerzeichen oder Kommas trennen.",
+  "settings.declaredApproaches.scope": "Wird nur vom Hinweis „Anflugbarkeit“ verwendet: an einem Ziel ohne veröffentlichten Instrumentenanflug wird eine IFR-Ankunft gelb statt rot — nie grün und nie bei LIFR, wo es keine veröffentlichten Minima gibt. Hat nie Einfluss auf die Ausweich-Minima oder darauf, ob ein Platz als Ausweichflugplatz gilt.",
+  "settings.declaredApproaches.unknown": "Nicht als Flugplatzcodes erkannt: {codes}. Es wurde nichts gespeichert — bitte Schreibweise prüfen."
 }

--- a/web/ts/i18n/locales/en.json
+++ b/web/ts/i18n/locales/en.json
@@ -925,5 +925,11 @@
   "flights.form.profileInfoTitle": "Profile",
   "flights.form.profileInfoBody": "A profile is what you intend to do with the aircraft — your cruise altitude, personal weather limits, and which advisories matter for this kind of trip. Keep several — an IFR touring profile, a VFR local one, a tighter-limits training profile — and switch between them per flight. Create and edit profiles in Settings.",
   "flights.form.profileInfoEditThis": "Edit this profile",
-  "flights.form.profileInfoEditAny": "Manage profiles"
+  "flights.form.profileInfoEditAny": "Manage profiles",
+  "settings.declaredApproaches.title": "Unpublished Approaches",
+  "settings.declaredApproaches.hint": "Airports where you have an approach available to you that is not published in the AIP — a cloud break procedure or a private/unpublished GNSS approach. This is a personal operational declaration about your own currency and procedures, not a published procedure.",
+  "settings.declaredApproaches.label": "Airports (ICAO)",
+  "settings.declaredApproaches.fieldHint": "Separate codes with spaces or commas.",
+  "settings.declaredApproaches.scope": "Used only by the Approach Feasibility advisory: at a destination with no published instrument approach, an IFR arrival reads amber rather than red — never green, and never in LIFR, where there are no published minima to fly to. It never affects alternate-minima calculations or whether a field qualifies as a filed alternate.",
+  "settings.declaredApproaches.unknown": "Not recognised as airport codes: {codes}. Nothing was saved — check the spelling."
 }

--- a/web/ts/i18n/locales/es.json
+++ b/web/ts/i18n/locales/es.json
@@ -855,5 +855,11 @@
   "flights.form.profileInfoTitle": "Perfil",
   "flights.form.profileInfoBody": "Un perfil es lo que pretendes hacer con la aeronave — tu altitud de crucero, tus límites meteorológicos personales y qué avisos importan para este tipo de vuelo. Mantén varios — un perfil de gira IFR, uno local VFR, uno de entrenamiento más estricto — y cambia entre ellos según el vuelo. Crea y edita perfiles en Configuración.",
   "flights.form.profileInfoEditThis": "Editar este perfil",
-  "flights.form.profileInfoEditAny": "Gestionar perfiles"
+  "flights.form.profileInfoEditAny": "Gestionar perfiles",
+  "settings.declaredApproaches.title": "Aproximaciones no publicadas",
+  "settings.declaredApproaches.hint": "Aeródromos donde dispone de una aproximación no publicada en el AIP — un procedimiento de rotura de nubes (cloud break) o una aproximación GNSS privada. Es una declaración operativa personal sobre sus propios procedimientos, no un procedimiento publicado.",
+  "settings.declaredApproaches.label": "Aeródromos (OACI)",
+  "settings.declaredApproaches.fieldHint": "Separe los códigos con espacios o comas.",
+  "settings.declaredApproaches.scope": "Solo lo usa el aviso de Viabilidad de la aproximación: en un destino sin aproximación instrumental publicada, una llegada IFR pasa a ámbar en lugar de rojo — nunca verde, y nunca en LIFR, donde no hay mínimos publicados. Nunca afecta al cálculo de mínimos de alternativo ni a si un aeródromo puede declararse como alternativo.",
+  "settings.declaredApproaches.unknown": "No se reconocen como códigos de aeródromo: {codes}. No se guardó nada — revise la ortografía."
 }

--- a/web/ts/i18n/locales/fr.json
+++ b/web/ts/i18n/locales/fr.json
@@ -855,5 +855,11 @@
   "flights.form.profileInfoTitle": "Profil",
   "flights.form.profileInfoBody": "Un profil, c'est ce que vous comptez faire avec l'aéronef — votre altitude de croisière, vos limites météo personnelles, et les avis qui comptent pour ce type de vol. Gardez-en plusieurs — un profil tourisme IFR, un local VFR, un entraînement plus strict — et basculez de l'un à l'autre selon le vol. Créez et modifiez vos profils dans les Paramètres.",
   "flights.form.profileInfoEditThis": "Modifier ce profil",
-  "flights.form.profileInfoEditAny": "Gérer les profils"
+  "flights.form.profileInfoEditAny": "Gérer les profils",
+  "settings.declaredApproaches.title": "Approches non publiées",
+  "settings.declaredApproaches.hint": "Aérodromes où vous disposez d'une approche non publiée à l'AIP — une percée sous les nuages (cloud break) ou une approche GNSS privée. Il s'agit d'une déclaration opérationnelle personnelle sur vos propres procédures et votre expérience récente, non d'une procédure publiée.",
+  "settings.declaredApproaches.label": "Aérodromes (OACI)",
+  "settings.declaredApproaches.fieldHint": "Séparez les codes par des espaces ou des virgules.",
+  "settings.declaredApproaches.scope": "Utilisé uniquement par l'avis Faisabilité de l'approche : à une destination sans approche aux instruments publiée, une arrivée IFR passe en orange plutôt qu'en rouge — jamais en vert, et jamais en LIFR, faute de minima publiés. N'affecte jamais le calcul des minima de dégagement ni l'éligibilité d'un terrain comme dégagement déposé.",
+  "settings.declaredApproaches.unknown": "Codes d'aérodrome non reconnus : {codes}. Rien n'a été enregistré — vérifiez l'orthographe."
 }

--- a/web/ts/settings-main.ts
+++ b/web/ts/settings-main.ts
@@ -880,6 +880,17 @@ function populateAccountForm(prefs: PreferencesResponse): void {
     deferToggle.checked = prefs.defer_email_for_model_update ?? false;
   }
 
+  // Declared unpublished approaches (#510) — rendered from the server's
+  // canonical list, so what the field shows after a save is exactly what was
+  // stored, not what the user happened to type.
+  const declaredInput = document.getElementById(
+    'input-declared-approaches',
+  ) as HTMLInputElement | null;
+  if (declaredInput) {
+    declaredInput.value = (prefs.declared_approach_icaos ?? []).join(' ');
+  }
+  clearDeclaredApproachError();
+
   renderNotificationSettings(prefs);
 }
 
@@ -1686,6 +1697,9 @@ async function handleSave(): Promise<void> {
     // Save account-level preferences (locale + optional services + autorouter creds in dev mode)
     const synopticEnabled = (document.getElementById('toggle-synoptic-forecast-map') as HTMLInputElement)?.checked ?? false;
     const deferModelUpdate = (document.getElementById('toggle-defer-model-update') as HTMLInputElement)?.checked ?? false;
+    const declaredInput = document.getElementById(
+      'input-declared-approaches',
+    ) as HTMLInputElement | null;
     const accountUpdate: import('./adapters/preferences-adapter').PreferencesUpdate = {
       locale: selectedLocale,
       units_region: selectedUnitsRegion,
@@ -1693,6 +1707,11 @@ async function handleSave(): Promise<void> {
       synoptic_forecast_map_enabled: synopticEnabled,
       defer_email_for_model_update: deferModelUpdate,
     };
+    // Sent verbatim — the server splits, uppercases, dedupes and validates
+    // against nav.db, and rejects the whole write if a code is unknown (#510).
+    if (declaredInput) {
+      accountUpdate.declared_approach_icaos = declaredInput.value;
+    }
 
     // Briefing notifications (issue #371). The 3-stop folds into scope +
     // change-only; channels persist as-is (the invariant is enforced live in
@@ -1720,8 +1739,14 @@ async function handleSave(): Promise<void> {
       if (arPassword) accountUpdate.autorouter_password = arPassword;
     }
 
+    clearDeclaredApproachError();
     const result = await savePreferences(accountUpdate);
     setUnitsPreference(result.units_region);
+    // Re-render from the canonical stored list, so the field shows what was
+    // actually saved rather than the user's spacing and casing.
+    if (declaredInput) {
+      declaredInput.value = (result.declared_approach_icaos ?? []).join(' ');
+    }
     updateAutorouterStatus(result.has_autorouter_creds, autorouterMode);
     if (autorouterMode === 'password') {
       const arPwdInput = document.getElementById('input-ar-password') as HTMLInputElement;
@@ -1738,8 +1763,42 @@ async function handleSave(): Promise<void> {
 
     showStatus(t('settings.saved'));
   } catch (err) {
+    // An unknown airport code is a fixable typo in one field, not a generic
+    // save failure — name it at the field so the user can see which code was
+    // rejected. #510 requires it never be silently dropped, and a message that
+    // only says "save failed" would be exactly that in effect.
+    const codes = unknownAirportCodes(err);
+    if (codes.length) {
+      showDeclaredApproachError(
+        t('settings.declaredApproaches.unknown', { codes: codes.join(', ') }),
+      );
+    }
     showStatus(t('settings.failedSave', { error: String(err) }), true);
   }
+}
+
+/** The unknown ICAO codes named by a rejected preferences save, if any. */
+function unknownAirportCodes(err: unknown): string[] {
+  const detail = (err as { detail?: unknown })?.detail;
+  if (!detail || typeof detail !== 'object') return [];
+  const d = detail as { error?: unknown; codes?: unknown };
+  if (d.error !== 'unknown_airports' || !Array.isArray(d.codes)) return [];
+  return d.codes.map(String);
+}
+
+function showDeclaredApproachError(message: string): void {
+  const el = document.getElementById('declared-approaches-error');
+  if (!el) return;
+  el.textContent = message;
+  el.style.display = '';
+  el.classList.add('field-error');
+}
+
+function clearDeclaredApproachError(): void {
+  const el = document.getElementById('declared-approaches-error');
+  if (!el) return;
+  el.textContent = '';
+  el.style.display = 'none';
 }
 
 // --- Autorouter status ---

--- a/web/ts/utils.ts
+++ b/web/ts/utils.ts
@@ -467,13 +467,28 @@ export async function apiFetch<T>(
       throw new Error(`API 403: ${detail403 || body403}`);
     }
     const body = await resp.text();
-    let detail: string;
+    let parsed: unknown;
     try {
-      detail = JSON.parse(body).detail || body;
+      parsed = JSON.parse(body).detail ?? body;
     } catch {
-      detail = body;
+      parsed = body;
     }
-    throw new Error(`API ${resp.status}: ${detail}`);
+    // A structured detail ({error, codes, message}) used to stringify as
+    // "[object Object]" here, hiding the only useful part. Prefer its `message`
+    // for display, and hand the whole object to the caller on `.detail` so a
+    // form can act on the specific field it names (e.g. the unknown ICAOs in
+    // the declared-approach list) rather than re-parsing prose.
+    const isObj = typeof parsed === 'object' && parsed !== null;
+    const message = isObj
+      ? String((parsed as { message?: unknown }).message ?? body)
+      : String(parsed || body);
+    const err = new Error(`API ${resp.status}: ${message}`) as Error & {
+      status?: number;
+      detail?: unknown;
+    };
+    err.status = resp.status;
+    err.detail = parsed;
+    throw err;
   }
   onResponse?.(resp);
   if (resp.status === 204) return undefined as T;


### PR DESCRIPTION
## What & why

`approach_feasibility` (#509) grades a destination with no published instrument approach as **RED** at IFR/LIFR. Correct as a default, and it over-fires in the UK: `EGTF` (Fairoaks) has **zero** rows in `procedures`, so for a pilot based there *every* IFR arrival at their home field graded RED. That is enough noise to make the advisory worth ignoring, which is worse than not having it.

This is **not a data gap** — #509 established these absences are genuine. The published data is right and the operational reality differs: pilots routinely fly a self-briefed **cloud break procedure** or a private/unpublished GNSS approach.

A pilot can now declare the airports where they have one. A declared field is treated as *"an approach exists, alignment unknown"*.

## Design

**Storage — a user preference, not an advisory param.** `app_prefs_json → declared_approach_icaos`, read by `api/preferences.py::load_declared_approaches` (sibling of `load_user_locale`). It is a fact about the pilot and the airport ("I'm current on the Fairoaks cloud break"), entered once and applied everywhere — not a per-profile judgment. It could not have been an `AdvisoryParameterDef` anyway: `default` is typed `float`, and all 83 params in use are numeric.

**Resolution in the collection step**, so the evaluator stays pure: `get_runway_approaches(icaos, db_path, declared_icaos)` injects a synthetic `RunwayApproach(source="user_declared")`. Every field that could confer credit is empty **by construction** — `approach_type` is `None` so no minima class can be inferred, `runway_id` is `None` so it can never be paired with a runway end's wind. The type is fixed rather than user-selectable precisely so a pilot cannot declare "ILS" and be handed a 200 ft decision height on a procedure with no plate. It is *not* injected over `lookup_failed`: that state means "we could not determine the picture", and a declaration does not determine it either.

**`AirportApproaches.published` is the split that keeps this honest.** Everything reasoning about minima, alignment or approach class reads it, never `approaches`. Miss that and the declaration (no runway, not circling) silently reads as UNRESOLVED alignment, and the best-case minima gate starts testing ceilings against a plate that does not exist.

| Destination | Undeclared | Declared |
|---|---|---|
| VFR | GREEN | GREEN |
| MVFR | AMBER (no IAP) | **GREEN** — own copy, never called "published" |
| IFR | RED (no IAP) | **AMBER** |
| LIFR | RED | **RED** — hard cap |

### The one place the issue's rationale was wrong

#510 says the IFR amber "falls out of #509's existing rule rather than being special-cased." **It does not.** The no-straight-in fallback only softens off RED when the weather supports circling (`circling_ceiling_ft` / `circling_visibility_m`, 1000 ft / 1500 m) — but an IFR ceiling is 500–1000 ft *by definition*. A declared EGTF at 700 ft would still have graded RED, leaving exactly the false REDs the declaration exists to damp.

So the issue's **table** is implemented as specified, via an explicit `_Softening.DECLARED` and a dedicated no-published branch in `_grade_full`. Only the stated mechanism is corrected, in the evaluator docstring and `designs/advisories.md`. `test_ifr_declared_amber_holds_below_circling_minima` pins the case the old rule missed.

**LIFR stays RED as an explicit cap** — with no published procedure there are no published minima, so no DH can be claimed at all. The cap gates both the bare declared field and the `DECLARED` softening on a published field.

Three rules bound what a declaration can do:
1. **Circling outranks it** — when the weather genuinely supports circling, "plan for circling" is the more actionable line and holds regardless.
2. **It never softens below the weather** (guardrail 3) — a ceiling below the best-case DH of a *real* plate stays RED. The declaration removes the *infrastructure* penalty only.
3. **The basis is always visible** (guardrail 2) — *"graded against your declared unpublished approach at EGTF, which has no published minima, so check your own"*. **Shared briefings are deliberately not handled:** a pack stores its computed manifest, so `/s/{code}` renders the owner's baked-in grades; we do not re-grade per viewer, and that sentence is the only thing that travels with the share.

### Guardrail 1 — containment, and why it is structural

A self-briefed approach cannot make a field qualify as a filed alternate under EASA NCO.OP.143, nor relieve the NCO.OP.140 trigger. If it ever set `has_instrument_approach` in the shared airport path, the alternates table and the FAA/EASA verdicts would start making **regulatory** claims out of a personal assertion.

It cannot today: `tasks/alternates.py:275` answers "does this field qualify?" from its own `ap.procedures_query.approaches()` and never calls `get_runway_approaches` — the only function that knows about declarations. `tests/test_declared_approach_guardrails.py` pins that, including an **enumeration of every module referencing `has_declared_approach`**, so a new consumer has to be a deliberate act rather than an accident.

### Wiring — four paths, all required

`BriefingOptions.declared_approach_icaos` covers the briefing run; `api/packs.py::_load_advisory_profile` returns it as a 12th tuple element, feeding **recalculate, the settings preview, the alt-departure re-run and `tasks/time_scan_runner`**. The time-scan is the easy one to miss and it matters: it grades the planned departure through the same path and asserts shift=0 reproduces the briefing grades, so omitting it would make the scan contradict the card beside it. All six unpack sites updated.

Validation on save is `airports.py::unknown_icaos` against `nav.db`. An unknown code **rejects the whole write** with a 400 naming the codes — dropping a typo'd `EGFT` silently would leave the pilot believing their home field is declared when it is not, reinstating the very false REDs this removes. A missing `AIRPORTS_DB` skips validation rather than blaming the user for a server-config gap.

**Incidental fix:** `apiFetch` stringified a structured `detail` as `[object Object]`, hiding the only useful part. It now prefers `detail.message` and attaches `.status`/`.detail` to the thrown Error, so a form can act on the field the server named. This affects every endpoint that returns a structured detail, for the better.

### Deferred / out of scope

Declaring approach type, minima or runway alignment; per-runway declarations (circling-equivalent confers no alignment credit either way); sharing the list between users; viewer-scoped re-grading of shared briefings; an iOS settings surface (iOS renders the advisory from the served catalog and needs no change to *display* a declared grade).

## Issue linkage

Closes #510

## Testing / verification

**Verified live** on the HTTPS dev server against a real flight (LFOH→LFOM, a field with zero procedure rows). Recalculate — not a full refresh — picked up the declaration: DWD ICON's IFR arrival went red→amber with the basis named, GFS/ECMWF MVFR→green. The three remaining red cards (IFR Feasibility, VFR Feasibility, Airport Weather) correctly did **not** move: they are weather, not infrastructure.

- **`tests/analysis/advisories/test_approach_feasibility.py`** — 17 new (63 total): the full grade map incl. amber holding below circling minima, the LIFR cap on both the bare field and the softening, "can never earn GREEN at IFR" with the wind dead on the nose, the basis named in every declared verdict, a declaration lending no minima and not reading as unresolved alignment, never softening below the weather at a published field, circling outranking it, the EGKA circling-only shape, and all four locales resolving.
- **`tests/test_runway_approaches.py`** — 6 new (35 total): injection, case/whitespace matching, no alignment or class by construction, `served_runway_ids` unchanged, and a declaration never overriding `lookup_failed`.
- **`tests/test_preferences.py`** — 8 new (23 total): free-form canonicalization, JSON-array form, clearing, sibling-key preservation, unknown-code rejection leaving the previous list intact, and validation skipped when the airport DB is unavailable.
- **`tests/test_declared_approach_guardrails.py`** — 6 new: the regulatory-module containment pin and the consumer enumeration.
- **Existing:** full backend suite **4482 passed, 9 skipped, 0 failures**. Web `npm test` 556 passed across 35 files; `tsc --noEmit` clean apart from the two pre-existing errors in `ts/eval/label-panel.ts`.

Design docs: a dedicated `### User-declared unpublished approaches (#510)` section in `designs/advisories.md` (storage rationale, the published/declared split, the grade map, the corrected IFR-amber rationale, the three bounding rules, containment, the four wiring points), and the now-shipped follow-up struck from the #509 deferred list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
