### PR TITLE
feat(flights): opt-in soonest-first ordering for upcoming flights (#536)

### DIFF
--- a/app/flyfun-weather/flyfun-weather/AppIntents/FlightEntityQuery.swift
+++ b/app/flyfun-weather/flyfun-weather/AppIntents/FlightEntityQuery.swift
@@ -32,10 +32,16 @@ struct FlightEntityQuery: EntityStringQuery {
     }
 
     /// Suggestions shown in the Shortcuts parameter picker — upcoming flights
-    /// first (soonest at top), then the rest most-recent-first.
+    /// first (in the user's chosen order), then the rest most-recent-first.
+    ///
+    /// The preference is read from the cached-prefs blob via a `nonisolated`
+    /// accessor rather than the `@MainActor` store, so this stays off the main
+    /// actor. Shortcuts caches suggested entities, so a preference flip may not
+    /// reorder its picker until iOS refreshes them; in-app order is immediate.
     func suggestedEntities() async throws -> [FlightEntity] {
         guard let flights = try? await Self.loadFlights() else { return [] }
-        return FlightResolver.orderedForSuggestions(flights).map(FlightEntity.init)
+        let order = UserPreferencesStore.cachedFlightOrder()
+        return FlightResolver.orderedForSuggestions(flights, order: order).map(FlightEntity.init)
     }
 
     /// Cache-first flight load, shared by every query path. Does *not* gate on

--- a/app/flyfun-weather/flyfun-weather/AppIntents/FlightResolver.swift
+++ b/app/flyfun-weather/flyfun-weather/AppIntents/FlightResolver.swift
@@ -32,10 +32,14 @@ enum FlightResolver {
             .min(by: { ($0.departureDate ?? .distantFuture) < ($1.departureDate ?? .distantFuture) })
     }
 
-    /// Upcoming flights in the user's chosen order, then past flights
-    /// most-recent-first — the order used for Shortcuts suggestions and for the
-    /// "overview" intent. This is the *display* list, so it follows the
-    /// `flight_order` preference and matches what the flight list shows.
+    /// Upcoming flights in the requested order, then past flights
+    /// most-recent-first — the order used for the Shortcuts entity picker.
+    ///
+    /// That picker is a *display* list, so its caller passes the user's
+    /// `flight_order` preference and it matches what the flight list shows. The
+    /// overview intent calls this too but pins `.soonestFirst`: it truncates to
+    /// five and is answering "what's coming up", so it must not read out the
+    /// five most distant flights.
     ///
     /// `order` is a parameter rather than a read of global state so the function
     /// stays pure and callable from the nonisolated test target; callers pass

--- a/app/flyfun-weather/flyfun-weather/AppIntents/FlightResolver.swift
+++ b/app/flyfun-weather/flyfun-weather/AppIntents/FlightResolver.swift
@@ -21,14 +21,33 @@ enum FlightResolver {
     // the nonisolated test target — and any actor context — can call them
     // synchronously. They touch no shared state, only their arguments.
 
-    /// The soonest upcoming flight (departure ≥ now), or nil if none upcoming.
+    /// Whether a flight still lies ahead of `now` — the one "upcoming" test for
+    /// every intent surface.
+    ///
+    /// Duration-aware, so it agrees with `FlightResponse.resolvedSection`,
+    /// `FlightListView.groupedFlights` and the server's `_flight_has_ended`
+    /// (#536): a flight that departed 30 minutes ago on a 3-hour trip is in
+    /// progress, and the app's list shows it at the top of Future. Gating these
+    /// surfaces on bare `departureDate >= now` instead would make Siri report no
+    /// upcoming flights while the list showed one — the exact disagreement the
+    /// shared boundary exists to prevent.
+    ///
+    /// A flight whose `departureTime` won't parse counts as upcoming, matching
+    /// what `resolvedSection` and the list's legacy bucketing do with it.
+    nonisolated static func isUpcoming(_ flight: FlightResponse, now: Date) -> Bool {
+        !flight.hasEnded(now: now)
+    }
+
+    /// The soonest upcoming flight, or nil if none upcoming. An in-progress
+    /// flight is the soonest of all — which is right: it's the flight whose
+    /// briefing you want when you ask for "my next flight" mid-trip.
     ///
     /// Deliberately does NOT follow the `flight_order` display preference: "my
     /// next flight" means the soonest departure however the list happens to be
     /// drawn, and returning the furthest-away one would be a real bug.
     nonisolated static func nextFlight(in flights: [FlightResponse], now: Date = Date()) -> FlightResponse? {
         flights
-            .filter { ($0.departureDate ?? .distantPast) >= now }
+            .filter { isUpcoming($0, now: now) }
             .min(by: { ($0.departureDate ?? .distantFuture) < ($1.departureDate ?? .distantFuture) })
     }
 
@@ -53,10 +72,10 @@ enum FlightResolver {
             ? { ($0.departureDate ?? .distantFuture) < ($1.departureDate ?? .distantFuture) }
             : { ($0.departureDate ?? .distantPast) > ($1.departureDate ?? .distantPast) }
         let upcoming = flights
-            .filter { ($0.departureDate ?? .distantPast) >= now }
+            .filter { isUpcoming($0, now: now) }
             .sorted(by: upcomingSorted)
         let past = flights
-            .filter { ($0.departureDate ?? .distantPast) < now }
+            .filter { !isUpcoming($0, now: now) }
             .sorted { ($0.departureDate ?? .distantPast) > ($1.departureDate ?? .distantPast) }
         return upcoming + past
     }

--- a/app/flyfun-weather/flyfun-weather/AppIntents/FlightResolver.swift
+++ b/app/flyfun-weather/flyfun-weather/AppIntents/FlightResolver.swift
@@ -22,18 +22,35 @@ enum FlightResolver {
     // synchronously. They touch no shared state, only their arguments.
 
     /// The soonest upcoming flight (departure ≥ now), or nil if none upcoming.
+    ///
+    /// Deliberately does NOT follow the `flight_order` display preference: "my
+    /// next flight" means the soonest departure however the list happens to be
+    /// drawn, and returning the furthest-away one would be a real bug.
     nonisolated static func nextFlight(in flights: [FlightResponse], now: Date = Date()) -> FlightResponse? {
         flights
             .filter { ($0.departureDate ?? .distantPast) >= now }
             .min(by: { ($0.departureDate ?? .distantFuture) < ($1.departureDate ?? .distantFuture) })
     }
 
-    /// Upcoming flights soonest-first, then past flights most-recent-first — the
-    /// order used for Shortcuts suggestions and for the "overview" intent.
-    nonisolated static func orderedForSuggestions(_ flights: [FlightResponse], now: Date = Date()) -> [FlightResponse] {
+    /// Upcoming flights in the user's chosen order, then past flights
+    /// most-recent-first — the order used for Shortcuts suggestions and for the
+    /// "overview" intent. This is the *display* list, so it follows the
+    /// `flight_order` preference and matches what the flight list shows.
+    ///
+    /// `order` is a parameter rather than a read of global state so the function
+    /// stays pure and callable from the nonisolated test target; callers pass
+    /// `UserPreferencesStore.cachedFlightOrder()`.
+    nonisolated static func orderedForSuggestions(
+        _ flights: [FlightResponse],
+        order: FlightOrder = .furthestFirst,
+        now: Date = Date()
+    ) -> [FlightResponse] {
+        let upcomingSorted: (FlightResponse, FlightResponse) -> Bool = order == .soonestFirst
+            ? { ($0.departureDate ?? .distantFuture) < ($1.departureDate ?? .distantFuture) }
+            : { ($0.departureDate ?? .distantPast) > ($1.departureDate ?? .distantPast) }
         let upcoming = flights
             .filter { ($0.departureDate ?? .distantPast) >= now }
-            .sorted { ($0.departureDate ?? .distantFuture) < ($1.departureDate ?? .distantFuture) }
+            .sorted(by: upcomingSorted)
         let past = flights
             .filter { ($0.departureDate ?? .distantPast) < now }
             .sorted { ($0.departureDate ?? .distantPast) > ($1.departureDate ?? .distantPast) }

--- a/app/flyfun-weather/flyfun-weather/AppIntents/FlightsOverviewIntent.swift
+++ b/app/flyfun-weather/flyfun-weather/AppIntents/FlightsOverviewIntent.swift
@@ -14,7 +14,8 @@ struct FlightsOverviewIntent: AppIntent {
         let repo = IntentSupport.makeRepository()
         do {
             let flights = try await repo.flights()
-            return .result(dialog: "\(IntentDialogs.overviewSummary(flights))")
+            let order = UserPreferencesStore.cachedFlightOrder()
+            return .result(dialog: "\(IntentDialogs.overviewSummary(flights, order: order))")
         } catch APIError.unauthorized {
             // Token expired and the silent refresh failed (Decision 4).
             return .result(dialog: "\(IntentSupport.signedOutSpokenLine)")

--- a/app/flyfun-weather/flyfun-weather/AppIntents/FlightsOverviewIntent.swift
+++ b/app/flyfun-weather/flyfun-weather/AppIntents/FlightsOverviewIntent.swift
@@ -14,8 +14,7 @@ struct FlightsOverviewIntent: AppIntent {
         let repo = IntentSupport.makeRepository()
         do {
             let flights = try await repo.flights()
-            let order = UserPreferencesStore.cachedFlightOrder()
-            return .result(dialog: "\(IntentDialogs.overviewSummary(flights, order: order))")
+            return .result(dialog: "\(IntentDialogs.overviewSummary(flights))")
         } catch APIError.unauthorized {
             // Token expired and the silent refresh failed (Decision 4).
             return .result(dialog: "\(IntentSupport.signedOutSpokenLine)")

--- a/app/flyfun-weather/flyfun-weather/AppIntents/IntentDialogs.swift
+++ b/app/flyfun-weather/flyfun-weather/AppIntents/IntentDialogs.swift
@@ -44,7 +44,7 @@ enum IntentDialogs {
     /// "next/upcoming" answers stay chronological.
     static func overviewSummary(_ flights: [FlightResponse], now: Date = Date()) -> String {
         let upcoming = FlightResolver.orderedForSuggestions(flights, order: .soonestFirst, now: now)
-            .filter { ($0.departureDate ?? .distantPast) >= now }
+            .filter { FlightResolver.isUpcoming($0, now: now) }
         guard !upcoming.isEmpty else { return "You have no upcoming flights." }
         let listLimit = 5
         let lines = upcoming.prefix(listLimit).map { flight -> String in

--- a/app/flyfun-weather/flyfun-weather/AppIntents/IntentDialogs.swift
+++ b/app/flyfun-weather/flyfun-weather/AppIntents/IntentDialogs.swift
@@ -32,14 +32,18 @@ enum IntentDialogs {
         return "Your \(route) flight has no assessment yet."
     }
 
-    /// One-line-per-flight traffic-light overview of upcoming flights, spoken in
-    /// the user's chosen list order (#536) so it matches what the app shows.
-    static func overviewSummary(
-        _ flights: [FlightResponse],
-        order: FlightOrder = .furthestFirst,
-        now: Date = Date()
-    ) -> String {
-        let upcoming = FlightResolver.orderedForSuggestions(flights, order: order, now: now)
+    /// One-line-per-flight traffic-light overview of upcoming flights, always
+    /// soonest-first.
+    ///
+    /// Deliberately does NOT follow the `flight_order` display preference
+    /// (#536), for the same reason `FlightResolver.nextFlight` doesn't: this is a
+    /// spoken answer to "what's coming up", not a rendering of the list. It also
+    /// truncates to `listLimit`, so following a furthest-first preference would
+    /// read out the five most *distant* flights and silently omit the one
+    /// departing tomorrow. Entity pickers follow the display preference; spoken
+    /// "next/upcoming" answers stay chronological.
+    static func overviewSummary(_ flights: [FlightResponse], now: Date = Date()) -> String {
+        let upcoming = FlightResolver.orderedForSuggestions(flights, order: .soonestFirst, now: now)
             .filter { ($0.departureDate ?? .distantPast) >= now }
         guard !upcoming.isEmpty else { return "You have no upcoming flights." }
         let listLimit = 5

--- a/app/flyfun-weather/flyfun-weather/AppIntents/IntentDialogs.swift
+++ b/app/flyfun-weather/flyfun-weather/AppIntents/IntentDialogs.swift
@@ -32,9 +32,14 @@ enum IntentDialogs {
         return "Your \(route) flight has no assessment yet."
     }
 
-    /// One-line-per-flight traffic-light overview of upcoming flights.
-    static func overviewSummary(_ flights: [FlightResponse], now: Date = Date()) -> String {
-        let upcoming = FlightResolver.orderedForSuggestions(flights, now: now)
+    /// One-line-per-flight traffic-light overview of upcoming flights, spoken in
+    /// the user's chosen list order (#536) so it matches what the app shows.
+    static func overviewSummary(
+        _ flights: [FlightResponse],
+        order: FlightOrder = .furthestFirst,
+        now: Date = Date()
+    ) -> String {
+        let upcoming = FlightResolver.orderedForSuggestions(flights, order: order, now: now)
             .filter { ($0.departureDate ?? .distantPast) >= now }
         guard !upcoming.isEmpty else { return "You have no upcoming flights." }
         let listLimit = 5

--- a/app/flyfun-weather/flyfun-weather/Models/API/FlightResponse.swift
+++ b/app/flyfun-weather/flyfun-weather/Models/API/FlightResponse.swift
@@ -93,16 +93,19 @@ struct FlightResponse: Codable, Identifiable, Sendable {
 
     /// Logbook section folded to an enum. On a legacy server that omits
     /// `section`, mirror `FlightListView.groupedFlights`' date bucketing exactly
-    /// (Recent = departed within 7 days) so a card's Recent-debrief nudge matches
-    /// the list's Recent group instead of never appearing.
-    var flightSection: FlightSection {
+    /// (Future until the flight *ends*, then Recent = departed within 7 days) so
+    /// a card's Recent-debrief nudge matches the list's Recent group instead of
+    /// never appearing. The Future boundary is duration-aware on both sides —
+    /// the server's `_flight_has_ended` — so an in-progress flight stays Future.
+    func resolvedSection(now: Date = Date()) -> FlightSection {
         if let section, let parsed = FlightSection(rawValue: section) { return parsed }
         guard let dep = departureDate else { return .future }
-        let now = Date()
-        if dep >= now { return .future }
+        if !hasEnded(now: now) { return .future }
         if dep >= now.addingTimeInterval(-7 * 24 * 3600) { return .recent }
         return .past
     }
+
+    var flightSection: FlightSection { resolvedSection() }
 
     /// Whether this flight already has a stored debrief.
     var hasDebrief: Bool { debrief != nil }
@@ -115,9 +118,17 @@ struct FlightResponse: Codable, Identifiable, Sendable {
     /// Whether the flight has already ended (departure + duration in the past).
     /// Mirrors the web `isFlightPast` so past-flight UI gating matches across
     /// clients (e.g. the per-flight notify bell is hidden for flown flights).
-    var isPast: Bool {
+    var isPast: Bool { hasEnded() }
+
+    /// Whether the flight has ended by `now` (departure + duration). The single
+    /// duration-aware boundary on this type, mirroring the server's
+    /// `_flight_has_ended` and the web's `isFlightPast`: a flight that departed
+    /// 30 minutes ago on a 3-hour trip is still in progress, not past. A
+    /// zero-duration flight (a real case — the add-flight flow confirms it) is
+    /// past the instant it departs. `now` is a parameter for deterministic tests.
+    func hasEnded(now: Date = Date()) -> Bool {
         guard let departure = departureDate else { return false }
-        return Date() > departure.addingTimeInterval(flightDurationHours * 3600)
+        return now > departure.addingTimeInterval(flightDurationHours * 3600)
     }
 
     /// Whether `now` falls in the flight's tracking window: departure −2h to

--- a/app/flyfun-weather/flyfun-weather/Models/API/NotificationModels.swift
+++ b/app/flyfun-weather/flyfun-weather/Models/API/NotificationModels.swift
@@ -26,6 +26,12 @@ struct BriefingUpdatesUpdateRequest: Encodable, Sendable {
     let notifyChangeOnly: Bool    // -> "notify_change_only"
 }
 
+/// Body for `PUT /api/user/preferences` when changing the upcoming-flights
+/// ordering (#536).
+struct FlightOrderUpdateRequest: Encodable, Sendable {
+    let flightOrder: String   // -> "flight_order" ("furthest_first" | "soonest_first")
+}
+
 /// Body for dismissing the one-time channel-invariant decay notice.
 struct NotifyDecayDismissRequest: Encodable, Sendable {
     let notifyDecayNotice: Bool   // -> "notify_decay_notice" (always false)

--- a/app/flyfun-weather/flyfun-weather/Models/API/PreferencesResponse.swift
+++ b/app/flyfun-weather/flyfun-weather/Models/API/PreferencesResponse.swift
@@ -17,6 +17,11 @@ struct PreferencesResponse: Codable, Sendable {
     let notifyDecayNotice: Bool?
     // Registered APNs device count — push is only actionable with ≥1 device.
     let pushDeviceCount: Int?
+    // Ordering of the *upcoming* flights section (#536). Optional for the same
+    // reason as the notify fields, and one more: this struct is cached to
+    // UserDefaults and decoded at launch, so a non-optional addition would fail
+    // that decode and silently reset every cached flag to `.empty`.
+    let flightOrder: String?
 
     var pushEnabled: Bool { notifyPush ?? false }
     var emailEnabled: Bool { notifyEmail ?? true }
@@ -25,6 +30,9 @@ struct PreferencesResponse: Codable, Sendable {
     var decayNotice: Bool { notifyDecayNotice ?? false }
     var deviceCount: Int { pushDeviceCount ?? 0 }
     var hasPushDevice: Bool { deviceCount > 0 }
+    /// Upcoming-flights ordering, defaulting to today's behaviour on an older
+    /// server (or an unknown value written by a future one).
+    var flightOrderPreference: FlightOrder { FlightOrder(rawValue: flightOrder ?? "") ?? .furthestFirst }
 
     /// "Briefing updates" 3-stop — folds scope + change-only into one control
     /// (off / changes / every). Kept identical to the web fold so the two
@@ -38,8 +46,25 @@ struct PreferencesResponse: Codable, Sendable {
     static let empty = PreferencesResponse(
         pirepCanView: false, pirepCanPublish: false,
         notifyEmail: nil, notifyPush: nil, notifyScope: nil, notifyChangeOnly: nil,
-        notifyDecayNotice: nil, pushDeviceCount: nil
+        notifyDecayNotice: nil, pushDeviceCount: nil, flightOrder: nil
     )
+}
+
+/// How the *upcoming* flights section is ordered (#536). Past and Recent are
+/// always most-recent-first, under both values. Raw values mirror the server's
+/// `flight_order` preference key.
+enum FlightOrder: String, CaseIterable, Sendable, Identifiable {
+    case furthestFirst = "furthest_first"
+    case soonestFirst = "soonest_first"
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .furthestFirst: "Furthest first"
+        case .soonestFirst: "Soonest first"
+        }
+    }
 }
 
 /// The three "Briefing updates" stops. Off silences default-resolution flights;

--- a/app/flyfun-weather/flyfun-weather/Services/UserPreferencesStore.swift
+++ b/app/flyfun-weather/flyfun-weather/Services/UserPreferencesStore.swift
@@ -9,7 +9,7 @@ import OSLog
 @MainActor
 @Observable
 final class UserPreferencesStore {
-    private static let defaultsKey = "cachedUserPreferences"
+    nonisolated private static let defaultsKey = "cachedUserPreferences"
     private static let logger = Logger(subsystem: "aero.flyfun.weather", category: "UserPreferences")
 
     private(set) var preferences: PreferencesResponse
@@ -57,6 +57,27 @@ final class UserPreferencesStore {
             BriefingUpdatesUpdateRequest(notifyScope: updates.scope, notifyChangeOnly: updates.changeOnly),
             field: "briefing_updates", client: client
         )
+    }
+
+    /// Change the upcoming-flights ordering (#536). Affects the Future section
+    /// only; Recent and Past stay most-recent-first.
+    func updateFlightOrder(_ order: FlightOrder, using client: APIClient) async {
+        await put(FlightOrderUpdateRequest(flightOrder: order.rawValue), field: "flight_order", client: client)
+    }
+
+    /// The cached upcoming-flights ordering, readable off the main actor.
+    ///
+    /// Exists for the App Intents surface: `FlightResolver.orderedForSuggestions`
+    /// is deliberately `nonisolated` and pure so the non-MainActor test target can
+    /// call it, and `FlightEntityQuery.suggestedEntities()` must not hop to the
+    /// main actor just to read one preference. Decodes the same UserDefaults blob
+    /// `init` reads at launch, with the same plain `JSONDecoder`, so the two can
+    /// never disagree about the stored shape.
+    nonisolated static func cachedFlightOrder() -> FlightOrder {
+        guard let data = UserDefaults.standard.data(forKey: defaultsKey),
+              let cached = try? JSONDecoder().decode(PreferencesResponse.self, from: data)
+        else { return .furthestFirst }
+        return cached.flightOrderPreference
     }
 
     /// Dismiss the one-time channel-invariant decay notice.

--- a/app/flyfun-weather/flyfun-weather/Views/Flights/FlightListView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/Flights/FlightListView.swift
@@ -89,7 +89,13 @@ struct FlightListView: View {
                             // Utility logbook (§4.4): Future · Recent · Past.
                             // Past is collapsible (collapsed by default).
                             List(selection: $selection) {
-                                ForEach(Self.groupedFlights(flights), id: \.title) { group in
+                                ForEach(
+                                    Self.groupedFlights(
+                                        flights,
+                                        order: appState.userPreferences.preferences.flightOrderPreference
+                                    ),
+                                    id: \.title
+                                ) { group in
                                     if group.title == "Past" {
                                         Section {
                                             if pastExpanded {
@@ -725,18 +731,31 @@ struct FlightListView: View {
 
     struct FlightGroup { let title: String; let flights: [FlightResponse] }
 
-    /// Group flights into Future · Recent · Past, sorted most-recent-first. Empty
-    /// groups are dropped.
+    /// Group flights into Future · Recent · Past. Recent and Past are always
+    /// most-recent-first; Future follows the user's `flight_order` preference
+    /// (#536). Empty groups are dropped.
     ///
     /// Prefers the server's `section` (the authoritative debrief-nudge window:
     /// `recent` = recent past flights not yet debriefed, bounded server-side). A
-    /// legacy server that omits `section` falls back to client-side date
-    /// bucketing (Recent = departed within 7 days) so the list still groups.
-    static func groupedFlights(_ flights: [FlightResponse], now: Date = Date()) -> [FlightGroup] {
+    /// legacy server that omits `section` falls back to client-side bucketing
+    /// (Future until the flight ends, Recent = departed within 7 days) so the
+    /// list still groups.
+    ///
+    /// The sort is applied here rather than inherited from the server because
+    /// this view has always owned its own ordering; passing `order` in keeps the
+    /// function pure and testable.
+    static func groupedFlights(
+        _ flights: [FlightResponse],
+        order: FlightOrder = .furthestFirst,
+        now: Date = Date()
+    ) -> [FlightGroup] {
         func date(_ f: FlightResponse) -> Date { f.departureDate ?? now }
         func bucketed(_ future: [FlightResponse], _ recent: [FlightResponse], _ past: [FlightResponse]) -> [FlightGroup] {
-            [
-                FlightGroup(title: "Future", flights: future.sorted { date($0) > date($1) }),
+            let futureSorted = order == .soonestFirst
+                ? future.sorted { date($0) < date($1) }
+                : future.sorted { date($0) > date($1) }
+            return [
+                FlightGroup(title: "Future", flights: futureSorted),
                 FlightGroup(title: "Recent", flights: recent.sorted { date($0) > date($1) }),
                 FlightGroup(title: "Past", flights: past.sorted { date($0) > date($1) }),
             ].filter { !$0.flights.isEmpty }
@@ -745,20 +764,21 @@ struct FlightListView: View {
         // Server-driven grouping when any flight carries a section.
         if flights.contains(where: { $0.section != nil }) {
             return bucketed(
-                flights.filter { $0.flightSection == .future },
-                flights.filter { $0.flightSection == .recent },
-                flights.filter { $0.flightSection == .past }
+                flights.filter { $0.resolvedSection(now: now) == .future },
+                flights.filter { $0.resolvedSection(now: now) == .recent },
+                flights.filter { $0.resolvedSection(now: now) == .past }
             )
         }
 
-        // Legacy fallback: client-side date bucketing.
+        // Legacy fallback: client-side bucketing, duration-aware at the Future
+        // boundary so it keeps mirroring the server exactly.
         let recentCutoff = now.addingTimeInterval(-7 * 24 * 3600)
         var future: [FlightResponse] = []
         var recent: [FlightResponse] = []
         var past: [FlightResponse] = []
         for f in flights {
             let dep = f.departureDate ?? now
-            if dep >= now { future.append(f) }
+            if !f.hasEnded(now: now) { future.append(f) }
             else if dep >= recentCutoff { recent.append(f) }
             else { past.append(f) }
         }

--- a/app/flyfun-weather/flyfun-weather/Views/SettingsView.swift
+++ b/app/flyfun-weather/flyfun-weather/Views/SettingsView.swift
@@ -17,6 +17,7 @@ struct SettingsView: View {
     @State private var errorMessage: String?
     @State private var pushBusy = false
     @State private var notifyBusy = false
+    @State private var flightOrderBusy = false
     @State private var showPushDeniedAlert = false
     #if DEBUG
     /// Transient footer message for the Developer sections (tips overrides, copy).
@@ -80,6 +81,22 @@ struct SettingsView: View {
                             Text("Email is your only channel — set Briefing updates to Off to stop, or enable Push.")
                         }
                     }
+                }
+
+                Section {
+                    Picker("Upcoming flights", selection: Binding(
+                        get: { notifyPrefs.flightOrderPreference },
+                        set: { setFlightOrder($0) }
+                    )) {
+                        ForEach(FlightOrder.allCases) { order in
+                            Text(order.label).tag(order)
+                        }
+                    }
+                    .disabled(flightOrderBusy || appState.apiClient == nil)
+                } header: {
+                    Text("Flights")
+                } footer: {
+                    Text("“Furthest first” puts the flight departing last at the top, so newly added flights appear first. “Soonest first” puts the flight departing next at the top. Applies to upcoming flights only — past flights always stay most-recent-first.")
                 }
 
                 Section {
@@ -321,6 +338,18 @@ struct SettingsView: View {
             }
             await appState.userPreferences.updateNotifyEmail(enabled, using: client)
             notifyBusy = false
+        }
+    }
+
+    /// Change the upcoming-flights ordering (#536). Server-backed: the PUT
+    /// returns the full fresh preferences, which the store adopts as its cache,
+    /// so the flight list reorders as soon as the round-trip lands.
+    private func setFlightOrder(_ order: FlightOrder) {
+        guard let client = appState.apiClient else { return }
+        flightOrderBusy = true
+        Task {
+            await appState.userPreferences.updateFlightOrder(order, using: client)
+            flightOrderBusy = false
         }
     }
 

--- a/app/flyfun-weather/flyfun-weatherTests/AppIntentsResolverTests.swift
+++ b/app/flyfun-weather/flyfun-weatherTests/AppIntentsResolverTests.swift
@@ -329,6 +329,24 @@ struct DialogTests {
         #expect(IntentDialogs.overviewSummary([past], now: now) == "You have no upcoming flights.")
     }
 
+    @Test("overview: truncation always keeps the SOONEST five, whatever the list preference")
+    func overviewTruncationIsChronological() {
+        // The spoken overview is not the display list: it cuts at five, so if it
+        // followed a furthest-first preference it would omit the flight
+        // departing tomorrow. Distinct routes make the selection observable.
+        let days = ["09", "10", "11", "12", "13", "14", "15"]
+        let flights = days.map { day in
+            makeFlight(
+                id: "flt-\(day)",
+                waypoints: ["LFMD", "LF\(day)"],
+                departureTime: "2026-07-\(day)T12:00:00Z"
+            )
+        }
+        let summary = IntentDialogs.overviewSummary(flights, now: now)
+        for day in days.prefix(5) { #expect(summary.contains("LFMD → LF\(day)")) }
+        for day in days.suffix(2) { #expect(!summary.contains("LFMD → LF\(day)")) }
+    }
+
     @Test("overview: more than five upcoming lists five and states the remainder")
     func overviewTruncates() {
         // 7 upcoming flights, soonest-first: 2026-07-09 … 2026-07-15.

--- a/app/flyfun-weather/flyfun-weatherTests/AppIntentsResolverTests.swift
+++ b/app/flyfun-weather/flyfun-weatherTests/AppIntentsResolverTests.swift
@@ -97,6 +97,46 @@ struct FlightOrderingTests {
         #expect(FlightResolver.nextFlight(in: flights, now: now) == nil)
     }
 
+    // MARK: - Duration-aware "upcoming" (#536 review round 2)
+    //
+    // The intent surfaces must agree with `FlightListView`/`resolvedSection`/the
+    // server about when a flight stops being upcoming. `now` is 10:00Z; the
+    // in-progress flight departed 09:30Z on a 3-hour trip, so it has not ended.
+
+    private var inProgress: FlightResponse {
+        makeFlight(id: "flying", departureTime: "2026-07-08T09:30:00Z", flightDurationHours: 3.0)
+    }
+
+    private var alreadyLanded: FlightResponse {
+        makeFlight(id: "landed", departureTime: "2026-07-08T06:00:00Z", flightDurationHours: 1.0)
+    }
+
+    @Test("isUpcoming is duration-aware, matching the list and the server")
+    func isUpcomingIsDurationAware() {
+        #expect(FlightResolver.isUpcoming(inProgress, now: now))
+        #expect(!FlightResolver.isUpcoming(alreadyLanded, now: now))
+        // Zero duration: past the instant it departs.
+        let zero = makeFlight(departureTime: "2026-07-08T09:59:00Z", flightDurationHours: 0)
+        #expect(!FlightResolver.isUpcoming(zero, now: now))
+    }
+
+    @Test("nextFlight returns the flight you're currently on, not the next scheduled one")
+    func nextFlightPrefersInProgress() {
+        let flights = [makeFlight(id: "tomorrow", departureTime: "2026-07-09T12:00:00Z"), inProgress]
+        #expect(FlightResolver.nextFlight(in: flights, now: now)?.id == "flying")
+    }
+
+    @Test("an in-progress flight is upcoming in the suggestions list, not past")
+    func suggestionsIncludeInProgress() {
+        let flights = [makeFlight(id: "tomorrow", departureTime: "2026-07-09T12:00:00Z"), inProgress, alreadyLanded]
+        // Soonest-first: the in-progress flight leads, landed one falls to the past half.
+        #expect(FlightResolver.orderedForSuggestions(flights, order: .soonestFirst, now: now).map(\.id)
+            == ["flying", "tomorrow", "landed"])
+        // Furthest-first flips the upcoming half only; past stays at the back.
+        #expect(FlightResolver.orderedForSuggestions(flights, order: .furthestFirst, now: now).map(\.id)
+            == ["tomorrow", "flying", "landed"])
+    }
+
     /// Two upcoming + two past, deliberately shuffled.
     private var mixed: [FlightResponse] {
         [
@@ -327,6 +367,20 @@ struct DialogTests {
     func overviewEmpty() {
         let past = makeFlight(departureTime: "2026-01-01T12:00:00Z")
         #expect(IntentDialogs.overviewSummary([past], now: now) == "You have no upcoming flights.")
+    }
+
+    @Test("overview: an in-progress flight still counts as upcoming")
+    func overviewIncludesInProgress() {
+        // `now` is 10:00Z (see the suite's `now`); departed 09:30Z on a 3-hour
+        // trip. The list shows it at the top of Future, so Siri must not say
+        // "you have no upcoming flights".
+        let flying = makeFlight(
+            waypoints: ["EGKB", "EGTF"],
+            departureTime: "2026-07-08T09:30:00Z",
+            flightDurationHours: 3.0
+        )
+        #expect(IntentDialogs.overviewSummary([flying], now: now)
+            == "You have 1 upcoming flight: EGKB → EGTF, not yet briefed.")
     }
 
     @Test("overview: truncation always keeps the SOONEST five, whatever the list preference")

--- a/app/flyfun-weather/flyfun-weatherTests/AppIntentsResolverTests.swift
+++ b/app/flyfun-weather/flyfun-weatherTests/AppIntentsResolverTests.swift
@@ -97,16 +97,41 @@ struct FlightOrderingTests {
         #expect(FlightResolver.nextFlight(in: flights, now: now) == nil)
     }
 
-    @Test("suggestions list upcoming soonest-first then past recent-first")
-    func ordering() {
-        let flights = [
+    /// Two upcoming + two past, deliberately shuffled.
+    private var mixed: [FlightResponse] {
+        [
             makeFlight(id: "later", departureTime: "2026-07-20T12:00:00Z"),
             makeFlight(id: "past-old", departureTime: "2026-06-01T12:00:00Z"),
             makeFlight(id: "soon", departureTime: "2026-07-09T12:00:00Z"),
             makeFlight(id: "past-recent", departureTime: "2026-07-05T12:00:00Z"),
         ]
-        let ordered = FlightResolver.orderedForSuggestions(flights, now: now).map(\.id)
+    }
+
+    @Test("suggestions follow the soonest-first preference, past stays recent-first")
+    func orderingSoonestFirst() {
+        let ordered = FlightResolver.orderedForSuggestions(mixed, order: .soonestFirst, now: now).map(\.id)
         #expect(ordered == ["soon", "later", "past-recent", "past-old"])
+    }
+
+    @Test("suggestions follow the furthest-first preference, past stays recent-first")
+    func orderingFurthestFirst() {
+        let ordered = FlightResolver.orderedForSuggestions(mixed, order: .furthestFirst, now: now).map(\.id)
+        #expect(ordered == ["later", "soon", "past-recent", "past-old"])
+    }
+
+    @Test("furthest-first is the default, matching the server's default preference")
+    func orderingDefault() {
+        #expect(FlightResolver.orderedForSuggestions(mixed, now: now).map(\.id)
+            == FlightResolver.orderedForSuggestions(mixed, order: .furthestFirst, now: now).map(\.id))
+    }
+
+    @Test("nextFlight ignores the display preference — it always means the soonest")
+    func nextFlightIgnoresPreference() {
+        // Regression guard: "my next flight" returning the furthest-away one
+        // would be a real bug, so `nextFlight` takes no `order` at all.
+        for _ in FlightOrder.allCases {
+            #expect(FlightResolver.nextFlight(in: mixed, now: now)?.id == "soon")
+        }
     }
 }
 

--- a/app/flyfun-weather/flyfun-weatherTests/FlightGroupingTests.swift
+++ b/app/flyfun-weather/flyfun-weatherTests/FlightGroupingTests.swift
@@ -19,8 +19,10 @@ struct FlightGroupingTests {
         ISO8601DateFormatter().string(from: now.addingTimeInterval(offsetDays * 86400))
     }
 
-    private func flight(_ id: String, days: Double, section: String? = nil) -> FlightResponse {
-        var f = makeFlight(id: id, departureTime: Self.iso(days))
+    private func flight(
+        _ id: String, days: Double, section: String? = nil, durationHours: Double = 2.0
+    ) -> FlightResponse {
+        var f = makeFlight(id: id, departureTime: Self.iso(days), flightDurationHours: durationHours)
         f.section = section
         return f
     }
@@ -59,6 +61,81 @@ struct FlightGroupingTests {
         )
         #expect(ids(groups.first { $0.title == "Recent" }) == ["a"])
         #expect(ids(groups.first { $0.title == "Past" }) == ["b"])
+    }
+
+    // MARK: - Upcoming-flights ordering preference (#536)
+
+    /// Future first (furthest → soonest by default), Recent and Past always
+    /// most-recent-first. Sections come from the server so the test pins the
+    /// ordering alone.
+    private var orderingFixture: [FlightResponse] {
+        [
+            flight("near", days: 2, section: "future"),
+            flight("far", days: 9, section: "future"),
+            flight("mid", days: 5, section: "future"),
+            flight("recent-old", days: -5, section: "recent"),
+            flight("recent-new", days: -1, section: "recent"),
+            flight("past-old", days: -40, section: "past"),
+            flight("past-new", days: -30, section: "past"),
+        ]
+    }
+
+    @Test("Default (furthest first) keeps Future most-distant-first")
+    func futureFurthestFirst() {
+        let groups = FlightListView.groupedFlights(orderingFixture, order: .furthestFirst, now: Self.now)
+        #expect(ids(groups.first { $0.title == "Future" }) == ["far", "mid", "near"])
+    }
+
+    @Test("Soonest first reverses Future only")
+    func futureSoonestFirst() {
+        let groups = FlightListView.groupedFlights(orderingFixture, order: .soonestFirst, now: Self.now)
+        #expect(ids(groups.first { $0.title == "Future" }) == ["near", "mid", "far"])
+    }
+
+    @Test("Recent and Past stay most-recent-first under both orders")
+    func recentAndPastUnaffected() {
+        for order in FlightOrder.allCases {
+            let groups = FlightListView.groupedFlights(orderingFixture, order: order, now: Self.now)
+            #expect(ids(groups.first { $0.title == "Recent" }) == ["recent-new", "recent-old"])
+            #expect(ids(groups.first { $0.title == "Past" }) == ["past-new", "past-old"])
+        }
+    }
+
+    @Test("Legacy fallback honours the order too")
+    func legacyFallbackOrdering() {
+        let flights = [flight("near", days: 2), flight("far", days: 9), flight("mid", days: 5)]
+        #expect(ids(FlightListView.groupedFlights(flights, order: .soonestFirst, now: Self.now)
+            .first { $0.title == "Future" }) == ["near", "mid", "far"])
+        #expect(ids(FlightListView.groupedFlights(flights, order: .furthestFirst, now: Self.now)
+            .first { $0.title == "Future" }) == ["far", "mid", "near"])
+    }
+
+    // MARK: - Duration-aware Future boundary (#536 part 2)
+
+    @Test("An in-progress flight is Future, and leads under soonest-first")
+    func inProgressFlightIsFuture() {
+        // Departed 30 min ago on a 3-hour trip — still flying.
+        let flying = flight("flying", days: -0.5 / 24, durationHours: 3.0)
+        let later = flight("later", days: 3)
+        let groups = FlightListView.groupedFlights([flying, later], order: .soonestFirst, now: Self.now)
+        #expect(ids(groups.first { $0.title == "Future" }) == ["flying", "later"])
+    }
+
+    @Test("A zero-duration flight is past the instant it departs")
+    func zeroDurationIsPastImmediately() {
+        let f = flight("zero", days: -1.0 / 1440, durationHours: 0)   // departed 1 min ago
+        let groups = FlightListView.groupedFlights([f], now: Self.now)
+        #expect(titles(groups) == ["Recent"])
+    }
+
+    @Test("hasEnded mirrors the server boundary")
+    func hasEndedBoundary() {
+        let f = makeFlight(departureTime: "2026-06-24T12:00:00Z", flightDurationHours: 2.0)
+        func at(_ iso: String) -> Date { ISO8601DateFormatter().date(from: iso)! }
+        #expect(!f.hasEnded(now: at("2026-06-24T12:00:00Z")))   // departing
+        #expect(!f.hasEnded(now: at("2026-06-24T13:59:59Z")))   // airborne
+        #expect(!f.hasEnded(now: at("2026-06-24T14:00:00Z")))   // exactly at the end
+        #expect(f.hasEnded(now: at("2026-06-24T14:00:01Z")))    // landed
     }
 
     // MARK: - flightSection computed fallback (uses real `Date()`)

--- a/designs/debrief.md
+++ b/designs/debrief.md
@@ -82,12 +82,43 @@ TS mirror in `web/ts/components/debrief-taxonomy.ts` must stay in sync
 
 ### Section assignment
 
-- **future**: `departure_time >= now`
+- **future**: the flight has not ended — `departure_time + flight_duration_hours >= now`, via the shared `_flight_has_ended(flight, now)` predicate. Duration-aware since #536: a flight that departed 30 minutes ago on a 3-hour trip is in progress, not past. Zero duration (a real case — the web add-flight flow confirms it) is past the instant it departs, exactly as before. This matches the web's `isFlightPast` and iOS's `FlightResponse.hasEnded(now:)`.
 - **recent**: most-recent `RECENT_SECTION_CAP` (= 2) past undebriefed flights whose `departure_time` is within the last `RECENT_SECTION_MAX_AGE_DAYS` (= 30) days. Independent of debrief history — debriefing one flight doesn't pull a third into the slot, but anything older than the window drops to Past so the nudge stays bounded.
 - **past**: everything else
 
+`_classify_section` and `_compute_recent_section` must both test the boundary
+through `_flight_has_ended`; if they diverge, an airborne flight is `future` to
+one and a `recent` candidate to the other.
+
 The cap is hard-coded in `api/flights.py` for Phase 1; revisit if usage
 patterns suggest a different ceiling or a per-user setting.
+
+### Section ordering (#536)
+
+Within a section the list order is `departure_time desc`, with one opt-in
+account preference — `flight_order` in `app_prefs_json` (no migration; default
+`"furthest_first"` = today's behaviour):
+
+- `"furthest_first"` — the flight departing last is at the top. Newly added
+  flights, usually the furthest ahead, appear first.
+- `"soonest_first"` — only the **future** section flips to ascending, so the
+  next departure (or the flight currently in progress) is at the top.
+
+Recent and Past stay most-recent-first under both values. Past pagination is
+offset-based over that order, so reordering it would produce duplicate and
+skipped rows across pages.
+
+`load_flight_order(db, user_id)` is read in the *body* of `list_all_flights`,
+never as a `Depends()` parameter: `api/agent.py` calls that route directly as a
+plain function, where a `Depends` default would arrive as a
+`fastapi.params.Depends` instance and silently compare unequal to every valid
+value. The agent/MCP surfaces inherit the ordering for free, which is intended —
+a chatbot printing the list then matches what the app shows.
+
+iOS applies the same preference in `FlightListView.groupedFlights(_:order:now:)`
+and in `FlightResolver.orderedForSuggestions(_:order:now:)` (the Siri/Shortcuts
+display list). `FlightResolver.nextFlight` deliberately does **not** follow it —
+"my next flight" means the soonest departure however the list is drawn.
 
 ## Stats
 

--- a/designs/ios-app-intents.md
+++ b/designs/ios-app-intents.md
@@ -115,6 +115,28 @@ struct FlyFunShortcuts: AppShortcutsProvider {
 }
 ```
 
+### Display ordering vs. "my next flight" (#536)
+
+`FlightResolver` has two ordering entry points and they answer different
+questions:
+
+- `orderedForSuggestions(_:order:now:)` — the **display** list, backing
+  `FlightEntityQuery.suggestedEntities()` and the overview intent. It follows the
+  account's `flight_order` preference so Shortcuts and Siri match what the flight
+  list shows; only the upcoming half flips, past stays most-recent-first.
+- `nextFlight(in:now:)` — deliberately **not** preference-driven. "My next
+  flight" means the soonest departure however the list happens to be drawn;
+  following a display preference here would return the furthest-away flight.
+
+`order` is a parameter rather than a read of global state: the function is
+`nonisolated` and pure so the non-MainActor test target can call it, while
+`UserPreferencesStore` is `@MainActor`. Callers pass
+`UserPreferencesStore.cachedFlightOrder()`, a `nonisolated` accessor that decodes
+the same `cachedUserPreferences` `UserDefaults` blob the store reads at launch —
+so `suggestedEntities()` never has to hop to the main actor. Shortcuts caches
+suggested entities, so a preference flip may not reorder its picker until iOS
+refreshes them; in-app order is immediate.
+
 ### Resolver Design — "the flight tomorrow to Fairoaks"
 
 `FlightEntity` is resolved by an `EntityStringQuery` over a **tiny, closed set** — the

--- a/designs/ios-app-intents.md
+++ b/designs/ios-app-intents.md
@@ -120,13 +120,28 @@ struct FlyFunShortcuts: AppShortcutsProvider {
 `FlightResolver` has two ordering entry points and they answer different
 questions:
 
-- `orderedForSuggestions(_:order:now:)` — the **display** list, backing
-  `FlightEntityQuery.suggestedEntities()` and the overview intent. It follows the
-  account's `flight_order` preference so Shortcuts and Siri match what the flight
-  list shows; only the upcoming half flips, past stays most-recent-first.
+- `orderedForSuggestions(_:order:now:)` — the **display** list backing
+  `FlightEntityQuery.suggestedEntities()`. Its caller passes the account's
+  `flight_order` preference so the Shortcuts picker matches what the flight list
+  shows; only the upcoming half flips, past stays most-recent-first.
 - `nextFlight(in:now:)` — deliberately **not** preference-driven. "My next
   flight" means the soonest departure however the list happens to be drawn;
   following a display preference here would return the furthest-away flight.
+- `IntentDialogs.overviewSummary` — calls `orderedForSuggestions` but pins
+  `.soonestFirst`, for that reason plus a second one: it truncates to five, so a
+  furthest-first preference would make it read out the five most *distant*
+  flights and silently omit the one departing tomorrow.
+
+The rule: **entity pickers follow the display preference; spoken
+"next/upcoming" answers stay chronological.**
+
+All three share one duration-aware `FlightResolver.isUpcoming(_:now:)`, so they
+agree with `FlightResponse.resolvedSection`, `FlightListView.groupedFlights` and
+the server's `_flight_has_ended` about when a flight stops being upcoming.
+Gating them on bare `departureDate >= now` would make Siri report no upcoming
+flights while the list showed an in-progress one at the top of Future — and
+`nextFlight` skip the flight you are actually on. A flight whose `departureTime`
+won't parse counts as upcoming, matching the list.
 
 `order` is a parameter rather than a read of global state: the function is
 `nonisolated` and pure so the non-MainActor test target can call it, while

--- a/src/weatherbrief/api/flights.py
+++ b/src/weatherbrief/api/flights.py
@@ -29,6 +29,7 @@ from weatherbrief.models import AdvisorySummary, Flight, FlightDebrief
 from weatherbrief.notify.badge import unseen_flight_ids
 from weatherbrief.storage.debriefs import bulk_get_debriefs, get_debrief as _get_debrief
 from weatherbrief.api.debriefs import DebriefResponse
+from weatherbrief.api.preferences import load_flight_order
 from weatherbrief.storage.flights import (
     SHARE_CODE_RE,
     SubscriptionError,
@@ -526,6 +527,28 @@ def _flight_to_response(
     )
 
 
+def _flight_has_ended(flight: Flight, now: datetime) -> bool:
+    """Has this flight finished — departure plus its planned duration?
+
+    The single boundary between the ``future`` section and everything behind
+    it. A flight that departed 30 minutes ago on a 3-hour trip is in progress,
+    not past, so it stays in the upcoming list (and under "soonest first" sits
+    at the very top, which is where you want it while flying). This mirrors the
+    web's ``isFlightPast`` (``web/ts/utils.ts``), which has always been
+    duration-aware.
+
+    ``flight_duration_hours`` defaults to ``0.0`` and zero-duration flights are
+    a real case (the add-flight flow has a ``confirmZeroDuration`` dialog) —
+    those behave exactly as before: past the instant they depart.
+
+    ``_classify_section`` and ``_compute_recent_section`` must both go through
+    here; if they disagree, an airborne flight can be ``future`` by one and a
+    ``recent`` candidate by the other.
+    """
+    duration = flight.flight_duration_hours or 0.0
+    return flight.departure_time + timedelta(hours=duration) < now
+
+
 def _classify_section(
     flight: Flight,
     *,
@@ -540,7 +563,7 @@ def _classify_section(
     ``_compute_recent_section`` and pass it in.
     """
     now = now or datetime.now(timezone.utc)
-    if flight.departure_time >= now:
+    if not _flight_has_ended(flight, now):
         return "future"
     if flight.id in recent_set:
         return "recent"
@@ -574,7 +597,7 @@ def _compute_recent_section(
         f
         for f, d in owned_flights_with_debrief
         if d is None
-        and f.departure_time < now
+        and _flight_has_ended(f, now)
         and f.departure_time >= cutoff
     ]
     candidates.sort(key=lambda f: f.departure_time, reverse=True)
@@ -625,6 +648,26 @@ def _get_latest_packs(db: Session, flight_ids: list[str]) -> dict[str, BriefingS
     }
 
 
+def _reorder_future_soonest_first(
+    flights: list[FlightResponse],
+    meta: list[tuple[str, datetime]],
+) -> None:
+    """Re-sort the ``future`` entries of ``flights`` ascending by departure, in place.
+
+    Only the slots holding future flights are rewritten; ``recent`` entries keep
+    both their positions and their most-recent-first order, which is what the
+    preference promises (#536). The two sections can interleave in the incoming
+    ``departure_time desc`` order — an in-progress flight departed before a
+    just-ended short one — so this deliberately permutes within a subset rather
+    than partitioning the list.
+    """
+    slots = [i for i, (section, _) in enumerate(meta) if section == "future"]
+    ordered = sorted(slots, key=lambda i: meta[i][1])
+    picked = [flights[i] for i in ordered]
+    for slot, resp in zip(slots, picked):
+        flights[slot] = resp
+
+
 @router.get("", response_model=list[FlightResponse])
 def list_all_flights(
     response: Response,
@@ -665,6 +708,10 @@ def list_all_flights(
     # (departure_time desc); the frontend re-buckets by ``section`` so the
     # concatenation order below only needs to preserve per-section order.
     other: list[FlightResponse] = []  # future + recent
+    # Parallel to ``other``: (section, departure_time) per entry, so the
+    # soonest-first reorder below can pick out the future members without
+    # re-parsing the ISO strings on the responses.
+    other_meta: list[tuple[str, datetime]] = []
     past: list[FlightResponse] = []
     for f, role, owner_name in paired:
         debrief = debrief_map.get(f.id) if role == "owner" else None
@@ -681,7 +728,18 @@ def list_all_flights(
             section=section,
             unseen=f.id in unseen_ids,
         )
-        (past if section == "past" else other).append(resp)
+        if section == "past":
+            past.append(resp)
+        else:
+            other.append(resp)
+            other_meta.append((section, f.departure_time))
+
+    # Upcoming-flights ordering (#536). Opt-in account preference, loaded here
+    # in the body rather than via ``Depends()``: ``api/agent.py`` (the ChatGPT
+    # connector) calls this function directly, where a Depends default would
+    # arrive as a ``fastapi.params.Depends`` instance and never match.
+    if load_flight_order(db, user_id) == "soonest_first":
+        _reorder_future_soonest_first(other, other_meta)
 
     response.headers["X-Past-Total"] = str(len(past))
     if past_limit is not None:

--- a/src/weatherbrief/api/preferences.py
+++ b/src/weatherbrief/api/preferences.py
@@ -34,6 +34,11 @@ router = APIRouter(prefix="/user/preferences", tags=["preferences"])
 #: Notification scope — which refreshes notify (single choice).
 NotifyScope = Literal["auto", "all", "off"]
 
+#: Ordering of the upcoming-flights section (#536). The default reproduces the
+#: historical ``departure_time desc`` ordering exactly.
+FlightOrder = Literal["furthest_first", "soonest_first"]
+DEFAULT_FLIGHT_ORDER: str = "furthest_first"
+
 
 class FxBlock(BaseModel):
     """Display-currency block carried on USD-canonical cost/donation responses.
@@ -83,6 +88,11 @@ class PreferencesResponse(BaseModel):
     icing_severity_enhance: bool
     locale: str
     units_region: str
+    # Ordering of the *upcoming* flights section only (#536). "furthest_first"
+    # is the historical behaviour (departure_time desc); "soonest_first" puts
+    # the next departure at the top. Past/Recent stay most-recent-first under
+    # both — past pagination is offset-based over that order.
+    flight_order: str
     display_currency: str  # ISO 4217 or "auto" (cost/donation display only)
     synoptic_forecast_map_enabled: bool
     defer_email_for_model_update: bool
@@ -129,6 +139,7 @@ class PreferencesUpdate(BaseModel):
     icing_severity_enhance: bool | None = None
     locale: str | None = None
     units_region: Literal["auto", "europe", "us"] | None = None
+    flight_order: FlightOrder | None = None
     display_currency: str | None = None  # "auto" or an ISO 4217 code (e.g. "EUR")
     synoptic_forecast_map_enabled: bool | None = None
     defer_email_for_model_update: bool | None = None
@@ -237,6 +248,7 @@ def _parse_service_toggles(raw: str) -> dict:
         "icing_severity_enhance": data.get("icing_severity_enhance", False),
         "locale": data.get("locale", "en"),
         "units_region": data.get("units_region", "auto"),
+        "flight_order": data.get("flight_order", DEFAULT_FLIGHT_ORDER),
         "display_currency": data.get("display_currency", "auto"),
         "synoptic_forecast_map_enabled": data.get("synoptic_forecast_map_enabled", False),
         "defer_email_for_model_update": data.get("defer_email_for_model_update", False),
@@ -389,6 +401,8 @@ def update_preferences(
         data["locale"] = body.locale
     if body.units_region is not None:
         data["units_region"] = body.units_region
+    if body.flight_order is not None:
+        data["flight_order"] = body.flight_order
     if body.display_currency is not None:
         # Already normalized by the PreferencesUpdate field validator.
         data["display_currency"] = body.display_currency
@@ -558,6 +572,29 @@ def load_units_region(db: Session, user_id: str) -> str:
         return "auto"
 
 
+def load_flight_order(db: Session, user_id: str) -> str:
+    """Load the user's upcoming-flights ordering ('furthest_first' | 'soonest_first').
+
+    Read in the *body* of ``flights.list_all_flights`` rather than injected as a
+    ``Depends()`` parameter: that route is also called directly as a plain
+    function by the ChatGPT connector (``api/agent.py``), where a ``Depends``
+    default would silently arrive as a ``fastapi.params.Depends`` instance and
+    compare unequal to every valid value. See .claude/CLAUDE.md →
+    "Changing Function Signatures".
+
+    Anything unrecognized falls back to the default, so a hand-edited blob can
+    never produce an ordering no client knows how to render.
+    """
+    row = db.get(UserPreferencesRow, user_id)
+    if not row or not row.app_prefs_json:
+        return DEFAULT_FLIGHT_ORDER
+    try:
+        value = json.loads(row.app_prefs_json).get("flight_order")
+    except json.JSONDecodeError:
+        return DEFAULT_FLIGHT_ORDER
+    return value if value in ("furthest_first", "soonest_first") else DEFAULT_FLIGHT_ORDER
+
+
 # Display-currency derivation from the existing units_region preference.
 _REGION_CURRENCY = {"europe": "EUR", "us": "USD"}
 
@@ -674,7 +711,7 @@ def load_service_toggles(db: Session, user_id: str) -> dict[str, Any]:
     """
     row = db.get(UserPreferencesRow, user_id)
     if not row:
-        return {"gramet_enabled": True, "llm_digest_enabled": True, "icing_severity_enhance": False, "units_region": "auto", "display_currency": "auto", "defer_email_for_model_update": False}
+        return {"gramet_enabled": True, "llm_digest_enabled": True, "icing_severity_enhance": False, "units_region": "auto", "flight_order": DEFAULT_FLIGHT_ORDER, "display_currency": "auto", "defer_email_for_model_update": False}
     run_pending_migrations(db, row)
     return _parse_service_toggles(row.app_prefs_json)
 

--- a/src/weatherbrief/api/preferences.py
+++ b/src/weatherbrief/api/preferences.py
@@ -40,6 +40,16 @@ FlightOrder = Literal["furthest_first", "soonest_first"]
 DEFAULT_FLIGHT_ORDER: str = "furthest_first"
 
 
+def _normalize_flight_order(value: object) -> str:
+    """Coerce a stored ``flight_order`` to a value every client can render.
+
+    The single normalizer, shared by the GET response and by
+    :func:`load_flight_order`, so a hand-edited or future-version blob can never
+    make the reported preference disagree with the ordering actually applied.
+    """
+    return value if value in ("furthest_first", "soonest_first") else DEFAULT_FLIGHT_ORDER
+
+
 class FxBlock(BaseModel):
     """Display-currency block carried on USD-canonical cost/donation responses.
 
@@ -248,7 +258,7 @@ def _parse_service_toggles(raw: str) -> dict:
         "icing_severity_enhance": data.get("icing_severity_enhance", False),
         "locale": data.get("locale", "en"),
         "units_region": data.get("units_region", "auto"),
-        "flight_order": data.get("flight_order", DEFAULT_FLIGHT_ORDER),
+        "flight_order": _normalize_flight_order(data.get("flight_order")),
         "display_currency": data.get("display_currency", "auto"),
         "synoptic_forecast_map_enabled": data.get("synoptic_forecast_map_enabled", False),
         "defer_email_for_model_update": data.get("defer_email_for_model_update", False),
@@ -582,8 +592,9 @@ def load_flight_order(db: Session, user_id: str) -> str:
     compare unequal to every valid value. See .claude/CLAUDE.md →
     "Changing Function Signatures".
 
-    Anything unrecognized falls back to the default, so a hand-edited blob can
-    never produce an ordering no client knows how to render.
+    Anything unrecognized falls back to the default via
+    :func:`_normalize_flight_order` — the same coercion the GET response applies,
+    so what the client is told and what the list does can't diverge.
     """
     row = db.get(UserPreferencesRow, user_id)
     if not row or not row.app_prefs_json:
@@ -592,7 +603,7 @@ def load_flight_order(db: Session, user_id: str) -> str:
         value = json.loads(row.app_prefs_json).get("flight_order")
     except json.JSONDecodeError:
         return DEFAULT_FLIGHT_ORDER
-    return value if value in ("furthest_first", "soonest_first") else DEFAULT_FLIGHT_ORDER
+    return _normalize_flight_order(value)
 
 
 # Display-currency derivation from the existing units_region preference.

--- a/tests/test_flights_api_sections.py
+++ b/tests/test_flights_api_sections.py
@@ -13,7 +13,11 @@ from sqlalchemy.orm import sessionmaker
 from flyfun_common.db import current_user_id, get_db, DEV_USER_ID
 from flyfun_common.db.models import UserPreferencesRow, UserRow
 from weatherbrief.api.app import create_app
-from weatherbrief.api.flights import _classify_section, _compute_recent_section
+from weatherbrief.api.flights import (
+    _classify_section,
+    _compute_recent_section,
+    _flight_has_ended,
+)
 from weatherbrief.debriefs.taxonomy import ConditionTag, Decision
 from weatherbrief.models import Flight, FlightDebrief
 from weatherbrief.storage.debriefs import upsert_debrief
@@ -36,6 +40,20 @@ def _flt(idx: int, days_offset: int) -> Flight:
         departure_time=dep,
         cruise_altitude_ft=8000,
         flight_duration_hours=1.0,
+        created_at=dep - timedelta(days=1),
+    )
+
+
+def _flt_hours(idx: int, hours_offset: float, duration: float) -> Flight:
+    """Build a Flight departing hours_offset hours from _NOW, with a given duration."""
+    dep = _NOW + timedelta(hours=hours_offset)
+    return Flight(
+        id=f"h-{idx}",
+        user_id="u",
+        route_name="r",
+        departure_time=dep,
+        cruise_altitude_ft=8000,
+        flight_duration_hours=duration,
         created_at=dep - timedelta(days=1),
     )
 
@@ -123,6 +141,57 @@ class TestClassifySection:
     def test_past_undebriefed_outside_recent(self):
         f = _flt(1, -100)
         assert _classify_section(f, has_debrief=False, recent_set=set(), now=_NOW) == "past"
+
+
+class TestDurationAwareBoundary:
+    """The future/past boundary is departure + duration, not departure (#536).
+
+    Matches the web's ``isFlightPast``, which has always been duration-aware.
+    """
+
+    def test_in_progress_flight_has_not_ended(self):
+        # Departed 30 minutes ago on a 3-hour trip — still flying.
+        f = _flt_hours(1, hours_offset=-0.5, duration=3.0)
+        assert _flight_has_ended(f, _NOW) is False
+
+    def test_flight_past_its_duration_has_ended(self):
+        f = _flt_hours(2, hours_offset=-4.0, duration=3.0)
+        assert _flight_has_ended(f, _NOW) is True
+
+    def test_zero_duration_is_past_the_instant_it_departs(self):
+        # Zero duration is a real case (the web add-flight flow confirms it) and
+        # must behave exactly as before: past as soon as it departs.
+        f = _flt_hours(3, hours_offset=-0.01, duration=0.0)
+        assert _flight_has_ended(f, _NOW) is True
+
+    def test_departure_exactly_now_is_not_ended(self):
+        # Unchanged from the old ``departure_time >= now`` boundary.
+        f = _flt_hours(4, hours_offset=0.0, duration=0.0)
+        assert _flight_has_ended(f, _NOW) is False
+
+    def test_none_duration_treated_as_zero(self):
+        f = _flt_hours(5, hours_offset=-0.01, duration=1.0)
+        f.flight_duration_hours = None  # type: ignore[assignment]
+        assert _flight_has_ended(f, _NOW) is True
+
+    def test_in_progress_flight_classifies_as_future(self):
+        f = _flt_hours(6, hours_offset=-0.5, duration=3.0)
+        assert _classify_section(f, has_debrief=False, recent_set=set(), now=_NOW) == "future"
+
+    def test_classify_and_recent_agree_for_in_progress_flight(self):
+        # The two functions test the boundary independently; if they disagree an
+        # airborne flight is ``future`` to one and a ``recent`` candidate to the
+        # other. Both must go through ``_flight_has_ended``.
+        f = _flt_hours(7, hours_offset=-0.5, duration=3.0)
+        recent = _compute_recent_section([(f, None)], now=_NOW)
+        assert recent == set()
+        assert _classify_section(f, has_debrief=False, recent_set=recent, now=_NOW) == "future"
+
+    def test_just_ended_flight_becomes_recent(self):
+        f = _flt_hours(8, hours_offset=-3.5, duration=3.0)
+        recent = _compute_recent_section([(f, None)], now=_NOW)
+        assert recent == {f.id}
+        assert _classify_section(f, has_debrief=False, recent_set=recent, now=_NOW) == "recent"
 
 
 # --- Integration test against the real API ---
@@ -285,6 +354,89 @@ class TestPastPagination:
         resp = client.get("/api/flights")
         assert resp.headers["X-Past-Total"] == "3"
         assert len([f for f in resp.json() if f["section"] == "past"]) == 3
+
+
+def _set_flight_order(app_db, order: str) -> None:
+    """Write the ordering preference straight into ``app_prefs_json``."""
+    s = app_db()
+    row = s.get(UserPreferencesRow, DEV_USER_ID)
+    data = json.loads(row.app_prefs_json) if row.app_prefs_json else {}
+    data["flight_order"] = order
+    row.app_prefs_json = json.dumps(data)
+    s.commit()
+    s.close()
+
+
+class TestFlightOrderPreference:
+    """Upcoming-flights ordering (#536): only the future section reorders."""
+
+    def _future_ids(self, client) -> list[str]:
+        return [f["id"] for f in client.get("/api/flights").json() if f["section"] == "future"]
+
+    def test_default_is_furthest_first(self, client, app_db):
+        near = _save_flight(app_db, route="fo-near", days_offset=+2, idx=1)
+        far = _save_flight(app_db, route="fo-far", days_offset=+9, idx=2)
+        mid = _save_flight(app_db, route="fo-mid", days_offset=+5, idx=3)
+        assert self._future_ids(client) == [far.id, mid.id, near.id]
+
+    def test_soonest_first_reverses_future_only(self, client, app_db):
+        near = _save_flight(app_db, route="so-near", days_offset=+2, idx=1)
+        far = _save_flight(app_db, route="so-far", days_offset=+9, idx=2)
+        mid = _save_flight(app_db, route="so-mid", days_offset=+5, idx=3)
+        _set_flight_order(app_db, "soonest_first")
+        assert self._future_ids(client) == [near.id, mid.id, far.id]
+
+    def test_recent_and_past_unchanged_under_both(self, client, app_db):
+        # 2 recent (within 30 days, undebriefed, capped at 2) + 2 past.
+        for i in range(4):
+            _save_flight(app_db, route=f"ro{i}", days_offset=-(i + 1), idx=i)
+        for i in range(2):
+            _save_flight(app_db, route=f"po{i}", days_offset=-(40 + i), idx=10 + i)
+        _save_flight(app_db, route="fo-a", days_offset=+3, idx=20)
+        _save_flight(app_db, route="fo-b", days_offset=+8, idx=21)
+
+        def sectioned(section: str) -> list[str]:
+            return [f["id"] for f in client.get("/api/flights").json() if f["section"] == section]
+
+        default_recent, default_past = sectioned("recent"), sectioned("past")
+        _set_flight_order(app_db, "soonest_first")
+        assert sectioned("recent") == default_recent
+        assert sectioned("past") == default_past
+
+    def test_past_pagination_unaffected(self, client, app_db):
+        for i in range(5):
+            _save_flight(app_db, route=f"pp{i}", days_offset=-(40 + i), idx=i)
+        _save_flight(app_db, route="pp-fut", days_offset=+5, idx=99)
+        _set_flight_order(app_db, "soonest_first")
+
+        resp = client.get("/api/flights?past_limit=2&past_offset=0")
+        assert resp.headers["X-Past-Total"] == "5"
+        page1 = [f["id"] for f in resp.json() if f["section"] == "past"]
+        page2 = [
+            f["id"]
+            for f in client.get("/api/flights?past_limit=2&past_offset=2").json()
+            if f["section"] == "past"
+        ]
+        assert len(page1) == 2 and len(page2) == 2
+        assert set(page1).isdisjoint(page2)
+        # The full-order past list is still most-recent-first.
+        full = [f["id"] for f in client.get("/api/flights").json() if f["section"] == "past"]
+        assert full[:2] == page1
+        assert full[2:4] == page2
+
+    def test_unknown_stored_value_falls_back_to_default(self, client, app_db):
+        near = _save_flight(app_db, route="uk-near", days_offset=+2, idx=1)
+        far = _save_flight(app_db, route="uk-far", days_offset=+9, idx=2)
+        _set_flight_order(app_db, "sideways")
+        assert self._future_ids(client) == [far.id, near.id]
+
+    def test_in_progress_flight_leads_under_soonest_first(self, client, app_db):
+        # Departed 30 min ago on a 1-hour trip → still future, and the soonest
+        # departure, so it sits at the very top while you're flying.
+        flying = _save_flight(app_db, route="ip-now", days_offset=-0.5 / 24, idx=1)
+        later = _save_flight(app_db, route="ip-later", days_offset=+3, idx=2)
+        _set_flight_order(app_db, "soonest_first")
+        assert self._future_ids(client) == [flying.id, later.id]
 
 
 class TestApiSections:

--- a/tests/test_preferences.py
+++ b/tests/test_preferences.py
@@ -131,6 +131,9 @@ class TestPreferencesAPI:
         s.commit()
         assert load_flight_order(s, DEV_USER_ID) == "furthest_first"
         s.close()
+        # The GET response applies the same coercion, so what the client is told
+        # can't disagree with the ordering the list actually uses.
+        assert client.get("/api/user/preferences").json()["flight_order"] == "furthest_first"
 
     def test_defer_email_for_model_update_round_trip(self, client, app_db):
         # Default off (current behaviour).

--- a/tests/test_preferences.py
+++ b/tests/test_preferences.py
@@ -85,6 +85,53 @@ class TestPreferencesAPI:
         resp = client.put("/api/user/preferences", json={"units_region": "metric"})
         assert resp.status_code == 422
 
+    def test_flight_order_defaults_to_furthest_first(self, client, app_db):
+        # Absent from app_prefs_json → today's ordering, for every existing user.
+        assert client.get("/api/user/preferences").json()["flight_order"] == "furthest_first"
+
+        from weatherbrief.api.preferences import load_flight_order
+
+        s = app_db()
+        assert load_flight_order(s, DEV_USER_ID) == "furthest_first"
+        s.close()
+
+    def test_flight_order_round_trip(self, client, app_db):
+        resp = client.put("/api/user/preferences", json={"flight_order": "soonest_first"})
+        assert resp.status_code == 200
+        assert resp.json()["flight_order"] == "soonest_first"
+        assert client.get("/api/user/preferences").json()["flight_order"] == "soonest_first"
+
+        from weatherbrief.api.preferences import load_flight_order
+
+        s = app_db()
+        assert load_flight_order(s, DEV_USER_ID) == "soonest_first"
+        s.close()
+
+    def test_flight_order_rejects_invalid(self, client):
+        resp = client.put("/api/user/preferences", json={"flight_order": "chronological"})
+        assert resp.status_code == 422
+
+    def test_flight_order_does_not_disturb_other_prefs(self, client):
+        client.put("/api/user/preferences", json={"units_region": "us"})
+        client.put("/api/user/preferences", json={"flight_order": "soonest_first"})
+        data = client.get("/api/user/preferences").json()
+        assert data["units_region"] == "us"
+        assert data["flight_order"] == "soonest_first"
+
+    def test_load_flight_order_ignores_unknown_stored_value(self, client, app_db):
+        """A hand-edited blob can't produce an order no client knows how to render."""
+        from weatherbrief.api.preferences import load_flight_order
+
+        client.get("/api/user/preferences")  # ensure the row exists
+        s = app_db()
+        row = s.get(UserPreferencesRow, DEV_USER_ID)
+        data = json.loads(row.app_prefs_json) if row.app_prefs_json else {}
+        data["flight_order"] = "sideways"
+        row.app_prefs_json = json.dumps(data)
+        s.commit()
+        assert load_flight_order(s, DEV_USER_ID) == "furthest_first"
+        s.close()
+
     def test_defer_email_for_model_update_round_trip(self, client, app_db):
         # Default off (current behaviour).
         assert client.get("/api/user/preferences").json()["defer_email_for_model_update"] is False

--- a/web/settings.html
+++ b/web/settings.html
@@ -132,6 +132,14 @@
                 <option value="RON">RON lei</option>
               </select>
             </div>
+            <div class="form-group">
+              <label for="input-flight-order">Upcoming flights</label>
+              <select id="input-flight-order" class="input-select">
+                <option value="furthest_first">Furthest first — the flight departing last is at the top</option>
+                <option value="soonest_first">Soonest first — the flight departing next is at the top</option>
+              </select>
+              <span class="field-hint">Applies to upcoming flights only. Past flights always stay most-recent-first, so with "Soonest first" the list runs forward through your upcoming flights, then backward through your past ones.</span>
+            </div>
           </div>
           <p class="muted section-hint">Automatic uses US units for US flights and metric for European flights. Altitude (ft), wind (kt) and distance (nm) are the same in both — only visibility differs today; QNH and temperature will follow this setting when added. Currency only affects how costs and donations are displayed.</p>
         </div>

--- a/web/ts/adapters/preferences-adapter.ts
+++ b/web/ts/adapters/preferences-adapter.ts
@@ -49,6 +49,9 @@ export interface PreferencesResponse {
   icing_severity_enhance: boolean;
   locale: string;
   units_region: string;
+  // Ordering of the upcoming-flights section only (#536):
+  // 'furthest_first' (default, historical) | 'soonest_first'.
+  flight_order: string;
   display_currency: string;
   synoptic_forecast_map_enabled: boolean;
   defer_email_for_model_update: boolean;
@@ -82,6 +85,7 @@ export interface PreferencesUpdate {
   icing_severity_enhance?: boolean;
   locale?: string;
   units_region?: string;
+  flight_order?: string;
   display_currency?: string;
   synoptic_forecast_map_enabled?: boolean;
   defer_email_for_model_update?: boolean;

--- a/web/ts/settings-main.ts
+++ b/web/ts/settings-main.ts
@@ -843,6 +843,12 @@ function populateAccountForm(prefs: PreferencesResponse): void {
     unitsRegionSelect.value = ur === 'us' || ur === 'europe' ? ur : 'auto';
   }
 
+  // Upcoming-flights ordering — server-stored, applies to the Future section only (#536)
+  const flightOrderSelect = document.getElementById('input-flight-order') as HTMLSelectElement;
+  if (flightOrderSelect) {
+    flightOrderSelect.value = prefs.flight_order === 'soonest_first' ? 'soonest_first' : 'furthest_first';
+  }
+
   // Display-currency picker — "auto" or an ISO code (cost/donation display only)
   const currencySelect = document.getElementById('input-display-currency') as HTMLSelectElement;
   if (currencySelect) {
@@ -1682,6 +1688,8 @@ async function handleSave(): Promise<void> {
   const unitsRegionVal = (document.getElementById('input-units-region') as HTMLSelectElement)?.value;
   const selectedUnitsRegion = unitsRegionVal === 'us' || unitsRegionVal === 'europe' ? unitsRegionVal : 'auto';
   const selectedDisplayCurrency = (document.getElementById('input-display-currency') as HTMLSelectElement)?.value || 'auto';
+  const flightOrderVal = (document.getElementById('input-flight-order') as HTMLSelectElement)?.value;
+  const selectedFlightOrder = flightOrderVal === 'soonest_first' ? 'soonest_first' : 'furthest_first';
 
   try {
     // Save profile settings
@@ -1703,6 +1711,7 @@ async function handleSave(): Promise<void> {
     const accountUpdate: import('./adapters/preferences-adapter').PreferencesUpdate = {
       locale: selectedLocale,
       units_region: selectedUnitsRegion,
+      flight_order: selectedFlightOrder,
       display_currency: selectedDisplayCurrency,
       synoptic_forecast_map_enabled: synopticEnabled,
       defer_email_for_model_update: deferModelUpdate,


### PR DESCRIPTION
## What & why

Saved flights are ordered newest-departure-first, so in the **Future** section the flight furthest ahead sits at the top and the one you're about to fly is buried at the bottom. Some users prefer that, so this ships as an **opt-in account preference**, not a default change — and only the Future section reorders.

`flight_order` lives in `app_prefs_json` (**no migration**), default `"furthest_first"` = today's behaviour exactly.

**Part 1 — backend.** `flight_order` added to the preferences response/update, parsed, persisted, and read back via `load_flight_order`. `list_all_flights` sorts only the *future* members of the future+recent list ascending under `"soonest_first"`; Recent entries keep both their positions and their order (the two sections can interleave in the incoming `departure_time desc` order once an in-progress flight is Future, so the reorder permutes within a subset rather than partitioning).

The preference is loaded **in the function body, not via `Depends()`** — `api/agent.py` calls `list_all_flights` directly as a plain Python function, where a `Depends` default would arrive as a `fastapi.params.Depends` instance and silently compare unequal to every valid value. No signature change, no callers to update. Agent/MCP surfaces inherit the ordering for free, which is the intended outcome.

An unrecognized stored value falls back to the default via a shared `_normalize_flight_order`, used by both the GET response and `load_flight_order`, so what a client is told and what the list actually does can't diverge.

**Part 2 — duration-aware future/past boundary.** The server used `departure_time >= now` while the web used `start + duration > now`. The web version is correct and is now used everywhere: a flight that departed 30 minutes ago on a 3-hour trip is in progress, not past. `_classify_section` and `_compute_recent_section` both go through a single `_flight_has_ended(flight, now)` helper, so an airborne flight can't be `future` to one and a `recent` candidate to the other. Zero/None duration behaves exactly as before — past the instant it departs.

Expected side effect: an in-progress flight moves Past → Future, leaving the paginated past list for the always-full future list, so `X-Past-Total` drops by one at that moment. Correct, not a pagination bug. Under "soonest first" it lands at the very top, which is where you want it while flying.

**Part 3 — web.** Settings select + `PreferencesUpdate`/`PreferencesResponse` types. `flights-ui.ts` needed no change: it already preserves server order within each section.

**Part 4 — iOS.** `FlightListView.groupedFlights(_:order:now:)` applies the preference to Future only; Recent/Past stay descending. Both duplicated copies of the boundary (`FlightResponse.resolvedSection(now:)` and the legacy `groupedFlights` fallback) move to the shared duration-aware `hasEnded(now:)`, keeping the "mirrors the server exactly" promise. Settings gains a server-backed Picker wired through `UserPreferencesStore.updateFlightOrder(_:using:)`. `PreferencesResponse.flightOrder` is **Optional** — a non-optional field would fail the cached-prefs decode at launch and visibly reset the notification toggles.

**Part 5 — Siri / App Intents.** `FlightResolver.orderedForSuggestions(_:order:now:)` takes the order as a parameter rather than reaching for global state, so it stays `nonisolated` and pure for the test target; `FlightEntityQuery.suggestedEntities()` passes `UserPreferencesStore.cachedFlightOrder()`, a `nonisolated` accessor over the same `cachedUserPreferences` blob, avoiding a main-actor hop.

The settled rule, arrived at over two review rounds and now written into `ios-app-intents.md`:

> **Entity pickers follow the display preference; spoken "next/upcoming" answers stay chronological.**

So the Shortcuts picker follows `flight_order`, while `nextFlight` and `IntentDialogs.overviewSummary` do not — the latter because it truncates to five, where a furthest-first preference would read out the five most *distant* flights and omit the one departing tomorrow.

All three intent surfaces share one duration-aware `FlightResolver.isUpcoming(_:now:)` delegating to `hasEnded(now:)`, so they agree with the list and the server about when a flight stops being upcoming. Without that, an in-progress flight sat at the top of Future in the app while Siri reported no upcoming flights and `nextFlight` opened the *next scheduled* briefing instead of the one you were flying.

Design docs updated: `debrief.md` (section assignment + ordering), `ios-app-intents.md` (display ordering vs. "my next flight", and the shared upcoming boundary).

### Worth a reviewer's eye

A flight whose `departureTime` won't parse now counts as **upcoming** on the intent surfaces rather than past — a consequence of `hasEnded` returning `false` for an unparseable date. That's the right side to land on: `resolvedSection` and the list's legacy bucketing already treat such a flight as Future, so this closes that gap rather than opening a new one.

## Issue linkage

Closes #536

## Testing / verification

- `tests/test_preferences.py` — default is `"furthest_first"` when absent from `app_prefs_json`; round-trip; invalid value 422s; doesn't disturb other prefs; an unknown stored value is coerced identically by `load_flight_order` and the GET response.
- `tests/test_flights_api_sections.py` — future ascending under `"soonest_first"`, unchanged under the default; Recent and Past identical under both; past pagination (`past_limit`/`past_offset`/`X-Past-Total`) unaffected; in-progress flight leads under soonest-first. New `TestDurationAwareBoundary`: in-progress → `future`, zero-duration → past on departure, departure-exactly-now unchanged, and `_classify_section`/`_compute_recent_section` agree for an airborne flight.
- Full Python suite: **4826 passed**, 1 pre-existing unrelated failure (`test_auth.py::TestLoginRedirect::test_google_login_redirects`, which also fails on a clean tree in this environment).
- Web: `npx tsc --noEmit` clean apart from two pre-existing errors in `ts/eval/label-panel.ts`.
- Swift tests written — `FlightGroupingTests` (Future ordering under both values, Recent/Past descending under both, legacy-fallback ordering, in-progress/zero-duration bucketing, `hasEnded` boundary) and `AppIntentsResolverTests` (`orderedForSuggestions` under both values, `isUpcoming` duration-awareness, `nextFlight` preferring the in-progress flight and ignoring the preference, overview truncation staying chronological) — but **not compiled or run**: no Swift toolchain in this environment. **They need an Xcode run before merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018ANhAoH9izJu5rdaYuvtDT