### PR TITLE
fix(verification,profile): convert the last two MSL ceiling reads to AGL

### DIFF
--- a/designs/metar-taf-accuracy.md
+++ b/designs/metar-taf-accuracy.md
@@ -557,6 +557,17 @@ def compute_verification_score(
     )
 ```
 
+**Ceiling datum.** Every ceiling that meets a METAR ceiling in a delta is first
+converted to **AGL**, because the METAR side always is. `model_ceiling` gets
+this from `reconcile_ceiling(..., field_elevation_ft=…, model=…)`; the extra
+`cloud_base_delta_ft` on the standalone path converts `cloud_base_ft` with the
+same `to_agl_ceiling` + `_nwp_ceiling_is_agl` helpers before differencing.
+`lcl_delta_ft` is the exception that looks like a bug: `lcl_ft` is the Espy
+surface approximation, a height above the *station*, so it is already AGL and
+must not have field elevation subtracted. Field elevations come from
+`get_airport_elevations`; when the lookup fails, scoring degrades to the legacy
+datum-naive deltas rather than failing the cycle. (#441 finding #3)
+
 ### TAF → METAR Comparison
 
 TAF fields are already parsed and stored in `verification_observations`. The TAF-derived flight category uses the same `classify_flight_category()` as advisories.

--- a/src/weatherbrief/api/airport_profile.py
+++ b/src/weatherbrief/api/airport_profile.py
@@ -268,13 +268,23 @@ def _surface_from_cache(
     icao: str,
     model: str,
     hours: list[datetime],
+    field_elevation_ft: float | None = None,
 ) -> list[dict[str, Any]]:
     """Read surface fields from airport_forecast_snapshots for each hour.
 
     Picks the most recent snapshot per (icao, model, forecast_hour). Hours
     with no data simply don't appear in the result; the frontend treats
     those as gaps.
+
+    ``ceiling_ft`` is emitted on the AGL datum when ``field_elevation_ft`` is
+    given, matching every other ceiling surface (map, alternates, advisories)
+    and the AGL METAR ceilings the chart plots alongside it. Without an
+    elevation the legacy datum-naive value is returned. (#441 #3)
     """
+    from weatherbrief.analysis.airport_conditions import (
+        _nwp_ceiling_is_agl,
+        to_agl_ceiling,
+    )
     from weatherbrief.db.models import AirportForecastSnapshotRow
 
     if not hours:
@@ -305,11 +315,26 @@ def _surface_from_cache(
         if fh not in by_hour:
             by_hour[fh] = r
 
+    # The NWP ceiling follows the model's datum (AGL for ECMWF, MSL otherwise);
+    # the sounding ceiling is geopotential-height MSL for every model.
+    nwp_is_agl = _nwp_ceiling_is_agl(model)
+
     result: list[dict[str, Any]] = []
     for h in hours:
         row = by_hour.get(h)
         if row is None:
             continue
+        # Explicit None-check rather than `or` — a NWP ceiling of 0 (literal
+        # ground-level fog: rare but valid for severe LIFR) would silently
+        # fall through to the sounding ceiling otherwise.
+        if row.nwp_ceiling_ft is not None:
+            ceiling_ft = to_agl_ceiling(
+                row.nwp_ceiling_ft, field_elevation_ft, source_is_agl=nwp_is_agl,
+            )
+        else:
+            ceiling_ft = to_agl_ceiling(
+                row.sounding_ceiling_ft, field_elevation_ft, source_is_agl=False,
+            )
         result.append({
             "time": _iso_utc(h),
             "temperature_2m_c": row.temperature_2m_c,
@@ -323,13 +348,7 @@ def _surface_from_cache(
             "cape_jkg": row.cape_jkg,
             "cloud_cover_pct": row.cloud_cover_pct,
             "cloud_cover_low_pct": row.cloud_cover_low_pct,
-            # Explicit None-check rather than `or` — a NWP ceiling of 0
-            # (literal ground-level fog: rare but valid for severe LIFR)
-            # would silently fall through to the sounding ceiling otherwise.
-            "ceiling_ft": (
-                row.nwp_ceiling_ft if row.nwp_ceiling_ft is not None
-                else row.sounding_ceiling_ft
-            ),
+            "ceiling_ft": ceiling_ft,
             "freezing_level_ft": row.freezing_level_ft,
         })
     return result
@@ -589,7 +608,7 @@ async def get_airport_profile(
     # Snapshot surface from cache before opening the long-lived stream so
     # any DB error surfaces as a normal HTTP error (cleaner UX than an
     # SSE error mid-stream).
-    surface = _surface_from_cache(db, icao, model, hours)
+    surface = _surface_from_cache(db, icao, model, hours, field_elevation_ft=elevation_ft)
 
     # Acquire the per-user / global concurrency slot before opening the
     # stream. Released in the generator's finally block. Done synchronously

--- a/src/weatherbrief/tasks/standalone_verification.py
+++ b/src/weatherbrief/tasks/standalone_verification.py
@@ -1292,6 +1292,10 @@ def _score_cycle(
     Returns number of scores created.
     """
     from weatherbrief.airports import get_airport_elevations, get_runway_ends
+    from weatherbrief.analysis.airport_conditions import (
+        _nwp_ceiling_is_agl,
+        to_agl_ceiling,
+    )
     from weatherbrief.tasks.scoring import _score_model_vs_metar, _score_taf_vs_metar
 
     # Fetch all snapshots that predict within ±90 min of cycle_time
@@ -1423,12 +1427,23 @@ def _score_cycle(
         )
 
         if score_row is not None:
-            # Add cloud_base and LCL deltas
+            # Add cloud_base and LCL deltas, both against the AGL METAR ceiling.
+            # cloud_base_ft carries the model's datum — MSL for GFS/ICON/HRRR,
+            # AGL for ECMWF — so it is converted first; lcl_ft is the Espy
+            # surface approximation, a height above the station and therefore
+            # already AGL, so it differences directly. (#441 #3)
             if obs.ceiling_ft is not None:
+                obs_ceiling_ft = float(obs.ceiling_ft)
                 if snap.cloud_base_ft is not None:
-                    score_row.cloud_base_delta_ft = snap.cloud_base_ft - float(obs.ceiling_ft)
+                    cloud_base_agl = to_agl_ceiling(
+                        snap.cloud_base_ft,
+                        elev_map.get(snap.icao),
+                        source_is_agl=_nwp_ceiling_is_agl(snap.model),
+                    )
+                    if cloud_base_agl is not None:
+                        score_row.cloud_base_delta_ft = cloud_base_agl - obs_ceiling_ft
                 if snap.lcl_ft is not None:
-                    score_row.lcl_delta_ft = snap.lcl_ft - float(obs.ceiling_ft)
+                    score_row.lcl_delta_ft = snap.lcl_ft - obs_ceiling_ft
             db.add(score_row)
             existing_score_keys.add(score_key)
             scores_created += 1

--- a/tests/test_airport_profile.py
+++ b/tests/test_airport_profile.py
@@ -371,3 +371,78 @@ class TestGribRunDedup:
             ["a:enter", "a:exit", "b:enter", "b:exit"],
             ["b:enter", "b:exit", "a:enter", "a:exit"],
         )
+
+
+class TestSurfaceCeilingDatum:
+    """``_surface_from_cache`` emits ceilings on the AGL datum. (#441 #3)
+
+    The chart plots this series against AGL METAR ceilings, and every other
+    ceiling surface (map, alternates, advisories) already converts — this was
+    the last datum-naive read.
+    """
+
+    @staticmethod
+    def _insert(db_session, **overrides):
+        from weatherbrief.db.models import AirportForecastSnapshotRow
+
+        hour = datetime(2026, 5, 7, 12, 0, tzinfo=timezone.utc)
+        defaults = dict(
+            icao="LSGS", region="eu", model="gfs",
+            model_init_time=datetime(2026, 5, 7, 6, 0, tzinfo=timezone.utc),
+            forecast_hour=hour,
+            fetched_at=hour,
+            nwp_ceiling_ft=4000.0,
+            sounding_ceiling_ft=5000.0,
+        )
+        defaults.update(overrides)
+        db_session.add(AirportForecastSnapshotRow(**defaults))
+        db_session.flush()
+        return hour
+
+    def test_msl_model_ceiling_converted_to_agl(self, db_session):
+        from weatherbrief.api.airport_profile import _surface_from_cache
+
+        hour = self._insert(db_session, model="gfs")
+        rows = _surface_from_cache(
+            db_session, "LSGS", "gfs", [hour], field_elevation_ft=1500.0,
+        )
+        assert rows[0]["ceiling_ft"] == pytest.approx(2500.0)  # 4000 MSL - 1500
+
+    def test_ecmwf_ceiling_already_agl_passes_through(self, db_session):
+        from weatherbrief.api.airport_profile import _surface_from_cache
+
+        hour = self._insert(db_session, model="ecmwf")
+        rows = _surface_from_cache(
+            db_session, "LSGS", "ecmwf", [hour], field_elevation_ft=1500.0,
+        )
+        assert rows[0]["ceiling_ft"] == pytest.approx(4000.0)
+
+    def test_sounding_fallback_is_always_msl(self, db_session):
+        """The sounding ceiling is geopotential-height MSL for every model —
+        including ECMWF, whose *NWP* ceiling is AGL."""
+        from weatherbrief.api.airport_profile import _surface_from_cache
+
+        hour = self._insert(db_session, model="ecmwf", nwp_ceiling_ft=None)
+        rows = _surface_from_cache(
+            db_session, "LSGS", "ecmwf", [hour], field_elevation_ft=1500.0,
+        )
+        assert rows[0]["ceiling_ft"] == pytest.approx(3500.0)  # 5000 MSL - 1500
+
+    def test_zero_nwp_ceiling_does_not_fall_through_to_sounding(self, db_session):
+        """A literal 0 ft ceiling (ground-level fog) is a real value, not a
+        missing one — the None-check must survive the AGL conversion."""
+        from weatherbrief.api.airport_profile import _surface_from_cache
+
+        hour = self._insert(db_session, model="gfs", nwp_ceiling_ft=0.0)
+        rows = _surface_from_cache(
+            db_session, "LSGS", "gfs", [hour], field_elevation_ft=1500.0,
+        )
+        # 0 MSL clamps to 0 AGL; it must NOT become 5000-1500 from the sounding.
+        assert rows[0]["ceiling_ft"] == pytest.approx(0.0)
+
+    def test_without_elevation_stays_datum_naive(self, db_session):
+        from weatherbrief.api.airport_profile import _surface_from_cache
+
+        hour = self._insert(db_session, model="gfs")
+        rows = _surface_from_cache(db_session, "LSGS", "gfs", [hour])
+        assert rows[0]["ceiling_ft"] == pytest.approx(4000.0)

--- a/tests/test_standalone_verification.py
+++ b/tests/test_standalone_verification.py
@@ -422,8 +422,42 @@ class TestScoreCycle:
         _score_cycle(NOW, [], "/fake/db", db_session)
 
         row = db_session.execute(select(VerificationScoreRow)).scalar_one()
+        # No elevation available (the fake db path fails the lookup) — legacy
+        # datum-naive deltas.
         assert row.cloud_base_delta_ft == pytest.approx(-200.0)  # 2800 - 3000
         assert row.lcl_delta_ft == pytest.approx(-1000.0)  # 2000 - 3000
+
+    @patch("weatherbrief.airports.get_airport_elevations", return_value={"LFPG": 1500.0})
+    @patch("weatherbrief.airports.get_runway_ends", return_value={})
+    def test_cloud_base_delta_converts_msl_model_to_agl(self, mock_rwy, mock_elev, db_session):
+        """GFS cloud_base_ft is MSL; the METAR ceiling is AGL. (#441 #3)"""
+        _insert_snapshot(db_session, model="gfs", cloud_base_ft=2800.0, lcl_ft=2000.0)
+        _insert_observation(db_session, ceiling_ft=3000)
+
+        _score_cycle(NOW, [], "/fake/db", db_session)
+
+        row = db_session.execute(select(VerificationScoreRow)).scalar_one()
+        # 2800 MSL - 1500 field = 1300 AGL, against a 3000 AGL METAR ceiling.
+        assert row.cloud_base_delta_ft == pytest.approx(-1700.0)
+        # lcl_ft is the Espy surface approximation — already AGL, so the field
+        # elevation must NOT be subtracted a second time.
+        assert row.lcl_delta_ft == pytest.approx(-1000.0)
+
+    @patch("weatherbrief.airports.get_airport_elevations", return_value={"LFPG": 1500.0})
+    @patch("weatherbrief.airports.get_runway_ends", return_value={})
+    def test_cloud_base_delta_leaves_ecmwf_agl_alone(self, mock_rwy, mock_elev, db_session):
+        """ECMWF cloud base is already AGL — it passes through unconverted."""
+        _insert_snapshot(
+            db_session, model="ecmwf", model_init_time=GFS_INIT,
+            cloud_base_ft=2800.0, lcl_ft=2000.0,
+        )
+        _insert_observation(db_session, ceiling_ft=3000)
+
+        _score_cycle(NOW, [], "/fake/db", db_session)
+
+        row = db_session.execute(select(VerificationScoreRow)).scalar_one()
+        assert row.cloud_base_delta_ft == pytest.approx(-200.0)  # 2800 - 3000
+        assert row.lcl_delta_ft == pytest.approx(-1000.0)
 
     @patch("weatherbrief.airports.get_runway_ends", return_value={})
     def test_multiple_models_scored_independently(self, mock_rwy, db_session):

--- a/web/ts/adapters/airport-profile-adapter.ts
+++ b/web/ts/adapters/airport-profile-adapter.ts
@@ -408,7 +408,15 @@ function synthesizeVizPoint(
     capeSurfaceJkg: indices?.cape_surface_jkg ?? surface?.cape_jkg ?? 0,
     worstModelAgreement: 'good',
     nwpCloudDiag: null,
-    soundingCeilingFt: indices?.sounding_ceiling_ft ?? surface?.ceiling_ft ?? null,
+    // MSL only — `VizPoint.soundingCeilingFt` is declared ft MSL and the one
+    // consumer (`ceiling-dd`) subtracts terrain to get AGL. The old
+    // `?? surface?.ceiling_ft` fallback used to be MSL-ish, but the profile
+    // endpoint now serves that field already converted to AGL, so keeping it
+    // would make this one field two different datums depending on which branch
+    // fired — and double-subtract elevation if the profile view ever wires up
+    // the route graph. The profile's AGL ceiling stays in `surface.ceiling_ft`
+    // for anything that wants it.
+    soundingCeilingFt: indices?.sounding_ceiling_ft ?? null,
     terrainElevationFt: elevationFt,
     temperatureC: surface?.temperature_2m_c ?? null,
     // Single-airport profile has no elected cruise level, so ISA deviation /


### PR DESCRIPTION
## What & why

The #441 finding-#3 datum sweep (delivered in #444) converted the airport panel, verification scoring, forecast map and route alternates to a common AGL datum — but two reads of the same raw MSL ceiling fields were left behind. Both are fixed here, which closes out the datum class properly.

**1. `_score_cycle` — `cloud_base_delta_ft` was elevation-biased**

`snap.cloud_base_ft` carries the model's datum (MSL for GFS/ICON/HRRR, AGL for ECMWF) and was differenced directly against the AGL METAR ceiling, so the stored delta was off by the field elevation at elevated airports. It now converts through the shared `to_agl_ceiling` + `_nwp_ceiling_is_agl` helpers, reusing the `elev_map` that #444 already loads a few lines up in the same function — no extra lookup or query.

`lcl_delta_ft` on the next line is deliberately left alone: `lcl_ft` is the Espy surface approximation (`_LCL_CONSTANT_FT * (T2m - Td2m)`), a height above the *station*, so it is already AGL and must not have field elevation subtracted a second time. A test pins that asymmetry so it doesn't read as an oversight later.

**2. Airport-profile chart — MSL ceilings plotted against AGL METARs**

`_surface_from_cache` emitted raw `nwp_ceiling_ft` / `sounding_ceiling_ft` for display. It now takes the field elevation the endpoint already resolves via `_resolve_airport_coords` and converts per source: the NWP ceiling on the model's datum, the sounding ceiling always MSL (it's geopotential height for every model, including ECMWF, whose *NWP* ceiling is the AGL one).

Both call sites degrade to the previous datum-naive value when no elevation is available, matching the convention `to_agl_ceiling` already established elsewhere.

**Scope note — item 2 of the issue is intentionally not here.** The issue also proposed reusing `_bilinear_grid_weights` in the scalar/surface decode paths (`decode_cloud_diag_per_point`, `decode_ecmwf_surface_per_point`). That is pure perf with a numerical-equivalence bar, it runs in `decode_worker` subprocesses off the request path, and those paths have churned substantially since the issue was filed (NCEP pressure-band carving, native cover provenance, dual microphysics). Dropped rather than deferred — worth reopening as its own issue only if decode latency shows up in profiling.

## Issue linkage

Closes #445

## Testing / verification

New tests:

- `test_cloud_base_delta_converts_msl_model_to_agl` — GFS cloud base 2800 MSL at a 1500 ft field vs a 3000 ft AGL METAR ceiling gives -1700, not -200; asserts in the same test that `lcl_delta_ft` is unchanged at -1000.
- `test_cloud_base_delta_leaves_ecmwf_agl_alone` — ECMWF cloud base passes through unconverted.
- `TestSurfaceCeilingDatum` (5 cases) — MSL→AGL conversion, ECMWF pass-through, the sounding fallback always being MSL, a literal 0 ft ceiling still not falling through to the sounding fallback, and the no-elevation legacy path.

The pre-existing `test_cloud_base_and_lcl_deltas` still passes unchanged (its fake DB path fails the elevation lookup, exercising the datum-naive fallback) and now carries a comment saying so.

Full suite: 4753 tests, all pass except `tests/test_auth.py::TestLoginRedirect::test_google_login_redirects`, which fails identically on a clean checkout of this branch's base (no Google OAuth config in the sandbox) — verified by stashing the diff and re-running.

Both changes shift stored/displayed metrics. `cloud_base_delta_ft` / `lcl_delta_ft` currently have no reader — no endpoint, no rollup, no UI (the `cloud_base_mae_ft` aggregate is still future work in `designs/future/standalone-verification-plan.md`) — so the change affects newly-written score rows only; existing rows keep their datum-naive values. The profile chart is user-visible and will show lower ceilings at elevated airports, which is the point.

---
_Generated by [Claude Code](https://claude.ai/code/session_0145eeuL4oEXGXbE4mWjGWNh)_