### PR TITLE
fix(route-graph): distinguish above-scale ceilings from missing data

### DIFF
--- a/designs/route-graph.md
+++ b/designs/route-graph.md
@@ -48,6 +48,8 @@ interface RouteGraphMetric {
   formatValue?: (v: number) => string;
   /** Optional: suggested Y-axis range [min, max]. Auto-scaled if omitted. */
   suggestedRange?: [number, number];
+  /** Optional: values above suggestedRange's max are above-scale, not data. Requires suggestedRange. */
+  aboveScale?: boolean;
   /** Optional: zero-line — draw a reference line at y=0 (useful for headwind). */
   showZeroLine?: boolean;
   /** Optional: labels drawn above/below the zero line, e.g. ["Headwind ↑", "Tailwind ↓"]. */
@@ -74,11 +76,29 @@ interface RouteGraphMetric {
 
 **ISA deviation** plots cruise-level temperature minus the ISA standard at that level — the zero line is "on-ISA", above = warmer (degraded density altitude / climb / TAS). It is derived in `data-extract.ts` from a separate `VizPoint.temperatureCruiseC` (cruise-level temperature, kept distinct from the surface `temperatureC`), so the surface and cruise temperatures stay independent.
 
-**Ceiling metrics** display height above ground level (AGL), not MSL. Both use terrain elevation from `ElevationProfile` for the AGL conversion and cap display at 5000ft AGL.
+**Ceiling metrics** display height above ground level (AGL), not MSL. Both use terrain elevation from `ElevationProfile` for the AGL conversion, and both pin their axis to 0–5000 ft AGL — a ceiling higher than that renders as **above-scale** (see below), not as a missing value.
 
 **CIN** is convention-negative (it inhibits convection), so its bars hang *below* the zero line as the "cap" beside CAPE's upward bars; it sets `showZeroLine` so the reference line is drawn at the top of the `[-300, 0]` range.
 
 **QNH is region-aware** (the only such metric). It carries canonical hPa on `VizPoint.qnhHpa` and converts at the display edge via `units.ts` (`qnhDisplayValue` / `qnhUnitLabel`): Europe shows **QNH in hPa**, the US shows **Altimeter in inHg**. Both the `unit` field (a getter) and the name (`getMetricLabel`, key `graph.altimeter` vs `graph.qnh`) switch on `getUnitsRegion()`, so the axis label, ticks, tooltip, and dropdown all agree. The model-comparison table keeps it as canonical-hPa "QNH" (advanced tier, hidden by default).
+
+### Three value states: value / above-scale / unavailable (#384)
+
+`getValue` returns `number | null`, where **null means genuinely unavailable and nothing else**. A metric that also has a display ceiling declares `suggestedRange` plus `aboveScale: true`, and `sampleMetric(metric, point)` classifies each point into a `MetricSample`:
+
+| State | Meaning | Axis | Line | Tooltip |
+|---|---|---|---|---|
+| `value` | plottable | drives auto-fit | drawn | formatted value |
+| `above-scale` | known, off the top | ignored | breaks, plus a top-edge chevron | `> 5,000 ft AGL` |
+| `unavailable` | no data | ignored | breaks | `N/A` |
+
+`sampleMetric` is the single place the cap is applied — `renderer.ts`, `axes.ts` and `interaction.ts` all consume samples rather than re-deriving it, so the three surfaces cannot drift.
+
+Before #384 the ceiling getters returned `null` for both "above 5000 ft AGL" and "no sounding". That made the best possible news — a ceiling far above the route — render exactly like absent data: a gap in the line and a tooltip reading `N/A`. It also degenerated the axis, since the ceiling metrics declared no `suggestedRange`: on a day where every point was above cap, `computeYScale` auto-fit an empty array and drew a **0–1 ft AGL axis with no line on it**. This is the mirror of #391/#392 ("absent data must never read as GREEN") — there, *unknown* looked like *fine*; here, *fine* looked like *unknown*. Both erode what a gap means.
+
+`aboveScale` metrics get their `suggestedRange` used **verbatim** — no 10% padding, no nice-rounding, no expanding to fit — so the top tick *is* the cap and a marker riding the top edge unambiguously reads "higher than that number". This is a presentation state only: the value is never clipped or rewritten, and no meteorological reclassification happens in the browser.
+
+Only line metrics support it today. A bar metric declaring `aboveScale` would need its own affordance (a clipped bar head); `renderBars` skips non-`value` samples rather than inventing one.
 
 ### Future Metrics (no code changes to renderer needed)
 

--- a/web/tests/unit/route-graph-axes.test.ts
+++ b/web/tests/unit/route-graph-axes.test.ts
@@ -1,0 +1,73 @@
+/** Tests for the route-graph Y-axis scale. */
+
+import { describe, it, expect } from 'vitest';
+import { computeYScale } from '../../ts/visualization/route-graph/axes';
+import {
+  getMetricById, type MetricSample, type RouteGraphMetric,
+} from '../../ts/visualization/route-graph/metrics';
+import type { PlotArea } from '../../ts/visualization/types';
+
+const PLOT: PlotArea = { left: 60, top: 8, width: 800, height: 200 };
+
+function metric(id: string): RouteGraphMetric {
+  const m = getMetricById(id);
+  if (!m) throw new Error(`metric ${id} not found`);
+  return m;
+}
+
+const value = (v: number): MetricSample => ({ kind: 'value', value: v });
+const aboveScale = (v: number): MetricSample => ({ kind: 'above-scale', value: v });
+const unavailable: MetricSample = { kind: 'unavailable' };
+
+describe('computeYScale — above-scale metrics', () => {
+  const ceiling = () => metric('ceiling-dd');
+
+  it('pins the axis to the declared range so the top tick is the cap', () => {
+    const scale = computeYScale([value(1200), value(3000)], ceiling(), PLOT);
+    expect(scale.min).toBe(0);
+    expect(scale.max).toBe(5000);
+  });
+
+  it('holds the range when every point is above the cap', () => {
+    // The bug: with no suggestedRange the filtered values were empty, the scale
+    // fell to its 0–1 branch and drew a 0–1 ft AGL axis with no line on it —
+    // on the best possible weather day.
+    const scale = computeYScale([aboveScale(7000), aboveScale(9000)], ceiling(), PLOT);
+    expect(scale.min).toBe(0);
+    expect(scale.max).toBe(5000);
+  });
+
+  it('holds the range when there is no data at all', () => {
+    const scale = computeYScale([unavailable, unavailable], ceiling(), PLOT);
+    expect(scale.min).toBe(0);
+    expect(scale.max).toBe(5000);
+  });
+
+  it('maps the cap to the top edge of the plot area', () => {
+    const scale = computeYScale([value(2500)], ceiling(), PLOT);
+    expect(scale.valueToY(5000)).toBeCloseTo(PLOT.top);
+    expect(scale.valueToY(0)).toBeCloseTo(PLOT.top + PLOT.height);
+    expect(scale.valueToY(2500)).toBeCloseTo(PLOT.top + PLOT.height / 2);
+  });
+});
+
+describe('computeYScale — ordinary metrics', () => {
+  it('still expands past a suggested range to fit the data', () => {
+    // cloud-cover suggests [0, 100] but does not declare `aboveScale`, so an
+    // over-range value must widen the axis rather than be treated as off-chart.
+    const scale = computeYScale([value(50), value(140)], metric('cloud-cover'), PLOT);
+    expect(scale.max).toBeGreaterThanOrEqual(140);
+  });
+
+  it('auto-fits when no range is suggested', () => {
+    const scale = computeYScale([value(-10), value(20)], metric('temperature'), PLOT);
+    expect(scale.min).toBeLessThanOrEqual(-10);
+    expect(scale.max).toBeGreaterThanOrEqual(20);
+  });
+
+  it('ignores unavailable samples when auto-fitting', () => {
+    const scale = computeYScale([unavailable, value(5), unavailable], metric('temperature'), PLOT);
+    expect(scale.min).toBeLessThanOrEqual(5);
+    expect(scale.max).toBeGreaterThanOrEqual(5);
+  });
+});

--- a/web/tests/unit/route-graph-metrics.test.ts
+++ b/web/tests/unit/route-graph-metrics.test.ts
@@ -3,6 +3,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   ROUTE_GRAPH_METRICS, getMetricById, getMetricOptions, METRIC_NONE,
+  sampleMetric, formatSample,
 } from '../../ts/visualization/route-graph/metrics';
 import { isaTemperatureC } from '../../ts/visualization/data-extract';
 import { makeVizPoint, makeAltitudeLines, makeNwpCloudDiag } from './fixtures/viz-point';
@@ -74,10 +75,11 @@ describe('ceiling-dd metric (sounding ceiling AGL)', () => {
     expect(m().getValue(p)).toBe(0);
   });
 
-  it('returns null when AGL exceeds 5000 ft cap', () => {
-    // Ceiling well above the route → not interesting for plotting.
+  it('reports the true AGL above the display cap, not null', () => {
+    // A ceiling well above the route is knowledge, not absence — null here is
+    // reserved for "no sounding" and would render as a data gap.
     const p = makeVizPoint({ soundingCeilingFt: 8000, terrainElevationFt: 1000 });
-    expect(m().getValue(p)).toBeNull();
+    expect(m().getValue(p)).toBe(7000);
   });
 
   it('keeps values exactly at 5000 ft AGL', () => {
@@ -107,12 +109,76 @@ describe('ceiling-nwp metric', () => {
     expect(m().getValue(p)).toBe(3000);
   });
 
-  it('returns null above 5000 ft AGL cap', () => {
+  it('reports the true AGL above the display cap, not null', () => {
     const p = makeVizPoint({
       terrainElevationFt: 500,
       nwpCloudDiag: makeNwpCloudDiag({ ceilingFt: 9500 }),
     });
-    expect(m().getValue(p)).toBeNull();
+    expect(m().getValue(p)).toBe(9000);
+  });
+});
+
+describe('ceiling above-scale state', () => {
+  // The bug this covers: above-cap and missing both returned null, so "ceiling
+  // is excellent" was indistinguishable from "we have no sounding" — a gap in
+  // the line and a tooltip reading N/A in both cases.
+  for (const id of ['ceiling-dd', 'ceiling-nwp'] as const) {
+    describe(id, () => {
+      const m = () => metric(id);
+      /** Build a point with the given ceiling AGL, for whichever source this metric reads. */
+      const atAgl = (agl: number | null) =>
+        makeVizPoint(
+          id === 'ceiling-dd'
+            ? { soundingCeilingFt: agl === null ? null : agl + 1000, terrainElevationFt: 1000 }
+            : {
+                terrainElevationFt: 1000,
+                nwpCloudDiag: makeNwpCloudDiag({ ceilingFt: agl === null ? null : agl + 1000 }),
+              },
+        );
+
+      it('declares a pinned 0–5000 ft AGL range', () => {
+        expect(m().suggestedRange).toEqual([0, 5000]);
+        expect(m().aboveScale).toBe(true);
+      });
+
+      it('exactly at the cap is a plottable value', () => {
+        expect(sampleMetric(m(), atAgl(5000))).toEqual({ kind: 'value', value: 5000 });
+      });
+
+      it('one foot above the cap is above-scale, carrying the real value', () => {
+        expect(sampleMetric(m(), atAgl(5001))).toEqual({ kind: 'above-scale', value: 5001 });
+      });
+
+      it('missing data is unavailable, distinct from above-scale', () => {
+        expect(sampleMetric(m(), atAgl(null))).toEqual({ kind: 'unavailable' });
+      });
+
+      it('formats above-scale as a bound and only missing data as N/A', () => {
+        expect(formatSample(m(), sampleMetric(m(), atAgl(8000)))).toBe('> 5,000 ft AGL');
+        expect(formatSample(m(), sampleMetric(m(), atAgl(null)))).toBe('N/A');
+        expect(formatSample(m(), sampleMetric(m(), atAgl(3000)))).toBe('3,000 ft AGL');
+      });
+    });
+  }
+});
+
+describe('sampleMetric on ordinary metrics', () => {
+  it('never yields above-scale for a metric that does not declare it', () => {
+    // cloud-cover has a suggestedRange but no `aboveScale`, so an over-range
+    // value stays a value and the axis expands to fit, as before.
+    const s = sampleMetric(metric('cloud-cover'), makeVizPoint({ cloudCoverTotalPct: 120 }));
+    expect(s).toEqual({ kind: 'value', value: 120 });
+  });
+
+  it('maps a null getValue to unavailable', () => {
+    expect(sampleMetric(metric('temperature'), makeVizPoint({ temperatureC: null })))
+      .toEqual({ kind: 'unavailable' });
+  });
+
+  it('formats a plain value through the metric formatValue', () => {
+    const m = metric('headwind');
+    expect(formatSample(m, { kind: 'value', value: 15 })).toBe('15 kt HW');
+    expect(formatSample(m, { kind: 'unavailable' })).toBe('N/A');
   });
 });
 

--- a/web/ts/visualization/route-graph/axes.ts
+++ b/web/ts/visualization/route-graph/axes.ts
@@ -1,7 +1,7 @@
 /** Draw Y-axes and X grid lines for the route graph. */
 
 import type { PlotArea, VizRouteData } from '../types';
-import type { RouteGraphMetric } from './metrics';
+import type { MetricSample, RouteGraphMetric } from './metrics';
 import { MARGIN } from './constants';
 import { chooseDistanceTickInterval, isDarkTheme } from '../interaction-utils';
 
@@ -18,16 +18,31 @@ export interface YAxisScale {
   valueToY: (v: number) => number;
 }
 
-/** Compute a nice Y-axis scale for a metric's data values. */
+/** Compute a nice Y-axis scale for a metric's sampled values. */
 export function computeYScale(
-  values: (number | null)[],
+  samples: MetricSample[],
   metric: RouteGraphMetric,
   plotArea: PlotArea,
 ): YAxisScale {
-  const nums = values.filter((v): v is number => v !== null);
+  // Only plottable values drive the scale. Above-scale samples deliberately do
+  // not — expanding the axis to fit them is exactly what the cap exists to avoid.
+  const nums = samples.filter((s) => s.kind === 'value').map((s) => s.value);
 
   let min: number;
   let max: number;
+
+  if (metric.aboveScale && metric.suggestedRange) {
+    // Pinned axis: use the range verbatim, so the top tick *is* the cap and a
+    // marker riding the top edge unambiguously reads "above this number".
+    return {
+      min: metric.suggestedRange[0],
+      max: metric.suggestedRange[1],
+      valueToY: (v: number) =>
+        plotArea.top +
+        (1 - (v - metric.suggestedRange![0]) / (metric.suggestedRange![1] - metric.suggestedRange![0])) *
+          plotArea.height,
+    };
+  }
 
   if (metric.suggestedRange) {
     [min, max] = metric.suggestedRange;

--- a/web/ts/visualization/route-graph/interaction.ts
+++ b/web/ts/visualization/route-graph/interaction.ts
@@ -2,7 +2,7 @@
 
 import type { VizRouteData, VizPoint } from '../types';
 import type { RouteGraphRenderer } from './renderer';
-import { getMetricLabel, type RouteGraphMetric } from './metrics';
+import { formatSample, getMetricLabel, sampleMetric, type RouteGraphMetric } from './metrics';
 import {
   getCanvasX, findNearestPointIndex, ensureTooltip as ensureTooltipEl,
   positionTooltip, hideTooltip as hideTooltipEl, findNearbyWaypoint,
@@ -104,10 +104,7 @@ export function attachRouteGraphInteraction(
   }
 
   function formatMetricLine(metric: RouteGraphMetric, point: VizPoint): string {
-    const v = metric.getValue(point);
-    const fmt = v !== null
-      ? (metric.formatValue ? metric.formatValue(v) : v.toFixed(1))
-      : 'N/A';
+    const fmt = formatSample(metric, sampleMetric(metric, point));
     return `<span style="color:${metric.color}">${getMetricLabel(metric.id)}: ${fmt}</span>`;
   }
 

--- a/web/ts/visualization/route-graph/metrics.ts
+++ b/web/ts/visualization/route-graph/metrics.ts
@@ -15,17 +15,39 @@ export interface RouteGraphMetric {
   readonly renderType: RenderType;
   /** Primary color for the line/bar. */
   readonly color: string;
-  /** Extract the numeric value from a VizPoint. Returns null if unavailable. */
+  /**
+   * Extract the numeric value from a VizPoint. Returns null — and *only* null —
+   * when the value is genuinely unavailable. A known value that happens to sit
+   * off the top of the axis is not null; see `aboveScale`.
+   */
   getValue(point: VizPoint): number | null;
   /** Optional: format value for tooltip. Defaults to rounding to 1 decimal. */
   formatValue?: (v: number) => string;
   /** Optional: fixed Y-axis range [min, max]. Auto-scaled from data if omitted. */
   suggestedRange?: [number, number];
+  /**
+   * Treat values above `suggestedRange`'s max as a distinct *above-scale* state
+   * instead of data: the axis is pinned to the range exactly (no padding, no
+   * expansion, so the top tick *is* the cap) and such points render as a capped
+   * marker on the top edge rather than a gap. Requires `suggestedRange`.
+   *
+   * This is a presentation state, not a claim about the weather — the value is
+   * known and is never clipped or rewritten, it just doesn't fit the axis.
+   */
+  aboveScale?: boolean;
   /** Draw a reference line at y=0 (useful for head/tailwind). */
   showZeroLine?: boolean;
   /** Labels drawn above/below the zero line: [aboveLabel, belowLabel]. */
   zeroLineLabels?: [string, string];
 }
+
+/**
+ * Display cap for the ceiling metrics, in ft AGL. Ceilings above this are of no
+ * practical interest to plot point-by-point, so the axis stops here and higher
+ * ceilings render as above-scale. Purely a display bound — it does not change
+ * any meteorological value or threshold.
+ */
+const CEILING_AGL_CAP_FT = 5000;
 
 /**
  * Metric registry — add new metrics here. They automatically appear in dropdowns
@@ -150,12 +172,17 @@ export const ROUTE_GRAPH_METRICS: readonly RouteGraphMetric[] = [
     unit: 'ft AGL',
     renderType: 'line',
     color: '#8b5cf6',
+    // A ceiling well above the route is the best possible news, so it must not
+    // return null — that is reserved for "no sounding", and the two used to be
+    // indistinguishable (gap in the line, tooltip "N/A"). Above the cap is an
+    // above-scale state instead; see `aboveScale`.
     getValue: (p) => {
       if (p.soundingCeilingFt == null) return null;
-      const agl = Math.max(0, p.soundingCeilingFt - p.terrainElevationFt);
-      return agl > 5000 ? null : agl;
+      return Math.max(0, p.soundingCeilingFt - p.terrainElevationFt);
     },
     formatValue: (v) => `${Math.round(v).toLocaleString()} ft AGL`,
+    suggestedRange: [0, CEILING_AGL_CAP_FT],
+    aboveScale: true,
   },
   {
     id: 'ceiling-nwp',
@@ -164,12 +191,59 @@ export const ROUTE_GRAPH_METRICS: readonly RouteGraphMetric[] = [
     color: '#d946ef',
     getValue: (p) => {
       if (p.nwpCloudDiag?.ceilingFt == null) return null;
-      const agl = Math.max(0, p.nwpCloudDiag.ceilingFt - p.terrainElevationFt);
-      return agl > 5000 ? null : agl;
+      return Math.max(0, p.nwpCloudDiag.ceilingFt - p.terrainElevationFt);
     },
     formatValue: (v) => `${Math.round(v).toLocaleString()} ft AGL`,
+    suggestedRange: [0, CEILING_AGL_CAP_FT],
+    aboveScale: true,
   },
 ];
+
+/**
+ * A metric's value at one route point, in three states rather than two.
+ *
+ * `unavailable` means we have no value. `above-scale` means we have one and it
+ * is off the top of the axis — the distinction the chart previously collapsed,
+ * rendering "ceiling is excellent" identically to "no data".
+ */
+export type MetricSample =
+  | { readonly kind: 'value'; readonly value: number }
+  | { readonly kind: 'above-scale'; readonly value: number }
+  | { readonly kind: 'unavailable' };
+
+const UNAVAILABLE_SAMPLE: MetricSample = { kind: 'unavailable' };
+
+/**
+ * Classify a metric's value at a point. The single place the three states are
+ * derived — renderer, axes and tooltip all read this rather than re-deriving
+ * the cap, so they cannot drift apart.
+ */
+export function sampleMetric(metric: RouteGraphMetric, point: VizPoint): MetricSample {
+  const v = metric.getValue(point);
+  if (v === null) return UNAVAILABLE_SAMPLE;
+  if (metric.aboveScale && metric.suggestedRange && v > metric.suggestedRange[1]) {
+    return { kind: 'above-scale', value: v };
+  }
+  return { kind: 'value', value: v };
+}
+
+/**
+ * Tooltip text for a sample, unit-aware via the metric's own `formatValue`.
+ * Above-scale reads "> <cap>"; only a genuinely absent value reads "N/A".
+ */
+export function formatSample(metric: RouteGraphMetric, sample: MetricSample): string {
+  const fmt = (v: number): string => (metric.formatValue ? metric.formatValue(v) : v.toFixed(1));
+  switch (sample.kind) {
+    case 'value':
+      return fmt(sample.value);
+    case 'above-scale':
+      // Formatted from the cap, not the value: we are reporting the axis limit
+      // we can show, not disclosing a number we declined to plot.
+      return `> ${fmt(metric.suggestedRange![1])}`;
+    case 'unavailable':
+      return 'N/A';
+  }
+}
 
 /** Sentinel value for "no metric selected" (used for the optional right Y-axis). */
 export const METRIC_NONE = 'none';

--- a/web/ts/visualization/route-graph/renderer.ts
+++ b/web/ts/visualization/route-graph/renderer.ts
@@ -1,7 +1,7 @@
 /** Route graph canvas renderer — 2D chart below the cross-section. */
 
 import type { PlotArea, VizRouteData, VizPoint } from '../types';
-import type { RouteGraphMetric } from './metrics';
+import { sampleMetric, type RouteGraphMetric } from './metrics';
 import type { YAxisScale } from './axes';
 import { computeYScale, drawLeftYAxis, drawRightYAxis, drawXGrid, drawZeroLine, drawBorder } from './axes';
 import { monotoneCubicTangents } from '../cross-section/layers/base';
@@ -111,10 +111,10 @@ export class RouteGraphRenderer {
 
     // Compute scales and render metrics
     const leftScale = this.leftMetric
-      ? computeYScale(this.data.points.map((p) => this.leftMetric!.getValue(p)), this.leftMetric, plotArea)
+      ? computeYScale(this.data.points.map((p) => sampleMetric(this.leftMetric!, p)), this.leftMetric, plotArea)
       : null;
     const rightScale = this.rightMetric
-      ? computeYScale(this.data.points.map((p) => this.rightMetric!.getValue(p)), this.rightMetric, plotArea)
+      ? computeYScale(this.data.points.map((p) => sampleMetric(this.rightMetric!, p)), this.rightMetric, plotArea)
       : null;
 
     // Clip to plot area for data rendering
@@ -214,7 +214,7 @@ export class RouteGraphRenderer {
     if (metric.renderType === 'bar') {
       this.renderBars(ctx, metric, scale, distanceToX, plotArea, points);
     } else {
-      this.renderLine(ctx, metric, scale, distanceToX, points);
+      this.renderLine(ctx, metric, scale, distanceToX, plotArea, points);
     }
   }
 
@@ -223,10 +223,12 @@ export class RouteGraphRenderer {
     metric: RouteGraphMetric,
     scale: YAxisScale,
     distanceToX: (d: number) => number,
+    plotArea: PlotArea,
     points: readonly VizPoint[],
   ): void {
-    const values = points.map((p) => metric.getValue(p));
+    const samples = points.map((p) => sampleMetric(metric, p));
     const allDots: Array<{ x: number; y: number }> = [];
+    const aboveScaleXs: number[] = [];
 
     ctx.strokeStyle = metric.color;
     ctx.lineWidth = 2;
@@ -240,8 +242,13 @@ export class RouteGraphRenderer {
     let curYs: number[] = [];
 
     for (let i = 0; i < points.length; i++) {
-      const v = values[i];
-      if (v === null) {
+      const s = samples[i];
+      if (s.kind !== 'value') {
+        // Both non-value states break the spline — there is no honest Y for
+        // either — but only one of them leaves the reader with nothing: an
+        // above-scale point gets its own marker below, so the break in the
+        // line reads as "off the top", not as "no data".
+        if (s.kind === 'above-scale') aboveScaleXs.push(distanceToX(points[i].distanceNm));
         if (curXs.length > 0) {
           segments.push({ xs: curXs, ys: curYs });
           curXs = [];
@@ -250,7 +257,7 @@ export class RouteGraphRenderer {
         continue;
       }
       const x = distanceToX(points[i].distanceNm);
-      const y = scale.valueToY(v);
+      const y = scale.valueToY(s.value);
       curXs.push(x);
       curYs.push(y);
       allDots.push({ x, y });
@@ -284,6 +291,18 @@ export class RouteGraphRenderer {
       ctx.arc(x, y, 2.5, 0, Math.PI * 2);
       ctx.fill();
     }
+
+    // Above-scale markers: upward chevrons riding the top edge. The value is
+    // known and is not drawn at any Y that would imply a reading — the marker
+    // says "higher than the top tick" and the tooltip gives the bound.
+    for (const x of aboveScaleXs) {
+      ctx.beginPath();
+      ctx.moveTo(x, plotArea.top + 1);
+      ctx.lineTo(x - 4, plotArea.top + 7);
+      ctx.lineTo(x + 4, plotArea.top + 7);
+      ctx.closePath();
+      ctx.fill();
+    }
   }
 
   private renderBars(
@@ -300,11 +319,13 @@ export class RouteGraphRenderer {
     ctx.globalAlpha = 0.6;
 
     for (let i = 0; i < points.length; i++) {
-      const v = metric.getValue(points[i]);
-      if (v === null || v === 0) continue;
+      // No bar metric declares `aboveScale` today; if one ever does it needs its
+      // own affordance (a clipped bar head), so skip rather than invent one.
+      const s = sampleMetric(metric, points[i]);
+      if (s.kind !== 'value' || s.value === 0) continue;
 
       const x = distanceToX(points[i].distanceNm);
-      const y = scale.valueToY(v);
+      const y = scale.valueToY(s.value);
 
       // Bar width: half distance to neighbors
       const prevDist = i > 0 ? points[i - 1].distanceNm : points[i].distanceNm;


### PR DESCRIPTION
## What & why

The `ceiling-dd` and `ceiling-nwp` getters returned `null` both when there was no sounding **and** when the ceiling was above the 5,000 ft AGL display cap. One `null`, three wrong consequences:

1. **The line broke** identically to a model with no data (`renderer.ts` renders only segments of consecutive non-null values).
2. **The tooltip read `N/A`** for an 8,000 ft AGL ceiling — the best possible news reported as an absence.
3. **The axis degenerated.** Neither metric declared a `suggestedRange`, so on a day where *every* point was above cap, `computeYScale` auto-fit an empty array, hit its `nums.length === 0` branch and drew a **0–1 ft AGL axis with no line on it**.

This is the mirror image of #391/#392. There, "we don't know" could read as "it's fine"; here "it's fine" reads as "we don't know". They compound — if a gap in the ceiling trace usually just means "above the chart", pilots learn to read every gap that way, including the ones where we genuinely have nothing.

**The fix: three states instead of two.** `getValue` now returns `null` only for genuinely absent data. A metric with a display ceiling declares `suggestedRange` plus `aboveScale: true`, and `sampleMetric()` classifies each point:

| State | Axis | Line | Tooltip |
|---|---|---|---|
| `value` | drives fit | drawn | `3,000 ft AGL` |
| `above-scale` | ignored | breaks, plus top-edge chevron | `> 5,000 ft AGL` |
| `unavailable` | ignored | breaks | `N/A` |

`sampleMetric` is the single place the cap is applied — `renderer.ts`, `axes.ts` and `interaction.ts` all consume samples rather than re-deriving it, so the three surfaces cannot drift.

For `aboveScale` metrics the declared range is used **verbatim** (no padding, no nice-rounding, no expanding to fit), so the top tick *is* the cap and a marker riding the top edge unambiguously reads "higher than that number". Above-scale points are drawn at no Y that would imply a reading.

No weather value is invented or clipped, and no meteorological reclassification happens in the browser — this is presentation state only, matching the issue's own acceptance criterion. Per the issue thread, above-scale is deliberately **not** folded into #393's `data_state`: the data is complete and known, only the axis can't show it.

Contained to `web/ts/visualization/route-graph/{metrics,renderer,interaction,axes}.ts`. iOS carries no ceiling metric in `RouteGraphMetrics.swift` (7 metrics, none of them ceiling), so there is no hand-copied cap to keep in sync.

## Issue linkage

Addresses #384

<sub>#384 was filed by an outside reporter, so this uses the deferred-close keyword rather than `Closes` — and the commit body carries the same keyword so a rebase-merge can't auto-close it early.</sub>

## Testing / verification

- **Two existing tests asserted the bug** (`returns null when AGL exceeds 5000 ft cap`, with the comment *"Ceiling well above the route → not interesting for plotting"*). They were enshrining it and now assert the true AGL instead.
- Added three-state coverage for both ceiling metrics at **exactly-cap (5000)**, **above-cap (5001)** and **missing (null)**, plus the tooltip strings.
- New `route-graph-axes.test.ts` covers the degenerate-axis case directly: all-points-above-cap and no-data-at-all both hold the 0–5000 range, and ordinary metrics still expand past a suggested range as before.
- Full web suite: **601 passed (37 files)**. `tsc --noEmit` clean for the touched files (two pre-existing errors remain in `ts/eval/label-panel.ts`, confirmed present on a stashed tree). `npm run build` succeeds.
- The canvas path itself isn't unit-testable (vitest runs `environment: 'node'`), so I drove the real `RouteGraphRenderer` through a recording 2D context out-of-tree, with points at 1,200 / 8,000 / null / 3,000 ft AGL: exactly **one** chevron, at the x of the above-cap point, the `null` point correctly still a gap, and the two in-range dots landing on a pinned 0–5000 axis.
- Not verified in a running browser — no venv/`.env` in this environment to serve a real briefing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ti5tyjneaXrF8jbkqooc27)_