### PR TITLE
feat(freshness): persist a model delivery log (#515)

### DIFF
--- a/alembic/versions/084_model_delivery_log.py
+++ b/alembic/versions/084_model_delivery_log.py
@@ -1,0 +1,69 @@
+"""Persist a model delivery log (issue #515).
+
+The freshness registry's ``delivery_offset`` constants were calibrated against
+observation once and never revisited, and nothing durable recorded what
+actually happened: ``published_at`` was fetched on every check, held on the
+in-memory ``Marker``, and dropped. The only persisted history —
+``MarkerStore``'s ``(observed_init, now)`` deque — recorded our *detection*
+time, which the 5-minute poll quantises and which by construction can never
+observe an early arrival (the loop doesn't look before a run is due).
+
+This table records one row per observed run, keeping the provider's publish
+time separate from our detection time so drift and poll lag stay distinct
+quantities. Collect-only: written by ``scheduler._run_freshness_check_once``,
+read by nothing yet.
+
+``create_table`` / ``create_index`` work on SQLite (dev) and MySQL (prod)
+without batch mode.
+
+Revision ID: 084
+Revises: 083
+Create Date: 2026-07-30
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "084"
+down_revision: Union[str, None] = "083"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "model_delivery_log",
+        sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),
+        # Registry key, e.g. "ecmwf:direct".
+        sa.Column("source", sa.String(32), nullable=False),
+        # Logical model ("ecmwf"), denormalised from the key prefix so
+        # "all GFS deliveries" needs no string split.
+        sa.Column("model", sa.String(20), nullable=False),
+        sa.Column("cycle_init", sa.DateTime(timezone=True), nullable=False),
+        # Registry prediction frozen at observation time — recomputing it at
+        # read time would erase the record of what was wrong the moment we
+        # recalibrate the constants.
+        sa.Column("expected_at", sa.DateTime(timezone=True), nullable=False),
+        # Provider-reported publish wallclock: the actual measurement.
+        sa.Column("published_at", sa.DateTime(timezone=True), nullable=True),
+        # When our loop noticed (quantised by the poll interval).
+        sa.Column("detected_at", sa.DateTime(timezone=True), nullable=False),
+        # Last dynamic check that did NOT yet see this run.
+        sa.Column("last_absent_at", sa.DateTime(timezone=True), nullable=True),
+        # "sentinel_mtime" | "http_last_modified" | "om_meta" — these
+        # instruments carry different systematic biases.
+        sa.Column("observed_via", sa.String(24), nullable=False),
+        sa.UniqueConstraint(
+            "source", "cycle_init", name="uq_model_delivery_source_cycle"
+        ),
+    )
+    # Calibration reads are "the last N weeks", optionally narrowed by source.
+    op.create_index("ix_model_delivery_cycle_init", "model_delivery_log", ["cycle_init"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_model_delivery_cycle_init", table_name="model_delivery_log")
+    op.drop_table("model_delivery_log")

--- a/designs/freshness-markers.md
+++ b/designs/freshness-markers.md
@@ -12,7 +12,7 @@ The old freshness path (`fetch/model_status.check_freshness`) called Open-Meteo'
 
 What should NOT change:
 - The pure-compute property: `now < pack.next_expected_update` ⇒ fresh, no I/O. Most freshness HTTP calls are a dict lookup, not a network round-trip.
-- The marker store stays **in-memory only**. No DB persistence — bootstrap from registry on restart (~2s of inline-fallback cost). Adding persistence would widen scope; the admin endpoint covers debugging.
+- The marker store stays **in-memory only**. No DB persistence — bootstrap from registry on restart (~2s of inline-fallback cost). (Issue #515 added a durable `model_delivery_log`, but that is an append-only *measurement* record, not marker state: restart behaviour is unchanged.)
 - Per-(model, source) granularity. The same logical model can be sourced multiple ways (`ecmwf:direct` vs `ecmwf:openmeteo`), and which one a pack used is a per-pack property — recorded as `pack.model_sources`.
 
 ## Architecture
@@ -22,9 +22,11 @@ Four modules under `src/weatherbrief/fetch/freshness/`:
 | Module | Purpose |
 |---|---|
 | `registry.py` | `SourceConfig` dataclass, `SOURCE_REGISTRY` dict (9 source/model pairs), pure functions: `next_run_after`, `next_cycle_init_after`, `run_horizon`, `cycle_init_for`, `expected_delivery_for_init`, `initial_marker_for`, plus horizon-query helpers `max_horizon`, `next_full_horizon_run`, `first_full_coverage` (used by the digest long-range gate to find the regime boundary and the date high-res GRIB first covers a flight — see [digest.md](./digest.md)). **Single source of truth** for descriptive fields too (`model_label`, `provider_label`, `provider_url`, `role`, `resolution`, `coverage`, `pressure_levels`, `description`) — consumed by the freshness popover, the public data-sources endpoint, and the help-page table. |
-| `markers.py` | `Marker` dataclass + `MarkerStore` (asyncio-locked, singleton via `get_store()`). Records `(cycle_init, arrival_wallclock)` observations in a maxlen=100 deque. |
-| `sources.py` | Unified `check_source(source, model)` dispatch wrapping existing helpers (`grib_fetch.find_latest_run_with_response` for GFS/NOAA, `icon_eu_fetch.find_latest_icon_eu_run_with_response` for ICON-EU/DWD, `ecmwf_watcher.get_latest_ready_with_mtime` for ECMWF/direct, `model_status.fetch_model_metadata` for `*:openmeteo`). The `_with_response` variants exist so the dispatch can pull `published_at` from the same HEAD's `Last-Modified` header. Each dispatch returns an `Observation(init, published_at)` — `published_at` is the provider's `Last-Modified` header for HTTP sources (NOAA, DWD), the OM `last_run_availability_time` for `*:openmeteo`, and the sentinel-file mtime for ECMWF direct (no central publish wallclock). |
+| `markers.py` | `Marker` dataclass + `MarkerStore` (asyncio-locked, singleton via `get_store()`). Records `(cycle_init, arrival_wallclock)` observations in a maxlen=100 deque. `Marker.last_probe_at` is the last *successful* dynamic check — distinct from the `last_check` heartbeat, which every tick bumps. |
+| `sources.py` | Unified `check_source(source, model)` dispatch wrapping existing helpers (`grib_fetch.find_latest_run_with_response` for GFS/NOAA, `icon_eu_fetch.find_latest_icon_eu_run_with_response` for ICON-EU/DWD, `ecmwf_watcher.get_latest_ready_with_mtime` for ECMWF/direct, `model_status.fetch_model_metadata` for `*:openmeteo`). The `_with_response` variants exist so the dispatch can pull `published_at` from the same HEAD's `Last-Modified` header. Each dispatch returns an `Observation(init, published_at, data_end, observed_via)` — `published_at` is the provider's `Last-Modified` header for HTTP sources (NOAA, DWD), the OM `last_run_availability_time` for `*:openmeteo`, and the sentinel-file mtime for ECMWF direct (no central publish wallclock); `observed_via` names which of those three clocks it was. |
 | `catalog.py` | Pure read-only merge of `SOURCE_REGISTRY` (static description + schedule) and `MarkerStore` (live `latest_init`, `published_at`, `next_expected`, `horizon_end`, `marker_health`). Backs `GET /api/data-sources` — the public catalog endpoint that drives the help-page Data Sources & Models table. |
+
+Plus one storage module outside the package: `storage/model_delivery.py` — the durable delivery log (below).
 
 The 5-min loop lives in `scheduler.run_freshness_loop` — bootstraps the store, then on each tick: for every `(source, model)` whose `next_expected` has passed, run `check_source` (offloaded to a thread), call `store.update`. Most ticks no-op.
 
@@ -66,6 +68,39 @@ if not status.fresh:
 # drift_p90_vs_config_s.
 ```
 
+## Delivery Log (issue #515)
+
+`model_delivery_log` is the **realised** counterpart to the registry's *expected* `delivery_offset`. One row per observed model run, appended by `scheduler._run_freshness_check_once` whenever a marker advances. **Collect-only — nothing reads it yet.**
+
+| Column | Meaning |
+|---|---|
+| `source` / `model` | Registry key (`"ecmwf:direct"`) and its denormalised prefix (`"ecmwf"`), so "all GFS" is a `WHERE`, not a string split |
+| `cycle_init` | The run being measured |
+| `expected_at` | The registry's prediction, **frozen at observation time** |
+| `published_at` | Provider-reported publish wallclock — the actual measurement (nullable) |
+| `detected_at` | When our loop noticed |
+| `last_absent_at` | Last dynamic check that did *not* yet see this run (nullable) |
+| `observed_via` | `sentinel_mtime` \| `http_last_modified` \| `om_meta` |
+
+Everything interesting is derived on read: `drift = published_at − expected_at`, `poll_lag = detected_at − published_at`, `cycle_hour = HOUR(cycle_init)`.
+
+Why the schema looks like this — each of these is easy to "simplify" back into the bug it fixes:
+
+- **`expected_at` is stored, not derived.** The point of the table is to *change* the offset constants. Recomputing expectation at read time would collapse every historical drift to ~0 the moment we recalibrated, erasing the record of what was wrong.
+- **`published_at` is distinct from `detected_at`.** Conflating them is the pre-existing bug: `MarkerStore.update()`'s deque records `(observed_init, now)`, i.e. *our detection*, which the 300 s poll quantises. Prod showed three different sources sharing an identical `arrived_at` and `drift=+159s` — poll lag, not lateness. Worse, the loop skips the check while `now < next_expected`, so **early arrival is unobservable** in that record: 0 negative drifts in 7 days, while the timeline (reading the provider's own `published_at`) correctly showed ICON and UKMO ~60 min early.
+- **`observed_via` is recorded, not assumed uniform.** A sentinel mtime is when *our* watcher finished writing after rsync; an OM `last_run_availability_time` is the provider's own record; an HTTP `Last-Modified` is the origin file's. Different systematic biases — pooling them silently would be sloppy. Each `sources._DISPATCH` wrapper declares its own on the returned `Observation`, so a new source can't inherit the wrong one.
+- **`last_absent_at` brackets the truth.** `(last_absent_at, published_at]` bounds arrival when `published_at` is null, and cross-checks it when it isn't (`published_at < last_absent_at` means the provider's timestamp contradicts what we observed). It comes from `Marker.last_probe_at` **snapshotted before `update()`** — the heartbeat `last_check` is useless here, since the loop bumps it on every tick including no-I/O ones.
+
+Decisions worth not relitigating:
+
+- **Written from the scheduler, not `MarkerStore.update()`.** The marker modules are deliberately I/O-free; the scheduler already holds the pre-update snapshot, the registry expectation, and the instrument. The insert is offloaded to a thread and is best-effort — a DB hiccup costs one calibration sample, never a freshness tick.
+- **Missed runs are reconstructed, not stored.** A skipped cycle never advances the marker, so no row appears. Find the hole by joining against the expected cycle grid. *Store facts about observations, derive facts about the schedule* — a synthetic "missing" row would also assert a schedule we might later stop believing.
+- **No backfill.** The `Marker advanced` journald lines carry detection time only; seeding from them would pollute the calibration set with a lesser measurement.
+- **No retention policy, no aggregation.** ~50 rows/day ≈ 18k/yr ≈ 2–3 MB/yr, three orders of magnitude below `verification_scores`. Aggregating would destroy the primary use case: "what time is safe on the bad days" is a P95/P99 question, and percentiles cannot be reconstructed from stored min/max/median. Revisit only if we ever log every *check* rather than every *advance* (60× the volume).
+- **`UNIQUE (source, cycle_init)`, first write wins.** A restart re-bootstraps markers, so the same run can legitimately be advanced onto twice; the first observation has the tighter bracket.
+
+Not in v1, in rough order: the timeline reading the log (draw an observed-lag band per source, gated on having enough points — a band over 3 samples is worse than the current dot); the registry consuming the measured distribution as per-cycle-hour offsets (`_OM_GFS_OFFSET` is one number but GFS 00Z and 06Z differ by ~80 min — and if it ever *auto*-consumes, `expected_at` will need to record which calibration produced it); recalibrating the current constants once a few weeks of signed drift exist.
+
 ## Tiered Refresh Gate (issue #167)
 
 `_build_data_status` answers "is anything stale?" with a **min-rule** — one newer covering run flips `fresh=False`. That's the right signal for the auto-refresh *scheduler's* freshness loop, but it makes the **manual refresh button** wasteful: any single model tick triggers a full token+compute+disk refresh, even when one model update can't move a multi-day-out picture. `decide_refresh` (in `api/packs.py`) layers a lead-time-aware gate on top of the same per-model states.
@@ -101,7 +136,8 @@ Without this, the bar's raw min-rule `fresh` flag disagreed with the button (sho
 
 ## Key Choices
 
-- **In-memory only.** Lost on restart, ~2s bootstrap cost. Admin endpoint provides debugging visibility; no DB persistence in scope.
+- **Marker state stays in-memory only.** Lost on restart, ~2s bootstrap cost. Admin endpoint provides debugging visibility. The one durable thing is the delivery log above — an append-only measurement record, not marker state, so a restart still re-bootstraps from the registry exactly as before.
+- **`marker_health="ok"` requires an actual observation.** `is_stale` measures time since the last check *attempt*, and the loop bumps that on ticks that do no I/O — so a source whose dynamic check has always failed used to report a green `"ok"` while serving nothing but registry guesses (`gem:openmeteo` in prod: `latest_init` ~36h stale, `published_at` null, health `"ok"`). `Marker.last_probe_at` records when `check_source` last *succeeded*; the catalog reports `"unobserved"` until it has.
 - **Source key prefix → model name.** `("icon_eu:dwd", "icon_eu")` vs `("icon:openmeteo", "icon")` — the marker store key is `(source, source.split(":", 1)[0])`. Pack-side may map the same logical pack-model name (`"icon"`) to either source; `model_for_source()` strips the suffix to find the marker.
 - **Min-rule for staleness.** If *any* source has new data covering the flight, the pack is stale. Avoids per-model weighting heuristics. If a refresh fires for a less-useful source, it just falls back to the previous source — no harm.
 - **Horizon-aware.** Without this, a 78h intermediate ICON-EU run would wrongly invalidate a 120h main-run pack for long-haul flights.
@@ -114,7 +150,7 @@ Without this, the bar's raw min-rule `fresh` flag disagreed with the button (sho
 
 When adding a new (source, model) pair:
 1. Add a `SourceConfig` to `SOURCE_REGISTRY` with **both** schedule fields (`cycles`, `delivery_offset`, `horizon`, `readiness_check`) **and** descriptive fields (`model_label`, `provider_label`, `provider_url`, `role`, `resolution`, `coverage`, `pressure_levels`, `description`). The catalog test (`test_data_sources_catalog.py`) enforces that descriptive fields are populated.
-2. Add a wrapper to `sources._DISPATCH` mapping the readiness_check symbol → callable returning `datetime | None`.
+2. Add a wrapper to `sources._DISPATCH` mapping the readiness_check symbol → callable returning an `Observation`. Set its `observed_via` to the `VIA_*` constant naming the clock the `published_at` actually came from — the delivery log keeps those instruments apart, and a default would silently pool incomparable measurements.
 3. If the source produces a new model name not seen by `_finalize_refresh`, extend `_DIRECT_SOURCE_KEYS` in `api/packs.py` so `model_sources` records correctly.
 
 The help-page table and the freshness popover both render from the same registry — no separate copy to keep in sync.
@@ -165,7 +201,7 @@ When tuning registry offsets:
 - **`marker.is_stale(loop_interval)` is heartbeat, not data freshness.** Returns True if `last_check is None` or older than `2 × loop_interval`. Used to surface `marker_health="suspect"` and trigger inline-check fallback. Not a comment on the underlying data.
 - **Open-Meteo ECMWF cycles are tracked as `(0, 12)` only.** OM publishes 06/18 as `bc-runs` with heavy lag (per issue #100); tracking them would cause the marker to bounce on bc-run shuffles.
 - **OM ICON cycles are `(0, 6, 12, 18)` not 3-hourly.** Even though DWD itself runs ICON every 3h, OM's `meta.json` reports `update_interval_seconds: 21600` — OM only republishes the 6-hourly main runs.
-- **The in-memory deque is lost on process restart.** Calibration data builds up over a few days then resets. If you need durable telemetry, add a SQL table (deferred — not in scope).
+- **The in-memory deque is lost on process restart.** The admin endpoint's calibration view builds up over a few days then resets. Durable telemetry lives in `model_delivery_log` instead — and note the two disagree by construction: the deque records *detection* time (poll-quantised, never early), the table records the provider's *publish* time. Prefer the table.
 - **Sync `get_sync()` returns a snapshot copy** so callers can't accidentally mutate the live deque. Don't pass markers across coroutines and expect mutations to land — use the async `update`/`mark_check` API.
 
 ## References
@@ -179,4 +215,5 @@ When tuning registry offsets:
 - Public catalog: `fetch/freshness/catalog.py`, `api/data_sources.py` (GET `/api/data-sources`)
 - Frontend consumers: `web/help.html` + `web/ts/data-sources-table.ts` (data-driven help table), `web/ts/managers/briefing-ui.ts:renderSourcesPopupContent` (per-flight popover)
 - Storage: `BriefingPackMeta.model_sources`, `BriefingPackRow.model_sources_json` (Text JSON, alembic 050)
-- Tests: `tests/test_freshness_{registry,markers,sources,admin}.py`, `tests/test_data_sources_catalog.py`, `tests/test_packs.py::TestDecideRefresh`
+- Delivery log (issue #515): `db/models.py:ModelDeliveryLogRow`, `storage/model_delivery.py`, alembic 084; written from `scheduler._run_freshness_check_once`
+- Tests: `tests/test_freshness_{registry,markers,sources,admin}.py`, `tests/test_data_sources_catalog.py`, `tests/test_packs.py::TestDecideRefresh`, `tests/test_model_delivery_log.py`

--- a/src/weatherbrief/db/models.py
+++ b/src/weatherbrief/db/models.py
@@ -1391,3 +1391,78 @@ class EdrCalibrationAccumulatorRow(Base):
     )
 
 
+
+
+class ModelDeliveryLogRow(Base):
+    """One observed model-run delivery, as measured by the freshness loop (issue #515).
+
+    The registry's ``delivery_offset`` constants are the *expected* side of
+    "did this run land on time"; this table is the *realised* side. Before it,
+    the only durable record was ``MarkerStore``'s in-memory deque of
+    ``(cycle_init, arrival_wallclock)`` pairs — lost on restart, and measuring
+    our detection time rather than the provider's publish time.
+
+    Write-only in v1: the scheduler appends a row each time a marker advances.
+    Nothing reads it yet. Derived quantities are deliberately *not* stored —
+    ``drift = published_at − expected_at``, ``poll_lag = detected_at −
+    published_at`` and ``cycle_hour = HOUR(cycle_init)`` all follow from the
+    columns below.
+
+    Two columns exist for reasons that are easy to undo by accident:
+
+    * ``expected_at`` is the registry's prediction **as it was at observation
+      time**, stored rather than recomputed. The whole point of the table is to
+      recalibrate those constants; deriving expectation at read time would
+      collapse every historical drift to ~0 the moment we did.
+    * ``published_at`` is kept distinct from ``detected_at``. Conflating them
+      is the bug this table exists to fix: our poll interval quantises
+      detection, so folding it into drift buries the provider's real lateness
+      under our own polling lag — and makes early arrival unobservable.
+
+    Missed runs are **not** stored. If a provider skips a cycle the marker
+    never advances and no row appears; find the hole by joining against the
+    expected cycle grid. Store facts about observations, derive facts about
+    the schedule.
+    """
+
+    __tablename__ = "model_delivery_log"
+    __table_args__ = (
+        # One row per observed run. The loop can re-observe the same init
+        # (restart, re-check) — the write path relies on this to stay
+        # idempotent rather than accumulating duplicates.
+        UniqueConstraint("source", "cycle_init", name="uq_model_delivery_source_cycle"),
+        # Calibration reads are "the last N weeks", optionally per source.
+        Index("ix_model_delivery_cycle_init", "cycle_init"),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    # Registry key, e.g. "ecmwf:direct" — matches SOURCE_REGISTRY.
+    source: Mapped[str] = mapped_column(String(32), nullable=False)
+    # Logical model, e.g. "ecmwf". Denormalised from the key prefix so
+    # "all GFS deliveries" is a plain WHERE, not a string split.
+    model: Mapped[str] = mapped_column(String(20), nullable=False)
+    # The run being measured (aware UTC).
+    cycle_init: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    # Registry prediction for this run, frozen at observation time.
+    expected_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    # Provider-reported publish wallclock — the actual measurement. Null when
+    # the instrument didn't yield one (missing Last-Modified, OM availability
+    # time of 0); the row is still worth keeping for its detection bracket.
+    published_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    # When our loop noticed. Quantised by the freshness poll interval.
+    detected_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    # Last dynamic check that did NOT yet see this run. Brackets the truth as
+    # ``(last_absent_at, published_at]`` when published_at is null, and acts as
+    # a consistency check when it isn't (published_at < last_absent_at means
+    # the provider's timestamp contradicts what we observed).
+    last_absent_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    # Which instrument produced published_at: "sentinel_mtime" |
+    # "http_last_modified" | "om_meta". These are not equivalent — a sentinel
+    # mtime is when *our* watcher finished writing, an OM availability time is
+    # the provider's own record, an HTTP Last-Modified is the origin file's.
+    # Different systematic biases; pooling them silently would be wrong.
+    observed_via: Mapped[str] = mapped_column(String(24), nullable=False)

--- a/src/weatherbrief/fetch/freshness/catalog.py
+++ b/src/weatherbrief/fetch/freshness/catalog.py
@@ -56,7 +56,7 @@ class SourceCatalogEntry:
     published_at: datetime | None
     next_expected: datetime | None
     horizon_end: datetime | None
-    marker_health: str  # "ok" | "suspect" | "unknown"
+    marker_health: str  # "ok" | "suspect" | "unobserved" | "unknown"
 
 
 def _per_cycle_hours(
@@ -74,13 +74,25 @@ def _per_cycle_hours(
 
 
 def _marker_health(marker: Marker | None, loop_interval_s: float) -> str:
-    """Return ``"ok" | "suspect" | "unknown"`` for the marker."""
+    """Return ``"ok" | "suspect" | "unobserved" | "unknown"`` for the marker.
+
+    ``"unobserved"`` separates "the loop is running and has confirmed this
+    source" from "the loop is running and has never once reached it" — which
+    :attr:`Marker.is_stale` cannot distinguish, because it measures time
+    since the last *check attempt* and the loop bumps that on every tick.
+    Without it a source whose dynamic check has always failed reports
+    ``"ok"`` while serving nothing but registry guesses: ``gem:openmeteo``
+    did exactly that in production, showing a 36 h-stale ``latest_init`` and
+    a null ``published_at`` under a green dot.
+    """
     from datetime import timedelta
 
     if marker is None:
         return "unknown"
     if marker.is_stale(timedelta(seconds=loop_interval_s)):
         return "suspect"
+    if marker.last_probe_at is None:
+        return "unobserved"
     return "ok"
 
 

--- a/src/weatherbrief/fetch/freshness/markers.py
+++ b/src/weatherbrief/fetch/freshness/markers.py
@@ -40,7 +40,18 @@ class Marker:
         model: Logical model name, e.g. ``"ecmwf"``.
         init: Latest observed init time (aware UTC).
         next_expected: Wallclock time at which the next run is expected.
-        last_check: When the dynamic check last ran (None until first check).
+        last_check: When the loop last touched this marker — bumped on every
+            tick, including the no-I/O "not yet due" path.  A heartbeat, not
+            evidence that we ever reached the provider.
+        last_probe_at: When a dynamic check last *succeeded* for this source
+            (i.e. ``check_source`` returned an Observation).  ``None`` means
+            every value on this marker still comes from the registry
+            bootstrap — nothing has been confirmed against the provider.
+            Two consumers: the catalog reports ``marker_health="unobserved"``
+            rather than the misleading ``"ok"``, and the freshness loop uses
+            the pre-advance value as ``last_absent_at`` in the delivery log —
+            the last time we looked and did *not* see the run that just
+            landed, which brackets its arrival from below.
         slip_count: Number of consecutive slip retries since last advance.
         published_at: Provider-reported wallclock when the run became
             available (only Open-Meteo exposes this via ``meta.json``'s
@@ -56,6 +67,7 @@ class Marker:
     init: datetime
     next_expected: datetime
     last_check: datetime | None = None
+    last_probe_at: datetime | None = None
     slip_count: int = 0
     published_at: datetime | None = None
     # Latest hourly timestamp the provider is actually serving for this
@@ -188,6 +200,11 @@ class MarkerStore:
           expected delivery and reset slip.
         - Else: just update ``last_check`` (early/null check).
 
+        Every branch stamps ``last_probe_at``: reaching this method at all
+        means ``check_source`` came back with an Observation, whatever it
+        said.  (:meth:`mark_check` deliberately does *not* — a check that
+        failed is not evidence about the provider.)
+
         State transitions go through a single atomic ``dict.__setitem__`` of
         a new ``Marker`` instance (with a copied observations deque).  The
         ``asyncio.Lock`` only serialises coroutines — :meth:`get_sync` is
@@ -210,6 +227,7 @@ class MarkerStore:
                     source=source, model=model,
                     init=observed_init, next_expected=next_exp,
                     last_check=now,
+                    last_probe_at=now,
                     published_at=published_at,
                     data_end=data_end,
                     observations=new_observations,
@@ -228,6 +246,7 @@ class MarkerStore:
                     next_expected=registry.next_run_after(source, observed_init),
                     slip_count=0,
                     last_check=now,
+                    last_probe_at=now,
                     published_at=published_at,
                     data_end=data_end,
                     observations=new_observations,
@@ -303,6 +322,7 @@ class MarkerStore:
                 next_expected=new_next_expected,
                 slip_count=new_slip_count,
                 last_check=now,
+                last_probe_at=now,
                 published_at=new_published_at,
                 data_end=new_data_end,
             )

--- a/src/weatherbrief/fetch/freshness/sources.py
+++ b/src/weatherbrief/fetch/freshness/sources.py
@@ -39,11 +39,40 @@ class Observation(NamedTuple):
     config horizon (e.g. ARPEGE advertises 6 days but a given run may
     deliver only ~4 days).  Direct GRIB sources return ``None`` and the
     catalog falls back to ``init + cfg.horizon``.
+
+    ``observed_via`` names the *instrument* that produced ``published_at``.
+    The three are not interchangeable measurements of the same thing — see
+    the module constants below — so the delivery log records which one was
+    used rather than pooling them.  Each dispatch declares its own, so a
+    new source can't silently inherit the wrong one.
     """
 
     init: datetime
     published_at: datetime | None = None
     data_end: datetime | None = None
+    observed_via: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Observation instruments
+# ---------------------------------------------------------------------------
+#
+# Each names a different clock, with a different systematic bias against the
+# provider's true publish moment.  Recorded per-observation in
+# ``model_delivery_log.observed_via`` so a calibration query can keep them
+# apart instead of averaging across incomparable measurements.
+
+#: mtime of the ECMWF readiness sentinel — when *our* watcher finished writing
+#: after rsync delivery.  Local arrival, biased late by the transfer.
+VIA_SENTINEL_MTIME = "sentinel_mtime"
+
+#: ``Last-Modified`` of the origin file on the provider's server (NOAA S3,
+#: DWD opendata).  The file's own timestamp, not a publish announcement.
+VIA_HTTP_LAST_MODIFIED = "http_last_modified"
+
+#: Open-Meteo ``meta.json``'s ``last_run_availability_time`` — the provider's
+#: own record of when it finished ingesting the run.
+VIA_OM_META = "om_meta"
 
 
 # ---------------------------------------------------------------------------
@@ -65,7 +94,7 @@ def _check_ecmwf_direct(model: str) -> Observation | None:
     if result is None:
         return None
     init, mtime = result
-    return Observation(init=init, published_at=mtime)
+    return Observation(init=init, published_at=mtime, observed_via=VIA_SENTINEL_MTIME)
 
 
 def _check_gfs_noaa(model: str) -> Observation | None:
@@ -90,6 +119,7 @@ def _check_gfs_noaa(model: str) -> Observation | None:
     return Observation(
         init=init,
         published_at=_parse_last_modified(resp.headers.get("Last-Modified")),
+        observed_via=VIA_HTTP_LAST_MODIFIED,
     )
 
 
@@ -119,6 +149,7 @@ def _check_icon_eu_dwd(model: str) -> Observation | None:
     return Observation(
         init=init,
         published_at=_parse_last_modified(resp.headers.get("Last-Modified")),
+        observed_via=VIA_HTTP_LAST_MODIFIED,
     )
 
 
@@ -147,6 +178,7 @@ def _check_icon_d2_dwd(model: str) -> Observation | None:
     return Observation(
         init=init,
         published_at=_parse_last_modified(resp.headers.get("Last-Modified")),
+        observed_via=VIA_HTTP_LAST_MODIFIED,
     )
 
 
@@ -195,6 +227,7 @@ def _check_om_meta(model: str) -> Observation | None:
         init=datetime.fromtimestamp(m.last_init_time, tz=timezone.utc),
         published_at=published_at,
         data_end=data_end,
+        observed_via=VIA_OM_META,
     )
 
 
@@ -229,13 +262,24 @@ def check_source(source: str, model: str) -> Observation | None:
         )
         return None
     try:
