### PR TITLE
MySQL usage optimization: correctness fixes, index hygiene, session lifetime, query shape

### DIFF
--- a/alembic/versions/085_mysql_review_fixes.py
+++ b/alembic/versions/085_mysql_review_fixes.py
@@ -30,12 +30,19 @@ Tier-1 item 4, Tier-2 items 5-7):
   indexed and duplicate-identity races impossible. A pre-check refuses with a
   clear error if duplicates exist (expected zero; they would need a manual
   account-merge decision, never a silent dedupe).
-* **Drop 15 redundant indexes** — 13 leftmost-prefix duplicates of wider
-  UNIQUE keys, the non-unique ``oauth_refresh_tokens.token_hash`` duplicate,
-  and ``ix_afs_hour_model`` (081's documented follow-up). Never dropped:
-  ``ix_verif_scores_lead`` / ``ix_verif_scores_model`` (need
-  ``sys.schema_unused_indexes`` evidence) and the FORCE-INDEXed
-  ``ix_verif_scores_source_time``.
+* **Drop 14 redundant indexes** — 13 leftmost-prefix duplicates of wider
+  UNIQUE keys and the non-unique ``oauth_refresh_tokens.token_hash``
+  duplicate. Never dropped: ``ix_verif_scores_lead`` /
+  ``ix_verif_scores_model`` (need ``sys.schema_unused_indexes`` evidence),
+  the FORCE-INDEXed ``ix_verif_scores_source_time``, and
+  ``ix_afs_hour_model`` — dropping that one was considered (081's documented
+  follow-up assumed region-aware serving) and rejected: the map path still
+  filters bare ``forecast_hour`` with no region predicate
+  (``api/maps.py:118-129`` availability scan,
+  ``tasks/map_queries.py:262-266`` per-model init-time probe,
+  ``tasks/cache_builder.py:275-279`` rebuild probe), so the region-leading
+  ``ix_afs_region_hour_model`` cannot serve those queries and the drop would
+  restore full/per-model scans on the hot map path.
 * **Money → DECIMAL** — ``cost_ledger.cost`` and
   ``donation_ledger.amount/amount_usd/net_usd`` to ``DECIMAL(12,4)``,
   ``donation_ledger.fx_rate`` to ``DECIMAL(12,6)``.
@@ -144,11 +151,18 @@ _NEW_INDEXES = [
     ("users", "uq_users_provider_sub", ["provider", "provider_sub"], True),
 ]
 
-# Spec Tier-2 item 5, verbatim: the 13 leftmost-prefix duplicates plus
-# ix_afs_hour_model (081's follow-up). Columns are kept on each row so the
-# downgrade can recreate them. The 15th drop — the non-unique duplicate on
-# oauth_refresh_tokens.token_hash — is handled separately in upgrade()
-# because its guard is uniqueness-aware.
+# Spec Tier-2 item 5: the 13 leftmost-prefix duplicates. Columns are kept on
+# each row so the downgrade can recreate them. The 14th drop — the non-unique
+# duplicate on oauth_refresh_tokens.token_hash — is handled separately in
+# upgrade() because its guard is uniqueness-aware.
+#
+# ix_afs_hour_model is deliberately NOT in this list: the spec's premise for
+# dropping it (081's "drop once serving filters by region" follow-up) is
+# unmet — the map path still filters bare forecast_hour with no region
+# predicate (api/maps.py:118-129, tasks/map_queries.py:262-266,
+# tasks/cache_builder.py:275-279), and the region-leading
+# ix_afs_region_hour_model needs a region predicate to be usable. Dropping it
+# would restore the full/per-model table scans migration 077 fixed (#415).
 _REDUNDANT_INDEXES = [
     ("verification_observations", "ix_verif_obs_icao", ["icao"]),
     ("verification_scores", "ix_verif_scores_icao", ["icao"]),
@@ -167,7 +181,6 @@ _REDUNDANT_INDEXES = [
     ("analytics_event_daily", "ix_aed_day", ["day"]),
     ("analytics_briefing_feature_daily", "ix_abfd_day", ["day"]),
     ("analytics_xsection_config_daily", "ix_axcd_day", ["day"]),
-    ("airport_forecast_snapshots", "ix_afs_hour_model", ["forecast_hour", "model"]),
 ]
 
 # Spec Tier-2 item 7: (table, column, target type, nullable).
@@ -231,11 +244,13 @@ def upgrade() -> None:
     for table, name, columns, unique in _NEW_INDEXES:
         _create_index_if_absent(name, table, columns, unique=unique)
 
-    # --- Drop the 15 redundant indexes (spec Tier-2 item 5) ---
+    # --- Drop the 14 redundant indexes (spec Tier-2 item 5) ---
     # Leftmost-prefix duplicates of wider UNIQUE keys; DROP INDEX is
     # metadata-only on MySQL 8. Kept: ix_verif_scores_lead / _model (awaiting
-    # sys.schema_unused_indexes evidence) and FORCE-INDEXed
-    # ix_verif_scores_source_time.
+    # sys.schema_unused_indexes evidence), FORCE-INDEXed
+    # ix_verif_scores_source_time, and ix_afs_hour_model (drop considered and
+    # rejected — the map path still filters bare forecast_hour, see the note
+    # above _REDUNDANT_INDEXES).
     for table, name, _columns in _REDUNDANT_INDEXES:
         _drop_index_if_present(table, name)
     # oauth_refresh_tokens.token_hash: migration 041 declared the column

--- a/alembic/versions/085_mysql_review_fixes.py
+++ b/alembic/versions/085_mysql_review_fixes.py
@@ -1,0 +1,73 @@
+"""Dedupe briefing_packs and enforce UNIQUE (flight_id, fetch_timestamp).
+
+``save_pack_meta`` inserted unconditionally while the readers
+(``load_pack_meta`` / ``update_pack_meta``) use ``scalar_one_or_none()`` — so
+a single duplicate ``(flight_id, fetch_timestamp)`` pair, left behind e.g. by
+two concurrent refreshes racing the provisional-pack insert, makes every
+subsequent read of that pack raise (HTTP 500). This migration first deletes
+all but the newest row (``MAX(id)``) of each duplicated pair, then adds the
+unique index that turns the race into a constraint violation the save path
+can catch and convert into an update (see the ``begin_nested`` guard in
+``storage/flights.py``).
+
+The dedupe is deliberately standard SQL — no MySQL-only JOIN-delete — so the
+same revision runs on SQLite (dev/tests) and MySQL (prod). The keep-set is
+double-nested in a derived table because MySQL refuses a DELETE whose
+subquery reads the target table directly (error 1093); the derived table
+forces the keep-set to materialize first. Singletons are their own
+``MAX(id)``, so they are retained by construction.
+
+Revision ID: 085
+Revises: 084
+Create Date: 2026-08-01
+"""
+from __future__ import annotations
+
+import logging
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "085"
+down_revision: Union[str, None] = "084"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+logger = logging.getLogger(__name__)
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    duplicate_rows = bind.execute(
+        sa.text(
+            "SELECT COALESCE(SUM(cnt - 1), 0) FROM ("
+            "SELECT COUNT(*) AS cnt FROM briefing_packs "
+            "GROUP BY flight_id, fetch_timestamp) d"
+        )
+    ).scalar_one()
+    if duplicate_rows:
+        logger.warning(
+            "briefing_packs: deleting %d duplicate "
+            "(flight_id, fetch_timestamp) row(s), keeping MAX(id) per pair",
+            duplicate_rows,
+        )
+    op.execute(
+        sa.text(
+            "DELETE FROM briefing_packs WHERE id NOT IN ("
+            "SELECT keep_id FROM ("
+            "SELECT MAX(id) AS keep_id FROM briefing_packs "
+            "GROUP BY flight_id, fetch_timestamp"
+            ") keep_ids)"
+        )
+    )
+    op.create_index(
+        "uq_briefing_packs_flight_ts",
+        "briefing_packs",
+        ["flight_id", "fetch_timestamp"],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("uq_briefing_packs_flight_ts", table_name="briefing_packs")

--- a/alembic/versions/085_mysql_review_fixes.py
+++ b/alembic/versions/085_mysql_review_fixes.py
@@ -17,6 +17,35 @@ subquery reads the target table directly (error 1093); the derived table
 forces the keep-set to materialize first. Singletons are their own
 ``MAX(id)``, so they are retained by construction.
 
+The rest of the mysql-review schema hygiene rides in the same revision
+(``docs/superpowers/specs/2026-07-31-mysql-optimization-design.md`` —
+Tier-1 item 4, Tier-2 items 5-7):
+
+* **Missing indexes**: ``ix_briefing_usage_timestamp``,
+  ``ix_cost_ledger_service_created (service, created_at)``,
+  ``ix_verif_scores_obs_time (observation_time)``,
+  ``ix_taf_verif_obs_time (observation_time)`` — audited hot/range paths,
+  retention DELETEs for the last two.
+* **users (provider, provider_sub) UNIQUE** — the OAuth login lookup becomes
+  indexed and duplicate-identity races impossible. A pre-check refuses with a
+  clear error if duplicates exist (expected zero; they would need a manual
+  account-merge decision, never a silent dedupe).
+* **Drop 15 redundant indexes** — 13 leftmost-prefix duplicates of wider
+  UNIQUE keys, the non-unique ``oauth_refresh_tokens.token_hash`` duplicate,
+  and ``ix_afs_hour_model`` (081's documented follow-up). Never dropped:
+  ``ix_verif_scores_lead`` / ``ix_verif_scores_model`` (need
+  ``sys.schema_unused_indexes`` evidence) and the FORCE-INDEXed
+  ``ix_verif_scores_source_time``.
+* **Money → DECIMAL** — ``cost_ledger.cost`` and
+  ``donation_ledger.amount/amount_usd/net_usd`` to ``DECIMAL(12,4)``,
+  ``donation_ledger.fx_rate`` to ``DECIMAL(12,6)``.
+
+Every create/drop is existence-guarded (``_index_exists``) so the revision
+runs on MySQL (prod) and SQLite (dev/tests) and is safe to re-run. The
+``users``/``cost_ledger``/``donation_ledger``/``oauth_refresh_tokens`` ORM
+models live in flyfun_common and stay untouched — their dev ``create_all``
+output keeps the pre-085 shape; this migration governs prod.
+
 Revision ID: 085
 Revises: 084
 Create Date: 2026-08-01
@@ -35,6 +64,120 @@ branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
 logger = logging.getLogger(__name__)
+
+
+def _index_exists(table: str, name: str) -> bool:
+    """Dialect-portable index-existence check.
+
+    MySQL answers via ``information_schema.STATISTICS``, SQLite via
+    ``PRAGMA index_list`` — the two dialects this project runs on. Table
+    names are fixed constants from this file, so the PRAGMA f-string is safe.
+    """
+    bind = op.get_bind()
+    if bind.dialect.name == "mysql":
+        return bool(
+            bind.execute(
+                sa.text(
+                    "SELECT COUNT(*) FROM information_schema.STATISTICS "
+                    "WHERE TABLE_SCHEMA = DATABASE() "
+                    "AND TABLE_NAME = :table AND INDEX_NAME = :name"
+                ),
+                {"table": table, "name": name},
+            ).scalar_one()
+        )
+    rows = bind.execute(sa.text(f"PRAGMA index_list({table})")).fetchall()
+    return any(row[1] == name for row in rows)
+
+
+def _index_is_unique(table: str, name: str) -> bool:
+    """Whether an existing index enforces uniqueness (same dialect split)."""
+    bind = op.get_bind()
+    if bind.dialect.name == "mysql":
+        return bool(
+            bind.execute(
+                sa.text(
+                    "SELECT COUNT(*) FROM information_schema.STATISTICS "
+                    "WHERE TABLE_SCHEMA = DATABASE() "
+                    "AND TABLE_NAME = :table AND INDEX_NAME = :name "
+                    "AND NON_UNIQUE = 0"
+                ),
+                {"table": table, "name": name},
+            ).scalar_one()
+        )
+    rows = bind.execute(sa.text(f"PRAGMA index_list({table})")).fetchall()
+    return any(row[1] == name and row[2] for row in rows)
+
+
+def _create_index_if_absent(
+    name: str, table: str, columns: list[str], unique: bool = False
+) -> None:
+    if not _index_exists(table, name):
+        op.create_index(name, table, columns, unique=unique)
+
+
+def _drop_index_if_present(table: str, name: str) -> None:
+    if _index_exists(table, name):
+        op.drop_index(name, table_name=table)
+
+
+# Spec Tier-1 item 4 + Tier-2 item 6: (table, index, columns, unique).
+_NEW_INDEXES = [
+    ("briefing_usage", "ix_briefing_usage_timestamp", ["timestamp"], False),
+    (
+        "cost_ledger",
+        "ix_cost_ledger_service_created",
+        ["service", "created_at"],
+        False,
+    ),
+    (
+        "verification_scores",
+        "ix_verif_scores_obs_time",
+        ["observation_time"],
+        False,
+    ),
+    (
+        "taf_verification_scores",
+        "ix_taf_verif_obs_time",
+        ["observation_time"],
+        False,
+    ),
+    ("users", "uq_users_provider_sub", ["provider", "provider_sub"], True),
+]
+
+# Spec Tier-2 item 5, verbatim: the 13 leftmost-prefix duplicates plus
+# ix_afs_hour_model (081's follow-up). Columns are kept on each row so the
+# downgrade can recreate them. The 15th drop — the non-unique duplicate on
+# oauth_refresh_tokens.token_hash — is handled separately in upgrade()
+# because its guard is uniqueness-aware.
+_REDUNDANT_INDEXES = [
+    ("verification_observations", "ix_verif_obs_icao", ["icao"]),
+    ("verification_scores", "ix_verif_scores_icao", ["icao"]),
+    ("taf_verification_scores", "ix_taf_verif_icao", ["icao"]),
+    ("flight_verification_map", "ix_fvm_flight", ["flight_id"]),
+    ("flight_subscriptions", "ix_flight_subs_flight", ["flight_id"]),
+    ("flight_briefing_seen", "ix_flight_seen_user", ["user_id"]),
+    ("verification_monthly_stats", "ix_vms_month", ["month"]),
+    (
+        "verification_daily_stats",
+        "ix_vds_date_model",
+        ["date", "source", "model", "days_out"],
+    ),
+    ("airport_monthly_summary", "ix_ams_month", ["month"]),
+    ("airport_daily_summary", "ix_ads_date", ["date"]),
+    ("analytics_event_daily", "ix_aed_day", ["day"]),
+    ("analytics_briefing_feature_daily", "ix_abfd_day", ["day"]),
+    ("analytics_xsection_config_daily", "ix_axcd_day", ["day"]),
+    ("airport_forecast_snapshots", "ix_afs_hour_model", ["forecast_hour", "model"]),
+]
+
+# Spec Tier-2 item 7: (table, column, target type, nullable).
+_MONEY_COLUMNS = [
+    ("cost_ledger", "cost", sa.DECIMAL(12, 4), False),
+    ("donation_ledger", "amount", sa.DECIMAL(12, 4), False),
+    ("donation_ledger", "amount_usd", sa.DECIMAL(12, 4), False),
+    ("donation_ledger", "net_usd", sa.DECIMAL(12, 4), True),
+    ("donation_ledger", "fx_rate", sa.DECIMAL(12, 6), False),
+]
 
 
 def upgrade() -> None:
@@ -61,13 +204,98 @@ def upgrade() -> None:
             ") keep_ids)"
         )
     )
-    op.create_index(
+    _create_index_if_absent(
         "uq_briefing_packs_flight_ts",
         "briefing_packs",
         ["flight_id", "fetch_timestamp"],
         unique=True,
     )
 
+    # --- users (provider, provider_sub) UNIQUE (spec Tier-2 item 6) ---
+    # Duplicates would mean two accounts sharing one external identity — a
+    # manual account-merge decision, never something a migration resolves
+    # silently. Expected zero: refuse loudly otherwise.
+    duplicate_identities = bind.execute(
+        sa.text(
+            "SELECT COUNT(*) FROM ("
+            "SELECT 1 FROM users GROUP BY provider, provider_sub "
+            "HAVING COUNT(*) > 1) d"
+        )
+    ).scalar_one()
+    if duplicate_identities:
+        raise RuntimeError(
+            f"users: {duplicate_identities} duplicate (provider, provider_sub) "
+            "identity pair(s) found — resolve them manually, then re-run; "
+            "refusing to create uq_users_provider_sub"
+        )
+    for table, name, columns, unique in _NEW_INDEXES:
+        _create_index_if_absent(name, table, columns, unique=unique)
+
+    # --- Drop the 15 redundant indexes (spec Tier-2 item 5) ---
+    # Leftmost-prefix duplicates of wider UNIQUE keys; DROP INDEX is
+    # metadata-only on MySQL 8. Kept: ix_verif_scores_lead / _model (awaiting
+    # sys.schema_unused_indexes evidence) and FORCE-INDEXed
+    # ix_verif_scores_source_time.
+    for table, name, _columns in _REDUNDANT_INDEXES:
+        _drop_index_if_present(table, name)
+    # oauth_refresh_tokens.token_hash: migration 041 declared the column
+    # ``unique=True, index=True``, which SQLAlchemy renders as ONE merged
+    # UNIQUE index (ix_oauth_refresh_tokens_token_hash). Prod MySQL carries
+    # an additional NON-UNIQUE index under that name next to the unique one —
+    # drop only that plain duplicate; where the index by this name IS the
+    # unique guard (SQLite dev/tests), keep it.
+    if _index_exists(
+        "oauth_refresh_tokens", "ix_oauth_refresh_tokens_token_hash"
+    ) and not _index_is_unique(
+        "oauth_refresh_tokens", "ix_oauth_refresh_tokens_token_hash"
+    ):
+        op.drop_index(
+            "ix_oauth_refresh_tokens_token_hash",
+            table_name="oauth_refresh_tokens",
+        )
+
+    # --- Money FLOAT → DECIMAL (spec Tier-2 item 7) ---
+    # One-way, lossy conversion: stored FLOAT values are rounded to the new
+    # scale (4 dp amounts, 6 dp fx_rate) as they convert; downgrading back to
+    # FLOAT cannot restore the original binary representation. The ORM
+    # mappings stay ``Float`` — they live in flyfun_common (external, not
+    # editable here) and read DECIMAL columns unchanged; the proper
+    # ``Numeric`` mapping is an upstream follow-up. Batch mode keeps SQLite
+    # (dev/tests) working; on MySQL batch_alter_table is plain ALTER TABLE.
+    for table, column, new_type, nullable in _MONEY_COLUMNS:
+        with op.batch_alter_table(table) as batch_op:
+            batch_op.alter_column(
+                column,
+                existing_type=sa.Float(),
+                type_=new_type,
+                existing_nullable=nullable,
+            )
+
 
 def downgrade() -> None:
+    # Money back to FLOAT — values already rounded by the upgrade do not
+    # recover their original precision (one-way conversion).
+    for table, column, decimal_type, nullable in _MONEY_COLUMNS:
+        with op.batch_alter_table(table) as batch_op:
+            batch_op.alter_column(
+                column,
+                existing_type=decimal_type,
+                type_=sa.Float(),
+                existing_nullable=nullable,
+            )
+
+    for table, name, columns in _REDUNDANT_INDEXES:
+        _create_index_if_absent(name, table, columns)
+    # The plain token_hash duplicate only ever existed on prod MySQL; where
+    # the name is taken by the UNIQUE index (SQLite), there is nothing to
+    # restore.
+    _create_index_if_absent(
+        "ix_oauth_refresh_tokens_token_hash",
+        "oauth_refresh_tokens",
+        ["token_hash"],
+    )
+
+    for table, name, _columns, _unique in _NEW_INDEXES:
+        _drop_index_if_present(table, name)
+
     op.drop_index("uq_briefing_packs_flight_ts", table_name="briefing_packs")

--- a/designs/data-models.md
+++ b/designs/data-models.md
@@ -372,6 +372,45 @@ See [advisories.md](./advisories.md) for the evaluator framework.
 - `at_time()` returns closest hour by absolute time difference — no interpolation
 - Pint units must not leak beyond `analysis/sounding/` subpackage — causes Pydantic serialization issues
 
+## FK Policy (DB schema)
+
+Audited 2026-08-01 (mysql-review branch, all 84 migrations): the schema is a deliberately mixed no-FK landscape. Every FK-shaped column below is a plain indexed column at the database level; the groups record *why*, so future migrations don't "fix" the intentional ones or keep ignoring the oversights. The mysql-review PR ships this policy plus `scripts/check_mysql_charset.py` — it does not add FKs (product decision per table).
+
+### Intentional no-FK — rows must survive deletion
+
+| Column | Rationale |
+|--------|-----------|
+| `cost_ledger.user_id` | Migration 020 explicitly dropped 019's CASCADE FK: ledger rows are retained for audit/reporting after account deletion. |
+| `donation_ledger.user_id` | Nullable, no FK by design (067): anonymous donors allowed; attributed donations must survive deletion of the donor's user row. |
+| `briefing_refresh_jobs.flight_id` | 082: the row must outlive the flight so boot-time reconciliation can distinguish "flight was deleted, don't resume" from "no record at all". (`user_id` does CASCADE.) |
+| `analytics_*` (all FK-shaped columns) | Snapshot semantics (054): dims capture flight/briefing state at event time, rollups are kept forever after retention deletes the raw events. FKs would make retention ordering cascade-dependent. |
+
+### Survive-deletion candidates — keep as-is pending product call
+
+Audit judgment: these have the same shape as the intentional set (history that arguably should outlive its parent), but no migration docstring records the decision. Left untouched; needs a product call, not a drive-by FK.
+
+| Column | Open question |
+|--------|---------------|
+| `feedback.flight_id` | `user_id` CASCADEs but `flight_id` doesn't (008/023): should triage history survive flight deletion? Current no-FK says yes, undocumented. |
+| `briefing_usage.flight_id` | Usage accounting per flight (002): deleting a flight leaves rows pointing at a dead id — fine for billing-style accounting, but unrecorded. |
+| `api_usage_log.user_id` / `flight_id` | Both nullable, no FK (042): pipeline-level API-call accounting. Account deletion leaves the dead `user_id` — same retention question as `cost_ledger`, opposite (undocumented) treatment. |
+
+### Oversight set — recommend FK or app-side cascade (future issue)
+
+Added in 041 (OAuth 2.1 for MCP) without FKs, and the account-deletion path never cleans them: `flyfun_common/auth/router.py` `delete_account` sweeps `UserPreferencesRow`, `ApiTokenRow`, `UserRow` (plus the app's `on_delete_user` callback) — it does not touch the oauth tables. Deleting a user today orphans their authorization codes and refresh tokens.
+
+| Column | Recommendation |
+|--------|----------------|
+| `oauth_authorization_codes.client_id` / `user_id` | FK with CASCADE (codes are short-lived, zero retention value) or extend the auth sweep. |
+| `oauth_refresh_tokens.client_id` / `user_id` | FK with CASCADE — a deleted user's refresh tokens must die with them; security issue, not just hygiene. |
+| `api_tokens.oauth_client_id` | FK → `oauth_clients` ON DELETE SET NULL, or an app-side revoke sweep on client deletion (tokens are already swept per-user, never per-client). |
+
+### Migration conventions
+
+- **Charset**: new tables declare `mysql_charset="utf8mb4"` explicitly. No table in the 84-migration history declares charset/collation/engine, so everything inherits server defaults while the code assumes utf8mb4 (the 191-char index caps exist for it). Existing prod tables are NOT rebuilt by the mysql-review PR — that needs prod verification plus a maintenance window; `scripts/check_mysql_charset.py` (exit 1 if any table is not InnoDB/utf8mb4-family) is the pre/post check.
+- **Index add/drop**: existence-guarded (`_index_exists`, see 085) so revisions run on MySQL and SQLite and are safe to re-run.
+- **Dedupe migrations**: keep the newest row (`MAX(id)`) per duplicate key and log per-table delete counts (see 085's `briefing_packs` dedupe).
+
 ## References
 
 - Waypoint resolution / route building: `airports.py` (`resolve_waypoints()`)

--- a/docs/superpowers/plans/2026-07-31-mysql-optimization.md
+++ b/docs/superpowers/plans/2026-07-31-mysql-optimization.md
@@ -1,0 +1,199 @@
+# MySQL usage optimization — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land the 12 approved MySQL fixes (correctness/outages, index hygiene, repo-level query/session improvements) from the audit-backed spec.
+
+**Architecture:** One Alembic migration (`085_mysql_review_fixes.py`) carrying all schema changes (unique constraints after dedupe, 4 missing indexes, 15 redundant drops, DECIMAL money), plus focused code changes: SSE/session scope fixes, a `latest_pack()` fast path, batch prefetch, and a deadlock-retry helper. Spec: `docs/superpowers/specs/2026-07-31-mysql-optimization-design.md`.
+
+**Tech Stack:** Python 3.12, SQLAlchemy 2 + PyMySQL, Alembic, FastAPI, pytest.
+
+## Global Constraints
+
+- Branch `mysql-review` at upstream/main `4abd5b49`; worktree `/home/qian/flyfun_weather/flyfun-weather-mysql`; tests via `./.venv/bin/python -m pytest <args> -q` from that root.
+- Migration head is `084`; new revision `085_mysql_review_fixes.py`, `down_revision = "084"` (030 is historically skipped — do not renumber anything).
+- Dedupe keeps the NEWEST `id` per `(flight_id, fetch_timestamp)` and logs counts; no silent data loss beyond exact-duplicate pack metadata rows.
+- Kept indexes (do NOT drop): `ix_verif_scores_lead`, `ix_verif_scores_model`, FORCE-INDEXed `ix_verif_scores_source_time`.
+- `CostLedgerRow`/`DonationRow` ORM models live in `flyfun_common` (external) — do NOT edit them; SQLAlchemy `Float` mappings read DECIMAL columns without change.
+- House rules: None≠0; no FK additions (documentation only); no reading other branches/worktrees; no network in unit tests; every session-scope change preserves notify-after-commit ordering.
+- The only allowed pre-existing test failure: `tests/test_auth.py::TestLoginRedirect::test_google_login_redirects`.
+
+---
+
+### Task 1: Migration 085 — briefing_packs unique + save race guard
+
+**Files:**
+- Create: `alembic/versions/085_mysql_review_fixes.py`
+- Modify: `src/weatherbrief/storage/flights.py` (`save_pack_meta`/`update_pack_meta`, ~lines 650-675)
+- Test: `tests/test_migration_085.py`, `tests/test_pack_meta_race.py`
+
+**Interfaces:**
+- Produces: revision `085` with `uq_briefing_packs_flight_ts (flight_id, fetch_timestamp)` UNIQUE; `save_pack_meta` becomes race-safe (IntegrityError → update path).
+- Consumes: `_meta_to_row`, `_apply_meta_to_row`, `_compute_pack_hmac` (existing helpers in storage/flights.py).
+
+Migration part A (upgrade): (1) dedupe — `DELETE bp FROM briefing_packs bp JOIN (SELECT flight_id, fetch_timestamp, MAX(id) keep_id FROM briefing_packs GROUP BY flight_id, fetch_timestamp HAVING COUNT(*) > 1) d ON bp.flight_id=d.flight_id AND bp.fetch_timestamp=d.fetch_timestamp AND bp.id != d.keep_id` executed via `op.execute`, with the duplicate count logged first; (2) `op.create_index("uq_briefing_packs_flight_ts", "briefing_packs", ["flight_id", "fetch_timestamp"], unique=True)`. Downgrade drops the index. The same file will host later tasks' ops — Task 1 creates the file with ONLY this op; Task 2 appends.
+
+`save_pack_meta` race guard (subscribe_flight precedent at flights.py:528-560):
+```python
+def save_pack_meta(session: Session, meta: BriefingPackMeta) -> None:
+    """Insert briefing pack metadata with integrity HMAC.
+
+    Race-safe against the (flight_id, fetch_timestamp) unique constraint:
+    a concurrent refresh inserting the same pack first flips this save to an
+    update of the existing row instead of poisoning the request transaction.
+    """
+    row = _meta_to_row(meta)
+    row.integrity_hmac = _compute_pack_hmac(row)
+    try:
+        with session.begin_nested():
+            session.add(row)
+            session.flush()
+    except IntegrityError:
+        if not update_pack_meta(session, meta):
+            raise
+```
+`begin_nested` (SAVEPOINT) contains the failure so the outer transaction survives; the fallback reuses `update_pack_meta`'s existing select+apply. Test: two `save_pack_meta` calls with the same `(flight_id, ts)` → second one updates, no raise, and `load_pack_meta` returns one row (SQLite enforces the unique constraint too — add the constraint to the ORM table args? The ORM `BriefingPackRow` model lives in `src/weatherbrief/db/models.py` — check and add the `UniqueConstraint` so dev `create_all` matches the migration; same for the Task-2 missing indexes' `__table_args__` where models live in-repo).
+
+- [ ] **Step 1:** failing tests (dedupe on a seeded duplicate pair via raw SQL against a temp SQLite DB upgraded to head; race test).
+- [ ] **Step 2:** run → FAIL.
+- [ ] **Step 3:** implement migration part A + race guard + ORM table args.
+- [ ] **Step 4:** run → PASS; `pytest tests/test_migration_085.py tests/test_pack_meta_race.py tests/test_storage_flights.py -q`.
+- [ ] **Step 5:** commit `feat(db): unique (flight_id, fetch_timestamp) on briefing_packs + race-safe save (#mysql-review)`.
+
+---
+
+### Task 2: Migration 085 — missing indexes, redundant drops, users unique, DECIMAL money
+
+**Files:**
+- Modify: `alembic/versions/085_mysql_review_fixes.py` (append to Task 1's file)
+- Modify: `src/weatherbrief/db/models.py` (in-repo ORM table args for matching indexes where models live here)
+- Test: `tests/test_migration_085.py` (extend)
+
+**Interfaces:**
+- Produces: `ix_briefing_usage_timestamp`, `ix_cost_ledger_service_created (service, created_at)`, `ix_verif_scores_obs_time (observation_time)`, `ix_taf_verif_obs_time (observation_time)`, `uq_users_provider_sub (provider, provider_sub)` UNIQUE; drops the 15 redundant indexes (spec item 5 list verbatim); DECIMAL(12,4)/DECIMAL(12,6) money columns.
+- Consumes: the audited index list (spec §Tier-2 item 5 — copy it verbatim from the spec into the migration).
+
+Ops (upgrade): (1) `op.execute` duplicate-identity check on users `(provider, provider_sub)` — raise with a clear message if any (prod would need manual resolution; expected zero); create the unique index. (2) Create the 4 missing indexes. (3) Drop the 15 redundant ones by name (guard each with an existence check helper `_index_exists(table, name)` using `information_schema.STATISTICS` on MySQL and `PRAGMA index_list` on SQLite — the migration must run on both; ORM `__table_args__` must match so dev `create_all` agrees). (4) `op.alter_column` the five money columns to DECIMAL — batch mode for SQLite; MySQL converts FLOAT→DECIMAL (document the one-way rounding in a comment). Downgrade: best-effort inverse (recreate dropped indexes, drop created ones, Float back).
+
+- [ ] **Step 1:** failing tests (index existence after upgrade; users-unique present; DECIMAL read-back of a 1234.56 value).
+- [ ] **Step 2:** run → FAIL.
+- [ ] **Step 3:** implement ops + ORM table args alignment.
+- [ ] **Step 4:** run → PASS; full `pytest tests/test_migration_085.py -q`.
+- [ ] **Step 5:** commit `feat(db): missing indexes, redundant-index drops, users identity unique, DECIMAL money (#mysql-review)`.
+
+---
+
+### Task 3: Airport-profile SSE session fix
+
+**Files:**
+- Modify: `src/weatherbrief/api/airport_profile.py` (`get_airport_profile`, ~lines 547-732)
+- Test: `tests/test_airport_profile.py` (extend or new session-scope test)
+
+**Interfaces:**
+- Consumes: the proven streaming-session pattern at `api/packs.py:2151-2153,2330` (own SessionLocal, closed before streaming).
+
+Change: remove `db: Session = Depends(get_db)`; open `SessionLocal()`; perform ALL DB reads (`_surface_from_cache` and anything else the stream's generator doesn't need); `db.close()` in a `finally` BEFORE returning the `StreamingResponse`. The stream generator must capture plain data, never the session. Verify no other statement in the function path needs the session afterward.
+
+- [ ] **Step 1:** failing test — mock `SessionLocal` + the stream; assert the session is closed before the response object is created (e.g. spy on `Session.close`).
+- [ ] **Step 2:** run → FAIL.
+- [ ] **Step 3:** implement.
+- [ ] **Step 4:** run → PASS; `pytest tests/test_airport_profile.py -q`.
+- [ ] **Step 5:** commit `fix(db): close session before airport-profile SSE stream (#mysql-review)`.
+
+---
+
+### Task 4: Session scope-downs (refresh loop, verification, time-scan)
+
+**Files:**
+- Modify: `src/weatherbrief/scheduler.py` (`process_auto_refreshes` ~148-198, `_auto_refresh_one` ~440-517)
+- Modify: `src/weatherbrief/tasks/verification.py` (`collect_and_store` ~449-525)
+- Modify: `src/weatherbrief/tasks/time_scan_runner.py` (`_run_scan_job` ~98-177)
+- Modify: `src/weatherbrief/tasks/refresh_resume.py` (~252-261)
+- Test: `tests/test_session_scope.py` (new)
+
+Pattern per site (adjust to local code): (1) open session, do ALL DB reads needed before the slow work, extract plain values, `db.close()` (or commit/rollback + close) in `finally`; (2) run the slow pipeline/fetch/scan WITHOUT any session; (3) open a fresh session for finalize + commit. The outer `process_auto_refreshes` must not hold a session across `asyncio.to_thread(_auto_refresh_one, ...)`; `_auto_refresh_one` must not hold one across `execute_briefing`; `collect_and_store` must not hold one across `fetch_observations_batch`; `_run_scan_job` not across `run_time_scan`. Preserve notify-after-commit ordering and the `_finalize_refresh` semantics exactly. Note: `execute_briefing`/`_prepare_refresh` currently take `db=` kwargs — untangle what genuinely needs DB during the pipeline (target: nothing; if something does, give it a short-lived dedicated session inside).
+
+- [ ] **Step 1:** failing tests — spy session factory per site: assert no session object remains unclosed across the slow-call boundary (mock the slow call).
+- [ ] **Step 2:** run → FAIL.
+- [ ] **Step 3:** implement the four scope-downs.
+- [ ] **Step 4:** run → PASS; `pytest tests/test_session_scope.py tests/test_scheduler.py tests/test_verification.py -q` (whichever exist).
+- [ ] **Step 5:** commit `fix(db): release pooled connections before pipelines and network fetches (#mysql-review)`.
+
+---
+
+### Task 5: `latest_pack()` fast path
+
+**Files:**
+- Modify: `src/weatherbrief/storage/flights.py` (add `latest_pack`; ~after `list_packs`)
+- Modify: `src/weatherbrief/scheduler.py` (:447), `src/weatherbrief/tasks/refresh_resume.py` (:142), `src/weatherbrief/scheduler.py` `_auto_refresh_one` (Task 4's version)
+- Test: `tests/test_storage_flights.py` (extend)
+
+**Interfaces:**
+- Produces: `latest_pack(session: Session, flight_id: str) -> BriefingPackMeta | None` — single query `WHERE flight_id … ORDER BY fetch_timestamp DESC, id DESC LIMIT 1` selecting ONLY the columns `_row_to_meta` needs (skip the HMAC verify and the artifact-path stat on this path — document why: the hot gate only needs assessment/status fields; keep the full check in `list_packs`).
+
+- [ ] **Step 1:** failing tests (returns newest; skips HMAC/stat via monkeypatch spies; None when no packs).
+- [ ] **Step 2:** run → FAIL.
+- [ ] **Step 3:** implement + swap the three hot callers.
+- [ ] **Step 4:** run → PASS; `pytest tests/test_storage_flights.py tests/test_scheduler.py -q`.
+- [ ] **Step 5:** commit `perf(db): latest_pack fast path for hot refresh gates (#mysql-review)`.
+
+---
+
+### Task 6: Flights-list aircraft batch prefetch
+
+**Files:**
+- Modify: `src/weatherbrief/api/flights.py` (`_flight_to_response` area, ~lines 358-461 and its list caller)
+- Test: `tests/test_api_flights_list.py` (extend or new)
+
+Change: in the flights-list endpoint, collect distinct `aircraft_id`s from the listed flights, fetch all `UserAircraftRow`s in ONE `select(...).where(UserAircraftRow.id.in_(ids))`, build a lookup dict, and pass it into `_flight_to_response` instead of letting it `db.get` per flight. Behaviour identical otherwise.
+
+- [ ] **Step 1:** failing test — two flights sharing one aircraft → exactly one aircraft query issued (count via a session execute spy).
+- [ ] **Step 2:** run → FAIL.
+- [ ] **Step 3:** implement.
+- [ ] **Step 4:** run → PASS; `pytest tests/test_api_flights_list.py -q` (or the file the endpoint's tests live in).
+- [ ] **Step 5:** commit `perf(db): batch aircraft lookup in flights list (#mysql-review)`.
+
+---
+
+### Task 7: Deadlock retry helper
+
+**Files:**
+- Create: `src/weatherbrief/db/retry.py` (check whether `src/weatherbrief/db/` is the right home; else `storage/retry.py`)
+- Modify: `src/weatherbrief/storage/flights.py` (`save_pack_meta`/`update_pack_meta`, `subscribe_flight`), `src/weatherbrief/storage/refresh_jobs.py` (write-through `_best_effort` paths)
+- Test: `tests/test_db_retry.py` (new)
+
+**Interfaces:**
+- Produces: `db_retry(max_attempts: int = 3, base_delay_s: float = 0.05)` — context manager/decorator that runs the wrapped block, catches `sqlalchemy.exc.OperationalError` whose `orig` is PyMySQL 1213/1205, rolls the session back, and retries with jittered exponential backoff; re-raises after the last attempt. Works on SQLite too (no-op unless such an error occurs — tests inject a fake OperationalError).
+
+Apply to the three hot write paths named above (wrap the retry around the smallest critical section; preserve the `begin_nested` race guard from Task 1 inside the retry).
+
+- [ ] **Step 1:** failing tests (succeeds on 2nd attempt; gives up after N; non-deadlock OperationalError NOT retried; session rolled back between attempts).
+- [ ] **Step 2:** run → FAIL.
+- [ ] **Step 3:** implement helper + apply.
+- [ ] **Step 4:** run → PASS; `pytest tests/test_db_retry.py tests/test_pack_meta_race.py -q`.
+- [ ] **Step 5:** commit `feat(db): deadlock/lock-wait retry helper for hot write paths (#mysql-review)`.
+
+---
+
+### Task 8: Charset check script + FK documentation + final suite
+
+**Files:**
+- Create: `scripts/check_mysql_charset.py`
+- Modify: `designs/data-models.md` (FK section)
+- Test: none (script is prod-tooling; doc is prose)
+
+Script: connects via `DATABASE_URL` (argparse `--url` optional), prints per-table ENGINE/COLLATION from `information_schema.TABLES` where table_schema=current db, exits non-zero if any user table is not InnoDB/utf8mb4*, plus a one-line `sys.schema_unused_indexes` dump when available. `designs/data-models.md`: new "FK policy" section — intentional no-FK set (cost_ledger.user_id, donation_ledger.user_id, briefing_refresh_jobs.flight_id, analytics_*), survive-deletion candidates (feedback.flight_id, briefing_usage.flight_id, api_usage_log), oauth oversight set (authorization_codes, refresh_tokens, api_tokens.oauth_client_id) with a per-table recommendation and rationale.
+
+- [ ] **Step 1:** write script + doc section.
+- [ ] **Step 2:** smoke-run the script against a temp SQLite (must exit cleanly with a clear "not MySQL" message) and against nothing (usage print).
+- [ ] **Step 3:** commit `docs(db): charset check script + FK policy documentation (#mysql-review)`.
+- [ ] **Step 4:** FULL suite `./.venv/bin/python -m pytest -q` — green except the allowed auth failure.
+- [ ] **Step 5:** push `mysql-review` to fork; PR to `roznet/flyfun-weather:main` (base main, head `downle:mysql-review`).
+
+---
+
+## Self-review log
+
+- Spec coverage: items 1-12 → tasks 3, 4, 1-2, 2 (charset script 8), 5, 6, 7, 8. Item 8's migration-convention note is folded into 085's comments + the data-models doc (Task 8).
+- Type consistency: `latest_pack` returns the same `BriefingPackMeta` type callers use today; `db_retry` wraps `begin_nested` from Task 1, not replaces it; migration revision chain 084→085 single head.
+- Placeholder scan: Task 3/4 line numbers are approximate by design ("~") with the pattern named explicitly; implementers verify exact spots first.

--- a/docs/superpowers/specs/2026-07-31-mysql-optimization-design.md
+++ b/docs/superpowers/specs/2026-07-31-mysql-optimization-design.md
@@ -1,0 +1,100 @@
+# MySQL usage optimization — design (mysql-review)
+
+**Date:** 2026-07-31
+**Status:** Approved design (superpowers brainstorming), full-scope Tier 1+2+repo-3.
+**Inputs:** three-track audit of the 84-migration schema, all `storage/` modules, and the
+`flyfun_common` engine + every `SessionLocal()` call site (full findings in the review
+presented to the user; top items independently re-verified against the code).
+**Delivery:** branch `mysql-review` (based on upstream/main `4abd5b49`), PR to
+`roznet/flyfun-weather:main` from the `downle` fork. Cleanly mergeable (based on latest main).
+
+## Scope
+
+Twelve items from the audit, grouped by tier. One new Alembic migration
+(`085_mysql_review_fixes.py` — revision numbering skips 030 historically; 084 is current head)
+plus focused code changes. FK additions are deliberately excluded (documented instead).
+
+### Tier 1 — correctness & reachable outages
+
+1. **Airport-profile SSE pool fix** (`api/airport_profile.py`): gather all DB reads, close
+   the session BEFORE constructing the `StreamingResponse` (the proven
+   `packs.py:2151-2153,2330` pattern), removing `Depends(get_db)` from this endpoint.
+   Today: 20 allowed concurrent streams vs a 15-connection pool → reachable 500s.
+2. **Session scope-downs** (web-pool connections pinned across slow work):
+   `_auto_refresh_one` (DB read → close → pipeline without session → DB finalize+commit);
+   `process_auto_refreshes` (close the due-flight read session before the loop);
+   `collect_and_store` (read → release → aviationweather.gov fetch → reopen to store);
+   the time-scan runner (same shape). `run_standalone_cycle` unchanged (subprocess-isolated
+   by default) + a code comment noting why.
+3. **`briefing_packs` UNIQUE `(flight_id, fetch_timestamp)`**: migration dedupes existing
+   pairs (keep newest `id` per pair, log counts), adds `uq_briefing_packs_flight_ts`;
+   `save_pack_meta` gains the savepoint + IntegrityError→update race guard (the
+   `subscribe_flight` precedent). Removes the silent-duplicate → `MultipleResultsFound`
+   → 500 trap; the composite also covers latest-pack lookups.
+4. **Missing indexes**: `ix_briefing_usage_timestamp`,
+   `ix_cost_ledger (service, created_at)`, `ix_verif_scores_obs_time`,
+   `ix_taf_verif_obs_time` (all serve audited hot/range paths; retention DELETEs for the
+   last two).
+
+### Tier 2 — safe hygiene
+
+5. **Drop 15 redundant indexes**: 13 leftmost-prefix duplicates (`ix_verif_obs_icao`,
+   `ix_verif_scores_icao`, `ix_taf_verif_icao`, `ix_fvm_flight`, `ix_flight_subs_flight`,
+   `ix_flight_seen_user`, `ix_vms_month`, `ix_vds_date_model`, `ix_ams_month`,
+   `ix_ads_date`, `ix_aed_day`, `ix_abfd_day`, `ix_axcd_day`), the
+   `oauth_refresh_tokens.token_hash` unique+plain duplicate, and `ix_afs_hour_model`
+   (081's documented follow-up). Kept: `ix_verif_scores_lead`, `ix_verif_scores_model`
+   (need `sys.schema_unused_indexes` evidence), FORCE-INDEXed `ix_verif_scores_source_time`.
+   DROP INDEX is metadata-only on MySQL 8.
+6. **`users (provider, provider_sub)` UNIQUE** — dedupe check + unique index; the OAuth
+   login lookup becomes indexed and duplicate-identity races impossible.
+7. **Money → DECIMAL**: `cost_ledger.cost`, `donation_ledger.amount/amount_usd/
+   fx_rate/net_usd` → `DECIMAL(12,4)` (fx `DECIMAL(12,6)`). ORM `Float` mappings read
+   DECIMAL without change; the proper `Numeric` mapping belongs upstream in
+   `flyfun_common` (noted in the PR, not done here).
+8. **Charset**: no table rebuilds in this PR (needs prod verification + maintenance
+   window). Deliver `scripts/check_mysql_charset.py` (`SHOW TABLE STATUS` report) and a
+   migration-convention note (new tables declare `mysql_charset="utf8mb4"`).
+
+### Tier 3 — repo-level improvements
+
+9. **`latest_pack(session, flight_id)`** in `storage/flights.py`: `LIMIT 1` + column
+   subset (no 5×`json.loads`, no per-row HMAC, no filesystem stats) replacing
+   `list_packs()[0]` in the scheduler gate, `tasks/refresh_resume.py`, and
+   `_auto_refresh_one`. `list_packs` unchanged for genuine list consumers.
+10. **Flights-list batch prefetch**: the per-flight `db.get(UserAircraftRow)` becomes one
+    `IN` query over distinct aircraft ids. Python-side pagination stays (bounded).
+11. **Deadlock retry helper**: `db_retry` context/decorator (OperationalError 1213/1205 →
+    rollback + jittered retry ×3) applied to the hottest write paths (pack meta
+    save/update, refresh-job write-through, `subscribe_flight`) with tests.
+12. **FKs NOT added** — documented in `designs/data-models.md`: the intentional no-FK set
+    (`cost_ledger.user_id`, `donation_ledger.user_id`, `briefing_refresh_jobs.flight_id`)
+    vs rows that arguably should survive deletion (feedback, usage logs) vs the oauth
+    oversight set — cascades here are product decisions, listed with per-table
+    recommendations for a later issue.
+
+## Error handling / house rules
+
+- Dedupe migration keeps the newest row per `(flight_id, fetch_timestamp)` and logs
+  counts — never silent data loss; non-destructive otherwise.
+- Every session-scope change preserves the notification-after-commit ordering.
+- None≠0 and the None-vs-quiet conventions are unaffected (no data-model semantic changes).
+
+## Verification
+
+- New/extended tests: migration chain (upgrade head on SQLite), dedupe migration unit
+  test, unique-race test (SQLite enforces the same constraint), session-scope tests
+  (mock-assert connection released before pipeline/stream), `latest_pack` tests,
+  deadlock-retry tests, DECIMAL read-back, batch-prefetch test.
+- MySQL-only paths (partitions, `ON DUPLICATE KEY UPDATE`, charset) remain
+  SQLite-untestable — documented; `scripts/check_mysql_charset.py` covers prod-side
+  verification.
+- Full suite green except the known pre-existing `test_google_login_redirects`
+  (environment-dependent, fails on the base too).
+
+## Out of scope
+
+FK additions (documented), `flyfun_common` engine tuning (pool size/timeouts/charset —
+upstream issue), `sys.schema_unused_indexes` audit in prod, `ix_verif_scores_lead`/
+`ix_verif_scores_model` drops (need evidence), CONVERT-to-utf8mb4 table rebuilds,
+`run_standalone_cycle` restructure (subprocess-isolated).

--- a/scripts/check_mysql_charset.py
+++ b/scripts/check_mysql_charset.py
@@ -15,7 +15,8 @@ Usage:
     python scripts/check_mysql_charset.py --url mysql+pymysql://user:pass@host/db
 
 Exit codes: 0 = all tables InnoDB + utf8mb4-family (or not a MySQL URL),
-1 = violations found, 2 = no URL given.
+1 = violations found, 2 = no/invalid URL, 3 = cannot connect,
+4 = zero tables found (no current database or empty schema).
 """
 
 from __future__ import annotations
@@ -25,6 +26,7 @@ import os
 import sys
 
 from sqlalchemy import create_engine, text
+from sqlalchemy.exc import ArgumentError, OperationalError
 
 _TABLES_SQL = """
 SELECT TABLE_NAME, ENGINE, TABLE_COLLATION, TABLE_ROWS
@@ -60,39 +62,56 @@ def main() -> int:
         print("error: no database URL — pass --url or set DATABASE_URL", file=sys.stderr)
         return 2
 
-    engine = create_engine(args.url)
+    try:
+        engine = create_engine(args.url)
+    except ArgumentError as exc:
+        print(f"error: invalid database URL: {str(exc).splitlines()[0]}", file=sys.stderr)
+        return 2
+
     if engine.dialect.name != "mysql":
         print(f"not MySQL (dialect: {engine.dialect.name}) — nothing to check")
         return 0
 
-    with engine.connect() as conn:
-        rows = conn.execute(text(_TABLES_SQL)).all()
+    try:
+        with engine.connect() as conn:
+            rows = conn.execute(text(_TABLES_SQL)).all()
 
-        print(f"{'TABLE_NAME':<40} {'ENGINE':<10} {'TABLE_COLLATION':<24} ~ROWS")
-        bad: list[str] = []
-        for name, eng, collation, approx_rows in rows:
-            print(f"{name:<40} {eng or '-':<10} {collation or '-':<24} {approx_rows}")
-            if eng != "InnoDB" or not (collation or "").startswith("utf8mb4"):
-                bad.append(name)
+            if not rows:
+                print(
+                    "error: zero tables found — the URL names no current database "
+                    "or the schema is empty; check --url/$DATABASE_URL",
+                    file=sys.stderr,
+                )
+                return 4
 
-        if bad:
-            print(f"\nFAIL: {len(bad)} table(s) not InnoDB/utf8mb4: {', '.join(bad)}")
-            rc = 1
-        else:
-            print(f"\nOK: {len(rows)} table(s), all InnoDB with utf8mb4-family collation")
-            rc = 0
+            print(f"{'TABLE_NAME':<40} {'ENGINE':<10} {'TABLE_COLLATION':<24} ~ROWS")
+            bad: list[str] = []
+            for name, eng, collation, approx_rows in rows:
+                print(f"{name:<40} {eng or '-':<10} {collation or '-':<24} {approx_rows}")
+                if eng != "InnoDB" or not (collation or "").startswith("utf8mb4"):
+                    bad.append(name)
 
-        try:
-            unused = conn.execute(text(_UNUSED_INDEXES_SQL)).all()
-        except Exception as exc:
-            print(f"\nunused-index check skipped ({type(exc).__name__}: {exc})")
-        else:
-            if unused:
-                print("\npossibly unused indexes (verify with uptime):")
-                for table_name, index_name in unused:
-                    print(f"  {table_name} / {index_name}")
+            if bad:
+                print(f"\nFAIL: {len(bad)} table(s) not InnoDB/utf8mb4: {', '.join(bad)}")
+                rc = 1
             else:
-                print("\nno unused indexes reported by sys.schema_unused_indexes")
+                print(f"\nOK: {len(rows)} table(s), all InnoDB with utf8mb4-family collation")
+                rc = 0
+
+            try:
+                unused = conn.execute(text(_UNUSED_INDEXES_SQL)).all()
+            except Exception as exc:
+                print(f"\nunused-index check skipped ({type(exc).__name__}: {exc})")
+            else:
+                if unused:
+                    print("\npossibly unused indexes (verify with uptime):")
+                    for table_name, index_name in unused:
+                        print(f"  {table_name} / {index_name}")
+                else:
+                    print("\nno unused indexes reported by sys.schema_unused_indexes")
+    except OperationalError as exc:
+        print(f"error: cannot connect to database: {str(exc).splitlines()[0]}", file=sys.stderr)
+        return 3
 
     return rc
 

--- a/scripts/check_mysql_charset.py
+++ b/scripts/check_mysql_charset.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Verify every table in a MySQL database is InnoDB / utf8mb4.
+
+No migration in the 84-revision history declares charset, collation, or
+engine — every table inherits server defaults while the app code assumes
+utf8mb4 (e.g. the 191-char index caps). The mysql-review PR deliberately
+does not rebuild tables (that needs prod verification + a maintenance
+window); this script is the pre/post check for when that happens, and a
+guard against new non-utf8mb4 tables landing in the meantime.
+
+Read-only. Needs only SQLAlchemy — no app code.
+
+Usage:
+    python scripts/check_mysql_charset.py                       # uses $DATABASE_URL
+    python scripts/check_mysql_charset.py --url mysql+pymysql://user:pass@host/db
+
+Exit codes: 0 = all tables InnoDB + utf8mb4-family (or not a MySQL URL),
+1 = violations found, 2 = no URL given.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+from sqlalchemy import create_engine, text
+
+_TABLES_SQL = """
+SELECT TABLE_NAME, ENGINE, TABLE_COLLATION, TABLE_ROWS
+FROM information_schema.TABLES
+WHERE TABLE_SCHEMA = DATABASE()
+  AND TABLE_TYPE = 'BASE TABLE'
+ORDER BY TABLE_NAME
+"""
+
+# sys.schema_unused_indexes only exists when the sys schema is installed, and
+# its stats reset on server restart — hence the "verify with uptime" caveat.
+_UNUSED_INDEXES_SQL = """
+SELECT object_name AS table_name, index_name
+FROM sys.schema_unused_indexes
+WHERE object_schema = DATABASE()
+ORDER BY 1, 2
+"""
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__.splitlines()[0],
+        epilog="Exit 0 when clean or not MySQL; exit 1 on violations.",
+    )
+    parser.add_argument(
+        "--url",
+        default=os.environ.get("DATABASE_URL"),
+        help="SQLAlchemy database URL (default: $DATABASE_URL)",
+    )
+    args = parser.parse_args()
+
+    if not args.url:
+        print("error: no database URL — pass --url or set DATABASE_URL", file=sys.stderr)
+        return 2
+
+    engine = create_engine(args.url)
+    if engine.dialect.name != "mysql":
+        print(f"not MySQL (dialect: {engine.dialect.name}) — nothing to check")
+        return 0
+
+    with engine.connect() as conn:
+        rows = conn.execute(text(_TABLES_SQL)).all()
+
+        print(f"{'TABLE_NAME':<40} {'ENGINE':<10} {'TABLE_COLLATION':<24} ~ROWS")
+        bad: list[str] = []
+        for name, eng, collation, approx_rows in rows:
+            print(f"{name:<40} {eng or '-':<10} {collation or '-':<24} {approx_rows}")
+            if eng != "InnoDB" or not (collation or "").startswith("utf8mb4"):
+                bad.append(name)
+
+        if bad:
+            print(f"\nFAIL: {len(bad)} table(s) not InnoDB/utf8mb4: {', '.join(bad)}")
+            rc = 1
+        else:
+            print(f"\nOK: {len(rows)} table(s), all InnoDB with utf8mb4-family collation")
+            rc = 0
+
+        try:
+            unused = conn.execute(text(_UNUSED_INDEXES_SQL)).all()
+        except Exception as exc:
+            print(f"\nunused-index check skipped ({type(exc).__name__}: {exc})")
+        else:
+            if unused:
+                print("\npossibly unused indexes (verify with uptime):")
+                for table_name, index_name in unused:
+                    print(f"  {table_name} / {index_name}")
+            else:
+                print("\nno unused indexes reported by sys.schema_unused_indexes")
+
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/weatherbrief/analytics/models.py
+++ b/src/weatherbrief/analytics/models.py
@@ -106,7 +106,6 @@ class AnalyticsEventDailyRow(Base):
     __tablename__ = "analytics_event_daily"
     __table_args__ = (
         PrimaryKeyConstraint("day", "event", name="pk_aed_day_event"),
-        Index("ix_aed_day", "day"),
     )
 
     day: Mapped[date_t] = mapped_column(Date, nullable=False)
@@ -120,7 +119,6 @@ class AnalyticsBriefingFeatureDailyRow(Base):
     __tablename__ = "analytics_briefing_feature_daily"
     __table_args__ = (
         PrimaryKeyConstraint("day", "feature", name="pk_abfd_day_feature"),
-        Index("ix_abfd_day", "day"),
     )
 
     day: Mapped[date_t] = mapped_column(Date, nullable=False)
@@ -150,7 +148,6 @@ class AnalyticsXsectionConfigDailyRow(Base):
     __tablename__ = "analytics_xsection_config_daily"
     __table_args__ = (
         PrimaryKeyConstraint("day", "dimension", "value", name="pk_axcd_day_dim_val"),
-        Index("ix_axcd_day", "day"),
     )
 
     day: Mapped[date_t] = mapped_column(Date, nullable=False)

--- a/src/weatherbrief/api/airport_profile.py
+++ b/src/weatherbrief/api/airport_profile.py
@@ -36,7 +36,7 @@ from fastapi.responses import StreamingResponse
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from flyfun_common.db import current_user_id, get_db
+from flyfun_common.db import current_user_id, SessionLocal
 
 from weatherbrief.api.deps import airports_db as _airports_db, data_dir as _data_dir
 
@@ -551,7 +551,6 @@ async def get_airport_profile(
     window_h: int = Query(default=_DEFAULT_WINDOW_H, ge=0, le=12),
     enrich: bool = Query(default=True, description="Run local-GRIB enrichment phase"),
     _user_id: str = Depends(current_user_id),
-    db: Session = Depends(get_db),
     airports_db: str = Depends(_airports_db),
     data_dir: Path = Depends(_data_dir),
 ):
@@ -586,10 +585,18 @@ async def get_airport_profile(
 
     hours = _build_hours(start_dt, window_h)
 
-    # Snapshot surface from cache before opening the long-lived stream so
-    # any DB error surfaces as a normal HTTP error (cleaner UX than an
-    # SSE error mid-stream).
-    surface = _surface_from_cache(db, icao, model, hours)
+    # Manage our own DB session — FastAPI's Depends(get_db) cleanup runs
+    # only after the StreamingResponse finishes, so a dependency-held
+    # session would pin a pooled connection for the stream's whole life
+    # (same pattern as packs.refresh_briefing_stream).
+    db = SessionLocal()
+    try:
+        # Snapshot surface from cache before opening the long-lived stream so
+        # any DB error surfaces as a normal HTTP error (cleaner UX than an
+        # SSE error mid-stream).
+        surface = _surface_from_cache(db, icao, model, hours)
+    finally:
+        db.close()
 
     # Acquire the per-user / global concurrency slot before opening the
     # stream. Released in the generator's finally block. Done synchronously

--- a/src/weatherbrief/api/flights.py
+++ b/src/weatherbrief/api/flights.py
@@ -19,7 +19,7 @@ from flyfun_common.auth import is_dev_mode
 from flyfun_common.db import current_user_id, get_db
 from flyfun_common.db.models import UserRow
 from weatherbrief.airports import RejectedWaypoint
-from weatherbrief.db.models import BriefingPackRow, FlightRow
+from weatherbrief.db.models import BriefingPackRow, FlightRow, UserAircraftRow
 from weatherbrief.fetch.variables import (
     MAX_BOOKING_LEAD_DAYS,
     coverage_start_date,
@@ -347,15 +347,27 @@ def _compute_coverage(departure_time: datetime) -> "CoveragePending | None":
 
 
 def _resolve_aircraft_info(
-    db: Session, aircraft_id: int | None, *, viewer_id: str | None = None,
+    db: Session,
+    aircraft_id: int | None,
+    *,
+    viewer_id: str | None = None,
+    aircraft_by_id: dict[int, UserAircraftRow] | None = None,
 ) -> AircraftInfo | None:
-    """Build AircraftInfo for a flight, privacy-gated by viewer."""
+    """Build AircraftInfo for a flight, privacy-gated by viewer.
+
+    ``aircraft_by_id`` is the list endpoint's batch-prefetched lookup (one
+    IN-query for the whole list); single-flight callers leave it None and
+    fall back to a per-call ``db.get``.
+    """
     if aircraft_id is None:
         return None
-    from weatherbrief.db.models import UserAircraftRow
     from weatherbrief.storage.aircraft_types import get_aircraft_type
 
-    row = db.get(UserAircraftRow, aircraft_id)
+    row = (
+        aircraft_by_id.get(aircraft_id)
+        if aircraft_by_id is not None
+        else db.get(UserAircraftRow, aircraft_id)
+    )
     if row is None:
         return None
 
@@ -451,6 +463,7 @@ def _flight_to_response(
     debrief: FlightDebrief | None = None,
     section: Literal["future", "recent", "past"] | None = None,
     unseen: bool = False,
+    aircraft_by_id: dict[int, UserAircraftRow] | None = None,
 ) -> FlightResponse:
     # viewer_id is required: the role derivation below compares flight.user_id
     # against it, and with viewer_id=None we would silently classify the
@@ -458,7 +471,10 @@ def _flight_to_response(
     # required signature keeps it that way.
     aircraft = None
     if flight.aircraft_id:
-        aircraft = _resolve_aircraft_info(db, flight.aircraft_id, viewer_id=viewer_id)
+        aircraft = _resolve_aircraft_info(
+            db, flight.aircraft_id,
+            viewer_id=viewer_id, aircraft_by_id=aircraft_by_id,
+        )
 
     effective_role = role if role is not None else ("owner" if flight.user_id == viewer_id else "subscriber")
 
@@ -625,6 +641,23 @@ def _get_latest_packs(db: Session, flight_ids: list[str]) -> dict[str, BriefingS
     }
 
 
+def _get_aircraft_by_id(db: Session, flights: list[Flight]) -> dict[int, UserAircraftRow]:
+    """Fetch every aircraft referenced by the listed flights in a single query.
+
+    Resolving aircraft per flight via ``db.get`` is an N+1 — the ORM row is
+    dropped as soon as the AircraftInfo is built, so the (weak-ref) identity
+    map doesn't even dedup repeat ids across flights. Returns an
+    ``{aircraft_id: row}`` lookup passed into ``_flight_to_response``.
+    """
+    ids = {f.aircraft_id for f in flights if f.aircraft_id is not None}
+    if not ids:
+        return {}
+    rows = db.execute(
+        select(UserAircraftRow).where(UserAircraftRow.id.in_(ids))
+    ).scalars().all()
+    return {row.id: row for row in rows}
+
+
 @router.get("", response_model=list[FlightResponse])
 def list_all_flights(
     response: Response,
@@ -654,6 +687,9 @@ def list_all_flights(
     # Flights with an unopened notify-qualifying update — drives the flight-list
     # red dot, kept consistent with the app-icon badge. One cheap query.
     unseen_ids = unseen_flight_ids(db, user_id)
+    # One IN-query for every aircraft referenced by the list, looked up per
+    # flight below instead of a per-flight db.get.
+    aircraft_by_id = _get_aircraft_by_id(db, [f for f, _, _ in paired])
 
     owned_pairs: list[tuple[Flight, FlightDebrief | None]] = [
         (f, debrief_map.get(f.id)) for f, role, _ in paired if role == "owner"
@@ -680,6 +716,7 @@ def list_all_flights(
             debrief=debrief,
             section=section,
             unseen=f.id in unseen_ids,
+            aircraft_by_id=aircraft_by_id,
         )
         (past if section == "past" else other).append(resp)
 

--- a/src/weatherbrief/api/packs.py
+++ b/src/weatherbrief/api/packs.py
@@ -1703,10 +1703,11 @@ def _persist_pack_provisional(
     The LLM digest hasn't run yet — ``has_digest=False`` and the assessment
     comes from advisories. ``_persist_pack_finalize`` will update this row
     once the digest completes (or update with ``has_digest=False`` if it
-    fails). The row is inserted unconditionally; if a row with the same
-    ``(flight_id, fetch_timestamp)`` already exists (which shouldn't happen
-    in practice — each refresh allocates a fresh timestamp), the SQL layer
-    will surface the conflict.
+    fails). If a row with the same ``(flight_id, fetch_timestamp)`` already
+    exists (shouldn't happen in practice — each refresh allocates a fresh
+    timestamp — but a concurrent refresh can race us), ``save_pack_meta``
+    turns the conflicting insert into an update of the existing row rather
+    than failing.
     """
     meta = _build_pack_meta(
         flight_id, flight, fetch_ts, pack_path, result,

--- a/src/weatherbrief/db/models.py
+++ b/src/weatherbrief/db/models.py
@@ -826,10 +826,16 @@ class AirportForecastSnapshotRow(Base):
         Index("ix_afs_icao_hour", "icao", "forecast_hour"),
         Index("ix_afs_fetched", "fetched_at"),
         Index("ix_afs_model_init", "model", "model_init_time"),
+        # The map's availability scan still filters bare forecast_hour with no
+        # region predicate (api/maps.py:118-129; likewise
+        # tasks/map_queries.py:262-266 and tasks/cache_builder.py:275-279), so
+        # the region-leading index below cannot serve it. Migration 085
+        # considered dropping this index as redundant (081's follow-up
+        # premise: region-aware serving) and rejected the drop — it stays.
+        Index("ix_afs_hour_model", "forecast_hour", "model"),
         # Region-leading, for the map's "which hours/models exist per day, in
-        # this region" scan as an index-only scan (EU/US seam). Its
-        # forecast_hour-leading predecessor ix_afs_hour_model was dropped by
-        # migration 085 as redundant (081's documented follow-up).
+        # this region" scan as an index-only scan (EU/US seam) once serving
+        # gains a region predicate.
         Index("ix_afs_region_hour_model", "region", "forecast_hour", "model"),
     )
 

--- a/src/weatherbrief/db/models.py
+++ b/src/weatherbrief/db/models.py
@@ -215,6 +215,14 @@ class FlightSubscriptionRow(Base):
 
 class BriefingPackRow(Base):
     __tablename__ = "briefing_packs"
+    # One row per (flight, fetch): mirrors migration 085's
+    # uq_briefing_packs_flight_ts so dev create_all agrees with prod, and
+    # makes the save_pack_meta race guard trigger under SQLite tests too.
+    __table_args__ = (
+        UniqueConstraint(
+            "flight_id", "fetch_timestamp", name="uq_briefing_packs_flight_ts"
+        ),
+    )
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     flight_id: Mapped[str] = mapped_column(

--- a/src/weatherbrief/db/models.py
+++ b/src/weatherbrief/db/models.py
@@ -192,7 +192,6 @@ class FlightSubscriptionRow(Base):
     __tablename__ = "flight_subscriptions"
     __table_args__ = (
         UniqueConstraint("flight_id", "user_id", name="uq_flight_subs_flight_user"),
-        Index("ix_flight_subs_flight", "flight_id"),
         Index("ix_flight_subs_user", "user_id"),
     )
 
@@ -291,6 +290,12 @@ class BriefingPackRow(Base):
 
 class BriefingUsageRow(Base):
     __tablename__ = "briefing_usage"
+    # Range scans/retention by timestamp (migration 085, spec Tier-1 item 4);
+    # named here rather than via ``index=True`` so dev's create_all and the
+    # migration agree on the name.
+    __table_args__ = (
+        Index("ix_briefing_usage_timestamp", "timestamp"),
+    )
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     user_id: Mapped[str] = mapped_column(
@@ -537,7 +542,6 @@ class FlightBriefingSeenRow(Base):
     __tablename__ = "flight_briefing_seen"
     __table_args__ = (
         UniqueConstraint("user_id", "flight_id", name="uq_flight_seen_user_flight"),
-        Index("ix_flight_seen_user", "user_id"),
     )
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
@@ -588,7 +592,6 @@ class VerificationObservationRow(Base):
     __tablename__ = "verification_observations"
     __table_args__ = (
         UniqueConstraint("icao", "observation_time", name="uq_verif_obs_icao_time"),
-        Index("ix_verif_obs_icao", "icao"),
         Index("ix_verif_obs_time", "observation_time"),
     )
 
@@ -640,9 +643,11 @@ class VerificationScoreRow(Base):
         ),
         Index("ix_verif_scores_obs", "observation_id"),
         Index("ix_verif_scores_model", "model", "days_out"),
-        Index("ix_verif_scores_icao", "icao"),
         Index("ix_verif_scores_lead", "lead_hours"),
         Index("ix_verif_scores_source_model_days", "source", "model", "days_out"),
+        # Range scans + retention DELETEs by observation_time (migration 085,
+        # spec Tier-1 item 4).
+        Index("ix_verif_scores_obs_time", "observation_time"),
         # Created by migration 038; load-bearing since #448 — the activity
         # COUNT(DISTINCT) queries FORCE INDEX it by name (hard SQL error on
         # MySQL if dropped), so the model must declare it. See
@@ -723,7 +728,9 @@ class TafVerificationScoreRow(Base):
             name="uq_taf_verif_key",
         ),
         Index("ix_taf_verif_obs", "observation_id"),
-        Index("ix_taf_verif_icao", "icao"),
+        # Retention DELETEs by observation_time (migration 085, spec Tier-1
+        # item 4).
+        Index("ix_taf_verif_obs_time", "observation_time"),
         # TAF pseudo-model stats are aggregated at query time from this table
         # (no rollup — key shape differs); without a (source, observation_time)
         # index every digest/dashboard TAF aggregate was a full scan (#448).
@@ -784,7 +791,6 @@ class FlightVerificationMapRow(Base):
             "flight_id", "icao", "observation_id",
             name="uq_fvm_flight_icao_obs",
         ),
-        Index("ix_fvm_flight", "flight_id"),
         Index("ix_fvm_icao", "icao"),
     )
 
@@ -820,14 +826,10 @@ class AirportForecastSnapshotRow(Base):
         Index("ix_afs_icao_hour", "icao", "forecast_hour"),
         Index("ix_afs_fetched", "fetched_at"),
         Index("ix_afs_model_init", "model", "model_init_time"),
-        # Forecast-hour-leading, for the map's "which hours/models exist per
-        # day" scan. Without it that DISTINCT has no usable index and reads the
-        # whole table on every map page load (#415).
-        Index("ix_afs_hour_model", "forecast_hour", "model"),
-        # Region-leading variant: once the map serving query filters by region
-        # (EU/US seam), this covers "which hours/models exist per day, in this
-        # region" as an index-only scan. Added alongside ix_afs_hour_model;
-        # the latter is dropped in a follow-up once serving is region-aware.
+        # Region-leading, for the map's "which hours/models exist per day, in
+        # this region" scan as an index-only scan (EU/US seam). Its
+        # forecast_hour-leading predecessor ix_afs_hour_model was dropped by
+        # migration 085 as redundant (081's documented follow-up).
         Index("ix_afs_region_hour_model", "region", "forecast_hour", "model"),
     )
 
@@ -979,7 +981,6 @@ class VerificationMonthlyStatsRow(Base):
             "month", "source", "model", "days_out", "icao",
             name="uq_vms_key",
         ),
-        Index("ix_vms_month", "month"),
         Index("ix_vms_model_days", "model", "days_out"),
         Index("ix_vms_icao", "icao"),
     )
@@ -1062,7 +1063,6 @@ class VerificationDailyStatsRow(Base):
         UniqueConstraint(
             "date", "source", "model", "days_out", "icao", name="uq_vds_key",
         ),
-        Index("ix_vds_date_model", "date", "source", "model", "days_out"),
         Index("ix_vds_icao_model", "icao", "source", "model", "days_out"),
         # The bias-leaderboard query filters (source, model, days_out) as
         # constants with a date *range*. The date-leading index only works for
@@ -1158,7 +1158,6 @@ class AirportMonthlySummaryRow(Base):
     __tablename__ = "airport_monthly_summary"
     __table_args__ = (
         UniqueConstraint("month", "icao", name="uq_ams_key"),
-        Index("ix_ams_month", "month"),
         Index("ix_ams_icao", "icao"),
     )
 
@@ -1241,7 +1240,6 @@ class AirportDailySummaryRow(Base):
     __tablename__ = "airport_daily_summary"
     __table_args__ = (
         UniqueConstraint("date", "icao", name="uq_ads_key"),
-        Index("ix_ads_date", "date"),
         Index("ix_ads_icao", "icao"),
     )
 

--- a/src/weatherbrief/db/retry.py
+++ b/src/weatherbrief/db/retry.py
@@ -1,0 +1,151 @@
+"""Deadlock / lock-wait retry helper for hot write paths.
+
+With several writer roles hitting MySQL concurrently (web endpoints, the
+scheduler refresh loop, boot resume, METAR ingest, verification, retention
+DDL, analytics rollup), InnoDB transiently fails writes with:
+
+- errno 1213 ("Deadlock found ...") — this transaction was chosen as the
+  deadlock victim and rolled back by the server;
+- errno 1205 ("Lock wait timeout exceeded ...") — gave up waiting for a lock
+  after ``innodb_lock_wait_timeout``.
+
+Both are safe to retry from the start of the failed transaction. This helper
+wraps the smallest critical section of a write path::
+
+    for attempt in db_retry(session):
+        with attempt:
+            ...  # the statements that may deadlock
+
+Each loop iteration is one attempt. A retryable ``OperationalError`` rolls
+the session back, sleeps a jittered exponential backoff, and re-enters the
+block; the error propagates unchanged after ``max_attempts``, or immediately
+when it isn't a lock conflict. Non-``OperationalError`` exceptions
+(``IntegrityError`` and friends) are never retried. On SQLite — or any run
+without an injected lock error — the loop is a pass-through: one iteration,
+no rollback, no sleep.
+
+The loop body must be exactly the ``with attempt:`` block: a suppressed
+failure re-enters the loop, so any statement after the ``with`` would run
+between attempts.
+
+Why an attempt-guard iterator rather than a plain context manager or
+decorator: a ``with`` block cannot re-run its own body, and a decorator
+would have to fish the session out of arbitrary call signatures. This is
+the shape tenacity uses (``for attempt in Retrying(): with attempt:``) —
+the session stays explicit and the retried block stays inline.
+"""
+
+from __future__ import annotations
+
+import logging
+import random
+import time
+from collections.abc import Iterator
+from types import TracebackType
+
+from sqlalchemy.exc import OperationalError
+from sqlalchemy.orm import Session
+
+logger = logging.getLogger(__name__)
+
+#: InnoDB error numbers worth retrying: deadlock victim, lock wait timeout.
+RETRYABLE_ERRNOS = frozenset((1213, 1205))
+
+#: Message fragments matched as a fallback for DBAPIs that don't expose the
+#: server errno as ``orig.args[0]`` the way PyMySQL does.
+_RETRYABLE_FRAGMENTS = ("Deadlock found", "Lock wait timeout")
+
+
+def is_retryable_lock_error(exc: OperationalError) -> bool:
+    """True when ``exc`` wraps an InnoDB deadlock (1213) / lock timeout (1205)."""
+    orig = getattr(exc, "orig", None)
+    args = getattr(orig, "args", ())
+    if args and args[0] in RETRYABLE_ERRNOS:
+        return True
+    text = f"{exc}{orig}"
+    return any(fragment in text for fragment in _RETRYABLE_FRAGMENTS)
+
+
+def db_retry(
+    session: Session, max_attempts: int = 3, base_delay_s: float = 0.05
+) -> Iterator["_AttemptGuard"]:
+    """Yield one attempt guard per try at a deadlock-prone critical section.
+
+    See the module docstring for the usage pattern. ``max_attempts`` counts
+    the initial try, so the default allows two retries; ``base_delay_s`` is
+    the backoff unit — the sleep before attempt N is
+    ``base × 2^(N-2) × (0.5 + random())``.
+    """
+    if max_attempts < 1:
+        raise ValueError("max_attempts must be >= 1")
+    return _RetryLoop(session, max_attempts, base_delay_s)
+
+
+class _RetryLoop:
+    """Iterator state for one ``db_retry`` loop."""
+
+    def __init__(self, session: Session, max_attempts: int, base_delay_s: float):
+        self._session = session
+        self._max_attempts = max_attempts
+        self._base_delay_s = base_delay_s
+        self._attempt = 0
+        self._succeeded = False
+
+    def __iter__(self) -> "_RetryLoop":
+        return self
+
+    def __next__(self) -> "_AttemptGuard":
+        # The body completed cleanly — the loop is done. (Reached only after
+        # success: failures either propagate out of the guard or are
+        # suppressed with attempts remaining, see _retry_or_raise.)
+        if self._succeeded:
+            raise StopIteration
+        self._attempt += 1
+        return _AttemptGuard(self)
+
+    def _retry_or_raise(self, exc: OperationalError) -> bool:
+        """Decide a failed attempt's fate. True suppresses the error so the
+        ``for`` loop takes another iteration; False lets it propagate."""
+        if not is_retryable_lock_error(exc) or self._attempt >= self._max_attempts:
+            return False
+        # After a 1213 the server has already rolled the transaction back;
+        # after a 1205 only the statement failed. Either way the session must
+        # be reset to a clean transaction before the next attempt.
+        self._session.rollback()
+        delay = (
+            self._base_delay_s
+            * (2 ** (self._attempt - 1))
+            * (0.5 + random.random())
+        )
+        logger.warning(
+            "InnoDB lock conflict on write (attempt %d/%d) — retrying in %.3fs: %s",
+            self._attempt,
+            self._max_attempts,
+            delay,
+            exc,
+        )
+        time.sleep(delay)
+        return True
+
+
+class _AttemptGuard:
+    """Context manager around one attempt's critical section."""
+
+    def __init__(self, loop: _RetryLoop):
+        self._loop = loop
+
+    def __enter__(self) -> None:
+        return None
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> bool:
+        if exc_type is None:
+            self._loop._succeeded = True
+            return False
+        if isinstance(exc, OperationalError):
+            return self._loop._retry_or_raise(exc)
+        return False

--- a/src/weatherbrief/db/retry.py
+++ b/src/weatherbrief/db/retry.py
@@ -28,6 +28,15 @@ The loop body must be exactly the ``with attempt:`` block: a suppressed
 failure re-enters the loop, so any statement after the ``with`` would run
 between attempts.
 
+Retry loops must never nest. A function wrapped in ``db_retry`` that falls
+back to another retried function must call that function's non-retrying
+core instead (e.g. ``save_pack_meta``'s race fallback calls
+``_update_pack_meta_once``, not ``update_pack_meta``): an inner loop's
+``session.rollback()`` discards ALL uncommitted work on the session —
+including anything the caller staged before the outer attempt — and the
+outer attempt could then complete "successfully", turning a loud,
+recoverable lock error into a silent partial commit.
+
 Why an attempt-guard iterator rather than a plain context manager or
 decorator: a ``with`` block cannot re-run its own body, and a decorator
 would have to fish the session out of arbitrary call signatures. This is
@@ -55,15 +64,44 @@ RETRYABLE_ERRNOS = frozenset((1213, 1205))
 #: server errno as ``orig.args[0]`` the way PyMySQL does.
 _RETRYABLE_FRAGMENTS = ("Deadlock found", "Lock wait timeout")
 
+#: Bound on the ``__context__``/``__cause__`` walk in
+#: ``is_retryable_lock_error`` — real chains are 1-2 links; the cap plus the
+#: visited-set keeps pathological or cyclic chains finite and cheap.
+_MAX_CHAIN_DEPTH = 8
 
-def is_retryable_lock_error(exc: OperationalError) -> bool:
-    """True when ``exc`` wraps an InnoDB deadlock (1213) / lock timeout (1205)."""
+
+def _matches_lock_error(exc: BaseException) -> bool:
+    """One link's check: PyMySQL-style errno first, message text as fallback."""
     orig = getattr(exc, "orig", None)
     args = getattr(orig, "args", ())
     if args and args[0] in RETRYABLE_ERRNOS:
         return True
     text = f"{exc}{orig}"
     return any(fragment in text for fragment in _RETRYABLE_FRAGMENTS)
+
+
+def is_retryable_lock_error(exc: OperationalError) -> bool:
+    """True when ``exc`` wraps an InnoDB deadlock (1213) / lock timeout (1205).
+
+    A 1213 raised inside ``session.begin_nested()`` arrives masked: the
+    server already rolled the transaction back, so SQLAlchemy's ``ROLLBACK
+    TO SAVEPOINT`` fails (MySQL 1305) and re-raises THAT error — the real
+    1213 survives only on the ``__context__`` chain. Walk ``__context__``
+    (and ``__cause__``, for explicit ``raise ... from`` wrappers) looking for
+    a retryable orig at any depth — bounded and cycle-safe.
+    """
+    seen: set[int] = set()
+    stack: list[BaseException | None] = [exc]
+    while stack and len(seen) <= _MAX_CHAIN_DEPTH:
+        current = stack.pop()
+        if current is None or id(current) in seen:
+            continue
+        seen.add(id(current))
+        if _matches_lock_error(current):
+            return True
+        stack.append(current.__context__)
+        stack.append(current.__cause__)
+    return False
 
 
 def db_retry(

--- a/src/weatherbrief/scheduler.py
+++ b/src/weatherbrief/scheduler.py
@@ -150,52 +150,57 @@ async def process_auto_refreshes(app_state) -> None:
     db = SessionLocal()
     try:
         due = _find_due_flights(db)
-        if not due:
-            return
-        logger.info("Auto-refresh: %d flight(s) due", len(due))
-
-        for row in due:
-            from weatherbrief.api.packs import refresh_registry
-
-            entry = refresh_registry.try_register(
-                row.id, triggered_by="scheduler", user_id=row.user_id,
-                source="scheduler",
-            )
-            if entry is None:
-                logger.info("Auto-refresh: skipping %s (refresh already in progress)", row.id)
-                continue
-
-            try:
-                refresh_registry.set_refreshing(row.id)
-                ran = await asyncio.to_thread(
-                    _auto_refresh_one, row, app_state, row.user_id
-                )
-                # Record the refresh timestamp
-                mark_db = SessionLocal()
-                try:
-                    mark_row = mark_db.get(FlightRow, row.id)
-                    if mark_row:
-                        mark_row.last_auto_refresh_at = datetime.now(timezone.utc)
-                        mark_db.commit()
-                finally:
-                    mark_db.close()
-                # "skipped" and "succeeded" are both terminal, but only one of
-                # them means a briefing was produced — the durable record has
-                # to tell them apart to be worth anything (#499).
-                refresh_registry.mark_outcome(
-                    row.id, "succeeded" if ran else "skipped",
-                    None if ran else "refresh gate declined a full run",
-                )
-                logger.info(
-                    "Auto-refresh %s: %s", "completed" if ran else "skipped", row.id,
-                )
-            except Exception as exc:
-                refresh_registry.mark_outcome(row.id, "failed", str(exc))
-                logger.error("Auto-refresh failed for %s", row.id, exc_info=True)
-            finally:
-                refresh_registry.unregister(row.id)
+        # Extract plain values and release the pooled connection BEFORE the
+        # loop: each refresh below runs a minutes-long pipeline in a thread
+        # and must not pin this session's connection across it.
+        due_refs = [(row.id, row.user_id) for row in due]
     finally:
         db.close()
+
+    if not due_refs:
+        return
+    logger.info("Auto-refresh: %d flight(s) due", len(due_refs))
+
+    for flight_id, user_id in due_refs:
+        from weatherbrief.api.packs import refresh_registry
+
+        entry = refresh_registry.try_register(
+            flight_id, triggered_by="scheduler", user_id=user_id,
+            source="scheduler",
+        )
+        if entry is None:
+            logger.info("Auto-refresh: skipping %s (refresh already in progress)", flight_id)
+            continue
+
+        try:
+            refresh_registry.set_refreshing(flight_id)
+            ran = await asyncio.to_thread(
+                _auto_refresh_one, flight_id, app_state, user_id
+            )
+            # Record the refresh timestamp
+            mark_db = SessionLocal()
+            try:
+                mark_row = mark_db.get(FlightRow, flight_id)
+                if mark_row:
+                    mark_row.last_auto_refresh_at = datetime.now(timezone.utc)
+                    mark_db.commit()
+            finally:
+                mark_db.close()
+            # "skipped" and "succeeded" are both terminal, but only one of
+            # them means a briefing was produced — the durable record has
+            # to tell them apart to be worth anything (#499).
+            refresh_registry.mark_outcome(
+                flight_id, "succeeded" if ran else "skipped",
+                None if ran else "refresh gate declined a full run",
+            )
+            logger.info(
+                "Auto-refresh %s: %s", "completed" if ran else "skipped", flight_id,
+            )
+        except Exception as exc:
+            refresh_registry.mark_outcome(flight_id, "failed", str(exc))
+            logger.error("Auto-refresh failed for %s", flight_id, exc_info=True)
+        finally:
+            refresh_registry.unregister(flight_id)
 
 
 # ---------------------------------------------------------------------------
@@ -410,7 +415,7 @@ def _flight_start_dt(row: FlightRow) -> datetime | None:
 
 
 def _auto_refresh_one(
-    flight_row: FlightRow,
+    flight_id: str,
     app_state,
     user_id: str,
     *,
@@ -429,6 +434,11 @@ def _auto_refresh_one(
     to close the durable job row honestly — a gated skip is the routine case
     for a flight that already has a recent pack, and recording it as
     ``succeeded`` would make the post-mortem record lie (issue #499).
+
+    Session scoping: the reads (flight row, gate, ``_prepare_refresh``) run in
+    one short session that is closed BEFORE the pipeline — a pooled connection
+    must not stay pinned across minutes of GRIB/LLM work — and the finalize +
+    commit + notify runs in a fresh session afterwards.
     """
     from weatherbrief.api.packs import (
         _build_data_status, _days_out_now, _finalize_refresh,
@@ -439,12 +449,16 @@ def _auto_refresh_one(
 
     db = SessionLocal()
     try:
+        flight_row = db.get(FlightRow, flight_id)
+        if flight_row is None:
+            logger.info("Auto-refresh: flight %s no longer exists, skipping", flight_id)
+            return False
         flight = _row_to_flight(flight_row)
 
         # Tiered refresh gate: the scheduler applies the same
         # full/none policy as the manual button but never the realtime
         # fallback — live METAR/TAF is the verification loop's job.
-        packs = list_packs(db, flight_row.id)
+        packs = list_packs(db, flight_id)
         if packs:
             latest = packs[0]
             status = _build_data_status(latest, flight)
@@ -452,50 +466,54 @@ def _auto_refresh_one(
             if decision.mode != "full":
                 logger.info(
                     "Auto-refresh: gate=%s for %s (%s), skipping",
-                    decision.mode, flight_row.id, decision.reason,
+                    decision.mode, flight_id, decision.reason,
                 )
                 return False
 
         db_path = getattr(app_state, "db_path", "")
         if not db_path:
-            logger.warning("Auto-refresh: AIRPORTS_DB not configured, skipping %s", flight_row.id)
+            logger.warning("Auto-refresh: AIRPORTS_DB not configured, skipping %s", flight_id)
             return False
 
         route, fetch_ts, pack_path, options, model_metadata, resolved_as_of = _prepare_refresh(
-            flight, db_path, user_id, flight_row.id, db=db, is_privileged=True,
+            flight, db_path, user_id, flight_id, db=db, is_privileged=True,
         )
+    finally:
+        db.close()
 
-        from weatherbrief.fetch.grib import DecodePriority, set_decode_priority
-        from weatherbrief.pipeline import execute_briefing
+    from weatherbrief.fetch.grib import DecodePriority, set_decode_priority
+    from weatherbrief.pipeline import execute_briefing
 
-        # Auto-refresh decode work is SCHEDULED — below interactive user
-        # refreshes / airport profiles, above background standalone cycles.
-        # Runs in asyncio.to_thread, which copies the context, so this set is
-        # isolated to the cycle and visible to enrich_forecasts.
-        set_decode_priority(DecodePriority.SCHEDULED)
+    # Auto-refresh decode work is SCHEDULED — below interactive user
+    # refreshes / airport profiles, above background standalone cycles.
+    # Runs in asyncio.to_thread, which copies the context, so this set is
+    # isolated to the cycle and visible to enrich_forecasts.
+    set_decode_priority(DecodePriority.SCHEDULED)
 
-        result = execute_briefing(
-            route=route,
-            departure_time=flight.departure_time,
-            options=options,
-            # Nobody streams a scheduled or resumed refresh, but a user who
-            # opens the briefing while one runs polls /refresh/status — without
-            # this they watch "Starting refresh" for the whole pipeline. It also
-            # keeps the durable job row's heartbeat and last-stage moving, so a
-            # resumed run that dies again still records where (#499).
-            progress_callback=lambda stage, detail=None: (
-                refresh_registry.update_progress(flight_row.id, stage, detail)
-            ),
-        )
+    result = execute_briefing(
+        route=route,
+        departure_time=flight.departure_time,
+        options=options,
+        # Nobody streams a scheduled or resumed refresh, but a user who
+        # opens the briefing while one runs polls /refresh/status — without
+        # this they watch "Starting refresh" for the whole pipeline. It also
+        # keeps the durable job row's heartbeat and last-stage moving, so a
+        # resumed run that dies again still records where (#499).
+        progress_callback=lambda stage, detail=None: (
+            refresh_registry.update_progress(flight_id, stage, detail)
+        ),
+    )
 
-        # Capture timing before unregister
-        queue_wait, total_elapsed = refresh_registry.get_timing(flight_row.id)
-        result.usage.elapsed_seconds = total_elapsed
-        result.usage.queue_wait_seconds = queue_wait
-        result.usage.triggered_by = triggered_by
+    # Capture timing before unregister
+    queue_wait, total_elapsed = refresh_registry.get_timing(flight_id)
+    result.usage.elapsed_seconds = total_elapsed
+    result.usage.queue_wait_seconds = queue_wait
+    result.usage.triggered_by = triggered_by
 
+    db = SessionLocal()
+    try:
         meta = _finalize_refresh(
-            flight_row.id, flight, fetch_ts, pack_path, result, db,
+            flight_id, flight, fetch_ts, pack_path, result, db,
             user_id=user_id, model_metadata=model_metadata,
             as_of_time=resolved_as_of,
         )
@@ -547,21 +565,17 @@ def _run_verification_once(app_state) -> None:
 
     from weatherbrief.tasks.verification import collect_and_store
 
-    db = SessionLocal()
-    try:
-        result = collect_and_store(db, db_path)
-        if result["flights"] > 0:
-            logger.info(
-                "Verification cycle: %d flight(s), %d airport(s), "
-                "%d observation(s) stored, %d finalized",
-                result["flights"], result["airports"],
-                result["observations"], result["finalized"],
-            )
-    except Exception:
-        db.rollback()
-        raise
-    finally:
-        db.close()
+    # collect_and_store owns its sessions: the read phases commit and close
+    # before the aviationweather.gov fetch, the store phase runs in a fresh
+    # session after it.
+    result = collect_and_store(db_path)
+    if result["flights"] > 0:
+        logger.info(
+            "Verification cycle: %d flight(s), %d airport(s), "
+            "%d observation(s) stored, %d finalized",
+            result["flights"], result["airports"],
+            result["observations"], result["finalized"],
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/src/weatherbrief/scheduler.py
+++ b/src/weatherbrief/scheduler.py
@@ -445,7 +445,7 @@ def _auto_refresh_one(
         _notify_refresh_complete, _prepare_refresh,
         decide_refresh, refresh_registry,
     )
-    from weatherbrief.storage.flights import _row_to_flight, list_packs
+    from weatherbrief.storage.flights import _row_to_flight, latest_pack
 
     db = SessionLocal()
     try:
@@ -458,10 +458,9 @@ def _auto_refresh_one(
         # Tiered refresh gate: the scheduler applies the same
         # full/none policy as the manual button but never the realtime
         # fallback — live METAR/TAF is the verification loop's job.
-        packs = list_packs(db, flight_id)
-        if packs:
-            latest = packs[0]
-            status = _build_data_status(latest, flight)
+        pack = latest_pack(db, flight_id)
+        if pack is not None:
+            status = _build_data_status(pack, flight)
             decision = decide_refresh(status, _days_out_now(flight))
             if decision.mode != "full":
                 logger.info(

--- a/src/weatherbrief/storage/flights.py
+++ b/src/weatherbrief/storage/flights.py
@@ -362,7 +362,15 @@ def parse_advisory_summary(raw: str | None) -> AdvisorySummary | None:
         return None
 
 
-def _row_to_meta(row: BriefingPackRow) -> BriefingPackMeta:
+def _row_to_meta(row: BriefingPackRow, *, resolve_artifact: bool = True) -> BriefingPackMeta:
+    """Map a pack row to its meta.
+
+    ``resolve_artifact=False`` returns ``artifact_path`` as stored, skipping
+    ``_resolve_artifact_path``'s filesystem stats — for hot read paths that
+    never touch pack files (see ``latest_pack``). The raw value equals the
+    resolved one unless the stored path is missing under the current CWD but
+    re-roots under the current DATA_DIR (worktree edge case).
+    """
     return BriefingPackMeta(
         id=row.id,
         flight_id=row.flight_id,
@@ -378,7 +386,11 @@ def _row_to_meta(row: BriefingPackRow) -> BriefingPackMeta:
         outlook=row.outlook,
         outlook_reason=row.outlook_reason,
         digest_trace_id=row.digest_trace_id,
-        artifact_path=_resolve_artifact_path(row.artifact_path),
+        artifact_path=(
+            _resolve_artifact_path(row.artifact_path)
+            if resolve_artifact
+            else row.artifact_path
+        ),
         model_init_times=json.loads(row.model_init_times_json) if row.model_init_times_json else {},
         grib_init_times=json.loads(row.grib_init_times_json) if row.grib_init_times_json else {},
         model_sources=json.loads(row.model_sources_json) if row.model_sources_json else {},
@@ -750,6 +762,50 @@ def list_packs(session: Session, flight_id: str) -> list[BriefingPackMeta]:
                 "Pack integrity check failed: flight=%s id=%d", flight_id, row.id,
             )
     return [_row_to_meta(r) for r in rows]
+
+
+def latest_pack(session: Session, flight_id: str) -> BriefingPackMeta | None:
+    """Return the newest pack for a flight, or None when it has none.
+
+    Fast path for the hot refresh gates (scheduler auto-refresh, resume
+    reconciliation), which only ever read ``packs[0]``: one ``LIMIT 1``
+    query instead of loading, HMAC-verifying and JSON-parsing the flight's
+    entire pack history on every scheduler cycle.
+
+    Deliberately skips two per-row checks ``list_packs`` performs:
+
+    - **Integrity HMAC** — the gates consume status/freshness fields (model
+      init times, model sources), not integrity verdicts, and a tampered
+      row would still be caught by the full check wherever pack contents
+      are actually served (``list_packs`` / ``load_pack_meta``).
+    - **Artifact-path resolution** — ``_resolve_artifact_path`` stats the
+      filesystem, which the gates never need; ``artifact_path`` here is the
+      raw stored value (equal to the resolved one outside the worktree
+      re-root edge case — see ``_row_to_meta``).
+
+    Ordered by fetch_timestamp DESC with an id DESC tiebreak; the tiebreak
+    is unreachable in practice (uq_briefing_packs_flight_ts forbids
+    duplicate (flight_id, fetch_timestamp) rows) but keeps the ordering
+    total, so the result always matches ``list_packs(...)[0]``.
+    """
+    from weatherbrief.eval_workbench.config import eval_workbench_enabled, is_eval_flight_id
+
+    if eval_workbench_enabled() and is_eval_flight_id(flight_id):
+        from weatherbrief.eval_workbench.resolver import resolve_eval_pack_list
+
+        packs = resolve_eval_pack_list(flight_id)
+        return packs[0] if packs else None
+
+    stmt = (
+        select(BriefingPackRow)
+        .where(BriefingPackRow.flight_id == flight_id)
+        .order_by(BriefingPackRow.fetch_timestamp.desc(), BriefingPackRow.id.desc())
+        .limit(1)
+    )
+    row = session.execute(stmt).scalar_one_or_none()
+    if row is None:
+        return None
+    return _row_to_meta(row, resolve_artifact=False)
 
 
 # --- FlightProfile CRUD ---

--- a/src/weatherbrief/storage/flights.py
+++ b/src/weatherbrief/storage/flights.py
@@ -648,11 +648,23 @@ def bulk_delete_flights(
 
 
 def save_pack_meta(session: Session, meta: BriefingPackMeta) -> None:
-    """Insert briefing pack metadata with integrity HMAC."""
+    """Insert briefing pack metadata with integrity HMAC.
+
+    Race-safe against the (flight_id, fetch_timestamp) unique constraint:
+    a concurrent refresh inserting the same pack first flips this save to an
+    update of the existing row instead of poisoning the request transaction.
+    The SAVEPOINT (begin_nested) contains the IntegrityError so any earlier
+    work on this session survives — same pattern as ``subscribe_flight``.
+    """
     row = _meta_to_row(meta)
     row.integrity_hmac = _compute_pack_hmac(row)
-    session.add(row)
-    session.flush()
+    try:
+        with session.begin_nested():
+            session.add(row)
+            session.flush()
+    except IntegrityError:
+        if not update_pack_meta(session, meta):
+            raise
 
 
 def update_pack_meta(session: Session, meta: BriefingPackMeta) -> bool:

--- a/src/weatherbrief/storage/flights.py
+++ b/src/weatherbrief/storage/flights.py
@@ -25,6 +25,7 @@ from weatherbrief.db.models import (
     FlightRow,
     FlightSubscriptionRow,
 )
+from weatherbrief.db.retry import db_retry
 from weatherbrief.models import (
     AdvisorySummary,
     BriefingPackMeta,
@@ -543,33 +544,40 @@ def subscribe_flight(session: Session, flight_id: str, user_id: str) -> bool:
     Returns True if a new subscription was created, False if it already existed.
     Raises KeyError if the flight doesn't exist, and SubscriptionError if the
     user is the flight owner.
+
+    Retried on InnoDB deadlocks/lock-wait timeouts (``db_retry``): the whole
+    check-then-insert re-runs per attempt (the rollback expires the loaded
+    flight, so it must be re-fetched), with the SAVEPOINT race guard inside
+    each attempt.
     """
-    flight = session.get(FlightRow, flight_id)
-    if flight is None:
-        raise KeyError(f"Flight not found: {flight_id}")
-    if flight.user_id == user_id:
-        raise SubscriptionError("Owners cannot subscribe to their own flights")
+    for attempt in db_retry(session):
+        with attempt:
+            flight = session.get(FlightRow, flight_id)
+            if flight is None:
+                raise KeyError(f"Flight not found: {flight_id}")
+            if flight.user_id == user_id:
+                raise SubscriptionError("Owners cannot subscribe to their own flights")
 
-    existing = session.execute(
-        select(FlightSubscriptionRow).where(
-            FlightSubscriptionRow.flight_id == flight_id,
-            FlightSubscriptionRow.user_id == user_id,
-        )
-    ).scalar_one_or_none()
-    if existing is not None:
-        return False
+            existing = session.execute(
+                select(FlightSubscriptionRow).where(
+                    FlightSubscriptionRow.flight_id == flight_id,
+                    FlightSubscriptionRow.user_id == user_id,
+                )
+            ).scalar_one_or_none()
+            if existing is not None:
+                return False
 
-    # Wrap the insert in a SAVEPOINT so only this statement rolls back if two
-    # concurrent subscribe calls race past the existence check and the loser
-    # trips the uq_flight_subs_flight_user constraint. A full session.rollback()
-    # here would discard any prior work on this session (safe today since the
-    # endpoint only does a SELECT first, but fragile for future callers).
-    try:
-        with session.begin_nested():
-            session.add(FlightSubscriptionRow(flight_id=flight_id, user_id=user_id))
-        return True
-    except IntegrityError:
-        return False
+            # Wrap the insert in a SAVEPOINT so only this statement rolls back if two
+            # concurrent subscribe calls race past the existence check and the loser
+            # trips the uq_flight_subs_flight_user constraint. A full session.rollback()
+            # here would discard any prior work on this session (safe today since the
+            # endpoint only does a SELECT first, but fragile for future callers).
+            try:
+                with session.begin_nested():
+                    session.add(FlightSubscriptionRow(flight_id=flight_id, user_id=user_id))
+                return True
+            except IntegrityError:
+                return False
 
 
 def unsubscribe_flight(session: Session, flight_id: str, user_id: str) -> bool:
@@ -667,16 +675,24 @@ def save_pack_meta(session: Session, meta: BriefingPackMeta) -> None:
     update of the existing row instead of poisoning the request transaction.
     The SAVEPOINT (begin_nested) contains the IntegrityError so any earlier
     work on this session survives — same pattern as ``subscribe_flight``.
+
+    Retried on InnoDB deadlocks/lock-wait timeouts (``db_retry``): the whole
+    insert-or-update attempt — SAVEPOINT race guard included — re-runs after
+    a rollback, since the server killed the transaction. Only the DB
+    statements sit inside the retry; row building and the HMAC are pure
+    local computation done once.
     """
     row = _meta_to_row(meta)
     row.integrity_hmac = _compute_pack_hmac(row)
-    try:
-        with session.begin_nested():
-            session.add(row)
-            session.flush()
-    except IntegrityError:
-        if not update_pack_meta(session, meta):
-            raise
+    for attempt in db_retry(session):
+        with attempt:
+            try:
+                with session.begin_nested():
+                    session.add(row)
+                    session.flush()
+            except IntegrityError:
+                if not update_pack_meta(session, meta):
+                    raise
 
 
 def update_pack_meta(session: Session, meta: BriefingPackMeta) -> bool:
@@ -684,19 +700,24 @@ def update_pack_meta(session: Session, meta: BriefingPackMeta) -> bool:
 
     Returns True when an existing row was updated, False when no row existed
     (caller should fall back to ``save_pack_meta``).
+
+    Retried on InnoDB deadlocks/lock-wait timeouts (``db_retry``) — the row
+    lookup re-runs per attempt because the retry rollback expires it.
     """
     naive_ts = meta.fetch_timestamp.replace(tzinfo=None)
     stmt = select(BriefingPackRow).where(
         BriefingPackRow.flight_id == meta.flight_id,
         BriefingPackRow.fetch_timestamp == naive_ts,
     )
-    row = session.execute(stmt).scalar_one_or_none()
-    if row is None:
-        return False
-    _apply_meta_to_row(row, meta)
-    row.integrity_hmac = _compute_pack_hmac(row)
-    session.flush()
-    return True
+    for attempt in db_retry(session):
+        with attempt:
+            row = session.execute(stmt).scalar_one_or_none()
+            if row is None:
+                return False
+            _apply_meta_to_row(row, meta)
+            row.integrity_hmac = _compute_pack_hmac(row)
+            session.flush()
+            return True
 
 
 def load_pack_meta(

--- a/src/weatherbrief/storage/flights.py
+++ b/src/weatherbrief/storage/flights.py
@@ -680,7 +680,11 @@ def save_pack_meta(session: Session, meta: BriefingPackMeta) -> None:
     insert-or-update attempt — SAVEPOINT race guard included — re-runs after
     a rollback, since the server killed the transaction. Only the DB
     statements sit inside the retry; row building and the HMAC are pure
-    local computation done once.
+    local computation done once. The update fallback calls the non-retrying
+    ``_update_pack_meta_once`` core: this function's own retry loop already
+    re-runs the whole insert-or-update, and retry loops must never nest —
+    an inner loop's ``session.rollback()`` could silently discard the
+    caller's prior uncommitted work (see ``db/retry.py``).
     """
     row = _meta_to_row(meta)
     row.integrity_hmac = _compute_pack_hmac(row)
@@ -691,8 +695,29 @@ def save_pack_meta(session: Session, meta: BriefingPackMeta) -> None:
                     session.add(row)
                     session.flush()
             except IntegrityError:
-                if not update_pack_meta(session, meta):
+                if not _update_pack_meta_once(session, meta):
                     raise
+
+
+def _update_pack_meta_once(session: Session, meta: BriefingPackMeta) -> bool:
+    """One attempt at the update, with no retry of its own.
+
+    The non-retrying core of ``update_pack_meta`` — and the entry point for
+    ``save_pack_meta``'s race fallback, which already runs inside its own
+    ``db_retry`` loop (retry loops must never nest; see ``db/retry.py``).
+    """
+    naive_ts = meta.fetch_timestamp.replace(tzinfo=None)
+    stmt = select(BriefingPackRow).where(
+        BriefingPackRow.flight_id == meta.flight_id,
+        BriefingPackRow.fetch_timestamp == naive_ts,
+    )
+    row = session.execute(stmt).scalar_one_or_none()
+    if row is None:
+        return False
+    _apply_meta_to_row(row, meta)
+    row.integrity_hmac = _compute_pack_hmac(row)
+    session.flush()
+    return True
 
 
 def update_pack_meta(session: Session, meta: BriefingPackMeta) -> bool:
@@ -704,20 +729,9 @@ def update_pack_meta(session: Session, meta: BriefingPackMeta) -> bool:
     Retried on InnoDB deadlocks/lock-wait timeouts (``db_retry``) — the row
     lookup re-runs per attempt because the retry rollback expires it.
     """
-    naive_ts = meta.fetch_timestamp.replace(tzinfo=None)
-    stmt = select(BriefingPackRow).where(
-        BriefingPackRow.flight_id == meta.flight_id,
-        BriefingPackRow.fetch_timestamp == naive_ts,
-    )
     for attempt in db_retry(session):
         with attempt:
-            row = session.execute(stmt).scalar_one_or_none()
-            if row is None:
-                return False
-            _apply_meta_to_row(row, meta)
-            row.integrity_hmac = _compute_pack_hmac(row)
-            session.flush()
-            return True
+            return _update_pack_meta_once(session, meta)
 
 
 def load_pack_meta(

--- a/src/weatherbrief/storage/refresh_jobs.py
+++ b/src/weatherbrief/storage/refresh_jobs.py
@@ -23,6 +23,7 @@ from sqlalchemy.orm import Session
 
 from flyfun_common.db import SessionLocal
 from weatherbrief.db.models import BriefingRefreshJobRow
+from weatherbrief.db.retry import db_retry
 
 logger = logging.getLogger(__name__)
 
@@ -147,12 +148,23 @@ def latest_job_for_flight(db: Session, flight_id: str) -> BriefingRefreshJobRow 
 
 
 def _best_effort(what: str, fn):
-    """Run ``fn(db)`` in its own committed session, swallowing all failures."""
+    """Run ``fn(db)`` in its own committed session, swallowing all failures.
+
+    Transient InnoDB deadlocks/lock-wait timeouts are retried first
+    (``db_retry`` — ``fn`` plus the commit re-run after a rollback, since a
+    lock error can surface at either the flush or the commit); only once
+    those retries are exhausted does the failure hit the swallow below, so a
+    momentary lock conflict no longer silently drops the job row. The
+    swallow contract itself is unchanged: any persistent failure still
+    returns None instead of raising into a refresh.
+    """
     db = None
     try:
         db = SessionLocal()
-        result = fn(db)
-        db.commit()
+        for attempt in db_retry(db):
+            with attempt:
+                result = fn(db)
+                db.commit()
         return result
     except Exception:
         # Deliberately broad and non-fatal: refresh durability is diagnostic.

--- a/src/weatherbrief/tasks/refresh_resume.py
+++ b/src/weatherbrief/tasks/refresh_resume.py
@@ -246,18 +246,22 @@ async def reconcile_one(job_id: int, app_state) -> None:
         f"interrupted by process restart; resumed as {decision.reason}",
     )
 
-    # Own session for the duration: _auto_refresh_one reads attributes off the
-    # FlightRow while it runs, so the row must stay attached to a live session
-    # (same shape as the scheduler's auto-refresh cycle).
+    # The flight-exists check gets its own short session — _auto_refresh_one
+    # opens and closes its own sessions around its reads and its finalize, so
+    # no pooled connection is pinned across the pipeline here either.
     run_db = SessionLocal()
     try:
         flight_row = run_db.get(FlightRow, flight_id)
+    finally:
+        run_db.close()
+
+    try:
         if flight_row is None:
             refresh_registry.mark_outcome(flight_id, "abandoned", "flight disappeared")
             return
         refresh_registry.set_refreshing(flight_id)
         ran = await asyncio.to_thread(
-            _auto_refresh_one, flight_row, app_state, user_id, triggered_by="resume",
+            _auto_refresh_one, flight_id, app_state, user_id, triggered_by="resume",
         )
         # decide_resume already checked the gate, so a skip here means it moved
         # underneath us (the scheduler got there first). Record it as such
@@ -275,7 +279,6 @@ async def reconcile_one(job_id: int, app_state) -> None:
         logger.error("Refresh resume failed for flight %s", flight_id, exc_info=True)
     finally:
         refresh_registry.unregister(flight_id)
-        run_db.close()
 
 
 async def run_refresh_resume(app_state) -> None:

--- a/src/weatherbrief/tasks/refresh_resume.py
+++ b/src/weatherbrief/tasks/refresh_resume.py
@@ -103,7 +103,7 @@ def decide_resume(
         decide_refresh,
         pending_coverage_date,
     )
-    from weatherbrief.storage.flights import _row_to_flight, list_packs
+    from weatherbrief.storage.flights import _row_to_flight, latest_pack
 
     limit = resume_max_attempts() if max_attempts is None else max_attempts
 
@@ -139,9 +139,9 @@ def decide_resume(
     # The refresh gate is a free correctness check: if a full run is no longer
     # warranted — the scheduler already re-briefed this flight, or no model has
     # moved since — there is nothing to resume.
-    packs = list_packs(db, job.flight_id)
-    if packs:
-        status = _build_data_status(packs[0], flight)
+    pack = latest_pack(db, job.flight_id)
+    if pack is not None:
+        status = _build_data_status(pack, flight)
         decision = decide_refresh(status, _days_out_now(flight, now))
         if decision.mode != "full":
             return ResumeDecision(

--- a/src/weatherbrief/tasks/time_scan_runner.py
+++ b/src/weatherbrief/tasks/time_scan_runner.py
@@ -100,14 +100,18 @@ def _run_scan_job(flight_id: str, pack_dir: Path, fetch_ts: datetime, db_path: s
     from flyfun_common.db import SessionLocal
 
     try:
+        from weatherbrief.api.packs import _build_route_config, _load_advisory_profile
+        from weatherbrief.storage.flights import load_flight
+        from weatherbrief.tasks.advise import derive_assessment_from_advisories
+        from weatherbrief.tasks.artifacts import save_time_options
+        from weatherbrief.tasks.time_scan import run_time_scan
+
+        # Reads run in one short session, closed BEFORE run_time_scan: the
+        # scan is a slow GRIB decode and a pooled connection must not stay
+        # pinned across it. The pack-row update + usage row commit in a
+        # fresh session afterwards.
         db = SessionLocal()
         try:
-            from weatherbrief.api.packs import _build_route_config, _load_advisory_profile
-            from weatherbrief.storage.flights import load_flight
-            from weatherbrief.tasks.advise import derive_assessment_from_advisories
-            from weatherbrief.tasks.artifacts import save_time_options
-            from weatherbrief.tasks.time_scan import run_time_scan
-
             flight = load_flight(db, flight_id)
             # Re-read mode inside the worker — it may have changed while queued.
             if flight.flexibility == "none":
@@ -140,39 +144,44 @@ def _run_scan_job(flight_id: str, pack_dir: Path, fetch_ts: datetime, db_path: s
             ) = _load_advisory_profile(
                 db, flight, flight.user_id, None, pack_dir, db_path=db_path,
             )
+        finally:
+            db.close()
 
-            scan = run_time_scan(
-                pack_dir, route, flight.departure_time,
-                flexibility=flight.flexibility,
-                alt_departure_time=flight.alt_departure_time,
-                advisory_models=adv_models,
-                enabled_ids=enabled_ids,
-                advisory_enabled=enabled_map,
-                user_params=user_params,
-                aggregation=aggregation,
-                airports_db_path=db_path,
-                airport_conditions_recompute=recompute_conds,
-                icing_method=icing_method,
-                cloud_source=cloud_source,
-                convective_method=convective_method,
-                locale=locale,
-                declared_approach_icaos=declared_approaches,
-            )
-            if scan is None:
-                _write_status(pack_dir, "skipped", flight.flexibility, reason="no_data")
-                return
+        scan = run_time_scan(
+            pack_dir, route, flight.departure_time,
+            flexibility=flight.flexibility,
+            alt_departure_time=flight.alt_departure_time,
+            advisory_models=adv_models,
+            enabled_ids=enabled_ids,
+            advisory_enabled=enabled_map,
+            user_params=user_params,
+            aggregation=aggregation,
+            airports_db_path=db_path,
+            airport_conditions_recompute=recompute_conds,
+            icing_method=icing_method,
+            cloud_source=cloud_source,
+            convective_method=convective_method,
+            locale=locale,
+            declared_approach_icaos=declared_approaches,
+        )
+        if scan is None:
+            _write_status(pack_dir, "skipped", flight.flexibility, reason="no_data")
+            return
 
-            # Preserve paid confirm verdicts across a same-run rescan (e.g.
-            # the "Set as alternate" flow rebuilding the candidate list).
-            from weatherbrief.tasks.artifacts import load_time_options
+        # Preserve paid confirm verdicts across a same-run rescan (e.g.
+        # the "Set as alternate" flow rebuilding the candidate list).
+        from weatherbrief.tasks.artifacts import load_time_options
 
-            merge_confirmed(load_time_options(pack_dir), scan)
-            save_time_options(pack_dir, scan)
+        merge_confirmed(load_time_options(pack_dir), scan)
+        save_time_options(pack_dir, scan)
 
-            # The pinned alternate row keeps the legacy pack-row alt fields
-            # (and the planned↔alt web UI) alive — mirror what the retired
-            # in-pipeline alt stage recorded.
-            alt_row = next((c for c in scan.candidates if c.is_alternate), None)
+        # The pinned alternate row keeps the legacy pack-row alt fields
+        # (and the planned↔alt web UI) alive — mirror what the retired
+        # in-pipeline alt stage recorded.
+        alt_row = next((c for c in scan.candidates if c.is_alternate), None)
+
+        db = SessionLocal()
+        try:
             if alt_row is not None:
                 _update_pack_alt_fields(db, flight_id, pack_dir, fetch_ts, alt_row)
 
@@ -188,10 +197,10 @@ def _run_scan_job(flight_id: str, pack_dir: Path, fetch_ts: datetime, db_path: s
                 api_calls=1, user_id=flight.user_id, flight_id=flight_id,
             )
             db.commit()
-
-            _write_status(pack_dir, "done", flight.flexibility)
         finally:
             db.close()
+
+        _write_status(pack_dir, "done", flight.flexibility)
     except Exception:
         logger.warning("time-scan: job failed for %s", flight_id, exc_info=True)
         try:

--- a/src/weatherbrief/tasks/verification.py
+++ b/src/weatherbrief/tasks/verification.py
@@ -19,6 +19,7 @@ from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
+from flyfun_common.db import SessionLocal
 from weatherbrief.db.models import (
     BriefingPackRow,
     FlightRow,
@@ -447,11 +448,15 @@ def _ms_since(t0: float) -> int:
 
 
 def collect_and_store(
-    db: Session,
     airports_db_path: str,
     corridor_nm: float = _DEFAULT_CORRIDOR_NM,
 ) -> dict:
     """Run one complete collection cycle.
+
+    Session scoping: the read phases share one short session that is
+    committed and closed BEFORE the aviationweather.gov fetch — a pooled
+    connection must not stay pinned across that network I/O — and the store
+    phase runs in a fresh session afterwards.
 
     Returns summary dict with counts.
     """
@@ -459,35 +464,43 @@ def collect_and_store(
     started_at = datetime.now(timezone.utc)
     timings: dict[str, int] = {}
 
-    # Phase E — finalize flights past their window (runs independently)
-    t0 = time.monotonic()
-    finalized = finalize_completed_flights(db)
-    if finalized:
+    db = SessionLocal()
+    try:
+        # Phase E — finalize flights past their window (runs independently)
+        t0 = time.monotonic()
+        finalized = finalize_completed_flights(db)
+        if finalized:
+            db.commit()
+        timings["finalize"] = _ms_since(t0)
+
+        t0 = time.monotonic()
+        scored = _score_completed(db, airports_db_path)
+        timings["score"] = _ms_since(t0)
+
+        # Phase A — find active flights
+        t0 = time.monotonic()
+        flights = find_verifiable_flights(db)
+        timings["find"] = _ms_since(t0)
+
+        if not flights:
+            # No active flights — skip metrics row
+            return {"flights": 0, "airports": 0, "observations": 0, "finalized": finalized, "scored": scored}
+
+        t0 = time.monotonic()
+        icao_to_flights = gather_airports(flights, db, airports_db_path, corridor_nm)
+        timings["gather"] = _ms_since(t0)
+
+        if not icao_to_flights:
+            _record_cycle(db, started_at, cycle_start, timings,
+                          flights=len(flights), airports=0, inserted=0,
+                          finalized=finalized, scored=scored)
+            return {"flights": len(flights), "airports": 0, "observations": 0, "finalized": finalized, "scored": scored}
+
+        # Checkpoint the corridor-cache writes before the fetch — the
+        # connection goes back to the pool here, not after the network call.
         db.commit()
-    timings["finalize"] = _ms_since(t0)
-
-    t0 = time.monotonic()
-    scored = _score_completed(db, airports_db_path)
-    timings["score"] = _ms_since(t0)
-
-    # Phase A — find active flights
-    t0 = time.monotonic()
-    flights = find_verifiable_flights(db)
-    timings["find"] = _ms_since(t0)
-
-    if not flights:
-        # No active flights — skip metrics row
-        return {"flights": 0, "airports": 0, "observations": 0, "finalized": finalized, "scored": scored}
-
-    t0 = time.monotonic()
-    icao_to_flights = gather_airports(flights, db, airports_db_path, corridor_nm)
-    timings["gather"] = _ms_since(t0)
-
-    if not icao_to_flights:
-        _record_cycle(db, started_at, cycle_start, timings,
-                      flights=len(flights), airports=0, inserted=0,
-                      finalized=finalized, scored=scored)
-        return {"flights": len(flights), "airports": 0, "observations": 0, "finalized": finalized, "scored": scored}
+    finally:
+        db.close()
 
     unique_icaos = sorted(icao_to_flights.keys())
     logger.info(
@@ -495,21 +508,25 @@ def collect_and_store(
         len(flights), len(unique_icaos),
     )
 
-    # Phase B — fetch METARs
+    # Phase B — fetch METARs (no session held across the network fetch)
     t0 = time.monotonic()
     observations = fetch_observations_batch(unique_icaos, airports_db_path)
     timings["fetch"] = _ms_since(t0)
 
-    # Phase C — store observations
-    t0 = time.monotonic()
-    inserted = store_observations(observations, icao_to_flights, db)
-    timings["store"] = _ms_since(t0)
+    db = SessionLocal()
+    try:
+        # Phase C — store observations
+        t0 = time.monotonic()
+        inserted = store_observations(observations, icao_to_flights, db)
+        timings["store"] = _ms_since(t0)
 
-    _record_cycle(db, started_at, cycle_start, timings,
-                  flights=len(flights), airports=len(unique_icaos),
-                  inserted=inserted, finalized=finalized, scored=scored)
+        _record_cycle(db, started_at, cycle_start, timings,
+                      flights=len(flights), airports=len(unique_icaos),
+                      inserted=inserted, finalized=finalized, scored=scored)
 
-    db.commit()
+        db.commit()
+    finally:
+        db.close()
 
     logger.info(
         "Verification: %d observations stored, %d flights finalized, %d scored",

--- a/src/weatherbrief/verify/__main__.py
+++ b/src/weatherbrief/verify/__main__.py
@@ -79,10 +79,11 @@ def cmd_collect(args):
 
             print(f"Stored {inserted} new observations from {len(observations)} fetched.")
         else:
-            # Full collection cycle
+            # Full collection cycle (owns its sessions — the db above is only
+            # for the single-flight branch)
             from weatherbrief.tasks.verification import collect_and_store
 
-            result = collect_and_store(db, airports_db, args.corridor)
+            result = collect_and_store(airports_db, args.corridor)
             print(f"Flights: {result['flights']}")
             print(f"Airports: {result['airports']}")
             print(f"New observations: {result['observations']}")

--- a/tests/test_airport_profile.py
+++ b/tests/test_airport_profile.py
@@ -371,3 +371,195 @@ class TestGribRunDedup:
             ["a:enter", "a:exit", "b:enter", "b:exit"],
             ["b:enter", "b:exit", "a:enter", "a:exit"],
         )
+
+
+# ---------------------------------------------------------------------------
+# Session lifetime: the SSE stream must not pin a pooled connection.
+#
+# The endpoint manages its own ``SessionLocal()`` and closes it BEFORE the
+# StreamingResponse is constructed — the same pattern as
+# ``packs.refresh_briefing_stream``. FastAPI's ``Depends(get_db)`` cleanup
+# would only run after the stream finishes, pinning 1 of the pooled
+# connections for the stream's whole life (pool exhaustion → 500s once the
+# limiter's 20 concurrent streams exceed the pool). Tests below pin:
+#   (a) close() happens before the response object exists,
+#   (b) the stream generator never touches the session (structural +
+#       behavioral — the spy raises on any use beyond the pre-stream read),
+#   (c) the endpoint's response shape is unchanged.
+# ---------------------------------------------------------------------------
+
+
+class _SpySession:
+    """Stands in for a real SQLAlchemy Session.
+
+    Supports exactly the pre-stream read path
+    (``execute(...).scalars().all()`` → no rows) plus ``close()``. Any other
+    attribute access — which could only come from the stream generator
+    misusing the session — raises, as does any use after ``close()``.
+    """
+
+    def __init__(self) -> None:
+        self.closed = False
+        self.close_calls = 0
+
+    def close(self) -> None:
+        self.closed = True
+        self.close_calls += 1
+
+    def execute(self, *_args, **_kwargs):
+        if self.closed:
+            raise AssertionError("session used after close()")
+        return self
+
+    def scalars(self):
+        return self
+
+    def all(self):
+        return []
+
+    def __getattr__(self, name):
+        raise AssertionError(
+            f"unexpected session attribute {name!r} touched — "
+            "the airport-profile stream must not use the session"
+        )
+
+
+async def _call_profile_endpoint(ap, **overrides):
+    """Invoke get_airport_profile directly, bypassing FastAPI DI."""
+    kwargs = {
+        "icao": "EGLL",
+        "model": "ecmwf",
+        "start_hour": "2026-05-07T12:00:00Z",
+        "window_h": 0,
+        "enrich": False,
+        "_user_id": "session-spy-user",
+        "airports_db": "/unused",
+        "data_dir": Path("/tmp"),
+    }
+    kwargs.update(overrides)
+    return await ap.get_airport_profile(**kwargs)
+
+
+def _patch_pre_stream(monkeypatch, ap, session):
+    """Mock the session factory and everything upstream of the stream."""
+    monkeypatch.setattr(ap, "SessionLocal", lambda: session)
+    monkeypatch.setattr(
+        ap, "_resolve_airport_coords", lambda *_a: (51.4775, -0.4614, 83.0),
+    )
+
+
+class TestSessionLifetime:
+    @pytest.mark.asyncio
+    async def test_session_closed_before_streaming_response_created(self, monkeypatch):
+        """(a) The response object must only ever exist after close()."""
+        from weatherbrief.api import airport_profile as ap
+
+        session = _SpySession()
+        _patch_pre_stream(monkeypatch, ap, session)
+
+        closed_at_construction = []
+        real_response_cls = ap.StreamingResponse
+
+        def _checked_response(*args, **kwargs):
+            closed_at_construction.append(session.closed)
+            return real_response_cls(*args, **kwargs)
+
+        monkeypatch.setattr(ap, "StreamingResponse", _checked_response)
+
+        response = await _call_profile_endpoint(ap)
+
+        assert closed_at_construction == [True], (
+            "StreamingResponse was constructed before db.close() — the "
+            "stream would pin a pooled connection for its whole life"
+        )
+        assert session.close_calls == 1
+        assert isinstance(response, real_response_cls)
+
+    def test_event_generator_does_not_capture_db(self):
+        """(b, structural) No nested function of the endpoint — the SSE
+        generator and its helpers — may close over ``db``. If any did,
+        ``db`` would be promoted to a cell variable of the endpoint and
+        appear in the nested code's co_freevars. The dependency itself must
+        also be gone from the signature."""
+        import inspect
+
+        from weatherbrief.api import airport_profile as ap
+
+        assert "db" not in inspect.signature(ap.get_airport_profile).parameters, (
+            "get_airport_profile still takes db=Depends(get_db) — FastAPI's "
+            "yield-dependency cleanup closes it only after the stream ends"
+        )
+
+        def _walk(code):
+            yield code
+            for const in code.co_consts:
+                if hasattr(const, "co_consts"):
+                    yield from _walk(const)
+
+        endpoint_code = ap.get_airport_profile.__code__
+        assert "db" not in endpoint_code.co_cellvars, (
+            "`db` is captured by a nested function — the SSE generator must "
+            "only see plain data, never the session"
+        )
+        for code in _walk(endpoint_code):
+            assert "db" not in code.co_freevars, (
+                f"nested function {code.co_name!r} closes over `db`"
+            )
+
+    @pytest.mark.asyncio
+    async def test_stream_runs_without_session_and_shape_unchanged(self, monkeypatch):
+        """(b, behavioral) + (c) Drain the whole stream against the spy
+        session: any generator-side session use raises inside the spy, and
+        the event sequence / payload shape must match the pre-change
+        contract (levels fetch failed path, enrichment off)."""
+        from weatherbrief.api import airport_profile as ap
+
+        session = _SpySession()
+        _patch_pre_stream(monkeypatch, ap, session)
+        # Stream internals: pressure-level fetch "fails" (None → levels
+        # error event), enrichment off, derived runs for real on wf=None.
+        monkeypatch.setattr(ap, "_fetch_pressure_levels", lambda *_a: None)
+
+        limiter_before = ap._limiter.snapshot()["global"]
+        response = await _call_profile_endpoint(ap)
+        assert session.closed
+
+        assert response.media_type == "text/event-stream"
+        assert response.headers["cache-control"] == "no-cache"
+        assert response.headers["x-accel-buffering"] == "no"
+
+        parsed = []
+        async for chunk in response.body_iterator:
+            event_line, data_line = chunk.splitlines()[:2]
+            parsed.append((
+                event_line.removeprefix("event: "),
+                json.loads(data_line.removeprefix("data: ")),
+            ))
+
+        assert [event for event, _ in parsed] == [
+            "meta", "surface",
+            "progress", "levels",
+            "progress", "derived",
+            "complete",
+        ]
+        payloads = {event: data for event, data in parsed}
+
+        meta = payloads["meta"]
+        assert meta["type"] == "meta"
+        assert meta["icao"] == "EGLL"
+        assert meta["lat"] == 51.4775
+        assert meta["lon"] == -0.4614
+        assert meta["elevation_ft"] == 83.0
+        assert meta["model"] == "ecmwf"
+        assert len(meta["hours"]) == 1  # window_h=0 → single hour
+
+        assert payloads["surface"] == {"type": "surface", "hours": []}
+        assert payloads["levels"] == {
+            "type": "levels", "hours": [], "error": "fetch_failed",
+        }
+        assert payloads["derived"] == {"type": "derived", "points": []}
+        stages = [d["stage"] for e, d in parsed if e == "progress"]
+        assert stages == ["fetch_forecasts", "sounding_analysis"]
+
+        # Draining the stream released the limiter slot (generator finally).
+        assert ap._limiter.snapshot()["global"] == limiter_before

--- a/tests/test_api_flights_list.py
+++ b/tests/test_api_flights_list.py
@@ -1,0 +1,206 @@
+"""Tests for aircraft resolution in the GET /api/flights list response.
+
+The list endpoint batch-prefetches every referenced user aircraft in ONE
+``select(...).where(UserAircraftRow.id.in_(ids))`` query instead of a
+per-flight ``db.get`` (mysql-review N+1 fix). These tests pin both the query
+count — via an engine cursor spy filtering statements that read the
+``user_aircraft`` table — and the unchanged response shape (owner-visible
+tail/nickname, ``None`` aircraft block).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import event
+from sqlalchemy.orm import sessionmaker
+
+from flyfun_common.db import current_user_id, get_db, DEV_USER_ID
+from flyfun_common.db.models import UserPreferencesRow, UserRow
+from weatherbrief.api.app import create_app
+from weatherbrief.db.models import UserAircraftRow
+from weatherbrief.models import Flight
+from weatherbrief.storage.flights import save_flight
+
+
+@pytest.fixture
+def app_db():
+    from conftest import make_app_engine
+    engine = make_app_engine()
+    TestSession = sessionmaker(bind=engine)
+    s = TestSession()
+    s.add(UserRow(
+        id=DEV_USER_ID, provider="local", provider_sub="dev",
+        email="d@l", display_name="D", approved=True,
+    ))
+    s.flush()
+    s.add(UserPreferencesRow(user_id=DEV_USER_ID))
+    s.commit()
+    s.close()
+    yield TestSession
+    engine.dispose()
+
+
+@pytest.fixture
+def client(app_db, tmp_path, monkeypatch):
+    monkeypatch.setenv("DATA_DIR", str(tmp_path / "data"))
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.setenv("JWT_SECRET", "test")
+    app = create_app()
+
+    def _override_get_db():
+        s = app_db()
+        try:
+            yield s
+            s.commit()
+        except Exception:
+            s.rollback()
+            raise
+        finally:
+            s.close()
+
+    app.dependency_overrides[get_db] = _override_get_db
+    app.dependency_overrides[current_user_id] = lambda: DEV_USER_ID
+    return TestClient(app, raise_server_exceptions=False)
+
+
+@pytest.fixture
+def aircraft_query_count(app_db):
+    """Count SELECT statements that read the user_aircraft table.
+
+    Engine-level cursor spy (the ground truth for "queries issued") — a
+    per-flight ``db.get`` and the batch IN-select both surface here, while
+    identity-map hits emit no SQL at all.
+    """
+    engine = app_db.kw["bind"]
+    count = 0
+
+    @event.listens_for(engine, "before_cursor_execute")
+    def _spy(_conn, _cursor, statement, _parameters, _context, _executemany):
+        nonlocal count
+        if statement.lstrip().upper().startswith("SELECT") and "user_aircraft" in statement:
+            count += 1
+
+    yield lambda: count
+    event.remove(engine, "before_cursor_execute", _spy)
+
+
+def _save_aircraft(
+    app_db,
+    *,
+    icao_type: str,
+    tail: str | None = None,
+    nickname: str | None = None,
+) -> int:
+    s = app_db()
+    ac = UserAircraftRow(
+        user_id=DEV_USER_ID, icao_type=icao_type,
+        tail_number=tail, nickname=nickname,
+    )
+    s.add(ac)
+    s.commit()
+    aircraft_id = ac.id
+    s.close()
+    return aircraft_id
+
+
+def _save_flight(
+    app_db,
+    *,
+    route: str,
+    days_offset: int,
+    idx: int,
+    aircraft_id: int | None = None,
+) -> Flight:
+    s = app_db()
+    dep = datetime.now(timezone.utc) + timedelta(days=days_offset)
+    h = hashlib.sha256(json.dumps(
+        {"alt": 8000, "ceil": 18000, "dur": 1.0, "time": dep.strftime("%H:%M"),
+         "user": DEV_USER_ID, "idx": idx},
+        sort_keys=True,
+    ).encode()).hexdigest()[:4]
+    f = Flight(
+        id=f"{route}-{dep.strftime('%Y-%m-%d')}-{h}",
+        user_id=DEV_USER_ID,
+        route_name=route,
+        waypoints=["EGTK", "LFAT"],
+        departure_time=dep,
+        cruise_altitude_ft=8000,
+        flight_ceiling_ft=18000,
+        flight_duration_hours=1.0,
+        aircraft_id=aircraft_id,
+        created_at=datetime.now(timezone.utc) - timedelta(days=30),
+    )
+    save_flight(s, f, DEV_USER_ID)
+    s.commit()
+    s.close()
+    return f
+
+
+class TestAircraftBatchPrefetch:
+    def test_distinct_aircraft_fetched_in_one_query(self, client, app_db, aircraft_query_count):
+        # Two flights with different aircraft + one with none: the per-flight
+        # db.get path issues one SELECT per aircraft-carrying flight (the
+        # ORM row is dropped right after the AircraftInfo is built, so the
+        # weak-ref identity map never dedups); the batch prefetch issues 1.
+        ac1 = _save_aircraft(app_db, icao_type="P28A", tail="G-ABCD", nickname="Archer")
+        ac2 = _save_aircraft(app_db, icao_type="SR22", tail="G-EFGH")
+        f1 = _save_flight(app_db, route="ac1", days_offset=+5, idx=1, aircraft_id=ac1)
+        f2 = _save_flight(app_db, route="ac2", days_offset=+6, idx=2, aircraft_id=ac2)
+        f3 = _save_flight(app_db, route="noac", days_offset=+7, idx=3)
+
+        # Baseline after seeding: only request-time queries count.
+        baseline = aircraft_query_count()
+        resp = client.get("/api/flights")
+        assert resp.status_code == 200
+        assert aircraft_query_count() - baseline == 1
+
+        by_id = {f["id"]: f for f in resp.json()}
+        assert by_id[f1.id]["aircraft"] == {
+            "id": ac1,
+            "icao_type": "P28A",
+            "type_name": "Piper PA-28 Cherokee / Warrior / Archer",
+            "tail_number": "G-ABCD",  # owner sees own tail
+            "nickname": "Archer",
+        }
+        assert by_id[f2.id]["aircraft"] == {
+            "id": ac2,
+            "icao_type": "SR22",
+            "type_name": "Cirrus SR22",
+            "tail_number": "G-EFGH",
+            "nickname": None,
+        }
+        assert by_id[f3.id]["aircraft"] is None
+        assert by_id[f3.id]["aircraft_id"] is None
+
+    def test_shared_aircraft_still_one_query(self, client, app_db, aircraft_query_count):
+        # Two flights sharing one aircraft + one with none — the batch map is
+        # keyed on distinct ids, so shared references cost nothing extra.
+        ac = _save_aircraft(app_db, icao_type="C172", tail="G-IJKL")
+        f1 = _save_flight(app_db, route="sh1", days_offset=+5, idx=1, aircraft_id=ac)
+        f2 = _save_flight(app_db, route="sh2", days_offset=+6, idx=2, aircraft_id=ac)
+        f3 = _save_flight(app_db, route="shn", days_offset=+7, idx=3)
+
+        baseline = aircraft_query_count()
+        resp = client.get("/api/flights")
+        assert resp.status_code == 200
+        assert aircraft_query_count() - baseline == 1
+
+        by_id = {f["id"]: f for f in resp.json()}
+        assert by_id[f1.id]["aircraft"]["id"] == ac
+        assert by_id[f2.id]["aircraft"]["id"] == ac
+        assert by_id[f1.id]["aircraft"]["tail_number"] == "G-IJKL"
+        assert by_id[f3.id]["aircraft"] is None
+
+    def test_no_aircraft_referenced_issues_no_query(self, client, app_db, aircraft_query_count):
+        _save_flight(app_db, route="bare1", days_offset=+5, idx=1)
+        _save_flight(app_db, route="bare2", days_offset=+6, idx=2)
+
+        resp = client.get("/api/flights")
+        assert resp.status_code == 200
+        assert aircraft_query_count() == 0
+        assert all(f["aircraft"] is None for f in resp.json())

--- a/tests/test_db_retry.py
+++ b/tests/test_db_retry.py
@@ -1,0 +1,281 @@
+"""Deadlock/lock-wait retry helper (``weatherbrief.db.retry``).
+
+Why: with several writer roles hitting MySQL concurrently (web endpoints,
+scheduler refresh loop, boot resume, METAR ingest, verification, retention,
+analytics rollup), InnoDB errno 1213 (deadlock victim) / 1205 (lock wait
+timeout) are transient facts of life — without a retry they surface as
+failed requests/cycles. SQLite never raises them for real, so the tests
+inject fake PyMySQL-shaped ``OperationalError``s; that keeps the suite
+DB-agnostic while exercising the exact detection shapes production hits.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy.exc import IntegrityError, OperationalError
+from sqlalchemy.orm import Session, sessionmaker
+
+from flyfun_common.db import DEV_USER_ID
+from flyfun_common.db.models import UserRow
+from weatherbrief.db.retry import db_retry
+from weatherbrief.models import BriefingPackMeta, Flight
+from weatherbrief.storage import refresh_jobs
+from weatherbrief.storage.flights import load_pack_meta, save_flight, save_pack_meta
+
+
+class _FakeDBAPIError(Exception):
+    """Stands in for ``pymysql.err.OperationalError``: ``args[0]`` is the errno."""
+
+
+def _lock_error(errno: int, message: str) -> OperationalError:
+    return OperationalError("INSERT INTO t VALUES (1)", {}, _FakeDBAPIError(errno, message))
+
+
+def _deadlock() -> OperationalError:
+    return _lock_error(
+        1213, "Deadlock found when trying to get lock; try restarting transaction"
+    )
+
+
+def _lock_wait_timeout() -> OperationalError:
+    return _lock_error(1205, "Lock wait timeout exceeded; try restarting transaction")
+
+
+class TestDbRetry:
+    @pytest.mark.parametrize("errno_factory", [_deadlock, _lock_wait_timeout])
+    def test_retryable_lock_error_succeeds_on_second_attempt(
+        self, db_session, errno_factory
+    ):
+        calls = 0
+
+        def block() -> str:
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                raise errno_factory()
+            return "ok"
+
+        for attempt in db_retry(db_session, base_delay_s=0):
+            with attempt:
+                result = block()
+
+        assert result == "ok"
+        assert calls == 2
+
+    def test_gives_up_after_max_attempts_and_reraises(self, db_session):
+        calls = 0
+
+        def block() -> None:
+            nonlocal calls
+            calls += 1
+            raise _deadlock()
+
+        with pytest.raises(OperationalError):
+            for attempt in db_retry(db_session, max_attempts=3, base_delay_s=0):
+                with attempt:
+                    block()
+        assert calls == 3
+
+    def test_non_deadlock_operational_error_not_retried(self, db_session):
+        calls = 0
+        gone_away = OperationalError(
+            "SELECT 1", {}, _FakeDBAPIError(2006, "MySQL server has gone away")
+        )
+
+        def block() -> None:
+            nonlocal calls
+            calls += 1
+            raise gone_away
+
+        with pytest.raises(OperationalError) as exc_info:
+            for attempt in db_retry(db_session, base_delay_s=0):
+                with attempt:
+                    block()
+        assert exc_info.value is gone_away
+        assert calls == 1
+
+    def test_integrity_error_propagates_untouched(self, db_session):
+        calls = 0
+        duplicate = IntegrityError(
+            "INSERT INTO t VALUES (1)", {}, _FakeDBAPIError(1062, "Duplicate entry")
+        )
+
+        def block() -> None:
+            nonlocal calls
+            calls += 1
+            raise duplicate
+
+        with pytest.raises(IntegrityError) as exc_info:
+            for attempt in db_retry(db_session, base_delay_s=0):
+                with attempt:
+                    block()
+        assert exc_info.value is duplicate
+        assert calls == 1
+
+    def test_detection_falls_back_to_message_text(self, db_session):
+        """DBAPIs that don't expose the server errno as ``args[0]`` (unlike
+        PyMySQL) still match on the message text."""
+        errno_less = OperationalError(
+            "INSERT INTO t VALUES (1)",
+            {},
+            _FakeDBAPIError("Deadlock found when trying to get lock"),
+        )
+        calls = 0
+
+        def block() -> None:
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                raise errno_less
+
+        for attempt in db_retry(db_session, base_delay_s=0):
+            with attempt:
+                block()
+        assert calls == 2
+
+    def test_session_rolled_back_between_attempts(self, db_session, monkeypatch):
+        events: list[str] = []
+        real_rollback = db_session.rollback
+
+        def spy_rollback():
+            events.append("rollback")
+            return real_rollback()
+
+        monkeypatch.setattr(db_session, "rollback", spy_rollback)
+
+        def block() -> None:
+            events.append("block")
+            if events == ["block"]:
+                raise _deadlock()
+
+        for attempt in db_retry(db_session, base_delay_s=0):
+            with attempt:
+                block()
+
+        assert events == ["block", "rollback", "block"]
+
+    def test_backoff_grows_exponentially(self, db_session, monkeypatch):
+        """Sleeps follow base × 2^(attempt-1) × jitter, jitter in [0.5, 1.5)."""
+        from weatherbrief.db import retry as retry_mod
+
+        sleeps: list[float] = []
+        monkeypatch.setattr(retry_mod.time, "sleep", sleeps.append)
+        monkeypatch.setattr(retry_mod.random, "random", lambda: 0.0)
+
+        def block() -> None:
+            raise _deadlock()
+
+        with pytest.raises(OperationalError):
+            for attempt in db_retry(db_session, max_attempts=3, base_delay_s=0.05):
+                with attempt:
+                    block()
+        assert sleeps == [0.05 * 0.5, 0.1 * 0.5]
+
+
+# --- Applied-path smoke tests ---
+
+
+@pytest.fixture
+def sample_flight():
+    return Flight(
+        id="egtk_lsgs-2026-02-21",
+        user_id=DEV_USER_ID,
+        route_name="egtk_lsgs",
+        departure_time=datetime(2026, 2, 21, 9, tzinfo=timezone.utc),
+        cruise_altitude_ft=8000,
+        flight_duration_hours=4.5,
+        created_at=datetime(2026, 2, 14, 10, 0, 0, tzinfo=timezone.utc),
+    )
+
+
+def _meta(flight_id: str, **overrides) -> BriefingPackMeta:
+    base = {
+        "flight_id": flight_id,
+        "fetch_timestamp": datetime(2026, 2, 19, 18, 0, 0, tzinfo=timezone.utc),
+        "days_out": 2,
+        "has_gramet": True,
+        "has_digest": False,
+        "assessment": "AMBER",
+        "assessment_reason": "provisional",
+    }
+    return BriefingPackMeta(**(base | overrides))
+
+
+class TestAppliedPaths:
+    def test_save_pack_meta_survives_one_injected_deadlock(
+        self, sample_flight, monkeypatch
+    ):
+        """One injected 1213 at the insert flush: the attempt rolls back, the
+        SAVEPOINT race guard re-runs inside the retry, and the pack lands.
+
+        Runs on a private engine (same reason as the commit test in
+        test_pack_meta_race): the retry's ``session.rollback()`` discards ALL
+        uncommitted work, so the parent flight must be committed first — and
+        committing on the shared session-scoped engine would leak the
+        dev-user row into later tests.
+        """
+        from conftest import make_app_engine
+
+        engine = make_app_engine()
+        session = sessionmaker(bind=engine)()
+        try:
+            session.add(
+                UserRow(
+                    id=DEV_USER_ID,
+                    provider="local",
+                    provider_sub="dev",
+                    email="dev@localhost",
+                    display_name="Dev User",
+                    approved=True,
+                )
+            )
+            save_flight(session, sample_flight, DEV_USER_ID)
+            session.commit()
+
+            real_flush = session.flush
+            fired = False
+
+            def flaky_flush(*args, **kwargs):
+                nonlocal fired
+                if not fired:
+                    fired = True
+                    raise _deadlock()
+                return real_flush(*args, **kwargs)
+
+            monkeypatch.setattr(session, "flush", flaky_flush)
+
+            meta = _meta(sample_flight.id)
+            save_pack_meta(session, meta)
+
+            loaded = load_pack_meta(session, sample_flight.id, meta.fetch_timestamp)
+            assert loaded.assessment == "AMBER"
+        finally:
+            session.close()
+            engine.dispose()
+
+    def test_refresh_job_write_through_still_swallows_exhausted_retries(
+        self, monkeypatch
+    ):
+        """``_best_effort`` retries transient lock errors but keeps its
+        never-raises contract once they persist: ``record_queued`` returns
+        None instead of failing the refresh."""
+        from conftest import make_app_engine
+
+        class _DeadlockedCommitSession(Session):
+            def commit(self):
+                raise _deadlock()
+
+        engine = make_app_engine()
+        test_session = sessionmaker(bind=engine, class_=_DeadlockedCommitSession)
+        monkeypatch.setattr(refresh_jobs, "SessionLocal", test_session)
+
+        # Default backoff would cost ≤ ~0.5s of sleeps for 3 attempts — keep
+        # the test fast and deterministic.
+        import weatherbrief.db.retry as retry_mod
+
+        monkeypatch.setattr(retry_mod.time, "sleep", lambda _s: None)
+
+        assert refresh_jobs.record_queued("flight-x", user_id=DEV_USER_ID) is None
+        engine.dispose()

--- a/tests/test_db_retry.py
+++ b/tests/test_db_retry.py
@@ -43,6 +43,30 @@ def _lock_wait_timeout() -> OperationalError:
     return _lock_error(1205, "Lock wait timeout exceeded; try restarting transaction")
 
 
+def _savepoint_rollback_error() -> OperationalError:
+    """The masking shape: a failed ``ROLLBACK TO SAVEPOINT`` (MySQL 1305),
+    which SQLAlchemy re-raises in place of the original error."""
+    return OperationalError(
+        "ROLLBACK TO SAVEPOINT sa_savepoint_1",
+        {},
+        _FakeDBAPIError(1305, "SAVEPOINT sa_savepoint_1 does not exist"),
+    )
+
+
+def _deadlock_masked_two_levels_deep() -> OperationalError:
+    """The shape a 1213 takes when the victim dies inside begin_nested: the
+    server already rolled the transaction back, the savepoint rollback fails
+    (1305) and is re-raised — the real 1213 survives only on the
+    ``__context__`` chain, here two levels deep."""
+    try:
+        raise _deadlock()
+    except OperationalError:
+        try:
+            raise RuntimeError("savepoint rollback bookkeeping")
+        except RuntimeError:
+            raise _savepoint_rollback_error()
+
+
 class TestDbRetry:
     @pytest.mark.parametrize("errno_factory", [_deadlock, _lock_wait_timeout])
     def test_retryable_lock_error_succeeds_on_second_attempt(
@@ -134,6 +158,57 @@ class TestDbRetry:
             with attempt:
                 block()
         assert calls == 2
+
+    def test_deadlock_two_levels_deep_in_context_chain_is_retried(self, db_session):
+        """A 1213 raised inside ``session.begin_nested()`` arrives masked by
+        the savepoint-rollback 1305; the real deadlock sits two levels deep on
+        the ``__context__`` chain and must still be detected."""
+        calls = 0
+
+        def block() -> None:
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                raise _deadlock_masked_two_levels_deep()
+
+        for attempt in db_retry(db_session, base_delay_s=0):
+            with attempt:
+                block()
+        assert calls == 2
+
+    def test_deadlock_attached_via_cause_is_retried(self, db_session):
+        """Explicit ``raise ... from`` wrappers (``__cause__``) are walked too."""
+        wrapped = _savepoint_rollback_error()
+        wrapped.__cause__ = _deadlock()
+        calls = 0
+
+        def block() -> None:
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                raise wrapped
+
+        for attempt in db_retry(db_session, base_delay_s=0):
+            with attempt:
+                block()
+        assert calls == 2
+
+    def test_savepoint_error_without_lock_error_in_chain_not_retried(self, db_session):
+        """A bare 1305 — no 1213/1205 anywhere in the chain — is NOT retried."""
+        alone = _savepoint_rollback_error()
+        calls = 0
+
+        def block() -> None:
+            nonlocal calls
+            calls += 1
+            raise alone
+
+        with pytest.raises(OperationalError) as exc_info:
+            for attempt in db_retry(db_session, base_delay_s=0):
+                with attempt:
+                    block()
+        assert exc_info.value is alone
+        assert calls == 1
 
     def test_session_rolled_back_between_attempts(self, db_session, monkeypatch):
         events: list[str] = []

--- a/tests/test_donations_api.py
+++ b/tests/test_donations_api.py
@@ -578,7 +578,11 @@ def _seed_stats(session_factory, *, recent_usage=3, old_usage=0, packs=0,
     for i in range(packs):
         s.add(BriefingPackRow(
             flight_id="flt-1",
-            fetch_timestamp=datetime(2026, 6, 1, tzinfo=timezone.utc),
+            # Distinct per-row timestamps: uq_briefing_packs_flight_ts
+            # forbids duplicate (flight_id, fetch_timestamp) pairs.
+            fetch_timestamp=(
+                datetime(2026, 6, 1, tzinfo=timezone.utc) - timedelta(hours=i)
+            ),
             days_out=i,
         ))
     # Tokens ride on the first row only, so the word count stays predictable

--- a/tests/test_flights_storage.py
+++ b/tests/test_flights_storage.py
@@ -10,6 +10,7 @@ from flyfun_common.db import DEV_USER_ID
 from weatherbrief.models import BriefingPackMeta, Flight
 from weatherbrief.storage.flights import (
     delete_flight,
+    latest_pack,
     list_flights,
     list_packs,
     load_flight,
@@ -229,6 +230,137 @@ class TestBriefingPacks:
         # No provisional row inserted — update should report not-found.
         assert update_pack_meta(db_session, sample_pack_meta) is False
         assert list_packs(db_session, sample_flight.id) == []
+
+
+# --- latest_pack fast path ---
+
+
+class TestLatestPack:
+    def test_returns_none_when_no_packs(self, db_session, dev_user, sample_flight):
+        save_flight(db_session, sample_flight, dev_user)
+        assert latest_pack(db_session, sample_flight.id) is None
+
+    def test_returns_newest_by_fetch_timestamp(
+        self, db_session, dev_user, sample_flight, sample_pack_meta,
+    ):
+        save_flight(db_session, sample_flight, dev_user)
+        # Seed out of order so the result can't be an insertion-order accident.
+        oldest = BriefingPackMeta(
+            flight_id=sample_flight.id,
+            fetch_timestamp=datetime(2026, 2, 17, 8, 0, 0, tzinfo=timezone.utc),
+            days_out=4,
+            assessment="RED",
+        )
+        older = BriefingPackMeta(
+            flight_id=sample_flight.id,
+            fetch_timestamp=datetime(2026, 2, 18, 8, 0, 0, tzinfo=timezone.utc),
+            days_out=3,
+            assessment="AMBER",
+        )
+        save_pack_meta(db_session, older)
+        save_pack_meta(db_session, sample_pack_meta)  # 2026-02-19 18:00 — newest
+        save_pack_meta(db_session, oldest)
+
+        latest = latest_pack(db_session, sample_flight.id)
+        assert latest is not None
+        assert latest.fetch_timestamp == sample_pack_meta.fetch_timestamp
+        assert latest.assessment == "GREEN"
+        assert latest.days_out == 2
+
+    def test_order_by_carries_id_tiebreak(
+        self, db_session, dev_user, sample_flight, sample_pack_meta,
+    ):
+        """The query orders by fetch_timestamp DESC with an id DESC tiebreak.
+
+        A real same-timestamp tie can't be seeded — uq_briefing_packs_flight_ts
+        forbids duplicate (flight_id, fetch_timestamp) rows — so assert the
+        emitted SQL directly (one statement, with LIMIT).
+        """
+        from sqlalchemy import event
+
+        save_flight(db_session, sample_flight, dev_user)
+        save_pack_meta(db_session, sample_pack_meta)
+
+        statements: list[str] = []
+        engine = db_session.get_bind()
+
+        def _capture(_conn, _cursor, statement, _params, _context, _many):
+            statements.append(statement)
+
+        event.listen(engine, "before_cursor_execute", _capture)
+        try:
+            latest_pack(db_session, sample_flight.id)
+        finally:
+            event.remove(engine, "before_cursor_execute", _capture)
+
+        pack_selects = [s for s in statements if "FROM briefing_packs" in s]
+        assert len(pack_selects) == 1
+        normalized = " ".join(pack_selects[0].split())
+        assert "ORDER BY briefing_packs.fetch_timestamp DESC, briefing_packs.id DESC" in normalized
+        assert "LIMIT" in normalized
+
+    def test_skips_hmac_verify_and_artifact_stat(
+        self, db_session, dev_user, sample_flight, sample_pack_meta, monkeypatch,
+    ):
+        """The fast path never verifies HMACs nor stats the filesystem.
+
+        ``_resolve_artifact_path`` is the only filesystem touch in the
+        row→meta mapping (its Path.exists checks), so spying on it proves
+        the stat is skipped; ``_verify_pack_hmac`` covers the HMAC.
+        """
+        from weatherbrief.storage import flights as flights_mod
+
+        save_flight(db_session, sample_flight, dev_user)
+        save_pack_meta(db_session, sample_pack_meta)
+
+        verify_calls: list = []
+        resolve_calls: list = []
+        monkeypatch.setattr(
+            flights_mod, "_verify_pack_hmac",
+            lambda row: verify_calls.append(row) or True,
+        )
+        monkeypatch.setattr(
+            flights_mod, "_resolve_artifact_path",
+            lambda raw: resolve_calls.append(raw) or raw,
+        )
+
+        latest = latest_pack(db_session, sample_flight.id)
+        assert latest is not None
+        assert verify_calls == []
+        assert resolve_calls == []
+
+    def test_matches_list_packs_head(
+        self, db_session, dev_user, sample_flight, sample_pack_meta,
+    ):
+        """Meta is populated identically to ``list_packs()[0]``.
+
+        artifact_path has no "packs" component and doesn't exist on disk, so
+        ``_resolve_artifact_path`` returns it unchanged — raw == resolved and
+        the two paths must agree field-for-field.
+        """
+        save_flight(db_session, sample_flight, dev_user)
+        seeded = sample_pack_meta.model_copy(update={
+            "artifact_path": "artifacts/nonexistent-pack",
+            "model_init_times": {"ecmwf": 1771430400},
+            "grib_init_times": {"ecmwf": 1771430400},
+            "model_sources": {"ecmwf": "ecmwf:direct"},
+        })
+        save_pack_meta(db_session, seeded)
+        older = BriefingPackMeta(
+            flight_id=sample_flight.id,
+            fetch_timestamp=datetime(2026, 2, 18, 8, 0, 0, tzinfo=timezone.utc),
+            days_out=3,
+            assessment="AMBER",
+        )
+        save_pack_meta(db_session, older)
+
+        reference = list_packs(db_session, sample_flight.id)[0]
+        latest = latest_pack(db_session, sample_flight.id)
+        assert latest is not None
+        assert latest == reference
+        assert latest.artifact_path == "artifacts/nonexistent-pack"
+        assert latest.model_init_times == {"ecmwf": 1771430400}
+        assert latest.model_sources == {"ecmwf": "ecmwf:direct"}
 
 
 # --- Model tests ---

--- a/tests/test_migration_085.py
+++ b/tests/test_migration_085.py
@@ -1,0 +1,118 @@
+"""Migration 085 — dedupe + UNIQUE (flight_id, fetch_timestamp) on briefing_packs.
+
+Why these tests run the real alembic chain: ``Base.metadata.create_all`` would
+bake the new constraint in from the start (the ORM carries it now), making it
+impossible to seed the duplicate rows the migration exists to clean up. Only a
+schema built *by the migrations themselves* up to 084 reproduces the prod
+situation: a ``briefing_packs`` table with no uniqueness guard and possibly
+duplicate pairs — one of which would 500 every ``load_pack_meta`` read via
+``scalar_one_or_none()``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import sqlalchemy as sa
+from alembic import command
+from alembic.config import Config
+from sqlalchemy.exc import IntegrityError
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# SQLAlchemy renders SQLite DateTime as this exact text format; the dedupe
+# GROUP BY compares the stored values, so duplicates must match byte-for-byte.
+TS_A = "2026-02-19 18:00:00.000000"
+TS_B = "2026-02-18 08:00:00.000000"
+
+
+def _config() -> Config:
+    # No ini file: env.py then skips fileConfig and resolves the database
+    # purely from DATABASE_URL (set by the fixture below).
+    cfg = Config()
+    cfg.set_main_option("script_location", str(REPO_ROOT / "alembic"))
+    return cfg
+
+
+@pytest.fixture
+def db_at_084(tmp_path, monkeypatch):
+    """A temp SQLite DB migrated to 084 (pre-constraint schema)."""
+    db_path = tmp_path / "mig085.db"
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
+    command.upgrade(_config(), "084")
+    return f"sqlite:///{db_path}"
+
+
+def _insert_pack(conn, flight_id: str, fetch_ts: str) -> int:
+    """Raw-SQL insert of a minimal pack row; returns the new rowid.
+
+    FK enforcement stays off (alembic's own engine never enables the pragma),
+    so no parent flight row is needed.
+    """
+    result = conn.execute(
+        sa.text(
+            "INSERT INTO briefing_packs"
+            " (flight_id, fetch_timestamp, days_out, artifact_path)"
+            " VALUES (:f, :ts, 2, '')"
+        ),
+        {"f": flight_id, "ts": fetch_ts},
+    )
+    return result.lastrowid
+
+
+def _pack_rows(url: str) -> list[int]:
+    engine = sa.create_engine(url)
+    with engine.connect() as conn:
+        ids = [
+            r[0]
+            for r in conn.execute(sa.text("SELECT id FROM briefing_packs ORDER BY id"))
+        ]
+    engine.dispose()
+    return ids
+
+
+def test_upgrade_dedupes_keeping_max_id_and_enforces_unique(db_at_084):
+    engine = sa.create_engine(db_at_084)
+    with engine.begin() as conn:
+        # The duplicate pair a racing double-refresh would have left behind.
+        dupe_old = _insert_pack(conn, "flight-1", TS_A)
+        dupe_new = _insert_pack(conn, "flight-1", TS_A)
+        # Control rows: distinct timestamp, distinct flight — must survive.
+        other_ts = _insert_pack(conn, "flight-1", TS_B)
+        other_flight = _insert_pack(conn, "flight-2", TS_A)
+    engine.dispose()
+    assert dupe_old < dupe_new
+
+    command.upgrade(_config(), "head")
+
+    # Only the newest row of the duplicate pair survives; controls untouched.
+    assert _pack_rows(db_at_084) == sorted([dupe_new, other_ts, other_flight])
+
+    # The constraint physically exists and rejects a new duplicate.
+    engine = sa.create_engine(db_at_084)
+    with engine.connect() as conn:
+        indexes = sa.inspect(conn).get_indexes("briefing_packs")
+        uq = {i["name"]: i for i in indexes}["uq_briefing_packs_flight_ts"]
+        assert uq["unique"]  # SQLite reports 1, not True
+        assert uq["column_names"] == ["flight_id", "fetch_timestamp"]
+        with pytest.raises(IntegrityError):
+            _insert_pack(conn, "flight-1", TS_A)
+    engine.dispose()
+
+
+def test_upgrade_on_empty_table_and_downgrade(db_at_084):
+    """Dedupe on an empty table is a no-op; downgrade drops only the index."""
+    command.upgrade(_config(), "head")
+
+    engine = sa.create_engine(db_at_084)
+    with engine.connect() as conn:
+        names = {i["name"] for i in sa.inspect(conn).get_indexes("briefing_packs")}
+    assert "uq_briefing_packs_flight_ts" in names
+
+    command.downgrade(_config(), "084")
+
+    with engine.connect() as conn:
+        names = {i["name"] for i in sa.inspect(conn).get_indexes("briefing_packs")}
+    assert "uq_briefing_packs_flight_ts" not in names
+    engine.dispose()

--- a/tests/test_migration_085.py
+++ b/tests/test_migration_085.py
@@ -11,12 +11,15 @@ duplicate pairs — one of which would 500 every ``load_pack_meta`` read via
 
 from __future__ import annotations
 
+import importlib.util
 from pathlib import Path
 
 import pytest
 import sqlalchemy as sa
 from alembic import command
 from alembic.config import Config
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
 from sqlalchemy.exc import IntegrityError
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -115,4 +118,215 @@ def test_upgrade_on_empty_table_and_downgrade(db_at_084):
     with engine.connect() as conn:
         names = {i["name"] for i in sa.inspect(conn).get_indexes("briefing_packs")}
     assert "uq_briefing_packs_flight_ts" not in names
+    engine.dispose()
+
+
+# ---------------------------------------------------------------------------
+# Second half of revision 085: missing indexes, redundant-index drops,
+# users (provider, provider_sub) UNIQUE, DECIMAL money columns.
+# ---------------------------------------------------------------------------
+
+# (table, index, columns, unique) — spec Tier-1 item 4 + Tier-2 item 6.
+NEW_INDEXES = [
+    ("briefing_usage", "ix_briefing_usage_timestamp", ["timestamp"], False),
+    ("cost_ledger", "ix_cost_ledger_service_created", ["service", "created_at"], False),
+    ("verification_scores", "ix_verif_scores_obs_time", ["observation_time"], False),
+    ("taf_verification_scores", "ix_taf_verif_obs_time", ["observation_time"], False),
+    ("users", "uq_users_provider_sub", ["provider", "provider_sub"], True),
+]
+
+# Spec Tier-2 item 5, verbatim — the 13 leftmost-prefix duplicates plus
+# ix_afs_hour_model. All of these exist on a SQLite schema migrated to 084
+# (asserted below before the upgrade), so "gone at head" is meaningful. The
+# 15th drop (the plain duplicate on oauth_refresh_tokens.token_hash) never
+# exists on SQLite — covered separately in test_redundant_indexes_dropped.
+DROPPED_INDEXES = [
+    ("verification_observations", "ix_verif_obs_icao"),
+    ("verification_scores", "ix_verif_scores_icao"),
+    ("taf_verification_scores", "ix_taf_verif_icao"),
+    ("flight_verification_map", "ix_fvm_flight"),
+    ("flight_subscriptions", "ix_flight_subs_flight"),
+    ("flight_briefing_seen", "ix_flight_seen_user"),
+    ("verification_monthly_stats", "ix_vms_month"),
+    ("verification_daily_stats", "ix_vds_date_model"),
+    ("airport_monthly_summary", "ix_ams_month"),
+    ("airport_daily_summary", "ix_ads_date"),
+    ("analytics_event_daily", "ix_aed_day"),
+    ("analytics_briefing_feature_daily", "ix_abfd_day"),
+    ("analytics_xsection_config_daily", "ix_axcd_day"),
+    ("airport_forecast_snapshots", "ix_afs_hour_model"),
+]
+
+# Never dropped (spec Tier-2 item 5): the FORCE-INDEXed one and the two
+# awaiting sys.schema_unused_indexes evidence.
+KEPT_SCORES_INDEXES = [
+    "ix_verif_scores_lead",
+    "ix_verif_scores_model",
+    "ix_verif_scores_source_time",
+]
+
+
+def _index_map(conn, table: str) -> dict:
+    return {i["name"]: i for i in sa.inspect(conn).get_indexes(table)}
+
+
+def _insert_user(conn, user_id: str, provider_sub: str, provider: str = "google") -> None:
+    conn.execute(
+        sa.text(
+            "INSERT INTO users (id, provider, provider_sub, created_at)"
+            " VALUES (:i, :p, :s, :ts)"
+        ),
+        {"i": user_id, "p": provider, "s": provider_sub, "ts": TS_A},
+    )
+
+
+def test_new_indexes_created(db_at_084):
+    command.upgrade(_config(), "head")
+
+    engine = sa.create_engine(db_at_084)
+    with engine.connect() as conn:
+        for table, name, columns, unique in NEW_INDEXES:
+            idx = _index_map(conn, table).get(name)
+            assert idx is not None, f"{name} missing on {table}"
+            assert idx["column_names"] == columns
+            assert bool(idx["unique"]) == unique  # SQLite reports 0/1
+    engine.dispose()
+
+
+def test_redundant_indexes_dropped(db_at_084):
+    engine = sa.create_engine(db_at_084)
+    with engine.connect() as conn:
+        # Sanity: the whole drop list is really there at 084 — otherwise the
+        # "gone at head" assertions below would be vacuous on SQLite.
+        for table, name in DROPPED_INDEXES:
+            assert name in _index_map(conn, table), f"{name} never existed"
+    engine.dispose()
+
+    command.upgrade(_config(), "head")
+
+    engine = sa.create_engine(db_at_084)
+    with engine.connect() as conn:
+        for table, name in DROPPED_INDEXES:
+            assert name not in _index_map(conn, table), f"{name} survived"
+        kept = _index_map(conn, "verification_scores")
+        for name in KEPT_SCORES_INDEXES:
+            assert name in kept, f"FORCE-INDEXed/evidence-gated {name} dropped"
+        # The 15th drop targets the NON-UNIQUE duplicate of
+        # oauth_refresh_tokens.token_hash that only prod MySQL carries; on
+        # SQLite the only index by that name IS the unique one (migration 041
+        # declared unique=True + index=True, one merged index) — the guard
+        # must make the drop a no-op, not remove the uniqueness guard.
+        token_idx = _index_map(conn, "oauth_refresh_tokens")[
+            "ix_oauth_refresh_tokens_token_hash"
+        ]
+        assert token_idx["unique"]
+    engine.dispose()
+
+
+def test_users_provider_sub_unique_enforced(db_at_084):
+    command.upgrade(_config(), "head")
+
+    engine = sa.create_engine(db_at_084)
+    with engine.begin() as conn:
+        _insert_user(conn, "user-1", "sub-1")
+        # Control: same sub under a different provider is a different identity.
+        _insert_user(conn, "user-2", "sub-1", provider="local")
+    with engine.begin() as conn:
+        with pytest.raises(IntegrityError):
+            _insert_user(conn, "user-3", "sub-1")
+    engine.dispose()
+
+
+def test_users_duplicate_identity_blocks_upgrade(db_at_084):
+    """The unique-index pre-check must refuse, not dedupe silently."""
+    engine = sa.create_engine(db_at_084)
+    with engine.begin() as conn:
+        _insert_user(conn, "user-1", "dup-sub")
+        _insert_user(conn, "user-2", "dup-sub")
+    engine.dispose()
+
+    with pytest.raises(RuntimeError, match=r"duplicate \(provider, provider_sub\)"):
+        command.upgrade(_config(), "head")
+
+
+def test_money_columns_decimal_and_readback(db_at_084):
+    """FLOAT→DECIMAL keeps values through the conversion (1234.56 read-back)."""
+    engine = sa.create_engine(db_at_084)
+    with engine.begin() as conn:
+        # Seeded at 084 (FLOAT) so the read-back also proves the batch table
+        # rebuild on SQLite preserves existing rows.
+        conn.execute(
+            sa.text(
+                "INSERT INTO cost_ledger (user_id, service, action, cost, created_at)"
+                " VALUES ('user-1', 'flyfun-weather', 'briefing', 1234.56, :ts)"
+            ),
+            {"ts": TS_A},
+        )
+        conn.execute(
+            sa.text(
+                "INSERT INTO donation_ledger"
+                " (service, amount, currency, amount_usd, fx_rate,"
+                "  provider_ref, created_at)"
+                " VALUES ('flyfun-weather', 1234.56, 'EUR', 1234.56, 1.083333,"
+                "         'pi_test', :ts)"
+            ),
+            {"ts": TS_A},
+        )
+    engine.dispose()
+
+    command.upgrade(_config(), "head")
+
+    engine = sa.create_engine(db_at_084)
+    with engine.connect() as conn:
+        insp = sa.inspect(conn)
+
+        def col_type(table, column):
+            cols = {c["name"]: str(c["type"]).upper() for c in insp.get_columns(table)}
+            return cols[column]
+
+        assert col_type("cost_ledger", "cost") == "DECIMAL(12, 4)"
+        assert col_type("donation_ledger", "amount") == "DECIMAL(12, 4)"
+        assert col_type("donation_ledger", "amount_usd") == "DECIMAL(12, 4)"
+        assert col_type("donation_ledger", "net_usd") == "DECIMAL(12, 4)"
+        assert col_type("donation_ledger", "fx_rate") == "DECIMAL(12, 6)"
+
+        cost = conn.execute(sa.text("SELECT cost FROM cost_ledger")).scalar_one()
+        assert cost == 1234.56
+        amount = conn.execute(
+            sa.text("SELECT amount FROM donation_ledger")
+        ).scalar_one()
+        assert amount == 1234.56
+        fx = conn.execute(
+            sa.text("SELECT fx_rate FROM donation_ledger")
+        ).scalar_one()
+        assert fx == 1.083333
+    engine.dispose()
+
+
+def test_upgrade_is_idempotent(db_at_084):
+    command.upgrade(_config(), "head")
+    # Alembic-level re-run: already at head, a no-op by version tracking.
+    command.upgrade(_config(), "head")
+
+    # Stronger form: execute the revision body a second time against the
+    # already-migrated schema — every create/drop guard must make it a no-op
+    # instead of crashing on duplicate/absent index names.
+    spec = importlib.util.spec_from_file_location(
+        "migration_085", REPO_ROOT / "alembic" / "versions" / "085_mysql_review_fixes.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    engine = sa.create_engine(db_at_084)
+    with engine.begin() as conn:
+        ctx = MigrationContext.configure(conn)
+        with Operations.context(ctx):
+            mod.upgrade()
+    engine.dispose()
+
+    # State is still the post-upgrade one.
+    engine = sa.create_engine(db_at_084)
+    with engine.connect() as conn:
+        assert "uq_users_provider_sub" in _index_map(conn, "users")
+        for table, name in DROPPED_INDEXES:
+            assert name not in _index_map(conn, table)
     engine.dispose()

--- a/tests/test_migration_085.py
+++ b/tests/test_migration_085.py
@@ -135,11 +135,11 @@ NEW_INDEXES = [
     ("users", "uq_users_provider_sub", ["provider", "provider_sub"], True),
 ]
 
-# Spec Tier-2 item 5, verbatim — the 13 leftmost-prefix duplicates plus
-# ix_afs_hour_model. All of these exist on a SQLite schema migrated to 084
-# (asserted below before the upgrade), so "gone at head" is meaningful. The
-# 15th drop (the plain duplicate on oauth_refresh_tokens.token_hash) never
-# exists on SQLite — covered separately in test_redundant_indexes_dropped.
+# Spec Tier-2 item 5 — the 13 leftmost-prefix duplicates. All of these exist
+# on a SQLite schema migrated to 084 (asserted below before the upgrade), so
+# "gone at head" is meaningful. The 14th drop (the plain duplicate on
+# oauth_refresh_tokens.token_hash) never exists on SQLite — covered
+# separately in test_redundant_indexes_dropped.
 DROPPED_INDEXES = [
     ("verification_observations", "ix_verif_obs_icao"),
     ("verification_scores", "ix_verif_scores_icao"),
@@ -154,7 +154,6 @@ DROPPED_INDEXES = [
     ("analytics_event_daily", "ix_aed_day"),
     ("analytics_briefing_feature_daily", "ix_abfd_day"),
     ("analytics_xsection_config_daily", "ix_axcd_day"),
-    ("airport_forecast_snapshots", "ix_afs_hour_model"),
 ]
 
 # Never dropped (spec Tier-2 item 5): the FORCE-INDEXed one and the two
@@ -164,6 +163,14 @@ KEPT_SCORES_INDEXES = [
     "ix_verif_scores_model",
     "ix_verif_scores_source_time",
 ]
+
+# The spec listed ix_afs_hour_model among the drops (081's "once serving is
+# region-aware" follow-up), but serving never became region-aware — the map
+# path still filters bare forecast_hour (api/maps.py availability scan,
+# tasks/map_queries.py init-time probe, tasks/cache_builder.py rebuild
+# probe), which only this index serves. Final review Important #1: the drop
+# was removed from 085, so the index must still exist at head.
+AFS_KEPT_INDEX = ("airport_forecast_snapshots", "ix_afs_hour_model")
 
 
 def _index_map(conn, table: str) -> dict:
@@ -200,6 +207,7 @@ def test_redundant_indexes_dropped(db_at_084):
         # "gone at head" assertions below would be vacuous on SQLite.
         for table, name in DROPPED_INDEXES:
             assert name in _index_map(conn, table), f"{name} never existed"
+        assert AFS_KEPT_INDEX[1] in _index_map(conn, AFS_KEPT_INDEX[0])
     engine.dispose()
 
     command.upgrade(_config(), "head")
@@ -211,7 +219,12 @@ def test_redundant_indexes_dropped(db_at_084):
         kept = _index_map(conn, "verification_scores")
         for name in KEPT_SCORES_INDEXES:
             assert name in kept, f"FORCE-INDEXed/evidence-gated {name} dropped"
-        # The 15th drop targets the NON-UNIQUE duplicate of
+        # ix_afs_hour_model must EXIST at head: the drop was removed from 085
+        # (final review Important #1) because the map path still filters bare
+        # forecast_hour with no region predicate.
+        afs_idx = _index_map(conn, AFS_KEPT_INDEX[0])[AFS_KEPT_INDEX[1]]
+        assert afs_idx["column_names"] == ["forecast_hour", "model"]
+        # The 14th drop targets the NON-UNIQUE duplicate of
         # oauth_refresh_tokens.token_hash that only prod MySQL carries; on
         # SQLite the only index by that name IS the unique one (migration 041
         # declared unique=True + index=True, one merged index) — the guard
@@ -329,4 +342,5 @@ def test_upgrade_is_idempotent(db_at_084):
         assert "uq_users_provider_sub" in _index_map(conn, "users")
         for table, name in DROPPED_INDEXES:
             assert name not in _index_map(conn, table)
+        assert AFS_KEPT_INDEX[1] in _index_map(conn, AFS_KEPT_INDEX[0])
     engine.dispose()

--- a/tests/test_pack_meta_race.py
+++ b/tests/test_pack_meta_race.py
@@ -82,6 +82,40 @@ class TestSavePackMetaRace:
         assert loaded.assessment_reason == "digest concluded all clear"
         assert loaded.has_digest is True
 
+    def test_race_fallback_does_not_nest_a_second_retry_loop(
+        self, db_session, dev_user, sample_flight, monkeypatch
+    ):
+        """The IntegrityError fallback runs inside save_pack_meta's own
+        db_retry loop, so it must use the non-retrying ``_update_pack_meta_once``
+        core: exactly ONE db_retry loop is entered for the whole raced save.
+        An inner loop's ``session.rollback()`` could silently discard the
+        caller's prior uncommitted work (final review Important #3)."""
+        import weatherbrief.storage.flights as flights_mod
+        from weatherbrief.db.retry import db_retry as real_db_retry
+
+        calls = 0
+
+        def spy_db_retry(*args, **kwargs):
+            nonlocal calls
+            calls += 1
+            return real_db_retry(*args, **kwargs)
+
+        monkeypatch.setattr(flights_mod, "db_retry", spy_db_retry)
+
+        save_flight(db_session, sample_flight, dev_user)
+        save_pack_meta(db_session, _meta(sample_flight.id))
+        calls = 0  # only the raced (fallback) save counts
+
+        finalized = _meta(sample_flight.id, assessment="GREEN")
+        save_pack_meta(db_session, finalized)
+
+        assert calls == 1
+        assert _pack_count(db_session, sample_flight.id) == 1
+        loaded = load_pack_meta(
+            db_session, sample_flight.id, finalized.fetch_timestamp
+        )
+        assert loaded.assessment == "GREEN"
+
     def test_session_survives_the_conflict(self, sample_flight):
         """The SAVEPOINT contains the failure: the session stays usable and a
         commit afterwards persists both the raced row and later work.

--- a/tests/test_pack_meta_race.py
+++ b/tests/test_pack_meta_race.py
@@ -14,8 +14,10 @@ from datetime import datetime, timezone
 
 import pytest
 from sqlalchemy import func, select
+from sqlalchemy.orm import sessionmaker
 
 from flyfun_common.db import DEV_USER_ID
+from flyfun_common.db.models import UserRow
 from weatherbrief.db.models import BriefingPackRow
 from weatherbrief.models import BriefingPackMeta, Flight
 from weatherbrief.storage.flights import load_pack_meta, save_flight, save_pack_meta
@@ -80,25 +82,47 @@ class TestSavePackMetaRace:
         assert loaded.assessment_reason == "digest concluded all clear"
         assert loaded.has_digest is True
 
-    def test_session_survives_the_conflict(
-        self, db_session, dev_user, sample_flight
-    ):
+    def test_session_survives_the_conflict(self, sample_flight):
         """The SAVEPOINT contains the failure: the session stays usable and a
-        commit afterwards persists both the raced row and later work."""
-        save_flight(db_session, sample_flight, dev_user)
-        save_pack_meta(db_session, _meta(sample_flight.id))
-        save_pack_meta(db_session, _meta(sample_flight.id, assessment="GREEN"))
+        commit afterwards persists both the raced row and later work.
 
-        later = _meta(
-            sample_flight.id,
-            fetch_timestamp=datetime(2026, 2, 20, 9, 0, 0, tzinfo=timezone.utc),
-            days_out=1,
-        )
-        save_pack_meta(db_session, later)
-        db_session.commit()
+        Runs on a private engine, not the shared session-scoped ``db_engine``:
+        committing there would persist the dev-user row and make every later
+        ``dev_user`` fixture setup collide on ``users.id``.
+        """
+        from conftest import make_app_engine
 
-        assert _pack_count(db_session, sample_flight.id) == 2
-        loaded = load_pack_meta(
-            db_session, sample_flight.id, later.fetch_timestamp
-        )
-        assert loaded.days_out == 1
+        engine = make_app_engine()
+        session = sessionmaker(bind=engine)()
+        try:
+            session.add(
+                UserRow(
+                    id=DEV_USER_ID,
+                    provider="local",
+                    provider_sub="dev",
+                    email="dev@localhost",
+                    display_name="Dev User",
+                    approved=True,
+                )
+            )
+            session.flush()
+            save_flight(session, sample_flight, DEV_USER_ID)
+            save_pack_meta(session, _meta(sample_flight.id))
+            save_pack_meta(session, _meta(sample_flight.id, assessment="GREEN"))
+
+            later = _meta(
+                sample_flight.id,
+                fetch_timestamp=datetime(2026, 2, 20, 9, 0, 0, tzinfo=timezone.utc),
+                days_out=1,
+            )
+            save_pack_meta(session, later)
+            session.commit()
+
+            assert _pack_count(session, sample_flight.id) == 2
+            loaded = load_pack_meta(
+                session, sample_flight.id, later.fetch_timestamp
+            )
+            assert loaded.days_out == 1
+        finally:
+            session.close()
+            engine.dispose()

--- a/tests/test_pack_meta_race.py
+++ b/tests/test_pack_meta_race.py
@@ -1,0 +1,104 @@
+"""Race-safe ``save_pack_meta`` against UNIQUE (flight_id, fetch_timestamp).
+
+Why: the briefing-ready milestone inserts a provisional pack row, and a second
+refresh (sync ``/refresh`` endpoint vs. scheduler) can race to insert the same
+``(flight_id, fetch_timestamp)``. With ``uq_briefing_packs_flight_ts`` in place
+the loser of that race hits an IntegrityError; ``save_pack_meta`` must contain
+it in a SAVEPOINT and fall back to updating the winner's row — one row left,
+outer transaction unharmed — instead of poisoning the request transaction.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy import func, select
+
+from flyfun_common.db import DEV_USER_ID
+from weatherbrief.db.models import BriefingPackRow
+from weatherbrief.models import BriefingPackMeta, Flight
+from weatherbrief.storage.flights import load_pack_meta, save_flight, save_pack_meta
+
+
+@pytest.fixture
+def sample_flight():
+    return Flight(
+        id="egtk_lsgs-2026-02-21",
+        user_id=DEV_USER_ID,
+        route_name="egtk_lsgs",
+        departure_time=datetime(2026, 2, 21, 9, tzinfo=timezone.utc),
+        cruise_altitude_ft=8000,
+        flight_duration_hours=4.5,
+        created_at=datetime(2026, 2, 14, 10, 0, 0, tzinfo=timezone.utc),
+    )
+
+
+def _meta(flight_id: str, **overrides) -> BriefingPackMeta:
+    base = {
+        "flight_id": flight_id,
+        "fetch_timestamp": datetime(2026, 2, 19, 18, 0, 0, tzinfo=timezone.utc),
+        "days_out": 2,
+        "has_gramet": True,
+        "has_digest": False,
+        "assessment": "AMBER",
+        "assessment_reason": "provisional",
+    }
+    return BriefingPackMeta(**(base | overrides))
+
+
+def _pack_count(session, flight_id: str) -> int:
+    return session.scalar(
+        select(func.count())
+        .select_from(BriefingPackRow)
+        .where(BriefingPackRow.flight_id == flight_id)
+    )
+
+
+class TestSavePackMetaRace:
+    def test_conflicting_save_becomes_update(
+        self, db_session, dev_user, sample_flight
+    ):
+        save_flight(db_session, sample_flight, dev_user)
+        save_pack_meta(db_session, _meta(sample_flight.id))
+
+        # Loser of the insert race: same (flight_id, fetch_timestamp) but with
+        # finalized content. Must not raise — it updates the existing row.
+        finalized = _meta(
+            sample_flight.id,
+            has_digest=True,
+            assessment="GREEN",
+            assessment_reason="digest concluded all clear",
+        )
+        save_pack_meta(db_session, finalized)
+
+        assert _pack_count(db_session, sample_flight.id) == 1
+        loaded = load_pack_meta(
+            db_session, sample_flight.id, finalized.fetch_timestamp
+        )
+        assert loaded.assessment == "GREEN"
+        assert loaded.assessment_reason == "digest concluded all clear"
+        assert loaded.has_digest is True
+
+    def test_session_survives_the_conflict(
+        self, db_session, dev_user, sample_flight
+    ):
+        """The SAVEPOINT contains the failure: the session stays usable and a
+        commit afterwards persists both the raced row and later work."""
+        save_flight(db_session, sample_flight, dev_user)
+        save_pack_meta(db_session, _meta(sample_flight.id))
+        save_pack_meta(db_session, _meta(sample_flight.id, assessment="GREEN"))
+
+        later = _meta(
+            sample_flight.id,
+            fetch_timestamp=datetime(2026, 2, 20, 9, 0, 0, tzinfo=timezone.utc),
+            days_out=1,
+        )
+        save_pack_meta(db_session, later)
+        db_session.commit()
+
+        assert _pack_count(db_session, sample_flight.id) == 2
+        loaded = load_pack_meta(
+            db_session, sample_flight.id, later.fetch_timestamp
+        )
+        assert loaded.days_out == 1

--- a/tests/test_refresh_durability.py
+++ b/tests/test_refresh_durability.py
@@ -389,9 +389,9 @@ class TestReconcileOne:
         """Capture calls to the shared pipeline runner instead of running it."""
         calls: list[dict] = []
 
-        def _fake(flight_row, app_state, user_id, *, triggered_by="scheduler"):
+        def _fake(flight_id, app_state, user_id, *, triggered_by="scheduler"):
             calls.append({
-                "flight_id": flight_row.id,
+                "flight_id": flight_id,
                 "user_id": user_id,
                 "triggered_by": triggered_by,
             })

--- a/tests/test_refresh_durability.py
+++ b/tests/test_refresh_durability.py
@@ -258,7 +258,7 @@ class TestDecideResume:
         """Default: the flight has no packs, so the gate never runs."""
         from weatherbrief.storage import flights as flights_mod
 
-        monkeypatch.setattr(flights_mod, "list_packs", lambda db, fid: [])
+        monkeypatch.setattr(flights_mod, "latest_pack", lambda db, fid: None)
 
     def test_resumes_a_fresh_interruption(self, app_db):
         s = app_db()
@@ -364,7 +364,7 @@ class TestDecideResume:
         from weatherbrief.api import packs as packs_mod
         from weatherbrief.storage import flights as flights_mod
 
-        monkeypatch.setattr(flights_mod, "list_packs", lambda db, fid: ["pack"])
+        monkeypatch.setattr(flights_mod, "latest_pack", lambda db, fid: "pack")
         monkeypatch.setattr(packs_mod, "_build_data_status", lambda pack, flight: "status")
         monkeypatch.setattr(
             packs_mod, "decide_refresh",
@@ -382,7 +382,7 @@ class TestReconcileOne:
     def _no_packs(self, monkeypatch):
         from weatherbrief.storage import flights as flights_mod
 
-        monkeypatch.setattr(flights_mod, "list_packs", lambda db, fid: [])
+        monkeypatch.setattr(flights_mod, "latest_pack", lambda db, fid: None)
 
     @pytest.fixture
     def ran(self, monkeypatch):

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -531,7 +531,7 @@ class TestAutoRefreshGate:
             mode="realtime", reason="d0", needed=1, n_eligible=3, n_updated=0, days_out=0,
         )
 
-        _auto_refresh_one(_make_row(), SimpleNamespace(db_path="/fake/db"), "u1")
+        _auto_refresh_one("test-flight", SimpleNamespace(db_path="/fake/db"), "u1")
 
         mock_exec.assert_not_called()
         mock_prepare.assert_not_called()
@@ -571,7 +571,7 @@ class TestAutoRefreshGate:
         )
         mock_exec.return_value = MagicMock()
 
-        _auto_refresh_one(_make_row(), SimpleNamespace(db_path="/fake/db"), "u1")
+        _auto_refresh_one("test-flight", SimpleNamespace(db_path="/fake/db"), "u1")
 
         mock_exec.assert_called_once()
 
@@ -618,7 +618,7 @@ class TestAutoRefreshGate:
         )
         mock_exec.return_value = MagicMock()
 
-        _auto_refresh_one(_make_row(), SimpleNamespace(db_path="/fake/db"), "u1")
+        _auto_refresh_one("test-flight", SimpleNamespace(db_path="/fake/db"), "u1")
 
         callback = mock_exec.call_args.kwargs.get("progress_callback")
         assert callback is not None, "scheduled/resumed refreshes must report progress"

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -504,11 +504,11 @@ class TestAutoRefreshGate:
     @patch("weatherbrief.pipeline.execute_briefing")
     @patch("weatherbrief.api.packs.decide_refresh")
     @patch("weatherbrief.api.packs._build_data_status")
-    @patch("weatherbrief.storage.flights.list_packs")
+    @patch("weatherbrief.storage.flights.latest_pack")
     @patch("weatherbrief.storage.flights._row_to_flight")
     @patch("weatherbrief.scheduler.SessionLocal")
     def test_skips_when_gate_not_full(
-        self, mock_session, mock_row_to_flight, mock_list,
+        self, mock_session, mock_row_to_flight, mock_latest,
         mock_status, mock_decide, mock_exec, mock_prepare,
     ):
         from unittest.mock import MagicMock
@@ -521,10 +521,10 @@ class TestAutoRefreshGate:
         mock_row_to_flight.return_value = SimpleNamespace(
             departure_time=datetime.now(timezone.utc) + timedelta(hours=3),
         )
-        mock_list.return_value = [BriefingPackMeta(
+        mock_latest.return_value = BriefingPackMeta(
             flight_id="f", fetch_timestamp=datetime.now(timezone.utc),
             days_out=0, artifact_path="/tmp/pack",
-        )]
+        )
         mock_status.return_value = DataStatus(fresh=True)
         # Realtime is button-only; the scheduler must skip it.
         mock_decide.return_value = RefreshDecision(
@@ -541,11 +541,11 @@ class TestAutoRefreshGate:
     @patch("weatherbrief.pipeline.execute_briefing")
     @patch("weatherbrief.api.packs.decide_refresh")
     @patch("weatherbrief.api.packs._build_data_status")
-    @patch("weatherbrief.storage.flights.list_packs")
+    @patch("weatherbrief.storage.flights.latest_pack")
     @patch("weatherbrief.storage.flights._row_to_flight")
     @patch("weatherbrief.scheduler.SessionLocal")
     def test_runs_pipeline_when_full(
-        self, mock_session, mock_row_to_flight, mock_list,
+        self, mock_session, mock_row_to_flight, mock_latest,
         mock_status, mock_decide, mock_exec, mock_prepare, mock_finalize,
     ):
         from unittest.mock import MagicMock
@@ -558,10 +558,10 @@ class TestAutoRefreshGate:
         mock_row_to_flight.return_value = SimpleNamespace(
             departure_time=datetime.now(timezone.utc) + timedelta(days=2),
         )
-        mock_list.return_value = [BriefingPackMeta(
+        mock_latest.return_value = BriefingPackMeta(
             flight_id="f", fetch_timestamp=datetime.now(timezone.utc),
             days_out=2, artifact_path="/tmp/pack",
-        )]
+        )
         mock_status.return_value = DataStatus(fresh=False)
         mock_decide.return_value = RefreshDecision(
             mode="full", reason="all updated", needed=3, n_eligible=3, n_updated=3, days_out=2,
@@ -580,11 +580,11 @@ class TestAutoRefreshGate:
     @patch("weatherbrief.pipeline.execute_briefing")
     @patch("weatherbrief.api.packs.decide_refresh")
     @patch("weatherbrief.api.packs._build_data_status")
-    @patch("weatherbrief.storage.flights.list_packs")
+    @patch("weatherbrief.storage.flights.latest_pack")
     @patch("weatherbrief.storage.flights._row_to_flight")
     @patch("weatherbrief.scheduler.SessionLocal")
     def test_pipeline_progress_reaches_the_registry(
-        self, mock_session, mock_row_to_flight, mock_list,
+        self, mock_session, mock_row_to_flight, mock_latest,
         mock_status, mock_decide, mock_exec, mock_prepare, mock_finalize,
     ):
         """Stages must reach the registry even with no SSE stream attached.
@@ -605,10 +605,10 @@ class TestAutoRefreshGate:
         mock_row_to_flight.return_value = SimpleNamespace(
             departure_time=datetime.now(timezone.utc) + timedelta(days=2),
         )
-        mock_list.return_value = [BriefingPackMeta(
+        mock_latest.return_value = BriefingPackMeta(
             flight_id="f", fetch_timestamp=datetime.now(timezone.utc),
             days_out=2, artifact_path="/tmp/pack",
-        )]
+        )
         mock_status.return_value = DataStatus(fresh=False)
         mock_decide.return_value = RefreshDecision(
             mode="full", reason="all updated", needed=3, n_eligible=3, n_updated=3, days_out=2,

--- a/tests/test_session_scope.py
+++ b/tests/test_session_scope.py
@@ -116,7 +116,7 @@ class TestAutoRefreshOne:
         with (
             patch.object(scheduler, "SessionLocal", spy),
             patch.object(flights_mod, "_row_to_flight", return_value=self._flight()),
-            patch.object(flights_mod, "list_packs", return_value=[]),
+            patch.object(flights_mod, "latest_pack", return_value=None),
             patch.object(packs_mod, "refresh_registry", registry),
             patch.object(
                 packs_mod, "_prepare_refresh",

--- a/tests/test_session_scope.py
+++ b/tests/test_session_scope.py
@@ -1,0 +1,292 @@
+"""Session scope-down guards (#mysql-review).
+
+The audit found pooled web-pool connections pinned across minutes of non-DB
+work: the briefing pipeline (GRIB + LLM), the aviationweather.gov METAR/TAF
+fetch, and the timing-scenario GRIB scan. Per site these tests spy the
+session factory and the slow call (mocked — no network, no real pipeline)
+and assert:
+
+* no session remains unclosed across the slow-call boundary;
+* the finalize/commit after the slow work happens in a FRESH session;
+* notify still fires after commit on the refresh path.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class _SessionSpy:
+    """Session factory recording every session it hands out."""
+
+    def __init__(self) -> None:
+        self.sessions: list[MagicMock] = []
+
+    def __call__(self) -> MagicMock:
+        session = MagicMock(name=f"session-{len(self.sessions)}")
+        self.sessions.append(session)
+        return session
+
+    def unclosed(self) -> list[MagicMock]:
+        return [s for s in self.sessions if not s.close.called]
+
+
+# ---------------------------------------------------------------------------
+# scheduler.process_auto_refreshes — the due-flight read session must be
+# closed before asyncio.to_thread(_auto_refresh_one, ...) runs.
+# ---------------------------------------------------------------------------
+
+
+class TestProcessAutoRefreshes:
+    @pytest.mark.asyncio
+    async def test_read_session_closed_before_per_flight_pipeline(self):
+        from weatherbrief import scheduler
+        from weatherbrief.api import packs as packs_mod
+
+        spy = _SessionSpy()
+        seen: dict = {}
+
+        def _fake_refresh(flight_id, app_state, user_id, **kwargs):
+            seen["unclosed"] = spy.unclosed()
+            return True
+
+        registry = MagicMock()
+        registry.try_register.return_value = object()
+
+        with (
+            patch.object(scheduler, "SessionLocal", spy),
+            patch.object(
+                scheduler, "_find_due_flights",
+                return_value=[SimpleNamespace(id="f1", user_id="u1")],
+            ),
+            patch.object(scheduler, "_auto_refresh_one", _fake_refresh),
+            patch.object(packs_mod, "refresh_registry", registry),
+        ):
+            await scheduler.process_auto_refreshes(SimpleNamespace())
+
+        # The due-flight read session was closed before the refresh ran.
+        assert seen["unclosed"] == []
+        # Two sessions total: the due-flight read, then the last_auto_refresh
+        # marker write after the refresh — committed and closed.
+        assert len(spy.sessions) == 2
+        spy.sessions[1].commit.assert_called_once()
+        assert all(s.close.called for s in spy.sessions)
+
+
+# ---------------------------------------------------------------------------
+# scheduler._auto_refresh_one — reads + gate + _prepare_refresh in one short
+# session, execute_briefing with none held, finalize+commit+notify in a
+# fresh one.
+# ---------------------------------------------------------------------------
+
+
+class TestAutoRefreshOne:
+    def _flight(self):
+        return SimpleNamespace(
+            id="f1", user_id="u1",
+            departure_time=datetime.now(timezone.utc) + timedelta(days=2),
+            profile_id=None,
+        )
+
+    def test_pipeline_runs_sessionless_and_finalize_uses_a_fresh_one(self):
+        from weatherbrief import scheduler
+        from weatherbrief.api import packs as packs_mod
+        from weatherbrief.storage import flights as flights_mod
+
+        spy = _SessionSpy()
+        seen: dict = {}
+
+        def _fake_exec(**kwargs):
+            seen["unclosed"] = spy.unclosed()
+            return SimpleNamespace(usage=SimpleNamespace())
+
+        def _fake_notify(db, flight, meta, pack_path, **kwargs):
+            seen["notify_db"] = db
+            seen["committed_before_notify"] = db.commit.called
+
+        registry = MagicMock()
+        registry.get_timing.return_value = (1.0, 2.0)
+        fetch_ts = datetime.now(timezone.utc)
+
+        with (
+            patch.object(scheduler, "SessionLocal", spy),
+            patch.object(flights_mod, "_row_to_flight", return_value=self._flight()),
+            patch.object(flights_mod, "list_packs", return_value=[]),
+            patch.object(packs_mod, "refresh_registry", registry),
+            patch.object(
+                packs_mod, "_prepare_refresh",
+                return_value=(MagicMock(), fetch_ts, Path("/tmp/pack"), MagicMock(), {"m": 1}, None),
+            ) as mock_prepare,
+            patch("weatherbrief.pipeline.execute_briefing", side_effect=_fake_exec) as mock_exec,
+            patch.object(packs_mod, "_finalize_refresh", return_value=MagicMock()) as mock_finalize,
+            patch.object(packs_mod, "_notify_refresh_complete", side_effect=_fake_notify),
+        ):
+            ran = scheduler._auto_refresh_one("f1", SimpleNamespace(db_path="/fake/db"), "u1")
+
+        assert ran is True
+        mock_exec.assert_called_once()
+        # No session pinned across the pipeline.
+        assert seen["unclosed"] == []
+        # Reads used the first session; finalize + notify a fresh second one.
+        assert len(spy.sessions) == 2
+        read_db, final_db = spy.sessions
+        assert mock_prepare.call_args.kwargs["db"] is read_db
+        assert mock_finalize.call_args.args[5] is final_db
+        final_db.commit.assert_called_once()
+        # Notify-after-commit ordering, on that same fresh session.
+        assert seen["notify_db"] is final_db
+        assert seen["committed_before_notify"]
+        assert read_db.close.called and final_db.close.called
+
+
+# ---------------------------------------------------------------------------
+# tasks.verification.collect_and_store — reads commit + close before
+# fetch_observations_batch (aviationweather.gov); store in a fresh session.
+# ---------------------------------------------------------------------------
+
+
+class TestCollectAndStore:
+    def test_fetch_runs_sessionless_and_store_uses_a_fresh_one(self):
+        from weatherbrief.tasks import verification
+
+        spy = _SessionSpy()
+        seen: dict = {}
+
+        def _fake_fetch(icaos, airports_db_path):
+            seen["unclosed"] = spy.unclosed()
+            return []
+
+        with (
+            patch.object(verification, "SessionLocal", spy),
+            patch.object(verification, "finalize_completed_flights", return_value=0),
+            patch.object(verification, "_score_completed", return_value=0),
+            patch.object(
+                verification, "find_verifiable_flights",
+                return_value=[SimpleNamespace(id="f1")],
+            ),
+            patch.object(
+                verification, "gather_airports",
+                return_value={"EGTK": {"f1"}},
+            ) as mock_gather,
+            patch.object(verification, "fetch_observations_batch", side_effect=_fake_fetch),
+            patch.object(verification, "store_observations", return_value=0) as mock_store,
+        ):
+            result = verification.collect_and_store("/fake/airports.db")
+
+        assert result["flights"] == 1
+        # No session pinned across the network fetch.
+        assert seen["unclosed"] == []
+        # Reads used the first session; the store phase a fresh second one.
+        assert len(spy.sessions) == 2
+        read_db, store_db = spy.sessions
+        assert mock_gather.call_args.args[1] is read_db
+        assert mock_store.call_args.args[2] is store_db
+        store_db.commit.assert_called_once()
+        assert read_db.close.called and store_db.close.called
+
+
+# ---------------------------------------------------------------------------
+# tasks.time_scan_runner._run_scan_job — reads in one short session,
+# run_time_scan (slow GRIB scan) with none held, pack-row update + usage row
+# in a fresh one.
+# ---------------------------------------------------------------------------
+
+
+class TestRunScanJob:
+    def test_scan_runs_sessionless_and_writes_use_a_fresh_one(self):
+        from weatherbrief.api import packs as packs_mod
+        from weatherbrief.api import usage as usage_mod
+        from weatherbrief.storage import flights as flights_mod
+        from weatherbrief.tasks import artifacts as artifacts_mod
+        from weatherbrief.tasks import time_scan as time_scan_mod
+        from weatherbrief.tasks import time_scan_runner
+
+        spy = _SessionSpy()
+        seen: dict = {}
+        flight = SimpleNamespace(
+            id="f1", user_id="u1", flexibility="same_day",
+            alt_departure_time=None,
+            departure_time=datetime.now(timezone.utc) + timedelta(days=1),
+            profile_id=None,
+        )
+
+        def _fake_scan(*args, **kwargs):
+            seen["unclosed"] = spy.unclosed()
+            return SimpleNamespace(candidates=[])
+
+        with (
+            patch("flyfun_common.db.SessionLocal", spy),
+            patch.object(flights_mod, "load_flight", return_value=flight),
+            patch.object(packs_mod, "_build_route_config", return_value=MagicMock()),
+            patch.object(
+                packs_mod, "_load_advisory_profile",
+                return_value=(["a"], None, {}, MagicMock(), None, None, None,
+                              None, MagicMock(), "en", False, []),
+            ),
+            patch.object(time_scan_runner, "_write_status"),
+            patch.object(time_scan_runner, "_reusable_scan", return_value=None),
+            patch.object(time_scan_runner, "merge_confirmed"),
+            patch.object(time_scan_mod, "run_time_scan", side_effect=_fake_scan) as mock_scan,
+            patch.object(artifacts_mod, "load_time_options", return_value=None),
+            patch.object(artifacts_mod, "save_time_options"),
+            patch.object(usage_mod, "log_api_usage") as mock_usage,
+        ):
+            time_scan_runner._run_scan_job(
+                "f1", Path("/tmp/pack"), datetime.now(timezone.utc), "/fake/db",
+            )
+
+        mock_scan.assert_called_once()
+        # No session pinned across the scan.
+        assert seen["unclosed"] == []
+        # Reads used the first session; the usage/pack-row writes a fresh one.
+        assert len(spy.sessions) == 2
+        read_db, write_db = spy.sessions
+        assert mock_usage.call_args.args[0] is write_db
+        write_db.commit.assert_called_once()
+        assert read_db.close.called and write_db.close.called
+
+
+# ---------------------------------------------------------------------------
+# tasks.refresh_resume.reconcile_one — the run_db session must not stay open
+# across asyncio.to_thread(_auto_refresh_one, ...).
+# ---------------------------------------------------------------------------
+
+
+class TestReconcileOne:
+    @pytest.mark.asyncio
+    async def test_no_session_held_across_the_resumed_refresh(self):
+        from weatherbrief import scheduler as scheduler_mod
+        from weatherbrief.api import packs as packs_mod
+        from weatherbrief.tasks import refresh_resume
+
+        spy = _SessionSpy()
+        seen: dict = {}
+
+        def _fake_refresh(flight_id, app_state, user_id, **kwargs):
+            seen["unclosed"] = spy.unclosed()
+            return True
+
+        registry = MagicMock()
+        registry.try_register.return_value = object()
+
+        with (
+            patch.object(refresh_resume, "SessionLocal", spy),
+            patch.object(
+                refresh_resume, "decide_resume",
+                return_value=refresh_resume.ResumeDecision("resume", "go"),
+            ),
+            patch.object(refresh_resume, "_close_orphan"),
+            patch.object(packs_mod, "refresh_registry", registry),
+            patch.object(scheduler_mod, "_auto_refresh_one", _fake_refresh),
+        ):
+            await refresh_resume.reconcile_one(1, SimpleNamespace())
+
+        # The job-read and flight-exists sessions were both closed before the
+        # resumed refresh ran in its thread.
+        assert seen["unclosed"] == []
+        assert all(s.close.called for s in spy.sessions)


### PR DESCRIPTION
From a full three-track audit of the MySQL layer (all 84 alembic migrations, every `storage/` module, the `flyfun_common` engine + every `SessionLocal()` call site), with every top finding independently re-verified against the code before fixing. Branch is based on latest `main` (`4abd5b49`) and merges cleanly. Design + plan: `docs/superpowers/` (superpowers workflow, per-task reviews + final whole-branch review).

## Correctness & reachable outages

- **`briefing_packs` UNIQUE `(flight_id, fetch_timestamp)`** — the table had no such constraint; `save_pack_meta` inserted unconditionally while readers use `scalar_one_or_none()`, so one raced duplicate (manual refresh × scheduler auto-refresh) would 500 every subsequent read of that pack. Migration 085 dedupes (keeps newest row per pair, logs counts) and adds the constraint; `save_pack_meta` is now race-safe (savepoint + IntegrityError → update core, nested-retry-free).
- **Airport-profile SSE pool exhaustion** — the endpoint held a pooled session for the stream's whole life while the limiter allows 20 concurrent streams vs a 15-connection pool (arithmetically reachable 500s). Now closes the session before streaming, mirroring the proven `packs.py` pattern.
- **Pooled connections released before pipelines/network** — five sites (`process_auto_refreshes`, `_auto_refresh_one`, `collect_and_store`, `_run_scan_job`, `refresh_resume`) pinned web-pool connections across minutes of GRIB/LLM/network work. Now: read → close → sessionless slow work → fresh session to finalize. Notify-after-commit ordering preserved.
- **Deadlock/lock-wait retry helper** (`db/retry.py`) — there was none anywhere despite ≥6 concurrent writer roles. Retries only 1213/1205 (errno-first with `__context__`/`__cause__` chain-walking, because a 1213 inside a savepoint comes back masked as 1305), jittered backoff, applied to the hot write paths (pack meta, `subscribe_flight`, refresh-job write-through).

## Index hygiene (migration 085)

- **Missing, added**: `ix_briefing_usage_timestamp` (4 range-filtered call paths), `ix_cost_ledger (service, created_at)` (global cost rollups), `ix_verif_scores_obs_time` + `ix_taf_verif_obs_time` (monthly retention range-DELETEs on the largest tables), `uq_users_provider_sub` (the OAuth identity lookup, with a zero-duplicates pre-check).
- **Redundant, dropped (14)**: 13 leftmost-prefix duplicates of UNIQUE/PK columns + the `oauth_refresh_tokens.token_hash` unique+plain duplicate (guarded). Kept deliberately: `ix_verif_scores_lead/_model` (needs `sys.schema_unused_indexes` evidence), FORCE-INDEXed `ix_verif_scores_source_time`, and **`ix_afs_hour_model`** — the final review caught that the map path still filters bare `forecast_hour` (`maps.py`, `map_queries.py`, `cache_builder.py`), so its documented drop premise is false; kept with a comment.
- **Money → DECIMAL**: `cost_ledger.cost`, `donation_ledger.amount/amount_usd/fx_rate/net_usd` → `DECIMAL(12,4)`/`(12,6)` (was single-precision FLOAT). Python consumption verified safe (existing `float()`/pydantic coercions); the proper `Numeric` ORM remap belongs upstream in `flyfun_common`.

## Query shape

- **`latest_pack()`** — hot refresh gates loaded a flight's *entire* pack history (5 `json.loads` + 2 HMAC-SHA256 + 2 fs stats per row) to use only the newest. Now `LIMIT 1`, no HMAC, no artifact resolution on that path.
- **Flights-list aircraft batch prefetch** — one `IN` query instead of per-flight `db.get` (the audit found the identity map never deduped, so even shared aircraft repeated SELECTs).

## Tooling & docs

- `scripts/check_mysql_charset.py` — reports per-table engine/collation, exits non-zero on non-InnoDB/non-utf8mb4, guarded `sys.schema_unused_indexes` dump, clean errors (no false-pass).
- `designs/data-models.md` — FK policy: intentional no-FK set vs survive-deletion candidates vs oauth oversight set, with per-table recommendations (no FKs added here — cascades are product decisions); migration conventions (utf8mb4 on new tables, guarded index ops, dedupe-keeps-newest).

## Verification

- **Full suite: 4705 passed.** Only failures: `test_google_login_redirects` (environment-dependent, fails on base too) and 2 `test_grib_precache` order-dependent flakies (pass standalone; fail identically on base full-suite runs).
- New tests: migration chain + dedupe + idempotency, unique-race, session-scope discrimination (spy on close-before-pipeline/stream), `latest_pack` semantics, prefetch query counting, retry helper (chain-walking, non-retryable negatives, nesting), script smoke.
- Per-task spec+quality reviews (9) + final whole-branch review; three final Important findings fixed pre-merge (the `ix_afs_hour_model` keep, the 1305-masking detection, the nested-retry split).

## Before prod rollout (recorded gates, none merge-blocking)

1. Run migration 085 against a **scratch MySQL** with seeded duplicates (MySQL-only paths: derived-table dedupe vs error 1093, `information_schema` guards, FLOAT→DECIMAL ALTER, 1305-masked savepoint shape) — all reasoned, SQLite-verified, not executed.
2. `scripts/check_mysql_charset.py` against prod (one command — settles the charset question for good).
3. Post-deploy `EXPLAIN` on the map path (kept `ix_afs_hour_model` should serve it) and, after some uptime, `sys.schema_unused_indexes` to judge `ix_verif_scores_lead/_model` and the `token_hash` drift index.
4. Follow-ups (separate issues): `flyfun_common` engine tuning (pool size/timeouts/charset) + `Numeric` money remap + commit-level retry in `get_db`; FK decisions per `designs/data-models.md`; the preserved zero-airports `_record_cycle` never-commits latent bug (flagged); `run_standalone_cycle` in-process mode.

🤖 Generated with [Kimi Code](https://www.kimi.com/code) via the superpowers subagent-driven workflow — co-authored on the commits via `Co-authored-by`.