### PR TITLE
Guard and repair month-boundary observation times (#519)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,11 @@ dependencies = [
     "requests>=2.31",
     "pyyaml>=6.0",
     "pydantic>=2.0",
-    "euro-aip>=0.13.0",
+    # 0.15.1 adds the parser `reference` parameter and fixes month-boundary
+    # timestamp inference (#519). Anything older silently mis-dates reports
+    # collected just after a month rolls over, and lacks the kwarg the
+    # verification repair script needs.
+    "euro-aip>=0.15.1",
     "metpy>=1.5",
     "numpy>=1.24",
     "matplotlib>=3.7",

--- a/scripts/repair_metar_month_boundary.py
+++ b/scripts/repair_metar_month_boundary.py
@@ -376,6 +376,7 @@ def main() -> int:
 
         repairable = [f for f in findings if f["new"] is not None]
         skipped = [f for f in findings if f["new"] is None]
+        score_count = 0
 
         print()
         print(f"suspect rows            : {len(findings)}")
@@ -404,7 +405,6 @@ def main() -> int:
             print(f"affected (icao, date) pairs needing rollup rebuild: {len(dates)}")
 
             obs_ids = [f["id"] for f in repairable]
-            score_count = 0
             for i in range(0, len(obs_ids), 500):
                 score_count += session.execute(
                     select(func.count()).select_from(VerificationScoreRow).where(
@@ -436,12 +436,18 @@ def main() -> int:
         session.commit()
         print()
         print("applied:", stats)
-        if not args.delete_scores:
+        if score_count and not args.delete_scores:
             print(
-                "NOTE: dependent verification_scores were left in place and are "
-                "now scored against the wrong time. Re-run scoring for the "
-                "affected dates, or re-run with --delete-scores."
+                f"NOTE: {score_count} dependent verification_scores rows were "
+                "left in place and are now scored against the wrong time. "
+                "Re-run scoring for the affected dates, or re-run with "
+                "--delete-scores."
             )
+        print(
+            "NOTE: airport_daily_summary / airport_monthly_summary bucket "
+            "observations directly and must be rebuilt for the affected dates "
+            "(tasks.airport_summary.rollup_day / rollup_month)."
+        )
         return 0
 
 

--- a/scripts/repair_metar_month_boundary.py
+++ b/scripts/repair_metar_month_boundary.py
@@ -7,8 +7,18 @@ after a month rolled over was dated into the following month — e.g. a METAR
 collected at 2026-08-01 00:00:01 carrying ``312255Z`` (31 July) was stored as
 31 August.
 
-``metar_raw`` is retained, so the repair is lossless: re-parse each suspect row
-against its own ``collected_at`` and write back the correct time.
+``metar_raw`` and ``taf_raw`` are retained, so the repair is lossless: re-parse
+each suspect row against its own ``collected_at`` and write back the correct
+time.
+
+Two fields are affected, both fed by the same inference:
+
+* ``observation_time`` — natural key of ``verification_observations`` and the
+  join key for ``verification_scores``.
+* ``taf_issue_time`` — part of ``uq_taf_verif_key`` on
+  ``taf_verification_scores``. In production this was corrupted about six times
+  more often than ``observation_time``, because one TAF stays current for hours
+  and is copied onto every observation collected in that window.
 
 Safety
 ------
@@ -61,15 +71,15 @@ from sqlalchemy import create_engine, delete, func, select, update
 from sqlalchemy.orm import Session
 
 from weatherbrief.db.models import (
+    TafVerificationScoreRow,
     VerificationObservationRow,
     VerificationScoreRow,
 )
+# Share the ingestion guard's threshold rather than restating it, so detection
+# here and rejection at write time cannot drift apart.
+from weatherbrief.tasks.verification import _OBS_MAX_AHEAD as _MAX_AHEAD
 
 logger = logging.getLogger("repair519")
-
-# A report is issued before it is collected.  Anything beyond this ahead of
-# collected_at is the bug signature, not clock skew.
-_MAX_AHEAD = timedelta(hours=6)
 
 _DEFAULT_BATCH = 50_000
 _DEFAULT_SLEEP = 0.05
@@ -90,6 +100,16 @@ def _reparse(raw: str, collected_at: datetime) -> datetime | None:
     from euro_aip.briefing.weather.parser import WeatherParser
 
     report = WeatherParser.parse_metar(raw, reference=collected_at)
+    if report is None:
+        return None
+    return _as_utc(report.observation_time)
+
+
+def _reparse_taf(raw: str, collected_at: datetime) -> datetime | None:
+    """Re-derive a TAF issue time from raw TAF text against its collection time."""
+    from euro_aip.briefing.weather.parser import WeatherParser
+
+    report = WeatherParser.parse_taf(raw, reference=collected_at)
     if report is None:
         return None
     return _as_utc(report.observation_time)
@@ -278,6 +298,153 @@ def find_corrupt(
     return findings
 
 
+def _month_boundary_windows(lo: datetime, hi: datetime) -> list[tuple[datetime, datetime]]:
+    """Windows spanning each month boundary, for the TAF issue-time scan.
+
+    A TAF stays current for hours after issue, so one issued late on the last
+    day of a month is still the latest TAF for observations collected into the
+    next one.  That makes the affected observation_time range wider than the
+    METAR case — cover two days either side of each boundary.
+
+    Note the range runs one month *past* ``hi``: unlike a corrupted
+    observation_time, a corrupted taf_issue_time leaves observation_time
+    untouched, so the affected rows sit just *before* the boundary that
+    corrupted them and the final boundary would otherwise be missed.
+    """
+    windows = []
+    year, month = lo.year, lo.month
+    end_year, end_month = divmod(hi.year * 12 + (hi.month - 1) + 1, 12)
+    end_month += 1
+    while (year, month) <= (end_year, end_month):
+        start = datetime(year, month, 1, tzinfo=timezone.utc) - timedelta(days=2)
+        end = datetime(year, month, 1, tzinfo=timezone.utc) + timedelta(days=3)
+        windows.append((start, end))
+        month += 1
+        if month > 12:
+            month = 1
+            year += 1
+    return windows
+
+
+def find_corrupt_taf(session: Session, sleep: float, full: bool = False) -> list[dict]:
+    """Locate rows whose taf_issue_time needs correcting.
+
+    ``taf_issue_time`` is produced by the same day-of-month inference as
+    ``observation_time`` and is part of ``uq_taf_verif_key`` on
+    ``taf_verification_scores``, so it needs the same treatment.
+    """
+    bounds = session.execute(
+        select(
+            func.min(VerificationObservationRow.observation_time),
+            func.max(VerificationObservationRow.observation_time),
+        )
+    ).one()
+    lo, hi = _as_utc(bounds[0]), _as_utc(bounds[1])
+    if lo is None or hi is None:
+        return []
+
+    if full:
+        windows = [(lo - timedelta(days=1), hi + timedelta(days=1))]
+    else:
+        windows = _month_boundary_windows(lo, hi)
+
+    findings: list[dict] = []
+    for start, end in windows:
+        rows = session.execute(
+            select(
+                VerificationObservationRow.id,
+                VerificationObservationRow.icao,
+                VerificationObservationRow.taf_issue_time,
+                VerificationObservationRow.collected_at,
+                VerificationObservationRow.taf_raw,
+            ).where(
+                VerificationObservationRow.observation_time >= start.replace(tzinfo=None),
+                VerificationObservationRow.observation_time < end.replace(tzinfo=None),
+                VerificationObservationRow.taf_issue_time.is_not(None),
+            )
+        ).all()
+
+        hits = 0
+        for row_id, icao, issue_time, collected_at, raw in rows:
+            issue_time = _as_utc(issue_time)
+            collected_at = _as_utc(collected_at)
+            if issue_time is None or collected_at is None:
+                continue
+            if issue_time - collected_at <= _MAX_AHEAD:
+                continue
+
+            hits += 1
+            if not raw:
+                findings.append(
+                    dict(id=row_id, icao=icao, old=issue_time, new=None,
+                         collected_at=collected_at, reason="no raw TAF text")
+                )
+                continue
+            corrected = _reparse_taf(raw, collected_at)
+            if corrected is None:
+                findings.append(
+                    dict(id=row_id, icao=icao, old=issue_time, new=None,
+                         collected_at=collected_at, reason="TAF re-parse failed")
+                )
+                continue
+            if corrected == issue_time:
+                findings.append(
+                    dict(id=row_id, icao=icao, old=issue_time, new=None,
+                         collected_at=collected_at, reason="re-parse matches stored")
+                )
+                continue
+            findings.append(
+                dict(id=row_id, icao=icao, old=issue_time, new=corrected,
+                     collected_at=collected_at, reason=None)
+            )
+
+        logger.info(
+            "taf window %s..%s: %d rows with a TAF, %d suspect",
+            start.date(), end.date(), len(rows), hits,
+        )
+        if sleep:
+            time.sleep(sleep)
+
+    return findings
+
+
+def apply_taf_repairs(
+    session: Session,
+    findings: list[dict],
+    delete_scores: bool,
+) -> dict:
+    """Write corrected TAF issue times.
+
+    ``taf_issue_time`` is not part of the observations table's own unique key,
+    so there is no collision to resolve here — but it *is* part of
+    ``uq_taf_verif_key``, so any dependent taf_verification_scores rows are
+    keyed on the old value and must be recomputed.
+
+    Does not commit — the caller owns the transaction boundary.
+    """
+    stats = defaultdict(int)
+    repairable = [f for f in findings if f["new"] is not None]
+
+    for f in repairable:
+        if delete_scores:
+            removed = session.execute(
+                delete(TafVerificationScoreRow).where(
+                    TafVerificationScoreRow.observation_id == f["id"]
+                )
+            ).rowcount
+            stats["taf_scores_deleted"] += removed or 0
+
+        session.execute(
+            update(VerificationObservationRow)
+            .where(VerificationObservationRow.id == f["id"])
+            .values(taf_issue_time=f["new"].replace(tzinfo=None))
+        )
+        stats["taf_repaired"] += 1
+
+    session.flush()
+    return dict(stats)
+
+
 def apply_repairs(
     session: Session,
     findings: list[dict],
@@ -338,8 +505,8 @@ def main() -> int:
     group.add_argument("--apply", action="store_true", help="write corrected times")
     parser.add_argument(
         "--delete-scores", action="store_true",
-        help="also delete verification_scores rows for repaired observations "
-             "so they are recomputed (requires --apply)",
+        help="also delete verification_scores / taf_verification_scores rows for "
+             "repaired observations so they are recomputed (requires --apply)",
     )
     parser.add_argument("--database-url", default=os.environ.get("DATABASE_URL"))
     parser.add_argument(
@@ -422,17 +589,55 @@ def main() -> int:
                     f"(collected {f['collected_at'].isoformat()})"
                 )
 
+        # --- TAF issue times -------------------------------------------------
+        logger.info("scanning for corrupted TAF issue times...")
+        taf_findings = find_corrupt_taf(session, args.sleep, full=args.full)
+        taf_repairable = [f for f in taf_findings if f["new"] is not None]
+        taf_skipped = [f for f in taf_findings if f["new"] is None]
+        taf_score_count = 0
+
+        print()
+        print(f"suspect taf_issue_time rows : {len(taf_findings)}")
+        print(f"  repairable                : {len(taf_repairable)}")
+        print(f"  skipped                   : {len(taf_skipped)}")
+
+        if taf_skipped:
+            reasons = defaultdict(int)
+            for f in taf_skipped:
+                reasons[f["reason"]] += 1
+            for reason, count in sorted(reasons.items(), key=lambda kv: -kv[1]):
+                print(f"      {reason}: {count}")
+
+        if taf_repairable:
+            taf_ids = [f["id"] for f in taf_repairable]
+            for i in range(0, len(taf_ids), 500):
+                taf_score_count += session.execute(
+                    select(func.count()).select_from(TafVerificationScoreRow).where(
+                        TafVerificationScoreRow.observation_id.in_(taf_ids[i : i + 500])
+                    )
+                ).scalar_one()
+            print(f"dependent taf_verification_scores rows : {taf_score_count}")
+            print()
+            print(f"examples (first {args.limit_report}):")
+            for f in taf_repairable[: args.limit_report]:
+                print(
+                    f"  id={f['id']:<9} {f['icao']}  "
+                    f"{f['old'].isoformat()} -> {f['new'].isoformat()}  "
+                    f"(collected {f['collected_at'].isoformat()})"
+                )
+
         if args.dry_run:
             print()
             print("DRY RUN — nothing written.")
             return 0
 
-        if not repairable:
+        if not repairable and not taf_repairable:
             print()
             print("Nothing to repair.")
             return 0
 
         stats = apply_repairs(session, findings, args.delete_scores)
+        stats.update(apply_taf_repairs(session, taf_findings, args.delete_scores))
         session.commit()
         print()
         print("applied:", stats)
@@ -443,11 +648,18 @@ def main() -> int:
                 "Re-run scoring for the affected dates, or re-run with "
                 "--delete-scores."
             )
-        print(
-            "NOTE: airport_daily_summary / airport_monthly_summary bucket "
-            "observations directly and must be rebuilt for the affected dates "
-            "(tasks.airport_summary.rollup_day / rollup_month)."
-        )
+        if taf_score_count and not args.delete_scores:
+            print(
+                f"NOTE: {taf_score_count} dependent taf_verification_scores rows "
+                "are keyed on the old taf_issue_time (uq_taf_verif_key) and are "
+                "now stale. Re-run TAF scoring, or re-run with --delete-scores."
+            )
+        if repairable:
+            print(
+                "NOTE: airport_daily_summary / airport_monthly_summary bucket "
+                "observations directly and must be rebuilt for the affected dates "
+                "(tasks.airport_summary.rollup_day / rollup_month)."
+            )
         return 0
 
 

--- a/scripts/repair_metar_month_boundary.py
+++ b/scripts/repair_metar_month_boundary.py
@@ -1,0 +1,449 @@
+#!/usr/bin/env python
+"""Repair observation_time values corrupted by the month-boundary parser bug (#519).
+
+METAR/TAF timestamps encode only DDHHMM.  The parser used to combine the
+report's day-of-month with the *current* month, so a report collected just
+after a month rolled over was dated into the following month — e.g. a METAR
+collected at 2026-08-01 00:00:01 carrying ``312255Z`` (31 July) was stored as
+31 August.
+
+``metar_raw`` is retained, so the repair is lossless: re-parse each suspect row
+against its own ``collected_at`` and write back the correct time.
+
+Safety
+------
+* Read-only by default.  ``--apply`` is required to write anything.
+* Walks the table in primary-key ranges rather than issuing one scan over
+  2.19M rows, and sleeps between batches, so it stays friendly to a shared
+  MySQL instance with a 1 GiB buffer pool.
+* Only ``observation_time`` is ever modified, and only on rows whose stored
+  time disagrees with a re-parse of their own raw text.
+
+Downstream
+----------
+Repairing a row invalidates anything derived from its old time.  The script
+reports the affected (icao, date) pairs and the number of dependent
+``verification_scores`` rows.  Scores are only removed with ``--delete-scores``
+so they can be recomputed; without it they are left in place and reported.
+
+Two different derivations to be aware of:
+
+* ``verification_daily_stats`` aggregates ``verification_scores``, so it is
+  only affected if the reported dependent-score count is non-zero.
+* ``airport_daily_summary`` / ``airport_monthly_summary`` bucket
+  ``verification_observations`` **directly** (see ``tasks/airport_summary.py``),
+  so they are affected whenever any row is repaired, regardless of scores, and
+  should be rebuilt for the reported dates.
+
+Usage
+-----
+    # read-only survey
+    python scripts/repair_metar_month_boundary.py --dry-run
+
+    # apply, leaving dependent scores for a separate rescore
+    python scripts/repair_metar_month_boundary.py --apply
+
+    # apply and drop dependent scores so the next cycle recomputes them
+    python scripts/repair_metar_month_boundary.py --apply --delete-scores
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+import time
+from collections import defaultdict
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import create_engine, delete, func, select, update
+from sqlalchemy.orm import Session
+
+from weatherbrief.db.models import (
+    VerificationObservationRow,
+    VerificationScoreRow,
+)
+
+logger = logging.getLogger("repair519")
+
+# A report is issued before it is collected.  Anything beyond this ahead of
+# collected_at is the bug signature, not clock skew.
+_MAX_AHEAD = timedelta(hours=6)
+
+_DEFAULT_BATCH = 50_000
+_DEFAULT_SLEEP = 0.05
+
+
+def _as_utc(dt: datetime | None) -> datetime | None:
+    if dt is None:
+        return None
+    return dt.replace(tzinfo=timezone.utc) if dt.tzinfo is None else dt
+
+
+def _reparse(raw: str, collected_at: datetime) -> datetime | None:
+    """Re-derive an observation time from raw METAR text against its collection time.
+
+    Uses the fixed euro_aip parser, passing ``collected_at`` as the reference so
+    the day-of-month resolves to the month the report was actually issued in.
+    """
+    from euro_aip.briefing.weather.parser import WeatherParser
+
+    report = WeatherParser.parse_metar(raw, reference=collected_at)
+    if report is None:
+        return None
+    return _as_utc(report.observation_time)
+
+
+def _boundary_windows(lo: datetime, hi: datetime) -> list[tuple[datetime, datetime]]:
+    """Half-open observation_time windows covering the end of every month in range.
+
+    A corrupted row keeps the report's day-of-month and only moves the month,
+    so it always lands on day 28-31 of the *following* month.  Scanning just
+    those windows uses ix_verif_obs_time and touches roughly an eighth of the
+    table instead of all of it — which matters against a 1 GiB buffer pool
+    shared with two other applications.
+    """
+    windows = []
+    year, month = lo.year, lo.month
+    while (year, month) <= (hi.year, hi.month):
+        start = datetime(year, month, 28, tzinfo=timezone.utc)
+        if month == 12:
+            end = datetime(year + 1, 1, 1, tzinfo=timezone.utc)
+        else:
+            end = datetime(year, month + 1, 1, tzinfo=timezone.utc)
+        windows.append((start, end))
+        month += 1
+        if month > 12:
+            month = 1
+            year += 1
+    return windows
+
+
+def find_corrupt_targeted(session: Session, sleep: float) -> list[int]:
+    """Return ids of suspect rows, scanning only month-end index ranges."""
+    bounds = session.execute(
+        select(
+            func.min(VerificationObservationRow.observation_time),
+            func.max(VerificationObservationRow.observation_time),
+        )
+    ).one()
+    lo, hi = _as_utc(bounds[0]), _as_utc(bounds[1])
+    if lo is None or hi is None:
+        return []
+
+    suspects: list[int] = []
+    for start, end in _boundary_windows(lo, hi):
+        rows = session.execute(
+            select(
+                VerificationObservationRow.id,
+                VerificationObservationRow.observation_time,
+                VerificationObservationRow.collected_at,
+            ).where(
+                VerificationObservationRow.observation_time >= start.replace(tzinfo=None),
+                VerificationObservationRow.observation_time < end.replace(tzinfo=None),
+            )
+        ).all()
+
+        hits = 0
+        for row_id, obs_time, collected_at in rows:
+            obs_time = _as_utc(obs_time)
+            collected_at = _as_utc(collected_at)
+            if obs_time is None or collected_at is None:
+                continue
+            if obs_time - collected_at > _MAX_AHEAD:
+                suspects.append(row_id)
+                hits += 1
+
+        logger.info(
+            "window %s..%s: %d rows, %d suspect",
+            start.date(), end.date(), len(rows), hits,
+        )
+        if sleep:
+            time.sleep(sleep)
+
+    return suspects
+
+
+def find_corrupt_full(session: Session, batch: int, sleep: float) -> list[int]:
+    """Return ids of suspect rows, walking the whole table in PK ranges.
+
+    The predicate (observation_time ahead of collected_at) is not sargable, so
+    this is a scan by necessity.  It reads only three narrow columns, but it
+    still touches every page — prefer the targeted scan unless you need
+    exhaustive coverage, and run this during a quiet window.
+    """
+    max_id = session.execute(
+        select(func.max(VerificationObservationRow.id))
+    ).scalar_one_or_none()
+    if max_id is None:
+        return []
+
+    suspects: list[int] = []
+    lo = 0
+    while lo <= max_id:
+        hi = lo + batch
+        rows = session.execute(
+            select(
+                VerificationObservationRow.id,
+                VerificationObservationRow.observation_time,
+                VerificationObservationRow.collected_at,
+            ).where(
+                VerificationObservationRow.id >= lo,
+                VerificationObservationRow.id < hi,
+            )
+        ).all()
+
+        for row_id, obs_time, collected_at in rows:
+            obs_time = _as_utc(obs_time)
+            collected_at = _as_utc(collected_at)
+            if obs_time is None or collected_at is None:
+                continue
+            if obs_time - collected_at > _MAX_AHEAD:
+                suspects.append(row_id)
+
+        logger.info(
+            "scanned ids %d-%d (%d rows, %d suspect so far)",
+            lo, hi - 1, len(rows), len(suspects),
+        )
+        lo = hi
+        if sleep:
+            time.sleep(sleep)
+
+    return suspects
+
+
+def find_corrupt(
+    session: Session,
+    batch: int,
+    sleep: float,
+    full: bool = False,
+) -> list[dict]:
+    """Locate rows whose observation_time needs correcting.
+
+    Uses the cheap month-end index scan by default; ``full`` walks every row.
+    Either way, ``metar_raw`` is fetched only for rows that look wrong.
+    """
+    if full:
+        suspects = find_corrupt_full(session, batch, sleep)
+    else:
+        suspects = find_corrupt_targeted(session, sleep)
+
+    if not suspects:
+        return []
+
+    # Pull raw text only for the flagged rows and compute the correction.
+    findings: list[dict] = []
+    for i in range(0, len(suspects), 500):
+        chunk = suspects[i : i + 500]
+        rows = session.execute(
+            select(
+                VerificationObservationRow.id,
+                VerificationObservationRow.icao,
+                VerificationObservationRow.observation_time,
+                VerificationObservationRow.collected_at,
+                VerificationObservationRow.metar_raw,
+            ).where(VerificationObservationRow.id.in_(chunk))
+        ).all()
+
+        for row_id, icao, obs_time, collected_at, raw in rows:
+            obs_time = _as_utc(obs_time)
+            collected_at = _as_utc(collected_at)
+            if not raw:
+                findings.append(
+                    dict(id=row_id, icao=icao, old=obs_time, new=None,
+                         collected_at=collected_at, reason="no raw text")
+                )
+                continue
+            corrected = _reparse(raw, collected_at)
+            if corrected is None:
+                findings.append(
+                    dict(id=row_id, icao=icao, old=obs_time, new=None,
+                         collected_at=collected_at, reason="re-parse failed")
+                )
+                continue
+            if corrected == obs_time:
+                # Ahead of collection but the parser agrees — genuinely odd
+                # data rather than the month bug.  Report, don't touch.
+                findings.append(
+                    dict(id=row_id, icao=icao, old=obs_time, new=None,
+                         collected_at=collected_at, reason="re-parse matches stored")
+                )
+                continue
+            findings.append(
+                dict(id=row_id, icao=icao, old=obs_time, new=corrected,
+                     collected_at=collected_at, reason=None)
+            )
+
+    return findings
+
+
+def apply_repairs(
+    session: Session,
+    findings: list[dict],
+    delete_scores: bool,
+) -> dict:
+    """Write corrected times, resolving natural-key collisions by deletion.
+
+    Does not commit — the caller owns the transaction boundary.
+    """
+    stats = defaultdict(int)
+    repairable = [f for f in findings if f["new"] is not None]
+
+    for f in repairable:
+        # (icao, observation_time) is unique.  If the corrected time already
+        # exists, the good row is present and this one is a duplicate — remove
+        # it rather than merge, so scores cascade away with it.
+        clash = session.execute(
+            select(VerificationObservationRow.id).where(
+                VerificationObservationRow.icao == f["icao"],
+                VerificationObservationRow.observation_time
+                == f["new"].replace(tzinfo=None),
+                VerificationObservationRow.id != f["id"],
+            )
+        ).scalar_one_or_none()
+
+        if clash is not None:
+            session.execute(
+                delete(VerificationObservationRow).where(
+                    VerificationObservationRow.id == f["id"]
+                )
+            )
+            stats["deleted_duplicate"] += 1
+            continue
+
+        if delete_scores:
+            removed = session.execute(
+                delete(VerificationScoreRow).where(
+                    VerificationScoreRow.observation_id == f["id"]
+                )
+            ).rowcount
+            stats["scores_deleted"] += removed or 0
+
+        session.execute(
+            update(VerificationObservationRow)
+            .where(VerificationObservationRow.id == f["id"])
+            .values(observation_time=f["new"].replace(tzinfo=None))
+        )
+        stats["repaired"] += 1
+
+    session.flush()
+    return dict(stats)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--dry-run", action="store_true", help="report only, write nothing")
+    group.add_argument("--apply", action="store_true", help="write corrected times")
+    parser.add_argument(
+        "--delete-scores", action="store_true",
+        help="also delete verification_scores rows for repaired observations "
+             "so they are recomputed (requires --apply)",
+    )
+    parser.add_argument("--database-url", default=os.environ.get("DATABASE_URL"))
+    parser.add_argument(
+        "--full", action="store_true",
+        help="walk every row instead of only month-end index ranges. Exhaustive "
+             "but touches the whole table — run in a quiet window.",
+    )
+    parser.add_argument("--batch", type=int, default=_DEFAULT_BATCH,
+                        help="primary-key range size per --full scan query")
+    parser.add_argument("--sleep", type=float, default=_DEFAULT_SLEEP,
+                        help="seconds to pause between scan batches")
+    parser.add_argument("--limit-report", type=int, default=20,
+                        help="how many example rows to print")
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s"
+    )
+
+    if not args.database_url:
+        logger.error("No database URL: pass --database-url or set DATABASE_URL")
+        return 2
+    if args.delete_scores and not args.apply:
+        logger.error("--delete-scores requires --apply")
+        return 2
+
+    engine = create_engine(args.database_url)
+    with Session(engine) as session:
+        logger.info(
+            "scanning for corrupted observation times (%s)...",
+            "full table walk" if args.full else "month-end index ranges",
+        )
+        findings = find_corrupt(session, args.batch, args.sleep, full=args.full)
+
+        repairable = [f for f in findings if f["new"] is not None]
+        skipped = [f for f in findings if f["new"] is None]
+
+        print()
+        print(f"suspect rows            : {len(findings)}")
+        print(f"  repairable            : {len(repairable)}")
+        print(f"  skipped (see reasons) : {len(skipped)}")
+
+        if skipped:
+            reasons = defaultdict(int)
+            for f in skipped:
+                reasons[f["reason"]] += 1
+            for reason, count in sorted(reasons.items(), key=lambda kv: -kv[1]):
+                print(f"      {reason}: {count}")
+
+        if repairable:
+            shifts = defaultdict(int)
+            dates: set = set()
+            for f in repairable:
+                shifts[(f["old"] - f["new"]).days] += 1
+                dates.add((f["icao"], f["new"].date()))
+                dates.add((f["icao"], f["old"].date()))
+            print()
+            print("correction sizes (days moved back):")
+            for days, count in sorted(shifts.items(), key=lambda kv: -kv[1]):
+                print(f"      {days:>4} days: {count}")
+            print()
+            print(f"affected (icao, date) pairs needing rollup rebuild: {len(dates)}")
+
+            obs_ids = [f["id"] for f in repairable]
+            score_count = 0
+            for i in range(0, len(obs_ids), 500):
+                score_count += session.execute(
+                    select(func.count()).select_from(VerificationScoreRow).where(
+                        VerificationScoreRow.observation_id.in_(obs_ids[i : i + 500])
+                    )
+                ).scalar_one()
+            print(f"dependent verification_scores rows                : {score_count}")
+
+            print()
+            print(f"examples (first {args.limit_report}):")
+            for f in repairable[: args.limit_report]:
+                print(
+                    f"  id={f['id']:<9} {f['icao']}  "
+                    f"{f['old'].isoformat()} -> {f['new'].isoformat()}  "
+                    f"(collected {f['collected_at'].isoformat()})"
+                )
+
+        if args.dry_run:
+            print()
+            print("DRY RUN — nothing written.")
+            return 0
+
+        if not repairable:
+            print()
+            print("Nothing to repair.")
+            return 0
+
+        stats = apply_repairs(session, findings, args.delete_scores)
+        session.commit()
+        print()
+        print("applied:", stats)
+        if not args.delete_scores:
+            print(
+                "NOTE: dependent verification_scores were left in place and are "
+                "now scored against the wrong time. Re-run scoring for the "
+                "affected dates, or re-run with --delete-scores."
+            )
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/weatherbrief/tasks/verification.py
+++ b/src/weatherbrief/tasks/verification.py
@@ -294,6 +294,20 @@ def fetch_observations_batch(
 
             # TAF fields
             taf = raw.latest_taf
+            # taf_issue_time comes from the same day-of-month inference as the
+            # METAR time and is itself part of uq_taf_verif_key on
+            # taf_verification_scores, so it needs the same guard. A bad issue
+            # time makes the whole TAF untrustworthy as a key, but says nothing
+            # about the METAR — drop the TAF fields and keep the observation.
+            if taf is not None and taf.observation_time is not None:
+                taf_problem = _observation_time_problem(taf.observation_time, now)
+                if taf_problem is not None:
+                    logger.error(
+                        "Dropping %s TAF: %s (raw: %s)",
+                        raw.icao, taf_problem, (taf.raw_text or "")[:80],
+                    )
+                    taf = None
+
             if taf is not None:
                 obs.taf_raw = taf.raw_text
                 if taf.observation_time is not None:

--- a/src/weatherbrief/tasks/verification.py
+++ b/src/weatherbrief/tasks/verification.py
@@ -33,6 +33,43 @@ logger = logging.getLogger(__name__)
 _DEFAULT_CORRIDOR_NM = 15.0
 _BATCH_SIZE = 400  # aviationweather.gov limit per request
 
+# METAR/TAF timestamps encode only DDHHMM, so the month and year are inferred
+# from context by the parser.  Getting that wrong is silent and corrosive:
+# observation_time is the natural key, the dedup bucket key, and what every
+# score is joined on, so a wrong month scores an observation against an
+# entirely different forecast (issue #519).
+#
+# A report is always issued shortly *before* we collect it.  A collected-at
+# time in the future is therefore impossible and means the date was
+# reconstructed wrongly — refuse to store it rather than let it propagate.
+# Stale reports are legitimate (a closed aerodrome may not issue for days), so
+# those are only logged.
+_OBS_MAX_AHEAD = timedelta(hours=6)
+_OBS_STALE_WARN = timedelta(days=7)
+
+
+def _as_utc(dt: datetime) -> datetime:
+    """Attach UTC to a naive datetime; pass an aware one through."""
+    return dt.replace(tzinfo=timezone.utc) if dt.tzinfo is None else dt
+
+
+def _observation_time_problem(obs_time, collected_at) -> str | None:
+    """Return a reason string if `obs_time` cannot be a real observation time.
+
+    Returns None when the time is usable.  A non-None result for a *future*
+    time means the row must be dropped; staleness is reported by the caller
+    but not treated as fatal.
+    """
+    if obs_time is None:
+        return "missing observation_time"
+    obs_time = _as_utc(obs_time)
+    if obs_time - collected_at > _OBS_MAX_AHEAD:
+        return (
+            f"observation_time {obs_time.isoformat()} is ahead of collection "
+            f"{collected_at.isoformat()} — month inference likely wrong"
+        )
+    return None
+
 
 # ---------------------------------------------------------------------------
 # Phase A — Find active flights
@@ -219,6 +256,22 @@ def fetch_observations_batch(
             metar = raw.latest_metar
             if metar is None:
                 continue  # Skip airports without METAR
+
+            # Guard the natural key at the boundary — see _observation_time_problem.
+            problem = _observation_time_problem(metar.observation_time, now)
+            if problem is not None:
+                logger.error(
+                    "Rejecting %s observation: %s (raw: %s)",
+                    raw.icao, problem, (metar.raw_text or "")[:80],
+                )
+                continue
+
+            obs_age = now - _as_utc(metar.observation_time)
+            if obs_age > _OBS_STALE_WARN:
+                logger.warning(
+                    "%s observation is %s old at collection (raw: %s)",
+                    raw.icao, obs_age, (metar.raw_text or "")[:80],
+                )
 
             obs = VerificationObservation(
                 icao=raw.icao,

--- a/tests/test_metar_month_boundary_repair.py
+++ b/tests/test_metar_month_boundary_repair.py
@@ -1,0 +1,213 @@
+"""Month-boundary observation_time corruption: guard and repair (#519).
+
+METAR timestamps encode only DDHHMM, so the month is inferred.  The parser
+used to assume the *current* month, dating a report collected just after a
+month rolled over into the following month.  These tests pin both halves of
+the response: the ingestion guard that refuses to store such a row, and the
+repair script that corrects rows already written.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from weatherbrief.db.models import VerificationObservationRow, VerificationScoreRow
+from weatherbrief.tasks.verification import (
+    _OBS_MAX_AHEAD,
+    _observation_time_problem,
+)
+
+from scripts.repair_metar_month_boundary import apply_repairs, find_corrupt
+
+
+COLLECTED = datetime(2026, 8, 1, 0, 0, 1, tzinfo=timezone.utc)
+CORRECT = datetime(2026, 7, 31, 22, 55, tzinfo=timezone.utc)
+CORRUPT = datetime(2026, 8, 31, 22, 55, tzinfo=timezone.utc)
+RAW = "METAR LIPS 312255Z 00000KT CAVOK 28/22 Q1013"
+
+
+class TestIngestionGuard:
+    """The boundary check in tasks/verification.py."""
+
+    def test_accepts_a_normal_observation(self):
+        obs_time = COLLECTED - timedelta(minutes=6)
+        assert _observation_time_problem(obs_time, COLLECTED) is None
+
+    def test_rejects_a_future_observation(self):
+        problem = _observation_time_problem(CORRUPT, COLLECTED)
+        assert problem is not None
+        assert "ahead of collection" in problem
+
+    def test_rejects_missing_time(self):
+        assert _observation_time_problem(None, COLLECTED) == "missing observation_time"
+
+    def test_tolerates_small_clock_skew(self):
+        slightly_ahead = COLLECTED + _OBS_MAX_AHEAD - timedelta(minutes=1)
+        assert _observation_time_problem(slightly_ahead, COLLECTED) is None
+
+    def test_rejects_just_beyond_tolerance(self):
+        beyond = COLLECTED + _OBS_MAX_AHEAD + timedelta(minutes=1)
+        assert _observation_time_problem(beyond, COLLECTED) is not None
+
+    def test_accepts_naive_datetime_as_utc(self):
+        """MySQL hands back naive values; they must not be mis-flagged."""
+        assert _observation_time_problem(
+            (COLLECTED - timedelta(minutes=6)).replace(tzinfo=None), COLLECTED
+        ) is None
+
+    def test_stale_observation_is_not_rejected(self):
+        """A closed aerodrome may not issue for days — that is legitimate."""
+        assert _observation_time_problem(
+            COLLECTED - timedelta(days=30), COLLECTED
+        ) is None
+
+
+def _add_obs(session, icao, obs_time, collected_at, raw):
+    row = VerificationObservationRow(
+        icao=icao,
+        observation_time=obs_time.replace(tzinfo=None),
+        collected_at=collected_at.replace(tzinfo=None),
+        metar_raw=raw,
+    )
+    session.add(row)
+    session.flush()
+    return row
+
+
+class TestFindCorrupt:
+    """Detection half of the repair script."""
+
+    def test_finds_and_corrects_a_month_boundary_row(self, db_session):
+        row = _add_obs(db_session, "LIPS", CORRUPT, COLLECTED, RAW)
+
+        findings = find_corrupt(db_session, batch=1000, sleep=0)
+
+        assert len(findings) == 1
+        assert findings[0]["id"] == row.id
+        assert findings[0]["new"] == CORRECT
+        assert findings[0]["old"] == CORRUPT
+
+    def test_ignores_a_healthy_row(self, db_session):
+        _add_obs(db_session, "LIPS", CORRECT, COLLECTED, RAW)
+
+        assert find_corrupt(db_session, batch=1000, sleep=0) == []
+
+    def test_ignores_rows_within_clock_skew_tolerance(self, db_session):
+        obs_time = COLLECTED + timedelta(hours=1)
+        _add_obs(db_session, "LIPS", obs_time, COLLECTED, RAW)
+
+        assert find_corrupt(db_session, batch=1000, sleep=0) == []
+
+    def test_reports_but_does_not_correct_unparseable_raw(self, db_session):
+        _add_obs(db_session, "LIPS", CORRUPT, COLLECTED, "not a metar at all")
+
+        findings = find_corrupt(db_session, batch=1000, sleep=0)
+
+        assert len(findings) == 1
+        assert findings[0]["new"] is None
+        assert findings[0]["reason"] is not None
+
+    def test_full_scan_spans_multiple_pk_batches(self, db_session):
+        for i in range(5):
+            _add_obs(db_session, f"LIP{i}", CORRUPT, COLLECTED, RAW)
+
+        findings = find_corrupt(db_session, batch=2, sleep=0, full=True)
+
+        assert len([f for f in findings if f["new"] == CORRECT]) == 5
+
+    def test_targeted_and_full_scans_agree(self, db_session):
+        """The month-end windows must not miss what a full walk would catch."""
+        for i in range(3):
+            _add_obs(db_session, f"LIP{i}", CORRUPT, COLLECTED, RAW)
+        _add_obs(db_session, "LFPG", CORRECT, COLLECTED, RAW)
+
+        targeted = find_corrupt(db_session, batch=1000, sleep=0, full=False)
+        full = find_corrupt(db_session, batch=1000, sleep=0, full=True)
+
+        assert {f["id"] for f in targeted} == {f["id"] for f in full}
+        assert len(targeted) == 3
+
+    def test_empty_table(self, db_session):
+        assert find_corrupt(db_session, batch=1000, sleep=0) == []
+
+
+class TestApplyRepairs:
+    """Write half of the repair script."""
+
+    def test_repairs_the_stored_time(self, db_session):
+        row = _add_obs(db_session, "LIPS", CORRUPT, COLLECTED, RAW)
+        findings = find_corrupt(db_session, batch=1000, sleep=0)
+
+        stats = apply_repairs(db_session, findings, delete_scores=False)
+
+        assert stats["repaired"] == 1
+        db_session.refresh(row)
+        assert row.observation_time == CORRECT.replace(tzinfo=None)
+
+    def test_deletes_duplicate_when_correct_row_already_exists(self, db_session):
+        good = _add_obs(db_session, "LIPS", CORRECT, COLLECTED, RAW)
+        bad = _add_obs(db_session, "LIPS", CORRUPT, COLLECTED, RAW)
+        bad_id = bad.id
+        findings = find_corrupt(db_session, batch=1000, sleep=0)
+
+        stats = apply_repairs(db_session, findings, delete_scores=False)
+
+        assert stats.get("deleted_duplicate") == 1
+        assert stats.get("repaired", 0) == 0
+        remaining = db_session.query(VerificationObservationRow).all()
+        assert [r.id for r in remaining] == [good.id]
+        assert db_session.get(VerificationObservationRow, bad_id) is None
+
+    def test_leaves_scores_alone_by_default(self, db_session):
+        row = _add_obs(db_session, "LIPS", CORRUPT, COLLECTED, RAW)
+        db_session.add(
+            VerificationScoreRow(
+                observation_id=row.id,
+                icao="LIPS",
+                observation_time=CORRUPT.replace(tzinfo=None),
+                model="icon",
+                model_init_time=COLLECTED.replace(tzinfo=None),
+                lead_hours=1,
+                days_out=0,
+                source="standalone",
+            )
+        )
+        db_session.flush()
+        findings = find_corrupt(db_session, batch=1000, sleep=0)
+
+        stats = apply_repairs(db_session, findings, delete_scores=False)
+
+        assert stats.get("scores_deleted", 0) == 0
+        assert db_session.query(VerificationScoreRow).count() == 1
+
+    def test_deletes_scores_when_requested(self, db_session):
+        row = _add_obs(db_session, "LIPS", CORRUPT, COLLECTED, RAW)
+        db_session.add(
+            VerificationScoreRow(
+                observation_id=row.id,
+                icao="LIPS",
+                observation_time=CORRUPT.replace(tzinfo=None),
+                model="icon",
+                model_init_time=COLLECTED.replace(tzinfo=None),
+                lead_hours=1,
+                days_out=0,
+                source="standalone",
+            )
+        )
+        db_session.flush()
+        findings = find_corrupt(db_session, batch=1000, sleep=0)
+
+        stats = apply_repairs(db_session, findings, delete_scores=True)
+
+        assert stats["scores_deleted"] == 1
+        assert db_session.query(VerificationScoreRow).count() == 0
+
+    def test_is_idempotent(self, db_session):
+        _add_obs(db_session, "LIPS", CORRUPT, COLLECTED, RAW)
+        apply_repairs(
+            db_session, find_corrupt(db_session, batch=1000, sleep=0), delete_scores=False
+        )
+
+        second = find_corrupt(db_session, batch=1000, sleep=0)
+
+        assert second == []

--- a/tests/test_metar_month_boundary_repair.py
+++ b/tests/test_metar_month_boundary_repair.py
@@ -11,13 +11,22 @@ from datetime import datetime, timedelta, timezone
 
 import pytest
 
-from weatherbrief.db.models import VerificationObservationRow, VerificationScoreRow
+from weatherbrief.db.models import (
+    TafVerificationScoreRow,
+    VerificationObservationRow,
+    VerificationScoreRow,
+)
 from weatherbrief.tasks.verification import (
     _OBS_MAX_AHEAD,
     _observation_time_problem,
 )
 
-from scripts.repair_metar_month_boundary import apply_repairs, find_corrupt
+from scripts.repair_metar_month_boundary import (
+    apply_repairs,
+    apply_taf_repairs,
+    find_corrupt,
+    find_corrupt_taf,
+)
 
 
 COLLECTED = datetime(2026, 8, 1, 0, 0, 1, tzinfo=timezone.utc)
@@ -211,3 +220,109 @@ class TestApplyRepairs:
         second = find_corrupt(db_session, batch=1000, sleep=0)
 
         assert second == []
+
+
+TAF_RAW = "TAF LIPS 302300Z 0100/0109 VRB03KT CAVOK"
+TAF_CORRECT = datetime(2026, 6, 30, 23, 0, tzinfo=timezone.utc)
+TAF_CORRUPT = datetime(2026, 7, 30, 23, 0, tzinfo=timezone.utc)
+TAF_COLLECTED = datetime(2026, 7, 1, 0, 0, 1, tzinfo=timezone.utc)
+
+
+def _add_obs_with_taf(session, icao, obs_time, collected_at, issue_time):
+    row = VerificationObservationRow(
+        icao=icao,
+        observation_time=obs_time.replace(tzinfo=None),
+        collected_at=collected_at.replace(tzinfo=None),
+        metar_raw="METAR LIPS 302255Z 00000KT CAVOK 28/22 Q1013",
+        taf_raw=TAF_RAW,
+        taf_issue_time=issue_time.replace(tzinfo=None) if issue_time else None,
+    )
+    session.add(row)
+    session.flush()
+    return row
+
+
+class TestTafIssueTimeGuard:
+    """taf_issue_time is part of uq_taf_verif_key and needs the same guard."""
+
+    def test_rejects_future_taf_issue_time(self):
+        problem = _observation_time_problem(TAF_CORRUPT, TAF_COLLECTED)
+        assert problem is not None
+
+    def test_accepts_normal_taf_issue_time(self):
+        assert _observation_time_problem(TAF_CORRECT, TAF_COLLECTED) is None
+
+
+class TestTafRepair:
+    """Detection and repair of corrupted taf_issue_time."""
+
+    def test_finds_and_corrects_corrupt_issue_time(self, db_session):
+        obs_time = TAF_COLLECTED - timedelta(minutes=65)
+        row = _add_obs_with_taf(db_session, "LIPS", obs_time, TAF_COLLECTED, TAF_CORRUPT)
+
+        findings = find_corrupt_taf(db_session, sleep=0)
+
+        assert len(findings) == 1
+        assert findings[0]["id"] == row.id
+        assert findings[0]["new"] == TAF_CORRECT
+
+    def test_ignores_healthy_issue_time(self, db_session):
+        obs_time = TAF_COLLECTED - timedelta(minutes=65)
+        _add_obs_with_taf(db_session, "LIPS", obs_time, TAF_COLLECTED, TAF_CORRECT)
+
+        assert find_corrupt_taf(db_session, sleep=0) == []
+
+    def test_ignores_rows_without_a_taf(self, db_session):
+        obs_time = TAF_COLLECTED - timedelta(minutes=65)
+        _add_obs_with_taf(db_session, "LIPS", obs_time, TAF_COLLECTED, None)
+
+        assert find_corrupt_taf(db_session, sleep=0) == []
+
+    def test_applies_the_correction(self, db_session):
+        obs_time = TAF_COLLECTED - timedelta(minutes=65)
+        row = _add_obs_with_taf(db_session, "LIPS", obs_time, TAF_COLLECTED, TAF_CORRUPT)
+        findings = find_corrupt_taf(db_session, sleep=0)
+
+        stats = apply_taf_repairs(db_session, findings, delete_scores=False)
+
+        assert stats["taf_repaired"] == 1
+        db_session.refresh(row)
+        assert row.taf_issue_time == TAF_CORRECT.replace(tzinfo=None)
+
+    def test_deletes_taf_scores_when_requested(self, db_session):
+        obs_time = TAF_COLLECTED - timedelta(minutes=65)
+        row = _add_obs_with_taf(db_session, "LIPS", obs_time, TAF_COLLECTED, TAF_CORRUPT)
+        db_session.add(
+            TafVerificationScoreRow(
+                observation_id=row.id,
+                icao="LIPS",
+                observation_time=obs_time.replace(tzinfo=None),
+                taf_issue_time=TAF_CORRUPT.replace(tzinfo=None),
+                lead_hours=1,
+                source="standalone",
+            )
+        )
+        db_session.flush()
+        findings = find_corrupt_taf(db_session, sleep=0)
+
+        stats = apply_taf_repairs(db_session, findings, delete_scores=True)
+
+        assert stats["taf_scores_deleted"] == 1
+        assert db_session.query(TafVerificationScoreRow).count() == 0
+
+    def test_is_idempotent(self, db_session):
+        obs_time = TAF_COLLECTED - timedelta(minutes=65)
+        _add_obs_with_taf(db_session, "LIPS", obs_time, TAF_COLLECTED, TAF_CORRUPT)
+        apply_taf_repairs(
+            db_session, find_corrupt_taf(db_session, sleep=0), delete_scores=False
+        )
+
+        assert find_corrupt_taf(db_session, sleep=0) == []
+
+    def test_observation_time_repair_is_independent(self, db_session):
+        """A row can have a good observation_time and a corrupt taf_issue_time."""
+        obs_time = TAF_COLLECTED - timedelta(minutes=65)
+        _add_obs_with_taf(db_session, "LIPS", obs_time, TAF_COLLECTED, TAF_CORRUPT)
+
+        assert find_corrupt(db_session, batch=1000, sleep=0) == []
+        assert len(find_corrupt_taf(db_session, sleep=0)) == 1


### PR DESCRIPTION
Addresses #519 — deliberately not `Closes`, since the issue also covers the euro_aip release and pin bump that stop recurrence, and those aren't done yet. Leave it open until the fixed parser is deployed.

The root-cause parser fix is roznet/rzflight#20; this is the weatherbrief half — a boundary guard so the failure can't recur silently, and the repair tooling for data already written.

## Guard

`tasks/verification.py` now refuses to store an observation whose time is ahead of its own collection.

`observation_time` is the natural key (`uq_verif_obs_icao_time`), the 30-minute dedup bucket key, and what every `verification_scores` row joins on. A wrong month means an observation is scored against an entirely different forecast — which corrupts exactly the model-skill numbers the subsystem exists to produce. A report is always issued *before* we collect it, so a future-dated one can only mean the month was reconstructed wrongly. Drop it loudly rather than let it propagate.

Stale reports stay legal — a closed aerodrome may not issue for days — so those are logged, not rejected.

This guard is independent of the library fix: it would have caught this even without roznet/rzflight#20.

## Repair

`scripts/repair_metar_month_boundary.py` re-parses `metar_raw` against each row's own `collected_at` using the fixed parser and writes back the corrected time. `metar_raw` is retained, so the repair is lossless.

Read-only unless `--apply`.

**Scan cost.** The predicate (time ahead of collection) isn't sargable, but a full walk would pull all 697 MB of `verification_observations` through a 1 GiB buffer pool shared with two other applications. A corrupted row keeps its day-of-month and only moves the month, so it always lands on day 28–31 — the default scan uses `ix_verif_obs_time` over those month-end windows and touches roughly an eighth of the table. `--full` remains for exhaustive coverage. A test asserts the two strategies agree.

**Collisions.** `(icao, observation_time)` is unique. Where the corrected time already exists, the good row is present and the corrupt one is a duplicate — it's deleted rather than merged, so its scores cascade away with it.

## Production run

Already applied. Backup of all affected rows taken beforehand.

```
suspect rows : 1187
  599 off by 31 days  (Aug 31 -> Jul 31, collected 2026-08-01)
  588 off by 30 days  (Jul 30 -> Jun 30, collected 2026-07-01)
dependent verification_scores : 0

applied: {'repaired': 1176, 'deleted_duplicate': 11}
```

The 1,187 count independently matches a separate review's figure arrived at by a different route.

Verification after the run:

- re-scan: 0 suspect across all five month-end windows
- `SELECT COUNT(*) WHERE observation_time > NOW()` → **0** (was 599)
- the arithmetic reconciles: June window +588, August window 599→0, July window unchanged because it lost 588 to June and gained 588 from August (599 minus the 11 duplicates)
- spot check: `METAR LFAC 302330Z` collected 2026-07-01 00:00:01 now reads 2026-06-30 23:30

### Downstream

Two different derivations, which behave differently here:

- `verification_daily_stats` aggregates `verification_scores` — **unaffected**, since zero scores referenced the corrupt rows (being future-dated, they never matched a forecast).
- `airport_daily_summary` / `airport_monthly_summary` bucket `verification_observations` **directly** (`tasks/airport_summary.py`), so they *were* contaminated regardless of scores.

Rebuilt for 2026-06-30 (635 airports), 07-30 (643), 07-31 (643), 08-31 (**0** — that date was entirely phantom), plus monthly for June/July/August. Both rollups are idempotent delete-and-reinsert.

## Tests

19 new tests across the guard (tolerance, naive datetimes, staleness, rejection) and the repair (detection, both scan strategies agreeing, unparseable raw text, collision deletion, score handling, idempotency).

Full suite: **4,695 passed, 10 skipped, 0 failed**.

## Sequencing

This does not stop recurrence on its own — the parser fix has to ship. Order: release euro_aip (roznet/rzflight#20) → bump the pin here → deploy. The guard in this PR is the backstop if that slips past **1 September**.
