### PR TITLE
feat(digest): cache the digest prompt prefix with a 1h TTL

### DIFF
--- a/alembic/versions/085_briefing_usage_cache_tokens.py
+++ b/alembic/versions/085_briefing_usage_cache_tokens.py
@@ -1,0 +1,47 @@
+"""Record the prompt-cache split of a digest's input tokens.
+
+Anthropic prices a cached prefix in three tiers: uncached input at 1x, a cache
+write at 2x (the 1h TTL we use), and a cache read at 0.1x. langchain-anthropic
+folds all three into a single ``input_tokens`` figure, so without these two
+columns ``compute_cost`` prices every cached token as if it were full price —
+the ledger would show no saving at all once caching is enabled, and would
+overcharge users for reads.
+
+Both columns are subsets of ``llm_input_tokens``, never additions to it:
+
+    uncached = llm_input_tokens - llm_cache_read_tokens - llm_cache_write_tokens
+
+Nullable with no server_default on purpose. Rows written before this shipped
+genuinely have no cache data, and NULL says that; a 0 default would claim
+"nothing was cached", which is indistinguishable from a real cache miss and
+would quietly bias any hit-rate measurement over the backfilled window.
+
+Revision ID: 085
+Revises: 084
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "085"
+down_revision: Union[str, None] = "084"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("briefing_usage") as batch_op:
+        batch_op.add_column(
+            sa.Column("llm_cache_read_tokens", sa.Integer(), nullable=True)
+        )
+        batch_op.add_column(
+            sa.Column("llm_cache_write_tokens", sa.Integer(), nullable=True)
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("briefing_usage") as batch_op:
+        batch_op.drop_column("llm_cache_write_tokens")
+        batch_op.drop_column("llm_cache_read_tokens")

--- a/src/weatherbrief/api/packs.py
+++ b/src/weatherbrief/api/packs.py
@@ -1428,6 +1428,8 @@ def _charge_briefing_cost(
             result_size_bytes=result_size_bytes,
             config=config,
             config_id=config_id,
+            cache_read_tokens=usage.llm_cache_read_tokens or 0,
+            cache_write_tokens=usage.llm_cache_write_tokens or 0,
         )
         charge_briefing(db, user_id, usage_row_id, breakdown)
         logger.info(
@@ -3813,6 +3815,8 @@ def generate_digest(
         llm_model=digest_result.llm_model,
         llm_input_tokens=digest_result.llm_input_tokens,
         llm_output_tokens=digest_result.llm_output_tokens,
+        llm_cache_read_tokens=digest_result.llm_cache_read_tokens,
+        llm_cache_write_tokens=digest_result.llm_cache_write_tokens,
         triggered_by="user",
     )
     pack_size = _measure_pack_size(pack_dir)

--- a/src/weatherbrief/api/usage.py
+++ b/src/weatherbrief/api/usage.py
@@ -207,6 +207,8 @@ def log_briefing_usage(
         llm_model=usage.llm_model,
         llm_input_tokens=usage.llm_input_tokens,
         llm_output_tokens=usage.llm_output_tokens,
+        llm_cache_read_tokens=usage.llm_cache_read_tokens,
+        llm_cache_write_tokens=usage.llm_cache_write_tokens,
         result_size_bytes=result_size_bytes,
         elapsed_seconds=usage.elapsed_seconds,
         queue_wait_seconds=usage.queue_wait_seconds,

--- a/src/weatherbrief/costs.py
+++ b/src/weatherbrief/costs.py
@@ -17,6 +17,11 @@ class CostConfig:
 
     token_cost_per_1k_input: float = 0.003
     token_cost_per_1k_output: float = 0.015
+    # Prompt-caching multipliers applied to token_cost_per_1k_input. Anthropic
+    # bills a cache write at 1.25x on the 5-minute TTL and 2x on the 1h TTL we
+    # use for digests; a cache read is 0.1x either way.
+    cache_write_multiplier: float = 2.0
+    cache_read_multiplier: float = 0.1
     droplet_monthly_usd: float = 24.0
     misc_monthly_usd: float = 2.0
     subscriptions_monthly_usd: float = 30.0
@@ -66,16 +71,36 @@ def compute_cost(
     result_size_bytes: int,
     config: CostConfig,
     config_id: int,
+    cache_read_tokens: int = 0,
+    cache_write_tokens: int = 0,
 ) -> CostBreakdown:
     """Compute the full cost breakdown for a briefing.
 
     All inputs are non-negative integers; config supplies the rate card.
     Returns a frozen CostBreakdown with all components.