-        return fn(model)
+        observation = fn(model)
     except Exception:
         logger.warning(
             "check_source: dynamic check failed for %s/%s",
             source, model, exc_info=True,
         )
         return None
+    if observation is not None and not observation.observed_via:
+        # A new dispatch that forgot to declare its instrument. Harmless to
+        # the freshness decision, but it would land unlabelled rows in the
+        # delivery log — where the whole point is not to pool measurements
+        # taken with different clocks. Loud, not fatal.
+        logger.warning(
+            "check_source: %s/%s returned an Observation with no observed_via — "
+            "set one of the VIA_* constants in its dispatch",
+            source, model,
+        )
+    return observation
 
 
 # ---------------------------------------------------------------------------

--- a/src/weatherbrief/scheduler.py
+++ b/src/weatherbrief/scheduler.py
@@ -20,6 +20,7 @@ import os
 import sys
 import time
 from datetime import datetime, timedelta, timezone
+from functools import partial
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -1532,9 +1533,19 @@ async def _run_freshness_check_once() -> None:
       event loop) until the loop got around to checking them.
     - Otherwise, run the dynamic ``check_source`` (offloaded to a thread)
       and either advance the marker or record a slip.
+
+    An advance is also the moment we learn when a run actually landed, so it
+    is where the durable ``model_delivery_log`` row is written (issue #515).
+    The scheduler owns that write rather than ``MarkerStore.update``: the
+    marker modules are deliberately I/O-free, and everything the row needs is
+    already in hand here — the pre-update marker snapshot (for
+    ``last_absent_at``), the registry expectation, and the instrument the
+    dispatch used.
     """
     from weatherbrief.fetch.freshness.markers import get_store
+    from weatherbrief.fetch.freshness.registry import expected_delivery_for_init
     from weatherbrief.fetch.freshness.sources import all_tracked_sources, check_source
+    from weatherbrief.storage.model_delivery import record_delivery
 
     store = get_store()
     now = datetime.now(timezone.utc)
@@ -1549,11 +1560,32 @@ async def _run_freshness_check_once() -> None:
         if observed is None:
             await store.mark_check(source, model, now=now)
             continue
+        # Snapshot before ``update`` overwrites it: the last probe that came
+        # back *without* this run is the lower bound on when it arrived.
+        last_absent_at = marker.last_probe_at
+        advanced = observed.init > marker.init
         await store.update(
             source, model, observed.init, now=now,
             published_at=observed.published_at,
             data_end=observed.data_end,
         )
+        if advanced:
+            # Expectation is frozen here, at observation time — recomputing it
+            # later against recalibrated constants would erase the drift this
+            # table exists to measure.
+            await asyncio.to_thread(
+                partial(
+                    record_delivery,
+                    source=source,
+                    model=model,
+                    cycle_init=observed.init,
+                    expected_at=expected_delivery_for_init(source, observed.init),
+                    published_at=observed.published_at,
+                    detected_at=now,
+                    last_absent_at=last_absent_at,
+                    observed_via=observed.observed_via,
+                )
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/src/weatherbrief/storage/model_delivery.py
+++ b/src/weatherbrief/storage/model_delivery.py
@@ -1,0 +1,140 @@
+"""Durable model-delivery observations — the realised half of freshness calibration.
+
+Two layers, matching ``storage/refresh_jobs.py``:
+
+* :func:`insert_delivery` takes a caller-supplied :class:`~sqlalchemy.orm.Session`
+  and behaves like any other storage function (flush, let the caller commit);
+* :func:`record_delivery` opens its own short-lived session, commits, and
+  **swallows every exception**. It is called from the freshness loop, which has
+  no session in hand and whose job — deciding whether a pack is stale — must
+  never fail because a telemetry insert did.
+
+Collect-only in v1 (issue #515): nothing reads these rows yet. See
+``designs/freshness-markers.md``.
+
+Note for whoever writes the read side: writes take aware-UTC datetimes, but
+both SQLite and MySQL hand them back **naive** despite ``DateTime(timezone=
+True)``. Re-attach UTC on read, as ``storage/flights.py`` does — subtracting
+a naive column from an aware ``now`` raises, and silently treating it as
+local time would corrupt exactly the drift figures this table exists for.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from flyfun_common.db import SessionLocal
+from weatherbrief.db.models import ModelDeliveryLogRow
+
+logger = logging.getLogger(__name__)
+
+
+def insert_delivery(
+    db: Session,
+    *,
+    source: str,
+    model: str,
+    cycle_init: datetime,
+    expected_at: datetime,
+    detected_at: datetime,
+    observed_via: str,
+    published_at: datetime | None = None,
+    last_absent_at: datetime | None = None,
+) -> ModelDeliveryLogRow | None:
+    """Append one observed delivery; return the row, or None if already logged.
+
+    ``(source, cycle_init)`` is unique — a re-observation of a run we already
+    recorded is a no-op rather than an error. The first observation is the one
+    worth keeping: a later one has a longer, less informative detection
+    bracket.
+    """
+    existing = db.execute(
+        select(ModelDeliveryLogRow).where(
+            ModelDeliveryLogRow.source == source,
+            ModelDeliveryLogRow.cycle_init == cycle_init,
+        )
+    ).scalars().first()
+    if existing is not None:
+        return None
+
+    row = ModelDeliveryLogRow(
+        source=source,
+        model=model,
+        cycle_init=cycle_init,
+        expected_at=expected_at,
+        published_at=published_at,
+        detected_at=detected_at,
+        last_absent_at=last_absent_at,
+        observed_via=observed_via,
+    )
+    db.add(row)
+    db.flush()
+    return row
+
+
+def record_delivery(
+    *,
+    source: str,
+    model: str,
+    cycle_init: datetime,
+    expected_at: datetime,
+    detected_at: datetime,
+    observed_via: str,
+    published_at: datetime | None = None,
+    last_absent_at: datetime | None = None,
+) -> None:
+    """Write one delivery observation in its own session, swallowing failures.
+
+    The freshness loop calls this on every marker advance. A DB hiccup here
+    costs one calibration sample, which is not worth failing a freshness tick
+    over — and the ``UNIQUE (source, cycle_init)`` constraint means a racing
+    duplicate is a no-op, not a lost row.
+    """
+    db = None
+    try:
+        db = SessionLocal()
+        insert_delivery(
+            db,
+            source=source,
+            model=model,
+            cycle_init=cycle_init,
+            expected_at=expected_at,
+            published_at=published_at,
+            detected_at=detected_at,
+            last_absent_at=last_absent_at,
+            observed_via=observed_via,
+        )
+        db.commit()
+    except IntegrityError:
+        # Lost the race on the unique constraint — the other writer's row is
+        # as good as ours. Not worth a warning.
+        logger.debug(
+            "model-delivery row already present for %s/%s", source, cycle_init,
+        )
+        _rollback(db)
+    except Exception:
+        # Deliberately broad and non-fatal: this is telemetry, not correctness.
+        logger.debug(
+            "model-delivery write failed for %s/%s", source, cycle_init, exc_info=True,
+        )
+        _rollback(db)
+    finally:
+        if db is not None:
+            try:
+                db.close()
+            except Exception:
+                pass
+
+
+def _rollback(db: Session | None) -> None:
+    if db is None:
+        return
+    try:
+        db.rollback()
+    except Exception:
+        pass

--- a/tests/test_data_sources_catalog.py
+++ b/tests/test_data_sources_catalog.py
@@ -133,16 +133,20 @@ class TestDynamicFields:
         # ``datetime.now()`` — the fixture pins ``last_check`` to a fixed
         # historical wallclock (2026-05-11) so other tests can assert
         # cycle-relative state. This test only checks that bootstrap
-        # populated the dynamic fields and ``marker_health == "ok"``; the
-        # staleness check is exercised elsewhere. Use a loop interval large
-        # enough that the fixture's fixed wallclock can never drift past
-        # ``2 × loop_interval`` for the lifetime of this codebase.
+        # populated the dynamic fields; the staleness check is exercised
+        # elsewhere. Use a loop interval large enough that the fixture's
+        # fixed wallclock can never drift past ``2 × loop_interval`` for the
+        # lifetime of this codebase.
         entries = catalog.build(store=bootstrapped_store, loop_interval_s=86400 * 36500)
         for e in entries:
             assert e.latest_init is not None
             assert e.next_expected is not None
             assert e.horizon_end is not None
-            assert e.marker_health == "ok"
+            # Bootstrap fills these fields from the registry alone — no
+            # dynamic check has run, so the health must say so rather than
+            # dressing a schedule guess up as a confirmed observation
+            # (issue #515). "ok" arrives with the first successful probe.
+            assert e.marker_health == "unobserved"
             # horizon_end must be in the future of latest_init
             assert e.horizon_end > e.latest_init
 

--- a/tests/test_model_delivery_log.py
+++ b/tests/test_model_delivery_log.py
@@ -1,0 +1,357 @@
+"""Durable model-delivery log (issue #515).
+
+Three layers under test:
+
+* ``storage/model_delivery`` — the insert, its idempotency on
+  ``(source, cycle_init)``, and the best-effort wrapper's refusal to raise;
+* ``scheduler._run_freshness_check_once`` — a row is written exactly when a
+  marker advances, carrying the registry expectation *as it was*, the
+  provider's publish time, our detection time, and the last probe that
+  didn't see the run;
+* ``Marker.last_probe_at`` and the ``marker_health="unobserved"`` it enables.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy.orm import sessionmaker
+
+from weatherbrief.db.models import ModelDeliveryLogRow
+from weatherbrief.fetch.freshness import catalog, registry
+from weatherbrief.fetch.freshness.markers import MarkerStore
+from weatherbrief.fetch.freshness.sources import (
+    VIA_HTTP_LAST_MODIFIED,
+    VIA_OM_META,
+    VIA_SENTINEL_MTIME,
+    Observation,
+)
+from weatherbrief.storage import model_delivery
+
+SOURCE = "gfs:noaa"
+MODEL = "gfs"
+
+
+def _utc(year: int, month: int, day: int, hour: int = 0, minute: int = 0) -> datetime:
+    return datetime(year, month, day, hour, minute, tzinfo=timezone.utc)
+
+
+@pytest.fixture
+def delivery_db(monkeypatch):
+    """In-memory DB wired as the storage module's ``SessionLocal``.
+
+    ``record_delivery`` opens its own session (it runs off the freshness
+    loop, which holds none), so the module-level symbol is what has to point
+    at the test engine.
+    """
+    from conftest import make_app_engine
+
+    engine = make_app_engine()
+    TestSession = sessionmaker(bind=engine)
+    monkeypatch.setattr(model_delivery, "SessionLocal", TestSession)
+    yield TestSession
+    engine.dispose()
+
+
+def _rows(session_factory) -> list[ModelDeliveryLogRow]:
+    s = session_factory()
+    try:
+        return s.query(ModelDeliveryLogRow).order_by(ModelDeliveryLogRow.id).all()
+    finally:
+        s.close()
+
+
+def _naive(dt: datetime) -> datetime:
+    """Drop tzinfo to compare against a value read back from the DB.
+
+    Both SQLite (dev) and MySQL (prod) hand back naive datetimes regardless
+    of ``DateTime(timezone=True)``; the codebase convention is that a reader
+    re-attaches UTC (see ``storage/flights.py``). Asserting against naive
+    values here keeps these tests honest about what is actually stored
+    rather than pretending the round-trip preserves the offset.
+    """
+    return dt.replace(tzinfo=None)
+
+
+# ---------------------------------------------------------------------------
+# Storage layer
+# ---------------------------------------------------------------------------
+
+
+class TestRecordDelivery:
+    def test_writes_one_row_with_every_column(self, delivery_db):
+        model_delivery.record_delivery(
+            source=SOURCE,
+            model=MODEL,
+            cycle_init=_utc(2026, 7, 30, 6),
+            expected_at=_utc(2026, 7, 30, 11, 30),
+            published_at=_utc(2026, 7, 30, 13, 47),
+            detected_at=_utc(2026, 7, 30, 13, 50),
+            last_absent_at=_utc(2026, 7, 30, 13, 45),
+            observed_via=VIA_HTTP_LAST_MODIFIED,
+        )
+        rows = _rows(delivery_db)
+        assert len(rows) == 1
+        row = rows[0]
+        assert row.source == SOURCE
+        assert row.model == MODEL
+        assert row.observed_via == VIA_HTTP_LAST_MODIFIED
+        # Derived-on-read, never stored: this run was 2h17m later than the
+        # registry predicted, and we noticed 3 min after it published.
+        assert row.published_at - row.expected_at == timedelta(hours=2, minutes=17)
+        assert row.detected_at - row.published_at == timedelta(minutes=3)
+        # The absence bracket must sit before the publish time it brackets.
+        assert row.last_absent_at < row.published_at
+
+    def test_second_observation_of_same_run_is_a_no_op(self, delivery_db):
+        """``UNIQUE (source, cycle_init)`` — re-observing a run must not
+        append a duplicate, and must keep the *first* (tightest) bracket."""
+        for detected_minute in (50, 55):
+            model_delivery.record_delivery(
+                source=SOURCE,
+                model=MODEL,
+                cycle_init=_utc(2026, 7, 30, 6),
+                expected_at=_utc(2026, 7, 30, 11, 30),
+                published_at=_utc(2026, 7, 30, 13, 47),
+                detected_at=_utc(2026, 7, 30, 13, detected_minute),
+                last_absent_at=_utc(2026, 7, 30, 13, 45),
+                observed_via=VIA_HTTP_LAST_MODIFIED,
+            )
+        rows = _rows(delivery_db)
+        assert len(rows) == 1
+        assert rows[0].detected_at == _naive(_utc(2026, 7, 30, 13, 50))
+
+    def test_same_cycle_from_a_different_source_is_a_separate_row(self, delivery_db):
+        """Uniqueness is per (source, cycle_init) — every model publishes an
+        06Z run and they are independent measurements."""
+        for source, model, via in (
+            (SOURCE, MODEL, VIA_HTTP_LAST_MODIFIED),
+            ("ecmwf:direct", "ecmwf", VIA_SENTINEL_MTIME),
+            ("gfs:openmeteo", "gfs", VIA_OM_META),
+        ):
+            model_delivery.record_delivery(
+                source=source,
+                model=model,
+                cycle_init=_utc(2026, 7, 30, 6),
+                expected_at=_utc(2026, 7, 30, 11, 30),
+                detected_at=_utc(2026, 7, 30, 13, 50),
+                observed_via=via,
+            )
+        assert len(_rows(delivery_db)) == 3
+
+    def test_null_published_at_still_records_the_bracket(self, delivery_db):
+        """A missing provider timestamp doesn't make the observation
+        worthless: ``(last_absent_at, detected_at]`` still bounds arrival."""
+        model_delivery.record_delivery(
+            source="ecmwf:direct",
+            model="ecmwf",
+            cycle_init=_utc(2026, 7, 30, 0),
+            expected_at=_utc(2026, 7, 30, 6, 40),
+            published_at=None,
+            detected_at=_utc(2026, 7, 30, 7, 5),
+            last_absent_at=_utc(2026, 7, 30, 7, 0),
+            observed_via=VIA_SENTINEL_MTIME,
+        )
+        row = _rows(delivery_db)[0]
+        assert row.published_at is None
+        assert row.last_absent_at == _naive(_utc(2026, 7, 30, 7, 0))
+
+    def test_db_failure_never_escapes(self, monkeypatch):
+        """Telemetry must not be able to fail a freshness tick."""
+
+        def _boom():
+            raise RuntimeError("db is down")
+
+        monkeypatch.setattr(model_delivery, "SessionLocal", _boom)
+        # No raise, no rows — the sample is simply lost.
+        model_delivery.record_delivery(
+            source=SOURCE,
+            model=MODEL,
+            cycle_init=_utc(2026, 7, 30, 6),
+            expected_at=_utc(2026, 7, 30, 11, 30),
+            detected_at=_utc(2026, 7, 30, 13, 50),
+            observed_via=VIA_HTTP_LAST_MODIFIED,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Scheduler wiring
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def loop_env(monkeypatch, delivery_db):
+    """Freshness loop pinned to one source, a fixed wallclock, and a stub check.
+
+    Returns a small handle so each test can set the wallclock and what
+    ``check_source`` reports, then drive a tick.
+    """
+    import weatherbrief.scheduler as scheduler_mod
+    from weatherbrief.fetch.freshness import markers as markers_mod
+    from weatherbrief.fetch.freshness import sources as sources_mod
+
+    class _Env:
+        now = _utc(2026, 7, 30, 12)
+        observation: Observation | None = None
+        store = MarkerStore()
+
+        async def tick(self):
+            await scheduler_mod._run_freshness_check_once()
+
+        def marker(self):
+            return self.store.get_sync(SOURCE, MODEL)
+
+    env = _Env()
+
+    class _FakeDatetime:
+        @staticmethod
+        def now(tz):
+            return env.now
+
+    monkeypatch.setattr(markers_mod, "_STORE", env.store)
+    monkeypatch.setattr(scheduler_mod, "datetime", _FakeDatetime)
+    monkeypatch.setattr(
+        sources_mod, "all_tracked_sources", lambda: [(SOURCE, MODEL)],
+    )
+    monkeypatch.setattr(
+        sources_mod, "check_source", lambda source, model: env.observation,
+    )
+    return env
+
+
+@pytest.mark.asyncio
+async def test_advance_writes_a_delivery_row(loop_env, delivery_db):
+    env = loop_env
+    await env.store.bootstrap([(SOURCE, MODEL)], now=_utc(2026, 7, 30, 6))
+    before = env.marker()
+
+    # A probe that confirms the bootstrapped init — no advance, no row, but
+    # it stamps the probe time that will become the next row's lower bound.
+    env.now = before.next_expected
+    env.observation = Observation(
+        init=before.init, published_at=None, observed_via=VIA_HTTP_LAST_MODIFIED,
+    )
+    await env.tick()
+    assert _rows(delivery_db) == []
+    assert env.marker().last_probe_at == before.next_expected
+
+    # Now the next cycle lands.
+    new_init = registry.next_cycle_init_after(SOURCE, before.init)
+    env.now = env.marker().next_expected + timedelta(minutes=20)
+    published = env.now - timedelta(minutes=4)
+    env.observation = Observation(
+        init=new_init, published_at=published, observed_via=VIA_HTTP_LAST_MODIFIED,
+    )
+    await env.tick()
+
+    rows = _rows(delivery_db)
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.source == SOURCE
+    assert row.model == MODEL
+    assert row.cycle_init == _naive(new_init)
+    assert row.published_at == _naive(published)
+    assert row.detected_at == _naive(env.now)
+    assert row.observed_via == VIA_HTTP_LAST_MODIFIED
+    # Expectation is the registry's, frozen at observation time.
+    assert row.expected_at == _naive(
+        registry.expected_delivery_for_init(SOURCE, new_init)
+    )
+    # The lower bound is the earlier probe that didn't see this run — not the
+    # heartbeat, which the loop bumps on every tick.
+    assert row.last_absent_at == _naive(before.next_expected)
+
+
+@pytest.mark.asyncio
+async def test_slip_writes_no_row(loop_env, delivery_db):
+    """Only an advance is an observed delivery. A run that hasn't shown up
+    is a fact about the schedule, reconstructed by joining against the cycle
+    grid — storing a synthetic row would assert a schedule we may stop
+    believing."""
+    env = loop_env
+    await env.store.bootstrap([(SOURCE, MODEL)], now=_utc(2026, 7, 30, 6))
+    before = env.marker()
+
+    env.now = before.next_expected + timedelta(minutes=5)
+    env.observation = Observation(
+        init=before.init, published_at=None, observed_via=VIA_HTTP_LAST_MODIFIED,
+    )
+    await env.tick()
+
+    assert env.marker().slip_count == 1
+    assert _rows(delivery_db) == []
+
+
+@pytest.mark.asyncio
+async def test_failed_check_writes_no_row_and_no_probe(loop_env, delivery_db):
+    """A check that couldn't reach the provider is not evidence of absence,
+    so it must not move the bracket that ``last_absent_at`` will report."""
+    env = loop_env
+    await env.store.bootstrap([(SOURCE, MODEL)], now=_utc(2026, 7, 30, 6))
+
+    env.now = env.marker().next_expected + timedelta(minutes=5)
+    env.observation = None
+    await env.tick()
+
+    assert _rows(delivery_db) == []
+    assert env.marker().last_probe_at is None
+    # The heartbeat still moves — a transient failure shouldn't force every
+    # freshness HTTP call into the inline-fallback path.
+    assert env.marker().last_check == env.now
+
+
+@pytest.mark.asyncio
+async def test_repeated_advance_of_the_same_run_writes_one_row(loop_env, delivery_db):
+    """A restart re-bootstraps markers from the registry, so the same run can
+    legitimately be 'advanced onto' twice. The unique constraint absorbs it."""
+    env = loop_env
+    await env.store.bootstrap([(SOURCE, MODEL)], now=_utc(2026, 7, 30, 6))
+    new_init = registry.next_cycle_init_after(SOURCE, env.marker().init)
+
+    for minute in (20, 25):
+        env.store = MarkerStore()
+        from weatherbrief.fetch.freshness import markers as markers_mod
+        markers_mod._STORE = env.store
+        await env.store.bootstrap([(SOURCE, MODEL)], now=_utc(2026, 7, 30, 6))
+        env.now = env.marker().next_expected + timedelta(minutes=minute)
+        env.observation = Observation(
+            init=new_init, published_at=None, observed_via=VIA_HTTP_LAST_MODIFIED,
+        )
+        await env.tick()
+
+    assert len(_rows(delivery_db)) == 1
+
+
+# ---------------------------------------------------------------------------
+# marker_health: "ok" must not mean "never observed"
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_bootstrapped_but_unprobed_marker_reports_unobserved():
+    """The prod symptom: ``gem:openmeteo`` showed a 36h-stale ``latest_init``
+    and a null ``published_at`` under a green ``marker_health="ok"``, because
+    ``is_stale`` measures time since the last check *attempt* and the loop
+    bumps that even on ticks that do no I/O."""
+    store = MarkerStore()
+    await store.bootstrap([(SOURCE, MODEL)], now=_utc(2026, 7, 30, 6))
+    # Loop interval large enough that the fixed bootstrap wallclock can never
+    # read as a stale heartbeat, isolating the unobserved signal.
+    entries = {
+        e.key: e for e in catalog.build(store=store, loop_interval_s=86400 * 36500)
+    }
+    assert entries[SOURCE].marker_health == "unobserved"
+
+
+@pytest.mark.asyncio
+async def test_marker_health_ok_once_a_probe_succeeds():
+    store = MarkerStore()
+    await store.bootstrap([(SOURCE, MODEL)], now=_utc(2026, 7, 30, 6))
+    marker = store.get_sync(SOURCE, MODEL)
+    await store.update(SOURCE, MODEL, marker.init, now=_utc(2026, 7, 30, 12))
+
+    entries = {
+        e.key: e for e in catalog.build(store=store, loop_interval_s=86400 * 36500)
+    }
+    assert entries[SOURCE].marker_health == "ok"

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -5280,6 +5280,13 @@ label {
 .data-source-health-ok { background: var(--green); }
 .data-source-health-suspect { background: var(--amber); }
 .data-source-health-unknown { background: var(--text-muted); opacity: 0.5; }
+/* Hollow: the loop is alive but has never confirmed this source, so every
+   value in the row is a registry guess. Distinct from the filled amber of a
+   stale heartbeat — nothing is late here, there is simply nothing behind it. */
+.data-source-health-unobserved {
+  background: transparent;
+  box-shadow: inset 0 0 0 1.5px var(--amber);
+}
 
 .data-sources-footer {
   margin-top: 0.4rem;

--- a/web/ts/i18n/locales/en.json
+++ b/web/ts/i18n/locales/en.json
@@ -193,6 +193,7 @@
   "dataSources.role.primary": "primary",
   "dataSources.health.ok": "Marker fresh",
   "dataSources.health.suspect": "Heartbeat suspect — last check is stale",
+  "dataSources.health.unobserved": "Never confirmed — schedule shown is the configured expectation, not an observation",
   "dataSources.health.unknown": "Marker not yet populated",
   "dataSources.view.label": "Data sources view",
   "dataSources.view.timeline": "Timeline",


### PR DESCRIPTION
## What & why

The registry's `delivery_offset` constants are the **expected** side of "did this run land on time". Nothing recorded the **realised** side: `published_at` was fetched on every freshness check, held on the in-memory `Marker`, served by `/api/data-sources`, and then dropped.

The one durable record we did have measures the wrong thing. `MarkerStore.update()` appends `(observed_init, now)` — our *detection* time:

- the 300 s poll quantises it (prod logged three different sources with an identical `arrived_at` and `drift=+159s`);
- and because the loop skips the check while `now < next_expected`, **early arrival is unobservable by construction** — 0 negative drifts in 7 days of prod logs, while the timeline, reading the provider's own `published_at`, correctly showed ICON and UKMO ~60 min early.

So the log and the timeline disagree in sign for exactly the sources whose constants most need correcting.

### v1 — collect only

New `model_delivery_log` table, appended by `scheduler._run_freshness_check_once` on each marker advance. **No consumer.** Follow-ups (timeline reads the log, per-cycle-hour offsets, recalibration) are deliberately out of scope and recorded in the design doc.

| Column | Meaning |
|---|---|
| `source` / `model` | Registry key (`ecmwf:direct`) + denormalised prefix (`ecmwf`) |
| `cycle_init` | The run being measured |
| `expected_at` | Registry prediction, **frozen at observation time** |
| `published_at` | Provider-reported publish wallclock — the actual measurement |
| `detected_at` | When our loop noticed |
| `last_absent_at` | Last dynamic check that did *not* yet see this run |
| `observed_via` | `sentinel_mtime` \| `http_last_modified` \| `om_meta` |

`drift`, `poll_lag` and `cycle_hour` are all derived on read.

Four schema choices, each easy to "simplify" back into the bug it fixes:

- **`expected_at` stored, not derived.** We are going to *change* the offset constants using this data; deriving expectation at read time would collapse all historical drift to ~0 the moment we recalibrated.
- **`published_at` separate from `detected_at`**, so poll lag stays its own quantity instead of contaminating drift.
- **`observed_via`** — a sentinel mtime is when *our* watcher finished writing, an OM availability time is the provider's own record, an HTTP `Last-Modified` is the origin file's. Different systematic biases; pooling them silently would be sloppy. Each `sources._DISPATCH` wrapper declares its own on the returned `Observation`, and `check_source` warns if a new one forgets.
- **`last_absent_at`** brackets arrival from below. It comes from a new `Marker.last_probe_at`, snapshotted *before* `update()` — the `last_check` heartbeat is useless here since every tick bumps it, including the no-I/O ones.

Decisions carried over from the issue: missed runs are **not** stored (a skipped cycle never advances the marker; find the hole by joining the expected cycle grid — *store facts about observations, derive facts about the schedule*); **no backfill** (the journald lines carry detection time only); **no retention or aggregation** (~2–3 MB/yr, and P95/P99 cannot be reconstructed from stored min/max/median).

The write is best-effort and offloaded to a thread: a DB hiccup costs one calibration sample, never a freshness tick. `UNIQUE (source, cycle_init)` makes re-observation after a restart a no-op, keeping the first (tightest) bracket.

### Also folded in — the related `marker_health` fix

`marker_health: "ok"` did not mean "we have observed this source": `is_stale` measures time since the last *check attempt*, and the loop bumps that even on ticks that do no I/O. A source whose dynamic check has always failed therefore showed a green dot over nothing but registry guesses — `gem:openmeteo` in prod, with `latest_init` ~36 h stale and `published_at` null. The catalog now returns `"unobserved"` until a probe actually succeeds, rendered as a hollow amber dot (`healthDot` was already generic, so this is CSS + one i18n string).

This is a visible behaviour change: a freshly bootstrapped store reports `unobserved`, not `ok`, until the first successful check — which is the point.

## Issue linkage

Closes #515

## Testing / verification

- New `tests/test_model_delivery_log.py` (11 tests) covers the storage layer (every column, idempotency on `(source, cycle_init)`, per-source independence, null `published_at`, and that a DB failure never escapes), the scheduler wiring (row written on advance with the frozen expectation and the correct `last_absent_at`; **no** row on a slip or a failed check; one row across a restart re-advance), and the `unobserved` → `ok` transition.
- Updated `test_data_sources_catalog.py::test_bootstrapped_store_populates_dynamic_fields`, which asserted the old `"ok"`-after-bootstrap behaviour.
- Freshness + scheduler + refresh-durability suites pass (220 tests). The full suite was not run in this environment.
- Migration 084 verified `upgrade head` and `downgrade 083` on a fresh SQLite DB; `create_table` / `create_index` need no batch mode on either dialect.
- Frontend changes are CSS and one locale string — no TypeScript touched, so no rebuild needed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TZyv2bHEUjXgtq2ieo9ToN)_