### PR TITLE
Couple the prompt-cache TTL to its write multiplier, and surface cache_saving_usd

### DIFF
--- a/designs/cost-attribution-design.md
+++ b/designs/cost-attribution-design.md
@@ -122,12 +122,67 @@ no migration. The serialized `CostConfig` keys: `token_cost_per_1k_input`,
 
 The two cache multipliers scale `token_cost_per_1k_input` for Anthropic prompt
 caching: a cache write bills at 2x on the 1-hour TTL the digest uses (1.25x on
-the 5-minute tier), a cache read at 0.1x. They are **not** independent of the
-TTL chosen in `digest/llm_digest.py:_system_content` — change one without the
-other and every digest is mis-priced. Note the admin cost-config form in
-`web/ts/admin-cost-view.ts` enumerates its fields explicitly and does not yet
-render these two, though `update_cost_config` already accepts them (it derives
-its allowed keys from the `CostConfig` dataclass).
+the 5-minute tier), a cache read at 0.1x.
+
+### TTL ↔ write multiplier are coupled by derivation
+
+A cache write's price depends on the TTL it was written with, and **nothing
+downstream records which TTL produced a write** — cost is computed later, in
+`_charge_briefing_cost()`, from a `briefing_usage` row that has only the token
+count. So a TTL change that the multiplier doesn't follow mis-prices every
+digest's writes by 60%, silently: no test fails, no log line.
+
+The defence is derivation, not documentation (issue #535):
+
+```
+costs.DIGEST_CACHE_TTL = "1h"                 # the TTL the charging path writes with
+costs.CACHE_WRITE_MULTIPLIERS = {"5m": 1.25, "1h": 2.0}   # the only price table
+CostConfig.cache_write_multiplier = CACHE_WRITE_MULTIPLIERS[DIGEST_CACHE_TTL]
+_system_content(..., ttl: str = DIGEST_CACHE_TTL)         # single call site default
+```
+
+- Move `DIGEST_CACHE_TTL` and the write price follows automatically.
+- An unpriced TTL (`"30m"`) raises `ValueError` at the call site rather than
+  billing at the wrong tier — a new Anthropic tier has to be priced first.
+- `tests/test_costs.py::TestCacheTtlPricingCoupling` pins the table against
+  Anthropic's published premiums and asserts the digest writes at the TTL the
+  rate card prices. `test_llm_digest.py` keeps a literal `"1h"` assertion as a
+  tripwire so a TTL change is a deliberate act.
+- The eval (`scripts/run_digest_eval.py`) overrides to `"5m"` — legitimate only
+  because a burst never expires *and* an eval writes no ledger row.
+- For the record, 5m is not the cheaper bet in prod: replayed arrival gaps give
+  a 20.0% hit rate against a 21.7% break-even, i.e. it bills more than not
+  caching at all. Break-even is `(w - 1) / (w - 0.1)`.
+
+A rate-card row can still override `cache_write_multiplier` (the DB wins over
+the derived default). `update_cost_config` logs a warning when a submitted
+value disagrees with `DIGEST_CACHE_TTL` rather than rejecting it, since the
+operator may be modelling a price change. Note the active prod row carries no
+cache keys at all, so both multipliers come from the dataclass defaults.
+
+Note the admin cost-config form in `web/ts/admin-cost-view.ts` enumerates its
+fields explicitly and does not yet render these two, though
+`update_cost_config` already accepts them (it derives its allowed keys from the
+`CostConfig` dataclass).
+
+### `cache_saving_usd` — what caching bought
+
+`CostBreakdown.cache_saving_usd` (and `ProgramCostReport.cache_saving_usd`)
+report the cached tokens priced at 1x minus what they actually billed:
+
+```python
+saving = (cache_read + cache_write) * rate
+       - (cache_read * read_mult + cache_write * write_mult) * rate
+```
+
+Reporting only — it is *already inside* `token_cost_usd` / `variable_token_usd`
+and must never be added to a subtotal. Negative on a pure cache write (2x is a
+real surcharge); the value is not floored. `detail_json` is schemaless, so this
+was purely additive — **no migration**. Rows charged before the field existed
+have no key, and every reader (`_program_variable_and_counts`, the per-user
+aggregate in `api/admin.py`, both frontends) keeps *absent* distinct from a
+measured `0.0`: `None`/omitted renders as nothing rather than "caching saved
+$0.00", which would be a lie about untracked history.
 
 Versioned: updating creates a new row, deactivates the previous. History queryable.
 `subscriptions_monthly_usd` is kept in sync server-side as the sum of
@@ -164,8 +219,8 @@ Versioned: updating creates a new row, deactivates the previous. History queryab
 
 - **adapters/credits-adapter.ts**: `fetchCostSummary()`, `fetchTransparency()` — typed API client
 - **adapters/admin-adapter.ts**: `fetchCostReport()`, `fetchCostConfig()`, `fetchCostConfigHistory()`, `updateCostConfig()` — program report + rate-card editing
-- **user-costs-main.ts**: Admin per-user cost dashboard with stacked bar chart, transaction ledger with expandable USD breakdowns
-- **admin-cost-view.ts**: Admin "Cost" tab — program report (7d/30d toggle, summary cards, fixed-line table) + rate-card editor (itemized subscription rows with live subtotal, versioned save, config history)
+- **user-costs-main.ts**: Admin per-user cost dashboard with stacked bar chart, transaction ledger with expandable USD breakdowns. Prompt-cache saving is shown as a line under the bar and a cell in the expanded breakdown — never a bar segment, since it is not a cost component
+- **admin-cost-view.ts**: Admin "Cost" tab — program report (7d/30d toggle, summary cards, fixed-line table) + rate-card editor (itemized subscription rows with live subtotal, versioned save, config history). A "Cache saved" card + note sentence appear only when the window has the figure (`cache_saving_usd != null`)
 - **cost-summary.html / cost-summary-main.ts**: Program cost (what it costs to run the service, fixed breakdown + composition bar + per-briefing/per-user economics) plus the viewer's own usage. Admin-gated now via `is_admin`; designed to move into a Settings tab + add a donation link + a public program endpoint later.
 
 ## Donations (Stripe)
@@ -470,6 +525,8 @@ there are no donations or `active_users == 0`.
 - The transparency endpoint is public (no auth) — intentionally exposes the cost structure.
 - Historical `description` fields may still contain "credits" text from before the migration.
 - `detail_json` holds the full CostBreakdown; `metadata_json` is for lightweight context. Don't mix them.
+- Adding a `CostBreakdown` field is migration-free but only reaches *new* rows. Readers must treat a missing key as unknown, never as `0.0` — see `cache_saving_usd` above.
+- Never hardcode a prompt-cache TTL. It lives in `costs.DIGEST_CACHE_TTL`, and the rate card's write multiplier is derived from it.
 - `reference_id` stores `briefing_usage_id` as a string — admin queries cast it to int for the JOIN.
 - The program report sums variable cost by parsing each briefing's `detail_json` in Python (dialect-agnostic) rather than SQL JSON extraction; bounded by briefings-per-window so it's cheap.
 - `/api/admin/cost-report` returns `null` (not 404) when no active config exists — the frontend renders an empty state.

--- a/designs/digest.md
+++ b/designs/digest.md
@@ -242,8 +242,10 @@ The `WEATHERBRIEF_GUIDANCE_DIR` env var can override the guidance directory to a
   ~40% of a request) are identical across digests sharing a (locale, guidance) pair, and
   Anthropic renders `tools` → `system` → `messages`, so one breakpoint covers both. 1-hour
   TTL, chosen against measured inter-digest gaps; skipped for long-range, whose Haiku 4.5