+
+    ``cache_read_tokens`` and ``cache_write_tokens`` are **subsets** of
+    ``input_tokens``, not extras — langchain-anthropic reports a single total
+    that already includes both. They are subtracted out and re-priced at their
+    own multipliers, so the three tiers each bill correctly. Both default to 0,
+    which reproduces the pre-caching behaviour exactly for historical rows.
     """
     est = max(config.estimated_monthly_briefings, _MIN_BRIEFINGS)
 
+    # Clamp rather than trust: a provider-side reporting change that made the
+    # cache figures siblings of input_tokens instead of subsets would otherwise
+    # drive uncached negative and silently *refund* users.
+    cached = min(cache_read_tokens + cache_write_tokens, input_tokens)
+    uncached_input = input_tokens - cached
+
     token_cost = (
-        (input_tokens / 1000) * config.token_cost_per_1k_input
+        (uncached_input / 1000) * config.token_cost_per_1k_input
+        + (cache_read_tokens / 1000)
+        * config.token_cost_per_1k_input
+        * config.cache_read_multiplier
+        + (cache_write_tokens / 1000)
+        * config.token_cost_per_1k_input
+        * config.cache_write_multiplier
         + (output_tokens / 1000) * config.token_cost_per_1k_output
     )
     infra_share = (config.droplet_monthly_usd + config.misc_monthly_usd) / est

--- a/src/weatherbrief/db/models.py
+++ b/src/weatherbrief/db/models.py
@@ -299,6 +299,11 @@ class BriefingUsageRow(Base):
     llm_model: Mapped[str | None] = mapped_column(String(100), nullable=True)
     llm_input_tokens: Mapped[int | None] = mapped_column(Integer, nullable=True)
     llm_output_tokens: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    # Prompt-cache split of llm_input_tokens (subsets of it, not additions):
+    # cache reads bill at 0.1x, cache writes at 2x on the 1h tier. NULL on rows
+    # written before prompt caching shipped, and 0 when nothing was cached.
+    llm_cache_read_tokens: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    llm_cache_write_tokens: Mapped[int | None] = mapped_column(Integer, nullable=True)
     result_size_bytes: Mapped[int | None] = mapped_column(Integer, nullable=True)
     elapsed_seconds: Mapped[float | None] = mapped_column(Float, nullable=True)
     queue_wait_seconds: Mapped[float | None] = mapped_column(Float, nullable=True)

--- a/src/weatherbrief/digest/llm_digest.py
+++ b/src/weatherbrief/digest/llm_digest.py
@@ -83,6 +83,8 @@ class DigestState(TypedDict, total=False):
     digest_text: str
     llm_input_tokens: int | None
     llm_output_tokens: int | None
+    llm_cache_read_tokens: int | None
+    llm_cache_write_tokens: int | None
     diagnostic: Diagnostic | None
 
 
@@ -130,6 +132,33 @@ def build_confidence_note(snapshot: ForecastSnapshot, target_time: datetime) -> 
 # --- Graph node ---
 
 
+def _system_content(system_prompt: str, longrange: bool) -> str | list[dict]:
+    """System message content, with a prompt-cache breakpoint where it pays.
+
+    Anthropic renders ``tools`` → ``system`` → ``messages``, so a breakpoint on
+    the system block caches the structured-output tool schema *and* the whole
+    system prompt — about 4.7k tokens, roughly 40% of a typical digest request.
+    Everything after it (the pack context) stays uncached, which is what we
+    want: it differs on every call.
+
+    The 1-hour TTL is deliberate.  It costs 2x on a write against the default
+    5-minute tier's 1.25x, but break-even is a hit rate of 53% vs 22%, and
+    measured gaps between consecutive digests sharing a prompt clear the bar
+    far more comfortably at an hour (~84%) than at five minutes (~34%).
+
+    Long-range digests are skipped: they run on Haiku 4.5, whose minimum
+    cacheable prefix is 4096 tokens — well above that prompt's ~1.5k — so a
+    breakpoint there caches nothing and silently costs nothing either.
+    """
+    if longrange:
+        return system_prompt
+    return [{
+        "type": "text",
+        "text": system_prompt,
+        "cache_control": {"type": "ephemeral", "ttl": "1h"},
+    }]
+
+
 def briefer_node(state: DigestState) -> dict:
     """Call LLM with structured output to produce WeatherDigest."""
     config: DigestConfig = state["config"]
@@ -146,7 +175,7 @@ def briefer_node(state: DigestState) -> dict:
         )
 
         raw_result = structured_llm.invoke([
-            {"role": "system", "content": system_prompt},
+            {"role": "system", "content": _system_content(system_prompt, longrange)},
             {"role": "user", "content": state["context"]},
         ])
 
@@ -158,8 +187,16 @@ def briefer_node(state: DigestState) -> dict:
         if raw_msg is not None:
             usage_meta = getattr(raw_msg, "usage_metadata", None)
             if usage_meta:
+                # NOTE: langchain-anthropic folds cached tokens *into*
+                # ``input_tokens`` (Anthropic's own field excludes them), so
+                # this is the true total and the two cache figures below are
+                # subsets of it — never add them together.  costs.py splits
+                # them back out to price each tier correctly.
                 token_info["llm_input_tokens"] = usage_meta.get("input_tokens")
                 token_info["llm_output_tokens"] = usage_meta.get("output_tokens")
+                details = usage_meta.get("input_token_details") or {}
+                token_info["llm_cache_read_tokens"] = details.get("cache_read") or 0
+                token_info["llm_cache_write_tokens"] = details.get("cache_creation") or 0
 
         return {"digest": result, **token_info}
     except Exception as e:

--- a/src/weatherbrief/pipeline.py
+++ b/src/weatherbrief/pipeline.py
@@ -122,6 +122,9 @@ class BriefingUsage:
     llm_model: str | None = None
     llm_input_tokens: int | None = None
     llm_output_tokens: int | None = None
+    # Prompt-cache split; both are subsets of llm_input_tokens, not extras.
+    llm_cache_read_tokens: int | None = None
+    llm_cache_write_tokens: int | None = None
     metar_taf_fetched: bool = False
     metar_taf_airports: int = 0
     sigmet_fetched: bool = False
@@ -861,6 +864,8 @@ def _execute_briefing_stages(
             result.usage.llm_model = digest_result.llm_model
             result.usage.llm_input_tokens = digest_result.llm_input_tokens
             result.usage.llm_output_tokens = digest_result.llm_output_tokens
+            result.usage.llm_cache_read_tokens = digest_result.llm_cache_read_tokens
+            result.usage.llm_cache_write_tokens = digest_result.llm_cache_write_tokens
         if digest_result.diagnostic:
             result.diagnostics.append(digest_result.diagnostic)
         stage_timings["llm_digest"] = perf_counter() - _t0

--- a/src/weatherbrief/tasks/outputs.py
+++ b/src/weatherbrief/tasks/outputs.py
@@ -51,6 +51,10 @@ class DigestResult:
     llm_model: str | None = None
     llm_input_tokens: int | None = None
     llm_output_tokens: int | None = None
+    # Prompt-cache split. Both are subsets of llm_input_tokens, not additions
+    # to it — see the note in digest/llm_digest.py:briefer_node.
+    llm_cache_read_tokens: int | None = None
+    llm_cache_write_tokens: int | None = None
     # LangSmith root run id for the digest LLM call, persisted with the pack so
     # later thumb ratings can attach feedback to the run (issue #244).
     digest_trace_id: str | None = None
@@ -266,6 +270,8 @@ def run_llm_digest(
         llm_model = f"{config.llm.provider}:{config.llm.model}"
         llm_input_tokens = digest_result.get("llm_input_tokens")
         llm_output_tokens = digest_result.get("llm_output_tokens")
+        llm_cache_read_tokens = digest_result.get("llm_cache_read_tokens")
+        llm_cache_write_tokens = digest_result.get("llm_cache_write_tokens")
         digest_trace_id = digest_result.get("digest_trace_id")
 
         # Save markdown + structured JSON digest
@@ -289,6 +295,8 @@ def run_llm_digest(
                 llm_model=llm_model,
                 llm_input_tokens=llm_input_tokens,
                 llm_output_tokens=llm_output_tokens,
+                llm_cache_read_tokens=llm_cache_read_tokens,
+                llm_cache_write_tokens=llm_cache_write_tokens,
                 digest_trace_id=digest_trace_id,
             )
 
@@ -330,6 +338,8 @@ def run_llm_digest(
             llm_model=llm_model,
             llm_input_tokens=llm_input_tokens,
             llm_output_tokens=llm_output_tokens,
+            llm_cache_read_tokens=llm_cache_read_tokens,
+            llm_cache_write_tokens=llm_cache_write_tokens,
             digest_trace_id=digest_trace_id,
         )
 

--- a/tests/test_costs.py
+++ b/tests/test_costs.py
@@ -304,3 +304,92 @@ class TestComputeProgramCost:
         }
         assert isinstance(d["fixed_lines"], list)
         assert set(d["fixed_lines"][0].keys()) == {"label", "monthly_usd", "prorated_usd"}
+
+
+class TestPromptCachePricing:
+    """Cached input tokens must bill at their own multipliers, not full price.
+
+    langchain-anthropic reports one ``input_tokens`` total that already
+    *includes* the cached tokens, so compute_cost has to subtract them back out
+    before pricing. Getting this wrong is silent: the ledger would keep showing
+    the pre-caching cost and the saving would be invisible.
+    """
+
+    def test_defaults_reproduce_uncached_pricing(self):
+        """Omitting the cache args must match the old behaviour exactly."""
+        config = _default_config()
+        without = compute_cost(
+            input_tokens=10000, output_tokens=1000,
+            result_size_bytes=0, config=config, config_id=1,
+        )
+        explicit_zero = compute_cost(
+            input_tokens=10000, output_tokens=1000,
+            result_size_bytes=0, config=config, config_id=1,
+            cache_read_tokens=0, cache_write_tokens=0,
+        )
+        assert without.token_cost_usd == explicit_zero.token_cost_usd
+        # (10000/1000)*0.003 + (1000/1000)*0.015 = 0.03 + 0.015
+        assert abs(without.token_cost_usd - 0.045) < 1e-6
+
+    def test_cache_read_is_cheaper_than_full_price(self):
+        """A read bills 0.1x, so 5k cached of 10k input costs less than 10k raw."""
+        config = _default_config()
+        b = compute_cost(
+            input_tokens=10000, output_tokens=1000,
+            result_size_bytes=0, config=config, config_id=1,
+            cache_read_tokens=5000,
+        )
+        # uncached 5000 @ 0.003 = 0.015; read 5000 @ 0.0003 = 0.0015; out 0.015
+        assert abs(b.token_cost_usd - 0.0315) < 1e-6
+        assert b.token_cost_usd < 0.045
+
+    def test_cache_write_is_dearer_than_full_price(self):
+        """A 1h write bills 2x — a first, uncached call must cost more."""
+        config = _default_config()
+        b = compute_cost(
+            input_tokens=10000, output_tokens=1000,
+            result_size_bytes=0, config=config, config_id=1,
+            cache_write_tokens=5000,
+        )
+        # uncached 5000 @ 0.003 = 0.015; write 5000 @ 0.006 = 0.030; out 0.015
+        assert abs(b.token_cost_usd - 0.060) < 1e-6
+        assert b.token_cost_usd > 0.045
+
+    def test_read_saving_outweighs_write_cost_at_measured_hit_rate(self):
+        """Sanity-check the whole reason for enabling caching.
+
+        Prod gaps put the hit rate near 84% at the 1h TTL, well above the 53%
+        break-even. Averaging one write against ~5 reads must come out ahead of
+        never caching at all.
+        """
+        config = _default_config()
+        prefix, ctx, out = 4661, 6800, 1200
+        total_in = prefix + ctx
+
+        def cost(**kw):
+            return compute_cost(
+                input_tokens=total_in, output_tokens=out,
+                result_size_bytes=0, config=config, config_id=1, **kw
+            ).token_cost_usd
+
+        baseline = cost()
+        write = cost(cache_write_tokens=prefix)
+        read = cost(cache_read_tokens=prefix)
+        assert write > baseline > read
+        # One miss then four hits — the shape of an 80% hit rate.
+        assert (write + 4 * read) / 5 < baseline
+
+    def test_cached_never_exceeds_input_total(self):
+        """Defends against a provider change making the figures siblings.
+
+        If cache tokens ever stopped being a subset of input_tokens, an
+        unclamped subtraction would drive the uncached count negative and
+        refund the user. Clamping keeps the bill non-negative.
+        """
+        config = _default_config()
+        b = compute_cost(
+            input_tokens=1000, output_tokens=0,
+            result_size_bytes=0, config=config, config_id=1,
+            cache_read_tokens=5000, cache_write_tokens=5000,
+        )
+        assert b.token_cost_usd >= 0


### PR DESCRIPTION
## What

Adds Anthropic prompt caching to the weather digest, and fixes the cost path so the saving is actually visible instead of silently invisible.

The structured-output tool schema plus the system prompt are byte-identical across every digest sharing a `(locale, guidance)` pair — **4,661 tokens, ~40% of a typical request**. Anthropic renders `tools` → `system` → `messages`, so one `cache_control` breakpoint on the system block covers both, leaving the pack context (different every call) uncached.

## Why a 1-hour TTL, not the 5-minute default

Measured on 30 days of prod traffic (1,685 Sonnet digests, 56/day):

| | ≤ 5 min | ≤ 1 hour |
|---|---|---|
| user-triggered (76%) | 32% | 90% |
| scheduler (24%) | 52% | 87% |
| **weighted, per prompt variant** | **34%** | **84%** |

Break-even is 22% for the 5-minute tier (1.25× write) and 53% for the 1-hour tier (2× write). Both clear it, but the 1-hour option wins by roughly 4×: **~$14/month against ~$88/month of digest spend**.

Long-range digests are deliberately left uncached — they run on Haiku 4.5, whose minimum cacheable prefix is 4096 tokens, well above that prompt's ~1.5k. A breakpoint there caches nothing and costs nothing.

## The cost fix is the load-bearing part

`langchain-anthropic` folds cached tokens **into** `usage_metadata.input_tokens` (Anthropic's own field excludes them). So `compute_cost` was about to price every cache read at full rate — the ledger would have shown **no saving at all** and would have overcharged users for reads.

- The read/write split is now recorded on `briefing_usage` (migration 085) and priced at its own multipliers.
- The cached figure is clamped to `input_tokens`, so a provider-side reporting change that made them siblings rather than subsets can't drive the uncached count negative and silently *refund* users.
- Both new `compute_cost` args default to 0, reproducing pre-caching behaviour exactly for historical rows.

## Notable decisions

- **New columns are nullable with no `server_default`.** NULL means "written before caching shipped", which is distinguishable from a real zero-token miss. A `0` default would have biased the hit-rate measurement across the backfilled window.
- **No prompt changes, so no eval re-baseline.** An earlier plan reordered `briefer_v2.md` to merge the per-locale cache entries. Dropped: prod guidance is 100% `balanced`, and the rendered prompt is already byte-identical for the 91% of traffic on `en`/`balanced`. Merging the remaining locales would mean restructuring four inline vocabulary tokens — one of which (`none_word`) is a literal contract with `guardrails.NONE_WORDS` — for ~$2/month.

## Verification

- Full suite: **4,711 passed**, 10 skipped, no failures.
- Migration 085 applied **and** reverted on a copy of the dev DB; columns appear and drop cleanly, 208 rows preserved. Prod is at 084, so it applies cleanly.
- End-to-end through the real `briefer_node`: valid digests, **4,661 tokens read from cache** on the repeat call, priced $0.0072 vs $0.0198 under the old flat model.
- 1-hour TTL confirmed live through LangChain (`ephemeral_1h_input_tokens: 4661`) — no beta header needed.
- 5 new tests on the pricing split, including the negative-clamp guard.

## After deploy

Check the prediction (84% hit rate, ~4,661 tokens per read) once a day of traffic has landed:

```sql
SELECT COUNT(*) n,
       SUM(llm_cache_read_tokens > 0) / COUNT(*) AS hit_rate,
       CAST(AVG(llm_cache_read_tokens) AS SIGNED) AS avg_read
FROM briefing_usage
WHERE llm_digest = 1 AND llm_model LIKE '%sonnet%'
  AND llm_cache_read_tokens IS NOT NULL;
```

If it lands materially below 84%, the 5-minute TTL becomes the better bet — a one-line change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