-  prompt is below that model's 4096-token cacheable minimum. See
-  `designs/cost-attribution-design.md` for how the read/write split is priced.
+  prompt is below that model's 4096-token cacheable minimum. The TTL is **not** a local
+  constant — it is `costs.DIGEST_CACHE_TTL`, and the rate card's write multiplier is derived
+  from it, so the two cannot drift. See `designs/cost-attribution-design.md` for how the
+  read/write split is priced.
 - **Versioned prompts** — `briefer_v1.md` allows prompt iteration without code changes
 
 ## Gotchas

--- a/scripts/run_digest_eval.py
+++ b/scripts/run_digest_eval.py
@@ -115,15 +115,21 @@ def run_one(
     ``cache=True`` puts a 5-minute prompt-cache breakpoint on the system block.
     An eval is the ideal caching workload — every call in a run shares a
     byte-identical prefix and they land seconds apart — so one write carries the
-    whole run. Five minutes rather than production's hour because nothing
-    expires inside a burst and the write premium is 1.25x instead of 2x.
+    whole run. Five minutes rather than production's ``DIGEST_CACHE_TTL``
+    because nothing expires inside a burst and the write premium is 1.25x
+    instead of 2x; the override is only legitimate here because an eval never
+    writes to the cost ledger, which prices writes at the production TTL.
     Off by default so importers (tests/test_digest_assertions.py) are unaffected.
+
+    The prompt is passed whole as the cached head with an empty tail: the eval
+    renders one prompt per run (guidance included), so there is no per-caller
+    tail to keep outside the breakpoint the way production has.
     """
     llm = create_llm(config)
     structured_llm = llm.with_structured_output(WeatherDigest, include_raw=True)
 
     system_content = (
-        _system_content(system_prompt, config.llm, longrange=False, ttl="5m")
+        _system_content(system_prompt, "", config.llm, longrange=False, ttl="5m")
         if cache else system_prompt
     )
 

--- a/src/weatherbrief/api/admin.py
+++ b/src/weatherbrief/api/admin.py
@@ -450,6 +450,11 @@ def get_user_costs(
         "margin_usd": 0.0,
         "total_usd": 0.0,
     }
+    # Prompt-cache saving is summed separately and stays absent unless at least
+    # one row carries it: briefings charged before the field existed would
+    # otherwise aggregate into a measured-looking $0.00.  It is informational —
+    # already inside token_cost_usd — so it never joins the sums above.
+    cache_saving_usd: float | None = None
     for (bj,) in briefing_entries:
         if not bj:
             continue
@@ -463,9 +468,14 @@ def get_user_costs(
         agg_breakdown["storage_cost_usd"] += bd.get("storage_cost_usd", 0.0)
         agg_breakdown["margin_usd"] += bd.get("margin_usd", 0.0)
         agg_breakdown["total_usd"] += bd.get("total_usd", 0.0)
+        saving = bd.get("cache_saving_usd")
+        if saving is not None:
+            cache_saving_usd = (cache_saving_usd or 0.0) + saving
     # Round all aggregated values
     for k in agg_breakdown:
         agg_breakdown[k] = round(agg_breakdown[k], 4)
+    if cache_saving_usd is not None:
+        agg_breakdown["cache_saving_usd"] = round(cache_saving_usd, 4)
 
     return {
         "user": {

--- a/src/weatherbrief/api/credits.py
+++ b/src/weatherbrief/api/credits.py
@@ -13,11 +13,13 @@ from sqlalchemy.orm import Session
 
 from weatherbrief.api.admin import require_admin
 from weatherbrief.costs import (
+    DIGEST_CACHE_TTL,
     CostBreakdown,
     CostConfig,
     DEFAULT_CONFIG,
     ProgramCostReport,
     breakdown_to_dict,
+    cache_write_multiplier_for,
     compute_cost,
     compute_program_cost,
     config_from_row,
@@ -335,6 +337,27 @@ def update_cost_config(
 
     CostConfig.from_json(json.dumps(merged))
 
+    # The rate card can override the write premium, but the digest writes at
+    # DIGEST_CACHE_TTL and nothing downstream records which TTL produced a
+    # write — so an override that disagrees with the TTL mis-prices every
+    # subsequent briefing.  Loud in the log rather than a hard 422: the
+    # operator may legitimately be modelling a price change.
+    try:
+        submitted_write = float(merged["cache_write_multiplier"])
+    except (KeyError, TypeError, ValueError):
+        # A non-numeric multiplier would otherwise store cleanly and only blow
+        # up later, inside the charging path, where failures are swallowed.
+        raise HTTPException(
+            status_code=422, detail="cache_write_multiplier must be a number",
+        )
+    expected_write = cache_write_multiplier_for(DIGEST_CACHE_TTL)
+    if abs(submitted_write - expected_write) > 1e-9:
+        logger.warning(
+            "cost_config cache_write_multiplier=%s disagrees with the %s digest "
+            "cache TTL (expected %s) — writes will be mis-priced",
+            submitted_write, DIGEST_CACHE_TTL, expected_write,
+        )
+
     new_row = CostConfigRow(
         active_from=now,
         config_json=json.dumps(merged),
@@ -370,11 +393,15 @@ _ALLOWED_WINDOWS = {"7d": 7, "30d": 30}
 
 def _program_variable_and_counts(
     db: Session, since: datetime,
-) -> tuple[float, float, int, int]:
+) -> tuple[float, float, int, int, float | None]:
     """Sum actual token/storage cost and count briefings + distinct users since.
 
     Variable cost is pulled from each briefing's stored CostBreakdown so it
     reflects what was actually charged, independent of the current rate card.
+
+    The trailing element is the prompt-cache saving over the window, or
+    ``None`` when no row carries it — rows written before ``cache_saving_usd``
+    existed must not read as a measured $0.00.
     """
     rows = (
         db.query(CostLedgerRow.detail_json, CostLedgerRow.user_id)
@@ -387,6 +414,7 @@ def _program_variable_and_counts(
     )
     token_usd = 0.0
     storage_usd = 0.0
+    cache_saving_usd: float | None = None
     users: set[str] = set()
     for detail_json, user_id in rows:
         users.add(user_id)
@@ -398,7 +426,10 @@ def _program_variable_and_counts(
             continue
         token_usd += bd.get("token_cost_usd", 0.0)
         storage_usd += bd.get("storage_cost_usd", 0.0)
-    return token_usd, storage_usd, len(rows), len(users)
+        saving = bd.get("cache_saving_usd")
+        if saving is not None:
+            cache_saving_usd = (cache_saving_usd or 0.0) + saving
+    return token_usd, storage_usd, len(rows), len(users), cache_saving_usd
 
 
 def build_program_report(db: Session, window_days: int) -> ProgramCostReport | None:
@@ -413,7 +444,9 @@ def build_program_report(db: Session, window_days: int) -> ProgramCostReport | N
 
     config, config_id = config_from_row(config_row)
     since = datetime.now(timezone.utc) - timedelta(days=window_days)
-    token_usd, storage_usd, num_briefings, num_users = _program_variable_and_counts(db, since)
+    (
+        token_usd, storage_usd, num_briefings, num_users, cache_saving_usd,
+    ) = _program_variable_and_counts(db, since)
 
     return compute_program_cost(
         config=config,
@@ -423,6 +456,7 @@ def build_program_report(db: Session, window_days: int) -> ProgramCostReport | N
         variable_storage_usd=storage_usd,
         num_briefings=num_briefings,
         num_users=num_users,
+        cache_saving_usd=cache_saving_usd,
     )
 
 

--- a/src/weatherbrief/costs.py
+++ b/src/weatherbrief/costs.py
@@ -6,6 +6,37 @@ import json
 from dataclasses import dataclass, fields
 
 
+# --- Prompt-cache pricing ---------------------------------------------------
+#
+# Anthropic's published cache-write premiums, keyed by TTL.  A cache *read* is
+# 0.1x on either tier.  This table is the only place a write premium is
+# written down.
+CACHE_WRITE_MULTIPLIERS: dict[str, float] = {"5m": 1.25, "1h": 2.0}
+CACHE_READ_MULTIPLIER: float = 0.1
+
+# The TTL the *charging* path writes with.  Single source of truth: the digest
+# reads it (``digest/llm_digest.py:_system_content``) and the rate card below
+# derives its write multiplier from it, so the two cannot drift.  Changing this
+# to "5m" re-prices writes at 1.25x automatically; a TTL with no entry in the
+# table above is rejected at the call site rather than silently mis-priced.
+DIGEST_CACHE_TTL: str = "1h"
+
+
+def cache_write_multiplier_for(ttl: str) -> float:
+    """Write premium for a prompt-cache TTL.
+
+    Raises ``ValueError`` for a TTL with no published premium — a new tier has
+    to be priced here before anything can write with it.
+    """
+    try:
+        return CACHE_WRITE_MULTIPLIERS[ttl]
+    except KeyError:
+        raise ValueError(
+            f"Unpriced prompt-cache TTL {ttl!r}; "
+            f"known: {', '.join(sorted(CACHE_WRITE_MULTIPLIERS))}"
+        ) from None
+
+
 @dataclass(frozen=True)
 class CostConfig:
     """Rate card for cost computation.
@@ -17,11 +48,11 @@ class CostConfig:
 
     token_cost_per_1k_input: float = 0.003
     token_cost_per_1k_output: float = 0.015
-    # Prompt-caching multipliers applied to token_cost_per_1k_input. Anthropic
-    # bills a cache write at 1.25x on the 5-minute TTL and 2x on the 1h TTL we
-    # use for digests; a cache read is 0.1x either way.
-    cache_write_multiplier: float = 2.0
-    cache_read_multiplier: float = 0.1
+    # Prompt-caching multipliers applied to token_cost_per_1k_input, derived
+    # from the TTL the digest actually writes with — do not hardcode a number
+    # here, or a TTL change silently mis-prices every write.
+    cache_write_multiplier: float = CACHE_WRITE_MULTIPLIERS[DIGEST_CACHE_TTL]
+    cache_read_multiplier: float = CACHE_READ_MULTIPLIER
     droplet_monthly_usd: float = 24.0
     misc_monthly_usd: float = 2.0
     subscriptions_monthly_usd: float = 30.0
@@ -59,6 +90,11 @@ class CostBreakdown:
     margin_usd: float
     total_usd: float
     config_id: int
+    # What prompt caching saved on this briefing: the cached tokens priced at
+    # 1x minus what they actually billed at their multipliers.  Informational —
+    # already reflected inside token_cost_usd, never added to the subtotal.
+    # Negative on a cache *write* (2x), positive once the reads come back.
+    cache_saving_usd: float = 0.0
 
 
 _BYTES_PER_GB = 1024**3
@@ -84,6 +120,10 @@ def compute_cost(
     that already includes both. They are subtracted out and re-priced at their
     own multipliers, so the three tiers each bill correctly. Both default to 0,
     which reproduces the pre-caching behaviour exactly for historical rows.
+
+    ``CostBreakdown.cache_saving_usd`` reports what that split saved against
+    pricing the same tokens at 1x — informational only, already inside
+    ``token_cost_usd``.
     """
     est = max(config.estimated_monthly_briefings, _MIN_BRIEFINGS)
 
@@ -103,6 +143,17 @@ def compute_cost(
         * config.cache_write_multiplier
         + (output_tokens / 1000) * config.token_cost_per_1k_output
     )
+    # What caching saved: the same cached tokens priced at 1x, minus what they
+    # actually billed.  Uses the reported counts (not the clamped ones) so it
+    # stays the exact complement of the two cache terms above.
+    cache_saving = (
+        (cache_read_tokens / 1000)
+        * config.token_cost_per_1k_input
+        * (1 - config.cache_read_multiplier)
+        + (cache_write_tokens / 1000)
+        * config.token_cost_per_1k_input
+        * (1 - config.cache_write_multiplier)
+    )
     infra_share = (config.droplet_monthly_usd + config.misc_monthly_usd) / est
     subscription_share = config.subscriptions_monthly_usd / est
     storage_cost = (result_size_bytes / _BYTES_PER_GB) * config.disk_cost_per_gb_monthly
@@ -120,6 +171,7 @@ def compute_cost(
         margin_usd=round(margin, 6),
         total_usd=round(total, 6),
         config_id=config_id,
+        cache_saving_usd=round(cache_saving, 6),
     )
 
 
@@ -152,6 +204,11 @@ class ProgramCostReport:
     variable_token_usd: float
     variable_storage_usd: float
     variable_usd: float
+    # What prompt caching saved over the window, summed from the same ledger
+    # rows.  ``None`` when no row in the window carries the figure at all
+    # (every briefing predates the field) — distinct from 0.0, which means
+    # "measured, and nothing was cached".
+    cache_saving_usd: float | None
     subtotal_usd: float  # fixed_prorated + variable
     margin_percent: float
     margin_usd: float
@@ -171,6 +228,7 @@ def compute_program_cost(
     variable_storage_usd: float,
     num_briefings: int,
     num_users: int,
+    cache_saving_usd: float | None = None,
 ) -> ProgramCostReport:
     """Compute a program-wide cost report for a time window.
 
@@ -178,6 +236,10 @@ def compute_program_cost(
     window.  Variable costs are the actual token/storage totals from the
     ledger.  Margin is applied to the combined subtotal so the rate card stays
     internally consistent.  Per-briefing/per-user figures are guarded for zero.
+
+    ``cache_saving_usd`` is reporting-only — it is *already* inside
+    ``variable_token_usd`` and must never be added to or subtracted from any
+    total.  ``None`` means no ledger row in the window recorded it.
     """
     months = window_days / _DAYS_PER_MONTH
 
@@ -214,6 +276,9 @@ def compute_program_cost(
         variable_token_usd=round(variable_token_usd, 4),
         variable_storage_usd=round(variable_storage_usd, 4),
         variable_usd=round(variable, 4),
+        cache_saving_usd=(
+            None if cache_saving_usd is None else round(cache_saving_usd, 4)
+        ),
         subtotal_usd=round(subtotal, 4),
         margin_percent=config.margin_percent,
         margin_usd=round(margin, 4),
@@ -239,6 +304,7 @@ def program_report_to_dict(r: ProgramCostReport) -> dict:
         "variable_token_usd": r.variable_token_usd,
         "variable_storage_usd": r.variable_storage_usd,
         "variable_usd": r.variable_usd,
+        "cache_saving_usd": r.cache_saving_usd,
         "subtotal_usd": r.subtotal_usd,
         "margin_percent": r.margin_percent,
         "margin_usd": r.margin_usd,
@@ -267,4 +333,7 @@ def breakdown_to_dict(b: CostBreakdown) -> dict:
         "margin_usd": b.margin_usd,
         "total_usd": b.total_usd,
         "config_id": b.config_id,
+        # Additive: rows written before this field existed simply lack the key.
+        # Readers must treat "absent" as unknown, not as a real zero.
+        "cache_saving_usd": b.cache_saving_usd,
     }

--- a/src/weatherbrief/digest/llm_digest.py
+++ b/src/weatherbrief/digest/llm_digest.py
@@ -20,6 +20,7 @@ from langgraph.graph.state import CompiledStateGraph
 from pydantic import BaseModel
 from typing_extensions import TypedDict
 
+from weatherbrief.costs import DIGEST_CACHE_TTL, cache_write_multiplier_for
 from weatherbrief.digest.exceptions import classify_llm_exception
 from weatherbrief.digest.llm_config import DigestConfig, LLMConfig, create_llm
 from weatherbrief.digest.outlook import OUTLOOK_ICONS, OUTLOOK_LABELS
@@ -160,7 +161,7 @@ def _system_content(
     tail: str,
     llm_config: LLMConfig,
     longrange: bool,
-    ttl: str = "1h",
+    ttl: str = DIGEST_CACHE_TTL,
 ) -> str | list[dict]:
     """System message content, with a prompt-cache breakpoint where it pays.
 
@@ -170,17 +171,25 @@ def _system_content(
     Everything after it (the pack context) stays uncached, which is what we
     want: it differs on every call.
 
-    The default 1-hour ``ttl`` is deliberate for production.  It costs 2x on a
-    write against the 5-minute tier's 1.25x, but break-even is a hit rate of
-    53% vs 22%, and measured gaps between consecutive production digests clear
-    the bar more comfortably at an hour than at five minutes.
+    The default ``ttl`` comes from ``costs.DIGEST_CACHE_TTL`` — 1 hour, which
+    is deliberate for production.  It costs 2x on a write against the 5-minute
+    tier's 1.25x, but break-even is a hit rate of 53% vs 22%, and measured gaps
+    between consecutive production digests clear the bar more comfortably at an
+    hour than at five minutes (replaying real arrival gaps at 5m gives a 20%
+    hit rate — below its own 21.7% break-even, i.e. worse than not caching).
+
+    **Do not hardcode a TTL here.**  The ledger's ``cache_write_multiplier`` is
+    derived from ``DIGEST_CACHE_TTL`` via ``CACHE_WRITE_MULTIPLIERS``, and the
+    charged write price never travels with the write — cost is computed later,
+    from a ``briefing_usage`` row that does not record which TTL produced its
+    tokens.  Move the constant and the price follows; hardcode a string and
+    every digest mis-prices its writes silently.  An unpriced TTL raises rather
+    than billing at the wrong tier.
 
     Callers running a *burst* — the eval replays back-to-back, seconds apart —
-    should pass ``ttl="5m"`` instead: nothing expires inside a run, so the
-    cheaper write premium wins outright.  Note the ledger's
-    ``cache_write_multiplier`` is calibrated to the 1h tier; anything changing
-    the TTL on a path that *charges* a user must move that with it.  The eval
-    does not write to the ledger, so it is free to choose.
+    may pass ``ttl="5m"``: nothing expires inside a run, so the cheaper write
+    premium wins outright.  That override is only legitimate because the eval
+    does not write to the ledger.
 
     Two cases fall back to a plain string:
 
@@ -198,6 +207,7 @@ def _system_content(
     """
     if llm_config.provider != "anthropic" or longrange:
         return head + tail
+    cache_write_multiplier_for(ttl)  # reject a TTL the rate card cannot price
     # Breakpoint on the head only. Everything after it is uncached, which is
     # the point: the head is identical for every pilot, the guidance tail is
     # not, so all guidance presets share one cache entry instead of forking.

--- a/tests/test_cost_report_api.py
+++ b/tests/test_cost_report_api.py
@@ -76,7 +76,13 @@ def _seed_active_config(session, **overrides) -> int:
     return cid
 
 
-def _add_briefing(session, user_id, token_usd, storage_usd, *, days_ago=0):
+def _add_briefing(session, user_id, token_usd, storage_usd, *, days_ago=0, cache_saving=None):
+    """Seed a charged briefing.
+
+    ``cache_saving=None`` writes a **historical-shaped** row — no
+    ``cache_saving_usd`` key at all, exactly like every row charged before the
+    field existed. That absence is the thing worth testing.
+    """
     bd = {
         "token_cost_usd": token_usd,
         "infra_share_usd": 0.05,
@@ -87,6 +93,8 @@ def _add_briefing(session, user_id, token_usd, storage_usd, *, days_ago=0):
         "total_usd": token_usd + storage_usd + 0.14,
         "config_id": 1,
     }
+    if cache_saving is not None:
+        bd["cache_saving_usd"] = cache_saving
     session.add(CostLedgerRow(
         user_id=user_id,
         service=SERVICE,
@@ -146,6 +154,90 @@ class TestCostReportEndpoint:
         assert abs(data["fixed_prorated_usd"] - 56.0 * 7 / 30) < 1e-2
 
 
+class TestCacheSavingReporting:
+    """``cache_saving_usd`` is additive on a schemaless ``detail_json``.
+
+    Every row charged before the field existed simply lacks the key, so the
+    reporting path has to tell "not recorded" apart from "recorded as zero" —
+    and must never blow up on the old shape.
+    """
+
+    def test_legacy_rows_report_absent_not_zero(self, client, app_db):
+        _seed_active_config(app_db())
+        s = app_db()
+        _add_briefing(s, "user-a", 0.20, 0.01)   # pre-field shape
+        _add_briefing(s, "user-b", 0.10, 0.02)
+        s.commit()
+        s.close()
+
+        data = client.get("/api/admin/cost-report?window=30d").json()
+        # A $0.00 here would read as "caching achieved nothing", which is a lie.
+        assert data["cache_saving_usd"] is None
+        assert abs(data["variable_token_usd"] - 0.30) < 1e-6
+
+    def test_sums_only_the_rows_that_carry_it(self, client, app_db):
+        _seed_active_config(app_db())
+        s = app_db()
+        _add_briefing(s, "user-a", 0.20, 0.01)                      # legacy
+        _add_briefing(s, "user-a", 0.10, 0.00, cache_saving=0.012)
+        _add_briefing(s, "user-b", 0.05, 0.00, cache_saving=0.008)
+        s.commit()
+        s.close()
+
+        data = client.get("/api/admin/cost-report?window=30d").json()
+        assert abs(data["cache_saving_usd"] - 0.02) < 1e-6
+        assert data["num_briefings"] == 3
+
+    def test_a_write_heavy_window_reports_a_negative_saving(self, client, app_db):
+        """A window of cache misses really did cost more — don't floor it."""
+        _seed_active_config(app_db())
+        s = app_db()
+        _add_briefing(s, "user-a", 0.20, 0.0, cache_saving=-0.03)
+        s.commit()
+        s.close()
+
+        data = client.get("/api/admin/cost-report?window=30d").json()
+        assert abs(data["cache_saving_usd"] + 0.03) < 1e-6
+
+    def test_saving_does_not_move_any_total(self, client, app_db):
+        """It is already inside the token cost — reporting only."""
+        _seed_active_config(app_db())
+        s = app_db()
+        _add_briefing(s, "user-a", 0.20, 0.01, cache_saving=0.05)
+        s.commit()
+        s.close()
+
+        data = client.get("/api/admin/cost-report?window=30d").json()
+        assert abs(data["variable_usd"] - 0.21) < 1e-6
+        assert abs(data["subtotal_usd"] - (56.0 + 0.21)) < 1e-3
+
+    def test_user_costs_aggregate_omits_the_key_for_legacy_rows(self, client, app_db):
+        _seed_active_config(app_db())
+        s = app_db()
+        _add_briefing(s, DEV_USER_ID, 0.20, 0.01)
+        s.commit()
+        s.close()
+
+        data = client.get(f"/api/admin/users/{DEV_USER_ID}/costs").json()
+        assert "cache_saving_usd" not in data["cost_breakdown"]
+        # The transaction breakdown is the raw stored detail — also untouched.
+        assert "cache_saving_usd" not in data["transactions"][0]["breakdown"]
+
+    def test_user_costs_aggregate_sums_recorded_savings(self, client, app_db):
+        _seed_active_config(app_db())
+        s = app_db()
+        _add_briefing(s, DEV_USER_ID, 0.20, 0.01)                       # legacy
+        _add_briefing(s, DEV_USER_ID, 0.10, 0.00, cache_saving=0.011)
+        _add_briefing(s, DEV_USER_ID, 0.10, 0.00, cache_saving=0.009)
+        s.commit()
+        s.close()
+
+        data = client.get(f"/api/admin/users/{DEV_USER_ID}/costs").json()
+        assert abs(data["cost_breakdown"]["cache_saving_usd"] - 0.02) < 1e-6
+        # Still not part of the cost sum it is reported alongside.
+        assert abs(data["cost_breakdown"]["token_cost_usd"] - 0.40) < 1e-6
+
+
 class TestConfigSubscriptionAutoSum:
     def test_put_auto_sums_subscriptions_from_details(self, client, app_db):
         _seed_active_config(app_db())
@@ -163,5 +255,46 @@ class TestConfigSubscriptionAutoSum:
         resp = client.put(
             "/api/admin/cost-config",
             json={"subscription_details": {"open_meteo": "free"}},
+        )
+        assert resp.status_code == 422
+
+
+class TestConfigCacheMultiplierGuard:
+    """A rate-card override can still disagree with the digest's cache TTL.
+
+    The derivation in ``costs.py`` fixes the *default*; the DB row wins over it.
+    Nothing records which TTL produced a write, so a disagreeing override
+    mis-prices every subsequent briefing — worth a log line, not a refusal
+    (the operator may be modelling an announced price change).
+    """
+
+    def test_matching_multiplier_is_silent(self, client, app_db, caplog):
+        from weatherbrief.costs import CACHE_WRITE_MULTIPLIERS, DIGEST_CACHE_TTL
+
+        _seed_active_config(app_db())
+        with caplog.at_level("WARNING"):
+            resp = client.put(
+                "/api/admin/cost-config",
+                json={"cache_write_multiplier": CACHE_WRITE_MULTIPLIERS[DIGEST_CACHE_TTL]},
+            )
+        assert resp.status_code == 200
+        assert "cache_write_multiplier" not in caplog.text
+
+    def test_disagreeing_multiplier_is_accepted_but_warned(self, client, app_db, caplog):
+        _seed_active_config(app_db())
+        with caplog.at_level("WARNING"):
+            resp = client.put(
+                "/api/admin/cost-config", json={"cache_write_multiplier": 1.25},
+            )
+        assert resp.status_code == 200
+        assert resp.json()["config"]["cache_write_multiplier"] == 1.25
+        assert "mis-priced" in caplog.text
+
+    def test_non_numeric_multiplier_rejected(self, client, app_db):
+        """Otherwise it stores fine and only fails inside the charging path,
+        where exceptions are swallowed so the briefing never blocks."""
+        _seed_active_config(app_db())
+        resp = client.put(
+            "/api/admin/cost-config", json={"cache_write_multiplier": "free"},
         )
         assert resp.status_code == 422

--- a/tests/test_costs.py
+++ b/tests/test_costs.py
@@ -1,10 +1,16 @@
 """Tests for the cost computation module."""
 
+import pytest
+
 from weatherbrief.costs import (
+    CACHE_READ_MULTIPLIER,
+    CACHE_WRITE_MULTIPLIERS,
+    DIGEST_CACHE_TTL,
     CostBreakdown,
     CostConfig,
     DEFAULT_CONFIG,
     breakdown_to_dict,
+    cache_write_multiplier_for,
     compute_cost,
     compute_program_cost,
     program_report_to_dict,
@@ -192,7 +198,7 @@ class TestBreakdownToDict:
         assert set(d.keys()) == {
             "token_cost_usd", "infra_share_usd", "subscription_share_usd",
             "storage_cost_usd", "subtotal_usd", "margin_usd", "total_usd",
-            "config_id",
+            "config_id", "cache_saving_usd",
         }
 
 
@@ -298,6 +304,7 @@ class TestComputeProgramCost:
         assert set(d.keys()) == {
             "window_days", "fixed_lines", "fixed_monthly_usd", "fixed_prorated_usd",
             "variable_token_usd", "variable_storage_usd", "variable_usd",
+            "cache_saving_usd",
             "subtotal_usd", "margin_percent", "margin_usd", "total_usd",
             "num_briefings", "num_users", "cost_per_briefing_usd",
             "cost_per_user_usd", "config_id",
@@ -379,6 +386,68 @@ class TestPromptCachePricing:
         # One miss then four hits — the shape of an 80% hit rate.
         assert (write + 4 * read) / 5 < baseline
 
+    def test_saving_is_the_gap_against_pricing_the_same_tokens_at_1x(self):
+        """cache_saving_usd = what the cached tokens would have cost at 1x,
+        minus what they actually cost at their multipliers."""
+        config = _default_config()
+        read, write = 4000, 1000
+        b = compute_cost(
+            input_tokens=10000, output_tokens=0,
+            result_size_bytes=0, config=config, config_id=1,
+            cache_read_tokens=read, cache_write_tokens=write,
+        )
+        rate = config.token_cost_per_1k_input
+        at_1x = (read + write) / 1000 * rate
+        actual = (
+            read / 1000 * rate * config.cache_read_multiplier
+            + write / 1000 * rate * config.cache_write_multiplier
+        )
+        assert abs(b.cache_saving_usd - (at_1x - actual)) < 1e-9
+
+    def test_saving_equals_the_gap_against_the_uncached_bill(self):
+        """The saving must reconcile against a real uncached run, not just its
+        own formula — otherwise it could drift from what token_cost_usd bills."""
+        config = _default_config()
+        kw = dict(
+            input_tokens=10000, output_tokens=1000,
+            result_size_bytes=0, config=config, config_id=1,
+        )
+        uncached = compute_cost(**kw)
+        cached = compute_cost(**kw, cache_read_tokens=6000)
+        assert abs(cached.cache_saving_usd - (uncached.token_cost_usd - cached.token_cost_usd)) < 1e-9
+
+    def test_a_pure_write_is_a_negative_saving(self):
+        """A first, uncached call bills 2x — the 'saving' is a real surcharge
+        and must show as negative rather than being floored at zero."""
+        b = compute_cost(
+            input_tokens=10000, output_tokens=0,
+            result_size_bytes=0, config=_default_config(), config_id=1,
+            cache_write_tokens=5000,
+        )
+        assert b.cache_saving_usd < 0
+
+    def test_no_caching_means_no_saving(self):
+        b = compute_cost(
+            input_tokens=10000, output_tokens=1000,
+            result_size_bytes=0, config=_default_config(), config_id=1,
+        )
+        assert b.cache_saving_usd == 0.0
+
+    def test_saving_is_not_double_counted_in_any_total(self):
+        """It is reporting-only: token_cost_usd already reflects it."""
+        config = _default_config()
+        b = compute_cost(
+            input_tokens=10000, output_tokens=1000,
+            result_size_bytes=0, config=config, config_id=1,
+            cache_read_tokens=6000,
+        )
+        expected_subtotal = (
+            b.token_cost_usd + b.infra_share_usd
+            + b.subscription_share_usd + b.storage_cost_usd
+        )
+        assert abs(b.subtotal_usd - expected_subtotal) < 1e-6
+        assert abs(b.total_usd - (b.subtotal_usd + b.margin_usd)) < 1e-6
+
     def test_cached_never_exceeds_input_total(self):
         """Defends against a provider change making the figures siblings.
 
@@ -393,3 +462,107 @@ class TestPromptCachePricing:
             cache_read_tokens=5000, cache_write_tokens=5000,
         )
         assert b.token_cost_usd >= 0
+
+
+class TestCacheTtlPricingCoupling:
+    """The cache TTL and its write multiplier must not be able to disagree.
+
+    Cost is computed long after the call, from a ``briefing_usage`` row that
+    records *how many* cache-write tokens there were but not which TTL produced
+    them. So nothing downstream can detect a TTL change — a switch from 1h to
+    5m without the multiplier following mis-prices every write by 60%, silently.
+    The defence is derivation: one named TTL constant, one price table, and the
+    rate-card default read out of the table rather than typed as a literal.
+    """
+
+    def test_default_multiplier_is_derived_from_the_digest_ttl(self):
+        """The whole point: no hand-typed number in the rate card."""
+        assert CostConfig().cache_write_multiplier == CACHE_WRITE_MULTIPLIERS[DIGEST_CACHE_TTL]
+        assert DEFAULT_CONFIG.cache_write_multiplier == CACHE_WRITE_MULTIPLIERS[DIGEST_CACHE_TTL]
+        assert CostConfig().cache_read_multiplier == CACHE_READ_MULTIPLIER
+
+    def test_price_table_matches_anthropics_published_premiums(self):
+        """Pins the table itself — the one place a wrong number could hide.
+
+        Anthropic bills a cache write at 1.25x on the 5-minute tier and 2x on
+        the 1-hour tier; a read is 0.1x on both.
+        """
+        assert CACHE_WRITE_MULTIPLIERS == {"5m": 1.25, "1h": 2.0}
+        assert CACHE_READ_MULTIPLIER == 0.1
+
+    def test_the_digest_writes_at_the_ttl_the_rate_card_prices(self):
+        """Closes the loop across modules: a hardcoded TTL at the call site
+        would still bill at the constant's multiplier, so assert the call site
+        uses the constant."""
+        from weatherbrief.digest.llm_config import LLMConfig
+        from weatherbrief.digest.llm_digest import _system_content
+
+        out = _system_content(
+            "HEAD", "TAIL",
+            LLMConfig(provider="anthropic", model="claude-sonnet-4-6"),
+            longrange=False,
+        )
+        assert out[0]["cache_control"]["ttl"] == DIGEST_CACHE_TTL
+
+    def test_an_unpriced_ttl_is_rejected_rather_than_mispriced(self):
+        """A new tier has to be priced before anything can write with it."""
+        from weatherbrief.digest.llm_config import LLMConfig
+        from weatherbrief.digest.llm_digest import _system_content
+
+        with pytest.raises(ValueError, match="Unpriced prompt-cache TTL"):
+            cache_write_multiplier_for("30m")
+        with pytest.raises(ValueError, match="Unpriced prompt-cache TTL"):
+            _system_content(
+                "HEAD", "TAIL",
+                LLMConfig(provider="anthropic", model="claude-sonnet-4-6"),
+                longrange=False, ttl="30m",
+            )
+
+    def test_switching_the_ttl_moves_the_price_with_it(self):
+        """The 5m tier is a legitimate future choice — it must arrive priced."""
+        assert cache_write_multiplier_for("5m") == 1.25
+        assert cache_write_multiplier_for("1h") == 2.0
+        # A 5m rate card bills a write at 1.25x, not the 1h tier's 2x.
+        cfg = _default_config(cache_write_multiplier=cache_write_multiplier_for("5m"))
+        b = compute_cost(
+            input_tokens=10000, output_tokens=0,
+            result_size_bytes=0, config=cfg, config_id=1,
+            cache_write_tokens=10000,
+        )
+        assert abs(b.token_cost_usd - (10000 / 1000 * 0.003 * 1.25)) < 1e-9
+
+
+class TestProgramCacheSaving:
+    """Program-wide saving is reporting-only, and absent when unmeasured."""
+
+    def test_none_when_no_row_carries_the_field(self):
+        """Windows made entirely of pre-field briefings must not report $0.00
+        saved — that reads as 'caching achieved nothing', which is a lie."""
+        r = compute_program_cost(
+            _default_config(), config_id=1, window_days=30,
+            variable_token_usd=1.0, variable_storage_usd=0.1,
+            num_briefings=10, num_users=3,
+        )
+        assert r.cache_saving_usd is None
+        assert program_report_to_dict(r)["cache_saving_usd"] is None
+
+    def test_measured_zero_is_kept_distinct_from_absent(self):
+        r = compute_program_cost(
+            _default_config(), config_id=1, window_days=30,
+            variable_token_usd=1.0, variable_storage_usd=0.1,
+            num_briefings=10, num_users=3, cache_saving_usd=0.0,
+        )
+        assert r.cache_saving_usd == 0.0
+
+    def test_saving_never_moves_a_total(self):
+        """It is already inside variable_token_usd."""
+        kw = dict(
+            config=_default_config(), config_id=1, window_days=30,
+            variable_token_usd=1.0, variable_storage_usd=0.1,
+            num_briefings=10, num_users=3,
+        )
+        without = compute_program_cost(**kw)
+        with_saving = compute_program_cost(**kw, cache_saving_usd=0.42)
+        assert with_saving.total_usd == without.total_usd
+        assert with_saving.variable_usd == without.variable_usd
+        assert with_saving.cost_per_briefing_usd == without.cost_per_briefing_usd

--- a/tests/test_llm_digest.py
+++ b/tests/test_llm_digest.py
@@ -229,6 +229,11 @@ class TestSystemContentCacheBreakpoint:
         # Breakpoint on the head only — the guidance tail must stay uncached,
         # or every guidance preset forks into its own cache entry again.
         assert out[0]["text"] == "HEAD"
+        # Literal on purpose: this is the tripwire that makes a TTL change an
+        # explicit act. The write *price* follows the constant automatically
+        # (costs.DIGEST_CACHE_TTL -> CACHE_WRITE_MULTIPLIERS, guarded in
+        # tests/test_costs.py::TestCacheTtlPricingCoupling); this line just
+        # stops one drifting in unnoticed.
         assert out[0]["cache_control"] == {"type": "ephemeral", "ttl": "1h"}
         assert out[1]["text"] == "TAIL"
         assert "cache_control" not in out[1]
@@ -250,6 +255,50 @@ class TestSystemContentCacheBreakpoint:
         from weatherbrief.digest.llm_digest import _system_content
         cfg = load_digest_config("openai")
         assert _system_content("HEAD", "TAIL", cfg.llm, longrange=False) == "HEADTAIL"
+
+
+class TestEvalCacheCallSite:
+    """The eval is the only legitimate caller of a non-production TTL.
+
+    It lives in ``scripts/``, outside the import graph pytest walks, so a
+    signature change to ``_system_content`` cannot break it visibly — the
+    ``head``/``tail`` split did exactly that and the cached eval path has been
+    raising ``TypeError`` ever since. This exercises the call site with the LLM
+    mocked out.
+    """
+
+    def _run_one(self):
+        import importlib.util
+        from pathlib import Path
+
+        script = Path(__file__).resolve().parent.parent / "scripts" / "run_digest_eval.py"
+        spec = importlib.util.spec_from_file_location("run_digest_eval_ttl", script)
+        assert spec and spec.loader
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+
+    def _invoke(self, module, *, cache):
+        structured = MagicMock()
+        structured.invoke.return_value = {"raw": None, "parsed": MagicMock()}
+        llm = MagicMock()
+        llm.with_structured_output.return_value = structured
+        with patch.object(module, "create_llm", return_value=llm):
+            module.run_one("ctx", "SYSTEM PROMPT", DigestConfig(), cache=cache)
+        return structured.invoke.call_args[0][0][0]["content"]
+
+    def test_cached_eval_call_still_matches_the_signature(self):
+        module = self._run_one()
+        content = self._invoke(module, cache=True)
+        assert isinstance(content, list)
+        assert content[0]["text"] == "SYSTEM PROMPT"
+        # 5m, not production's 1h: a burst never expires, and the eval writes
+        # no ledger row, so the cheaper write premium is free to take.
+        assert content[0]["cache_control"] == {"type": "ephemeral", "ttl": "5m"}
+
+    def test_uncached_eval_call_sends_a_plain_string(self):
+        module = self._run_one()
+        assert self._invoke(module, cache=False) == "SYSTEM PROMPT"
 
 
 class TestCacheUsageExtraction:

--- a/web/ts/adapters/admin-adapter.ts
+++ b/web/ts/adapters/admin-adapter.ts
@@ -159,6 +159,10 @@ export interface UserCostBreakdown {
   storage_cost_usd: number;
   margin_usd: number;
   total_usd: number;
+  /** What prompt caching saved. Absent when every charged briefing predates
+   *  the field — absent means unknown, not a measured $0.00. Already inside
+   *  token_cost_usd, so never add it to a total. */
+  cache_saving_usd?: number;
 }
 
 export interface UserCostsResponse {
@@ -208,6 +212,10 @@ export interface CostReport {
   variable_token_usd: number;
   variable_storage_usd: number;
   variable_usd: number;
+  /** Prompt-cache saving over the window. `null` when no ledger row in the
+   *  window records it (all pre-date the field); already inside
+   *  variable_token_usd, so it is reporting-only. */
+  cache_saving_usd?: number | null;
   subtotal_usd: number;
   margin_percent: number;
   margin_usd: number;

--- a/web/ts/admin-cost-view.ts
+++ b/web/ts/admin-cost-view.ts
@@ -25,6 +25,9 @@ let subItems: Array<{ name: string; amount: number }> = [];
 
 const usd = (n: number) => `$${n.toFixed(2)}`;
 const usd4 = (n: number) => `$${n.toFixed(4)}`;
+// A cache "saving" is genuinely negative in a write-heavy window, and "$-0.03"
+// reads as a typo — keep the sign in front of the currency.
+const signedUsd4 = (n: number) => (n < 0 ? `-$${Math.abs(n).toFixed(4)}` : usd4(n));
 
 export async function initCostTab(): Promise<void> {
   if (costInitialized) return;
@@ -81,9 +84,17 @@ function renderReport(r: CostReport | null): void {
     return;
   }
 
+  // Reporting-only: the saving is already netted off inside variable_usd, so
+  // it gets its own card rather than a slot in the cost sequence. Absent when
+  // no ledger row in the window carries the figure.
+  const savingCard = r.cache_saving_usd == null
+    ? ''
+    : `<div class="summary-card"><div class="value">${signedUsd4(r.cache_saving_usd)}</div><div class="label">Cache saved</div></div>`;
+
   summary.innerHTML = `
     <div class="summary-card"><div class="value">${usd(r.fixed_prorated_usd)}</div><div class="label">Fixed</div></div>
     <div class="summary-card"><div class="value">${usd(r.variable_usd)}</div><div class="label">Variable</div></div>
+    ${savingCard}
     <div class="summary-card"><div class="value">${usd(r.margin_usd)}</div><div class="label">Other costs (${r.margin_percent}%)</div></div>
     <div class="summary-card"><div class="value">${usd(r.total_usd)}</div><div class="label">Total</div></div>
     <div class="summary-card"><div class="value">${r.num_briefings}</div><div class="label">Briefings</div></div>
@@ -103,9 +114,18 @@ function renderReport(r: CostReport | null): void {
       <td class="num">${usd(r.fixed_prorated_usd)}</td>
     </tr>`;
 
+  // Prompt-cache saving is reporting-only — it is already inside the token
+  // figure above. `null`/absent means no row in the window recorded it (they
+  // pre-date the field), which must not render as a measured $0.00.
+  const saving = r.cache_saving_usd;
+  const savingNote = saving == null
+    ? ''
+    : ` Prompt caching saved ${signedUsd4(saving)} of that token cost`
+      + `${saving < 0 ? ' (negative: cache writes outran the reads in this window)' : ''}.`;
+
   note.innerHTML = `Fixed cost is prorated from the rate card (monthly &times; ${r.window_days}/30). `
     + `Variable is the actual LLM token (${usd4(r.variable_token_usd)}) + storage (${usd4(r.variable_storage_usd)}) `
-    + `charged over the window. Total includes the ${r.margin_percent}% margin.`;
+    + `charged over the window.${savingNote} Total includes the ${r.margin_percent}% margin.`;
 }
 
 // --- Rate-card editor ---

--- a/web/ts/user-costs-main.ts
+++ b/web/ts/user-costs-main.ts
@@ -23,6 +23,10 @@ const COST_COLORS: Record<CostKey, string> = {
   margin_usd: '#d97706',
 };
 
+// A cache "saving" is genuinely negative when writes outran reads, and
+// "$-0.03" reads as a typo — keep the sign in front of the currency.
+const signedUsd4 = (n: number) => (n < 0 ? `-$${Math.abs(n).toFixed(4)}` : `$${n.toFixed(4)}`);
+
 const COST_LABELS: Record<CostKey, string> = {
   token_cost_usd: 'LLM Tokens',
   infra_share_usd: 'Infrastructure',
@@ -154,11 +158,19 @@ function renderCostDistribution(bd: UserCostBreakdown, avgCost: number, totalBri
 
   const avgUsd = totalBriefings > 0 ? (total / totalBriefings).toFixed(4) : '0.0000';
 
+  // Prompt-cache saving is not a cost component — it is already netted off
+  // inside LLM Tokens — so it stays out of the bar and the legend. Absent
+  // (undefined) means no charged briefing recorded it, not a saving of zero.
+  const savingLine = bd.cache_saving_usd === undefined
+    ? ''
+    : `<div class="cost-avg">Prompt caching saved <strong>${signedUsd4(bd.cache_saving_usd)}</strong> of the LLM token cost</div>`;
+
   container.innerHTML = `
     <div class="cost-bar-container">
       <div class="cost-stacked-bar">${segments}</div>
       <div class="cost-legend">${legendItems}</div>
       <div class="cost-avg">Total: <strong>$${total.toFixed(2)}</strong> across ${totalBriefings} briefings &middot; Average: <strong>$${avgUsd}</strong> per briefing</div>
+      ${savingLine}
     </div>`;
 }
 
@@ -177,6 +189,10 @@ function renderTransactions(transactions: UserCostTransaction[]): void {
     let breakdownRow = '';
     if (tx.breakdown) {
       const bd = tx.breakdown;
+      // 'Cache saved' is informational (already inside LLM Tokens) and sits
+      // after the total for that reason. Briefings charged before the field
+      // existed have no key at all — the undefined filter below drops the
+      // cell rather than showing a $0.0000 that looks measured.
       const items = [
         ['LLM Tokens', bd.token_cost_usd],
         ['Infra', bd.infra_share_usd],
@@ -184,9 +200,10 @@ function renderTransactions(transactions: UserCostTransaction[]): void {
         ['Storage', bd.storage_cost_usd],
         ['Other costs', bd.margin_usd],
         ['Total', bd.total_usd],
+        ['Cache saved', bd.cache_saving_usd],
       ]
         .filter(([, v]) => v !== undefined)
-        .map(([label, v]) => `<div><span class="bd-label">${label}</span><br><span class="bd-value">${typeof v === 'number' ? '$' + v.toFixed(4) : v}</span></div>`)
+        .map(([label, v]) => `<div><span class="bd-label">${label}</span><br><span class="bd-value">${typeof v === 'number' ? signedUsd4(v) : v}</span></div>`)
         .join('');
       breakdownRow = `<tr class="tx-breakdown" data-tx-detail="${tx.id}"><td colspan="5"><div class="breakdown-grid">${items}</div></td></tr>`;
     }


### PR DESCRIPTION
## What & why

Two cost-side follow-ups on the digest prompt-cache work.

### A. The TTL and its write multiplier can no longer disagree

Cost is computed long after the digest call, at `_charge_briefing_cost()`, from a `briefing_usage` row that records *how many* cache-write tokens there were but **not which TTL produced them**. So nothing downstream could detect a TTL change: switching 1h → 5m without moving `cache_write_multiplier` mis-priced every write by 60%, silently — no failing test, no log line.

Fixed by derivation rather than documentation:

```python
costs.DIGEST_CACHE_TTL = "1h"                              # the TTL the charging path writes with
costs.CACHE_WRITE_MULTIPLIERS = {"5m": 1.25, "1h": 2.0}    # the only price table
CostConfig.cache_write_multiplier = CACHE_WRITE_MULTIPLIERS[DIGEST_CACHE_TTL]
_system_content(..., ttl: str = DIGEST_CACHE_TTL)
```

- Move the constant and the write price follows automatically.
- An unpriced TTL (`"30m"`) raises `ValueError` at the call site instead of billing at the wrong tier — a new Anthropic tier has to be priced first.
- The eval keeps its legitimate `"5m"` override; it writes no ledger row.
- The rate-card row can still override the multiplier (the DB wins over the derived default), so `update_cost_config` logs a warning when a submitted value disagrees with the TTL — a warning, not a 422, since the operator may be modelling an announced price change. It *does* now 422 a non-numeric multiplier, which previously stored cleanly and only blew up later inside the charging path, where exceptions are swallowed.
- Per the issue's gotcha, nothing assumes the active `cost_config` row carries the cache keys — prod's doesn't, and both multipliers come from the dataclass defaults.

### B. `cache_saving_usd` on `CostBreakdown` and the program report

What the cached tokens would have cost at 1x, minus what they actually billed at their multipliers. Reporting-only: it is already inside `token_cost_usd` / `variable_token_usd`, never joins a subtotal, and is not floored — a pure cache write is a real 2x surcharge and reads negative.

`detail_json` is schemaless, so this is purely additive: **no migration**. Rows charged before the field existed have no key, and every reader keeps *absent* distinct from a measured `0.0` — the program report carries `None`, the per-user aggregate omits the key, and both frontends render nothing rather than "caching saved $0.00", which would be a lie about untracked history.

Surfaced as a "Cache saved" card + note sentence on the admin Cost tab, and a line under the bar plus a breakdown cell on the per-user cost page.

### Drive-by

`scripts/run_digest_eval.py` still called `_system_content` with the pre-`head`/`tail` signature and had been raising `TypeError` on its cached path since briefer_v3. It lives in `scripts/`, outside the import graph pytest walks, so nothing caught it. Fixed and covered with the LLM mocked out.

## Issue linkage

Closes #535

## Testing / verification

- `tests/test_costs.py::TestCacheTtlPricingCoupling` — the rate-card default is derived from `DIGEST_CACHE_TTL`, the price table is pinned against Anthropic's published premiums, the digest writes at the TTL the rate card prices, and an unpriced TTL raises. `test_llm_digest.py` keeps a literal `"1h"` assertion as a tripwire so a TTL change stays a deliberate act.
- `tests/test_costs.py::TestPromptCachePricing` — the saving reconciles against a real uncached run (not just its own formula), a pure write is negative, and no total moves.
- `tests/test_cost_report_api.py::TestCacheSavingReporting` — legacy-shaped ledger rows (no key) report absent rather than zero, mixed windows sum only the rows that carry it, negatives pass through, and the per-user aggregate behaves the same. `TestConfigCacheMultiplierGuard` covers the warn/422 paths.
- `tests/test_llm_digest.py::TestEvalCacheCallSite` — the eval's cached call site matches the signature and sends a 5m breakpoint.
- Full suite: 4828 passed. `tests/test_auth.py::TestLoginRedirect::test_google_login_redirects` fails identically on the unmodified base branch (missing OAuth env in this container) — unrelated.
- `npx tsc --noEmit` clean apart from two pre-existing errors in `ts/eval/label-panel.ts`; `build:admin` and `build:user-costs` both build.
- Design docs updated: `cost-attribution-design.md` (the hazard section now describes the enforcement + the new field's absent-vs-zero contract) and `digest.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VBhRxWApGZpSCkReqRdCkF

---
_Generated by [Claude Code](https://claude.ai/code/session_01VBhRxWApGZpSCkReqRdCkF)_